### PR TITLE
Wrap fenced code blocks on word boundaries

### DIFF
--- a/crates/ag-tui-text/src/markdown.rs
+++ b/crates/ag-tui-text/src/markdown.rs
@@ -831,7 +831,10 @@ fn render_inline_line(content: &str, base_style: Style, width: usize) -> Vec<Lin
 }
 
 fn render_code_line(raw_line: &str, width: usize) -> Vec<Line<'static>> {
-    wrap_verbatim_line(raw_line, code_block_style(), width)
+    wrap_verbatim_spans_with_word_boundaries(
+        vec![Span::styled(raw_line.to_string(), code_block_style())],
+        width,
+    )
 }
 
 fn render_stats_line(raw_line: &str, width: usize) -> Vec<Line<'static>> {
@@ -2175,6 +2178,27 @@ mod tests {
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0].to_string(), "let value = **raw**;");
         assert_eq!(lines[0].spans[0].style, code_block_style());
+    }
+
+    #[test]
+    fn test_render_markdown_wraps_fenced_code_on_word_boundaries() {
+        // Arrange
+        let input = "```text\nformatted blocks in user messages without words breaking\n```";
+
+        // Act
+        let lines = render_markdown(input, 32);
+        let rendered_lines = lines.iter().map(ToString::to_string).collect::<Vec<_>>();
+
+        // Assert
+        assert_eq!(rendered_lines[0], "formatted blocks in user ");
+        assert_eq!(rendered_lines[1], "messages without words breaking");
+        assert!(!rendered_lines.iter().any(|line| line.ends_with("message")));
+        assert!(!rendered_lines.iter().any(|line| line.starts_with("s ")));
+        assert!(lines.iter().all(|line| {
+            line.spans
+                .first()
+                .is_some_and(|span| span.style == code_block_style())
+        }));
     }
 
     #[test]

--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -3143,6 +3143,34 @@ mod tests {
     }
 
     #[test]
+    fn test_append_user_prompt_markdown_lines_wraps_code_blocks_on_word_boundaries() {
+        // Arrange
+        let mut lines = Vec::new();
+        let prompt = "```text\nformatted blocks in user messages without words breaking\n```";
+
+        // Act
+        SessionOutput::append_user_prompt_markdown_lines(&mut lines, prompt, 36, None);
+        let rendered_lines = lines
+            .iter()
+            .map(|line| line.to_string().trim_end().to_string())
+            .collect::<Vec<_>>();
+
+        // Assert
+        assert!(
+            rendered_lines
+                .iter()
+                .any(|line| line == " › formatted blocks in user")
+        );
+        assert!(
+            rendered_lines
+                .iter()
+                .any(|line| line == "   messages without words breaking")
+        );
+        assert!(!rendered_lines.iter().any(|line| line.ends_with("message")));
+        assert!(!rendered_lines.iter().any(|line| line.starts_with("   s ")));
+    }
+
+    #[test]
     fn test_output_lines_render_user_prompt_markdown_with_minimum_content_width() {
         // Arrange
         let mut session = session_fixture();

--- a/crates/agentty/src/ui/markdown.rs
+++ b/crates/agentty/src/ui/markdown.rs
@@ -339,6 +339,30 @@ mod tests {
     }
 
     #[test]
+    fn test_render_markdown_wraps_fenced_code_on_word_boundaries() {
+        // Arrange
+        let input = "```text\nformatted blocks in user messages without words breaking\n```";
+
+        // Act
+        let lines = render_markdown(input, 32);
+        let rendered_lines = lines.iter().map(ToString::to_string).collect::<Vec<_>>();
+
+        // Assert
+        assert_eq!(rendered_lines[0], "formatted blocks in user ");
+        assert_eq!(rendered_lines[1], "messages without words breaking");
+        assert!(!rendered_lines.iter().any(|line| line.ends_with("message")));
+        assert!(!rendered_lines.iter().any(|line| line.starts_with("s ")));
+        let code_block_style = Style::default()
+            .fg(style::palette::text_muted())
+            .bg(style::palette::surface_overlay());
+        assert!(lines.iter().all(|line| {
+            line.spans
+                .first()
+                .is_some_and(|span| span.style == code_block_style)
+        }));
+    }
+
+    #[test]
     fn test_markdown_render_cache_reuses_prompt_block_lines() {
         // Arrange
         let cache = MarkdownRenderCache::default();

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -147,6 +147,10 @@ Use **bold** and `code`.
 | --- | --- |
 | User prompt | Markdown |
 
+```text
+formatted blocks in user messages without words breaking
+```
+
 ```mermaid {theme=default}
 flowchart TD
     A[Start] --> B[Finish]
@@ -1230,6 +1234,7 @@ fn session_view_user_prompt_markdown_output() -> E2eResult {
                 assertion::assert_text_in_region(frame, "Use bold and code.", &full);
                 assertion::assert_text_in_region(frame, "User prompt", &full);
                 assertion::assert_text_in_region(frame, "Markdown", &full);
+                assertion::assert_text_in_region(frame, "without words breaking", &full);
                 assertion::assert_text_in_region(frame, "Start", &full);
                 assertion::assert_text_in_region(frame, "Finish", &full);
                 assertion::assert_text_in_region(frame, "▼", &full);


### PR DESCRIPTION
- Render fenced code blocks with word-boundary wrapping in markdown and session prompt output.
- Add unit coverage for markdown rendering and session prompt line wrapping.
- Extend the session E2E fixture to cover wrapped user prompt code blocks.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)