### PR TITLE
Show sync conflict resolution status

### DIFF
--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -119,6 +119,8 @@ pub(crate) enum AppEvent {
     SyncMainCompleted {
         result: Result<SyncMainOutcome, SyncSessionStartError>,
     },
+    /// Indicates list-mode sync is resolving rebase conflicts.
+    SyncMainConflictResolutionStarted { conflicted_files: Vec<String> },
     /// Indicates recomputed diff-derived size and line-count totals for one
     /// session.
     SessionSizeUpdated {
@@ -238,6 +240,7 @@ pub(super) struct AppEventBatch {
     pub(super) requested_reviews:
         Option<(u64, i64, Result<Vec<ag_forge::RequestedReview>, String>)>,
     pub(super) requested_review_comment_snapshots: Vec<RequestedReviewCommentSnapshotUpdate>,
+    pub(super) sync_main_conflicted_files: Option<Vec<String>>,
     pub(super) sync_main_result: Option<Result<SyncMainOutcome, SyncSessionStartError>>,
     pub(super) update_status: Option<UpdateStatus>,
 }
@@ -349,6 +352,9 @@ impl AppEventBatch {
                 session_id,
             } => self.collect_session_progress_updated(session_id, progress_message),
             AppEvent::SyncMainCompleted { result } => self.collect_sync_main_completed(result),
+            AppEvent::SyncMainConflictResolutionStarted { conflicted_files } => {
+                self.collect_sync_main_conflict_resolution_started(conflicted_files);
+            }
             AppEvent::SessionSizeUpdated {
                 added_lines,
                 deleted_lines,
@@ -572,6 +578,11 @@ impl AppEventBatch {
         }
 
         self.sync_main_result = Some(result);
+    }
+
+    /// Stores the latest conflicted-file list for an in-progress sync batch.
+    fn collect_sync_main_conflict_resolution_started(&mut self, conflicted_files: Vec<String>) {
+        self.sync_main_conflicted_files = Some(conflicted_files);
     }
 
     /// Stores the latest branch-publish action result for this reducer batch.
@@ -816,6 +827,10 @@ impl App {
         }
         for (session_id, sync_update) in event_batch.published_branch_sync_updates {
             self.apply_published_branch_sync_update(&session_id, sync_update);
+        }
+
+        if let Some(conflicted_files) = event_batch.sync_main_conflicted_files.as_deref() {
+            self.apply_sync_main_conflict_resolution_started(conflicted_files);
         }
 
         self.sync_touched_sessions(&event_batch.session_ids);
@@ -1231,6 +1246,7 @@ impl App {
             || !event_batch.stacked_parent_merge_child_rebases.is_empty()
             || !event_batch.stacked_parent_syncs_completed.is_empty()
             || !event_batch.stacked_parent_turns_completed.is_empty()
+            || event_batch.sync_main_conflicted_files.is_some()
             || event_batch.sync_main_result.is_some()
             || !event_batch.system_log_events.is_empty()
     }
@@ -1291,6 +1307,24 @@ impl App {
                 sync_error.detail_message()
             )),
         }
+    }
+
+    /// Updates the loading sync popup with the current conflict-resolution
+    /// status when the user is still viewing that in-progress sync.
+    fn apply_sync_main_conflict_resolution_started(&mut self, conflicted_files: &[String]) {
+        if !matches!(
+            self.mode,
+            AppMode::SyncBlockedPopup {
+                is_loading: true,
+                ..
+            }
+        ) {
+            return;
+        }
+
+        let sync_popup_context = self.sync_popup_context();
+        self.mode =
+            Self::sync_main_conflict_resolution_popup_mode(conflicted_files, &sync_popup_context);
     }
 
     /// Builds system log events for sessions whose rendered status changed
@@ -1953,6 +1987,32 @@ impl App {
                 title: "Sync failed".to_string(),
             },
         }
+    }
+
+    /// Builds the in-progress sync popup shown while conflicts are being
+    /// resolved.
+    pub(super) fn sync_main_conflict_resolution_popup_mode(
+        conflicted_files: &[String],
+        sync_popup_context: &SyncPopupContext,
+    ) -> AppMode {
+        AppMode::SyncBlockedPopup {
+            project_name: Some(sync_popup_context.project_name.clone()),
+            default_branch: Some(sync_popup_context.default_branch.clone()),
+            is_loading: true,
+            message: Self::sync_conflict_resolution_message(conflicted_files),
+            title: "Resolving conflicts".to_string(),
+        }
+    }
+
+    /// Returns loading-state copy for assisted sync conflict resolution.
+    fn sync_conflict_resolution_message(conflicted_files: &[String]) -> String {
+        let file_list = conflicted_files
+            .iter()
+            .map(|file| format!("- {file}"))
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        format!("Resolving conflicts during sync.\n\nConflicted files:\n{file_list}")
     }
 
     /// Builds success copy for sync completion with pull/push/conflict metrics

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -1819,6 +1819,55 @@ fn sync_main_popup_mode_success_message_tracks_project_and_branch() {
     }
 }
 
+#[tokio::test]
+async fn apply_app_events_sync_conflicts_updates_loading_popup() {
+    // Arrange
+    let (mut app, base_dir) = crate::test_support::new_test_app().await;
+    let expected_project_name = base_dir
+        .path()
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("expected temp dir file name")
+        .to_string();
+    app.projects.update_active_project_context(
+        app.active_project_id(),
+        expected_project_name.clone(),
+        Some("develop".to_string()),
+        None,
+        base_dir.path().to_path_buf(),
+    );
+    app.mode = AppMode::SyncBlockedPopup {
+        default_branch: Some("develop".to_string()),
+        is_loading: true,
+        message: App::sync_loading_message(),
+        project_name: Some(expected_project_name.clone()),
+        title: "Sync in progress".to_string(),
+    };
+
+    // Act
+    app.apply_app_events(AppEvent::SyncMainConflictResolutionStarted {
+        conflicted_files: vec!["src/lib.rs".to_string(), "README.md".to_string()],
+    })
+    .await;
+
+    // Assert
+    assert!(matches!(
+        app.mode,
+        AppMode::SyncBlockedPopup {
+            ref default_branch,
+            is_loading: true,
+            ref message,
+            ref project_name,
+            ref title,
+        } if title == "Resolving conflicts"
+            && default_branch.as_deref() == Some("develop")
+            && project_name.as_deref() == Some(expected_project_name.as_str())
+            && message.contains("Resolving conflicts during sync.")
+            && message.contains("- README.md")
+            && message.contains("- src/lib.rs")
+    ));
+}
+
 #[test]
 fn sync_main_popup_mode_blocked_message_tracks_project_and_branch() {
     // Arrange

--- a/crates/agentty/src/app/service.rs
+++ b/crates/agentty/src/app/service.rs
@@ -266,6 +266,7 @@ fn app_event_label(event: &AppEvent) -> &'static str {
         }
         AppEvent::SessionProgressUpdated { .. } => "SessionProgressUpdated",
         AppEvent::SyncMainCompleted { .. } => "SyncMainCompleted",
+        AppEvent::SyncMainConflictResolutionStarted { .. } => "SyncMainConflictResolutionStarted",
         AppEvent::SessionSizeUpdated { .. } => "SessionSizeUpdated",
         AppEvent::SessionTitleGenerationFinished { .. } => "SessionTitleGenerationFinished",
         AppEvent::BranchPublishActionCompleted { .. } => "BranchPublishActionCompleted",

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -4633,6 +4633,7 @@ async fn test_sync_main_uses_active_project_branch_from_context() {
     let result = SessionManager::sync_main_for_project(
         app.projects.git_branch().map(str::to_string),
         app.projects.working_dir().to_path_buf(),
+        None,
         Arc::new(mock_git_client),
         AgentModel::Gemini3FlashPreview,
     )
@@ -4670,6 +4671,7 @@ async fn test_sync_main_requires_clean_selected_project_branch() {
     let result = SessionManager::sync_main_for_project(
         app.projects.git_branch().map(str::to_string),
         app.projects.working_dir().to_path_buf(),
+        None,
         Arc::new(mock_git_client),
         AgentModel::Gemini3FlashPreview,
     )
@@ -4694,6 +4696,7 @@ async fn test_sync_main_returns_error_without_upstream_remote() {
     let result = SessionManager::sync_main_for_project(
         app.projects.git_branch().map(str::to_string),
         app.projects.working_dir().to_path_buf(),
+        None,
         app.services.git_client(),
         AgentModel::Gemini3FlashPreview,
     )
@@ -4756,6 +4759,7 @@ async fn test_sync_main_pushes_local_commits_to_remote() {
     let result = SessionManager::sync_main_for_project(
         Some("main".to_string()),
         dir.path().to_path_buf(),
+        None,
         Arc::new(mock_git_client),
         AgentModel::Gemini3FlashPreview,
     )

--- a/crates/agentty/src/app/session/workflow/merge.rs
+++ b/crates/agentty/src/app/session/workflow/merge.rs
@@ -282,6 +282,7 @@ struct FinalizeMergeInput<'a> {
 
 /// Input context for assisted conflict resolution during `sync main`.
 struct SyncRebaseAssistInput {
+    app_event_tx: Option<mpsc::UnboundedSender<AppEvent>>,
     base_branch: String,
     folder: PathBuf,
     fs_client: Arc<dyn FsClient>,
@@ -403,6 +404,7 @@ impl RebaseAssistLoopInput {
                 SessionManager::run_rebase_assist_agent(input, conflicted_files).await
             }
             Self::Project(input) => {
+                SessionManager::emit_sync_rebase_conflict_status(input, conflicted_files);
                 SessionManager::run_sync_rebase_assist_agent(input, conflicted_files).await
             }
         }
@@ -1551,6 +1553,7 @@ impl SessionManager {
     pub(crate) async fn sync_main_for_project(
         default_branch: Option<String>,
         working_dir: PathBuf,
+        app_event_tx: Option<mpsc::UnboundedSender<AppEvent>>,
         git_client: Arc<dyn GitClient>,
         session_model: AgentModel,
     ) -> Result<SyncMainOutcome, SyncSessionStartError> {
@@ -1565,6 +1568,7 @@ impl SessionManager {
         Self::sync_main_for_project_with_assist_client(
             default_branch,
             working_dir,
+            app_event_tx,
             fs_client,
             git_client,
             session_agent,
@@ -1583,6 +1587,7 @@ impl SessionManager {
     async fn sync_main_for_project_with_assist_client(
         default_branch: Option<String>,
         working_dir: PathBuf,
+        app_event_tx: Option<mpsc::UnboundedSender<AppEvent>>,
         fs_client: Arc<dyn FsClient>,
         git_client: Arc<dyn GitClient>,
         session_agent: AgentSelection,
@@ -1622,6 +1627,7 @@ impl SessionManager {
         let mut resolved_conflict_files = Vec::new();
         if let git::PullRebaseResult::Conflict { detail } = pull_result {
             let sync_rebase_input = SyncRebaseAssistInput {
+                app_event_tx,
                 base_branch: default_branch.clone(),
                 folder: working_dir.clone(),
                 fs_client: Arc::clone(&fs_client),
@@ -1681,6 +1687,21 @@ impl SessionManager {
         )
         .await
         .map(|outcome| outcome.resolved_conflict_files)
+    }
+
+    /// Emits a foreground sync popup update listing the files currently being
+    /// resolved by the assisted project sync rebase.
+    fn emit_sync_rebase_conflict_status(
+        input: &SyncRebaseAssistInput,
+        conflicted_files: &[String],
+    ) {
+        let Some(app_event_tx) = &input.app_event_tx else {
+            return;
+        };
+
+        let _ = app_event_tx.send(AppEvent::SyncMainConflictResolutionStarted {
+            conflicted_files: conflicted_files.to_vec(),
+        });
     }
 
     /// Returns pull/push counts inferred around one completed sync run.
@@ -3090,6 +3111,7 @@ mod tests {
         sync_assist_client: Arc<dyn SyncAssistClient>,
     ) -> SyncRebaseAssistInput {
         SyncRebaseAssistInput {
+            app_event_tx: None,
             base_branch: "main".to_string(),
             folder,
             fs_client: test_fs_client(),
@@ -3099,6 +3121,96 @@ mod tests {
                 AgentModel::Gemini3FlashPreview,
             ),
             sync_assist_client,
+        }
+    }
+
+    /// Builds a git client mock for a successful project sync that stops on
+    /// one conflict, receives assistance, and then pushes.
+    fn successful_sync_conflict_git_client() -> git::MockGitClient {
+        let mut mock_git_client = git::MockGitClient::new();
+        mock_git_client
+            .expect_find_git_repo_root()
+            .times(1)
+            .returning(|folder| Box::pin(async move { Some(folder) }));
+        mock_git_client
+            .expect_is_worktree_clean()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(true) }));
+        mock_git_client
+            .expect_get_ahead_behind()
+            .times(1)
+            .return_once(|_| Box::pin(async { Ok((1, 2)) }));
+        mock_git_client
+            .expect_list_upstream_commit_titles()
+            .times(1)
+            .returning(|_| {
+                Box::pin(async {
+                    Ok(vec![
+                        "Update changelog format".to_string(),
+                        "Fix sync popup copy".to_string(),
+                    ])
+                })
+            });
+        mock_git_client
+            .expect_get_ahead_behind()
+            .times(1)
+            .return_once(|_| Box::pin(async { Ok((1, 0)) }));
+        mock_git_client
+            .expect_list_local_commit_titles()
+            .times(1)
+            .returning(|_| {
+                Box::pin(async { Ok(vec!["Refine sync conflict messaging".to_string()]) })
+            });
+        mock_git_client
+            .expect_pull_rebase()
+            .times(1)
+            .returning(|_| {
+                Box::pin(async {
+                    Ok(git::PullRebaseResult::Conflict {
+                        detail: "CONFLICT (content): Merge conflict in src/lib.rs".to_string(),
+                    })
+                })
+            });
+        mock_git_client
+            .expect_list_conflicted_files()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(vec!["src/lib.rs".to_string()]) }));
+        mock_git_client
+            .expect_list_staged_conflict_marker_files()
+            .times(2)
+            .returning(|_, _| Box::pin(async { Ok(vec![]) }));
+        mock_git_client
+            .expect_stage_all()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(()) }));
+        mock_git_client
+            .expect_has_unmerged_paths()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(false) }));
+        mock_git_client
+            .expect_rebase_continue()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(git::RebaseStepResult::Completed) }));
+        mock_git_client
+            .expect_push_current_branch()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok("origin/main".to_string()) }));
+        mock_git_client.expect_abort_rebase().times(0);
+
+        mock_git_client
+    }
+
+    /// Returns the expected result for the successful assisted sync fixture.
+    fn successful_sync_conflict_outcome() -> SyncMainOutcome {
+        SyncMainOutcome {
+            pulled_commit_titles: vec![
+                "Update changelog format".to_string(),
+                "Fix sync popup copy".to_string(),
+            ],
+            pulled_commits: Some(2),
+            pushed_commit_titles: vec!["Refine sync conflict messaging".to_string()],
+            pushed_commits: Some(1),
+            resolved_conflict_files: vec!["src/lib.rs".to_string()],
         }
     }
 
@@ -4303,86 +4415,20 @@ mod tests {
         // Arrange
         let temp_dir = tempdir().expect("failed to create temporary test directory");
         let working_dir = temp_dir.path().to_path_buf();
-        let mut mock_git_client = git::MockGitClient::new();
-        mock_git_client
-            .expect_find_git_repo_root()
-            .times(1)
-            .returning(|folder| Box::pin(async move { Some(folder) }));
-        mock_git_client
-            .expect_is_worktree_clean()
-            .times(1)
-            .returning(|_| Box::pin(async { Ok(true) }));
-        mock_git_client
-            .expect_get_ahead_behind()
-            .times(1)
-            .return_once(|_| Box::pin(async { Ok((1, 2)) }));
-        mock_git_client
-            .expect_list_upstream_commit_titles()
-            .times(1)
-            .returning(|_| {
-                Box::pin(async {
-                    Ok(vec![
-                        "Update changelog format".to_string(),
-                        "Fix sync popup copy".to_string(),
-                    ])
-                })
-            });
-        mock_git_client
-            .expect_get_ahead_behind()
-            .times(1)
-            .return_once(|_| Box::pin(async { Ok((1, 0)) }));
-        mock_git_client
-            .expect_list_local_commit_titles()
-            .times(1)
-            .returning(|_| {
-                Box::pin(async { Ok(vec!["Refine sync conflict messaging".to_string()]) })
-            });
-        mock_git_client
-            .expect_pull_rebase()
-            .times(1)
-            .returning(|_| {
-                Box::pin(async {
-                    Ok(git::PullRebaseResult::Conflict {
-                        detail: "CONFLICT (content): Merge conflict in src/lib.rs".to_string(),
-                    })
-                })
-            });
-        mock_git_client
-            .expect_list_conflicted_files()
-            .times(1)
-            .returning(|_| Box::pin(async { Ok(vec!["src/lib.rs".to_string()]) }));
-        mock_git_client
-            .expect_list_staged_conflict_marker_files()
-            .times(2)
-            .returning(|_, _| Box::pin(async { Ok(vec![]) }));
-        mock_git_client
-            .expect_stage_all()
-            .times(1)
-            .returning(|_| Box::pin(async { Ok(()) }));
-        mock_git_client
-            .expect_has_unmerged_paths()
-            .times(1)
-            .returning(|_| Box::pin(async { Ok(false) }));
-        mock_git_client
-            .expect_rebase_continue()
-            .times(1)
-            .returning(|_| Box::pin(async { Ok(git::RebaseStepResult::Completed) }));
-        mock_git_client
-            .expect_push_current_branch()
-            .times(1)
-            .returning(|_| Box::pin(async { Ok("origin/main".to_string()) }));
-        mock_git_client.expect_abort_rebase().times(0);
-
+        let mock_git_client = successful_sync_conflict_git_client();
         let mut mock_sync_assist_client = MockSyncAssistClient::new();
         mock_sync_assist_client
             .expect_resolve_rebase_conflicts()
             .times(1)
             .returning(|_, _, _| Box::pin(async { Ok(()) }));
 
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+
         // Act
         let result = SessionManager::sync_main_for_project_with_assist_client(
             Some("main".to_string()),
             working_dir,
+            Some(app_event_tx),
             test_fs_client(),
             Arc::new(mock_git_client),
             AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini3FlashPreview),
@@ -4391,18 +4437,19 @@ mod tests {
         .await;
 
         // Assert
+        let status_event = app_event_rx
+            .try_recv()
+            .expect("sync conflict status event should be emitted");
+        assert!(matches!(
+            status_event,
+            AppEvent::SyncMainConflictResolutionStarted {
+                conflicted_files
+            } if conflicted_files == vec!["src/lib.rs".to_string()]
+        ));
+        assert!(app_event_rx.try_recv().is_err());
         assert_eq!(
             result,
-            Ok(SyncMainOutcome {
-                pulled_commit_titles: vec![
-                    "Update changelog format".to_string(),
-                    "Fix sync popup copy".to_string(),
-                ],
-                pulled_commits: Some(2),
-                pushed_commit_titles: vec!["Refine sync conflict messaging".to_string()],
-                pushed_commits: Some(1),
-                resolved_conflict_files: vec!["src/lib.rs".to_string()],
-            }),
+            Ok(successful_sync_conflict_outcome()),
             "sync should succeed after assistance with summary details"
         );
     }
@@ -4472,6 +4519,7 @@ mod tests {
         let result = SessionManager::sync_main_for_project_with_assist_client(
             Some("main".to_string()),
             working_dir,
+            None,
             test_fs_client(),
             Arc::new(mock_git_client),
             AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini3FlashPreview),

--- a/crates/agentty/src/app/sync.rs
+++ b/crates/agentty/src/app/sync.rs
@@ -635,6 +635,7 @@ impl SyncOrchestrator {
         let result = session::SessionManager::sync_main_for_project(
             default_branch,
             working_dir,
+            Some(app_event_tx.clone()),
             git_client,
             session_model,
         )

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -56,6 +56,10 @@ New session worktrees start from the local active base branch. If local `main` i
 `origin/main`, the session branch still starts from local `main`; run list-mode sync
 (`s`) first when you want a new session to include remote-only commits.
 
+If list-mode sync stops on rebase conflicts, the sync popup stays in its loading state
+and changes to a conflict-resolution message listing the conflicted files being handed
+to the assist agent.
+
 ## Session Lifecycle
 
 <a id="usage-session-lifecycle"></a> Session statuses:


### PR DESCRIPTION
- Emit a sync event when assisted `sync main` starts resolving rebase conflicts.
- Keep the loading popup visible and replace its copy with the conflicted file list.
- Update sync tests and workflow docs for the new conflict-resolution state.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)