### PR TITLE
Blocks unsafe session branch pushes

### DIFF
--- a/crates/ag-git/src/client.rs
+++ b/crates/ag-git/src/client.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 
 use super::error::GitError;
 use super::merge::SquashMergeOutcome;
-use super::rebase::RebaseStepResult;
+use super::rebase::{InProgressGitOperation, RebaseStepResult};
 #[cfg(test)]
 use super::sync;
 use super::sync::{BranchTrackingMap, PullRebaseResult, SingleCommitMessageStrategy};
@@ -14,8 +14,8 @@ use super::{
     abort_rebase, branch_tracking_statuses, commit_all, commit_all_preserving_single_commit,
     create_worktree, current_upstream_reference, delete_branch, detect_git_info, diff,
     fetch_remote, find_git_repo_root, get_ahead_behind, get_ref_ahead_behind, has_commits_since,
-    has_unmerged_paths, head_commit_message, head_hash, head_short_hash, is_rebase_in_progress,
-    is_worktree_clean, list_conflicted_files, list_local_commit_titles,
+    has_unmerged_paths, head_commit_message, head_hash, head_short_hash, in_progress_operation,
+    is_rebase_in_progress, is_worktree_clean, list_conflicted_files, list_local_commit_titles,
     list_staged_conflict_marker_files, list_upstream_commit_titles, main_repo_root, pull_rebase,
     push_current_branch, push_current_branch_to_remote_branch, rebase, rebase_continue,
     rebase_onto_start, rebase_start, ref_hash, remote_branch_exists, remove_worktree, repo_url,
@@ -133,6 +133,15 @@ pub trait GitClient: Send + Sync {
     /// # Errors
     /// Returns an error when git state cannot be inspected.
     fn is_rebase_in_progress(&self, repo_path: PathBuf) -> GitFuture<Result<bool, GitError>>;
+
+    /// Returns detected in-progress git operation metadata in `repo_path`.
+    ///
+    /// # Errors
+    /// Returns an error when git state cannot be inspected.
+    fn in_progress_operation(
+        &self,
+        repo_path: PathBuf,
+    ) -> GitFuture<Result<Option<InProgressGitOperation>, GitError>>;
 
     /// Returns whether unmerged index entries remain in `repo_path`.
     ///
@@ -470,6 +479,13 @@ impl GitClient for RealGitClient {
 
     fn is_rebase_in_progress(&self, repo_path: PathBuf) -> GitFuture<Result<bool, GitError>> {
         Box::pin(async move { is_rebase_in_progress(repo_path).await })
+    }
+
+    fn in_progress_operation(
+        &self,
+        repo_path: PathBuf,
+    ) -> GitFuture<Result<Option<InProgressGitOperation>, GitError>> {
+        Box::pin(async move { in_progress_operation(repo_path).await })
     }
 
     fn has_unmerged_paths(&self, repo_path: PathBuf) -> GitFuture<Result<bool, GitError>> {

--- a/crates/ag-git/src/lib.rs
+++ b/crates/ag-git/src/lib.rs
@@ -26,9 +26,9 @@ pub use error::GitError;
 pub use merge::{SquashMergeOutcome, squash_merge, squash_merge_diff};
 /// Re-exported rebase/conflict APIs.
 pub use rebase::{
-    RebaseStepResult, abort_rebase, has_unmerged_paths, is_rebase_in_progress,
-    list_conflicted_files, list_staged_conflict_marker_files, rebase, rebase_continue,
-    rebase_onto_start, rebase_start,
+    InProgressGitOperation, RebaseStepResult, abort_rebase, has_unmerged_paths,
+    in_progress_operation, is_rebase_in_progress, list_conflicted_files,
+    list_staged_conflict_marker_files, rebase, rebase_continue, rebase_onto_start, rebase_start,
 };
 /// Re-exported repository metadata APIs.
 pub use repo::{main_repo_root, repo_url};

--- a/crates/ag-git/src/rebase.rs
+++ b/crates/ag-git/src/rebase.rs
@@ -56,6 +56,42 @@ pub enum RebaseStepResult {
     Conflict { detail: String },
 }
 
+/// Git operation metadata that marks a worktree as unsafe for branch pushes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InProgressGitOperation {
+    /// A cherry-pick is in progress.
+    CherryPick,
+    /// A merge is in progress.
+    Merge,
+    /// A rebase is in progress.
+    Rebase,
+    /// A revert is in progress.
+    Revert,
+}
+
+impl InProgressGitOperation {
+    /// Returns an indefinite article plus the operation name for user-facing
+    /// status text.
+    pub fn article_name(self) -> &'static str {
+        match self {
+            Self::CherryPick => "a cherry-pick",
+            Self::Merge => "a merge",
+            Self::Rebase => "a rebase",
+            Self::Revert => "a revert",
+        }
+    }
+
+    /// Returns the operation name for user-facing status text.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::CherryPick => "cherry-pick",
+            Self::Merge => "merge",
+            Self::Rebase => "rebase",
+            Self::Revert => "revert",
+        }
+    }
+}
+
 /// Rebases the current branch onto `target_branch`.
 ///
 /// If the rebase fails due to conflict, this function aborts it immediately so
@@ -241,12 +277,54 @@ pub async fn is_rebase_in_progress(repo_path: PathBuf) -> Result<bool, GitError>
     spawn_blocking(move || -> Result<bool, GitError> {
         let git_dir = resolve_git_dir(&repo_path)
             .ok_or_else(|| GitError::OutputParse("Failed to resolve git directory".to_string()))?;
-        let rebase_merge = git_dir.join("rebase-merge");
-        let rebase_apply = git_dir.join("rebase-apply");
 
-        Ok(rebase_merge.exists() || rebase_apply.exists())
+        Ok(has_rebase_metadata(&git_dir))
     })
     .await?
+}
+
+/// Returns the first detected in-progress git operation in `repo_path`.
+///
+/// # Arguments
+/// * `repo_path` - Path to the git repository or worktree
+///
+/// # Returns
+/// An operation when rebase, merge, cherry-pick, or revert metadata exists.
+///
+/// # Errors
+/// Returns a [`GitError`] when the git directory cannot be resolved.
+pub async fn in_progress_operation(
+    repo_path: PathBuf,
+) -> Result<Option<InProgressGitOperation>, GitError> {
+    spawn_blocking(move || in_progress_operation_sync(&repo_path)).await?
+}
+
+fn in_progress_operation_sync(
+    repo_path: &Path,
+) -> Result<Option<InProgressGitOperation>, GitError> {
+    let git_dir = resolve_git_dir(repo_path)
+        .ok_or_else(|| GitError::OutputParse("Failed to resolve git directory".to_string()))?;
+    if has_rebase_metadata(&git_dir) {
+        return Ok(Some(InProgressGitOperation::Rebase));
+    }
+    if git_dir.join("MERGE_HEAD").exists() {
+        return Ok(Some(InProgressGitOperation::Merge));
+    }
+    if git_dir.join("CHERRY_PICK_HEAD").exists() {
+        return Ok(Some(InProgressGitOperation::CherryPick));
+    }
+    if git_dir.join("REVERT_HEAD").exists() {
+        return Ok(Some(InProgressGitOperation::Revert));
+    }
+
+    Ok(None)
+}
+
+fn has_rebase_metadata(git_dir: &Path) -> bool {
+    let rebase_merge = git_dir.join("rebase-merge");
+    let rebase_apply = git_dir.join("rebase-apply");
+
+    rebase_merge.exists() || rebase_apply.exists()
 }
 
 /// Returns whether unresolved paths still exist in the index.
@@ -719,6 +797,86 @@ mod tests {
 
         // Assert
         assert!(is_stale_metadata_error);
+    }
+
+    #[test]
+    fn test_in_progress_operation_detects_rebase_metadata() {
+        // Arrange
+        let temp_dir = tempdir().expect("tempdir should be created");
+        let git_dir = temp_dir.path().join(".git");
+        fs::create_dir(&git_dir).expect("git dir should be created");
+        fs::create_dir(git_dir.join("rebase-merge")).expect("rebase metadata should be created");
+
+        // Act
+        let operation =
+            in_progress_operation_sync(temp_dir.path()).expect("operation should be detected");
+
+        // Assert
+        assert_eq!(operation, Some(InProgressGitOperation::Rebase));
+    }
+
+    #[test]
+    fn test_in_progress_operation_detects_merge_metadata() {
+        // Arrange
+        let temp_dir = tempdir().expect("tempdir should be created");
+        let git_dir = temp_dir.path().join(".git");
+        fs::create_dir(&git_dir).expect("git dir should be created");
+        fs::write(git_dir.join("MERGE_HEAD"), "merge").expect("merge metadata should be created");
+
+        // Act
+        let operation =
+            in_progress_operation_sync(temp_dir.path()).expect("operation should be detected");
+
+        // Assert
+        assert_eq!(operation, Some(InProgressGitOperation::Merge));
+    }
+
+    #[test]
+    fn test_in_progress_operation_detects_cherry_pick_metadata() {
+        // Arrange
+        let temp_dir = tempdir().expect("tempdir should be created");
+        let git_dir = temp_dir.path().join(".git");
+        fs::create_dir(&git_dir).expect("git dir should be created");
+        fs::write(git_dir.join("CHERRY_PICK_HEAD"), "cherry-pick")
+            .expect("cherry-pick metadata should be created");
+
+        // Act
+        let operation =
+            in_progress_operation_sync(temp_dir.path()).expect("operation should be detected");
+
+        // Assert
+        assert_eq!(operation, Some(InProgressGitOperation::CherryPick));
+    }
+
+    #[test]
+    fn test_in_progress_operation_detects_revert_metadata() {
+        // Arrange
+        let temp_dir = tempdir().expect("tempdir should be created");
+        let git_dir = temp_dir.path().join(".git");
+        fs::create_dir(&git_dir).expect("git dir should be created");
+        fs::write(git_dir.join("REVERT_HEAD"), "revert")
+            .expect("revert metadata should be created");
+
+        // Act
+        let operation =
+            in_progress_operation_sync(temp_dir.path()).expect("operation should be detected");
+
+        // Assert
+        assert_eq!(operation, Some(InProgressGitOperation::Revert));
+    }
+
+    #[test]
+    fn test_in_progress_operation_returns_none_for_clean_git_dir() {
+        // Arrange
+        let temp_dir = tempdir().expect("tempdir should be created");
+        fs::create_dir(temp_dir.path().join(".git")).expect("git dir should be created");
+
+        // Act
+        let operation =
+            in_progress_operation_sync(temp_dir.path()).expect("operation should be detected");
+
+        // Assert
+        assert_eq!(operation, None);
     }
 
     #[test]

--- a/crates/agentty/src/app/branch_publish.rs
+++ b/crates/agentty/src/app/branch_publish.rs
@@ -489,6 +489,14 @@ pub(crate) async fn push_session_branch_to_remote(
     let target_branch =
         remote_branch_name.map_or_else(|| session::session_branch(session_id), str::to_string);
 
+    ensure_session_branch_push_safe(
+        git_client.as_ref(),
+        folder.clone(),
+        publish_branch_action,
+        session_id,
+    )
+    .await?;
+
     if let Some(target_branch) = remote_branch_name
         && published_upstream_ref.is_none()
     {
@@ -563,6 +571,61 @@ pub(crate) async fn push_session_branch_to_remote(
         })?;
 
     Ok(upstream_reference)
+}
+
+/// Blocks session-branch force-pushes while the worktree is in an unsafe git
+/// state.
+async fn ensure_session_branch_push_safe(
+    git_client: &dyn GitClient,
+    folder: PathBuf,
+    publish_branch_action: PublishBranchAction,
+    session_id: &str,
+) -> Result<(), BranchPublishTaskFailure> {
+    let retry_text = retry_action_text(publish_branch_action);
+    let folder_display = folder.display().to_string();
+    let in_progress_operation = git_client
+        .in_progress_operation(folder.clone())
+        .await
+        .map_err(|error| {
+            BranchPublishTaskFailure::failed(
+                publish_branch_action,
+                format!(
+                    "Failed to inspect session branch git state in `{folder_display}`: {error}"
+                ),
+            )
+        })?;
+    if let Some(in_progress_operation) = in_progress_operation {
+        return Err(BranchPublishTaskFailure::blocked(
+            publish_branch_action,
+            format!(
+                "Session branch push is paused because {} is in progress in `{folder_display}`. \
+                 Finish or abort the {}, then {retry_text}.",
+                in_progress_operation.article_name(),
+                in_progress_operation.name()
+            ),
+        ));
+    }
+
+    let expected_branch = session::session_branch(session_id);
+    let Some(current_branch) = git_client.detect_git_info(folder).await else {
+        return Err(BranchPublishTaskFailure::failed(
+            publish_branch_action,
+            format!(
+                "Failed to detect the current session branch in `{folder_display}` before pushing."
+            ),
+        ));
+    };
+    if current_branch != expected_branch {
+        return Err(BranchPublishTaskFailure::blocked(
+            publish_branch_action,
+            format!(
+                "Refusing to push session branch because the worktree is on `{current_branch}` \
+                 instead of `{expected_branch}`. Return to the session branch, then {retry_text}."
+            ),
+        ));
+    }
+
+    Ok(())
 }
 
 /// Resolves one forge remote for review-request publishing.
@@ -858,6 +921,49 @@ mod tests {
     use super::*;
     use crate::infra::db::AppRepositories;
 
+    fn expect_safe_session_branch_push(mock_git_client: &mut git::MockGitClient, session_id: &str) {
+        let expected_branch = session::session_branch(session_id);
+        mock_git_client
+            .expect_in_progress_operation()
+            .once()
+            .returning(|_| Box::pin(async { Ok(None) }));
+        mock_git_client
+            .expect_detect_git_info()
+            .once()
+            .returning(move |_| {
+                let expected_branch = expected_branch.clone();
+
+                Box::pin(async move { Some(expected_branch) })
+            });
+    }
+
+    async fn push_session_branch_to_remote_with_mock(
+        mock_git_client: git::MockGitClient,
+    ) -> Result<String, BranchPublishTaskFailure> {
+        let database = AppRepositories::in_memory().await;
+        let project_id = database
+            .projects()
+            .upsert_project("/tmp/project", Some("main".to_string()))
+            .await
+            .expect("failed to insert project");
+        database
+            .sessions()
+            .insert_session("session-id", "gpt-5.5", "main", "Review", project_id)
+            .await
+            .expect("failed to insert session");
+
+        push_session_branch_to_remote(
+            &database,
+            PathBuf::from("/tmp/session-worktree"),
+            Arc::new(mock_git_client),
+            PublishBranchAction::Push,
+            "session-id",
+            None,
+            Some("origin/wt/session-id"),
+        )
+        .await
+    }
+
     #[tokio::test]
     async fn review_request_remote_attaches_session_worktree_to_detected_remote() {
         // Arrange
@@ -933,6 +1039,7 @@ mod tests {
             .expect_remote_branch_exists()
             .once()
             .returning(|_, _| Box::pin(async { Ok(false) }));
+        expect_safe_session_branch_push(&mut mock_git_client, "session-id");
         mock_git_client
             .expect_push_current_branch_to_remote_branch()
             .once()
@@ -1130,6 +1237,7 @@ mod tests {
             .expect("failed to insert session");
         let session_folder = PathBuf::from("/tmp/session-worktree");
         let mut mock_git_client = git::MockGitClient::new();
+        expect_safe_session_branch_push(&mut mock_git_client, "session-id");
         mock_git_client
             .expect_remote_branch_exists()
             .once()
@@ -1170,6 +1278,7 @@ mod tests {
         let session_folder = PathBuf::from("/tmp/session-worktree");
         let expected_folder = session_folder.clone();
         let mut mock_git_client = git::MockGitClient::new();
+        expect_safe_session_branch_push(&mut mock_git_client, "session-id");
         mock_git_client
             .expect_push_current_branch_to_remote_branch()
             .once()
@@ -1213,6 +1322,7 @@ mod tests {
         let expected_upstream = format!("origin/{expected_branch}");
         let expected_upstream_assertion = expected_upstream.clone();
         let mut mock_git_client = git::MockGitClient::new();
+        expect_safe_session_branch_push(&mut mock_git_client, "session-id");
         mock_git_client
             .expect_push_current_branch_to_remote_branch()
             .once()
@@ -1241,6 +1351,192 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn push_blocks_while_session_branch_rebase_is_in_progress() {
+        // Arrange
+        let database = AppRepositories::in_memory().await;
+        let project_id = database
+            .projects()
+            .upsert_project("/tmp/project", Some("main".to_string()))
+            .await
+            .expect("failed to insert project");
+        database
+            .sessions()
+            .insert_session("session-id", "gpt-5.5", "main", "Review", project_id)
+            .await
+            .expect("failed to insert session");
+        let session_folder = PathBuf::from("/tmp/session-worktree");
+        let mut mock_git_client = git::MockGitClient::new();
+        mock_git_client
+            .expect_in_progress_operation()
+            .once()
+            .returning(|_| Box::pin(async { Ok(Some(git::InProgressGitOperation::Rebase)) }));
+        mock_git_client.expect_detect_git_info().times(0);
+        mock_git_client.expect_remote_branch_exists().times(0);
+        mock_git_client
+            .expect_push_current_branch_to_remote_branch()
+            .times(0);
+
+        // Act
+        let result = push_session_branch_to_remote(
+            &database,
+            session_folder,
+            Arc::new(mock_git_client),
+            PublishBranchAction::Push,
+            "session-id",
+            Some("feature/new-branch"),
+            None,
+        )
+        .await;
+
+        // Assert
+        let failure = result.expect_err("push should be blocked");
+        assert_eq!(failure.title, "Branch push blocked");
+        assert!(failure.message.contains("rebase is in progress"));
+    }
+
+    #[tokio::test]
+    async fn push_blocks_while_session_branch_merge_is_in_progress() {
+        // Arrange
+        let mut mock_git_client = git::MockGitClient::new();
+        mock_git_client
+            .expect_in_progress_operation()
+            .once()
+            .returning(|_| Box::pin(async { Ok(Some(git::InProgressGitOperation::Merge)) }));
+        mock_git_client.expect_detect_git_info().times(0);
+        mock_git_client
+            .expect_push_current_branch_to_remote_branch()
+            .times(0);
+
+        // Act
+        let result = push_session_branch_to_remote_with_mock(mock_git_client).await;
+
+        // Assert
+        let failure = result.expect_err("push should be blocked");
+        assert_eq!(failure.title, "Branch push blocked");
+        assert!(failure.message.contains("merge is in progress"));
+    }
+
+    #[tokio::test]
+    async fn push_blocks_while_session_branch_cherry_pick_is_in_progress() {
+        // Arrange
+        let mut mock_git_client = git::MockGitClient::new();
+        mock_git_client
+            .expect_in_progress_operation()
+            .once()
+            .returning(|_| Box::pin(async { Ok(Some(git::InProgressGitOperation::CherryPick)) }));
+        mock_git_client.expect_detect_git_info().times(0);
+        mock_git_client
+            .expect_push_current_branch_to_remote_branch()
+            .times(0);
+
+        // Act
+        let result = push_session_branch_to_remote_with_mock(mock_git_client).await;
+
+        // Assert
+        let failure = result.expect_err("push should be blocked");
+        assert_eq!(failure.title, "Branch push blocked");
+        assert!(failure.message.contains("cherry-pick is in progress"));
+    }
+
+    #[tokio::test]
+    async fn push_blocks_while_session_branch_revert_is_in_progress() {
+        // Arrange
+        let mut mock_git_client = git::MockGitClient::new();
+        mock_git_client
+            .expect_in_progress_operation()
+            .once()
+            .returning(|_| Box::pin(async { Ok(Some(git::InProgressGitOperation::Revert)) }));
+        mock_git_client.expect_detect_git_info().times(0);
+        mock_git_client
+            .expect_push_current_branch_to_remote_branch()
+            .times(0);
+
+        // Act
+        let result = push_session_branch_to_remote_with_mock(mock_git_client).await;
+
+        // Assert
+        let failure = result.expect_err("push should be blocked");
+        assert_eq!(failure.title, "Branch push blocked");
+        assert!(failure.message.contains("revert is in progress"));
+    }
+
+    #[tokio::test]
+    async fn push_blocks_when_worktree_is_not_on_session_branch() {
+        // Arrange
+        let database = AppRepositories::in_memory().await;
+        let project_id = database
+            .projects()
+            .upsert_project("/tmp/project", Some("main".to_string()))
+            .await
+            .expect("failed to insert project");
+        database
+            .sessions()
+            .insert_session("session-id", "gpt-5.5", "main", "Review", project_id)
+            .await
+            .expect("failed to insert session");
+        let session_folder = PathBuf::from("/tmp/session-worktree");
+        let mut mock_git_client = git::MockGitClient::new();
+        mock_git_client
+            .expect_in_progress_operation()
+            .once()
+            .returning(|_| Box::pin(async { Ok(None) }));
+        mock_git_client
+            .expect_detect_git_info()
+            .once()
+            .returning(|_| Box::pin(async { Some("main".to_string()) }));
+        mock_git_client
+            .expect_push_current_branch_to_remote_branch()
+            .times(0);
+
+        // Act
+        let result = push_session_branch_to_remote(
+            &database,
+            session_folder,
+            Arc::new(mock_git_client),
+            PublishBranchAction::Push,
+            "session-id",
+            None,
+            Some("origin/wt/session-id"),
+        )
+        .await;
+
+        // Assert
+        let failure = result.expect_err("push should be blocked");
+        assert_eq!(failure.title, "Branch push blocked");
+        assert!(failure.message.contains("worktree is on `main`"));
+        assert!(failure.message.contains("instead of `wt/session-`"));
+    }
+
+    #[tokio::test]
+    async fn push_reports_folder_when_session_branch_cannot_be_detected() {
+        // Arrange
+        let mut mock_git_client = git::MockGitClient::new();
+        mock_git_client
+            .expect_in_progress_operation()
+            .once()
+            .returning(|_| Box::pin(async { Ok(None) }));
+        mock_git_client
+            .expect_detect_git_info()
+            .once()
+            .returning(|_| Box::pin(async { None }));
+        mock_git_client
+            .expect_push_current_branch_to_remote_branch()
+            .times(0);
+
+        // Act
+        let result = push_session_branch_to_remote_with_mock(mock_git_client).await;
+
+        // Assert
+        let failure = result.expect_err("push should fail");
+        assert_eq!(failure.title, "Branch push failed");
+        assert!(
+            failure
+                .message
+                .contains("`/tmp/session-worktree` before pushing")
+        );
+    }
+
+    #[tokio::test]
     async fn push_shows_auth_guidance_when_ls_remote_returns_auth_error() {
         // Arrange
         let database = AppRepositories::in_memory().await;
@@ -1256,6 +1552,7 @@ mod tests {
             .expect("failed to insert session");
         let session_folder = PathBuf::from("/tmp/session-worktree");
         let mut mock_git_client = git::MockGitClient::new();
+        expect_safe_session_branch_push(&mut mock_git_client, "session-id");
         mock_git_client
             .expect_remote_branch_exists()
             .once()
@@ -1309,6 +1606,7 @@ mod tests {
         let expected_branch = session::session_branch("session-id");
         let expected_push_command = format!("git push origin HEAD:{expected_branch}");
         let mut mock_git_client = git::MockGitClient::new();
+        expect_safe_session_branch_push(&mut mock_git_client, "session-id");
         mock_git_client
             .expect_push_current_branch_to_remote_branch()
             .once()

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -1142,6 +1142,14 @@ async fn push_session_branch_auth_failure_shows_git_guidance() {
     );
     let mut mock_git_client = ag_git::MockGitClient::new();
     mock_git_client
+        .expect_in_progress_operation()
+        .once()
+        .returning(|_| Box::pin(async { Ok(None) }));
+    mock_git_client
+        .expect_detect_git_info()
+        .once()
+        .returning(|_| Box::pin(async { Some(session::session_branch("session-1")) }));
+    mock_git_client
         .expect_push_current_branch_to_remote_branch()
         .once()
         .with(
@@ -1191,6 +1199,14 @@ async fn push_session_branch_preserves_blocked_when_remote_branch_exists() {
     );
     let mut mock_git_client = ag_git::MockGitClient::new();
     mock_git_client
+        .expect_in_progress_operation()
+        .once()
+        .returning(|_| Box::pin(async { Ok(None) }));
+    mock_git_client
+        .expect_detect_git_info()
+        .once()
+        .returning(|_| Box::pin(async { Some(session::session_branch("session-1")) }));
+    mock_git_client
         .expect_remote_branch_exists()
         .once()
         .returning(|_, _| Box::pin(async { Ok(true) }));
@@ -1220,6 +1236,14 @@ async fn push_session_branch_shows_auth_guidance_when_ls_remote_fails_with_auth_
         &crate::test_support::session_fixture_with_folder(PathBuf::from("/tmp/review-session")),
     );
     let mut mock_git_client = ag_git::MockGitClient::new();
+    mock_git_client
+        .expect_in_progress_operation()
+        .once()
+        .returning(|_| Box::pin(async { Ok(None) }));
+    mock_git_client
+        .expect_detect_git_info()
+        .once()
+        .returning(|_| Box::pin(async { Some(session::session_branch("session-1")) }));
     mock_git_client
         .expect_remote_branch_exists()
         .once()
@@ -1382,6 +1406,14 @@ async fn push_session_branch_uses_custom_remote_branch_name_when_provided() {
         .once()
         .returning(|_, _| Box::pin(async { Ok(false) }));
     mock_git_client
+        .expect_in_progress_operation()
+        .once()
+        .returning(|_| Box::pin(async { Ok(None) }));
+    mock_git_client
+        .expect_detect_git_info()
+        .once()
+        .returning(|_| Box::pin(async { Some(session::session_branch("session-1")) }));
+    mock_git_client
         .expect_push_current_branch_to_remote_branch()
         .with(
             mockall::predicate::eq(PathBuf::from("/tmp/review-session")),
@@ -1433,6 +1465,14 @@ async fn push_session_branch_succeeds_without_review_request_link_for_unsupporte
         &crate::test_support::session_fixture_with_folder(PathBuf::from("/tmp/review-session")),
     );
     let mut mock_git_client = ag_git::MockGitClient::new();
+    mock_git_client
+        .expect_in_progress_operation()
+        .once()
+        .returning(|_| Box::pin(async { Ok(None) }));
+    mock_git_client
+        .expect_detect_git_info()
+        .once()
+        .returning(|_| Box::pin(async { Some(session::session_branch("session-1")) }));
     mock_git_client
         .expect_push_current_branch_to_remote_branch()
         .with(

--- a/crates/agentty/src/app/session/workflow/merge.rs
+++ b/crates/agentty/src/app/session/workflow/merge.rs
@@ -4867,6 +4867,14 @@ mod tests {
 
         let mut mock_git_client = git::MockGitClient::new();
         mock_git_client
+            .expect_in_progress_operation()
+            .once()
+            .returning(|_| Box::pin(async { Ok(None) }));
+        mock_git_client
+            .expect_detect_git_info()
+            .once()
+            .returning(|_| Box::pin(async { Some("wt/sess-reb".to_string()) }));
+        mock_git_client
             .expect_push_current_branch_to_remote_branch()
             .once()
             .withf(|session_folder, remote_branch_name| {

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -2524,6 +2524,19 @@ mod tests {
         }
     }
 
+    /// Expects the branch-publish safety preflight used by published-branch
+    /// auto-push.
+    fn expect_safe_auto_push_state(mock_git_client: &mut MockGitClient) {
+        mock_git_client
+            .expect_in_progress_operation()
+            .once()
+            .returning(|_| Box::pin(async { Ok(None) }));
+        mock_git_client
+            .expect_detect_git_info()
+            .once()
+            .returning(|_| Box::pin(async { Some("wt/sess1".to_string()) }));
+    }
+
     /// Returns one git client mock that produces a successful auto-commit
     /// outcome.
     fn auto_commit_git_client(commit_message: &str, sequence: &mut Sequence) -> MockGitClient {
@@ -2556,6 +2569,7 @@ mod tests {
             .expect_head_short_hash()
             .once()
             .returning(|_| Box::pin(async { Ok("abc1234".to_string()) }));
+        expect_safe_auto_push_state(&mut mock_git_client);
         mock_git_client
             .expect_push_current_branch_to_remote_branch()
             .once()
@@ -2607,6 +2621,7 @@ mod tests {
             .expect_head_short_hash()
             .once()
             .returning(|_| Box::pin(async { Ok("abc1234".to_string()) }));
+        expect_safe_auto_push_state(&mut mock_git_client);
         mock_git_client
             .expect_push_current_branch_to_remote_branch()
             .once()
@@ -2724,6 +2739,7 @@ mod tests {
             .expect_is_worktree_clean()
             .times(1)
             .returning(|_| Box::pin(async { Ok(true) }));
+        expect_safe_auto_push_state(&mut mock_git_client);
         mock_git_client
             .expect_push_current_branch_to_remote_branch()
             .once()
@@ -2923,6 +2939,7 @@ mod tests {
             .expect_is_worktree_clean()
             .times(1)
             .returning(|_| Box::pin(async { Ok(true) }));
+        expect_safe_auto_push_state(&mut mock_git_client);
         mock_git_client
             .expect_push_current_branch_to_remote_branch()
             .once()
@@ -4101,7 +4118,7 @@ mod tests {
         let main_repo_root = base_dir.path().join("main");
         mock_git_client
             .expect_detect_git_info()
-            .times(1)
+            .times(2)
             .returning(|_| Box::pin(async { Some("wt/sess1".to_string()) }));
         mock_git_client.expect_main_repo_root().times(1).returning({
             let main_repo_root = main_repo_root.clone();
@@ -4119,6 +4136,10 @@ mod tests {
             .expect_is_worktree_clean()
             .times(1)
             .returning(|_| Box::pin(async { Ok(true) }));
+        mock_git_client
+            .expect_in_progress_operation()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(None) }));
         mock_git_client
             .expect_diff()
             .returning(|_, _| Box::pin(async { Ok(String::new()) }));


### PR DESCRIPTION
- Detects rebase, merge, cherry-pick, and revert metadata before publishing a session branch.
- Verifies the worktree is on the expected session branch before pushing.
- Adds in-progress operation detection to `ag-git` and updates branch-publish, merge, worker, and state tests.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)