### PR TITLE
Inject git client into startup discovery

### DIFF
--- a/crates/ag-git/src/lib.rs
+++ b/crates/ag-git/src/lib.rs
@@ -22,28 +22,25 @@ pub use client::MockGitClient;
 pub use client::{GitClient, GitFuture, RealGitClient};
 /// Re-exported typed error for git infrastructure operations.
 pub use error::GitError;
-/// Re-exported squash-merge APIs.
-pub use merge::{SquashMergeOutcome, squash_merge, squash_merge_diff};
-/// Re-exported rebase/conflict APIs.
-pub use rebase::{
-    InProgressGitOperation, RebaseStepResult, abort_rebase, has_unmerged_paths,
-    in_progress_operation, is_rebase_in_progress, list_conflicted_files,
-    list_staged_conflict_marker_files, rebase, rebase_continue, rebase_onto_start, rebase_start,
+pub use merge::SquashMergeOutcome;
+pub(crate) use merge::{squash_merge, squash_merge_diff};
+pub use rebase::{InProgressGitOperation, RebaseStepResult};
+pub(crate) use rebase::{
+    abort_rebase, has_unmerged_paths, in_progress_operation, is_rebase_in_progress,
+    list_conflicted_files, list_staged_conflict_marker_files, rebase, rebase_continue,
+    rebase_onto_start, rebase_start,
 };
-/// Re-exported repository metadata APIs.
-pub use repo::{main_repo_root, repo_url};
+pub(crate) use repo::{main_repo_root, repo_url};
 #[cfg(test)]
 pub(crate) use sleeper::MockSleeper;
 pub(crate) use sleeper::{Sleeper, ThreadSleeper};
-/// Re-exported commit/sync/diff APIs.
-pub use sync::{
-    BranchTrackingMap, PullRebaseResult, SingleCommitMessageStrategy, branch_tracking_statuses,
-    commit_all, commit_all_preserving_single_commit, current_upstream_reference, delete_branch,
-    diff, fetch_remote, get_ahead_behind, get_ref_ahead_behind, has_commits_since,
-    head_commit_message, head_hash, head_short_hash, is_worktree_clean, list_local_commit_titles,
-    list_upstream_commit_titles, pull_rebase, push_current_branch,
-    push_current_branch_to_remote_branch, ref_hash, remote_branch_exists, stage_all,
-    tracked_worktree_status, worktree_status,
+pub use sync::{BranchTrackingMap, PullRebaseResult, SingleCommitMessageStrategy};
+pub(crate) use sync::{
+    branch_tracking_statuses, commit_all, commit_all_preserving_single_commit,
+    current_upstream_reference, delete_branch, diff, fetch_remote, get_ahead_behind,
+    get_ref_ahead_behind, has_commits_since, head_commit_message, head_hash, head_short_hash,
+    is_worktree_clean, list_local_commit_titles, list_upstream_commit_titles, pull_rebase,
+    push_current_branch, push_current_branch_to_remote_branch, ref_hash, remote_branch_exists,
+    stage_all, tracked_worktree_status, worktree_status,
 };
-/// Re-exported worktree and branch-detection APIs.
-pub use worktree::{create_worktree, detect_git_info, find_git_repo_root, remove_worktree};
+pub(crate) use worktree::{create_worktree, detect_git_info, find_git_repo_root, remove_worktree};

--- a/crates/ag-git/src/merge.rs
+++ b/crates/ag-git/src/merge.rs
@@ -31,7 +31,7 @@ pub enum SquashMergeOutcome {
 /// # Errors
 /// Returns an error if invoking `git` fails or `git diff` exits with a
 /// non-zero status.
-pub async fn squash_merge_diff(
+pub(crate) async fn squash_merge_diff(
     repo_path: PathBuf,
     source_branch: String,
     target_branch: String,
@@ -71,7 +71,7 @@ pub async fn squash_merge_diff(
 /// # Errors
 /// Returns an error if the repository is on the wrong branch, the merge
 /// fails, or the commit fails.
-pub async fn squash_merge(
+pub(crate) async fn squash_merge(
     repo_path: PathBuf,
     source_branch: String,
     target_branch: String,

--- a/crates/ag-git/src/rebase.rs
+++ b/crates/ag-git/src/rebase.rs
@@ -107,7 +107,7 @@ impl InProgressGitOperation {
 /// # Errors
 /// Returns a [`GitError`] if rebase fails, or aborting a conflicted rebase
 /// also fails.
-pub async fn rebase(repo_path: PathBuf, target_branch: String) -> Result<(), GitError> {
+pub(crate) async fn rebase(repo_path: PathBuf, target_branch: String) -> Result<(), GitError> {
     match rebase_start(repo_path.clone(), target_branch.clone()).await? {
         RebaseStepResult::Completed => Ok(()),
         RebaseStepResult::Conflict { detail } => {
@@ -138,7 +138,7 @@ pub async fn rebase(repo_path: PathBuf, target_branch: String) -> Result<(), Git
 ///
 /// # Errors
 /// Returns a [`GitError`] for non-conflict git failures.
-pub async fn rebase_start(
+pub(crate) async fn rebase_start(
     repo_path: PathBuf,
     target_branch: String,
 ) -> Result<RebaseStepResult, GitError> {
@@ -167,7 +167,7 @@ pub async fn rebase_start(
 ///
 /// # Errors
 /// Returns a [`GitError`] for non-conflict git failures.
-pub async fn rebase_onto_start(
+pub(crate) async fn rebase_onto_start(
     repo_path: PathBuf,
     new_base: String,
     old_base: String,
@@ -192,7 +192,7 @@ pub async fn rebase_onto_start(
 ///
 /// # Errors
 /// Returns a [`GitError`] for non-conflict git failures.
-pub async fn rebase_continue(repo_path: PathBuf) -> Result<RebaseStepResult, GitError> {
+pub(crate) async fn rebase_continue(repo_path: PathBuf) -> Result<RebaseStepResult, GitError> {
     spawn_blocking(move || {
         let output = run_git_command_with_index_lock_retry(
             &repo_path,
@@ -231,7 +231,7 @@ pub async fn rebase_continue(repo_path: PathBuf) -> Result<RebaseStepResult, Git
 ///
 /// # Errors
 /// Returns a [`GitError`] when `git rebase --abort` cannot be executed.
-pub async fn abort_rebase(repo_path: PathBuf) -> Result<(), GitError> {
+pub(crate) async fn abort_rebase(repo_path: PathBuf) -> Result<(), GitError> {
     spawn_blocking(move || {
         let output =
             run_git_command_with_index_lock_retry(&repo_path, &["rebase", "--abort"], &[])?;
@@ -273,7 +273,7 @@ pub async fn abort_rebase(repo_path: PathBuf) -> Result<(), GitError> {
 ///
 /// # Errors
 /// Returns a [`GitError`] when the git directory cannot be resolved.
-pub async fn is_rebase_in_progress(repo_path: PathBuf) -> Result<bool, GitError> {
+pub(crate) async fn is_rebase_in_progress(repo_path: PathBuf) -> Result<bool, GitError> {
     spawn_blocking(move || -> Result<bool, GitError> {
         let git_dir = resolve_git_dir(&repo_path)
             .ok_or_else(|| GitError::OutputParse("Failed to resolve git directory".to_string()))?;
@@ -293,7 +293,7 @@ pub async fn is_rebase_in_progress(repo_path: PathBuf) -> Result<bool, GitError>
 ///
 /// # Errors
 /// Returns a [`GitError`] when the git directory cannot be resolved.
-pub async fn in_progress_operation(
+pub(crate) async fn in_progress_operation(
     repo_path: PathBuf,
 ) -> Result<Option<InProgressGitOperation>, GitError> {
     spawn_blocking(move || in_progress_operation_sync(&repo_path)).await?
@@ -337,7 +337,7 @@ fn has_rebase_metadata(git_dir: &Path) -> bool {
 ///
 /// # Errors
 /// Returns a [`GitError`] when conflicted files cannot be queried.
-pub async fn has_unmerged_paths(repo_path: PathBuf) -> Result<bool, GitError> {
+pub(crate) async fn has_unmerged_paths(repo_path: PathBuf) -> Result<bool, GitError> {
     let conflicted_files = list_conflicted_files(repo_path).await?;
 
     Ok(!conflicted_files.is_empty())
@@ -366,7 +366,7 @@ pub async fn has_unmerged_paths(repo_path: PathBuf) -> Result<bool, GitError> {
 /// Returns a [`GitError`] if `git grep` cannot be executed or exits with an
 /// unexpected error code. An exit code of `1` (no matches) is treated as
 /// success with an empty result.
-pub async fn list_staged_conflict_marker_files(
+pub(crate) async fn list_staged_conflict_marker_files(
     repo_path: PathBuf,
     paths: Vec<String>,
 ) -> Result<Vec<String>, GitError> {
@@ -414,7 +414,7 @@ pub async fn list_staged_conflict_marker_files(
 /// # Errors
 /// Returns a [`GitError`] if invoking `git diff --name-only --diff-filter=U`
 /// fails.
-pub async fn list_conflicted_files(repo_path: PathBuf) -> Result<Vec<String>, GitError> {
+pub(crate) async fn list_conflicted_files(repo_path: PathBuf) -> Result<Vec<String>, GitError> {
     spawn_blocking(move || -> Result<Vec<String>, GitError> {
         let output = run_git_command_sync(
             &repo_path,

--- a/crates/ag-git/src/repo.rs
+++ b/crates/ag-git/src/repo.rs
@@ -16,7 +16,7 @@ use super::error::GitError;
 ///
 /// # Errors
 /// Returns an error if the remote URL cannot be read via `git remote get-url`.
-pub async fn repo_url(repo_path: PathBuf) -> Result<String, GitError> {
+pub(crate) async fn repo_url(repo_path: PathBuf) -> Result<String, GitError> {
     let remote = run_git_command(
         repo_path,
         vec![
@@ -46,7 +46,7 @@ pub async fn repo_url(repo_path: PathBuf) -> Result<String, GitError> {
 ///
 /// # Errors
 /// Returns an error if git metadata cannot be queried from `repo_path`.
-pub async fn main_repo_root(repo_path: PathBuf) -> Result<PathBuf, GitError> {
+pub(crate) async fn main_repo_root(repo_path: PathBuf) -> Result<PathBuf, GitError> {
     spawn_blocking(move || main_repo_root_sync(&repo_path)).await?
 }
 

--- a/crates/ag-git/src/sync.rs
+++ b/crates/ag-git/src/sync.rs
@@ -48,7 +48,7 @@ pub enum PullRebaseResult {
 ///
 /// # Errors
 /// Returns a [`GitError`] if staging or committing changes fails.
-pub async fn commit_all(
+pub(crate) async fn commit_all(
     repo_path: PathBuf,
     commit_message: String,
     no_verify: bool,
@@ -84,7 +84,7 @@ pub async fn commit_all(
 /// # Errors
 /// Returns a [`GitError`] if staging, commit lookup, or committing changes
 /// fails.
-pub async fn commit_all_preserving_single_commit(
+pub(crate) async fn commit_all_preserving_single_commit(
     repo_path: PathBuf,
     base_branch: String,
     commit_message: String,
@@ -113,7 +113,7 @@ pub async fn commit_all_preserving_single_commit(
 ///
 /// # Errors
 /// Returns a [`GitError`] if `git add -A` fails.
-pub async fn stage_all(repo_path: PathBuf) -> Result<(), GitError> {
+pub(crate) async fn stage_all(repo_path: PathBuf) -> Result<(), GitError> {
     spawn_blocking(move || stage_all_sync(&repo_path)).await?
 }
 
@@ -127,7 +127,7 @@ pub async fn stage_all(repo_path: PathBuf) -> Result<(), GitError> {
 ///
 /// # Errors
 /// Returns a [`GitError`] if resolving `HEAD` fails.
-pub async fn head_short_hash(repo_path: PathBuf) -> Result<String, GitError> {
+pub(crate) async fn head_short_hash(repo_path: PathBuf) -> Result<String, GitError> {
     let hash = run_git_command(
         repo_path,
         vec![
@@ -158,7 +158,7 @@ pub async fn head_short_hash(repo_path: PathBuf) -> Result<String, GitError> {
 ///
 /// # Errors
 /// Returns a [`GitError`] if resolving `HEAD` fails.
-pub async fn head_hash(repo_path: PathBuf) -> Result<String, GitError> {
+pub(crate) async fn head_hash(repo_path: PathBuf) -> Result<String, GitError> {
     let hash = run_git_command(
         repo_path,
         vec!["rev-parse".to_string(), "HEAD".to_string()],
@@ -186,7 +186,7 @@ pub async fn head_hash(repo_path: PathBuf) -> Result<String, GitError> {
 ///
 /// # Errors
 /// Returns a [`GitError`] if the reference cannot be resolved to a commit.
-pub async fn ref_hash(repo_path: PathBuf, reference: String) -> Result<String, GitError> {
+pub(crate) async fn ref_hash(repo_path: PathBuf, reference: String) -> Result<String, GitError> {
     let hash = run_git_command(
         repo_path,
         vec![
@@ -211,7 +211,7 @@ pub async fn ref_hash(repo_path: PathBuf, reference: String) -> Result<String, G
 ///
 /// # Errors
 /// Returns a [`GitError`] if `HEAD` cannot be inspected.
-pub async fn head_commit_message(repo_path: PathBuf) -> Result<Option<String>, GitError> {
+pub(crate) async fn head_commit_message(repo_path: PathBuf) -> Result<Option<String>, GitError> {
     spawn_blocking(move || head_commit_message_sync(&repo_path)).await?
 }
 
@@ -228,7 +228,7 @@ pub async fn head_commit_message(repo_path: PathBuf) -> Result<Option<String>, G
 ///
 /// # Errors
 /// Returns a [`GitError`] if the branch delete command fails.
-pub async fn delete_branch(repo_path: PathBuf, branch_name: String) -> Result<(), GitError> {
+pub(crate) async fn delete_branch(repo_path: PathBuf, branch_name: String) -> Result<(), GitError> {
     run_git_command(
         repo_path,
         vec!["branch".to_string(), "-D".to_string(), branch_name],
@@ -259,7 +259,7 @@ pub async fn delete_branch(repo_path: PathBuf, branch_name: String) -> Result<()
 /// # Errors
 /// Returns a [`GitError`] if preparing the index, generating the diff, or
 /// restoring index state fails.
-pub async fn diff(repo_path: PathBuf, base_branch: String) -> Result<String, GitError> {
+pub(crate) async fn diff(repo_path: PathBuf, base_branch: String) -> Result<String, GitError> {
     spawn_blocking(move || -> Result<String, GitError> {
         run_git_command_sync(
             &repo_path,
@@ -316,7 +316,7 @@ pub async fn diff(repo_path: PathBuf, base_branch: String) -> Result<String, Git
 ///
 /// # Errors
 /// Returns a [`GitError`] if `git status --porcelain` cannot be executed.
-pub async fn is_worktree_clean(repo_path: PathBuf) -> Result<bool, GitError> {
+pub(crate) async fn is_worktree_clean(repo_path: PathBuf) -> Result<bool, GitError> {
     let status_output = worktree_status(repo_path).await?;
 
     Ok(status_output.trim().is_empty())
@@ -335,7 +335,7 @@ pub async fn is_worktree_clean(repo_path: PathBuf) -> Result<bool, GitError> {
 ///
 /// # Errors
 /// Returns a [`GitError`] if the status command cannot be executed.
-pub async fn worktree_status(repo_path: PathBuf) -> Result<String, GitError> {
+pub(crate) async fn worktree_status(repo_path: PathBuf) -> Result<String, GitError> {
     run_git_command(
         repo_path,
         vec![
@@ -362,7 +362,7 @@ pub async fn worktree_status(repo_path: PathBuf) -> Result<String, GitError> {
 ///
 /// # Errors
 /// Returns a [`GitError`] if the status command cannot be executed.
-pub async fn tracked_worktree_status(repo_path: PathBuf) -> Result<String, GitError> {
+pub(crate) async fn tracked_worktree_status(repo_path: PathBuf) -> Result<String, GitError> {
     run_git_command(
         repo_path,
         vec![
@@ -390,7 +390,7 @@ pub async fn tracked_worktree_status(repo_path: PathBuf) -> Result<String, GitEr
 ///
 /// # Errors
 /// Returns a [`GitError`] for non-conflict pull/rebase failures.
-pub async fn pull_rebase(repo_path: PathBuf) -> Result<PullRebaseResult, GitError> {
+pub(crate) async fn pull_rebase(repo_path: PathBuf) -> Result<PullRebaseResult, GitError> {
     spawn_blocking(move || {
         let pull_arguments = pull_rebase_arguments(&repo_path)
             .unwrap_or_else(|_| vec!["pull".to_string(), "--rebase".to_string()]);
@@ -542,7 +542,7 @@ fn current_branch_name(repo_path: &Path) -> Result<String, GitError> {
 /// # Errors
 /// Returns a [`GitError`] if `git push` fails or upstream tracking cannot be
 /// resolved afterwards.
-pub async fn push_current_branch(repo_path: PathBuf) -> Result<String, GitError> {
+pub(crate) async fn push_current_branch(repo_path: PathBuf) -> Result<String, GitError> {
     spawn_blocking(move || -> Result<String, GitError> {
         let push_output = run_git_command_output_sync(&repo_path, &["push", "--force-with-lease"])?;
 
@@ -587,7 +587,7 @@ pub async fn push_current_branch(repo_path: PathBuf) -> Result<String, GitError>
 ///
 /// # Errors
 /// Returns a [`GitError`] if the `git ls-remote` command fails.
-pub async fn remote_branch_exists(
+pub(crate) async fn remote_branch_exists(
     repo_path: PathBuf,
     remote_branch_name: String,
 ) -> Result<bool, GitError> {
@@ -631,7 +631,7 @@ pub async fn remote_branch_exists(
 ///
 /// # Errors
 /// Returns a [`GitError`] if `git push` fails.
-pub async fn push_current_branch_to_remote_branch(
+pub(crate) async fn push_current_branch_to_remote_branch(
     repo_path: PathBuf,
     remote_branch_name: String,
 ) -> Result<String, GitError> {
@@ -668,7 +668,7 @@ pub async fn push_current_branch_to_remote_branch(
 /// # Errors
 /// Returns a [`GitError`] when upstream tracking information cannot be
 /// resolved.
-pub async fn current_upstream_reference(repo_path: PathBuf) -> Result<String, GitError> {
+pub(crate) async fn current_upstream_reference(repo_path: PathBuf) -> Result<String, GitError> {
     spawn_blocking(move || primary_upstream_reference(&repo_path)).await?
 }
 
@@ -682,7 +682,7 @@ pub async fn current_upstream_reference(repo_path: PathBuf) -> Result<String, Gi
 ///
 /// # Errors
 /// Returns a [`GitError`] if `git fetch` cannot be executed successfully.
-pub async fn fetch_remote(repo_path: PathBuf) -> Result<(), GitError> {
+pub(crate) async fn fetch_remote(repo_path: PathBuf) -> Result<(), GitError> {
     run_git_command(
         repo_path,
         vec!["fetch".to_string()],
@@ -704,7 +704,7 @@ pub async fn fetch_remote(repo_path: PathBuf) -> Result<(), GitError> {
 /// # Errors
 /// Returns a [`GitError`] if `git rev-list` fails or returns unexpected
 /// output.
-pub async fn get_ahead_behind(repo_path: PathBuf) -> Result<(u32, u32), GitError> {
+pub(crate) async fn get_ahead_behind(repo_path: PathBuf) -> Result<(u32, u32), GitError> {
     get_ref_ahead_behind(repo_path, "HEAD".to_string(), "@{u}".to_string()).await
 }
 
@@ -717,7 +717,7 @@ pub async fn get_ahead_behind(repo_path: PathBuf) -> Result<(u32, u32), GitError
 /// # Errors
 /// Returns a [`GitError`] if `git rev-list` fails or returns unexpected
 /// output.
-pub async fn get_ref_ahead_behind(
+pub(crate) async fn get_ref_ahead_behind(
     repo_path: PathBuf,
     left_ref: String,
     right_ref: String,
@@ -761,7 +761,9 @@ fn parse_ahead_behind_counts(rev_list_output: &str) -> Result<(u32, u32), GitErr
 ///
 /// # Errors
 /// Returns a [`GitError`] if `git for-each-ref` fails.
-pub async fn branch_tracking_statuses(repo_path: PathBuf) -> Result<BranchTrackingMap, GitError> {
+pub(crate) async fn branch_tracking_statuses(
+    repo_path: PathBuf,
+) -> Result<BranchTrackingMap, GitError> {
     let git_output = run_git_command(
         repo_path,
         vec![
@@ -786,7 +788,9 @@ pub async fn branch_tracking_statuses(repo_path: PathBuf) -> Result<BranchTracki
 /// # Errors
 /// Returns a [`GitError`] when `git log` fails or upstream tracking refs are
 /// unavailable.
-pub async fn list_upstream_commit_titles(repo_path: PathBuf) -> Result<Vec<String>, GitError> {
+pub(crate) async fn list_upstream_commit_titles(
+    repo_path: PathBuf,
+) -> Result<Vec<String>, GitError> {
     let git_output = run_git_command(
         repo_path,
         vec![
@@ -812,7 +816,7 @@ pub async fn list_upstream_commit_titles(repo_path: PathBuf) -> Result<Vec<Strin
 /// # Errors
 /// Returns a [`GitError`] when `git log` fails or upstream tracking refs are
 /// unavailable.
-pub async fn list_local_commit_titles(repo_path: PathBuf) -> Result<Vec<String>, GitError> {
+pub(crate) async fn list_local_commit_titles(repo_path: PathBuf) -> Result<Vec<String>, GitError> {
     let git_output = run_git_command(
         repo_path,
         vec![
@@ -833,7 +837,10 @@ pub async fn list_local_commit_titles(repo_path: PathBuf) -> Result<Vec<String>,
 ///
 /// # Errors
 /// Returns a [`GitError`] if commit ancestry cannot be queried.
-pub async fn has_commits_since(repo_path: PathBuf, base_branch: String) -> Result<bool, GitError> {
+pub(crate) async fn has_commits_since(
+    repo_path: PathBuf,
+    base_branch: String,
+) -> Result<bool, GitError> {
     spawn_blocking(move || -> Result<bool, GitError> {
         let rev_list_output = run_git_command_sync(
             &repo_path,

--- a/crates/ag-git/src/worktree.rs
+++ b/crates/ag-git/src/worktree.rs
@@ -8,7 +8,7 @@ use super::repo::{main_repo_root_sync, resolve_git_dir, run_git_command_sync};
 
 /// Detects git repository information for the given directory.
 /// Returns the current branch name if in a git repository, None otherwise.
-pub async fn detect_git_info(dir: PathBuf) -> Option<String> {
+pub(crate) async fn detect_git_info(dir: PathBuf) -> Option<String> {
     spawn_blocking(move || detect_git_info_sync(&dir))
         .await
         .ok()
@@ -18,7 +18,7 @@ pub async fn detect_git_info(dir: PathBuf) -> Option<String> {
 /// Walks up the directory tree to find a .git directory.
 /// Returns the directory containing .git (the repository root) if found, None
 /// otherwise.
-pub async fn find_git_repo_root(dir: PathBuf) -> Option<PathBuf> {
+pub(crate) async fn find_git_repo_root(dir: PathBuf) -> Option<PathBuf> {
     spawn_blocking(move || find_git_repo_root_sync(&dir))
         .await
         .ok()
@@ -39,7 +39,7 @@ pub async fn find_git_repo_root(dir: PathBuf) -> Option<PathBuf> {
 /// # Errors
 /// Returns [`GitError::CommandFailed`] if spawning fails or the worktree
 /// command exits with a non-zero status.
-pub async fn create_worktree(
+pub(crate) async fn create_worktree(
     repo_path: PathBuf,
     worktree_path: PathBuf,
     branch_name: String,
@@ -79,7 +79,7 @@ pub async fn create_worktree(
 /// # Errors
 /// Returns [`GitError::CommandFailed`] if spawning fails or the worktree
 /// remove command exits with a non-zero status.
-pub async fn remove_worktree(worktree_path: PathBuf) -> Result<(), GitError> {
+pub(crate) async fn remove_worktree(worktree_path: PathBuf) -> Result<(), GitError> {
     spawn_blocking(move || {
         let repo_root = main_repo_root_sync(&worktree_path)?;
         let worktree_path = worktree_path.to_string_lossy().to_string();

--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -405,12 +405,14 @@ impl App {
     #[cfg(test)]
     pub(super) async fn load_projects_from_home_directory(
         db: &AppRepositories,
+        git_client: &dyn GitClient,
         project_discovery_client: &dyn ProjectDiscoveryClient,
         session_worktree_root: &Path,
         home_directory: Option<&Path>,
     ) {
         AppStartup::load_projects_from_home_directory(
             db,
+            git_client,
             project_discovery_client,
             session_worktree_root,
             home_directory,

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -4112,11 +4112,17 @@ async fn refresh_project_catalog_on_startup_discovers_home_directory_repositorie
     let discovered_repo = home_directory.path().join("agentty");
     create_git_repo_marker(discovered_repo.as_path());
     let fs_client = RealFsClient;
+    let mut mock_git_client = ag_git::MockGitClient::new();
     let session_worktree_root = home_directory.path().join(".agentty").join(AGENTTY_WT_DIR);
+    mock_git_client
+        .expect_detect_git_info()
+        .times(1)
+        .returning(|_| Box::pin(async { Some("main".to_string()) }));
 
     // Act
     App::load_projects_from_home_directory(
         &database,
+        &mock_git_client,
         &RealProjectDiscoveryClient,
         session_worktree_root.as_path(),
         Some(home_directory.path()),
@@ -4133,6 +4139,7 @@ async fn refresh_project_catalog_on_startup_discovers_home_directory_repositorie
     // Assert
     assert_eq!(project_items.len(), 1);
     assert_eq!(project_items[0].project.path, discovered_repo);
+    assert_eq!(project_items[0].project.git_branch.as_deref(), Some("main"));
 }
 
 /// Creates one directory with a `.git` marker for repository discovery

--- a/crates/agentty/src/app/startup.rs
+++ b/crates/agentty/src/app/startup.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use ag_agent::agent::AgentAvailabilityProbe;
-use ag_git::{GitClient, detect_git_info};
+use ag_git::GitClient;
 use ratatui::widgets::TableState;
 use tokio::sync::mpsc;
 
@@ -175,7 +175,8 @@ impl AppStartup {
                     startup_working_dir.display()
                 ))
             })?;
-        Self::refresh_project_catalog_on_startup(db, project_discovery_client).await;
+        Self::refresh_project_catalog_on_startup(db, git_client.as_ref(), project_discovery_client)
+            .await;
 
         let project_items = Self::load_project_items(db, fs_client).await;
         let active_project_name =
@@ -335,6 +336,7 @@ impl AppStartup {
     /// through the injected project-discovery boundary.
     pub(crate) async fn refresh_project_catalog_on_startup(
         db: &AppRepositories,
+        git_client: &dyn GitClient,
         project_discovery_client: &dyn ProjectDiscoveryClient,
     ) {
         let session_worktree_root = super::core::agentty_home().join(AGENTTY_WT_DIR);
@@ -342,6 +344,7 @@ impl AppStartup {
 
         Self::load_projects_from_home_directory(
             db,
+            git_client,
             project_discovery_client,
             session_worktree_root.as_path(),
             home_directory.as_deref(),
@@ -353,6 +356,7 @@ impl AppStartup {
     /// injected project-discovery boundary and persists them.
     pub(crate) async fn load_projects_from_home_directory(
         db: &AppRepositories,
+        git_client: &dyn GitClient,
         project_discovery_client: &dyn ProjectDiscoveryClient,
         session_worktree_root: &Path,
         home_directory: Option<&Path>,
@@ -369,7 +373,7 @@ impl AppStartup {
         };
 
         for project_path in discovered_project_paths {
-            let git_branch = detect_git_info(project_path.clone()).await;
+            let git_branch = git_client.detect_git_info(project_path.clone()).await;
             let project_path = project_path.to_string_lossy().to_string();
             // Best-effort: project metadata persistence is non-critical.
             let _ = db


### PR DESCRIPTION
- Route startup project catalog refresh through the injected `GitClient` boundary.
- Keep lower-level git helper exports crate-private in `ag-git`.
- Update startup coverage to mock branch detection and assert persisted branch metadata.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)