### PR TITLE
Rename validation workflow and gate release checks on tags

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -50,7 +50,8 @@ jobs:
         run: prek run ${{ matrix.hook }} --all-files --hook-stage manual
 
   validate:
-    uses: ./.github/workflows/rust-validation.yml
+    name: Workspace checks
+    uses: ./.github/workflows/workspace-validation.yml
     with:
       cargo-audit: true
       cargo-machete: true

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -10,7 +10,8 @@ permissions:
 
 jobs:
   validate:
-    uses: ./.github/workflows/rust-validation.yml
+    name: Workspace checks
+    uses: ./.github/workflows/workspace-validation.yml
     with:
       cargo-audit: true
       cargo-machete: true

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -8,12 +8,16 @@ permissions:
 
 jobs:
   validate:
-    uses: ./.github/workflows/rust-validation.yml
+    name: Release validation
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    uses: ./.github/workflows/workspace-validation.yml
     with:
       llvm-tools-preview: true
       workspace-tests: true
 
   e2e:
+    name: Release E2E
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/workspace-validation.yml
+++ b/.github/workflows/workspace-validation.yml
@@ -1,4 +1,4 @@
-name: Rust Validation
+name: Workspace Validation
 
 on:
   workflow_call:
@@ -32,6 +32,7 @@ env:
 
 jobs:
   validate:
+    name: Workspace validation
     runs-on: ubuntu-latest
 
     steps:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,8 +10,9 @@ ci = "github"
 # Keep release CI marked as intentionally customized because the checked-in
 # workflow avoids blanket secret forwarding on custom jobs that do not need it,
 # and the generated `host` job is patched to require release checks before
-# creating the GitHub release announcement. The workflow also keeps merge queue
-# validation wired to the release plan and custom release-check jobs.
+# creating the GitHub release announcement. The generated workflow still runs
+# the release plan on pull requests and merge queue checks, while release-only
+# validation is tag-gated in `.github/workflows/release-checks.yml`.
 allow-dirty = ["ci"]
 # The installers to generate for each app
 installers = ["shell", "npm"]


### PR DESCRIPTION
- Rename the shared validation workflow to `workspace-validation.yml` and name the jobs for clearer output.
- Run release validation and E2E only on tag pushes.
- Note the customized release workflow behavior in `dist-workspace.toml`.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)