### PR TITLE
Replace arboard with ag-clipboard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: djlint-reformat
         name: djlint reformat
         description: Format HTML files and embedded CSS blocks.
-        entry: djlint --reformat --format-css
+        entry: python -X cpu_count=1 -m djlint --reformat --format-css
         language: python
         additional_dependencies: [djlint==1.36.4]
         files: \.html?$
@@ -100,6 +100,14 @@ repos:
         name: cargo nextest ag-protocol src
         description: Source tests for `crates/ag-protocol/src`.
         entry: cargo nextest run --locked --profile ci -p ag-protocol --lib
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [manual]
+      - id: test-ag-clipboard-src
+        name: cargo nextest ag-clipboard src
+        description: Source tests for `crates/ag-clipboard/src`.
+        entry: cargo nextest run --locked --profile ci -p ag-clipboard --lib
         language: system
         always_run: true
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - agentty: open settings selector dropdowns for fixed-choice values instead of cycling
   values directly with `Enter`.
+- agentty: replace `arboard` clipboard image capture with the internal `ag-clipboard`
+  backend for macOS, X11, and Wayland through `wl-paste`.
+- agentty: require the `wl-clipboard` package for Wayland clipboard image paste.
 
 ## [v0.11.1] - 2026-07-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ag-clipboard"
+version = "0.11.1"
+dependencies = [
+ "image",
+ "mockall",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "percent-encoding",
+ "rustix",
+ "thiserror 2.0.18",
+ "x11rb",
+]
+
+[[package]]
 name = "ag-forge"
 version = "0.11.1"
 dependencies = [
@@ -69,7 +84,7 @@ dependencies = [
  "shell-words",
  "tracing",
  "uuid",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -102,11 +117,11 @@ dependencies = [
 name = "agentty"
 version = "0.11.1"
 dependencies = [
+ "ag-clipboard",
  "ag-forge",
  "ag-git",
  "ag-protocol",
  "agent-client-protocol",
- "arboard",
  "askama",
  "assert_cmd",
  "async-trait",
@@ -196,7 +211,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -207,7 +222,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -223,27 +238,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "arboard"
-version = "3.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
-dependencies = [
- "clipboard-win",
- "image",
- "log",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation",
- "parking_lot",
- "percent-encoding",
- "windows-sys 0.60.2",
- "wl-clipboard-rs",
- "x11rb",
 ]
 
 [[package]]
@@ -347,7 +341,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -394,7 +388,7 @@ dependencies = [
  "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -700,15 +694,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "clipboard-win"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
-dependencies = [
- "error-code",
-]
 
 [[package]]
 name = "cmov"
@@ -1036,17 +1021,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "dispatch2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags 2.13.0",
- "objc2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1115,14 +1090,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
-
-[[package]]
-name = "error-code"
-version = "3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "etcetera"
@@ -1131,7 +1100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2047,7 +2016,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2134,21 +2103,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2203,32 +2163,7 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.0",
  "objc2",
- "objc2-core-graphics",
  "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags 2.13.0",
- "dispatch2",
- "objc2",
-]
-
-[[package]]
-name = "objc2-core-graphics"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
-dependencies = [
- "bitflags 2.13.0",
- "dispatch2",
- "objc2",
- "objc2-core-foundation",
- "objc2-io-surface",
 ]
 
 [[package]]
@@ -2245,18 +2180,6 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
  "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-io-surface"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
-dependencies = [
- "bitflags 2.13.0",
- "objc2",
- "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2284,16 +2207,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "os_pipe"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2396,17 +2309,6 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2 0.10.9",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset 0.5.7",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -2528,7 +2430,7 @@ dependencies = [
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2630,15 +2532,6 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
-name = "quick-xml"
-version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "quote"
@@ -2888,7 +2781,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3201,7 +3094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3491,7 +3384,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3504,7 +3397,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3514,7 +3407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom 7.1.3",
+ "nom",
  "phf",
  "phf_codegen",
 ]
@@ -3725,7 +3618,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3819,17 +3712,6 @@ dependencies = [
  "thread_local",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "tree_magic_mini"
-version = "3.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
-dependencies = [
- "memchr",
- "nom 8.0.0",
- "petgraph",
 ]
 
 [[package]]
@@ -4113,76 +3995,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wayland-backend"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
-dependencies = [
- "cc",
- "downcast-rs",
- "rustix",
- "smallvec",
- "wayland-sys",
-]
-
-[[package]]
-name = "wayland-client"
-version = "0.31.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
-dependencies = [
- "bitflags 2.13.0",
- "rustix",
- "wayland-backend",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols"
-version = "0.32.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
-dependencies = [
- "bitflags 2.13.0",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols-wlr"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
-dependencies = [
- "bitflags 2.13.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-scanner"
-version = "0.31.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
-dependencies = [
- "proc-macro2",
- "quick-xml",
- "quote",
-]
-
-[[package]]
-name = "wayland-sys"
-version = "0.31.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
-dependencies = [
- "pkg-config",
-]
-
-[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4288,7 +4100,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4358,86 +4170,12 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -4543,24 +4281,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
-]
-
-[[package]]
-name = "wl-clipboard-rs"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
-dependencies = [
- "libc",
- "log",
- "os_pipe",
- "rustix",
- "thiserror 2.0.18",
- "tree_magic_mini",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-protocols-wlr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.11.1" }
 ag-forge = { path = "crates/ag-forge", version = "0.11.1" }
 ag-git = { path = "crates/ag-git", version = "0.11.1" }
 ag-protocol = { path = "crates/ag-protocol", version = "0.11.1" }
@@ -23,7 +24,6 @@ testty = { path = "crates/testty", version = "0.11.1" }
 async-trait = "0.1"
 agent-client-protocol = "1.0.0"
 assert_cmd = "2"
-arboard = { version = "3", features = ["image-data", "wayland-data-control"] }
 askama = "0.16.0"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
@@ -32,9 +32,14 @@ dirs = "6.0"
 ignore = "0.4"
 image = { version = "0.25", default-features = false, features = ["png", "gif"] }
 mockall = "0.14"
+objc2 = "0.6"
+objc2-app-kit = { version = "0.3", default-features = false }
+objc2-foundation = { version = "0.3", default-features = false }
+percent-encoding = "2"
 portable-pty = "0.9"
 ratatui = "0.30.1"
 rustc-hash = "2"
+rustix = { version = "1.1", features = ["event"] }
 schemars = { version = "1", features = ["derive"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
@@ -54,6 +59,7 @@ unicode-width = "0.2"
 url = "2"
 uuid = { version = "1", features = ["v4"] }
 vt100 = "0.16"
+x11rb = "0.13"
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -4,6 +4,8 @@ Contains the workspace member crates.
 
 ## Workspace Crates
 
+- `crates/ag-clipboard/` holds read-only clipboard backends shared by Agentty prompt
+  image capture.
 - `crates/ag-forge/` holds forge review-request types and provider integrations shared
   across the workspace.
 - `crates/ag-git/` holds reusable git, worktree, sync, rebase, and squash-merge

--- a/crates/ag-clipboard/AGENTS.md
+++ b/crates/ag-clipboard/AGENTS.md
@@ -1,0 +1,18 @@
+# ag-clipboard
+
+Read-only clipboard support crate for Agentty prompt image capture.
+
+## Purpose
+
+- Exposes the narrow clipboard surface Agentty needs: text, file-list, and RGBA image
+  reads.
+- Owns platform clipboard details so `crates/agentty/` can keep prompt image persistence
+  behind `ClipboardImageClient`.
+
+## Boundaries
+
+- Keep the public API synchronous; Agentty runs clipboard reads on a blocking thread.
+- Keep platform integrations inside `src/backend/`.
+- Preserve audit-clean Wayland behavior: Wayland reads go through the approved
+  `wl-paste` subprocess backend instead of Rust Wayland protocol crates.
+- Do not add write support until a user-facing copy feature is specified.

--- a/crates/ag-clipboard/CLAUDE.md
+++ b/crates/ag-clipboard/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/ag-clipboard/Cargo.toml
+++ b/crates/ag-clipboard/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "ag-clipboard"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+description.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+image.workspace = true
+percent-encoding.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+mockall.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+rustix.workspace = true
+x11rb.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+image = { workspace = true, features = ["tiff"] }
+objc2.workspace = true
+objc2-app-kit = { workspace = true, features = ["std", "NSPasteboard", "NSPasteboardItem"] }
+objc2-foundation = { workspace = true, features = ["std", "NSEnumerator", "NSString"] }

--- a/crates/ag-clipboard/GEMINI.md
+++ b/crates/ag-clipboard/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/ag-clipboard/src/backend.rs
+++ b/crates/ag-clipboard/src/backend.rs
@@ -1,0 +1,19 @@
+mod contract;
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+mod unsupported;
+#[cfg(any(target_os = "linux", test))]
+mod wayland;
+#[cfg(target_os = "linux")]
+mod x11;
+
+pub(crate) use contract::ClipboardBackend;
+#[cfg(target_os = "linux")]
+pub(crate) use linux::new_backend;
+#[cfg(target_os = "macos")]
+pub(crate) use macos::new_backend;
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub(crate) use unsupported::new_backend;

--- a/crates/ag-clipboard/src/backend/contract.rs
+++ b/crates/ag-clipboard/src/backend/contract.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+
+use crate::{ClipboardError, RgbaImageData};
+
+pub(crate) trait ClipboardBackend {
+    fn read_text(&mut self) -> Result<String, ClipboardError>;
+
+    fn read_file_list(&mut self) -> Result<Vec<PathBuf>, ClipboardError>;
+
+    fn read_image_rgba(&mut self) -> Result<RgbaImageData, ClipboardError>;
+}

--- a/crates/ag-clipboard/src/backend/linux.rs
+++ b/crates/ag-clipboard/src/backend/linux.rs
@@ -1,0 +1,106 @@
+use std::env;
+
+use super::{ClipboardBackend, wayland, x11};
+use crate::ClipboardError;
+
+pub(crate) fn new_backend() -> Result<Box<dyn ClipboardBackend>, ClipboardError> {
+    match select_backend(&LinuxClipboardEnvironment::from_env()) {
+        LinuxBackendSelection::Wayland => Ok(Box::new(wayland::WaylandClipboard::new()?)),
+        LinuxBackendSelection::X11 => Ok(Box::new(x11::X11Clipboard::new()?)),
+        LinuxBackendSelection::Unavailable => Err(ClipboardError::Unavailable {
+            reason: "no supported Linux clipboard display was detected".to_string(),
+        }),
+    }
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+struct LinuxClipboardEnvironment {
+    display: Option<String>,
+    wayland_display: Option<String>,
+}
+
+impl LinuxClipboardEnvironment {
+    fn from_env() -> Self {
+        Self {
+            display: env::var("DISPLAY").ok(),
+            wayland_display: env::var("WAYLAND_DISPLAY").ok(),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum LinuxBackendSelection {
+    Unavailable,
+    Wayland,
+    X11,
+}
+
+fn select_backend(environment: &LinuxClipboardEnvironment) -> LinuxBackendSelection {
+    if environment
+        .wayland_display
+        .as_deref()
+        .is_some_and(|value| !value.is_empty())
+    {
+        return LinuxBackendSelection::Wayland;
+    }
+
+    if environment
+        .display
+        .as_deref()
+        .is_some_and(|value| !value.is_empty())
+    {
+        return LinuxBackendSelection::X11;
+    }
+
+    LinuxBackendSelection::Unavailable
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_select_backend_prefers_wayland_over_x11() {
+        // Arrange
+        let environment = LinuxClipboardEnvironment {
+            display: Some(":0".to_string()),
+            wayland_display: Some("wayland-0".to_string()),
+        };
+
+        // Act
+        let backend_selection = select_backend(&environment);
+
+        // Assert
+        assert_eq!(backend_selection, LinuxBackendSelection::Wayland);
+    }
+
+    #[test]
+    fn test_select_backend_uses_x11_when_only_display_is_set() {
+        // Arrange
+        let environment = LinuxClipboardEnvironment {
+            display: Some(":0".to_string()),
+            wayland_display: None,
+        };
+
+        // Act
+        let backend_selection = select_backend(&environment);
+
+        // Assert
+        assert_eq!(backend_selection, LinuxBackendSelection::X11);
+    }
+
+    #[test]
+    fn test_select_backend_reports_unavailable_without_display_variables() {
+        // Arrange
+        let environment = LinuxClipboardEnvironment {
+            display: None,
+            wayland_display: None,
+        };
+
+        // Act
+        let backend_selection = select_backend(&environment);
+
+        // Assert
+        assert_eq!(backend_selection, LinuxBackendSelection::Unavailable);
+    }
+}

--- a/crates/ag-clipboard/src/backend/macos.rs
+++ b/crates/ag-clipboard/src/backend/macos.rs
@@ -1,0 +1,100 @@
+use std::path::PathBuf;
+
+use image::ImageFormat;
+use objc2::rc::{Retained, autoreleasepool};
+use objc2_app_kit::NSPasteboard;
+use objc2_foundation::NSString;
+
+use super::ClipboardBackend;
+use crate::{ClipboardError, RgbaImageData, format, uri};
+
+const PASTEBOARD_TYPE_FILE_URL: &str = "public.file-url";
+const PASTEBOARD_TYPE_PNG: &str = "public.png";
+const PASTEBOARD_TYPE_STRING: &str = "public.utf8-plain-text";
+const PASTEBOARD_TYPE_TIFF: &str = "public.tiff";
+
+pub(crate) fn new_backend() -> Box<dyn ClipboardBackend> {
+    Box::new(MacosClipboard::new())
+}
+
+struct MacosClipboard {
+    pasteboard: Retained<NSPasteboard>,
+}
+
+impl MacosClipboard {
+    fn new() -> Self {
+        Self {
+            pasteboard: NSPasteboard::generalPasteboard(),
+        }
+    }
+
+    fn read_first_string_for_type(
+        &self,
+        pasteboard_type: &NSString,
+    ) -> Result<String, ClipboardError> {
+        autoreleasepool(|_| {
+            let pasteboard_items = self
+                .pasteboard
+                .pasteboardItems()
+                .ok_or(ClipboardError::ContentUnavailable)?;
+
+            for pasteboard_item in &pasteboard_items {
+                if let Some(text) = pasteboard_item.stringForType(pasteboard_type) {
+                    return Ok(text.to_string());
+                }
+            }
+
+            Err(ClipboardError::ContentUnavailable)
+        })
+    }
+
+    fn read_data_for_type(&self, pasteboard_type: &NSString) -> Result<Vec<u8>, ClipboardError> {
+        autoreleasepool(|_| {
+            self.pasteboard
+                .dataForType(pasteboard_type)
+                .map(|data| data.to_vec())
+                .ok_or(ClipboardError::ContentUnavailable)
+        })
+    }
+}
+
+impl ClipboardBackend for MacosClipboard {
+    fn read_text(&mut self) -> Result<String, ClipboardError> {
+        let pasteboard_type = NSString::from_str(PASTEBOARD_TYPE_STRING);
+
+        self.read_first_string_for_type(&pasteboard_type)
+    }
+
+    fn read_file_list(&mut self) -> Result<Vec<PathBuf>, ClipboardError> {
+        autoreleasepool(|_| {
+            let pasteboard_type = NSString::from_str(PASTEBOARD_TYPE_FILE_URL);
+            let pasteboard_items = self
+                .pasteboard
+                .pasteboardItems()
+                .ok_or(ClipboardError::ContentUnavailable)?;
+            let paths = pasteboard_items
+                .iter()
+                .filter_map(|pasteboard_item| pasteboard_item.stringForType(&pasteboard_type))
+                .filter_map(|file_url| uri::path_from_file_url_text(&file_url.to_string()))
+                .collect::<Vec<_>>();
+
+            if paths.is_empty() {
+                return Err(ClipboardError::ContentUnavailable);
+            }
+
+            Ok(paths)
+        })
+    }
+
+    fn read_image_rgba(&mut self) -> Result<RgbaImageData, ClipboardError> {
+        let png_type = NSString::from_str(PASTEBOARD_TYPE_PNG);
+        if let Ok(png_bytes) = self.read_data_for_type(&png_type) {
+            return format::decode_image_rgba(&png_bytes, ImageFormat::Png);
+        }
+
+        let tiff_type = NSString::from_str(PASTEBOARD_TYPE_TIFF);
+        let tiff_bytes = self.read_data_for_type(&tiff_type)?;
+
+        format::decode_image_rgba(&tiff_bytes, ImageFormat::Tiff)
+    }
+}

--- a/crates/ag-clipboard/src/backend/unsupported.rs
+++ b/crates/ag-clipboard/src/backend/unsupported.rs
@@ -1,0 +1,11 @@
+use super::ClipboardBackend;
+use crate::ClipboardError;
+
+pub(crate) fn new_backend() -> Result<Box<dyn ClipboardBackend>, ClipboardError> {
+    Err(ClipboardError::Unavailable {
+        reason: format!(
+            "clipboard access is unsupported on {}",
+            std::env::consts::OS
+        ),
+    })
+}

--- a/crates/ag-clipboard/src/backend/wayland.rs
+++ b/crates/ag-clipboard/src/backend/wayland.rs
@@ -1,0 +1,423 @@
+#[cfg(target_os = "linux")]
+use std::io;
+use std::path::PathBuf;
+#[cfg(target_os = "linux")]
+use std::process::Command;
+
+use image::ImageFormat;
+
+use super::ClipboardBackend;
+use crate::{ClipboardError, RgbaImageData, format, uri};
+
+const IMAGE_PNG_MIME: &str = "image/png";
+const TEXT_URI_LIST_MIME: &str = "text/uri-list";
+#[cfg(target_os = "linux")]
+const WL_PASTE_COMMAND: &str = "wl-paste";
+const WL_PASTE_LIST_TYPES_ARGS: &[&str] = &["--list-types"];
+#[cfg(target_os = "linux")]
+const WL_PASTE_VERSION_ARGS: &[&str] = &["--version"];
+const TEXT_MIME_CANDIDATES: &[&str] = &[
+    "text/plain;charset=utf-8",
+    "text/plain;charset=UTF-8",
+    "text/plain",
+    "UTF8_STRING",
+    "TEXT",
+    "STRING",
+];
+
+pub(crate) struct WaylandClipboard {
+    runner: Box<dyn WaylandCommandRunner>,
+}
+
+impl WaylandClipboard {
+    #[cfg(target_os = "linux")]
+    pub(crate) fn new() -> Result<Self, ClipboardError> {
+        let clipboard = Self::with_runner(Box::new(SystemWaylandCommandRunner));
+        clipboard.ensure_wl_paste_available()?;
+
+        Ok(clipboard)
+    }
+
+    fn with_runner(runner: Box<dyn WaylandCommandRunner>) -> Self {
+        Self { runner }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn ensure_wl_paste_available(&self) -> Result<(), ClipboardError> {
+        let output = self.run_wl_paste(WL_PASTE_VERSION_ARGS)?;
+        if !output.status_success {
+            return Err(ClipboardError::Unavailable {
+                reason: "`wl-paste --version` failed; install the `wl-clipboard` package"
+                    .to_string(),
+            });
+        }
+
+        Ok(())
+    }
+
+    fn read_clipboard_bytes_for_mime(&self, mime_type: &str) -> Result<Vec<u8>, ClipboardError> {
+        let args = ["--no-newline", "--type", mime_type];
+
+        self.run_successful(&args, "failed to read Wayland clipboard payload")
+    }
+
+    fn available_mime_types(&self) -> Result<Vec<String>, ClipboardError> {
+        let stdout = self.run_successful(
+            WL_PASTE_LIST_TYPES_ARGS,
+            "failed to list Wayland clipboard types",
+        )?;
+        let mime_types = parse_mime_types(&stdout);
+        if mime_types.is_empty() {
+            return Err(ClipboardError::ContentUnavailable);
+        }
+
+        Ok(mime_types)
+    }
+
+    fn run_successful(
+        &self,
+        args: &[&str],
+        context: &'static str,
+    ) -> Result<Vec<u8>, ClipboardError> {
+        let output = self.run_wl_paste(args)?;
+        if !output.status_success {
+            return Err(ClipboardError::Backend {
+                reason: wl_paste_failure_reason(context, &output.stderr),
+            });
+        }
+
+        Ok(output.stdout)
+    }
+
+    fn run_wl_paste(&self, args: &[&str]) -> Result<WaylandCommandOutput, ClipboardError> {
+        let owned_args = args
+            .iter()
+            .map(|arg| (*arg).to_string())
+            .collect::<Vec<_>>();
+
+        self.runner.run(&owned_args)
+    }
+}
+
+impl ClipboardBackend for WaylandClipboard {
+    fn read_text(&mut self) -> Result<String, ClipboardError> {
+        let mime_types = self.available_mime_types()?;
+        let mime_type =
+            select_text_mime_type(&mime_types).ok_or(ClipboardError::ContentUnavailable)?;
+        let bytes = self.read_clipboard_bytes_for_mime(mime_type)?;
+
+        String::from_utf8(bytes).map_err(|error| {
+            ClipboardError::image_conversion(
+                "failed to decode Wayland clipboard text as UTF-8",
+                error,
+            )
+        })
+    }
+
+    fn read_file_list(&mut self) -> Result<Vec<PathBuf>, ClipboardError> {
+        let mime_types = self.available_mime_types()?;
+        if !mime_types
+            .iter()
+            .any(|mime_type| mime_type == TEXT_URI_LIST_MIME)
+        {
+            return Err(ClipboardError::ContentUnavailable);
+        }
+        let bytes = self.read_clipboard_bytes_for_mime(TEXT_URI_LIST_MIME)?;
+        let paths = uri::paths_from_uri_list(&bytes);
+        if paths.is_empty() {
+            return Err(ClipboardError::ContentUnavailable);
+        }
+
+        Ok(paths)
+    }
+
+    fn read_image_rgba(&mut self) -> Result<RgbaImageData, ClipboardError> {
+        let mime_types = self.available_mime_types()?;
+        if !mime_types
+            .iter()
+            .any(|mime_type| mime_type == IMAGE_PNG_MIME)
+        {
+            return Err(ClipboardError::ContentUnavailable);
+        }
+        let bytes = self.read_clipboard_bytes_for_mime(IMAGE_PNG_MIME)?;
+
+        format::decode_image_rgba(&bytes, ImageFormat::Png)
+    }
+}
+
+struct WaylandCommandOutput {
+    status_success: bool,
+    stderr: Vec<u8>,
+    stdout: Vec<u8>,
+}
+
+#[cfg_attr(test, mockall::automock)]
+trait WaylandCommandRunner {
+    fn run(&self, args: &[String]) -> Result<WaylandCommandOutput, ClipboardError>;
+}
+
+#[cfg(target_os = "linux")]
+struct SystemWaylandCommandRunner;
+
+#[cfg(target_os = "linux")]
+impl WaylandCommandRunner for SystemWaylandCommandRunner {
+    fn run(&self, args: &[String]) -> Result<WaylandCommandOutput, ClipboardError> {
+        let output = Command::new(WL_PASTE_COMMAND)
+            .args(args)
+            .output()
+            .map_err(map_wl_paste_spawn_error)?;
+
+        Ok(WaylandCommandOutput {
+            status_success: output.status.success(),
+            stderr: output.stderr,
+            stdout: output.stdout,
+        })
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn map_wl_paste_spawn_error(error: io::Error) -> ClipboardError {
+    if error.kind() == io::ErrorKind::NotFound {
+        return ClipboardError::Unavailable {
+            reason: "Wayland clipboard image paste requires `wl-paste`; install the \
+                     `wl-clipboard` package"
+                .to_string(),
+        };
+    }
+
+    ClipboardError::backend("failed to run `wl-paste`", error)
+}
+
+fn parse_mime_types(stdout: &[u8]) -> Vec<String> {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn select_text_mime_type(mime_types: &[String]) -> Option<&str> {
+    TEXT_MIME_CANDIDATES
+        .iter()
+        .find(|candidate| mime_types.iter().any(|mime_type| mime_type == **candidate))
+        .copied()
+}
+
+fn wl_paste_failure_reason(context: &str, stderr: &[u8]) -> String {
+    let stderr = String::from_utf8_lossy(stderr).trim().to_string();
+    if stderr.is_empty() {
+        return format!("{context}: `wl-paste` exited unsuccessfully");
+    }
+
+    format!("{context}: {stderr}")
+}
+
+#[cfg(test)]
+mod tests {
+    use image::codecs::png::PngEncoder;
+    use image::{ExtendedColorType, ImageEncoder};
+    use mockall::predicate;
+
+    use super::*;
+
+    #[test]
+    fn test_read_image_rgba_reads_wayland_png_payload() {
+        // Arrange
+        let mut runner = MockWaylandCommandRunner::new();
+        runner
+            .expect_run()
+            .once()
+            .with(predicate::function(|args: &[String]| {
+                args_match(args, &["--list-types"])
+            }))
+            .returning(|_| {
+                Ok(WaylandCommandOutput {
+                    status_success: true,
+                    stderr: Vec::new(),
+                    stdout: b"image/png\ntext/plain;charset=utf-8\n".to_vec(),
+                })
+            });
+        runner
+            .expect_run()
+            .once()
+            .with(predicate::function(|args: &[String]| {
+                args_match(args, &["--no-newline", "--type", "image/png"])
+            }))
+            .returning(|_| {
+                Ok(WaylandCommandOutput {
+                    status_success: true,
+                    stderr: Vec::new(),
+                    stdout: test_png_bytes(),
+                })
+            });
+        let mut clipboard = WaylandClipboard::with_runner(Box::new(runner));
+
+        // Act
+        let image_data = clipboard
+            .read_image_rgba()
+            .expect("mocked PNG payload should decode");
+
+        // Assert
+        assert_eq!(image_data.width, 1);
+        assert_eq!(image_data.height, 1);
+        assert_eq!(image_data.rgba_bytes, vec![255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn test_read_file_list_reads_wayland_uri_list_payload() {
+        // Arrange
+        let mut runner = MockWaylandCommandRunner::new();
+        runner
+            .expect_run()
+            .once()
+            .with(predicate::function(|args: &[String]| {
+                args_match(args, &["--list-types"])
+            }))
+            .returning(|_| {
+                Ok(WaylandCommandOutput {
+                    status_success: true,
+                    stderr: Vec::new(),
+                    stdout: b"text/uri-list\ntext/plain;charset=utf-8\n".to_vec(),
+                })
+            });
+        runner
+            .expect_run()
+            .once()
+            .with(predicate::function(|args: &[String]| {
+                args_match(args, &["--no-newline", "--type", "text/uri-list"])
+            }))
+            .returning(|_| {
+                Ok(WaylandCommandOutput {
+                    status_success: true,
+                    stderr: Vec::new(),
+                    stdout: b"file:///tmp/image%201.png\r\n".to_vec(),
+                })
+            });
+        let mut clipboard = WaylandClipboard::with_runner(Box::new(runner));
+
+        // Act
+        let paths = clipboard
+            .read_file_list()
+            .expect("mocked URI list should parse");
+
+        // Assert
+        assert_eq!(paths, vec![PathBuf::from("/tmp/image 1.png")]);
+    }
+
+    #[test]
+    fn test_read_text_prefers_utf8_plain_text_payload() {
+        // Arrange
+        let mut runner = MockWaylandCommandRunner::new();
+        runner
+            .expect_run()
+            .once()
+            .with(predicate::function(|args: &[String]| {
+                args_match(args, &["--list-types"])
+            }))
+            .returning(|_| {
+                Ok(WaylandCommandOutput {
+                    status_success: true,
+                    stderr: Vec::new(),
+                    stdout: b"text/html\ntext/plain;charset=utf-8\n".to_vec(),
+                })
+            });
+        runner
+            .expect_run()
+            .once()
+            .with(predicate::function(|args: &[String]| {
+                args_match(
+                    args,
+                    &["--no-newline", "--type", "text/plain;charset=utf-8"],
+                )
+            }))
+            .returning(|_| {
+                Ok(WaylandCommandOutput {
+                    status_success: true,
+                    stderr: Vec::new(),
+                    stdout: b"/tmp/image.png".to_vec(),
+                })
+            });
+        let mut clipboard = WaylandClipboard::with_runner(Box::new(runner));
+
+        // Act
+        let text = clipboard
+            .read_text()
+            .expect("mocked text payload should decode");
+
+        // Assert
+        assert_eq!(text, "/tmp/image.png");
+    }
+
+    #[test]
+    fn test_read_image_rgba_reports_content_unavailable_without_png_mime() {
+        // Arrange
+        let mut runner = MockWaylandCommandRunner::new();
+        runner
+            .expect_run()
+            .once()
+            .with(predicate::function(|args: &[String]| {
+                args_match(args, &["--list-types"])
+            }))
+            .returning(|_| {
+                Ok(WaylandCommandOutput {
+                    status_success: true,
+                    stderr: Vec::new(),
+                    stdout: b"text/plain;charset=utf-8\n".to_vec(),
+                })
+            });
+        let mut clipboard = WaylandClipboard::with_runner(Box::new(runner));
+
+        // Act
+        let result = clipboard.read_image_rgba();
+
+        // Assert
+        assert!(matches!(result, Err(ClipboardError::ContentUnavailable)));
+    }
+
+    #[test]
+    fn test_parse_mime_types_trims_blank_lines() {
+        // Arrange
+        let stdout = b"\n image/png \n\ntext/plain;charset=utf-8\n";
+
+        // Act
+        let mime_types = parse_mime_types(stdout);
+
+        // Assert
+        assert_eq!(
+            mime_types,
+            vec![
+                "image/png".to_string(),
+                "text/plain;charset=utf-8".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_wl_paste_failure_reason_uses_stderr_when_present() {
+        // Arrange
+        let stderr = b"compositor does not support data-control\n";
+
+        // Act
+        let reason = wl_paste_failure_reason("failed to list Wayland clipboard types", stderr);
+
+        // Assert
+        assert_eq!(
+            reason,
+            "failed to list Wayland clipboard types: compositor does not support data-control"
+        );
+    }
+
+    fn test_png_bytes() -> Vec<u8> {
+        let mut png_bytes = Vec::new();
+        PngEncoder::new(&mut png_bytes)
+            .write_image(&[255, 0, 0, 255], 1, 1, ExtendedColorType::Rgba8)
+            .expect("test PNG should encode");
+
+        png_bytes
+    }
+
+    fn args_match(args: &[String], expected: &[&str]) -> bool {
+        args.iter().map(String::as_str).eq(expected.iter().copied())
+    }
+}

--- a/crates/ag-clipboard/src/backend/x11.rs
+++ b/crates/ag-clipboard/src/backend/x11.rs
@@ -1,0 +1,616 @@
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use image::ImageFormat;
+use rustix::event::{self, PollFd, PollFlags, Timespec};
+use x11rb::connection::Connection;
+use x11rb::protocol::Event;
+use x11rb::protocol::xproto::{
+    Atom, ConnectionExt, CreateWindowAux, EventMask, GetPropertyReply, Property,
+    PropertyNotifyEvent, SelectionNotifyEvent, Time, WindowClass,
+};
+use x11rb::rust_connection::RustConnection;
+use x11rb::{COPY_DEPTH_FROM_PARENT, COPY_FROM_PARENT, NONE};
+
+use super::ClipboardBackend;
+use crate::{ClipboardError, RgbaImageData, format, uri};
+
+const INCR_RESERVATION_BYTE_CAP: usize = 16 * 1024 * 1024;
+const INCR_SEGMENT_TIMEOUT: Duration = Duration::from_secs(1);
+const INCR_TRANSFER_TIMEOUT: Duration = Duration::from_secs(30);
+const INCR_HEADER_LONG_LENGTH: u32 = 1;
+const MAX_CLIPBOARD_BYTE_COUNT: usize = 64 * 1024 * 1024;
+const MAX_CLIPBOARD_PROPERTY_LONG_LENGTH: u32 = 16 * 1024 * 1024;
+const SELECTION_TIMEOUT: Duration = Duration::from_millis(4000);
+
+x11rb::atom_manager! {
+    AtomCollection: AtomCollectionCookie {
+        CLIPBOARD,
+        TARGETS,
+        INCR,
+        UTF8_STRING,
+        UTF8_MIME_LOWER: b"text/plain;charset=utf-8",
+        UTF8_MIME_UPPER: b"text/plain;charset=UTF-8",
+        STRING,
+        TEXT,
+        TEXT_MIME: b"text/plain",
+        URI_LIST: b"text/uri-list",
+        PNG_MIME: b"image/png",
+        AGENTTY_CLIPBOARD,
+    }
+}
+
+pub(crate) struct X11Clipboard {
+    atoms: AtomCollection,
+    connection: RustConnection,
+    window_id: u32,
+}
+
+impl X11Clipboard {
+    pub(crate) fn new() -> Result<Self, ClipboardError> {
+        let (connection, screen_number) =
+            RustConnection::connect(None).map_err(|error| ClipboardError::Unavailable {
+                reason: format!("X11 clipboard connection failed: {error}"),
+            })?;
+        let screen =
+            connection
+                .setup()
+                .roots
+                .get(screen_number)
+                .ok_or_else(|| ClipboardError::Backend {
+                    reason: "X11 screen was not found".to_string(),
+                })?;
+        let window_id = connection
+            .generate_id()
+            .map_err(|error| ClipboardError::backend("failed to allocate X11 window id", error))?;
+        let event_mask = EventMask::PROPERTY_CHANGE | EventMask::STRUCTURE_NOTIFY;
+
+        connection
+            .create_window(
+                COPY_DEPTH_FROM_PARENT,
+                window_id,
+                screen.root,
+                0,
+                0,
+                1,
+                1,
+                0,
+                WindowClass::COPY_FROM_PARENT,
+                COPY_FROM_PARENT,
+                &CreateWindowAux::new().event_mask(event_mask),
+            )
+            .map_err(|error| {
+                ClipboardError::backend("failed to create X11 clipboard window", error)
+            })?;
+        connection.flush().map_err(|error| {
+            ClipboardError::backend("failed to flush X11 clipboard window", error)
+        })?;
+        let atoms = AtomCollection::new(&connection)
+            .map_err(|error| {
+                ClipboardError::backend("failed to request X11 clipboard atoms", error)
+            })?
+            .reply()
+            .map_err(|error| {
+                ClipboardError::backend("failed to load X11 clipboard atoms", error)
+            })?;
+
+        Ok(Self {
+            atoms,
+            connection,
+            window_id,
+        })
+    }
+
+    fn read_clipboard_data(
+        &self,
+        target_formats: &[Atom],
+    ) -> Result<ClipboardData, ClipboardError> {
+        for target_format in target_formats {
+            match self.read_target(*target_format) {
+                Ok(bytes) => {
+                    return Ok(ClipboardData {
+                        bytes,
+                        format: *target_format,
+                    });
+                }
+                Err(ClipboardError::ContentUnavailable) => {}
+                Err(error) => return Err(error),
+            }
+        }
+
+        Err(ClipboardError::ContentUnavailable)
+    }
+
+    fn read_target(&self, target_format: Atom) -> Result<Vec<u8>, ClipboardError> {
+        self.connection
+            .delete_property(self.window_id, self.atoms.AGENTTY_CLIPBOARD)
+            .map_err(|error| {
+                ClipboardError::backend("failed to clear X11 clipboard property", error)
+            })?;
+        self.connection
+            .convert_selection(
+                self.window_id,
+                self.atoms.CLIPBOARD,
+                target_format,
+                self.atoms.AGENTTY_CLIPBOARD,
+                Time::CURRENT_TIME,
+            )
+            .map_err(|error| {
+                ClipboardError::backend("failed to request X11 clipboard selection", error)
+            })?;
+        self.connection.flush().map_err(|error| {
+            ClipboardError::backend("failed to flush X11 clipboard request", error)
+        })?;
+
+        let mut timeout_end = Instant::now() + SELECTION_TIMEOUT;
+        let mut is_incr_transfer = false;
+        let mut incr_transfer_timeout_end = None;
+        let mut incr_transfer = IncrTransfer::default();
+
+        while Instant::now() < timeout_end {
+            let Some(event) = self.connection.poll_for_event().map_err(|error| {
+                ClipboardError::backend("failed to poll X11 clipboard events", error)
+            })?
+            else {
+                if !wait_for_x11_event(&self.connection, timeout_end)? {
+                    break;
+                }
+                continue;
+            };
+
+            match event {
+                Event::SelectionNotify(event) => match self.handle_selection_notify(
+                    event,
+                    target_format,
+                    &mut is_incr_transfer,
+                    &mut incr_transfer,
+                )? {
+                    SelectionRead::Complete(bytes) => return Ok(bytes),
+                    SelectionRead::IncrStarted => {
+                        let now = Instant::now();
+                        incr_transfer_timeout_end = Some(now + INCR_TRANSFER_TIMEOUT);
+                        timeout_end = next_incr_timeout(now, incr_transfer_timeout_end);
+                    }
+                    SelectionRead::Ignored => {}
+                },
+                Event::PropertyNotify(event)
+                    if self.handle_property_notify(
+                        &event,
+                        target_format,
+                        is_incr_transfer,
+                        &mut incr_transfer,
+                        incr_transfer_timeout_end,
+                        &mut timeout_end,
+                    )? =>
+                {
+                    return Ok(incr_transfer.finish());
+                }
+                _ => {}
+            }
+        }
+
+        Err(ClipboardError::ContentUnavailable)
+    }
+
+    fn handle_selection_notify(
+        &self,
+        event: SelectionNotifyEvent,
+        target_format: Atom,
+        is_incr_transfer: &mut bool,
+        incr_transfer: &mut IncrTransfer,
+    ) -> Result<SelectionRead, ClipboardError> {
+        if event.property == NONE || event.target != target_format {
+            return Err(ClipboardError::ContentUnavailable);
+        }
+        if event.selection != self.atoms.CLIPBOARD {
+            return Ok(SelectionRead::Ignored);
+        }
+        if *is_incr_transfer {
+            return Ok(SelectionRead::Ignored);
+        }
+
+        let mut property = self
+            .connection
+            .get_property(
+                true,
+                event.requestor,
+                event.property,
+                event.target,
+                0,
+                MAX_CLIPBOARD_PROPERTY_LONG_LENGTH,
+            )
+            .map_err(|error| {
+                ClipboardError::backend("failed to read X11 clipboard property", error)
+            })?
+            .reply()
+            .map_err(|error| {
+                ClipboardError::backend("failed to receive X11 clipboard property", error)
+            })?;
+        ensure_property_payload_within_limit(&property)?;
+
+        if property.type_ == target_format {
+            return Ok(SelectionRead::Complete(property.value));
+        }
+        if property.type_ != self.atoms.INCR {
+            return Err(ClipboardError::Backend {
+                reason: "X11 clipboard owner returned an unexpected property type".to_string(),
+            });
+        }
+
+        property = self
+            .connection
+            .get_property(
+                true,
+                event.requestor,
+                event.property,
+                self.atoms.INCR,
+                0,
+                INCR_HEADER_LONG_LENGTH,
+            )
+            .map_err(|error| ClipboardError::backend("failed to read X11 INCR header", error))?
+            .reply()
+            .map_err(|error| ClipboardError::backend("failed to receive X11 INCR header", error))?;
+        if let Some(minimum_byte_count) = minimum_incr_byte_count(&property) {
+            incr_transfer.reserve_at_least(minimum_byte_count)?;
+        }
+        *is_incr_transfer = true;
+
+        Ok(SelectionRead::IncrStarted)
+    }
+
+    fn handle_property_notify(
+        &self,
+        event: &PropertyNotifyEvent,
+        target_format: Atom,
+        is_incr_transfer: bool,
+        incr_transfer: &mut IncrTransfer,
+        incr_transfer_timeout_end: Option<Instant>,
+        timeout_end: &mut Instant,
+    ) -> Result<bool, ClipboardError> {
+        if event.atom != self.atoms.AGENTTY_CLIPBOARD || event.state != Property::NEW_VALUE {
+            return Ok(false);
+        }
+        if !is_incr_transfer {
+            return Ok(false);
+        }
+
+        let property = self
+            .connection
+            .get_property(
+                true,
+                event.window,
+                event.atom,
+                target_format,
+                0,
+                MAX_CLIPBOARD_PROPERTY_LONG_LENGTH,
+            )
+            .map_err(|error| ClipboardError::backend("failed to read X11 INCR segment", error))?
+            .reply()
+            .map_err(|error| {
+                ClipboardError::backend("failed to receive X11 INCR segment", error)
+            })?;
+        ensure_property_payload_within_limit(&property)?;
+        if property.value_len == 0 {
+            return Ok(true);
+        }
+
+        incr_transfer.push_chunk(property.value)?;
+        *timeout_end = next_incr_timeout(Instant::now(), incr_transfer_timeout_end);
+
+        Ok(false)
+    }
+}
+
+impl ClipboardBackend for X11Clipboard {
+    fn read_text(&mut self) -> Result<String, ClipboardError> {
+        let target_formats = [
+            self.atoms.UTF8_STRING,
+            self.atoms.UTF8_MIME_LOWER,
+            self.atoms.UTF8_MIME_UPPER,
+            self.atoms.STRING,
+            self.atoms.TEXT,
+            self.atoms.TEXT_MIME,
+        ];
+        let clipboard_data = self.read_clipboard_data(&target_formats)?;
+        if clipboard_data.format == self.atoms.STRING {
+            return Ok(latin1_bytes_to_string(clipboard_data.bytes));
+        }
+
+        String::from_utf8(clipboard_data.bytes).map_err(|error| {
+            ClipboardError::image_conversion("failed to decode X11 clipboard text as UTF-8", error)
+        })
+    }
+
+    fn read_file_list(&mut self) -> Result<Vec<PathBuf>, ClipboardError> {
+        let clipboard_data = self.read_clipboard_data(&[self.atoms.URI_LIST])?;
+        let paths = uri::paths_from_uri_list(&clipboard_data.bytes);
+        if paths.is_empty() {
+            return Err(ClipboardError::ContentUnavailable);
+        }
+
+        Ok(paths)
+    }
+
+    fn read_image_rgba(&mut self) -> Result<RgbaImageData, ClipboardError> {
+        let clipboard_data = self.read_clipboard_data(&[self.atoms.PNG_MIME])?;
+
+        format::decode_image_rgba(&clipboard_data.bytes, ImageFormat::Png)
+    }
+}
+
+impl Drop for X11Clipboard {
+    fn drop(&mut self) {
+        if self.connection.destroy_window(self.window_id).is_ok() {
+            let _ = self.connection.flush();
+        }
+    }
+}
+
+struct ClipboardData {
+    bytes: Vec<u8>,
+    format: Atom,
+}
+
+enum SelectionRead {
+    Complete(Vec<u8>),
+    Ignored,
+    IncrStarted,
+}
+
+#[derive(Default)]
+struct IncrTransfer {
+    bytes: Vec<u8>,
+}
+
+impl IncrTransfer {
+    fn reserve_at_least(&mut self, minimum_byte_count: u32) -> Result<(), ClipboardError> {
+        let minimum_byte_count = checked_clipboard_byte_count(0, minimum_byte_count as usize)?;
+
+        self.bytes
+            .reserve_exact(Self::capped_reservation(minimum_byte_count));
+
+        Ok(())
+    }
+
+    fn push_chunk(&mut self, chunk: Vec<u8>) -> Result<(), ClipboardError> {
+        checked_clipboard_byte_count(self.bytes.len(), chunk.len())?;
+        self.bytes.extend(chunk);
+
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.bytes)
+    }
+
+    fn capped_reservation(minimum_byte_count: usize) -> usize {
+        minimum_byte_count.min(INCR_RESERVATION_BYTE_CAP)
+    }
+}
+
+fn minimum_incr_byte_count(property: &GetPropertyReply) -> Option<u32> {
+    property.value32().and_then(|mut values| values.next())
+}
+
+fn ensure_property_payload_within_limit(property: &GetPropertyReply) -> Result<(), ClipboardError> {
+    checked_clipboard_byte_count(property.value.len(), property.bytes_after as usize)?;
+
+    Ok(())
+}
+
+fn checked_clipboard_byte_count(
+    current_byte_count: usize,
+    additional_byte_count: usize,
+) -> Result<usize, ClipboardError> {
+    let byte_count = current_byte_count
+        .checked_add(additional_byte_count)
+        .ok_or_else(|| clipboard_payload_too_large(usize::MAX))?;
+    if byte_count > MAX_CLIPBOARD_BYTE_COUNT {
+        return Err(clipboard_payload_too_large(byte_count));
+    }
+
+    Ok(byte_count)
+}
+
+fn clipboard_payload_too_large(byte_count: usize) -> ClipboardError {
+    ClipboardError::Backend {
+        reason: format!(
+            "X11 clipboard payload exceeds {MAX_CLIPBOARD_BYTE_COUNT} byte limit ({byte_count} \
+             bytes)"
+        ),
+    }
+}
+
+fn wait_for_x11_event(
+    connection: &RustConnection,
+    timeout_end: Instant,
+) -> Result<bool, ClipboardError> {
+    let Some(timeout) = poll_timeout_until(Instant::now(), timeout_end) else {
+        return Ok(false);
+    };
+    let mut poll_fds = [PollFd::new(connection.stream(), PollFlags::IN)];
+    let ready_count = event::poll(&mut poll_fds, Some(&timeout)).map_err(|error| {
+        ClipboardError::backend("failed to wait for X11 clipboard events", error)
+    })?;
+
+    Ok(ready_count > 0)
+}
+
+fn poll_timeout_until(now: Instant, timeout_end: Instant) -> Option<Timespec> {
+    if now >= timeout_end {
+        return None;
+    }
+    let duration = timeout_end.checked_duration_since(now)?;
+
+    Some(duration_to_timespec(duration))
+}
+
+fn duration_to_timespec(duration: Duration) -> Timespec {
+    Timespec::try_from(duration).unwrap_or(Timespec {
+        tv_sec: i64::MAX,
+        tv_nsec: 999_999_999,
+    })
+}
+
+fn next_incr_timeout(now: Instant, transfer_timeout_end: Option<Instant>) -> Instant {
+    let segment_timeout_end = now + INCR_SEGMENT_TIMEOUT;
+
+    transfer_timeout_end.map_or(segment_timeout_end, |deadline| {
+        segment_timeout_end.min(deadline)
+    })
+}
+
+fn latin1_bytes_to_string(bytes: Vec<u8>) -> String {
+    bytes.into_iter().map(char::from).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MAX_CLIPBOARD_BYTE_COUNT_U32: u32 = 64 * 1024 * 1024;
+
+    #[test]
+    fn test_latin1_bytes_to_string_maps_bytes_directly_to_unicode_scalars() {
+        // Arrange
+        let bytes = vec![b'a', 0xE9, b'z'];
+
+        // Act
+        let text = latin1_bytes_to_string(bytes);
+
+        // Assert
+        assert_eq!(text, "a\u{e9}z");
+    }
+
+    #[test]
+    fn test_incr_transfer_reassembles_chunks_and_resets_on_finish() {
+        // Arrange
+        let mut transfer = IncrTransfer::default();
+        transfer
+            .reserve_at_least(8)
+            .expect("small reservation should fit");
+
+        // Act
+        transfer
+            .push_chunk(b"abc".to_vec())
+            .expect("first chunk should fit");
+        transfer
+            .push_chunk(b"def".to_vec())
+            .expect("second chunk should fit");
+        let bytes = transfer.finish();
+
+        // Assert
+        assert_eq!(bytes, b"abcdef");
+        assert_eq!(transfer.finish(), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn test_incr_transfer_caps_advertised_reservation() {
+        // Arrange
+        let advertised_byte_count = MAX_CLIPBOARD_BYTE_COUNT;
+
+        // Act
+        let reservation_byte_count = IncrTransfer::capped_reservation(advertised_byte_count);
+
+        // Assert
+        assert_eq!(reservation_byte_count, INCR_RESERVATION_BYTE_CAP);
+    }
+
+    #[test]
+    fn test_incr_transfer_rejects_advertised_payload_above_limit() {
+        // Arrange
+        let mut transfer = IncrTransfer::default();
+        let advertised_byte_count = MAX_CLIPBOARD_BYTE_COUNT_U32 + 1;
+
+        // Act
+        let result = transfer.reserve_at_least(advertised_byte_count);
+
+        // Assert
+        assert!(matches!(result, Err(ClipboardError::Backend { .. })));
+    }
+
+    #[test]
+    fn test_checked_clipboard_byte_count_rejects_payload_above_limit() {
+        // Arrange
+        let current_byte_count = MAX_CLIPBOARD_BYTE_COUNT;
+        let additional_byte_count = 1;
+
+        // Act
+        let result = checked_clipboard_byte_count(current_byte_count, additional_byte_count);
+
+        // Assert
+        assert!(matches!(result, Err(ClipboardError::Backend { .. })));
+    }
+
+    #[test]
+    fn test_property_payload_limit_rejects_payload_above_limit() {
+        // Arrange
+        let property = GetPropertyReply {
+            bytes_after: MAX_CLIPBOARD_BYTE_COUNT_U32,
+            format: 8,
+            length: 0,
+            sequence: 0,
+            type_: 0,
+            value: vec![0],
+            value_len: 1,
+        };
+
+        // Act
+        let result = ensure_property_payload_within_limit(&property);
+
+        // Assert
+        assert!(matches!(result, Err(ClipboardError::Backend { .. })));
+    }
+
+    #[test]
+    fn test_next_incr_timeout_uses_segment_timeout_without_transfer_cap() {
+        // Arrange
+        let now = Instant::now();
+
+        // Act
+        let timeout_end = next_incr_timeout(now, None);
+
+        // Assert
+        assert_eq!(timeout_end, now + INCR_SEGMENT_TIMEOUT);
+    }
+
+    #[test]
+    fn test_next_incr_timeout_caps_segment_timeout_to_transfer_deadline() {
+        // Arrange
+        let now = Instant::now();
+        let transfer_timeout_end = now + Duration::from_millis(50);
+
+        // Act
+        let timeout_end = next_incr_timeout(now, Some(transfer_timeout_end));
+
+        // Assert
+        assert_eq!(timeout_end, transfer_timeout_end);
+    }
+
+    #[test]
+    fn test_poll_timeout_until_returns_remaining_duration() {
+        // Arrange
+        let now = Instant::now();
+        let timeout_end = now + Duration::from_millis(1500);
+
+        // Act
+        let timeout = poll_timeout_until(now, timeout_end).expect("deadline should be in future");
+
+        // Assert
+        assert_eq!(timeout.tv_sec, 1);
+        assert_eq!(timeout.tv_nsec, 500_000_000);
+    }
+
+    #[test]
+    fn test_poll_timeout_until_returns_none_after_deadline() {
+        // Arrange
+        let now = Instant::now();
+        let timeout_end = now;
+
+        // Act
+        let timeout = poll_timeout_until(now, timeout_end);
+
+        // Assert
+        assert_eq!(timeout, None);
+    }
+}

--- a/crates/ag-clipboard/src/error.rs
+++ b/crates/ag-clipboard/src/error.rs
@@ -1,0 +1,53 @@
+use std::fmt;
+
+/// Error returned by platform clipboard backends.
+#[derive(Debug, thiserror::Error)]
+pub enum ClipboardError {
+    /// Clipboard access is unavailable on the current platform or display
+    /// server.
+    #[error("Clipboard backend is unavailable: {reason}")]
+    Unavailable {
+        /// Human-readable backend availability reason.
+        reason: String,
+    },
+
+    /// The clipboard does not contain the requested payload type.
+    #[error("Clipboard content is unavailable")]
+    ContentUnavailable,
+
+    /// The selected backend does not support the requested operation.
+    #[error("Clipboard operation is unsupported: {operation}")]
+    Unsupported {
+        /// Operation name.
+        operation: &'static str,
+    },
+
+    /// The backend failed while talking to the platform clipboard service.
+    #[error("Clipboard backend failed: {reason}")]
+    Backend {
+        /// Human-readable backend failure reason.
+        reason: String,
+    },
+
+    /// Clipboard image bytes could not be decoded into RGBA pixels.
+    #[error("Clipboard image conversion failed: {reason}")]
+    ImageConversion {
+        /// Human-readable image conversion reason.
+        reason: String,
+    },
+}
+
+impl ClipboardError {
+    #[cfg(target_os = "linux")]
+    pub(crate) fn backend(context: &str, error: impl fmt::Display) -> Self {
+        Self::Backend {
+            reason: format!("{context}: {error}"),
+        }
+    }
+
+    pub(crate) fn image_conversion(context: &str, error: impl fmt::Display) -> Self {
+        Self::ImageConversion {
+            reason: format!("{context}: {error}"),
+        }
+    }
+}

--- a/crates/ag-clipboard/src/format.rs
+++ b/crates/ag-clipboard/src/format.rs
@@ -1,0 +1,52 @@
+use image::ImageFormat;
+
+use crate::{ClipboardError, RgbaImageData};
+
+pub(crate) fn decode_image_rgba(
+    image_bytes: &[u8],
+    image_format: ImageFormat,
+) -> Result<RgbaImageData, ClipboardError> {
+    let decoded_image = image::load_from_memory_with_format(image_bytes, image_format)
+        .map_err(|error| {
+            ClipboardError::image_conversion("failed to decode clipboard image", error)
+        })?
+        .into_rgba8();
+    let (width, height) = decoded_image.dimensions();
+
+    Ok(RgbaImageData {
+        height,
+        rgba_bytes: decoded_image.into_raw(),
+        width,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use image::codecs::png::PngEncoder;
+    use image::{ExtendedColorType, ImageEncoder};
+
+    use super::*;
+
+    #[test]
+    fn test_decode_image_rgba_returns_dimensions_and_rgba_bytes() {
+        // Arrange
+        let mut png_bytes = Vec::new();
+        PngEncoder::new(&mut png_bytes)
+            .write_image(
+                &[255, 0, 0, 255, 0, 255, 0, 255],
+                2,
+                1,
+                ExtendedColorType::Rgba8,
+            )
+            .expect("test PNG should encode");
+
+        // Act
+        let image_data =
+            decode_image_rgba(&png_bytes, ImageFormat::Png).expect("PNG should decode");
+
+        // Assert
+        assert_eq!(image_data.width, 2);
+        assert_eq!(image_data.height, 1);
+        assert_eq!(image_data.rgba_bytes, vec![255, 0, 0, 255, 0, 255, 0, 255]);
+    }
+}

--- a/crates/ag-clipboard/src/image_data.rs
+++ b/crates/ag-clipboard/src/image_data.rs
@@ -1,0 +1,10 @@
+/// Owned RGBA image pixels read from the system clipboard.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RgbaImageData {
+    /// Image height in pixels.
+    pub height: u32,
+    /// Pixel data in RGBA byte order.
+    pub rgba_bytes: Vec<u8>,
+    /// Image width in pixels.
+    pub width: u32,
+}

--- a/crates/ag-clipboard/src/lib.rs
+++ b/crates/ag-clipboard/src/lib.rs
@@ -1,0 +1,88 @@
+//! Narrow read-only clipboard access used by Agentty prompt image capture.
+
+mod backend;
+mod error;
+mod format;
+mod image_data;
+mod uri;
+
+use std::path::PathBuf;
+
+pub use error::ClipboardError;
+pub use image_data::RgbaImageData;
+
+const DISABLE_CLIPBOARD_ENV: &str = "AGENTTY_DISABLE_CLIPBOARD";
+
+/// System clipboard reader for text, copied files, and RGBA image data.
+pub struct Clipboard {
+    backend: Box<dyn backend::ClipboardBackend>,
+}
+
+impl Clipboard {
+    /// Opens the best clipboard backend available on the current platform.
+    ///
+    /// # Errors
+    /// Returns [`ClipboardError::Unavailable`] when no supported clipboard
+    /// backend is available for the current display server or operating
+    /// system.
+    #[cfg(target_os = "macos")]
+    pub fn new() -> Result<Self, ClipboardError> {
+        if let Some(error) = Self::disabled_by_env() {
+            return Err(error);
+        }
+
+        Ok(Self {
+            backend: backend::new_backend(),
+        })
+    }
+
+    /// Opens the best clipboard backend available on the current platform.
+    ///
+    /// # Errors
+    /// Returns [`ClipboardError::Unavailable`] when no supported clipboard
+    /// backend is available for the current display server or operating
+    /// system.
+    #[cfg(not(target_os = "macos"))]
+    pub fn new() -> Result<Self, ClipboardError> {
+        if let Some(error) = Self::disabled_by_env() {
+            return Err(error);
+        }
+
+        Ok(Self {
+            backend: backend::new_backend()?,
+        })
+    }
+
+    /// Reads clipboard text.
+    ///
+    /// # Errors
+    /// Returns a [`ClipboardError`] when the clipboard has no text or the
+    /// backend cannot complete the read.
+    pub fn read_text(&mut self) -> Result<String, ClipboardError> {
+        self.backend.read_text()
+    }
+
+    /// Reads copied filesystem paths from the clipboard.
+    ///
+    /// # Errors
+    /// Returns a [`ClipboardError`] when the clipboard has no file-list payload
+    /// or the backend cannot complete the read.
+    pub fn read_file_list(&mut self) -> Result<Vec<PathBuf>, ClipboardError> {
+        self.backend.read_file_list()
+    }
+
+    /// Reads clipboard image data as RGBA pixels.
+    ///
+    /// # Errors
+    /// Returns a [`ClipboardError`] when the clipboard has no image payload,
+    /// image decoding fails, or the backend cannot complete the read.
+    pub fn read_image_rgba(&mut self) -> Result<RgbaImageData, ClipboardError> {
+        self.backend.read_image_rgba()
+    }
+
+    fn disabled_by_env() -> Option<ClipboardError> {
+        std::env::var_os(DISABLE_CLIPBOARD_ENV).map(|_| ClipboardError::Unavailable {
+            reason: format!("clipboard access is disabled by `{DISABLE_CLIPBOARD_ENV}`"),
+        })
+    }
+}

--- a/crates/ag-clipboard/src/uri.rs
+++ b/crates/ag-clipboard/src/uri.rs
@@ -1,0 +1,82 @@
+use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
+use std::path::PathBuf;
+
+use percent_encoding::percent_decode_str;
+
+#[cfg(any(target_os = "linux", test))]
+pub(crate) fn paths_from_uri_list(uri_list_bytes: &[u8]) -> Vec<PathBuf> {
+    String::from_utf8_lossy(uri_list_bytes)
+        .lines()
+        .filter_map(|line| path_from_file_url_text(line.trim_end_matches('\r')))
+        .collect()
+}
+
+pub(crate) fn path_from_file_url_text(file_url: &str) -> Option<PathBuf> {
+    let file_url = file_url.trim();
+    if file_url.is_empty() || file_url.starts_with('#') {
+        return None;
+    }
+
+    let path_fragment = file_url.strip_prefix("file://")?;
+    let path_fragment = path_fragment
+        .strip_prefix("localhost")
+        .unwrap_or(path_fragment);
+    if !path_fragment.starts_with('/') {
+        return None;
+    }
+
+    let decoded_path = percent_decode_str(path_fragment).collect::<Vec<_>>();
+
+    Some(PathBuf::from(os_string_from_bytes(decoded_path)))
+}
+
+#[cfg(unix)]
+fn os_string_from_bytes(bytes: Vec<u8>) -> OsString {
+    OsString::from_vec(bytes)
+}
+
+#[cfg(not(unix))]
+fn os_string_from_bytes(bytes: Vec<u8>) -> OsString {
+    OsString::from(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_paths_from_uri_list_ignores_comments_and_decodes_file_paths() {
+        // Arrange
+        let uri_list =
+            b"# copied files\r\nfile:///tmp/image%201.png\r\nfile://localhost/tmp/second.png\r\n";
+
+        // Act
+        let paths = paths_from_uri_list(uri_list);
+
+        // Assert
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("/tmp/image 1.png"),
+                PathBuf::from("/tmp/second.png")
+            ]
+        );
+    }
+
+    #[test]
+    fn test_path_from_file_url_text_rejects_non_file_and_remote_urls() {
+        // Arrange
+        let http_url = "https://example.com/image.png";
+        let remote_file_url = "file://example.com/tmp/image.png";
+
+        // Act
+        let http_path = path_from_file_url_text(http_url);
+        let remote_file_path = path_from_file_url_text(remote_file_url);
+
+        // Assert
+        assert_eq!(http_path, None);
+        assert_eq!(remote_file_path, None);
+    }
+}

--- a/crates/ag-xtask/src/workspace_map.rs
+++ b/crates/ag-xtask/src/workspace_map.rs
@@ -13,10 +13,11 @@ const ARCHITECTURE_DOCS: [&str; 4] = [
     "docs/site/content/docs/architecture/change-recipes.md",
     "docs/site/content/docs/architecture/testability-boundaries.md",
 ];
-const AGENT_GUIDES: [&str; 15] = [
+const AGENT_GUIDES: [&str; 16] = [
     "AGENTS.md",
     "skills/AGENTS.md",
     "crates/AGENTS.md",
+    "crates/ag-clipboard/AGENTS.md",
     "crates/ag-forge/AGENTS.md",
     "crates/ag-git/AGENTS.md",
     "crates/ag-protocol/AGENTS.md",

--- a/crates/agentty/Cargo.toml
+++ b/crates/agentty/Cargo.toml
@@ -16,12 +16,12 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
+ag-clipboard.workspace = true
 ag-forge.workspace = true
 ag-git.workspace = true
 ag-protocol.workspace = true
 agent-client-protocol.workspace = true
 async-trait.workspace = true
-arboard.workspace = true
 askama.workspace = true
 base64.workspace = true
 crossterm.workspace = true

--- a/crates/agentty/src/infra/clipboard_image.rs
+++ b/crates/agentty/src/infra/clipboard_image.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
-use arboard::Clipboard;
+use ag_clipboard::Clipboard;
 use image::codecs::png::PngEncoder;
 use image::{ExtendedColorType, ImageEncoder};
 
@@ -38,13 +38,6 @@ pub(crate) enum ClipboardError {
     /// A referenced PNG path from clipboard text does not exist on disk.
     #[error("Clipboard PNG path does not exist")]
     PngPathNotFound,
-
-    /// Clipboard image dimensions exceed the `u32` range.
-    #[error("Clipboard image {dimension} is too large")]
-    DimensionOverflow {
-        /// Which dimension overflowed (`"width"` or `"height"`).
-        dimension: &'static str,
-    },
 
     /// A parent directory for the clipboard image is missing from the path.
     #[error("Missing clipboard image directory")]
@@ -107,7 +100,7 @@ pub(crate) trait ClipboardImageClient: Send + Sync {
     ) -> ClipboardImageFuture<Result<PersistedClipboardImage, ClipboardError>>;
 }
 
-/// Production [`ClipboardImageClient`] backed by `arboard`, the injected
+/// Production [`ClipboardImageClient`] backed by `ag-clipboard`, the injected
 /// filesystem boundary, and the injected wall clock.
 pub(crate) struct RealClipboardImageClient {
     clock: Arc<dyn Clock>,
@@ -170,6 +163,10 @@ async fn persist_clipboard_image(
 #[must_use]
 pub(crate) fn normalize_clipboard_image_error(error: &ClipboardError) -> String {
     match error {
+        ClipboardError::Unavailable { reason } if reason.contains("wl-paste") => {
+            "Wayland clipboard image paste requires wl-paste. Install the wl-clipboard package."
+                .to_string()
+        }
         ClipboardError::Unavailable { .. } => {
             "Clipboard is unavailable. Try again after granting clipboard access.".to_string()
         }
@@ -182,9 +179,7 @@ pub(crate) fn normalize_clipboard_image_error(error: &ClipboardError) -> String 
             "Failed to persist pasted image from the clipboard.".to_string()
         }
         ClipboardError::TaskJoin(_) => "Clipboard image capture failed.".to_string(),
-        ClipboardError::DimensionOverflow { .. }
-        | ClipboardError::EmptySessionId
-        | ClipboardError::SystemClock(_) => error.to_string(),
+        ClipboardError::EmptySessionId | ClipboardError::SystemClock(_) => error.to_string(),
     }
 }
 
@@ -240,8 +235,7 @@ fn session_temp_directory_name(session_id: &str) -> Result<&str, ClipboardError>
 /// file is present.
 fn clipboard_png_path_from_file_list(clipboard: &mut Clipboard) -> Result<PathBuf, ClipboardError> {
     clipboard
-        .get()
-        .file_list()
+        .read_file_list()
         .map_err(|_| ClipboardError::NoImage)?
         .into_iter()
         .find(|path| is_png_path(path))
@@ -254,7 +248,7 @@ fn clipboard_png_path_from_file_list(clipboard: &mut Clipboard) -> Result<PathBu
 /// # Errors
 /// Returns an error when clipboard text is unavailable or is not a PNG path.
 fn clipboard_png_path_from_text(clipboard: &mut Clipboard) -> Result<PathBuf, ClipboardError> {
-    let clipboard_text = clipboard.get_text().map_err(|_| ClipboardError::NoImage)?;
+    let clipboard_text = clipboard.read_text().map_err(|_| ClipboardError::NoImage)?;
     let source_image_path = PathBuf::from(clipboard_text.trim());
 
     if !is_png_path(&source_image_path) {
@@ -285,9 +279,9 @@ async fn read_clipboard_payload() -> Result<ClipboardPayload, ClipboardError> {
 
         if let Ok(source_image_path) = clipboard_png_path_from_file_list(&mut clipboard) {
             Ok(ClipboardPayload::ExistingPngPath(source_image_path))
-        } else if let Ok(image_data) = clipboard.get_image() {
+        } else if let Ok(image_data) = clipboard.read_image_rgba() {
             let encoded_png = encode_clipboard_image_to_png(
-                image_data.bytes.as_ref(),
+                &image_data.rgba_bytes,
                 image_data.width,
                 image_data.height,
             )?;
@@ -330,18 +324,12 @@ enum ClipboardPayload {
 /// Encodes one clipboard image buffer into PNG bytes.
 ///
 /// # Errors
-/// Returns an error when either image dimension exceeds the `u32` range or
-/// the PNG encoder fails.
+/// Returns an error when the PNG encoder fails.
 fn encode_clipboard_image_to_png(
     image_bytes: &[u8],
-    width: usize,
-    height: usize,
+    image_width: u32,
+    image_height: u32,
 ) -> Result<Vec<u8>, ClipboardError> {
-    let image_width = u32::try_from(width)
-        .map_err(|_| ClipboardError::DimensionOverflow { dimension: "width" })?;
-    let image_height = u32::try_from(height).map_err(|_| ClipboardError::DimensionOverflow {
-        dimension: "height",
-    })?;
     let mut encoded_png = Vec::new();
 
     PngEncoder::new(&mut encoded_png)
@@ -648,6 +636,25 @@ mod tests {
     }
 
     #[test]
+    fn test_normalize_clipboard_image_error_maps_missing_wl_paste_to_package_status() {
+        // Arrange
+        let error = ClipboardError::Unavailable {
+            reason: "Clipboard backend is unavailable: Wayland clipboard image paste requires \
+                     `wl-paste`; install the `wl-clipboard` package"
+                .to_string(),
+        };
+
+        // Act
+        let normalized_error = normalize_clipboard_image_error(&error);
+
+        // Assert
+        assert_eq!(
+            normalized_error,
+            "Wayland clipboard image paste requires wl-paste. Install the wl-clipboard package."
+        );
+    }
+
+    #[test]
     fn test_normalize_clipboard_image_error_maps_no_image_to_short_status() {
         // Arrange
         let error = ClipboardError::NoImage;
@@ -692,17 +699,5 @@ mod tests {
 
         // Assert
         assert_eq!(normalized_error, "Clipboard image capture failed.");
-    }
-
-    #[test]
-    fn test_normalize_clipboard_image_error_passes_through_dimension_overflow() {
-        // Arrange
-        let error = ClipboardError::DimensionOverflow { dimension: "width" };
-
-        // Act
-        let normalized_error = normalize_clipboard_image_error(&error);
-
-        // Assert
-        assert_eq!(normalized_error, "Clipboard image width is too large");
     }
 }

--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -1279,6 +1279,47 @@ mod tests {
         }
     }
 
+    /// Verifies unavailable clipboard backends surface as inline paste errors
+    /// without mutating prompt attachments.
+    #[tokio::test]
+    async fn test_handle_prompt_image_paste_reports_unavailable_clipboard_backend() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("Review ", None).await;
+        let prompt_context = prompt_context(&mut app).expect("expected prompt context");
+        let mut clipboard_image_client =
+            crate::infra::clipboard_image::MockClipboardImageClient::new();
+        clipboard_image_client
+            .expect_persist_clipboard_image()
+            .once()
+            .returning(|_, _| {
+                Box::pin(async {
+                    Err(crate::infra::clipboard_image::ClipboardError::Unavailable {
+                        reason: "unsupported clipboard backend".to_string(),
+                    })
+                })
+            });
+        install_mock_clipboard_image_client(&mut app, clipboard_image_client);
+
+        // Act
+        handle_prompt_image_paste(&mut app, &prompt_context).await;
+
+        // Assert
+        app.sessions.sync_from_handles();
+        assert!(app.sessions.sessions()[0].output.contains(
+            "[Paste Image Error] Clipboard is unavailable. Try again after granting clipboard \
+             access."
+        ));
+        if let AppMode::Prompt {
+            attachment_state,
+            input,
+            ..
+        } = &app.mode
+        {
+            assert_eq!(input.text(), "Review ");
+            assert!(attachment_state.attachments.is_empty());
+        }
+    }
+
     #[tokio::test]
     async fn test_take_submitted_turn_prompt_drains_text_and_attachment_state() {
         // Arrange

--- a/crates/agentty/tests/e2e/common.rs
+++ b/crates/agentty/tests/e2e/common.rs
@@ -574,6 +574,8 @@ impl ZolaFeaturePage {
 /// }
 /// ```
 pub(crate) struct FeatureTest {
+    /// Extra child-process environment variables applied to PTY and VHS runs.
+    child_env: Vec<(String, String)>,
     /// Whether PTY and VHS runs inherit the ambient system `PATH`.
     inherit_system_path: bool,
     /// Feature name used for GIF filename and Zola page filename.
@@ -600,6 +602,7 @@ impl FeatureTest {
     /// The name is used as the GIF filename stem and Zola page filename.
     pub(crate) fn new(name: impl Into<String>) -> Self {
         Self {
+            child_env: Vec::new(),
             inherit_system_path: true,
             name: name.into(),
             setup: None,
@@ -617,6 +620,13 @@ impl FeatureTest {
         setup: impl Fn(&BuilderEnv) -> Result<(), Box<dyn std::error::Error>> + 'static,
     ) -> Self {
         self.setup = Some(Box::new(setup));
+
+        self
+    }
+
+    /// Add an environment variable for the PTY session and VHS recording.
+    pub(crate) fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.child_env.push((key.into(), value.into()));
 
         self
     }
@@ -691,25 +701,30 @@ impl FeatureTest {
         let terminal_rows = self.terminal_rows;
         let uses_default_terminal_size =
             terminal_cols == DEFAULT_TERMINAL_COLS && terminal_rows == DEFAULT_TERMINAL_ROWS;
-        let (builder, owned_pairs) = if self.inherit_system_path && uses_default_terminal_size {
-            (env.builder(), env.as_vhs_env_pairs())
-        } else if self.inherit_system_path {
-            (
-                env.builder_with_path_and_size(
-                    env.path_with_stub_bin(),
-                    terminal_cols,
-                    terminal_rows,
-                ),
-                env.as_vhs_env_pairs(),
-            )
-        } else {
-            let path_env = env.stub_only_path();
+        let (mut builder, mut owned_pairs) =
+            if self.inherit_system_path && uses_default_terminal_size {
+                (env.builder(), env.as_vhs_env_pairs())
+            } else if self.inherit_system_path {
+                (
+                    env.builder_with_path_and_size(
+                        env.path_with_stub_bin(),
+                        terminal_cols,
+                        terminal_rows,
+                    ),
+                    env.as_vhs_env_pairs(),
+                )
+            } else {
+                let path_env = env.stub_only_path();
 
-            (
-                env.builder_with_path_and_size(path_env.clone(), terminal_cols, terminal_rows),
-                env.as_vhs_env_pairs_with_path(path_env),
-            )
-        };
+                (
+                    env.builder_with_path_and_size(path_env.clone(), terminal_cols, terminal_rows),
+                    env.as_vhs_env_pairs_with_path(path_env),
+                )
+            };
+        for (key, value) in &self.child_env {
+            builder = builder.env(key.clone(), value.clone());
+            owned_pairs.push((key.clone(), value.clone()));
+        }
         let env_pairs: Vec<(&str, &str)> = owned_pairs
             .iter()
             .map(|(key, value)| (key.as_str(), value.as_str()))

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1010,6 +1010,40 @@ fn session_creation_opens_prompt_mode() -> E2eResult {
     Ok(())
 }
 
+/// Verify that prompt image paste reports unavailable clipboard backends
+/// inline.
+#[test]
+fn prompt_image_paste_unavailable_shows_inline_error() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("prompt_image_paste_unavailable")
+        .with_git()
+        .env("AGENTTY_DISABLE_CLIPBOARD", "1")
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .press_key("ctrl+v")
+                    .wait_for_text("Paste Image Error", 5000)
+                    .capture_labeled(
+                        "paste_error",
+                        "Prompt mode showing unavailable clipboard paste error",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Paste Image Error", &full);
+                assertion::assert_text_in_region(frame, "Clipboard is unavailable", &full);
+                assertion::assert_not_visible(frame, "[Image #1]");
+            },
+        )?;
+
+    Ok(())
+}
+
 /// Verify that choosing Stacked creates a startable draft under the selected
 /// parent and renders the one-level stack with a tree connection in the
 /// session list.

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -16,6 +16,10 @@ module docstrings directly.
 
 ## Workspace Crates
 
+- `crates/ag-clipboard/`: Read-only clipboard support crate with the narrow text,
+  file-list, and RGBA image read surface used by prompt image capture. Platform backends
+  own macOS pasteboard access, X11 selection reads, Wayland `wl-paste` reads, and
+  unsupported-backend reporting.
 - `crates/ag-forge/`: Shared forge review-request library crate with normalized
   review-request types, GitHub/GitLab remote detection, and the `gh`/`glab` adapters
   behind the `ReviewRequestClient` and `ForgeCommandRunner` boundaries.
@@ -50,8 +54,10 @@ module docstrings directly.
 - `infra/`: External integrations behind traits — SQLite persistence (`infra/db/`
   repositories), git (`GitClient`, backed by `ag-git`), filesystem (`FsClient`), tmux,
   clipboard images, version checks, project discovery, file indexing, and the agent
-  stack: provider registry, per-provider backends (`infra/agent/`), shared prompt
-  preparation and access-root selection (`infra/agent/prompt.rs`), transport channels
+  stack. Clipboard image capture delegates host clipboard reads to `ag-clipboard`, then
+  owns temp-file persistence and attachment metadata. The agent stack includes provider
+  registry, per-provider backends (`infra/agent/`), shared prompt preparation and
+  access-root selection (`infra/agent/prompt.rs`), transport channels
   (`infra/channel/`), app-server clients plus shared command and stdio transport helpers
   (`infra/agent/app_server/`), and the structured response protocol compatibility layer
   backed by `ag-protocol` prompt-envelope, schema, and parser APIs.

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -327,8 +327,11 @@ their triggers:
   loader updates and final buffers.
 - **App-server stream bridge** (every app-server turn): bridges provider stream events
   into the unified turn event stream.
-- **Clipboard image persistence** (prompt image paste): captures the clipboard image via
-  `spawn_blocking` and stores it under `AGENTTY_ROOT/tmp/<session-id>/images/`.
+- **Clipboard image persistence** (prompt image paste): reads a copied PNG file,
+  clipboard image, or PNG path from `ag-clipboard` via `spawn_blocking`, stores it under
+  `AGENTTY_ROOT/tmp/<session-id>/images/`, and inserts an inline `[Image #n]`
+  placeholder. The backend supports macOS pasteboard, X11 reads, and Wayland reads via
+  `wl-paste`; missing or unsupported backends report an inline paste error.
 - **Session title generation** (first start turn): runs a one-shot title prompt and
   persists a concise generated title.
 - **At-mention file indexing** (`@` in prompt or question input): lists session files

--- a/docs/site/content/docs/architecture/testability-boundaries.md
+++ b/docs/site/content/docs/architecture/testability-boundaries.md
@@ -27,7 +27,7 @@ major boundaries:
 | `EventSource`          | `runtime/event.rs`              | Terminal event polling for deterministic event-loop tests.                                                                                                                         |
 | `Clock`                | `infra/clock.rs`                | Wall-clock and monotonic time for session orchestration and render throttling.                                                                                                     |
 | `TmuxClient`           | `infra/tmux.rs`                 | Tmux subprocess operations for opening worktrees.                                                                                                                                  |
-| `ClipboardImageClient` | `infra/clipboard_image.rs`      | Clipboard image capture and temp-file persistence.                                                                                                                                 |
+| `ClipboardImageClient` | `infra/clipboard_image.rs`      | Clipboard image capture and temp-file persistence; host clipboard reads are isolated in `ag-clipboard`.                                                                            |
 | Repository traits      | `infra/db/*.rs`                 | Narrow persistence boundaries (`SessionRepository`, `ProjectRepository`, `ReviewRepository`, `UsageRepository`, `ActivityRepository`, `OperationRepository`, `SettingRepository`). |
 
 Beyond these, narrower internal command-runner boundaries (for example

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -146,6 +146,14 @@ next word | | `Option+Backspace` | Delete previous word | | `Cmd+Backspace` | De
 current line | | `Esc` | Cancel | | `@` | Open file picker | | `/` | Open slash commands
 |
 
+Prompt input keeps regular text paste on terminal `Event::Paste`. The dedicated image
+paste shortcuts insert highlighted `[Image #n]` tokens directly in the composer and send
+the referenced local image for Codex, Antigravity, and Claude session models. Clipboard
+image capture uses Agentty's host clipboard backend, with Wayland reads using `wl-paste`
+when it is available. Missing or unsupported clipboard backends report an inline paste
+error. Codex preserves the multimodal ordering at transport level, while Antigravity and
+Claude rewrite the placeholders to local image paths before streaming the prompt.
+
 Agentty requests enhanced keyboard reporting from supporting terminals and `tmux` panes
 so remote sessions can distinguish `Shift+Enter` from plain `Enter`. Image paste and `@`
 lookup behavior are described in [Workflow](@/docs/usage/workflow.md).

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -288,9 +288,12 @@ later.
 
 <a id="usage-prompt-extras"></a> In prompt input, `Ctrl+V`, `Ctrl+Shift+V`, and `Alt+V`
 paste one clipboard image into the current draft or reply as an inline `[Image #n]`
-token; the referenced local images are sent to the agent with the prompt. Draft image
-files are removed when the composer is canceled, after a submitted turn finishes, and
-when a session is deleted or canceled.
+token; the referenced local images are sent to the agent with the prompt. The clipboard
+source can be a copied PNG file, raw image data, or PNG path text from the host
+clipboard backend. Wayland reads use `wl-paste` when it is available; missing or
+unsupported clipboard backends report an inline paste error. Draft image files are
+removed when the composer is canceled, after a submitted turn finishes, and when a
+session is deleted or canceled.
 
 `@` file lookups keep the raw `@path/to/file` text visible in the composer and
 transcript; the agent-facing prompt rewrites them to quoted `path/to/file` tokens.


### PR DESCRIPTION
- Add `ag-clipboard` as the shared read-only clipboard crate for macOS pasteboard, X11 selection, Wayland `wl-paste`, and unsupported-backend handling.
- Route prompt image capture through the new backend, keep inline paste failures from mutating attachments, and require `wl-clipboard` on Wayland.
- Update source and E2E coverage, docs, workspace metadata, pre-commit hooks, and `README.md`, and remove `arboard` from the lockfile.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)