### PR TITLE
Disallow commit creation guidance in session turn protocol

### DIFF
--- a/crates/agentty/src/infra/agent/prompt.rs
+++ b/crates/agentty/src/infra/agent/prompt.rs
@@ -387,6 +387,8 @@ mod tests {
         assert!(rendered_prompt.contains("Authoritative JSON Schema:"));
         assert!(rendered_prompt.contains("---"));
         assert!(rendered_prompt.contains("For this session turn"));
+        assert!(normalized_rendered_prompt.contains("Do not create commits"));
+        assert!(normalized_rendered_prompt.contains("suggest creating commits"));
         assert!(rendered_prompt.contains("summary"));
         assert!(rendered_prompt.contains("turn"));
         assert!(rendered_prompt.contains("session"));

--- a/crates/agentty/src/infra/agent/template/protocol_instruction_session_turn_usage.md
+++ b/crates/agentty/src/infra/agent/template/protocol_instruction_session_turn_usage.md
@@ -1,2 +1,3 @@
 For this session turn, keep user-facing content in `answer`, emit clarification prompts
-through `questions`, and populate `summary` when reporting delivered work.
+through `questions`, and populate `summary` when reporting delivered work. Do not create
+commits or suggest creating commits at the end of the turn.


### PR DESCRIPTION
- Update the session-turn protocol template to state assistants do not create or suggest creating commits at the end of a turn.
- Extend prompt rendering tests to verify normalized prompt text includes the new no-commit guidance and summary field coverage.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)