### PR TITLE
Warn only on dirty main checkout changes

### DIFF
--- a/crates/agentty/src/app/session/workflow/turn.rs
+++ b/crates/agentty/src/app/session/workflow/turn.rs
@@ -55,7 +55,6 @@ pub(super) fn live_transcript_source(
 
 /// Main-checkout tracked-file status captured before one provider turn.
 struct MainCheckoutSnapshot {
-    head_hash: String,
     main_repo_root: PathBuf,
     tracked_status_output: String,
 }
@@ -79,25 +78,20 @@ impl MainCheckoutSnapshot {
             .tracked_worktree_status(validation.main_repo_root.clone())
             .await
             .map_err(|error| Self::status_error(&error))?;
-        let head_hash = context
-            .git_client
-            .head_hash(validation.main_repo_root.clone())
-            .await
-            .map_err(|error| Self::head_hash_error(&error))?;
 
         Ok(Self {
-            head_hash,
             main_repo_root: validation.main_repo_root,
             tracked_status_output,
         })
     }
 
-    /// Builds a warning when a provider turn changed the main checkout.
+    /// Builds a warning when the main checkout tracked-file status changed and
+    /// remains dirty after a provider turn.
     ///
     /// # Errors
     /// Returns a workflow error when main-checkout status cannot be read after
     /// the provider turn.
-    async fn changed_warning(
+    async fn dirty_warning(
         &self,
         context: &SessionWorkerContext,
     ) -> Result<Option<String>, SessionError> {
@@ -106,15 +100,10 @@ impl MainCheckoutSnapshot {
             .tracked_worktree_status(self.main_repo_root.clone())
             .await
             .map_err(|error| Self::status_error(&error))?;
-        let current_head_hash = context
-            .git_client
-            .head_hash(self.main_repo_root.clone())
-            .await
-            .map_err(|error| Self::head_hash_error(&error))?;
-        if current_status != self.tracked_status_output || current_head_hash != self.head_hash {
+        if current_status != self.tracked_status_output && !current_status.trim().is_empty() {
             return Ok(Some(TranscriptNotice::MainCheckoutWarning.format(
-                "The main checkout changed during this turn. Continuing this session; merge and \
-                 sync actions still require a clean main checkout.",
+                "The main checkout's tracked-file status changed during this turn. Continuing \
+                 this session; merge and sync actions still require a clean main checkout.",
             )));
         }
 
@@ -125,13 +114,6 @@ impl MainCheckoutSnapshot {
     fn status_error(error: &ag_git::GitError) -> SessionError {
         SessionError::Workflow(format!(
             "Session isolation violation: failed to inspect main checkout tracked status: {error}"
-        ))
-    }
-
-    /// Converts main-checkout `HEAD` hash failures into workflow errors.
-    fn head_hash_error(error: &ag_git::GitError) -> SessionError {
-        SessionError::Workflow(format!(
-            "Session isolation violation: failed to inspect main checkout `HEAD`: {error}"
         ))
     }
 }
@@ -505,15 +487,15 @@ fn set_child_pid(child_pid: &Mutex<Option<u32>>, pid: Option<u32>) {
     }
 }
 
-/// Converts post-turn main-checkout changes into transcript warnings while
-/// preserving the successful provider result.
+/// Converts post-turn main-checkout tracked-file changes into transcript
+/// warnings while preserving the successful provider result.
 async fn add_main_checkout_warning(
     context: &SessionWorkerContext,
     main_checkout_snapshot: &MainCheckoutSnapshot,
     turn_result: Result<TurnResult, AgentError>,
 ) -> Result<TurnResult, AgentError> {
     let result = turn_result?;
-    match main_checkout_snapshot.changed_warning(context).await {
+    match main_checkout_snapshot.dirty_warning(context).await {
         Ok(Some(warning)) => {
             append_main_checkout_warning(context, warning).await;
 

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -1152,10 +1152,6 @@ mod tests {
             .once()
             .returning(|_| Box::pin(async { Ok(String::new()) }));
         mock_git_client
-            .expect_head_hash()
-            .once()
-            .returning(|_| Box::pin(async { Ok("main-before".to_string()) }));
-        mock_git_client
             .expect_diff()
             .returning(|_, _| Box::pin(async { Ok(String::new()) }));
     }
@@ -1565,10 +1561,6 @@ mod tests {
             .times(2)
             .returning(|_| Box::pin(async { Ok(String::new()) }));
         mock_git_client
-            .expect_head_hash()
-            .times(2)
-            .returning(|_| Box::pin(async { Ok("main-before".to_string()) }));
-        mock_git_client
             .expect_diff()
             .returning(|_, _| Box::pin(async { Ok(String::new()) }));
         mock_git_client
@@ -1669,10 +1661,6 @@ mod tests {
                 })
             });
         mock_git_client
-            .expect_head_hash()
-            .times(2)
-            .returning(|_| Box::pin(async { Ok("main-before".to_string()) }));
-        mock_git_client
             .expect_diff()
             .returning(|_, _| Box::pin(async { Ok(String::new()) }));
         mock_git_client
@@ -1716,13 +1704,14 @@ mod tests {
         assert!(result.is_ok(), "main checkout changes should warn only");
         let output_text = transcript_text(&transcript);
         assert!(output_text.contains("[Main Checkout Warning]"));
+        assert!(output_text.contains("tracked-file status changed"));
         assert!(output_text.contains("done"));
     }
 
     #[tokio::test]
-    /// Verifies a turn that moves the main checkout `HEAD` records a warning
-    /// even when tracked-file status stays clean.
-    async fn test_run_channel_turn_warns_when_main_checkout_head_changes() {
+    /// Verifies a clean post-turn tracked status completes without warning,
+    /// even when pre-turn status was dirty.
+    async fn test_run_channel_turn_skips_warning_when_main_checkout_is_clean_after_turn() {
         // Arrange
         let base_dir = tempdir().expect("failed to create temp dir");
         let db = AppRepositories::in_memory().await;
@@ -1748,30 +1737,27 @@ mod tests {
                 })
             });
 
-        let head_call_count = Arc::new(Mutex::new(0));
+        let status_call_count = Arc::new(Mutex::new(0));
         let mut mock_git_client = mock_git_client_detecting_main_repo(base_dir.path().join("main"));
         mock_git_client
             .expect_tracked_worktree_status()
             .times(2)
-            .returning(|_| Box::pin(async { Ok(String::new()) }));
-        mock_git_client
-            .expect_head_hash()
-            .times(2)
             .returning(move |_| {
-                let head_call_count = Arc::clone(&head_call_count);
+                let status_call_count = Arc::clone(&status_call_count);
 
                 Box::pin(async move {
-                    let mut call_count = head_call_count
+                    let mut call_count = status_call_count
                         .lock()
-                        .expect("head call count lock poisoned");
+                        .expect("status call count lock poisoned");
                     *call_count += 1;
                     if *call_count == 1 {
-                        Ok("main-before".to_string())
+                        Ok(" M README.md\n".to_string())
                     } else {
-                        Ok("main-after".to_string())
+                        Ok(String::new())
                     }
                 })
             });
+        mock_git_client.expect_head_hash().times(0);
         mock_git_client
             .expect_diff()
             .returning(|_, _| Box::pin(async { Ok(String::new()) }));
@@ -1815,10 +1801,95 @@ mod tests {
         // Assert
         assert!(
             result.is_ok(),
-            "main checkout `HEAD` changes should warn only"
+            "clean post-turn tracked status should complete"
         );
         let output_text = transcript_text(&transcript);
-        assert!(output_text.contains("[Main Checkout Warning]"));
+        assert!(!output_text.contains("[Main Checkout Warning]"));
+        assert!(output_text.contains("done"));
+    }
+
+    #[tokio::test]
+    /// Verifies an unchanged pre-existing dirty tracked status completes
+    /// without warning.
+    async fn test_run_channel_turn_skips_warning_when_main_checkout_stays_dirty() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let db = AppRepositories::in_memory().await;
+        insert_in_progress_test_session(&db).await;
+
+        let mut mock_channel = MockAgentChannel::new();
+        mock_channel
+            .expect_run_turn()
+            .once()
+            .returning(|_session_id, _req, _events| {
+                Box::pin(async {
+                    Ok(TurnResult {
+                        assistant_message: AgentResponse {
+                            answer: "done".to_string(),
+                            questions: Vec::new(),
+                            summary: None,
+                        },
+                        context_reset: false,
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        provider_conversation_id: None,
+                    })
+                })
+            });
+
+        let mut mock_git_client = mock_git_client_detecting_main_repo(base_dir.path().join("main"));
+        mock_git_client
+            .expect_tracked_worktree_status()
+            .times(2)
+            .returning(|_| Box::pin(async { Ok(" M README.md\n".to_string()) }));
+        mock_git_client.expect_head_hash().times(0);
+        mock_git_client
+            .expect_diff()
+            .returning(|_, _| Box::pin(async { Ok(String::new()) }));
+        mock_git_client
+            .expect_is_worktree_clean()
+            .returning(|_| Box::pin(async { Ok(true) }));
+
+        let transcript = empty_transcript();
+        let context = SessionWorkerContext {
+            app_event_tx: mpsc::unbounded_channel().0,
+            cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
+            channel: Arc::new(mock_channel),
+            child_pid: Arc::new(Mutex::new(None)),
+            clock: Arc::new(crate::infra::clock::RealClock),
+            db: db.clone(),
+            folder: base_dir.path().to_path_buf(),
+            fs_client: Arc::new(mock_fs_client_with_existing_directories()),
+            git_client: Arc::new(mock_git_client),
+            transcript: Arc::clone(&transcript),
+            queued_messages: Arc::new(Mutex::new(VecDeque::new())),
+            review_request_client: Arc::new(forge::MockReviewRequestClient::new()),
+            session_update_versions: Arc::default(),
+            session_id: "sess1".into(),
+            session_agent: AgentSelection::new(
+                crate::domain::agent::AgentKind::Antigravity,
+                AgentModel::Gemini3FlashPreview,
+            ),
+            status: Arc::new(Mutex::new(Status::InProgress)),
+        };
+
+        // Act
+        let result = run_channel_turn(
+            &context,
+            default_turn_metadata(),
+            AgentRequestKind::SessionStart,
+            None,
+            "test prompt".into(),
+        )
+        .await;
+
+        // Assert
+        assert!(
+            result.is_ok(),
+            "unchanged dirty tracked status should complete"
+        );
+        let output_text = transcript_text(&transcript);
+        assert!(!output_text.contains("[Main Checkout Warning]"));
         assert!(output_text.contains("done"));
     }
 
@@ -3860,10 +3931,6 @@ mod tests {
             .times(0..)
             .returning(|_| Box::pin(async { Ok(String::new()) }));
         mock_git_client
-            .expect_head_hash()
-            .times(0..)
-            .returning(|_| Box::pin(async { Ok("main-before".to_string()) }));
-        mock_git_client
             .expect_diff()
             .returning(|_, _| Box::pin(async { Ok(String::new()) }));
         mock_git_client
@@ -4048,10 +4115,6 @@ mod tests {
             .expect_tracked_worktree_status()
             .times(2)
             .returning(|_| Box::pin(async { Ok(String::new()) }));
-        mock_git_client
-            .expect_head_hash()
-            .times(2)
-            .returning(|_| Box::pin(async { Ok("main-before".to_string()) }));
         mock_git_client
             .expect_is_worktree_clean()
             .times(1)

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -265,9 +265,11 @@ compact reminder.
 - Before every worker-dispatched turn, `workflow/isolation.rs` verifies the session
   folder exists, is checked out on the expected `wt/<hash>` branch, and resolves to a
   linked worktree with a distinct main checkout.
-- The worker snapshots the main checkout's tracked-file git status and `HEAD` hash
-  before and after each turn and appends a `[Main Checkout Warning]` transcript notice
-  when either changed.
+- The worker snapshots the main checkout's tracked-file git status before each turn and
+  inspects that status again after the turn. It appends a `[Main Checkout Warning]`
+  transcript notice only when the status changed and remains dirty, so clean `HEAD`
+  movement from parallel session merges and unchanged pre-existing dirt do not add
+  transcript noise.
 - Merge and `sync main` workflows require a clean target checkout before changing
   base-branch state.
 - Provider permission policies are scoped per transport: Codex turns run with a

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -237,8 +237,10 @@ the existing agent session to resolve only the conflicted files, then stages the
 and continues the rebase itself.
 
 During normal turns, the agent prompt names the session worktree as the only writable
-root. If Agentty detects that the main checkout's tracked status or `HEAD` changed
-during a turn, it appends a `[Main Checkout Warning]` notice to the transcript.
+root. After a turn, if Agentty detects that the main checkout's tracked-file status
+changed and remains dirty, it appends a `[Main Checkout Warning]` notice to the
+transcript. Clean `HEAD` movement, such as another session landing on the base branch,
+and unchanged pre-existing tracked changes do not emit this warning.
 
 ### Continuing a Done Session
 


### PR DESCRIPTION
- Drop `HEAD` snapshotting from main-checkout turn checks.
- Warn only when tracked-file status changes and remains dirty after a turn.
- Update worker tests and runtime docs to match the new behavior.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)