### PR TITLE
Session messages store the durable transcript

### DIFF
--- a/crates/agentty/migrations/050_backfill_session_message.sql
+++ b/crates/agentty/migrations/050_backfill_session_message.sql
@@ -1,0 +1,22 @@
+INSERT INTO session_message (session_id, position, kind, content, created_at)
+SELECT session.id,
+       COALESCE(
+           (
+               SELECT MAX(existing_message.position) + 1
+               FROM session_message AS existing_message
+               WHERE existing_message.session_id = session.id
+           ),
+           0
+       ),
+       'legacy_transcript',
+       session.output,
+       session.created_at
+FROM session
+WHERE LENGTH(session.output) > 0
+  AND NOT EXISTS (
+      SELECT 1
+      FROM session_message AS existing_legacy_message
+      WHERE existing_legacy_message.session_id = session.id
+        AND existing_legacy_message.kind = 'legacy_transcript'
+        AND existing_legacy_message.content = session.output
+  );

--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -2499,8 +2499,20 @@ mod tests {
             .load_session_activity_timestamps()
             .await
             .expect("failed to load session activity timestamps");
+        let messages = app
+            .services
+            .db()
+            .sessions()
+            .load_session_messages(db_sessions[0].id.as_str())
+            .await
+            .expect("failed to load session messages");
         assert_eq!(db_sessions[0].prompt, "Hello");
-        assert_eq!(db_sessions[0].output, " › Hello\n\n");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].kind,
+            crate::domain::session_message::SessionMessageKind::UserPrompt.as_str()
+        );
+        assert_eq!(messages[0].content, "Hello");
         assert_eq!(activity_timestamps.len(), 1);
     }
 
@@ -3228,9 +3240,13 @@ mod tests {
             .await
             .expect("failed to update prompt");
         db.sessions()
-            .append_session_output("12345678", "Output")
+            .append_session_message(
+                "12345678",
+                crate::domain::session_message::SessionMessageKind::LegacyTranscript,
+                "Output",
+            )
             .await
-            .expect("failed to update output");
+            .expect("failed to append message");
 
         // Act
         let app = new_test_app_with_db(

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -11,7 +11,10 @@ use crate::domain::session::{
     DailyActivity, PublishedBranchSyncStatus, ReviewRequest, ReviewRequestSummary, Session,
     SessionFollowUpTask, SessionHandles, SessionId, SessionSize, SessionStats, Status,
 };
-use crate::infra::db::{AppRepositories, SessionDetailRow, SessionListRow};
+use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
+use crate::infra::db::{
+    AppRepositories, DbError, SessionDetailRow, SessionListRow, SessionMessageRow,
+};
 use crate::infra::fs::FsClient;
 use crate::infra::git::GitClient;
 
@@ -172,29 +175,22 @@ impl SessionManager {
         let session_model = AgentModel::parse_persisted(&row.model)
             .unwrap_or_else(|_| AgentKind::Antigravity.default_model());
 
-        let session_detail = if active_session_id.is_some_and(|active_id| active_id == row.id) {
-            db.sessions()
-                .load_session_detail(&row.id)
-                .await
-                .ok()
-                .flatten()
-        } else {
-            None
-        };
+        let (session_detail, session_output) =
+            load_active_session_detail(db, *active_session_id, &row.id).await;
 
         let (session_output, session_status) =
             if let Some(existing_handle) = handles.get(&session_id) {
                 output_and_status_from_existing_handle(
                     existing_handle,
                     persisted_status,
-                    session_detail.as_ref(),
+                    session_output.as_deref(),
                 )
             } else {
                 let output = insert_loaded_session_handle(
                     handles,
                     session_id.clone(),
                     persisted_status,
-                    session_detail.as_ref(),
+                    session_output.as_deref(),
                 );
 
                 (output, persisted_status)
@@ -283,8 +279,11 @@ impl SessionManager {
         else {
             return;
         };
+        let Ok(transcript_output) = load_session_transcript_output(db, session_id).await else {
+            return;
+        };
 
-        self.apply_session_detail(session_id, detail);
+        self.apply_session_detail(session_id, detail, transcript_output);
     }
 
     /// Builds one in-memory session snapshot from a database row plus the
@@ -326,19 +325,25 @@ impl SessionManager {
         }
     }
 
-    /// Applies one lazily loaded detail row to the session snapshot and its
-    /// shared runtime handle without clobbering live in-process output.
-    fn apply_session_detail(&mut self, session_id: &str, detail: SessionDetailRow) {
+    /// Applies one lazily loaded detail row and message transcript to the
+    /// session snapshot and its shared runtime handle without clobbering live
+    /// in-process output.
+    fn apply_session_detail(
+        &mut self,
+        session_id: &str,
+        detail: SessionDetailRow,
+        transcript_output: String,
+    ) {
         let session_output = if let Some(handles) = self.state.handles.get(session_id)
             && let Ok(mut handle_output) = handles.output.lock()
         {
             if handle_output.is_empty() {
-                handle_output.clone_from(&detail.output);
+                handle_output.clone_from(&transcript_output);
             }
 
             handle_output.clone()
         } else {
-            detail.output.clone()
+            transcript_output
         };
 
         let Some(session) = self.state.session_mut_for_id(session_id) else {
@@ -354,12 +359,37 @@ impl SessionManager {
     }
 }
 
+/// Loads active-session detail metadata and transcript text for the selected
+/// row only.
+async fn load_active_session_detail(
+    db: &AppRepositories,
+    active_session_id: Option<&str>,
+    row_id: &str,
+) -> (Option<SessionDetailRow>, Option<String>) {
+    if active_session_id.is_none_or(|active_id| active_id != row_id) {
+        return (None, None);
+    }
+
+    let Some(detail) = db
+        .sessions()
+        .load_session_detail(row_id)
+        .await
+        .ok()
+        .flatten()
+    else {
+        return (None, None);
+    };
+    let output = load_session_transcript_output(db, row_id).await.ok();
+
+    (Some(detail), output)
+}
+
 /// Reads output/status from an existing handle while hydrating empty output
 /// from lazily loaded detail when the session has become active.
 fn output_and_status_from_existing_handle(
     existing_handle: &SessionHandles,
     persisted_status: Status,
-    session_detail: Option<&SessionDetailRow>,
+    session_output: Option<&str>,
 ) -> (String, Status) {
     let output_from_handle =
         existing_handle
@@ -368,9 +398,9 @@ fn output_and_status_from_existing_handle(
             .ok()
             .map_or_else(String::new, |mut output| {
                 if output.is_empty()
-                    && let Some(detail) = session_detail
+                    && let Some(session_output) = session_output
                 {
-                    output.push_str(&detail.output);
+                    output.push_str(session_output);
                 }
 
                 output.clone()
@@ -395,17 +425,41 @@ fn insert_loaded_session_handle(
     handles: &mut HashMap<SessionId, SessionHandles>,
     session_id: SessionId,
     persisted_status: Status,
-    session_detail: Option<&SessionDetailRow>,
+    session_output: Option<&str>,
 ) -> String {
-    let output = session_detail
-        .map(|detail| detail.output.clone())
-        .unwrap_or_default();
+    let output = session_output.map(str::to_string).unwrap_or_default();
     handles.insert(
         session_id,
         SessionHandles::new(output.clone(), persisted_status),
     );
 
     output
+}
+
+/// Loads ordered session messages and serializes them into the render
+/// transcript snapshot.
+async fn load_session_transcript_output(
+    db: &AppRepositories,
+    session_id: &str,
+) -> Result<String, DbError> {
+    let messages = db.sessions().load_session_messages(session_id).await?;
+
+    Ok(SessionTranscript::new(session_messages_from_rows(messages)).to_legacy_output())
+}
+
+/// Converts database message rows into domain messages, preserving unknown
+/// kind content as exact legacy transcript text.
+fn session_messages_from_rows(rows: Vec<SessionMessageRow>) -> Vec<SessionMessage> {
+    rows.into_iter()
+        .map(|row| {
+            let kind = row
+                .kind
+                .parse::<SessionMessageKind>()
+                .unwrap_or(SessionMessageKind::LegacyTranscript);
+
+            SessionMessage::new(row.position, kind, row.content)
+        })
+        .collect()
 }
 
 /// Returns whether one persisted session row should be skipped because its
@@ -560,9 +614,13 @@ mod tests {
             .await
             .expect("failed to insert session");
         db.sessions()
-            .append_session_output(session_id, "DB Output")
+            .append_session_message(
+                session_id,
+                SessionMessageKind::LegacyTranscript,
+                "DB Output",
+            )
             .await
-            .expect("failed to append persisted output");
+            .expect("failed to append persisted message");
 
         let base_path = Path::new("/virtual/session-base");
         let session_dir = session_folder(base_path, session_id);
@@ -709,9 +767,13 @@ mod tests {
             .await
             .expect("failed to update session summary");
         db.sessions()
-            .append_session_output(session_id, "persisted output")
+            .append_session_message(
+                session_id,
+                SessionMessageKind::LegacyTranscript,
+                "persisted output",
+            )
             .await
-            .expect("failed to append session output");
+            .expect("failed to append session message");
 
         let base_path = Path::new("/virtual/session-base");
         let session_dir = session_folder(base_path, session_id);
@@ -787,9 +849,13 @@ mod tests {
             .await
             .expect("failed to update summary");
         db.sessions()
-            .append_session_output(session_id, "large output")
+            .append_session_message(
+                session_id,
+                SessionMessageKind::LegacyTranscript,
+                "large output",
+            )
             .await
-            .expect("failed to append output");
+            .expect("failed to append message");
 
         let base_path = Path::new("/virtual/session-base");
         let session_dir = session_folder(base_path, session_id);
@@ -847,9 +913,13 @@ mod tests {
             .await
             .expect("failed to insert session");
         db.sessions()
-            .append_session_output(session_id, "persisted output")
+            .append_session_message(
+                session_id,
+                SessionMessageKind::LegacyTranscript,
+                "persisted output",
+            )
             .await
-            .expect("failed to append output");
+            .expect("failed to append message");
 
         let base_path = Path::new("/virtual/session-base");
         let session_dir = session_folder(base_path, session_id);
@@ -882,6 +952,26 @@ mod tests {
         let handle = handles.get(session_id).expect("missing runtime handle");
         let handle_output = handle.output.lock().expect("failed to lock output");
         assert_eq!(handle_output.as_str(), "persisted output");
+    }
+
+    /// Ensures transcript loading returns database failures instead of
+    /// converting them into empty transcript text.
+    #[tokio::test]
+    async fn test_load_session_transcript_output_returns_query_errors() {
+        // Arrange
+        let (db, pool) = AppRepositories::in_memory_with_pool().await;
+        sqlx::query("DROP TABLE session_message")
+            .execute(&pool)
+            .await
+            .expect("failed to drop session_message table");
+
+        // Act
+        let error = load_session_transcript_output(&db, "missing-session")
+            .await
+            .expect_err("transcript load should fail");
+
+        // Assert
+        assert!(matches!(error, DbError::Query(_)));
     }
 
     /// Ensures terminal persisted statuses replace stale active handle status

--- a/crates/agentty/src/app/session/workflow/post_turn.rs
+++ b/crates/agentty/src/app/session/workflow/post_turn.rs
@@ -209,8 +209,8 @@ impl TurnPersistence<'_> {
 /// The raw agent `summary` payload is stored only in the session row. The
 /// reducer receives a matching [`TurnAppliedState`] projection so the active UI
 /// can render the same summary and follow-up metadata without embedding a
-/// second markdown copy into `session.output`. If canonical metadata
-/// persistence fails, the worker appends a recovery error, triggers
+/// second markdown copy into the transcript message store. If canonical
+/// metadata persistence fails, the worker appends a recovery error, triggers
 /// `RefreshSessions`, and skips reducer projection emission.
 pub(super) async fn apply_turn_result(
     context: &PostTurnContext,

--- a/crates/agentty/src/app/session/workflow/task.rs
+++ b/crates/agentty/src/app/session/workflow/task.rs
@@ -92,7 +92,7 @@ pub(crate) struct RunAgentAssistTaskInput {
 /// conversation content in the message table.
 pub(crate) struct SessionOutputMessageAppend<'a> {
     /// Formatted transcript chunk appended to the live output buffer and
-    /// legacy `session.output` column.
+    /// in-memory render snapshot.
     pub(crate) formatted_message: &'a str,
     /// Raw conversation message kind persisted in `session_message`.
     pub(crate) kind: SessionMessageKind,
@@ -1004,7 +1004,8 @@ impl SessionTaskService {
         true
     }
 
-    /// Appends output to the in-memory handle buffer and database.
+    /// Appends formatted workflow output to the in-memory handle buffer and
+    /// durable message store.
     pub(crate) async fn append_session_output(
         output: &Arc<Mutex<String>>,
         db: &AppRepositories,
@@ -1023,7 +1024,11 @@ impl SessionTaskService {
                 );
             }
         }
-        if let Err(error) = db.sessions().append_session_output(id, message).await {
+        if let Err(error) = db
+            .sessions()
+            .append_session_message(id, SessionMessageKind::WorkflowNotice, message)
+            .await
+        {
             warn!(
                 session_id = id,
                 error = %error,
@@ -1034,7 +1039,7 @@ impl SessionTaskService {
     }
 
     /// Appends formatted output with a durable raw user/assistant message to
-    /// the in-memory handle buffer and database.
+    /// the in-memory handle buffer and message store.
     pub(crate) async fn append_session_output_message(
         output: &Arc<Mutex<String>>,
         db: &AppRepositories,
@@ -1055,12 +1060,7 @@ impl SessionTaskService {
         }
         if let Err(error) = db
             .sessions()
-            .append_session_output_message(
-                id,
-                message.kind,
-                message.formatted_message,
-                message.raw_content,
-            )
+            .append_session_message(id, message.kind, message.raw_content)
             .await
         {
             warn!(

--- a/crates/agentty/src/domain/session_message.rs
+++ b/crates/agentty/src/domain/session_message.rs
@@ -114,8 +114,20 @@ pub struct SessionTranscript {
 
 impl SessionTranscript {
     /// Creates an ordered transcript from persisted messages.
+    ///
+    /// A `LegacyTranscript` row is a lossless checkpoint copied from the
+    /// historical `session.output` column. When it appears after earlier
+    /// canonical rows, those earlier rows are still preserved in the database
+    /// but are already represented by the checkpoint text, so rendering starts
+    /// from the latest checkpoint and continues with later rows.
     pub fn new(mut messages: Vec<SessionMessage>) -> Self {
         messages.sort_by_key(|message| message.position);
+        if let Some(legacy_checkpoint_index) = messages
+            .iter()
+            .rposition(|message| message.kind == SessionMessageKind::LegacyTranscript)
+        {
+            messages = messages.split_off(legacy_checkpoint_index);
+        }
 
         Self { messages }
     }
@@ -130,8 +142,8 @@ impl SessionTranscript {
         &self.messages
     }
 
-    /// Serializes the message store into the legacy `session.output`
-    /// transcript.
+    /// Serializes the message store into formatted session-chat transcript
+    /// text.
     ///
     /// User and assistant rows store raw content, so this method injects the
     /// legacy prompt marker and transcript spacing only at the compatibility
@@ -145,6 +157,19 @@ impl SessionTranscript {
 
         output
     }
+}
+
+/// Returns the durable message content for one kind.
+///
+/// Conversation rows store raw user/assistant text with outer whitespace
+/// removed. Compatibility rows preserve their exact formatted content so a
+/// migrated legacy transcript can round-trip without spacing changes.
+pub fn stored_message_content(kind: SessionMessageKind, content: &str) -> String {
+    if kind.is_conversation_message() {
+        return normalized_message_content(content);
+    }
+
+    content.to_string()
 }
 
 impl SessionMessage {
@@ -254,11 +279,55 @@ mod tests {
     }
 
     #[test]
+    fn test_session_transcript_uses_latest_legacy_checkpoint() {
+        // Arrange
+        let messages = vec![
+            SessionMessage::conversation(0, SessionMessageKind::UserPrompt, "old prompt"),
+            SessionMessage::new(
+                1,
+                SessionMessageKind::LegacyTranscript,
+                " › old prompt\n\nold answer\n\n[Sync Error] failed\n",
+            ),
+            SessionMessage::conversation(2, SessionMessageKind::AssistantAnswer, "new answer"),
+        ];
+
+        // Act
+        let transcript = SessionTranscript::new(messages);
+
+        // Assert
+        assert_eq!(
+            transcript.to_legacy_output(),
+            " › old prompt\n\nold answer\n\n[Sync Error] failed\nnew answer\n\n"
+        );
+    }
+
+    #[test]
     fn test_normalized_message_content_removes_outer_whitespace_only() {
         // Arrange, Act, Assert
         assert_eq!(
             normalized_message_content("\n  keep\ninner spacing  \n"),
             "keep\ninner spacing"
+        );
+    }
+
+    #[test]
+    fn test_stored_message_content_preserves_compatibility_spacing() {
+        // Arrange
+        let workflow_notice = "\n[Sync Error] failed\n";
+
+        // Act
+        let stored = stored_message_content(SessionMessageKind::WorkflowNotice, workflow_notice);
+
+        // Assert
+        assert_eq!(stored, workflow_notice);
+    }
+
+    #[test]
+    fn test_stored_message_content_normalizes_conversation_spacing() {
+        // Arrange, Act, Assert
+        assert_eq!(
+            stored_message_content(SessionMessageKind::UserPrompt, "\n  hello  \n"),
+            "hello"
         );
     }
 }

--- a/crates/agentty/src/infra/db/connection.rs
+++ b/crates/agentty/src/infra/db/connection.rs
@@ -337,7 +337,6 @@ WHERE id = ?
         assert_eq!(session_row.in_progress_total_seconds, 120);
         assert_eq!(session_row.project_id, Some(project_id));
         assert_eq!(session_row.prompt, "Implement the feature");
-        assert_eq!(session_row.output, "First line\nSecond line");
         assert_eq!(session_row.added_lines, 14);
         assert_eq!(session_row.deleted_lines, 6);
         assert_eq!(session_row.input_tokens, 11);
@@ -357,10 +356,10 @@ WHERE id = ?
         assert_review_request_row(&session_row);
     }
 
-    /// Verifies output appends preserve the legacy transcript while writing
-    /// ordered message rows for the new transcript store.
+    /// Verifies message appends write ordered rows for the canonical
+    /// transcript store without updating the legacy backup column.
     #[tokio::test]
-    async fn test_append_session_output_message_dual_writes_message_rows() {
+    async fn test_append_session_message_writes_message_rows() {
         // Arrange
         let database = Database::open_in_memory()
             .await
@@ -375,27 +374,29 @@ WHERE id = ?
         // Act
         database
             .sessions()
-            .append_session_output_message(
-                "session-a",
-                SessionMessageKind::UserPrompt,
-                " › hi\n\n",
-                " hi ",
-            )
+            .append_session_message("session-a", SessionMessageKind::UserPrompt, " hi ")
             .await
             .expect("failed to append prompt message");
         database
             .sessions()
-            .append_session_output_message(
+            .append_session_message(
                 "session-a",
                 SessionMessageKind::AssistantAnswer,
-                "Hello\n\n",
                 "\nHello\n",
             )
             .await
             .expect("failed to append assistant message");
+        database
+            .sessions()
+            .append_session_message(
+                "session-a",
+                SessionMessageKind::WorkflowNotice,
+                "\n[Sync Error] failed\n",
+            )
+            .await
+            .expect("failed to append workflow notice");
 
         // Assert
-        let session_row = load_session_row(&database, "session-a").await;
         let messages = database
             .sessions()
             .load_session_messages("session-a")
@@ -407,9 +408,8 @@ WHERE id = ?
             .await
             .expect("failed to load session detail")
             .expect("session detail should exist");
-        assert_eq!(session_row.output, " › hi\n\nHello\n\n");
-        assert_eq!(detail.output, " › hi\n\nHello\n\n");
-        assert_eq!(messages.len(), 2);
+        assert!(detail.prompt.is_empty());
+        assert_eq!(messages.len(), 3);
         assert_eq!(messages[0].position, 0);
         assert_eq!(messages[0].kind, SessionMessageKind::UserPrompt.as_str());
         assert_eq!(messages[0].content, "hi");
@@ -419,12 +419,18 @@ WHERE id = ?
             SessionMessageKind::AssistantAnswer.as_str()
         );
         assert_eq!(messages[1].content, "Hello");
+        assert_eq!(messages[2].position, 2);
+        assert_eq!(
+            messages[2].kind,
+            SessionMessageKind::WorkflowNotice.as_str()
+        );
+        assert_eq!(messages[2].content, "\n[Sync Error] failed\n");
     }
 
-    /// Verifies session detail keeps using formatted `session.output` even when
-    /// raw message rows exist for the conversation store.
+    /// Verifies canonical transcript appends refresh session list ordering
+    /// metadata.
     #[tokio::test]
-    async fn test_load_session_detail_keeps_formatted_transcript_with_raw_messages() {
+    async fn test_append_session_message_refreshes_session_updated_at() {
         // Arrange
         let database = Database::open_in_memory()
             .await
@@ -437,24 +443,159 @@ WHERE id = ?
         insert_session_fixture(&database, "session-a", "main", "Review", project_id).await;
         database
             .sessions()
-            .append_session_output_message(
-                "session-a",
-                SessionMessageKind::UserPrompt,
-                " › migrated prompt\n\n",
-                "migrated prompt",
-            )
+            .update_session_updated_at("session-a", 10)
             .await
-            .expect("failed to append prompt message");
+            .expect("failed to backdate session updated_at");
+
+        // Act
         database
             .sessions()
-            .append_session_output_message(
+            .append_session_message(
                 "session-a",
                 SessionMessageKind::AssistantAnswer,
-                "migrated answer\n\n",
-                "migrated answer",
+                "current answer",
             )
             .await
             .expect("failed to append assistant message");
+
+        // Assert
+        let (_, updated_at) = database
+            .sessions()
+            .load_session_timestamps("session-a")
+            .await
+            .expect("failed to load session timestamps")
+            .expect("session timestamps should exist");
+        assert!(
+            updated_at > 10,
+            "expected updated_at refresh, got {updated_at}"
+        );
+    }
+
+    /// Verifies the legacy-output backfill appends to existing canonical
+    /// transcript rows instead of replacing them.
+    #[tokio::test]
+    async fn test_session_message_backfill_preserves_existing_messages() {
+        // Arrange
+        let options = SqliteConnectOptions::new().filename(":memory:");
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .expect("failed to open in-memory pool");
+        sqlx::query(
+            r"
+CREATE TABLE session (
+    id TEXT PRIMARY KEY NOT NULL,
+    output TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+)
+",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to create session table");
+        sqlx::query(
+            r"
+CREATE TABLE session_message (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    content TEXT NOT NULL,
+    created_at INTEGER NOT NULL DEFAULT 0
+)
+",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to create session_message table");
+        sqlx::query(
+            r"
+INSERT INTO session (id, output, created_at)
+VALUES ('session-a', 'legacy transcript with workflow notice', 100)
+",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to insert session row");
+        sqlx::query(
+            r"
+INSERT INTO session_message (session_id, position, kind, content, created_at)
+VALUES
+    ('session-a', 0, 'user_prompt', 'Prompt text', 101),
+    ('session-a', 1, 'assistant_answer', 'Answer text', 102)
+",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to insert existing messages");
+
+        // Act
+        sqlx::query(include_str!(
+            "../../../migrations/050_backfill_session_message.sql"
+        ))
+        .execute(&pool)
+        .await
+        .expect("failed to run session_message backfill");
+
+        // Assert
+        let messages: Vec<(i64, String, String)> = sqlx::query_as(
+            r"
+SELECT position, kind, content
+FROM session_message
+WHERE session_id = 'session-a'
+ORDER BY position
+",
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("failed to load backfilled messages");
+        assert_eq!(
+            messages,
+            vec![
+                (
+                    0,
+                    SessionMessageKind::UserPrompt.as_str().to_string(),
+                    "Prompt text".to_string()
+                ),
+                (
+                    1,
+                    SessionMessageKind::AssistantAnswer.as_str().to_string(),
+                    "Answer text".to_string()
+                ),
+                (
+                    2,
+                    SessionMessageKind::LegacyTranscript.as_str().to_string(),
+                    "legacy transcript with workflow notice".to_string()
+                ),
+            ]
+        );
+    }
+
+    /// Verifies session detail loads transcript metadata without reading
+    /// legacy formatted output.
+    #[tokio::test]
+    async fn test_load_session_detail_omits_legacy_output() {
+        // Arrange
+        let database = Database::open_in_memory()
+            .await
+            .expect("failed to open in-memory db");
+        let project_id = database
+            .projects()
+            .upsert_project("/tmp/project", Some("main".to_string()))
+            .await
+            .expect("failed to insert project");
+        insert_session_fixture(&database, "session-a", "main", "Review", project_id).await;
+        database
+            .sessions()
+            .update_session_prompt("session-a", "Do something")
+            .await
+            .expect("failed to update prompt");
+        database
+            .sessions()
+            .update_session_summary("session-a", "migrated summary")
+            .await
+            .expect("failed to update summary");
 
         // Act
         let detail = database
@@ -465,7 +606,8 @@ WHERE id = ?
             .expect("session detail should exist");
 
         // Assert
-        assert_eq!(detail.output, " › migrated prompt\n\nmigrated answer\n\n");
+        assert_eq!(detail.prompt, "Do something");
+        assert_eq!(detail.summary.as_deref(), Some("migrated summary"));
     }
 
     /// Builds an in-memory database with one session covering joined fields
@@ -483,7 +625,7 @@ WHERE id = ?
 
         insert_session_fixture(&database, "session-a", "main", "Review", project_id).await;
         persist_joined_session_metadata(&database, &review_request).await;
-        persist_joined_session_output(&database).await;
+        persist_joined_session_state(&database).await;
 
         (database, project_id)
     }
@@ -558,9 +700,8 @@ WHERE id = ?
             .expect("failed to update review request");
     }
 
-    /// Persists timing and output fields asserted by the joined-session
-    /// mapping test.
-    async fn persist_joined_session_output(database: &Database) {
+    /// Persists timing fields asserted by the joined-session mapping test.
+    async fn persist_joined_session_state(database: &Database) {
         database
             .sessions()
             .update_session_status_with_timing_at("session-a", "InProgress", 50)
@@ -571,16 +712,6 @@ WHERE id = ?
             .update_session_status_with_timing_at("session-a", "Review", 170)
             .await
             .expect("failed to close in-progress timing window");
-        database
-            .sessions()
-            .replace_session_output("session-a", "First line")
-            .await
-            .expect("failed to replace session output");
-        database
-            .sessions()
-            .append_session_output("session-a", "\nSecond line")
-            .await
-            .expect("failed to append session output");
         database
             .sessions()
             .update_session_updated_at("session-a", 200)

--- a/crates/agentty/src/infra/db/session.rs
+++ b/crates/agentty/src/infra/db/session.rs
@@ -6,7 +6,7 @@ use sqlx::SqlitePool;
 use super::review::SessionReviewRequestRow;
 use crate::domain::agent::ReasoningLevel;
 use crate::domain::session::{SessionFollowUpTask, SessionId, SessionStats};
-use crate::domain::session_message::{SessionMessageKind, normalized_message_content};
+use crate::domain::session_message::{SessionMessageKind, stored_message_content};
 use crate::infra::agent;
 use crate::infra::db::DbError;
 
@@ -50,7 +50,6 @@ pub struct SessionRow {
     pub input_tokens: i64,
     pub is_draft: bool,
     pub model: String,
-    pub output: String,
     pub output_tokens: i64,
     pub parent_session_id: Option<String>,
     pub project_id: Option<i64>,
@@ -117,9 +116,6 @@ pub struct SessionListRow {
 /// Transcript-detail row loaded lazily for the session being viewed.
 #[derive(sqlx::FromRow)]
 pub struct SessionDetailRow {
-    /// Captured provider transcript text from the legacy `session.output`
-    /// compatibility column.
-    pub output: String,
     /// Initial or staged prompt text.
     pub prompt: String,
     /// Serialized clarification-question payload, when present.
@@ -180,17 +176,13 @@ impl SessionFollowUpTaskRow {
 /// Session-focused persistence boundary used by app orchestration and tests.
 #[async_trait]
 pub trait SessionRepository: Send + Sync {
-    /// Appends text to the saved output for a session row.
-    async fn append_session_output(&self, id: &str, chunk: &str) -> Result<(), DbError>;
-
-    /// Appends formatted text to the saved output and writes the matching raw
-    /// typed conversation message in one transaction.
-    async fn append_session_output_message(
+    /// Appends one typed transcript message and refreshes session ordering
+    /// metadata.
+    async fn append_session_message(
         &self,
         id: &str,
         kind: SessionMessageKind,
-        formatted_chunk: &str,
-        raw_content: &str,
+        content: &str,
     ) -> Result<(), DbError>;
 
     /// Sets `project_id` for sessions that do not yet reference a project.
@@ -331,9 +323,13 @@ pub trait SessionRepository: Send + Sync {
     ) -> Result<(), DbError>;
 
     #[cfg(test)]
-    /// Replaces the full output for a session row and clears raw conversation
-    /// messages so test fixtures do not leave stale sidecar rows.
-    async fn replace_session_output(&self, id: &str, output: &str) -> Result<(), DbError>;
+    /// Replaces the full message list for a session with one legacy
+    /// transcript row.
+    async fn replace_session_messages_with_legacy_transcript(
+        &self,
+        id: &str,
+        output: &str,
+    ) -> Result<(), DbError>;
 
     /// Replaces the persisted follow-up task list for one session inside one
     /// transaction so task deletion and reinsertion commit atomically.
@@ -507,6 +503,7 @@ struct SessionTimestampsRow {
 /// Row returned when loading one `session` plus aliased
 /// `session_review_request` join columns.
 #[cfg(test)]
+#[derive(sqlx::FromRow)]
 pub(crate) struct SessionJoinRow {
     added_lines: i64,
     base_branch: String,
@@ -518,7 +515,6 @@ pub(crate) struct SessionJoinRow {
     input_tokens: i64,
     is_draft: bool,
     model: String,
-    output: String,
     output_tokens: i64,
     parent_session_id: Option<String>,
     project_id: Option<i64>,
@@ -557,7 +553,6 @@ impl SessionJoinRow {
             input_tokens,
             is_draft,
             model,
-            output,
             output_tokens,
             parent_session_id,
             project_id,
@@ -605,7 +600,6 @@ impl SessionJoinRow {
             input_tokens,
             is_draft,
             model,
-            output,
             output_tokens,
             parent_session_id,
             project_id,
@@ -636,7 +630,6 @@ impl SessionJoinRow {
             input_tokens: 11,
             is_draft: false,
             model: "gpt-5.5".to_string(),
-            output: "Saved output".to_string(),
             output_tokens: 29,
             parent_session_id: Some("parent-session".to_string()),
             project_id: Some(7),
@@ -817,63 +810,50 @@ impl SessionReviewRequestJoinRow {
 
 #[async_trait]
 impl SessionRepository for SqliteSessionRepository {
-    async fn append_session_output(&self, id: &str, chunk: &str) -> Result<(), DbError> {
-        sqlx::query(
-            r"
-UPDATE session
-SET output = output || ?
-WHERE id = ?
-",
-        )
-        .bind(chunk)
-        .bind(id)
-        .execute(&self.0)
-        .await?;
-
-        Ok(())
-    }
-
-    async fn append_session_output_message(
+    async fn append_session_message(
         &self,
         id: &str,
         kind: SessionMessageKind,
-        formatted_chunk: &str,
-        raw_content: &str,
+        content: &str,
     ) -> Result<(), DbError> {
+        let content = stored_message_content(kind, content);
+        if content.trim().is_empty() {
+            return Ok(());
+        }
+
         let mut transaction = self.0.begin().await?;
 
         let update_result = sqlx::query(
             r"
 UPDATE session
-SET output = output || ?
+SET updated_at = CAST(strftime('%s', 'now') AS INTEGER)
 WHERE id = ?
 ",
         )
-        .bind(formatted_chunk)
         .bind(id)
         .execute(&mut *transaction)
         .await?;
 
-        let content = normalized_message_content(raw_content);
-        if update_result.rows_affected() != 0
-            && kind.is_conversation_message()
-            && !content.is_empty()
-        {
-            sqlx::query(
-                r"
+        if update_result.rows_affected() == 0 {
+            transaction.commit().await?;
+
+            return Ok(());
+        }
+
+        sqlx::query(
+            r"
 INSERT INTO session_message (session_id, position, kind, content, created_at)
 SELECT ?, COALESCE(MAX(position), -1) + 1, ?, ?, CAST(strftime('%s', 'now') AS INTEGER)
 FROM session_message
 WHERE session_id = ?
 ",
-            )
-            .bind(id)
-            .bind(kind.as_str())
-            .bind(content)
-            .bind(id)
-            .execute(&mut *transaction)
-            .await?;
-        }
+        )
+        .bind(id)
+        .bind(kind.as_str())
+        .bind(content)
+        .bind(id)
+        .execute(&mut *transaction)
+        .await?;
 
         transaction.commit().await?;
 
@@ -1030,46 +1010,44 @@ WHERE id = ?
 
     #[cfg(test)]
     async fn load_sessions(&self) -> Result<Vec<SessionRow>, DbError> {
-        let rows = sqlx::query_as!(
-            SessionJoinRow,
-            r#"
-SELECT session.base_branch AS "base_branch!",
-       session.added_lines AS "added_lines!",
-       session.created_at AS "created_at!",
-       session.deleted_lines AS "deleted_lines!",
-       session.id AS "id!",
+        let rows = sqlx::query_as::<_, SessionJoinRow>(
+            r"
+SELECT session.base_branch AS base_branch,
+       session.added_lines AS added_lines,
+       session.created_at AS created_at,
+       session.deleted_lines AS deleted_lines,
+       session.id AS id,
        session.in_progress_started_at,
-       session.in_progress_total_seconds AS "in_progress_total_seconds!",
-       session.input_tokens AS "input_tokens!",
-       session.is_draft AS "is_draft!: bool",
-       session.model AS "model!",
-       session.output AS "output!",
-       session.output_tokens AS "output_tokens!",
+       session.in_progress_total_seconds AS in_progress_total_seconds,
+       session.input_tokens AS input_tokens,
+       session.is_draft AS is_draft,
+       session.model AS model,
+       session.output_tokens AS output_tokens,
        session.parent_session_id,
        session.project_id,
-       session.prompt AS "prompt!",
-       session.reasoning_level AS "reasoning_level_override?",
+       session.prompt AS prompt,
+       session.reasoning_level AS reasoning_level_override,
        session.published_upstream_ref,
        session.questions,
-       session_review_request.display_id AS "review_request_display_id?",
-       session_review_request.forge_kind AS "review_request_forge_kind?",
-       session_review_request.last_refreshed_at AS "review_request_last_refreshed_at?",
-       session_review_request.source_branch AS "review_request_source_branch?",
-       session_review_request.state AS "review_request_state?",
-       session_review_request.status_summary AS "review_request_status_summary?",
-       session_review_request.target_branch AS "review_request_target_branch?",
-       session_review_request.title AS "review_request_title?",
-       session_review_request.web_url AS "review_request_web_url?",
-       session.size AS "size!",
-       session.status AS "status!",
+       session_review_request.display_id AS review_request_display_id,
+       session_review_request.forge_kind AS review_request_forge_kind,
+       session_review_request.last_refreshed_at AS review_request_last_refreshed_at,
+       session_review_request.source_branch AS review_request_source_branch,
+       session_review_request.state AS review_request_state,
+       session_review_request.status_summary AS review_request_status_summary,
+       session_review_request.target_branch AS review_request_target_branch,
+       session_review_request.title AS review_request_title,
+       session_review_request.web_url AS review_request_web_url,
+       session.size AS size,
+       session.status AS status,
        session.summary,
        session.title,
-       session.updated_at AS "updated_at!"
+       session.updated_at AS updated_at
 FROM session
 LEFT JOIN session_review_request
 ON session_review_request.session_id = session.id
 ORDER BY session.updated_at DESC, session.id
-"#
+",
         )
         .fetch_all(&self.0)
         .await?;
@@ -1136,18 +1114,16 @@ ORDER BY session.updated_at DESC, session.id
         &self,
         session_id: &str,
     ) -> Result<Option<SessionDetailRow>, DbError> {
-        let row = sqlx::query_as!(
-            SessionDetailRow,
-            r#"
-SELECT output AS "output!",
-       prompt AS "prompt!",
+        let row = sqlx::query_as::<_, SessionDetailRow>(
+            r"
+SELECT prompt,
        questions,
        summary
 FROM session
 WHERE id = ?
-"#,
-            session_id
+",
         )
+        .bind(session_id)
         .fetch_optional(&self.0)
         .await?;
 
@@ -1433,20 +1409,12 @@ ON CONFLICT(session_id, model) DO UPDATE SET
     }
 
     #[cfg(test)]
-    async fn replace_session_output(&self, id: &str, output: &str) -> Result<(), DbError> {
+    async fn replace_session_messages_with_legacy_transcript(
+        &self,
+        id: &str,
+        output: &str,
+    ) -> Result<(), DbError> {
         let mut transaction = self.0.begin().await?;
-
-        sqlx::query(
-            r"
-UPDATE session
-SET output = ?
-WHERE id = ?
-",
-        )
-        .bind(output)
-        .bind(id)
-        .execute(&mut *transaction)
-        .await?;
 
         sqlx::query(
             r"
@@ -1457,6 +1425,20 @@ WHERE session_id = ?
         .bind(id)
         .execute(&mut *transaction)
         .await?;
+
+        if !output.trim().is_empty() {
+            sqlx::query(
+                r"
+INSERT INTO session_message (session_id, position, kind, content, created_at)
+VALUES (?, 0, ?, ?, CAST(strftime('%s', 'now') AS INTEGER))
+",
+            )
+            .bind(id)
+            .bind(SessionMessageKind::LegacyTranscript.as_str())
+            .bind(output)
+            .execute(&mut *transaction)
+            .await?;
+        }
 
         transaction.commit().await?;
 

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -15,6 +15,7 @@ use agentty::domain::agent::ReasoningLevel;
 use agentty::domain::session::{
     ForgeKind, ReviewRequest, ReviewRequestState, ReviewRequestSummary,
 };
+use agentty::domain::session_message::SessionMessageKind;
 use agentty::test_support;
 use testty::assertion;
 use testty::region::Region;
@@ -70,8 +71,9 @@ fn seed_session_with_beautified_agent_error(
             .await?;
         database
             .sessions()
-            .append_session_output(
+            .append_session_message(
                 "agent-error-0001",
+                SessionMessageKind::LegacyTranscript,
                 "\
  › hi
 

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -134,9 +134,9 @@ a machine-readable workspace summary to `target/agentty/workspace-map.json`.
 - `crates/agentty/src/domain/session.rs`: Session entities, statuses, sizes, stats,
   review-request linkage wrappers, and re-exports of shared forge review-request types
   from `ag-forge`.
-- `crates/agentty/src/domain/session_message.rs`: Typed raw conversation messages,
-  message-kind identifiers, and compatibility serialization back into legacy transcript
-  text.
+- `crates/agentty/src/domain/session_message.rs`: Typed transcript messages,
+  message-kind identifiers, exact legacy transcript preservation, and compatibility
+  serialization into session-chat render text.
 - `crates/agentty/src/domain/session_order.rs`: Pure grouped session-list ordering,
   selectable row navigation, and stack-child placement shared by app workflows and UI
   rendering.
@@ -164,9 +164,9 @@ a machine-readable workspace summary to `target/agentty/workspace-map.json`.
 - `crates/agentty/src/infra/db/error.rs`: `DbError` variants shared by database
   connection and repository adapters.
 - `crates/agentty/src/infra/db/session.rs`: `SessionRepository`,
-  `SqliteSessionRepository`, session row models, turn-metadata persistence,
-  session-message persistence, focused-review cache persistence, and session query
-  helpers.
+  `SqliteSessionRepository`, session row models, turn-metadata persistence, canonical
+  `session_message` transcript persistence, focused-review cache persistence, and
+  session query helpers.
 - `crates/agentty/src/infra/db/project.rs`: `ProjectRepository`,
   `SqliteProjectRepository`, project row models, and project list queries.
 - `crates/agentty/src/infra/db/review.rs`: `ReviewRepository`, `SqliteReviewRepository`,

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -178,19 +178,21 @@ exact lines printed inside the bordered output panel.
 
 The printed session-chat data comes from these sources:
 
-- Formatted session transcript text is loaded from the legacy `session.output` column in
-  `crates/agentty/src/app/session/workflow/load.rs`, then kept hot from the per-session
-  handle via `crates/agentty/src/app/session_state.rs`. Runtime workers append formatted
-  transcript text through `SessionTaskService::append_session_output()` or
-  `SessionTaskService::append_session_output_message()` in
-  `crates/agentty/src/app/session/workflow/task.rs`, which updates the in-memory handle
-  buffer and `session.output`. When the append is a user prompt or assistant answer, the
-  same call also stores normalized raw content in the ordered `session_message` store
-  without TUI prompt markers or transcript padding.
+- Durable transcript text is loaded from ordered `session_message` rows in
+  `crates/agentty/src/app/session/workflow/load.rs`, converted through
+  `SessionTranscript::to_legacy_output()`, then kept hot in the render snapshot
+  `Session.output` field and per-session handle via
+  `crates/agentty/src/app/session_state.rs`. Runtime workers append user and assistant
+  content through `SessionTaskService::append_session_output_message()` and append
+  workflow notices through `SessionTaskService::append_session_output()` in
+  `crates/agentty/src/app/session/workflow/task.rs`; both paths insert typed
+  `session_message` rows, refresh `session.updated_at`, and update only the in-memory
+  handle buffer. The legacy `session.output` database column is retained as a migration
+  backup and is not a runtime read/write source.
 - `active_prompt_output` Cached by `SessionManager::set_active_prompt_output()` in
   `crates/agentty/src/app/session/core.rs` when a start or reply prompt is submitted.
-  This stores the exact prompt-shaped transcript block that was just appended to
-  `session.output` so `SessionOutput` can split completed-turn content from the
+  This stores the exact prompt-shaped render block for the typed `UserPrompt` row that
+  was just inserted, so `SessionOutput` can split completed-turn content from the
   currently active turn without reparsing generic prompt-looking lines from assistant
   output.
 - `session.summary` Persisted by post-turn application in
@@ -223,10 +225,9 @@ The printed session-chat data comes from these sources:
 
 ### Output Assembly Diagram
 
-`SessionOutput` still renders from the formatted `session.output` transcript string.
-`session_message` rows are the raw conversation sidecar for user and assistant content,
-not the current UI transcript source. The component assembles the panel from
-`session.output` plus synthetic metadata and transient view state:
+`SessionOutput` renders from the formatted `Session.output` render snapshot assembled
+from `session_message` rows. The component assembles the panel from that snapshot plus
+synthetic metadata and transient view state:
 
 ```mermaid
 flowchart TD
@@ -237,7 +238,7 @@ flowchart TD
   base["Choose base body text"]
   lines --> base
   base --> draft["Draft preview<br/>(draft-status session)"]
-  base --> transcript["session.output<br/>(all other statuses)"]
+  base --> transcript["Session.output render snapshot<br/>(all other statuses)"]
 
   split["Split transcript with active_prompt_output"]
   completed["Completed-turn text"]
@@ -259,11 +260,13 @@ flowchart TD
   branch_sync --> final_row["Append final status row<br/>or done continuation hint"]
 ```
 
-This means `session.output` remains the formatted durable transcript for rendering and
-replay compatibility, while `session_message` stores normalized raw user/assistant
-conversation rows for future message-oriented features. Summary and focused review are
-still layered on during render instead of being appended back into that transcript
-string.
+This means `session_message` is the durable transcript. `UserPrompt` and
+`AssistantAnswer` rows store normalized raw content, `WorkflowNotice` rows store exact
+formatted notice text, and `LegacyTranscript` rows preserve pre-migration transcript
+strings losslessly. When a legacy row appears after earlier canonical rows, it acts as a
+checkpoint for that prior history so render assembly does not duplicate the old
+transcript before later rows. Summary and focused review are still layered on during
+render instead of being appended back into that transcript string.
 
 `App` owns one UI `RenderCacheStore` instead of individual concrete render caches and
 threads that store's shared markdown, diff, and session-output caches through
@@ -287,8 +290,8 @@ The exact session-chat render path is:
 1. `SessionChatPage::render_session_header()` prints the single-line session header
    above the bordered output region.
 1. `SessionOutput::output_text()` in `crates/agentty/src/ui/component/session_output.rs`
-   selects the base text: staged draft preview for draft-status sessions, otherwise
-   `session.output`.
+   selects the base text: staged draft preview for draft-status sessions, otherwise the
+   `Session.output` render snapshot assembled from `session_message`.
 1. `SessionOutput::output_lines()` converts that source text into final panel lines: it
    optionally splits the transcript using `active_prompt_output`, normalizes prompt
    spacing, splits any trailing workflow notices, renders the completed-turn markdown,
@@ -309,7 +312,7 @@ The session output panel shows different data at different lifecycle points:
 ```mermaid
 flowchart TD
   submit["Start or reply submitted"]
-  submit --> append_prompt["Append prompt block to session.output"]
+  submit --> append_prompt["Insert UserPrompt row"]
   submit --> cache_prompt["Cache same block as active_prompt_output"]
   submit --> progress["Render loader row from active_progress"]
 
@@ -318,7 +321,7 @@ flowchart TD
   cache_prompt --> turn_done
   progress --> turn_done
 
-  turn_done --> answer["Append assistant transcript chunk to session.output"]
+  turn_done --> answer["Insert AssistantAnswer row"]
   answer --> answer_kind["Protocol answer<br/>or joined clarification-question text"]
   turn_done --> metadata["Persist and apply latest-turn metadata"]
   metadata --> summary_meta["session.summary"]
@@ -343,7 +346,8 @@ narrow screens.
 
 #### User prompt blocks
 
-- Comes from: `session.output` and `active_prompt_output`
+- Comes from: `UserPrompt` rows serialized into the `Session.output` render snapshot and
+  `active_prompt_output`
 - Prints: immediately after start or reply submission. The same block stays in the
   transcript after the turn finishes.
 - Hidden or removed: the transcript entry is durable. Only the transient
@@ -352,13 +356,15 @@ narrow screens.
 
 #### Assistant answer
 
-- Comes from: `session.output`
+- Comes from: `AssistantAnswer` rows serialized into the `Session.output` render
+  snapshot
 - Prints: after a successful turn when protocol `answer` is non-empty.
 - Hidden or removed: durable transcript entry; not removed by `SessionOutput`.
 
 #### Clarification question text from the assistant
 
-- Comes from: `session.output` fallback when no `answer` exists
+- Comes from: `AssistantAnswer` rows containing joined clarification text when no
+  protocol `answer` exists
 - Prints: after a successful turn with questions but without top-level `answer` text.
 - Hidden or removed: durable transcript entry once appended. Pending structured
   `session.questions` continue separately in question mode until answered.
@@ -373,7 +379,7 @@ narrow screens.
 
 #### Clarification answers
 
-- Comes from: a new reply prompt built by runtime and appended into `session.output`.
+- Comes from: a new reply prompt built by runtime and persisted as a `UserPrompt` row.
 - Prints: when the user finishes all questions and submits the generated
   `Clarifications:` reply turn.
 - Hidden or removed: durable transcript entry. `SessionOutput` only adjusts spacing
@@ -390,10 +396,10 @@ narrow screens.
 
 #### Trailing workflow notices
 
-- Comes from: trailing paragraphs in `session.output` that begin with known workflow
-  labels such as `[Commit]`, `[Commit Error]`, `[Commit Assist]`, `[Sync Assist]`,
-  `[Sync Error]`, or other bracketed workflow errors. Producers and the renderer share
-  these labels through `TranscriptNotice` in
+- Comes from: `WorkflowNotice` rows and any pre-migration `LegacyTranscript` paragraphs
+  that begin with known workflow labels such as `[Commit]`, `[Commit Error]`,
+  `[Commit Assist]`, `[Sync Assist]`, `[Sync Error]`, or other bracketed workflow
+  errors. Producers and the renderer share these labels through `TranscriptNotice` in
   `crates/agentty/src/domain/transcript_notice.rs`.
 - Prints: reattached after the synthetic summary so the summary stays at the completed
   agent-turn boundary and later workflow notices remain below it in transcript order.


### PR DESCRIPTION
- Backfills legacy `session.output` text into `LegacyTranscript` rows without duplicating existing migrated content.
- Loads render snapshots from ordered `session_message` rows and treats the legacy output column as migration backup.
- Persists user prompts, assistant answers, and workflow notices through `append_session_message()` while refreshing session ordering metadata.
- Preserves exact compatibility-message spacing while normalizing conversation content.
- Updates transcript persistence tests, E2E seed data, and architecture docs for the canonical message store.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)