### PR TITLE
Add tabbed navigation with `Sessions` and `Roadmap` tabs

### DIFF
--- a/crates/ag-cli/src/app.rs
+++ b/crates/ag-cli/src/app.rs
@@ -11,7 +11,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use ratatui::widgets::TableState;
 
 use crate::agent::{AgentBackend, AgentKind};
-use crate::model::{AppMode, Session};
+use crate::model::{AppMode, Session, Tab};
 
 pub const AGENTTY_WORKSPACE: &str = "/var/tmp/.agentty";
 
@@ -19,6 +19,7 @@ pub struct App {
     pub sessions: Vec<Session>,
     pub table_state: TableState,
     pub mode: AppMode,
+    pub current_tab: Tab,
     base_path: PathBuf,
     agent_kind: AgentKind,
     backend: Box<dyn AgentBackend>,
@@ -37,6 +38,7 @@ impl App {
             sessions,
             table_state,
             mode: AppMode::List,
+            current_tab: Tab::Sessions,
             base_path,
             agent_kind,
             backend,
@@ -45,6 +47,10 @@ impl App {
 
     pub fn agent_kind(&self) -> AgentKind {
         self.agent_kind
+    }
+
+    pub fn next_tab(&mut self) {
+        self.current_tab = self.current_tab.next();
     }
 
     pub fn next(&mut self) {
@@ -633,5 +639,19 @@ mod tests {
         drop(file);
         let content = std::fs::read_to_string(file_path).expect("failed to read file");
         assert!(content.contains("File Line"));
+    }
+
+    #[test]
+    fn test_next_tab() {
+        // Arrange
+        let dir = tempdir().expect("failed to create temp dir");
+        let mut app = new_test_app(dir.path().to_path_buf());
+
+        // Act & Assert
+        assert_eq!(app.current_tab, Tab::Sessions);
+        app.next_tab();
+        assert_eq!(app.current_tab, Tab::Roadmap);
+        app.next_tab();
+        assert_eq!(app.current_tab, Tab::Sessions);
     }
 }

--- a/crates/ag-cli/src/main.rs
+++ b/crates/ag-cli/src/main.rs
@@ -45,6 +45,7 @@ fn main() -> io::Result<()> {
 
     loop {
         let current_agent_kind = app.agent_kind();
+        let current_tab = app.current_tab;
         terminal.draw(|f| {
             ui::render(
                 f,
@@ -52,6 +53,7 @@ fn main() -> io::Result<()> {
                 &app.sessions,
                 &mut app.table_state,
                 current_agent_kind,
+                current_tab,
             );
         })?;
 
@@ -64,6 +66,9 @@ fn main() -> io::Result<()> {
                 match &mut app.mode {
                     AppMode::List => match key.code {
                         KeyCode::Char('q') => break,
+                        KeyCode::Tab => {
+                            app.next_tab();
+                        }
                         KeyCode::Char('a') => {
                             app.mode = AppMode::Prompt {
                                 input: String::new(),

--- a/crates/ag-cli/src/model.rs
+++ b/crates/ag-cli/src/model.rs
@@ -5,6 +5,12 @@ use std::sync::{Arc, Mutex};
 use ratatui::style::Color;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Tab {
+    Sessions,
+    Roadmap,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Status {
     InProgress,
     Done,
@@ -41,6 +47,23 @@ impl Session {
             Status::InProgress
         } else {
             Status::Done
+        }
+    }
+}
+
+impl Tab {
+    pub fn title(self) -> &'static str {
+        match self {
+            Tab::Sessions => "Sessions",
+            Tab::Roadmap => "Roadmap",
+        }
+    }
+
+    #[must_use]
+    pub fn next(self) -> Self {
+        match self {
+            Tab::Sessions => Tab::Roadmap,
+            Tab::Roadmap => Tab::Sessions,
         }
     }
 }
@@ -101,5 +124,19 @@ mod tests {
         // Arrange & Act & Assert
         assert_eq!(Status::InProgress.color(), Color::Yellow);
         assert_eq!(Status::Done.color(), Color::Green);
+    }
+
+    #[test]
+    fn test_tab_title() {
+        // Arrange & Act & Assert
+        assert_eq!(Tab::Sessions.title(), "Sessions");
+        assert_eq!(Tab::Roadmap.title(), "Roadmap");
+    }
+
+    #[test]
+    fn test_tab_next() {
+        // Arrange & Act & Assert
+        assert_eq!(Tab::Sessions.next(), Tab::Roadmap);
+        assert_eq!(Tab::Roadmap.next(), Tab::Sessions);
     }
 }

--- a/crates/ag-cli/src/ui/components/mod.rs
+++ b/crates/ag-cli/src/ui/components/mod.rs
@@ -1,2 +1,3 @@
 pub mod chat_input;
 pub mod status_bar;
+pub mod tabs;

--- a/crates/ag-cli/src/ui/components/tabs.rs
+++ b/crates/ag-cli/src/ui/components/tabs.rs
@@ -1,0 +1,44 @@
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::model::Tab;
+use crate::ui::Component;
+
+pub struct Tabs {
+    current_tab: Tab,
+}
+
+impl Tabs {
+    pub fn new(current_tab: Tab) -> Self {
+        Self { current_tab }
+    }
+}
+
+impl Component for Tabs {
+    fn render(&self, f: &mut Frame, area: Rect) {
+        let tabs = [Tab::Sessions, Tab::Roadmap];
+        let tab_titles: Vec<_> = tabs
+            .iter()
+            .map(|tab| {
+                let title = tab.title();
+                if *tab == self.current_tab {
+                    Span::styled(
+                        format!(" {title} "),
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                } else {
+                    Span::styled(format!(" {title} "), Style::default().fg(Color::Gray))
+                }
+            })
+            .collect();
+
+        let line = Line::from(tab_titles);
+        let paragraph = Paragraph::new(line).block(Block::default().borders(Borders::BOTTOM));
+        f.render_widget(paragraph, area);
+    }
+}

--- a/crates/ag-cli/src/ui/pages/mod.rs
+++ b/crates/ag-cli/src/ui/pages/mod.rs
@@ -1,3 +1,4 @@
 pub mod new_session;
+pub mod roadmap;
 pub mod session_chat;
 pub mod sessions_list;

--- a/crates/ag-cli/src/ui/pages/roadmap.rs
+++ b/crates/ag-cli/src/ui/pages/roadmap.rs
@@ -1,0 +1,20 @@
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::ui::Page;
+
+pub struct RoadmapPage;
+
+impl Page for RoadmapPage {
+    fn render(&mut self, f: &mut Frame, area: Rect) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title("Roadmap")
+            .style(Style::default().fg(Color::White));
+
+        let paragraph = Paragraph::new("").block(block);
+        f.render_widget(paragraph, area);
+    }
+}


### PR DESCRIPTION
  - Add Tab enum to model layer with `Sessions` and `Roadmap` variants
  - Add `current_tab` state to App with `next_tab()` navigation method
  - Create `Tabs` component for rendering the tab bar
  - Create empty `RoadmapPage` for future roadmap features
  - Update UI rendering to show tabs only in List mode
  - Add `Tab` key binding to cycle between tabs
  -  Add formatting rule to `AGENTS.md` under a new
  "Documentation Conventions" section.

