### PR TITLE
Add a dedicated selection surface color for highlighted rows

### DIFF
--- a/crates/agentty/src/infra/agent/availability.rs
+++ b/crates/agentty/src/infra/agent/availability.rs
@@ -12,7 +12,7 @@ use crate::domain::agent::{AgentCliInfo, AgentKind};
 /// Maximum time spent waiting for one provider CLI `--version` command.
 const AGENT_CLI_VERSION_TIMEOUT: Duration = Duration::from_secs(2);
 /// Maximum time spent waiting for one provider CLI `update` command.
-const AGENT_CLI_UPDATE_TIMEOUT: Duration = Duration::from_secs(300);
+const AGENT_CLI_UPDATE_TIMEOUT: Duration = Duration::from_mins(5);
 /// Poll interval used while waiting for one bounded provider CLI subprocess.
 const AGENT_CLI_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(25);
 

--- a/crates/agentty/src/ui/component/file_explorer.rs
+++ b/crates/agentty/src/ui/component/file_explorer.rs
@@ -403,7 +403,7 @@ impl Component for FileExplorer {
                     ))
                     .border_style(style::border_style()),
             )
-            .highlight_style(Style::default().bg(style::palette::surface()));
+            .highlight_style(Style::default().bg(style::palette::surface_selection()));
 
         let mut state = ListState::default();
         state.select(Some(self.selected_index));

--- a/crates/agentty/src/ui/page/project_list.rs
+++ b/crates/agentty/src/ui/page/project_list.rs
@@ -108,7 +108,7 @@ impl Page for ProjectListPage<'_> {
             .block(agent_cli_block)
             .wrap(Wrap { trim: true });
 
-        let selected_style = Style::default().bg(style::palette::surface());
+        let selected_style = Style::default().bg(style::palette::surface_selection());
         let header_cells = ["Project", "Branch", "Sessions", "Path"]
             .iter()
             .map(|header| left_aligned_cell(*header));

--- a/crates/agentty/src/ui/page/review_list.rs
+++ b/crates/agentty/src/ui/page/review_list.rs
@@ -126,7 +126,7 @@ fn render_review_table(
         .column_spacing(TABLE_COLUMN_SPACING)
         .header(header)
         .block(block)
-        .row_highlight_style(Style::default().bg(style::palette::surface()))
+        .row_highlight_style(Style::default().bg(style::palette::surface_selection()))
         .highlight_symbol(ROW_HIGHLIGHT_SYMBOL);
 
     f.render_stateful_widget(table, area, table_state);
@@ -549,8 +549,8 @@ mod tests {
             .expect("selected review row should render");
         let unselected_cell = find_text_start_cell(buffer, "PR #42 Add review tab")
             .expect("unselected review row should render");
-        assert_eq!(selected_cell.bg, style::palette::surface());
-        assert_ne!(unselected_cell.bg, style::palette::surface());
+        assert_eq!(selected_cell.bg, style::palette::surface_selection());
+        assert_ne!(unselected_cell.bg, style::palette::surface_selection());
     }
 
     #[test]

--- a/crates/agentty/src/ui/page/session_list.rs
+++ b/crates/agentty/src/ui/page/session_list.rs
@@ -58,7 +58,7 @@ impl Page for SessionListPage<'_> {
     fn render(&mut self, f: &mut Frame, area: Rect) {
         let areas = layout::tab_page_areas(area);
 
-        let selected_style = Style::default().bg(style::palette::surface());
+        let selected_style = Style::default().bg(style::palette::surface_selection());
         let header_style = Style::default()
             .bg(style::palette::surface())
             .fg(style::palette::text_muted())
@@ -778,7 +778,7 @@ mod tests {
         let fallback_cell = &buffer.content()[0];
         let tree_cell = find_text_start_cell(buffer, "└").unwrap_or(fallback_cell);
         assert_eq!(tree_cell.fg, style::palette::text_muted());
-        assert_eq!(tree_cell.bg, style::palette::surface());
+        assert_eq!(tree_cell.bg, style::palette::surface_selection());
         assert_ne!(tree_cell.fg, tree_cell.bg);
     }
 
@@ -1102,7 +1102,7 @@ mod tests {
         let new_cell = find_text_start_cell(buffer, "Draft").unwrap_or(fallback_cell);
         assert_ne!(title_cell.fg, title_cell.bg);
         assert_eq!(new_cell.fg, style::palette::text_muted());
-        assert_eq!(new_cell.bg, style::palette::surface());
+        assert_eq!(new_cell.bg, style::palette::surface_selection());
         assert_ne!(new_cell.fg, new_cell.bg);
     }
 }

--- a/crates/agentty/src/ui/page/setting.rs
+++ b/crates/agentty/src/ui/page/setting.rs
@@ -40,7 +40,7 @@ impl Page for SettingsPage<'_> {
     fn render(&mut self, f: &mut Frame, area: Rect) {
         let areas = layout::tab_page_areas(area);
 
-        let selected_style = Style::default().bg(style::palette::surface());
+        let selected_style = Style::default().bg(style::palette::surface_selection());
         let global_rows = settings_table_rows(self.manager.global_settings_rows());
         let project_rows = settings_table_rows(self.manager.project_settings_rows());
 

--- a/crates/agentty/src/ui/style.rs
+++ b/crates/agentty/src/ui/style.rs
@@ -73,7 +73,7 @@ pub mod palette {
         token_color(|palette| palette.question)
     }
 
-    /// Base surface color for bars and selected rows.
+    /// Base surface color for bars and table headers.
     #[must_use]
     pub fn surface() -> Color {
         token_color(|palette| palette.surface)
@@ -96,6 +96,12 @@ pub mod palette {
     #[must_use]
     pub fn surface_elevated() -> Color {
         token_color(|palette| palette.surface_elevated)
+    }
+
+    /// Highlight surface color for selected rows and list entries.
+    #[must_use]
+    pub fn surface_selection() -> Color {
+        token_color(|palette| palette.surface_selection)
     }
 
     /// Subtle success-tinted surface used behind added diff lines.
@@ -176,7 +182,7 @@ pub struct ThemePalette {
     pub info: Color,
     /// Color used for question-status emphasis.
     pub question: Color,
-    /// Base surface color for bars and selected rows.
+    /// Base surface color for bars and table headers.
     pub surface: Color,
     /// Subtle blue-gray surface used behind clarification prompt blocks.
     pub surface_clarification: Color,
@@ -184,6 +190,8 @@ pub struct ThemePalette {
     pub surface_danger: Color,
     /// Elevated surface color for table headers.
     pub surface_elevated: Color,
+    /// Highlight surface color for selected rows and list entries.
+    pub surface_selection: Color,
     /// Subtle success-tinted surface used behind added diff lines.
     pub surface_success: Color,
     /// Dark surface used to dim background content behind modal overlays.
@@ -216,6 +224,7 @@ const CURRENT_PALETTE: ThemePalette = ThemePalette {
     surface_clarification: Color::Rgb(28, 38, 48),
     surface_danger: Color::Rgb(48, 24, 24),
     surface_elevated: Color::Gray,
+    surface_selection: Color::DarkGray,
     surface_success: Color::Rgb(18, 44, 26),
     surface_overlay: Color::Black,
     text: Color::White,
@@ -241,6 +250,7 @@ const HACKER_PALETTE: ThemePalette = ThemePalette {
     surface_clarification: Color::Rgb(12, 28, 14),
     surface_danger: Color::Rgb(44, 18, 18),
     surface_elevated: Color::Rgb(10, 32, 12),
+    surface_selection: Color::Rgb(6, 18, 8),
     surface_success: Color::Rgb(12, 38, 17),
     surface_overlay: Color::Black,
     text: Color::Rgb(205, 245, 211),
@@ -274,6 +284,7 @@ const DARK_HORIZON_PALETTE: ThemePalette = ThemePalette {
     surface_clarification: Color::Rgb(28, 32, 44),
     surface_danger: Color::Rgb(63, 32, 42),
     surface_elevated: Color::Rgb(33, 36, 48),
+    surface_selection: Color::Rgb(45, 50, 68),
     surface_success: Color::Rgb(28, 64, 54),
     surface_overlay: Color::Rgb(14, 16, 22),
     text: Color::Rgb(214, 217, 232),
@@ -549,6 +560,7 @@ mod tests {
         // Assert
         assert_eq!(palette.surface, Color::Rgb(22, 24, 31));
         assert_eq!(palette.surface_elevated, Color::Rgb(33, 36, 48));
+        assert_eq!(palette.surface_selection, Color::Rgb(45, 50, 68));
         assert_eq!(palette.border, Color::Rgb(52, 60, 82));
         assert_eq!(palette.text, Color::Rgb(214, 217, 232));
         assert_eq!(palette.text_muted, Color::Rgb(132, 136, 168));
@@ -568,6 +580,37 @@ mod tests {
         assert_eq!(palette.warning, Color::Rgb(250, 194, 154));
         assert_eq!(palette.danger, Color::Rgb(209, 67, 76));
         assert_eq!(palette.question, Color::Rgb(184, 119, 219));
+    }
+
+    #[test]
+    fn dark_horizon_selection_surface_is_lighter_than_base_surface() {
+        // Arrange
+        let _theme_scope = scoped_active_theme(ColorTheme::DarkHorizon);
+
+        // Act
+        let selection = palette::surface_selection();
+        let surface = palette::surface();
+
+        // Assert
+        let (selection_red, selection_green, selection_blue) =
+            rgb_components(selection).expect("dark horizon selection surface must be RGB");
+        let (surface_red, surface_green, surface_blue) =
+            rgb_components(surface).expect("dark horizon base surface must be RGB");
+        assert!(
+            selection_red > surface_red
+                && selection_green > surface_green
+                && selection_blue > surface_blue,
+            "selected rows must stay visually distinct from the base surface",
+        );
+    }
+
+    /// Returns the RGB components of a palette color, or `None` for
+    /// non-RGB terminal colors.
+    fn rgb_components(color: Color) -> Option<(u8, u8, u8)> {
+        match color {
+            Color::Rgb(red, green, blue) => Some((red, green, blue)),
+            _ => None,
+        }
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -18,6 +18,7 @@ use agentty::domain::session::{
 use agentty::domain::session_message::SessionMessageKind;
 use agentty::test_support;
 use testty::assertion;
+use testty::frame::CellColor;
 use testty::region::Region;
 use testty::scenario::Scenario;
 
@@ -599,6 +600,71 @@ fn session_list_model_reasoning_level() -> E2eResult {
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "gpt-5.5 [medium]", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that the selected session row renders on the dedicated selection
+/// surface, distinct from the base surface used by the table header.
+///
+/// Cycles the theme to Dark Horizon, where `surface_selection` and `surface`
+/// have different RGB values, then opens the Sessions tab and asserts the
+/// selected row background matches the selection surface while the header
+/// keeps the base surface background. The scenario finishes by wrapping the
+/// theme back to `Agentty Default` so the persisted theme is identical before
+/// the PTY proof run and the VHS replay.
+#[test]
+fn session_list_selected_row_uses_selection_surface() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_selection_highlight")
+        .with_git()
+        .setup(seed_review_ready_session)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .compose(&common::switch_to_tab("Review"))
+                    .compose(&common::switch_to_tab("Settings"))
+                    .press_key("Enter")
+                    .wait_for_text("Agentty Green", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Dark Horizon", 5000)
+                    .compose(&common::switch_to_tab("Logs"))
+                    .compose(&common::switch_to_tab("Projects"))
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .wait_for_text("Review-ready session shortcuts", 5000)
+                    .capture_labeled(
+                        "selected_row_highlight",
+                        "Selected session row on the dedicated selection surface",
+                    )
+                    .compose(&common::switch_to_tab("Review"))
+                    .compose(&common::switch_to_tab("Settings"))
+                    .press_key("Enter")
+                    .wait_for_text("Agentty Default", 5000)
+            },
+            |_frame, report| {
+                assert_eq!(
+                    report.captures.len(),
+                    1,
+                    "Expected 1 capture (selected session row under Dark Horizon)"
+                );
+
+                // Dark Horizon `surface_selection` and `surface` RGB values
+                // from the `ThemePalette` definitions in `ui/style.rs`.
+                let sessions_frame = common::frame_from_capture(&report.captures[0]);
+                assertion::assert_text_has_bg_color(
+                    &sessions_frame,
+                    "Review-ready session shortcuts",
+                    &CellColor::new(45, 50, 68),
+                );
+                assertion::assert_text_has_bg_color(
+                    &sessions_frame,
+                    "Model",
+                    &CellColor::new(22, 24, 31),
+                );
             },
         )?;
 


### PR DESCRIPTION
- Introduce a `surface_selection` palette token and `palette::surface_selection()` accessor, with per-theme values for the current, hacker, and dark horizon palettes
- Switch selected rows and list highlights in the file explorer, project list, review list, session list, and settings pages to use `surface_selection()` instead of `surface()`
- Refine `surface` docs to describe bars and table headers now that selection has its own token
- Cover the dark horizon selection surface with a unit test asserting it stays lighter than the base surface
- Add an E2E feature test that verifies the selected session row renders on the selection surface while the header keeps the base surface under Dark Horizon
- Express the agent CLI update timeout as `Duration::from_mins(5)`