### PR TITLE
Adjust release workflow permissions for publish escalation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,6 @@ jobs:
 
   custom-release-checks:
     uses: ./.github/workflows/release-checks.yml
-    secrets: inherit
 
   # Build and packages all the platform-specific things
   build-local-artifacts:
@@ -295,7 +294,6 @@ jobs:
     uses: ./.github/workflows/publish-npm-oidc.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
-    secrets: inherit
     # publish jobs get escalated permissions
     permissions:
       "contents": "read"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -7,6 +7,9 @@ members = ["cargo:crates/agentty"]
 cargo-dist-version = "0.31.0"
 # CI backends to support
 ci = "github"
+# Keep release CI marked as intentionally customized because the checked-in
+# workflow avoids blanket secret forwarding on custom jobs that do not need it.
+allow-dirty = ["ci"]
 # The installers to generate for each app
 installers = ["shell", "npm"]
 # Target platforms to build apps for (Rust target-triple syntax)


### PR DESCRIPTION
- Remove `secrets: inherit` from reusable workflow invocations in `.github/workflows/release.yml` to avoid unnecessary secret forwarding.
- Add `allow-dirty = ["ci"]` in `dist-workspace.toml` so the intentionally customized release workflow remains recognized during CI.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)