### PR TITLE
Harden GitHub workflow security

### DIFF
--- a/.github/actions/setup-rust-prek/action.yml
+++ b/.github/actions/setup-rust-prek/action.yml
@@ -27,11 +27,15 @@ runs:
 
     - name: Install `prek`
       shell: bash
+      env:
+        UV_TOOL_BIN_DIR: /tmp/agentty-uv-tools/bin
       # Pin `prek`, require wheels so CI does not run package build hooks, and
-      # expose the installed executable to the workflow steps that run hooks.
+      # expose the installed executable from a fixed trusted path to workflow
+      # steps that run hooks.
       run: |
+        mkdir -p "$UV_TOOL_BIN_DIR"
         uv tool install --no-build prek==0.4.3
-        echo "$(uv tool dir --bin)" >> "$GITHUB_PATH"
+        echo "/tmp/agentty-uv-tools/bin" >> "$GITHUB_PATH"
 
     - name: Install Rust nightly toolchain
       if: ${{ inputs['llvm-tools-preview'] != 'true' }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     assignees:
       - "minev-dev"
       - "andagaev"
@@ -28,6 +30,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     assignees:
       - "minev-dev"
       - "andagaev"
@@ -40,6 +44,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     assignees:
       - "minev-dev"
       - "andagaev"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,8 +11,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -24,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
@@ -44,6 +44,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Rust and `prek`
         uses: ./.github/actions/setup-rust-prek
@@ -49,6 +51,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Rust and `prek`
         uses: ./.github/actions/setup-rust-prek
@@ -70,6 +74,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Rust and `prek`
         uses: ./.github/actions/setup-rust-prek
@@ -122,6 +128,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Rust and `prek`
         uses: ./.github/actions/setup-rust-prek

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Rust and `prek`
         uses: ./.github/actions/setup-rust-prek

--- a/.github/workflows/publish-crates-io.yml
+++ b/.github/workflows/publish-crates-io.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install Rust nightly toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
@@ -30,10 +32,16 @@ jobs:
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
 
       - name: Publish `ag-forge` to crates.io
-        run: cargo publish -p ag-forge --token "${{ steps.auth.outputs.token }}"
+        env:
+          CRATES_IO_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish -p ag-forge --token "$CRATES_IO_TOKEN"
 
       - name: Publish `testty` to crates.io
-        run: cargo publish -p testty --token "${{ steps.auth.outputs.token }}"
+        env:
+          CRATES_IO_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish -p testty --token "$CRATES_IO_TOKEN"
 
       - name: Publish `agentty` to crates.io
-        run: cargo publish -p agentty --token "${{ steps.auth.outputs.token }}"
+        env:
+          CRATES_IO_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish -p agentty --token "$CRATES_IO_TOKEN"

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Rust and `prek`
         uses: ./.github/actions/setup-rust-prek

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,24 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install dist
-        # we specify bash to get pipefail; it guards against the `curl` command
-        # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+        run: |
+          # Download a checksummed release archive instead of piping the installer
+          # script into the shell.
+          set -euo pipefail
+
+          cargo_dist_version="0.31.0"
+          cargo_dist_target="x86_64-unknown-linux-gnu"
+          cargo_dist_archive="cargo-dist-${cargo_dist_target}.tar.xz"
+          cargo_dist_url="https://github.com/axodotdev/cargo-dist/releases/download/v${cargo_dist_version}"
+
+          curl --proto '=https' --tlsv1.2 -LsSf -O "${cargo_dist_url}/${cargo_dist_archive}"
+          curl --proto '=https' --tlsv1.2 -LsSf -O "${cargo_dist_url}/${cargo_dist_archive}.sha256"
+          shasum -a 256 --check "${cargo_dist_archive}.sha256"
+
+          tar -xJf "$cargo_dist_archive"
+          mkdir -p "$HOME/.cargo/bin"
+          install -m 755 "cargo-dist-${cargo_dist_target}/dist" "$HOME/.cargo/bin/dist"
       - name: Cache dist
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -80,8 +94,14 @@ jobs:
       # (PRs run on the *source* but secrets are usually on the *target* -- that's *good*
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
+        env:
+          DIST_TAG: ${{ github.ref_name }}
         run: |
-          dist ${{ (github.event_name == 'push' && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            dist host --steps=create "--tag=$DIST_TAG" --output-format=json > plan-dist-manifest.json
+          else
+            dist plan --output-format=json > plan-dist-manifest.json
+          fi
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -116,7 +136,6 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
-    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -128,15 +147,43 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: Install Rust non-interactively if not already installed
-        if: ${{ matrix.container }}
-        run: |
-          if ! command -v cargo > /dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          fi
       - name: Install dist
-        run: ${{ matrix.install_dist.run }}
+        shell: bash
+        run: |
+          # Download a checksummed release archive instead of piping the installer
+          # script into the shell.
+          set -euo pipefail
+
+          cargo_dist_version="0.31.0"
+          cargo_dist_url="https://github.com/axodotdev/cargo-dist/releases/download/v${cargo_dist_version}"
+
+          case "$(uname -s)-$(uname -m)" in
+            Darwin-arm64)
+              cargo_dist_target="aarch64-apple-darwin"
+              ;;
+            Darwin-x86_64)
+              cargo_dist_target="x86_64-apple-darwin"
+              ;;
+            Linux-aarch64)
+              cargo_dist_target="aarch64-unknown-linux-gnu"
+              ;;
+            Linux-x86_64)
+              cargo_dist_target="x86_64-unknown-linux-gnu"
+              ;;
+            *)
+              echo "unsupported cargo-dist host: $(uname -s)-$(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+
+          cargo_dist_archive="cargo-dist-${cargo_dist_target}.tar.xz"
+          curl --proto '=https' --tlsv1.2 -LsSf -O "${cargo_dist_url}/${cargo_dist_archive}"
+          curl --proto '=https' --tlsv1.2 -LsSf -O "${cargo_dist_url}/${cargo_dist_archive}.sha256"
+          shasum -a 256 --check "${cargo_dist_archive}.sha256"
+
+          tar -xJf "$cargo_dist_archive"
+          mkdir -p "$HOME/.cargo/bin"
+          install -m 755 "cargo-dist-${cargo_dist_target}/dist" "$HOME/.cargo/bin/dist"
       # Get the dist-manifest
       - name: Fetch local artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -144,13 +191,23 @@ jobs:
           pattern: artifacts-*
           path: target/distrib/
           merge-multiple: true
-      - name: Install dependencies
-        run: |
-          ${{ matrix.packages_install }}
       - name: Build artifacts
+        env:
+          DIST_TAG: ${{ needs.plan.outputs.tag }}
+          DIST_TARGETS: ${{ join(matrix.targets, ' ') }}
         run: |
           # Actually do builds and make zips and whatnot
-          dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
+          tag_args=()
+          if [ -n "$DIST_TAG" ]; then
+            tag_args=("--tag=$DIST_TAG")
+          fi
+
+          dist_args=("--artifacts=local")
+          for target in $DIST_TARGETS; do
+            dist_args+=("--target=$target")
+          done
+
+          dist build "${tag_args[@]}" --print=linkage --output-format=json "${dist_args[@]}" > dist-manifest.json
           echo "dist ran successfully"
       - id: cargo-dist
         name: Post-build
@@ -202,8 +259,15 @@ jobs:
           merge-multiple: true
       - id: cargo-dist
         shell: bash
+        env:
+          DIST_TAG: ${{ needs.plan.outputs.tag }}
         run: |
-          dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" > dist-manifest.json
+          tag_args=()
+          if [ -n "$DIST_TAG" ]; then
+            tag_args=("--tag=$DIST_TAG")
+          fi
+
+          dist build "${tag_args[@]}" --output-format=json "--artifacts=global" > dist-manifest.json
           echo "dist ran successfully"
 
           # Parse out what we just built and upload it to scratch storage
@@ -255,8 +319,10 @@ jobs:
           merge-multiple: true
       - id: host
         shell: bash
+        env:
+          DIST_TAG: ${{ needs.plan.outputs.tag }}
         run: |
-          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
+          dist host "--tag=$DIST_TAG" --steps=upload --steps=release --output-format=json > dist-manifest.json
           echo "artifacts uploaded and released successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -283,11 +349,17 @@ jobs:
           ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
           ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
           RELEASE_COMMIT: "${{ github.sha }}"
+          RELEASE_TAG: "${{ needs.plan.outputs.tag }}"
         run: |
           # Write and read notes from a file to avoid quoting breaking things
           echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
 
-          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          release_args=()
+          if [ -n "$PRERELEASE_FLAG" ]; then
+            release_args+=("$PRERELEASE_FLAG")
+          fi
+
+          gh release create "$RELEASE_TAG" --target "$RELEASE_COMMIT" "${release_args[@]}" --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
   custom-publish-npm-oidc:
     needs:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0


### PR DESCRIPTION
- Disable checkout credential persistence across workflows and scope Pages write permissions to deploy.
- Install `prek` from a fixed `uv` tool bin directory and pass crates.io publish tokens through environment variables.
- Add Dependabot cooldowns and install `cargo-dist` from checksummed release archives.
- Pass release tags and build targets through shell variables and arrays instead of generated command fragments.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)