### PR TITLE
Use session folder directly for Antigravity

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ authenticate at least one provider CLI before starting a session:
 > uncertainty, but commentary does not guarantee that subscription-backed usage is safe
 > for third-party tool invocation.
 
-- Antigravity (`agy`): install the
+- Antigravity (`agy`): install version 1.1.0 or newer of the
   [Antigravity CLI](https://github.com/google-antigravity/antigravity-cli) and run `agy`
   to sign in when prompted.
 

--- a/crates/ag-agent/src/agent.rs
+++ b/crates/ag-agent/src/agent.rs
@@ -29,9 +29,9 @@ pub use instruction::{
 };
 pub use prompt::{PromptPreparationRequest, diff_fence, prepare_prompt_text};
 pub use provider::{
-    build_command_stdin_payload, cleanup_session_worktree_artifacts, create_app_server_client,
-    create_backend, is_app_server_thought_chunk, parse_response, parse_stream_output_line,
-    parse_turn_response, protocol_schema_instruction_mode, provider_kind_for_model, transport_mode,
+    build_command_stdin_payload, create_app_server_client, create_backend,
+    is_app_server_thought_chunk, parse_response, parse_stream_output_line, parse_turn_response,
+    protocol_schema_instruction_mode, provider_kind_for_model, transport_mode,
 };
 pub use response_parser::{
     ParsedResponse, compact_codex_progress_message, is_codex_completion_status_message,

--- a/crates/ag-agent/src/agent/antigravity.rs
+++ b/crates/ag-agent/src/agent/antigravity.rs
@@ -1,7 +1,5 @@
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash as _, Hasher as _};
 use std::io::Write as _;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::{fs, io};
 
@@ -22,8 +20,6 @@ const ANTIGRAVITY_PROJECT_STATE_PATTERNS: &[&str] = &[
     ANTIGRAVITY_PROJECT_STATE_PATTERN,
     ANTIGRAVITY_PROJECT_CACHE_PATTERN,
 ];
-/// Non-hidden temp directory used for Antigravity worktree aliases.
-const ANTIGRAVITY_WORKTREE_ALIAS_DIR: &str = "agentty-antigravity-worktrees";
 
 /// Backend implementation for the Antigravity CLI.
 ///
@@ -36,7 +32,6 @@ pub(super) struct AntigravityBackend;
 impl AgentBackend for AntigravityBackend {
     fn setup(&self, folder: &Path) -> Result<(), AgentBackendError> {
         ensure_antigravity_project_state_ignored(folder)?;
-        ensure_antigravity_workspace_alias(folder)?;
 
         Ok(())
     }
@@ -58,10 +53,9 @@ impl AgentBackend for AntigravityBackend {
         let mut command = Command::new("agy");
 
         ensure_antigravity_project_state_ignored(folder)?;
-        let workspace_folder = ensure_antigravity_workspace_alias(folder)?;
         shared_prompt::append_cli_prompt_access_directories(
             &mut command,
-            &workspace_folder,
+            folder,
             attachments,
             CliPromptAccessRootMode::WorkspaceThenAttachments,
         );
@@ -74,165 +68,12 @@ impl AgentBackend for AntigravityBackend {
             .arg(ANTIGRAVITY_PRINT_TIMEOUT)
             .arg("--model")
             .arg(model)
-            .current_dir(workspace_folder)
+            .current_dir(folder)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
         Ok(command)
     }
-}
-
-/// Returns a workspace path Antigravity can mount for one session folder.
-///
-/// Antigravity rejects workspace roots whose path contains hidden components
-/// such as Agentty's default `.agentty` home. For those worktrees, Agentty
-/// creates a stable non-hidden symlink under the system temp directory and
-/// gives Antigravity that alias as both its cwd and primary `--add-dir` root.
-/// Git metadata updates still use the real worktree path.
-///
-/// # Errors
-/// Returns an error when the folder needs an alias but the alias cannot be
-/// created, verified, or placed at a non-hidden path.
-fn ensure_antigravity_workspace_alias(folder: &Path) -> Result<PathBuf, AgentBackendError> {
-    if !has_hidden_path_component(folder) {
-        return Ok(folder.to_path_buf());
-    }
-
-    let alias = antigravity_workspace_alias_path(folder);
-    if has_hidden_path_component(&alias) {
-        return Err(AgentBackendError::Setup(format!(
-            "Antigravity refuses hidden workspace folders and Agentty could not create a \
-             non-hidden alias for `{}` because the temp alias path `{}` also contains a hidden \
-             path component.",
-            folder.display(),
-            alias.display()
-        )));
-    }
-
-    ensure_directory_symlink(folder, &alias).map_err(|error| {
-        AgentBackendError::Setup(format!(
-            "Antigravity refuses hidden workspace folders and Agentty failed to create a \
-             non-hidden alias from `{}` to `{}`: {error}",
-            alias.display(),
-            folder.display()
-        ))
-    })?;
-
-    Ok(alias)
-}
-
-/// Removes the Antigravity temp symlink alias for one session worktree.
-///
-/// The cleanup only removes the alias when it is a symlink that still points at
-/// `folder`, preventing unrelated files at the deterministic alias path from
-/// being deleted. After removing the symlink, this prunes the shared alias
-/// directory only when no sibling aliases remain.
-///
-/// # Errors
-/// Returns an error when the alias symlink or its now-empty parent directory
-/// cannot be removed.
-pub(crate) fn cleanup_workspace_alias(folder: &Path) -> Result<(), AgentBackendError> {
-    if !has_hidden_path_component(folder) {
-        return Ok(());
-    }
-
-    let alias = antigravity_workspace_alias_path(folder);
-    let alias_target = match fs::read_link(&alias) {
-        Ok(alias_target) => alias_target,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(error) if error.kind() == io::ErrorKind::InvalidInput => return Ok(()),
-        Err(error) => {
-            return Err(AgentBackendError::Setup(format!(
-                "Failed to inspect Antigravity workspace alias `{}`: {error}",
-                alias.display()
-            )));
-        }
-    };
-
-    if alias_target != folder {
-        return Ok(());
-    }
-
-    fs::remove_file(&alias).map_err(|error| {
-        AgentBackendError::Setup(format!(
-            "Failed to remove Antigravity workspace alias `{}`: {error}",
-            alias.display()
-        ))
-    })?;
-
-    if let Some(parent) = alias.parent()
-        && let Err(error) = fs::remove_dir(parent)
-        && error.kind() != io::ErrorKind::NotFound
-        && error.kind() != io::ErrorKind::DirectoryNotEmpty
-    {
-        return Err(AgentBackendError::Setup(format!(
-            "Failed to prune Antigravity workspace alias directory `{}`: {error}",
-            parent.display()
-        )));
-    }
-
-    Ok(())
-}
-
-/// Returns whether a path contains a dot-prefixed component.
-fn has_hidden_path_component(path: &Path) -> bool {
-    path.components().any(|component| {
-        matches!(component, Component::Normal(name) if name.to_string_lossy().starts_with('.'))
-    })
-}
-
-/// Builds the stable non-hidden alias path for one real worktree folder.
-fn antigravity_workspace_alias_path(folder: &Path) -> PathBuf {
-    let mut hasher = DefaultHasher::new();
-    folder.hash(&mut hasher);
-
-    let folder_name = folder
-        .file_name()
-        .and_then(|name| name.to_str())
-        .map(|name| name.trim_start_matches('.'))
-        .filter(|name| !name.is_empty())
-        .unwrap_or("worktree");
-    let alias_name = format!("{folder_name}-{:016x}", hasher.finish());
-
-    std::env::temp_dir()
-        .join(ANTIGRAVITY_WORKTREE_ALIAS_DIR)
-        .join(alias_name)
-}
-
-/// Ensures one directory symlink exists and points at the requested target.
-///
-/// # Errors
-/// Returns an I/O error when the alias parent cannot be created, the alias path
-/// is already occupied by another filesystem entry, or the symlink cannot be
-/// created.
-fn ensure_directory_symlink(target: &Path, link: &Path) -> Result<(), io::Error> {
-    if let Some(parent) = link.parent() {
-        fs::create_dir_all(parent)?;
-    }
-
-    match fs::read_link(link) {
-        Ok(existing_target) if existing_target == target => return Ok(()),
-        Ok(existing_target) => {
-            return Err(io::Error::new(
-                io::ErrorKind::AlreadyExists,
-                format!(
-                    "alias already points to `{}` instead of `{}`",
-                    existing_target.display(),
-                    target.display()
-                ),
-            ));
-        }
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-        Err(error) => return Err(error),
-    }
-
-    create_directory_symlink(target, link)
-}
-
-#[cfg(unix)]
-/// Creates a Unix directory symlink.
-fn create_directory_symlink(target: &Path, link: &Path) -> Result<(), io::Error> {
-    std::os::unix::fs::symlink(target, link)
 }
 
 /// Ensures Antigravity's workspace-local project state stays out of session
@@ -415,8 +256,6 @@ fn append_git_exclude_pattern(exclude_path: &Path, pattern: &str) -> Result<(), 
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use ag_protocol::ProtocolSchemaInstructionMode;
     use tempfile::{TempDir, tempdir};
 
@@ -428,26 +267,6 @@ mod tests {
     use crate::model::agent::{AgentModel, ReasoningLevel};
     use crate::model::turn_prompt::TurnPromptAttachment;
 
-    struct AliasCleanup {
-        link: PathBuf,
-    }
-
-    impl AliasCleanup {
-        /// Tracks one Antigravity alias path so tests remove global temp
-        /// symlinks they create.
-        fn new(folder: &Path) -> Self {
-            Self {
-                link: antigravity_workspace_alias_path(folder),
-            }
-        }
-    }
-
-    impl Drop for AliasCleanup {
-        fn drop(&mut self) {
-            let _ = fs::remove_file(&self.link);
-        }
-    }
-
     fn session_resume_request_kind(_replay_transcript: Option<&str>) -> AgentRequestKind {
         AgentRequestKind::SessionResume
     }
@@ -456,9 +275,8 @@ mod tests {
         AgentRequestKind::SessionStart
     }
 
-    /// Creates a temp directory whose own basename is visible so no-alias
-    /// command assertions are stable on platforms where `tempdir()` uses dot
-    /// prefixes.
+    /// Creates a temp directory whose own basename is visible so command
+    /// assertions are stable on platforms where `tempdir()` uses dot prefixes.
     fn visible_tempdir() -> TempDir {
         tempfile::Builder::new()
             .prefix("agentty-antigravity-test-")
@@ -543,9 +361,9 @@ mod tests {
     }
 
     #[test]
-    /// Verifies Antigravity receives a non-hidden symlink alias when the real
-    /// session worktree path contains a hidden component.
-    fn test_antigravity_build_command_aliases_hidden_session_folder() {
+    /// Verifies Antigravity receives the real session worktree even when its
+    /// path contains a hidden component.
+    fn test_antigravity_build_command_uses_hidden_session_folder_directly() {
         // Arrange
         let temp_directory = visible_tempdir();
         let session_folder = temp_directory
@@ -555,7 +373,6 @@ mod tests {
             .join("00cbfefe");
         fs::create_dir_all(&session_folder).expect("failed to create hidden session folder");
         create_standard_git_directory(&session_folder);
-        let _alias_cleanup = AliasCleanup::new(&session_folder);
         let backend = AntigravityBackend;
         let requested_model = AgentModel::Gemini31ProPreview.provider_model_str();
 
@@ -578,17 +395,12 @@ mod tests {
             .get_args()
             .map(|arg| arg.to_string_lossy().into_owned())
             .collect::<Vec<_>>();
-        let alias = antigravity_workspace_alias_path(&session_folder);
+        let session_folder_display = session_folder.to_string_lossy().into_owned();
 
         // Assert
-        assert!(!has_hidden_path_component(&alias));
-        assert_eq!(
-            fs::read_link(&alias).expect("alias should exist"),
-            session_folder
-        );
-        assert_eq!(command.get_current_dir(), Some(alias.as_path()));
+        assert_eq!(command.get_current_dir(), Some(session_folder.as_path()));
         assert_eq!(args[0], "--add-dir");
-        assert_eq!(args[1], alias.to_string_lossy());
+        assert_eq!(args[1], session_folder_display);
         assert_antigravity_project_state_patterns_ignored(&read_standard_git_exclude(
             &session_folder,
         ));
@@ -613,37 +425,8 @@ mod tests {
     }
 
     #[test]
-    /// Verifies Antigravity setup prepares a non-hidden alias before the first
-    /// command is built for a hidden session worktree path.
-    fn test_antigravity_setup_aliases_hidden_session_folder() {
-        // Arrange
-        let temp_directory = visible_tempdir();
-        let session_folder = temp_directory
-            .path()
-            .join(".agentty")
-            .join("wt")
-            .join("00cbfefe");
-        fs::create_dir_all(&session_folder).expect("failed to create hidden session folder");
-        create_standard_git_directory(&session_folder);
-        let _alias_cleanup = AliasCleanup::new(&session_folder);
-        let backend = AntigravityBackend;
-
-        // Act
-        AgentBackend::setup(&backend, &session_folder).expect("setup should succeed");
-        let alias = antigravity_workspace_alias_path(&session_folder);
-
-        // Assert
-        assert!(!has_hidden_path_component(&alias));
-        assert_eq!(
-            fs::read_link(alias).expect("alias should exist"),
-            session_folder
-        );
-    }
-
-    #[test]
-    /// Verifies Antigravity cleanup removes the non-hidden alias created for a
-    /// hidden session worktree path.
-    fn test_cleanup_workspace_alias_removes_hidden_session_alias() {
+    /// Verifies Antigravity setup accepts a hidden session worktree path.
+    fn test_antigravity_setup_accepts_hidden_session_folder() {
         // Arrange
         let temp_directory = visible_tempdir();
         let session_folder = temp_directory
@@ -654,45 +437,13 @@ mod tests {
         fs::create_dir_all(&session_folder).expect("failed to create hidden session folder");
         create_standard_git_directory(&session_folder);
         let backend = AntigravityBackend;
+
+        // Act
         AgentBackend::setup(&backend, &session_folder).expect("setup should succeed");
-        let alias = antigravity_workspace_alias_path(&session_folder);
-
-        // Act
-        cleanup_workspace_alias(&session_folder).expect("cleanup should succeed");
+        let exclude = read_standard_git_exclude(&session_folder);
 
         // Assert
-        let error = fs::read_link(alias).expect_err("alias should be removed");
-        assert_eq!(error.kind(), io::ErrorKind::NotFound);
-    }
-
-    #[test]
-    /// Verifies Antigravity cleanup leaves an alias path alone when it points
-    /// at a different target.
-    fn test_cleanup_workspace_alias_preserves_unrelated_symlink() {
-        // Arrange
-        let temp_directory = visible_tempdir();
-        let session_folder = temp_directory
-            .path()
-            .join(".agentty")
-            .join("wt")
-            .join("00cbfefe");
-        let other_folder = temp_directory.path().join("other-worktree");
-        fs::create_dir_all(&session_folder).expect("failed to create hidden session folder");
-        fs::create_dir_all(&other_folder).expect("failed to create other folder");
-        let alias = antigravity_workspace_alias_path(&session_folder);
-        fs::create_dir_all(alias.parent().expect("alias should have parent"))
-            .expect("failed to create alias parent");
-        create_directory_symlink(&other_folder, &alias).expect("failed to create unrelated alias");
-        let _alias_cleanup = AliasCleanup::new(&session_folder);
-
-        // Act
-        cleanup_workspace_alias(&session_folder).expect("cleanup should succeed");
-
-        // Assert
-        assert_eq!(
-            fs::read_link(alias).expect("alias should remain"),
-            other_folder
-        );
+        assert_antigravity_project_state_patterns_ignored(&exclude);
     }
 
     #[test]

--- a/crates/ag-agent/src/agent/provider.rs
+++ b/crates/ag-agent/src/agent/provider.rs
@@ -1,6 +1,5 @@
 //! Shared provider registry and transport policy descriptors.
 
-use std::path::Path;
 use std::sync::Arc;
 
 #[cfg(test)]
@@ -40,20 +39,6 @@ pub fn create_app_server_client(
 /// Parses provider output and returns final response content and usage stats.
 pub fn parse_response(kind: AgentKind, stdout: &str, stderr: &str) -> ParsedResponse {
     (provider_descriptor(kind).parse_response)(stdout, stderr)
-}
-
-/// Removes provider-owned worktree artifacts that are derived from one session
-/// folder.
-///
-/// This is used by session teardown paths after provider setup or command
-/// construction has created auxiliary filesystem state outside the real
-/// worktree. Providers that do not create such state are no-ops.
-///
-/// # Errors
-/// Returns an error when a provider-owned artifact exists but cannot be
-/// removed safely.
-pub fn cleanup_session_worktree_artifacts(folder: &Path) -> Result<(), AgentBackendError> {
-    super::antigravity::cleanup_workspace_alias(folder)
 }
 
 /// Parses one stream line into incremental text and content classification.

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -2759,12 +2759,6 @@ impl SessionManager {
             }
         }
 
-        if let Err(error) = agent::cleanup_session_worktree_artifacts(&folder) {
-            cleanup_errors.push(format!(
-                "failed to remove provider worktree artifacts: {error}"
-            ));
-        }
-
         if let Err(error) = fs_client.remove_dir_all(folder).await {
             cleanup_errors.push(format!("failed to remove worktree directory: {error}"));
         }
@@ -3061,19 +3055,6 @@ mod tests {
             .returning(|path| path.is_dir());
 
         mock_fs_client
-    }
-
-    /// Returns whether an Antigravity temp alias currently points at the
-    /// requested session folder.
-    fn antigravity_alias_exists_for(folder: &Path) -> bool {
-        let alias_root = std::env::temp_dir().join("agentty-antigravity-worktrees");
-        let Ok(alias_entries) = std::fs::read_dir(alias_root) else {
-            return false;
-        };
-
-        alias_entries.filter_map(Result::ok).any(|entry| {
-            std::fs::read_link(entry.path()).is_ok_and(|alias_target| alias_target == folder)
-        })
     }
 
     /// Persists one session row that matches the in-memory fixture.
@@ -3705,58 +3686,6 @@ mod tests {
                 .iter()
                 .any(|message| message.contains("failed to remove worktree directory"))
         );
-    }
-
-    #[tokio::test]
-    async fn test_cleanup_session_worktree_resources_removes_provider_artifacts() {
-        // Arrange
-        let temp_dir = tempfile::tempdir().expect("temp dir should exist");
-        let folder = temp_dir
-            .path()
-            .join(".agentty")
-            .join("wt")
-            .join("session-id");
-        std::fs::create_dir_all(folder.join(".git"))
-            .expect("failed to create hidden session git metadata");
-        agent::create_backend(AgentKind::Antigravity)
-            .setup(&folder)
-            .expect("Antigravity setup should create alias");
-        assert!(antigravity_alias_exists_for(&folder));
-        let mut mock_fs_client = fs::MockFsClient::new();
-        mock_fs_client
-            .expect_remove_dir_all()
-            .once()
-            .returning(|path| {
-                Box::pin(async move {
-                    tokio::fs::remove_dir_all(path)
-                        .await
-                        .map_err(fs::FsError::from)
-                })
-            });
-        let mut mock_git_client = git::MockGitClient::new();
-        mock_git_client
-            .expect_remove_worktree()
-            .once()
-            .returning(|_| Box::pin(async { Ok(()) }));
-        mock_git_client
-            .expect_delete_branch()
-            .once()
-            .returning(|_, _| Box::pin(async { Ok(()) }));
-
-        // Act
-        let cleanup_errors = SessionManager::cleanup_session_worktree_resources(
-            Arc::new(mock_fs_client),
-            Arc::new(mock_git_client),
-            folder.clone(),
-            "wt/session-id".to_string(),
-            Some(temp_dir.path().join("repo")),
-            true,
-        )
-        .await;
-
-        // Assert
-        assert!(cleanup_errors.is_empty());
-        assert!(!antigravity_alias_exists_for(&folder));
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/session/workflow/merge.rs
+++ b/crates/agentty/src/app/session/workflow/merge.rs
@@ -2911,13 +2911,6 @@ impl SessionManager {
             git_client.delete_branch(repo_root, source_branch).await?;
         }
 
-        if let Err(error) = agent::cleanup_session_worktree_artifacts(&folder) {
-            warn!(
-                error = %error,
-                "failed to remove provider worktree artifacts during merged session cleanup"
-            );
-        }
-
         if let Err(error) = fs_client.remove_dir_all(folder).await {
             warn!(
                 error = %error,

--- a/docs/site/content/docs/agents/backends.md
+++ b/docs/site/content/docs/agents/backends.md
@@ -17,7 +17,7 @@ options.
 requires its respective CLI to be installed and available on your `PATH`.
 
 - Gemini (`gemini`): Google Gemini CLI agent.
-- Antigravity (`agy`): Google Antigravity CLI agent.
+- Antigravity (`agy` 1.1.0 or newer): Google Antigravity CLI agent.
 - Claude (`claude`): Anthropic Claude Code agent.
 - Codex (`codex`): OpenAI Codex CLI agent.
 


### PR DESCRIPTION
- Remove the temporary workspace alias and cleanup flow.
- Pass the real session folder to `agy`.
- Document the Antigravity 1.1.0 minimum in `README.md` and `docs/site/content/docs/agents/backends.md`.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)