### PR TITLE
Preserve partial clarification answers when leaving question mode

### DIFF
--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -1437,6 +1437,7 @@ impl App {
 
         self.sessions
             .apply_turn_applied_state(session_id, turn_applied_state);
+        self.question_progress.remove(session_id);
         let questions = turn_applied_state.questions.clone();
         if questions.is_empty() {
             return;

--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -173,6 +173,7 @@ impl App {
             projects,
             services,
             sessions,
+            question_progress: std::collections::HashMap::new(),
             requested_review_generation: 0,
             requested_review_comment_fetches: std::collections::HashSet::new(),
             requested_review_selected_index: None,

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -45,6 +45,7 @@ use crate::domain::agent::AgentCliInfo;
 use crate::domain::agent::AgentSelection;
 use crate::domain::agent::{AgentKind, ReasoningLevel};
 use crate::domain::input::InputState;
+use crate::domain::question::{QuestionItem, QuestionProgress};
 use crate::domain::session::{FollowUpTaskAction, PublishBranchAction, Session, SessionId, Status};
 use crate::domain::system_log::{
     SystemLogBuffer, SystemLogCategory, SystemLogEvent, SystemLogLevel,
@@ -235,6 +236,11 @@ pub struct App {
     pub settings: SettingsManager,
     /// Manages the selected top-level list tab.
     pub tabs: TabManager,
+    /// Saves partially answered clarification progress per session so
+    /// already-submitted answers survive leaving question mode with `q` and
+    /// reopening the session. Entries are consumed on restore and cleared
+    /// when a new turn result replaces the session's question list.
+    pub(crate) question_progress: HashMap<SessionId, QuestionProgress>,
     /// Caches generated focused review text per session so it survives mode
     /// switches, is hydrated after restart, and is ready when the user presses
     /// `f`.
@@ -1665,21 +1671,7 @@ impl App {
         };
         if session.status == Status::Question {
             let questions = session.questions.clone();
-            let selected_option_index = question::default_option_index(&questions, 0);
-            let (review_status_message, review_text) = self.review_view_state(target_session_id);
-            self.mode = AppMode::Question {
-                at_mention_state: None,
-                session_id: SessionId::from(target_session_id),
-                questions,
-                review_status_message,
-                review_text,
-                responses: Vec::new(),
-                current_index: 0,
-                focus: QuestionFocus::Answer,
-                input: InputState::default(),
-                scroll_offset: None,
-                selected_option_index,
-            };
+            self.enter_question_mode(target_session_id, questions);
 
             return;
         }
@@ -1691,6 +1683,48 @@ impl App {
             review_text,
             session_id: SessionId::from(target_session_id),
             scroll_offset: None,
+        };
+    }
+
+    /// Enters question mode for a clarification session.
+    ///
+    /// Consumes saved partial answers from a previous visit when they still
+    /// match the session's question list, so leaving question mode with `q`
+    /// does not lose already-submitted answers.
+    pub(crate) fn enter_question_mode(&mut self, session_id: &str, questions: Vec<QuestionItem>) {
+        let progress = self
+            .question_progress
+            .remove(session_id)
+            .filter(|progress| progress.applies_to(&questions));
+        let (current_index, input, responses, selected_option_index) = match progress {
+            Some(progress) => (
+                progress.current_index,
+                progress.input,
+                progress.responses,
+                progress.selected_option_index,
+            ),
+            None => (
+                0,
+                InputState::default(),
+                Vec::new(),
+                question::default_option_index(&questions, 0),
+            ),
+        };
+
+        let (review_status_message, review_text) = self.review_view_state(session_id);
+
+        self.mode = AppMode::Question {
+            at_mention_state: None,
+            current_index,
+            focus: QuestionFocus::Answer,
+            input,
+            questions,
+            responses,
+            review_status_message,
+            review_text,
+            scroll_offset: None,
+            selected_option_index,
+            session_id: SessionId::from(session_id),
         };
     }
 

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -2824,6 +2824,123 @@ async fn apply_app_events_agent_response_switches_view_mode_to_question_mode() {
 }
 
 #[tokio::test]
+async fn apply_app_events_agent_response_clears_saved_question_progress() {
+    // Arrange — stale partial answers saved from the previous question set
+    // must not survive a new turn result for the session.
+    let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    app.sessions
+        .push_session(crate::test_support::session_fixture_with_folder(
+            PathBuf::from("/tmp/session-progress-clear"),
+        ));
+    app.question_progress.insert(
+        "session-1".into(),
+        QuestionProgress {
+            current_index: 1,
+            input: InputState::default(),
+            responses: vec!["Old answer".to_string()],
+            selected_option_index: None,
+        },
+    );
+
+    // Act
+    app.apply_app_events(AppEvent::AgentResponseReceived {
+        session_id: "session-1".into(),
+        turn_applied_state: test_turn_applied_state(
+            vec![QuestionItem::new("New question?")],
+            Vec::new(),
+            None,
+            SessionStats::default(),
+        ),
+    })
+    .await;
+
+    // Assert
+    assert!(app.question_progress.is_empty());
+}
+
+#[tokio::test]
+async fn enter_question_mode_restores_saved_progress() {
+    // Arrange — progress saved by a previous `q` exit from question mode.
+    let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    let questions = vec![
+        QuestionItem::with_options("First?", vec!["Yes".to_string(), "No".to_string()]),
+        QuestionItem::new("Second?"),
+    ];
+    app.question_progress.insert(
+        "session-restore".into(),
+        QuestionProgress {
+            current_index: 1,
+            input: InputState::with_text("draft answer".to_string()),
+            responses: vec!["Yes".to_string()],
+            selected_option_index: None,
+        },
+    );
+
+    // Act
+    app.enter_question_mode("session-restore", questions);
+
+    // Assert — resumes at the second question with the saved answer, and
+    // the stored entry is consumed.
+    assert!(matches!(
+        &app.mode,
+        AppMode::Question {
+            current_index: 1,
+            responses,
+            input,
+            selected_option_index: None,
+            session_id,
+            ..
+        } if responses == &vec!["Yes".to_string()]
+            && input.text() == "draft answer"
+            && session_id == "session-restore"
+    ));
+    assert!(app.question_progress.is_empty());
+}
+
+#[tokio::test]
+async fn enter_question_mode_discards_progress_for_changed_question_list() {
+    // Arrange — saved progress no longer matches the question list.
+    let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    let questions = vec![QuestionItem::with_options(
+        "Only question?",
+        vec!["Yes".to_string()],
+    )];
+    app.question_progress.insert(
+        "session-stale".into(),
+        QuestionProgress {
+            current_index: 2,
+            input: InputState::default(),
+            responses: vec!["One".to_string(), "Two".to_string()],
+            selected_option_index: None,
+        },
+    );
+
+    // Act
+    app.enter_question_mode("session-stale", questions);
+
+    // Assert — starts fresh at the first question with its first option
+    // highlighted.
+    assert!(matches!(
+        &app.mode,
+        AppMode::Question {
+            current_index: 0,
+            responses,
+            selected_option_index: Some(0),
+            ..
+        } if responses.is_empty()
+    ));
+}
+
+#[tokio::test]
 async fn apply_app_events_agent_response_keeps_list_mode_when_not_viewing_session() {
     // Arrange
     let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(

--- a/crates/agentty/src/domain/question.rs
+++ b/crates/agentty/src/domain/question.rs
@@ -1,3 +1,115 @@
-//! Compatibility re-export for shared protocol clarification question models.
+//! Clarification question domain state built on the shared protocol
+//! clarification question models re-exported from `ag_protocol`.
 
 pub use ag_protocol::QuestionItem;
+
+use crate::domain::input::InputState;
+
+/// Partially answered clarification state saved when the user leaves question
+/// mode for the sessions list.
+///
+/// Stored per session so already-submitted answers survive exiting with `q`
+/// and are restored the next time the session's question mode opens.
+pub struct QuestionProgress {
+    /// Index of the next unanswered question.
+    pub current_index: usize,
+    /// Free-text input typed for the current question.
+    pub input: InputState,
+    /// Responses already submitted for earlier questions.
+    pub responses: Vec<String>,
+    /// Highlighted predefined option for the current question, or `None`
+    /// when the free-text input is active.
+    pub selected_option_index: Option<usize>,
+}
+
+impl QuestionProgress {
+    /// Returns whether this progress still matches the given question list.
+    ///
+    /// Guards against restoring stale progress after the question set
+    /// changed: every stored response must map to an earlier question, the
+    /// next question must exist, and any highlighted option must be valid
+    /// for that question.
+    #[must_use]
+    pub fn applies_to(&self, questions: &[QuestionItem]) -> bool {
+        if self.responses.len() != self.current_index || self.current_index >= questions.len() {
+            return false;
+        }
+
+        match self.selected_option_index {
+            Some(option_index) => option_index < questions[self.current_index].options.len(),
+            None => true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_applies_to_accepts_matching_progress() {
+        // Arrange
+        let questions = vec![
+            QuestionItem::with_options("Continue?", vec!["Yes".to_string()]),
+            QuestionItem::with_options("Scope?", vec!["Small".to_string(), "Large".to_string()]),
+        ];
+        let progress = QuestionProgress {
+            current_index: 1,
+            input: InputState::default(),
+            responses: vec!["Yes".to_string()],
+            selected_option_index: Some(1),
+        };
+
+        // Act & Assert
+        assert!(progress.applies_to(&questions));
+    }
+
+    #[test]
+    fn test_applies_to_rejects_response_count_mismatch() {
+        // Arrange — one response recorded but the index says none answered.
+        let questions = vec![QuestionItem::new("First?"), QuestionItem::new("Second?")];
+        let progress = QuestionProgress {
+            current_index: 0,
+            input: InputState::default(),
+            responses: vec!["Yes".to_string()],
+            selected_option_index: None,
+        };
+
+        // Act & Assert
+        assert!(!progress.applies_to(&questions));
+    }
+
+    #[test]
+    fn test_applies_to_rejects_index_past_question_list() {
+        // Arrange — the saved index points past a shrunken question list.
+        let questions = vec![QuestionItem::new("Only question?")];
+        let progress = QuestionProgress {
+            current_index: 1,
+            input: InputState::default(),
+            responses: vec!["Yes".to_string()],
+            selected_option_index: None,
+        };
+
+        // Act & Assert
+        assert!(!progress.applies_to(&questions));
+    }
+
+    #[test]
+    fn test_applies_to_rejects_out_of_range_option_index() {
+        // Arrange — the highlighted option no longer exists on the current
+        // question.
+        let questions = vec![QuestionItem::with_options(
+            "Continue?",
+            vec!["Yes".to_string()],
+        )];
+        let progress = QuestionProgress {
+            current_index: 0,
+            input: InputState::default(),
+            responses: Vec::new(),
+            selected_option_index: Some(1),
+        };
+
+        // Act & Assert
+        assert!(!progress.applies_to(&questions));
+    }
+}

--- a/crates/agentty/src/runtime/mode/list.rs
+++ b/crates/agentty/src/runtime/mode/list.rs
@@ -7,8 +7,7 @@ use crate::domain::input::InputState;
 use crate::domain::session::{Session, Status};
 use crate::runtime::EventResult;
 use crate::runtime::mode::confirmation::DEFAULT_OPTION_INDEX;
-use crate::runtime::mode::question;
-use crate::ui::state::app_mode::{AppMode, ConfirmationIntent, HelpContext, QuestionFocus};
+use crate::ui::state::app_mode::{AppMode, ConfirmationIntent, HelpContext};
 use crate::ui::state::help_action::{
     HelpAction, project_list_actions, session_list_actions, settings_actions, system_log_actions,
 };
@@ -134,21 +133,7 @@ async fn handle_enter_key(app: &mut App) -> io::Result<EventResult> {
                     && session.status == Status::Question
                 {
                     let questions = session.questions.clone();
-                    let selected_option_index = question::default_option_index(&questions, 0);
-                    let (review_status_message, review_text) = app.review_view_state(&session_id);
-                    app.mode = AppMode::Question {
-                        at_mention_state: None,
-                        review_status_message,
-                        review_text,
-                        session_id,
-                        questions,
-                        responses: Vec::new(),
-                        current_index: 0,
-                        focus: QuestionFocus::Answer,
-                        input: InputState::default(),
-                        scroll_offset: None,
-                        selected_option_index,
-                    };
+                    app.enter_question_mode(session_id.as_str(), questions);
                 } else {
                     let (review_status_message, review_text) = app.review_view_state(&session_id);
                     app.mode = AppMode::View {

--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -4,7 +4,7 @@ use ratatui::layout::Rect;
 use crate::app::session::SessionTaskService;
 use crate::app::{self, App, AppEvent};
 use crate::domain::input::InputState;
-use crate::domain::question::QuestionItem;
+use crate::domain::question::{QuestionItem, QuestionProgress};
 use crate::domain::session::{SessionId, Status};
 use crate::domain::turn_prompt::TurnPrompt;
 use crate::runtime::EventResult;
@@ -23,9 +23,10 @@ const NO_ANSWER: &str = "no answer";
 /// typed answer (or `no answer` when blank), `Ctrl+C` and `Esc` end the entire
 /// turn without sending a reply (with `Esc` only doing so when the answer
 /// input is focused and no at-mention dropdown is open, so it stays available
-/// to dismiss those overlays), and `q` returns to the sessions list (skipped
-/// while the user is actively typing a free-text answer so the character can
-/// still be inserted into the response).
+/// to dismiss those overlays), and `q` returns to the sessions list while
+/// saving already-submitted answers for the next visit (skipped while the
+/// user is actively typing a free-text answer so the character can still be
+/// inserted into the response).
 pub(crate) async fn handle(app: &mut App, terminal_size: Rect, key: KeyEvent) -> EventResult {
     if handle_focus_toggle(app, key) {
         return EventResult::Continue;
@@ -38,7 +39,7 @@ pub(crate) async fn handle(app: &mut App, terminal_size: Rect, key: KeyEvent) ->
     }
 
     if is_plain_q(key) && should_exit_to_list_on_q(app) {
-        app.mode = AppMode::List;
+        exit_to_list_saving_progress(app);
 
         return EventResult::Continue;
     }
@@ -102,6 +103,35 @@ fn should_exit_to_list_on_q(app: &App) -> bool {
     };
 
     *focus == QuestionFocus::Chat || selected_option_index.is_some()
+}
+
+/// Saves in-progress clarification answers and returns to the sessions list.
+///
+/// The saved progress is restored by `App::enter_question_mode` the next
+/// time the session's question mode opens, so answers already submitted for
+/// earlier questions survive leaving the view with `q`.
+fn exit_to_list_saving_progress(app: &mut App) {
+    let mode = std::mem::replace(&mut app.mode, AppMode::List);
+
+    if let AppMode::Question {
+        current_index,
+        input,
+        responses,
+        selected_option_index,
+        session_id,
+        ..
+    } = mode
+    {
+        app.question_progress.insert(
+            session_id,
+            QuestionProgress {
+                current_index,
+                input,
+                responses,
+                selected_option_index,
+            },
+        );
+    }
 }
 
 /// Toggles focus between the question panel and chat output on `Tab`.
@@ -1230,6 +1260,47 @@ mod tests {
 
         // Assert — switched to the sessions list.
         assert!(matches!(app.mode, AppMode::List));
+    }
+
+    #[tokio::test]
+    async fn test_handle_q_saves_partial_answers_for_reopen() {
+        // Arrange — first question already answered, second in option
+        // navigation. `q` must keep the submitted answer for the next visit.
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.mode = AppMode::Question {
+            at_mention_state: None,
+            review_status_message: None,
+            review_text: None,
+            session_id: "session-q-save".into(),
+            questions: vec![
+                QuestionItem::with_options("First?", vec!["Yes".to_string(), "No".to_string()]),
+                QuestionItem::with_options("Second?", vec!["A".to_string(), "B".to_string()]),
+            ],
+            responses: vec!["Yes".to_string()],
+            current_index: 1,
+            focus: QuestionFocus::Answer,
+            input: InputState::default(),
+            scroll_offset: None,
+            selected_option_index: Some(1),
+        };
+
+        // Act
+        let _ = handle(
+            &mut app,
+            TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
+        )
+        .await;
+
+        // Assert — list mode plus saved progress for the session.
+        assert!(matches!(app.mode, AppMode::List));
+        let progress = app
+            .question_progress
+            .get("session-q-save")
+            .expect("progress should be saved");
+        assert_eq!(progress.responses, vec!["Yes".to_string()]);
+        assert_eq!(progress.current_index, 1);
+        assert_eq!(progress.selected_option_index, Some(1));
     }
 
     #[tokio::test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -31,6 +31,16 @@ const LOADER_SESSION_ID: &str = "loader-session-0001";
 /// Stable id for the seeded running session used by stop-turn tests.
 const RUNNING_STOP_SESSION_ID: &str = "running-stop-0001";
 
+/// Stable id for the seeded clarification-question session used by the
+/// question-resume test.
+const QUESTION_RESUME_SESSION_ID: &str = "question-resume-0001";
+
+/// First clarification question shown when the seeded question session opens.
+const FIRST_QUESTION_TEXT: &str = "Use the default target branch?";
+
+/// Second clarification question that must be shown after resuming.
+const SECOND_QUESTION_TEXT: &str = "Which tests should be added?";
+
 /// Seeds one review-ready session whose transcript contains a beautified
 /// provider command failure.
 fn seed_session_with_beautified_agent_error(
@@ -423,6 +433,37 @@ fn seed_running_stop_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error:
     // runtime expects for this session id.
     let worktree_name = &RUNNING_STOP_SESSION_ID[..8];
     std::fs::create_dir_all(env.agentty_root.join("wt").join(worktree_name))?;
+
+    Ok(())
+}
+
+/// Seeds one `Question`-status session with two option questions so the
+/// question-resume flow can run without a live agent backend.
+fn seed_question_resume_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    common::seed_session(
+        env,
+        SessionSeed::regular(QUESTION_RESUME_SESSION_ID, "gpt-5.5", "main", "Question")
+            .with_title("Question resume session"),
+    )?;
+
+    std::fs::create_dir_all(test_support::session_folder(
+        &env.agentty_root.join("wt"),
+        QUESTION_RESUME_SESSION_ID,
+    ))?;
+
+    let questions_json = format!(
+        r#"[{{"options":["Yes","No"],"text":"{FIRST_QUESTION_TEXT}"}},{{"options":["Unit","Integration"],"text":"{SECOND_QUESTION_TEXT}"}}]"#
+    );
+    let runtime = common::seed_runtime()?;
+
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+
+        database
+            .sessions()
+            .update_session_questions(QUESTION_RESUME_SESSION_ID, &questions_json)
+            .await
+    })?;
 
     Ok(())
 }
@@ -954,6 +995,54 @@ fn session_stop_turn_returns_to_review() -> E2eResult {
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "Enter: reply", &full);
                 assertion::assert_not_visible(frame, "Ctrl+c: stop");
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that answering one clarification question, leaving question mode
+/// with `q`, and reopening the session resumes at the next unanswered
+/// question instead of restarting from the first.
+#[test]
+fn session_question_resume_after_leaving_to_list() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_question_resume")
+        .with_git()
+        .setup(seed_question_resume_session)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .wait_for_text("Question resume session", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Question 1/2", 5000)
+                    .capture_labeled(
+                        "first_question",
+                        "Question mode opens on the first question",
+                    )
+                    .press_key("Enter")
+                    .wait_for_text("Question 2/2", 5000)
+                    .press_key("q")
+                    .wait_for_text("new session", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Question 2/2", 5000)
+                    .capture_labeled(
+                        "resumed_second_question",
+                        "Reopening the session resumes at the second question",
+                    )
+            },
+            |frame, report| {
+                let first_frame = common::frame_from_capture(&report.captures[0]);
+                let first_full = Region::full(first_frame.cols(), first_frame.rows());
+                assertion::assert_text_in_region(&first_frame, "Question 1/2", &first_full);
+                assertion::assert_text_in_region(&first_frame, FIRST_QUESTION_TEXT, &first_full);
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Question 2/2", &full);
+                assertion::assert_text_in_region(frame, SECOND_QUESTION_TEXT, &full);
+                assertion::assert_not_visible(frame, FIRST_QUESTION_TEXT);
             },
         )?;
 

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -192,4 +192,6 @@ to review without answering |
 <a id="usage-question-input-submit-flow"></a> After the last question is answered,
 Agentty sends one follow-up message with each question and its response, then returns to
 session view. Pressing `q` (outside free-text input) returns to the sessions list while
-leaving the session in **Question** state so the clarification can be resumed later.
+leaving the session in **Question** state; answers already submitted and the current
+free-text draft are kept, so reopening the session resumes at the next unanswered
+question.

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -282,7 +282,8 @@ the highlighted choice. Moving past the list edges switches to the free-text inp
 Submitting a blank free-text answer stores `no answer`. `Ctrl+C` ends the clarification
 turn and returns the session to **Review** without sending a reply, while `q` (outside
 free-text input) returns to the sessions list with the **Question** state kept for
-later.
+later; answers already submitted are saved, and reopening the session resumes at the
+next unanswered question.
 
 ## Prompt Input Extras
 


### PR DESCRIPTION
- Add a `QuestionProgress` domain type that captures the current question index, free-text input, submitted responses, and highlighted option, with an `applies_to` guard that rejects stale progress after the question list changes.
- Store progress per session in `App::question_progress`, saving it when `q` exits question mode and consuming it in the new `App::enter_question_mode` helper so reopening the session resumes at the next unanswered question.
- Clear saved progress when a new turn result replaces the session's question list.
- Route the list and state entry points through `enter_question_mode` to remove duplicated question-mode setup.
- Add an E2E feature test that answers one question, leaves with `q`, and reopens to confirm the session resumes at the next unanswered question.
- Update the keybindings and workflow docs to note that submitted answers and the current draft are kept when returning to the sessions list with `q`.