### PR TITLE
Reconcile open session view into the clarification panel

### DIFF
--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -175,6 +175,7 @@ impl App {
             services,
             sessions,
             question_progress: std::collections::HashMap::new(),
+            question_reconcile_reload_attempted: None,
             requested_review_generation: 0,
             requested_review_comment_fetches: std::collections::HashSet::new(),
             requested_review_selected_index: None,

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -227,6 +227,13 @@ pub struct App {
     /// reopening the session. Entries are consumed on restore and cleared
     /// when a new turn result replaces the session's question list.
     pub(crate) question_progress: HashMap<SessionId, QuestionProgress>,
+    /// Records the session for which `reconcile_open_session_question_mode`
+    /// already reloaded detail and still found no persisted questions, so the
+    /// per-frame reconciliation does not reissue that database load every
+    /// render cycle. Cleared once the open view leaves `Status::Question` or
+    /// `AppMode::View`, or once the panel opens, so a later legitimate
+    /// transition reloads again.
+    pub(crate) question_reconcile_reload_attempted: Option<SessionId>,
     /// Caches generated focused review text per session so it survives mode
     /// switches, is hydrated after restart, and is ready when the user presses
     /// `f`.
@@ -947,8 +954,9 @@ impl App {
     ///
     /// Starting a new turn clears cached and persisted focused-review output
     /// for that session so review text does not persist past prompt
-    /// submission.
-    pub async fn reply(&mut self, session_id: &str, prompt: impl Into<TurnPrompt>) {
+    /// submission. Returns `true` when the reply command was enqueued on the
+    /// session worker.
+    pub async fn reply(&mut self, session_id: &str, prompt: impl Into<TurnPrompt>) -> bool {
         self.review_cache.remove(session_id);
         let _ = self
             .services
@@ -956,9 +964,10 @@ impl App {
             .sessions()
             .update_session_focused_review(session_id, None, None)
             .await;
+
         self.sessions
             .reply(&self.services, session_id, prompt)
-            .await;
+            .await
     }
 
     /// Queues one chat prompt for an existing `InProgress` session so the
@@ -1644,6 +1653,75 @@ impl App {
             session_id: SessionId::from(target_session_id),
             scroll_offset: None,
         };
+    }
+
+    /// Enters the interactive clarification panel when the actively viewed
+    /// session has reached [`Status::Question`] but the UI is still on the
+    /// plain session view.
+    ///
+    /// The live transition into `AppMode::Question` is a one-shot side effect
+    /// of the `AgentResponseReceived` projection, gated on the session being
+    /// viewed at the instant the turn completes. When that projection is
+    /// missed — an overlay was open, the projection coalesced to empty, or the
+    /// worker fell back to a reload-only recovery — the durable `Question`
+    /// status still reaches the snapshot, stranding the question behind the
+    /// session view until a manual reopen. This reconciliation mirrors the
+    /// reopen path so the panel appears without one.
+    ///
+    /// A session view showing `Status::Question` is always an anomaly: every
+    /// path that leaves the panel (answering, `Ctrl+C`/`Esc`, or `q`) moves the
+    /// session off `Question` or out of `AppMode::View`, so entering the panel
+    /// here cannot fight a legitimate view state.
+    pub(crate) async fn reconcile_open_session_question_mode(&mut self) {
+        let AppMode::View { session_id, .. } = &self.mode else {
+            self.question_reconcile_reload_attempted = None;
+
+            return;
+        };
+
+        let session_id = session_id.clone();
+        let is_pending_question = self
+            .sessions
+            .session_for_id(&session_id)
+            .is_some_and(|session| session.status == Status::Question);
+        if !is_pending_question {
+            self.question_reconcile_reload_attempted = None;
+
+            return;
+        }
+
+        let mut questions = self
+            .sessions
+            .session_for_id(&session_id)
+            .map(|session| session.questions.clone())
+            .unwrap_or_default();
+        if questions.is_empty() {
+            // The list snapshot only carries persisted questions for the
+            // active session, so reload detail before giving up, mirroring the
+            // reopen path in `open_session_by_index`. A `Question` status with
+            // no persisted questions is malformed, so reload at most once per
+            // stuck session: without this guard `run_cycle` would reissue the
+            // async load on every render frame while the view stays stuck.
+            if self.question_reconcile_reload_attempted.as_deref() == Some(session_id.as_str()) {
+                return;
+            }
+
+            self.question_reconcile_reload_attempted = Some(session_id.clone());
+            self.sessions
+                .load_session_detail_into_state(self.services.db(), &session_id)
+                .await;
+            questions = self
+                .sessions
+                .session_for_id(&session_id)
+                .map(|session| session.questions.clone())
+                .unwrap_or_default();
+        }
+        if questions.is_empty() {
+            return;
+        }
+
+        self.question_reconcile_reload_attempted = None;
+        self.enter_question_mode(&session_id, questions);
     }
 
     /// Enters question mode for a clarification session.

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -61,6 +61,37 @@ fn test_confirmation_view_mode(session_id: &str) -> ConfirmationViewMode {
     }
 }
 
+fn test_view_app_mode(session_id: &str) -> AppMode {
+    AppMode::View {
+        review_status_message: None,
+        review_text: None,
+        session_id: session_id.into(),
+        scroll_offset: None,
+    }
+}
+
+async fn test_app_viewing_reconcile_session(
+    status: Status,
+    questions: Vec<QuestionItem>,
+    folder_name: &str,
+) -> App {
+    let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    app.sessions.push_session(
+        crate::test_support::SessionFixtureBuilder::new()
+            .id("session-1")
+            .folder(PathBuf::from(format!("/tmp/{folder_name}")))
+            .status(status)
+            .questions(questions)
+            .build(),
+    );
+    app.mode = test_view_app_mode("session-1");
+
+    app
+}
+
 /// Builds a successful branch-publish batch payload for one session.
 fn test_pushed_branch_result(branch_name: &str) -> BranchPublishTaskSuccess {
     BranchPublishTaskSuccess::Pushed {
@@ -2835,6 +2866,126 @@ async fn apply_app_events_agent_response_switches_view_mode_to_question_mode() {
             && responses.is_empty()
             && input.text().is_empty()
     ));
+}
+
+#[tokio::test]
+async fn reconcile_open_session_question_mode_enters_question_mode_from_view() {
+    // Arrange — a viewed session reached `Question` status with pending
+    // questions, but the view was never flipped into the clarification panel
+    // (for example the live projection was missed while an overlay was open).
+    let pending_questions = vec![
+        QuestionItem::with_options("Need a target branch?", vec!["main".to_string()]),
+        QuestionItem::new("Need integration tests?"),
+    ];
+    let mut app = test_app_viewing_reconcile_session(
+        Status::Question,
+        pending_questions.clone(),
+        "session-question-reconcile",
+    )
+    .await;
+
+    // Act
+    app.reconcile_open_session_question_mode().await;
+
+    // Assert
+    assert!(matches!(
+        app.mode,
+        AppMode::Question {
+            ref session_id,
+            questions: ref mode_questions,
+            current_index: 0,
+            ..
+        } if session_id == "session-1" && mode_questions == &pending_questions
+    ));
+}
+
+#[tokio::test]
+async fn reconcile_open_session_question_mode_ignores_non_question_status() {
+    // Arrange — the viewed session is in `Review`, not awaiting a question.
+    let mut app =
+        test_app_viewing_reconcile_session(Status::Review, Vec::new(), "session-review-reconcile")
+            .await;
+
+    // Act
+    app.reconcile_open_session_question_mode().await;
+
+    // Assert — the view is preserved.
+    assert!(matches!(
+        app.mode,
+        AppMode::View { ref session_id, .. } if session_id == "session-1"
+    ));
+}
+
+#[tokio::test]
+async fn reconcile_open_session_question_mode_ignores_non_view_modes() {
+    // Arrange — a `Question` session exists, but the user is on the list, not
+    // viewing that session, so the panel must not steal focus.
+    let mut app = test_app_viewing_reconcile_session(
+        Status::Question,
+        vec![QuestionItem::new("Need integration tests?")],
+        "session-list-reconcile",
+    )
+    .await;
+    app.mode = AppMode::List;
+
+    // Act
+    app.reconcile_open_session_question_mode().await;
+
+    // Assert — the list stays active.
+    assert!(matches!(app.mode, AppMode::List));
+}
+
+#[tokio::test]
+async fn reconcile_open_session_question_mode_reloads_detail_at_most_once_when_still_empty() {
+    // Arrange — a viewed session reports `Question` status but carries no
+    // questions in the snapshot, and no persisted detail exists to reload, so
+    // the reconciliation cannot open the panel.
+    let mut app =
+        test_app_viewing_reconcile_session(Status::Question, Vec::new(), "session-question-empty")
+            .await;
+
+    // Act — run two reconciliations to emulate two consecutive render cycles
+    // while the session stays stuck without questions.
+    app.reconcile_open_session_question_mode().await;
+    let attempted_after_first = app.question_reconcile_reload_attempted.clone();
+    app.reconcile_open_session_question_mode().await;
+
+    // Assert — the first pass records the stuck session so the second cycle
+    // short-circuits before reloading detail again, and the view is preserved
+    // because no questions became available.
+    assert_eq!(attempted_after_first.as_deref(), Some("session-1"));
+    assert_eq!(
+        app.question_reconcile_reload_attempted.as_deref(),
+        Some("session-1")
+    );
+    assert!(matches!(
+        app.mode,
+        AppMode::View { ref session_id, .. } if session_id == "session-1"
+    ));
+}
+
+#[tokio::test]
+async fn reconcile_open_session_question_mode_clears_reload_guard_when_leaving_view() {
+    // Arrange — a stuck `Question` view records the reload guard, then the user
+    // navigates back to the list.
+    let mut app = test_app_viewing_reconcile_session(
+        Status::Question,
+        Vec::new(),
+        "session-question-guard-reset",
+    )
+    .await;
+    app.reconcile_open_session_question_mode().await;
+    assert_eq!(
+        app.question_reconcile_reload_attempted.as_deref(),
+        Some("session-1")
+    );
+
+    // Act — leave the session view and reconcile again.
+    app.mode = AppMode::List;
+    app.reconcile_open_session_question_mode().await;
+
+    // Assert — the guard is cleared so a later legitimate transition reloads.
+    assert!(app.question_reconcile_reload_attempted.is_none());
 }
 
 #[tokio::test]

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -1121,19 +1121,24 @@ impl SessionManager {
     }
 
     /// Submits a follow-up prompt to an existing session.
+    ///
+    /// Returns `true` when the reply command was enqueued on the session
+    /// worker, letting callers gate optimistic status advances on a real
+    /// enqueue.
     pub async fn reply(
         &mut self,
         services: &AppServices,
         session_id: &str,
         prompt: impl Into<TurnPrompt>,
-    ) {
+    ) -> bool {
         let prompt = prompt.into();
         let Ok(session) = self.session_or_err(session_id) else {
-            return;
+            return false;
         };
         let session_agent = session.agent;
+
         self.reply_impl(services, session_id, prompt, session_agent)
-            .await;
+            .await
     }
 
     /// Stages one chat prompt into the in-memory queue for the running turn.
@@ -1731,27 +1736,29 @@ impl SessionManager {
     ///
     /// Gathers reply context, appends the prompt line to session output, builds
     /// a [`SessionCommand::Run`] with the appropriate [`AgentRequestKind`],
-    /// and enqueues it on the session worker.
+    /// and enqueues it on the session worker. Returns `true` only when the
+    /// command reached the worker queue, so callers can defer optimistic status
+    /// advances until the reply is genuinely in flight.
     async fn reply_impl(
         &mut self,
         services: &AppServices,
         session_id: &str,
         prompt: TurnPrompt,
         session_agent: AgentSelection,
-    ) {
+    ) -> bool {
         let Ok(session_index) = self.session_index_or_err(session_id) else {
-            return;
+            return false;
         };
         let should_replay_history = self.should_replay_history(session_id);
         let (session_output, is_first_message, persisted_session_id, title_to_save) =
             match self.prepare_reply_context(session_index, &prompt, should_replay_history) {
                 Ok(Some(reply_context)) => reply_context,
-                Ok(None) => return,
+                Ok(None) => return false,
                 Err(error) => {
                     self.append_reply_status_error(services, session_id, &error)
                         .await;
 
-                    return;
+                    return false;
                 }
             };
 
@@ -1762,7 +1769,7 @@ impl SessionManager {
         let app_event_tx = services.event_sender();
 
         let Ok(handles) = self.session_handles_or_err(&persisted_session_id) else {
-            return;
+            return false;
         };
 
         let output = Arc::clone(&handles.output);
@@ -1816,7 +1823,7 @@ impl SessionManager {
             &effective_prompt,
             command,
         )
-        .await;
+        .await
     }
 
     /// Validates reply eligibility and gathers per-session values needed for
@@ -2085,6 +2092,8 @@ impl SessionManager {
         .await;
     }
 
+    /// Returns `true` when the command reached the session worker queue and
+    /// `false` when enqueueing failed and a reply-error notice was appended.
     async fn enqueue_reply_command(
         &mut self,
         services: &AppServices,
@@ -2093,7 +2102,7 @@ impl SessionManager {
         persisted_session_id: &str,
         prompt: &TurnPrompt,
         command: SessionCommand,
-    ) {
+    ) -> bool {
         if let Err(error) = self
             .enqueue_session_command(services, persisted_session_id, command)
             .await
@@ -2110,7 +2119,11 @@ impl SessionManager {
                 &error_line,
             )
             .await;
+
+            return false;
         }
+
+        true
     }
 
     /// Spawns one detached model command that generates a session title for

--- a/crates/agentty/src/runtime/core.rs
+++ b/crates/agentty/src/runtime/core.rs
@@ -135,9 +135,13 @@ where
     /// Runs one render/event cycle and returns the continuation result.
     ///
     /// Pending app events are reduced before draw so touched sessions refresh
-    /// from their live handles without a full per-frame session sweep.
+    /// from their live handles without a full per-frame session sweep. The open
+    /// session view then reconciles into the clarification panel when its
+    /// session has reached `Status::Question`, covering cases where the live
+    /// `AgentResponseReceived` projection did not flip the view.
     async fn run_cycle(&mut self) -> io::Result<EventResult> {
         self.app.process_pending_app_events().await;
+        self.app.reconcile_open_session_question_mode().await;
         render_frame(
             self.app,
             self.terminal,

--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -822,19 +822,120 @@ fn handle_question_at_mention_select(app: &mut App) {
 
 /// Stores one question response and runs follow-up reply when complete.
 async fn submit_response(app: &mut App, response: String) {
-    let Some((session_id, questions, responses)) = store_question_response(app, response) else {
+    let Some(completed_response) = store_question_response(app, response) else {
         return;
     };
 
-    let question_reply = build_question_reply_prompt(&questions, &responses);
+    let session_id = completed_response.session_id.clone();
+    let question_reply =
+        build_question_reply_prompt(&completed_response.questions, &completed_response.responses);
     app.mode = AppMode::View {
         review_status_message: None,
         review_text: None,
         session_id: session_id.clone(),
         scroll_offset: None,
     };
-    app.reply(&session_id, TurnPrompt::from_text(question_reply))
+    let reply_enqueued = app
+        .reply(&session_id, TurnPrompt::from_text(question_reply))
         .await;
+
+    // Optimistically advance the session out of `Question` once the reply is
+    // enqueued so the open-view question reconciliation does not re-open the
+    // just-answered panel before the worker transitions to `InProgress`. The
+    // reply eligibility check runs against the pre-reply `Question` status, so
+    // this must happen after `reply`. Skip the advance when the reply never
+    // reached the worker (for example a rejected stacked reply) so the pending
+    // question is not hidden behind a stalled `InProgress` state.
+    if reply_enqueued {
+        mark_session_in_progress(app, &session_id);
+    } else {
+        restore_completed_question_response(app, completed_response);
+    }
+}
+
+struct CompletedQuestionResponse {
+    questions: Vec<QuestionItem>,
+    responses: Vec<String>,
+    review_status_message: Option<String>,
+    review_text: Option<String>,
+    scroll_offset: Option<u16>,
+    session_id: SessionId,
+}
+
+/// Restores the final question and answer when reply enqueue fails.
+///
+/// `store_question_response` has already consumed the completed question-mode
+/// vectors by this point. Rebuilding the panel at the final question keeps all
+/// earlier answers plus the just-entered final answer visible so pressing
+/// `Enter` retries the same clarification reply instead of discarding input.
+fn restore_completed_question_response(
+    app: &mut App,
+    mut completed_response: CompletedQuestionResponse,
+) {
+    let Some(final_response) = completed_response.responses.pop() else {
+        return;
+    };
+    if completed_response.questions.is_empty() {
+        return;
+    }
+
+    let current_index = completed_response
+        .responses
+        .len()
+        .min(completed_response.questions.len().saturating_sub(1));
+    let selected_option_index =
+        completed_response
+            .questions
+            .get(current_index)
+            .and_then(|question| {
+                question
+                    .options
+                    .iter()
+                    .position(|option| option == &final_response)
+            });
+    let input = if selected_option_index.is_some() || final_response == NO_ANSWER {
+        InputState::default()
+    } else {
+        InputState::with_text(final_response)
+    };
+
+    app.mode = AppMode::Question {
+        at_mention_state: None,
+        current_index,
+        focus: QuestionFocus::Answer,
+        input,
+        questions: completed_response.questions,
+        responses: completed_response.responses,
+        review_status_message: completed_response.review_status_message,
+        review_text: completed_response.review_text,
+        scroll_offset: completed_response.scroll_offset,
+        selected_option_index,
+        session_id: completed_response.session_id,
+    };
+}
+
+/// Optimistically advances one session's live handle and snapshot status to
+/// [`Status::InProgress`] so a submitted answer is reflected immediately.
+///
+/// Both the shared handle and the render snapshot are updated so the next
+/// `sync_from_handles` sweep does not revert the snapshot back to `Question`.
+/// The session worker persists the authoritative transition when it dequeues
+/// the reply command.
+fn mark_session_in_progress(app: &mut App, session_id: &str) {
+    if let Some(handles) = app.sessions.session_handles().get(session_id)
+        && let Ok(mut handle_status) = handles.status.lock()
+    {
+        *handle_status = Status::InProgress;
+    }
+
+    if let Some(session) = app
+        .sessions
+        .sessions_mut()
+        .iter_mut()
+        .find(|session| session.id == session_id)
+    {
+        session.status = Status::InProgress;
+    }
 }
 
 /// Ends the question turn without sending a reply to the agent.
@@ -912,16 +1013,16 @@ async fn end_turn_no_answer(app: &mut App) {
 
 /// Writes one response into question mode and returns completion payload when
 /// all questions are answered.
-fn store_question_response(
-    app: &mut App,
-    response: String,
-) -> Option<(SessionId, Vec<QuestionItem>, Vec<String>)> {
+fn store_question_response(app: &mut App, response: String) -> Option<CompletedQuestionResponse> {
     let AppMode::Question {
         at_mention_state,
         current_index,
         input,
         questions,
+        review_status_message,
+        review_text,
         responses,
+        scroll_offset,
         selected_option_index,
         session_id,
         ..
@@ -940,11 +1041,14 @@ fn store_question_response(
         return None;
     }
 
-    Some((
-        session_id.clone(),
-        std::mem::take(questions),
-        std::mem::take(responses),
-    ))
+    Some(CompletedQuestionResponse {
+        questions: std::mem::take(questions),
+        responses: std::mem::take(responses),
+        review_status_message: review_status_message.clone(),
+        review_text: review_text.clone(),
+        scroll_offset: *scroll_offset,
+        session_id: session_id.clone(),
+    })
 }
 
 /// Returns a normalized user response, falling back to `no answer`.
@@ -1573,8 +1677,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_enter_on_last_question_transitions_to_view_mode() {
-        // Arrange — free-text mode on last question.
+    async fn test_handle_enter_on_last_question_restores_answer_when_reply_is_not_enqueued() {
+        // Arrange — free-text mode on last question with no matching session handle.
         let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
         app.mode = AppMode::Question {
             at_mention_state: None,
@@ -1604,10 +1708,125 @@ mod tests {
         // Assert
         assert!(matches!(
             app.mode,
-            AppMode::View {
+            AppMode::Question {
+                current_index: 0,
+                ref input,
+                ref questions,
+                ref responses,
+                selected_option_index: None,
                 ref session_id,
                 ..
             } if session_id == "missing-session"
+                && questions.len() == 1
+                && responses.is_empty()
+                && input.text() == "March 4, 2026"
+        ));
+    }
+
+    #[tokio::test]
+    async fn mark_session_in_progress_advances_snapshot_and_handle_status() {
+        // Arrange — a session sits in `Question` with a matching runtime handle.
+        use crate::domain::session::SessionHandles;
+
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let session_id = "session-in-progress";
+        app.sessions.push_session(
+            crate::test_support::SessionFixtureBuilder::new()
+                .id(session_id)
+                .folder(std::path::PathBuf::from("/tmp/test"))
+                .status(Status::Question)
+                .build(),
+        );
+        app.sessions.session_handles_mut().insert(
+            session_id.to_string().into(),
+            SessionHandles::new(String::new(), Status::Question),
+        );
+
+        // Act
+        mark_session_in_progress(&mut app, session_id);
+
+        // Assert — both the snapshot and the shared handle advance to
+        // InProgress so sync_from_handles keeps the session off `Question`.
+        let session = app
+            .sessions
+            .sessions()
+            .iter()
+            .find(|session| session.id == session_id)
+            .expect("session should exist");
+        assert_eq!(session.status, Status::InProgress);
+
+        let handles = app
+            .sessions
+            .session_handles()
+            .get(session_id)
+            .expect("handle should exist");
+        assert_eq!(
+            *handles.status.lock().expect("lock should succeed"),
+            Status::InProgress
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_response_keeps_question_status_when_reply_is_not_enqueued() {
+        // Arrange — a viewed `Question` session with no runtime handle, so the
+        // reply cannot be enqueued on any worker and `App::reply` reports
+        // failure.
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let session_id = "session-no-handle";
+        let questions = vec![
+            QuestionItem::with_options(
+                "Use the default target branch?",
+                vec!["Yes".to_string(), "No".to_string()],
+            ),
+            QuestionItem::new("Which tests should be added?"),
+        ];
+        app.sessions.push_session(
+            crate::test_support::SessionFixtureBuilder::new()
+                .id(session_id)
+                .folder(std::path::PathBuf::from("/tmp/test"))
+                .status(Status::Question)
+                .questions(questions.clone())
+                .build(),
+        );
+        app.mode = AppMode::Question {
+            at_mention_state: None,
+            review_status_message: None,
+            review_text: None,
+            session_id: session_id.into(),
+            questions,
+            responses: vec!["Yes".to_string()],
+            current_index: 1,
+            focus: QuestionFocus::Answer,
+            input: InputState::default(),
+            scroll_offset: None,
+            selected_option_index: None,
+        };
+
+        // Act — answer the final question so `submit_response` attempts the reply.
+        submit_response(&mut app, "Unit and integration tests".to_string()).await;
+
+        // Assert — the failed reply leaves the session on `Question` instead of
+        // stranding it behind an optimistic `InProgress` no worker will advance,
+        // and restores the panel with the completed answers ready to retry.
+        let session = app
+            .sessions
+            .sessions()
+            .iter()
+            .find(|session| session.id == session_id)
+            .expect("session should exist");
+        assert_eq!(session.status, Status::Question);
+        assert!(matches!(
+            app.mode,
+            AppMode::Question {
+                current_index: 1,
+                ref input,
+                ref questions,
+                ref responses,
+                selected_option_index: None,
+                ..
+            } if questions.len() == 2
+                && responses == &vec!["Yes".to_string()]
+                && input.text() == "Unit and integration tests"
         ));
     }
 

--- a/crates/agentty/src/test_support.rs
+++ b/crates/agentty/src/test_support.rs
@@ -25,6 +25,8 @@ use crate::db::{Database, DbError};
 #[cfg(test)]
 use crate::domain::agent::{AgentKind, AgentModel, AgentSelection, ReasoningLevel};
 #[cfg(test)]
+use crate::domain::question::QuestionItem;
+#[cfg(test)]
 use crate::domain::session::{
     PublishedBranchSyncStatus, ReviewRequest, Session, SessionHandles, SessionId, SessionSize,
     SessionStats, Status,
@@ -201,6 +203,13 @@ impl SessionFixtureBuilder {
     /// Overrides the user prompt text.
     pub(crate) fn prompt(mut self, prompt: impl Into<String>) -> Self {
         self.session.prompt = prompt.into();
+
+        self
+    }
+
+    /// Overrides the pending clarification questions.
+    pub(crate) fn questions(mut self, questions: Vec<QuestionItem>) -> Self {
+        self.session.questions = questions;
 
         self
     }

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -17,6 +17,8 @@ use agentty::domain::session::{
 };
 use agentty::domain::session_message::SessionMessageKind;
 use agentty::test_support;
+use sqlx::sqlite::SqliteConnectOptions;
+use sqlx::{ConnectOptions, Connection, Executor};
 use testty::assertion;
 use testty::frame::CellColor;
 use testty::region::Region;
@@ -40,6 +42,9 @@ const FIRST_QUESTION_TEXT: &str = "Use the default target branch?";
 
 /// Second clarification question that must be shown after resuming.
 const SECOND_QUESTION_TEXT: &str = "Which tests should be added?";
+
+/// Clarification question emitted by the delayed stub while help is open.
+const RECONCILE_QUESTION_TEXT: &str = "Should I add a regression test?";
 
 /// Seeds one review-ready session whose transcript contains a beautified
 /// provider command failure.
@@ -463,6 +468,71 @@ fn seed_question_resume_session(env: &BuilderEnv) -> Result<(), Box<dyn std::err
             .sessions()
             .update_session_questions(QUESTION_RESUME_SESSION_ID, &questions_json)
             .await
+    })?;
+
+    Ok(())
+}
+
+/// Installs a Claude stub that emits one structured clarification question
+/// after a delay, giving the scenario time to cover the active view with help.
+fn install_delayed_question_claude_stub(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let claude_path = env.stub_bin.join("claude");
+    let script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
+cat > /dev/null 2>&1
+sleep 1
+printf '%s\n' '{{"type":"system","subtype":"init"}}'
+sleep 2
+printf '%s\n' '{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"Need one clarification."}}]}}}}'
+sleep 1
+printf '%s\n' '{{"type":"result","subtype":"success","result":"{{\"answer\":\"Need one clarification.\",\"questions\":[{{\"text\":\"{RECONCILE_QUESTION_TEXT}\",\"options\":[\"Yes\",\"No\"]}}],\"summary\":null}}","usage":{{"input_tokens":5,"output_tokens":9}}}}'
+"#
+    );
+
+    std::fs::write(&claude_path, script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o755))?;
+
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let db_path = env.agentty_root.join(DB_DIR).join(DB_FILE);
+        let database = Database::open(&db_path).await?;
+        let canonical_workdir = env.workdir.canonicalize()?;
+        let project_id = database
+            .projects()
+            .upsert_project(
+                &canonical_workdir.to_string_lossy(),
+                Some("main".to_string()),
+            )
+            .await?;
+        database
+            .projects()
+            .touch_project_last_opened(project_id)
+            .await?;
+        drop(database);
+
+        let mut connection = SqliteConnectOptions::new()
+            .filename(&db_path)
+            .connect()
+            .await?;
+        let query = sqlx::query(
+            r"
+INSERT INTO project_setting (project_id, name, value)
+VALUES (?, ?, ?)
+ON CONFLICT(project_id, name) DO UPDATE SET value = excluded.value
+",
+        )
+        .bind(project_id)
+        .bind("DefaultSmartModel")
+        .bind("claude-haiku-4-5-20251001");
+        connection.execute(query).await?;
+        connection.close().await?;
+
+        Result::<(), Box<dyn std::error::Error>>::Ok(())
     })?;
 
     Ok(())
@@ -1101,6 +1171,58 @@ fn session_question_resume_after_leaving_to_list() -> E2eResult {
                 assertion::assert_text_in_region(frame, "Question 2/2", &full);
                 assertion::assert_text_in_region(frame, SECOND_QUESTION_TEXT, &full);
                 assertion::assert_not_visible(frame, FIRST_QUESTION_TEXT);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that an already-open session view enters question mode after a
+/// structured question arrives while the help overlay hides the live
+/// transition.
+#[test]
+fn session_question_reconcile_after_help_overlay() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_question_reconcile")
+        .with_git()
+        .setup(install_delayed_question_claude_stub)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("Need clarification")
+                    .wait_for_text("Need clarification", 3000)
+                    .press_key("Enter")
+                    .wait_for_text("q: back", 5000)
+                    .press_key("?")
+                    .wait_for_text("Keybindings", 5000)
+                    .viewing_pause_ms(4500)
+                    .capture_labeled(
+                        "help_during_completion",
+                        "Help overlay remains open while the turn completes",
+                    )
+                    .press_key("Escape")
+                    .wait_for_text("Question 1/1", 30000)
+                    .capture_labeled(
+                        "reconciled_question",
+                        "Question panel appears without reopening the session",
+                    )
+            },
+            |frame, report| {
+                let help_frame = common::frame_from_capture(&report.captures[0]);
+                let help_full = Region::full(help_frame.cols(), help_frame.rows());
+                assertion::assert_text_in_region(&help_frame, "Keybindings", &help_full);
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Question 1/1", &full);
+                assertion::assert_text_in_region(frame, RECONCILE_QUESTION_TEXT, &full);
+                assertion::assert_text_in_region(frame, "Yes", &full);
+                assertion::assert_text_in_region(frame, "No", &full);
+                assertion::assert_not_visible(frame, "Keybindings");
             },
         )?;
 


### PR DESCRIPTION
- Add `reconcile_open_session_question_mode` so a viewed session that reached `Status::Question` enters `AppMode::Question` even when the live `AgentResponseReceived` projection did not flip the view, reloading session detail before giving up
- Track `question_reconcile_reload_attempted` so a stuck `Question` view with no persisted questions reloads detail at most once per session instead of reissuing the load every render frame, and clear it once the view leaves `Status::Question` or `AppMode::View`
- Run the reconciliation in `run_cycle` after pending app events are processed and before the frame renders
- Return a bool from `reply`, `reply_impl`, and `enqueue_reply_command` so callers know when the reply command actually reached the session worker queue
- Advance the answered session to `Status::InProgress` through `mark_session_in_progress` only after the reply is enqueued, updating both the shared handle and the render snapshot so the reconciliation does not re-open the just-answered panel
- Restore the completed question and answers through `restore_completed_question_response` when a reply is not enqueued so a rejected reply keeps the pending question visible and ready to retry
- Add a `questions` override to `SessionFixtureBuilder` and cover the new behavior with unit and E2E tests, including a help-overlay reconciliation scenario