### PR TITLE
Harden testty's published proof API surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- testty: `ProofBackend::render` now takes a single `RenderContext` argument instead of
+  `(&ProofReport, &Path)`, so future render inputs can be added without breaking
+  external backends. Callers using `ProofReport::save` are unaffected. (Breaking for
+  custom `ProofBackend` implementations.)
+- testty: `ProofError` is now `#[non_exhaustive]`. (Breaking for exhaustive matches.)
+
+### Removed
+
+- testty: `CellStyle::from_cell` is no longer public; it leaked the `vt100::Cell`
+  implementation-detail type. Use `TerminalFrame::cell_style` instead. (Breaking.)
+
 ## [v0.10.0] - 2026-06-02
 
 ### Added

--- a/crates/testty/docs/upgrading.md
+++ b/crates/testty/docs/upgrading.md
@@ -10,6 +10,38 @@ items (`testty::recipe`, `testty::snapshot::DEFAULT_UPDATE_ENV_VAR`,
 
 ## From earlier 0.x releases
 
+- `ProofBackend::render` now takes a single `testty::proof::backend::RenderContext`
+  argument instead of `(&ProofReport, &Path)`. Callers that render through
+  `ProofReport::save(&backend, path)` are unaffected. Custom backends read the report
+  and destination from the context:
+
+  ```rust
+  // Before
+  fn render(&self, report: &ProofReport, output: &Path) -> Result<(), ProofError> {
+      let html = build(report)?;
+      std::fs::write(output, html)?;
+      Ok(())
+  }
+
+  // After
+  fn render(&self, context: &RenderContext<'_>) -> Result<(), ProofError> {
+      let html = build(context.report)?;
+      std::fs::write(context.output, html)?;
+      Ok(())
+  }
+  ```
+
+  `RenderContext` is `#[non_exhaustive]` so future render inputs can be added without
+  another breaking change; build one with `RenderContext::new(report, output)` and read
+  its `report` / `output` fields.
+
+- `ProofError` is `#[non_exhaustive]`. Match arms over it need a fallback `_` arm so new
+  error variants stay non-breaking.
+
+- `CellStyle::from_cell` is no longer public — it borrowed a `vt100::Cell`, an
+  implementation-detail type that must not appear in testty's public API. Obtain a
+  `CellStyle` through `TerminalFrame::cell_style(row, col)` instead.
+
 - The `testty::prelude` wildcard re-export module has been removed. Replace
   `use testty::prelude::*;` with explicit per-module imports for the items each call
   site actually uses, for example:

--- a/crates/testty/src/frame.rs
+++ b/crates/testty/src/frame.rs
@@ -69,7 +69,11 @@ impl CellStyle {
     }
 
     /// Extract style flags from a `vt100` terminal cell.
-    pub fn from_cell(cell: &vt100::Cell) -> Self {
+    ///
+    /// Crate-internal: this borrows a `vt100::Cell`, an implementation-detail
+    /// type that must not appear in testty's public API. External callers
+    /// obtain a [`CellStyle`] through [`TerminalFrame::cell_style`] instead.
+    pub(crate) fn from_cell(cell: &vt100::Cell) -> Self {
         let mut flags = 0u8;
         if cell.bold() {
             flags |= BOLD_FLAG;

--- a/crates/testty/src/proof/backend.rs
+++ b/crates/testty/src/proof/backend.rs
@@ -8,17 +8,43 @@ use std::path::Path;
 
 use super::report::{ProofError, ProofReport};
 
+/// Inputs passed to a [`ProofBackend`] when it renders a report.
+///
+/// Bundling the render inputs in a single struct lets new inputs (an output
+/// directory, a theme, run metadata) be added later as additional fields
+/// without changing the [`ProofBackend::render`] signature, so external
+/// backend implementations stay source-compatible across non-breaking testty
+/// releases. The struct is `#[non_exhaustive]`: backends read its fields
+/// (`report`, `output`) but never construct it with a struct literal; build
+/// one through [`RenderContext::new`].
+#[non_exhaustive]
+pub struct RenderContext<'a> {
+    /// The proof report to render.
+    pub report: &'a ProofReport,
+    /// Destination path for the rendered output.
+    pub output: &'a Path,
+}
+
+impl<'a> RenderContext<'a> {
+    /// Create a render context from a report and its destination path.
+    pub fn new(report: &'a ProofReport, output: &'a Path) -> Self {
+        Self { report, output }
+    }
+}
+
 /// Trait for rendering a [`ProofReport`] to a file.
 ///
-/// Each implementation produces a different visual format. The report
-/// is passed by reference so multiple backends can render the same data.
+/// Each implementation produces a different visual format. Render inputs are
+/// passed by reference through a [`RenderContext`] so multiple backends can
+/// render the same data and so new inputs can be added without breaking the
+/// method signature for external implementors.
 pub trait ProofBackend {
-    /// Render the proof report and write the output to `path`.
+    /// Render the report described by `context` and write the output.
     ///
     /// # Errors
     ///
     /// Returns a [`ProofError`] if rendering or I/O fails.
-    fn render(&self, report: &ProofReport, output: &Path) -> Result<(), ProofError>;
+    fn render(&self, context: &RenderContext<'_>) -> Result<(), ProofError>;
 }
 
 #[cfg(test)]
@@ -31,7 +57,7 @@ mod tests {
     }
 
     impl ProofBackend for StubBackend {
-        fn render(&self, _report: &ProofReport, _output: &Path) -> Result<(), ProofError> {
+        fn render(&self, _context: &RenderContext<'_>) -> Result<(), ProofError> {
             if self.should_fail {
                 return Err(ProofError::Format("stub failure".to_string()));
             }
@@ -41,13 +67,27 @@ mod tests {
     }
 
     #[test]
+    fn render_context_exposes_report_and_output() {
+        // Arrange
+        let report = ProofReport::new("ctx_scenario");
+        let path = Path::new("/tmp/ctx.txt");
+
+        // Act
+        let context = RenderContext::new(&report, path);
+
+        // Assert
+        assert_eq!(context.report.scenario_name, "ctx_scenario");
+        assert_eq!(context.output, path);
+    }
+
+    #[test]
     fn stub_backend_succeeds() {
         // Arrange
         let backend = StubBackend { should_fail: false };
         let report = ProofReport::new("test");
 
         // Act
-        let result = backend.render(&report, Path::new("/tmp/test.txt"));
+        let result = backend.render(&RenderContext::new(&report, Path::new("/tmp/test.txt")));
 
         // Assert
         assert!(result.is_ok());
@@ -60,7 +100,7 @@ mod tests {
         let report = ProofReport::new("test");
 
         // Act
-        let result = backend.render(&report, Path::new("/tmp/test.txt"));
+        let result = backend.render(&RenderContext::new(&report, Path::new("/tmp/test.txt")));
 
         // Assert
         assert!(result.is_err());

--- a/crates/testty/src/proof/frame_text.rs
+++ b/crates/testty/src/proof/frame_text.rs
@@ -5,10 +5,8 @@
 //! [`ProofReport::to_annotated_text()`](super::report::ProofReport::to_annotated_text)
 //! but routed through the [`ProofBackend`](super::backend::ProofBackend) trait.
 
-use std::path::Path;
-
-use super::backend::ProofBackend;
-use super::report::{ProofError, ProofReport};
+use super::backend::{ProofBackend, RenderContext};
+use super::report::ProofError;
 
 /// Renders a proof report as annotated plain-text frame dumps.
 ///
@@ -23,9 +21,9 @@ impl ProofBackend for FrameTextBackend {
     /// # Errors
     ///
     /// Returns a [`ProofError::Io`] if writing the file fails.
-    fn render(&self, report: &ProofReport, output: &Path) -> Result<(), ProofError> {
-        let text = report.to_annotated_text();
-        std::fs::write(output, text)?;
+    fn render(&self, context: &RenderContext<'_>) -> Result<(), ProofError> {
+        let text = context.report.to_annotated_text();
+        std::fs::write(context.output, text)?;
 
         Ok(())
     }
@@ -35,6 +33,7 @@ impl ProofBackend for FrameTextBackend {
 mod tests {
     use super::*;
     use crate::frame::TerminalFrame;
+    use crate::proof::report::ProofReport;
 
     #[test]
     fn frame_text_backend_produces_same_output_as_to_annotated_text() {
@@ -51,7 +50,7 @@ mod tests {
         // Act
         let backend = FrameTextBackend;
         backend
-            .render(&report, &output_path)
+            .render(&RenderContext::new(&report, &output_path))
             .expect("render should succeed");
 
         // Assert
@@ -73,7 +72,7 @@ mod tests {
         // Act
         let backend = FrameTextBackend;
         backend
-            .render(&report, &output_path)
+            .render(&RenderContext::new(&report, &output_path))
             .expect("render should succeed");
 
         // Assert

--- a/crates/testty/src/proof/gif.rs
+++ b/crates/testty/src/proof/gif.rs
@@ -5,13 +5,12 @@
 //! delays, suitable for PR comments and documentation.
 
 use std::fs::File;
-use std::path::Path;
 
 use image::codecs::gif::{GifEncoder, Repeat};
 use image::{Frame, RgbaImage};
 
-use super::backend::ProofBackend;
-use super::report::{ProofError, ProofReport};
+use super::backend::{ProofBackend, RenderContext};
+use super::report::ProofError;
 use crate::frame::TerminalFrame;
 use crate::renderer;
 
@@ -65,7 +64,10 @@ impl ProofBackend for GifBackend {
     /// # Errors
     ///
     /// Returns a [`ProofError`] if rendering or encoding fails.
-    fn render(&self, report: &ProofReport, output: &Path) -> Result<(), ProofError> {
+    fn render(&self, context: &RenderContext<'_>) -> Result<(), ProofError> {
+        let report = context.report;
+        let output = context.output;
+
         if report.captures.is_empty() {
             return Err(ProofError::Format(
                 "cannot create GIF from empty report".to_string(),
@@ -107,6 +109,7 @@ fn build_gif_frame(image: RgbaImage, delay_hundredths: u32) -> Frame {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::proof::report::ProofReport;
 
     #[test]
     fn gif_backend_default_delay() {
@@ -147,7 +150,7 @@ mod tests {
         // Act
         let backend = GifBackend::default();
         backend
-            .render(&report, &output_path)
+            .render(&RenderContext::new(&report, &output_path))
             .expect("render should succeed");
 
         // Assert — file exists and has non-trivial size.
@@ -165,7 +168,7 @@ mod tests {
 
         // Act
         let backend = GifBackend::default();
-        let result = backend.render(&report, &output_path);
+        let result = backend.render(&RenderContext::new(&report, &output_path));
 
         // Assert
         assert!(result.is_err());
@@ -183,7 +186,7 @@ mod tests {
 
         // Act
         let backend = GifBackend::with_delay_ms(500);
-        let result = backend.render(&report, &output_path);
+        let result = backend.render(&RenderContext::new(&report, &output_path));
 
         // Assert
         assert!(result.is_ok());

--- a/crates/testty/src/proof/html.rs
+++ b/crates/testty/src/proof/html.rs
@@ -7,13 +7,12 @@
 
 use std::fmt::Write;
 use std::io::Cursor;
-use std::path::Path;
 
 use base64::Engine;
 use image::ImageFormat;
 use unicode_width::UnicodeWidthStr;
 
-use super::backend::ProofBackend;
+use super::backend::{ProofBackend, RenderContext};
 use super::report::{AssertionResult, ProofCapture, ProofError, ProofReport};
 use crate::assertion::{AssertionFailure, Expected};
 use crate::frame::{CellColor, CellStyle, TerminalFrame};
@@ -32,9 +31,9 @@ impl ProofBackend for HtmlBackend {
     /// # Errors
     ///
     /// Returns a [`ProofError`] if rendering or writing fails.
-    fn render(&self, report: &ProofReport, output: &Path) -> Result<(), ProofError> {
-        let html = build_html(report)?;
-        std::fs::write(output, html)?;
+    fn render(&self, context: &RenderContext<'_>) -> Result<(), ProofError> {
+        let html = build_html(context.report)?;
+        std::fs::write(context.output, html)?;
 
         Ok(())
     }
@@ -806,7 +805,7 @@ mod tests {
         // Act
         let backend = HtmlBackend;
         backend
-            .render(&report, &output_path)
+            .render(&RenderContext::new(&report, &output_path))
             .expect("render should succeed");
 
         // Assert

--- a/crates/testty/src/proof/report.rs
+++ b/crates/testty/src/proof/report.rs
@@ -7,7 +7,7 @@
 use std::fmt::Write;
 use std::path::Path;
 
-use super::backend::ProofBackend;
+use super::backend::{ProofBackend, RenderContext};
 use crate::assertion::AssertionFailure;
 use crate::diff::FrameDiff;
 use crate::frame::TerminalFrame;
@@ -68,7 +68,12 @@ pub struct AssertionResult {
 }
 
 /// Errors that can occur during proof report generation.
+///
+/// Marked `#[non_exhaustive]` so future error variants stay non-breaking for
+/// downstream callers that match on this type; such callers must include a
+/// fallback `_` arm.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ProofError {
     /// An I/O operation failed during proof output.
     #[error("proof I/O error: {0}")]
@@ -210,7 +215,9 @@ impl ProofReport {
     ///
     /// Returns a [`ProofError`] if rendering or I/O fails.
     pub fn save(&self, backend: &dyn ProofBackend, path: &Path) -> Result<(), ProofError> {
-        backend.render(self, path)
+        let context = RenderContext::new(self, path);
+
+        backend.render(&context)
     }
 
     /// Render the report as annotated plain text.

--- a/crates/testty/src/proof/strip.rs
+++ b/crates/testty/src/proof/strip.rs
@@ -4,11 +4,9 @@
 //! renderer and composes them vertically into a single tall PNG image with
 //! step labels between each frame.
 
-use std::path::Path;
-
 use image::{Rgba, RgbaImage};
 
-use super::backend::ProofBackend;
+use super::backend::{ProofBackend, RenderContext};
 use super::report::{ProofCapture, ProofError, ProofReport};
 use crate::frame::TerminalFrame;
 use crate::renderer;
@@ -37,11 +35,13 @@ impl ProofBackend for ScreenshotStripBackend {
     /// # Errors
     ///
     /// Returns a [`ProofError::Io`] if writing the image file fails.
-    fn render(&self, report: &ProofReport, output: &Path) -> Result<(), ProofError> {
+    fn render(&self, context: &RenderContext<'_>) -> Result<(), ProofError> {
+        let report = context.report;
+
         let rendered_frames = render_all_frames(report);
         let strip = compose_strip(&rendered_frames, report);
         strip
-            .save(output)
+            .save(context.output)
             .map_err(|err| ProofError::Format(err.to_string()))?;
 
         Ok(())
@@ -237,7 +237,7 @@ mod tests {
         // Act
         let backend = ScreenshotStripBackend;
         backend
-            .render(&report, &output_path)
+            .render(&RenderContext::new(&report, &output_path))
             .expect("render should succeed");
 
         // Assert — file exists and is a valid PNG.

--- a/crates/testty/tests/public_api.rs
+++ b/crates/testty/tests/public_api.rs
@@ -30,7 +30,7 @@ use testty::feature::{
 use testty::frame::{CellColor, CellStyle, TerminalFrame};
 use testty::journey::{Journey, StartupWait};
 use testty::locator::MatchedSpan;
-use testty::proof::backend::ProofBackend;
+use testty::proof::backend::{ProofBackend, RenderContext};
 use testty::proof::report::{AssertionResult, ProofCapture, ProofError, ProofReport};
 use testty::region::Region;
 use testty::scenario::Scenario;
@@ -40,10 +40,14 @@ use testty::step::{FramePredicate, Step};
 
 /// Minimal `ProofBackend` impl used to exercise the trait through its
 /// owning module path without instantiating a real backend.
+///
+/// The `render` signature pins the stable contract that backends receive a
+/// single `&RenderContext` argument, so a downstream implementor's code keeps
+/// compiling as long as that shape holds.
 struct NoopBackend;
 
 impl ProofBackend for NoopBackend {
-    fn render(&self, _report: &ProofReport, _output: &Path) -> Result<(), ProofError> {
+    fn render(&self, _context: &RenderContext<'_>) -> Result<(), ProofError> {
         Ok(())
     }
 }
@@ -104,6 +108,15 @@ fn public_surface_is_stable() {
     let _: Option<ProofReport> = None;
     let _: Option<ProofError> = None;
     let _: Option<AssertionResult> = None;
+
+    // `RenderContext` is the stable input bundle every `ProofBackend::render`
+    // receives. Pin construction through the builder and field reads so the
+    // documented shape — and its `#[non_exhaustive]` lock-down — cannot
+    // regress to a struct literal in downstream backend implementations.
+    let render_report = ProofReport::new("render-context");
+    let render_context = RenderContext::new(&render_report, Path::new("/tmp/proof"));
+    let _: &ProofReport = render_context.report;
+    let _: &Path = render_context.output;
 
     let _: fn(&NoopBackend) = accept_backend::<NoopBackend>;
 
@@ -253,6 +266,21 @@ fn step_eventually_destructuring_is_stable(step: &Step) -> &'static str {
             "eventually"
         }
         _ => "other",
+    }
+}
+
+/// Lock in the supported pattern for matching `ProofError` variants.
+///
+/// `ProofError` is `#[non_exhaustive]` so future variants stay non-breaking.
+/// Downstream callers that match on it must include a fallback `_` arm. This
+/// function is compiled (not run) so accidental renames of the documented
+/// variants fail the build before publication.
+#[allow(dead_code)]
+fn proof_error_destructuring_is_stable(error: &ProofError) -> &'static str {
+    match error {
+        ProofError::Io(_err) => "io",
+        ProofError::Format(_message) => "format",
+        _ => "unknown",
     }
 }
 


### PR DESCRIPTION
Hardens testty's published proof API surface (Phase 1 of the testty API-hardening plan).

## Changes
- Replace `ProofBackend::render(&ProofReport, &Path)` with a single `&RenderContext` argument so new render inputs can be added later without breaking external backends; route `ProofReport::save` and all built-in backends (frame-text, gif, html, strip) through it.
- Mark `ProofError` `#[non_exhaustive]` so future variants stay non-breaking.
- Seal `CellStyle::from_cell` to `pub(crate)`; it leaked the `vt100::Cell` implementation type into the public API. External callers use `TerminalFrame::cell_style`.
- Pin the new shape in the `public_api.rs` tripwire and document the breaking changes in the testty upgrade guide and `CHANGELOG.md`.

## Validation
- testty lib (276) + `public_api` tripwire (3) pass; agentty/ag-forge/ag-xtask source suites pass; `cargo build --all-targets --all-features` clean; `prek run --all-files` green.
- Breaking changes for testty (pre-1.0); recorded under `CHANGELOG.md` `[Unreleased]` for the next release to version.
