### PR TITLE
Add maximum reasoning level

### DIFF
--- a/crates/ag-agent/src/agent/claude.rs
+++ b/crates/ag-agent/src/agent/claude.rs
@@ -274,6 +274,7 @@ mod tests {
             (ReasoningLevel::Medium, "medium"),
             (ReasoningLevel::High, "high"),
             (ReasoningLevel::XHigh, "max"),
+            (ReasoningLevel::Max, "max"),
         ];
 
         for (reasoning_level, expected_effort) in cases {

--- a/crates/ag-agent/src/model/agent.rs
+++ b/crates/ag-agent/src/model/agent.rs
@@ -132,6 +132,8 @@ pub enum ReasoningLevel {
     High,
     /// Extra-high reasoning effort for deeper analysis.
     XHigh,
+    /// Maximum reasoning effort for the hardest tasks.
+    Max,
 }
 
 impl AgentSelection {
@@ -397,7 +399,7 @@ pub fn resolve_prompt_model_agent_kind(
 
 impl ReasoningLevel {
     /// All selectable reasoning-effort levels in UI display order.
-    pub const ALL: [Self; 4] = [Self::Low, Self::Medium, Self::High, Self::XHigh];
+    pub const ALL: [Self; 5] = [Self::Low, Self::Medium, Self::High, Self::XHigh, Self::Max];
 
     /// Returns the stable persisted identifier for this level.
     ///
@@ -409,6 +411,7 @@ impl ReasoningLevel {
             Self::Medium => "medium",
             Self::High => "high",
             Self::XHigh => "xhigh",
+            Self::Max => "max",
         }
     }
 
@@ -419,12 +422,13 @@ impl ReasoningLevel {
             Self::Medium => "medium",
             Self::High => "high",
             Self::XHigh => "xhigh",
+            Self::Max => "max",
         }
     }
 
     /// Returns the Claude `--effort` value for this level.
     ///
-    /// Maps `XHigh` to `"max"`, which is currently only supported on
+    /// Maps `XHigh` and `Max` to `"max"`, which is currently only supported on
     /// `claude-opus-4-8`. The Claude CLI enforces this restriction and will
     /// surface an error for other models.
     pub fn claude(self) -> &'static str {
@@ -432,7 +436,7 @@ impl ReasoningLevel {
             Self::Low => "low",
             Self::Medium => "medium",
             Self::High => "high",
-            Self::XHigh => "max",
+            Self::XHigh | Self::Max => "max",
         }
     }
 
@@ -442,7 +446,8 @@ impl ReasoningLevel {
             Self::Low => "Fastest responses with lighter reasoning.",
             Self::Medium => "Balanced speed and reasoning depth.",
             Self::High => "Deeper reasoning for tougher tasks.",
-            Self::XHigh => "Maximum reasoning effort for the hardest tasks.",
+            Self::XHigh => "Extra-high reasoning for complex tasks.",
+            Self::Max => "Maximum reasoning effort for the hardest tasks.",
         }
     }
 }
@@ -456,6 +461,7 @@ impl FromStr for ReasoningLevel {
             "medium" => Ok(Self::Medium),
             "high" => Ok(Self::High),
             "xhigh" => Ok(Self::XHigh),
+            "max" => Ok(Self::Max),
             other => Err(format!("unknown reasoning level: {other}")),
         }
     }
@@ -858,12 +864,14 @@ mod tests {
         let medium_level = "medium".parse::<ReasoningLevel>();
         let high_level = "high".parse::<ReasoningLevel>();
         let xhigh_level = "xhigh".parse::<ReasoningLevel>();
+        let max_level = "max".parse::<ReasoningLevel>();
 
         // Assert
         assert_eq!(low_level, Ok(ReasoningLevel::Low));
         assert_eq!(medium_level, Ok(ReasoningLevel::Medium));
         assert_eq!(high_level, Ok(ReasoningLevel::High));
         assert_eq!(xhigh_level, Ok(ReasoningLevel::XHigh));
+        assert_eq!(max_level, Ok(ReasoningLevel::Max));
     }
 
     #[test]
@@ -960,13 +968,25 @@ mod tests {
 
     #[test]
     /// Ensures `ReasoningLevel::claude()` maps all levels to the correct
-    /// Claude `--effort` values, including `XHigh` → `"max"`.
+    /// Claude `--effort` values, including the highest generic levels.
     fn test_reasoning_level_claude_maps_all_levels() {
         // Arrange / Act / Assert
         assert_eq!(ReasoningLevel::Low.claude(), "low");
         assert_eq!(ReasoningLevel::Medium.claude(), "medium");
         assert_eq!(ReasoningLevel::High.claude(), "high");
         assert_eq!(ReasoningLevel::XHigh.claude(), "max");
+        assert_eq!(ReasoningLevel::Max.claude(), "max");
+    }
+
+    #[test]
+    /// Ensures Codex reasoning values include the distinct `max` effort.
+    fn test_reasoning_level_codex_maps_all_levels() {
+        // Arrange / Act / Assert
+        assert_eq!(ReasoningLevel::Low.codex(), "low");
+        assert_eq!(ReasoningLevel::Medium.codex(), "medium");
+        assert_eq!(ReasoningLevel::High.codex(), "high");
+        assert_eq!(ReasoningLevel::XHigh.codex(), "xhigh");
+        assert_eq!(ReasoningLevel::Max.codex(), "max");
     }
 
     #[test]
@@ -978,6 +998,7 @@ mod tests {
         assert_eq!(ReasoningLevel::Medium.as_str(), "medium");
         assert_eq!(ReasoningLevel::High.as_str(), "high");
         assert_eq!(ReasoningLevel::XHigh.as_str(), "xhigh");
+        assert_eq!(ReasoningLevel::Max.as_str(), "max");
     }
 
     #[test]

--- a/crates/agentty/src/app/setting.rs
+++ b/crates/agentty/src/app/setting.rs
@@ -2403,13 +2403,13 @@ mod tests {
     fn settings_rows_show_reasoning_level_value() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.reasoning_level = ReasoningLevel::XHigh;
+        manager.reasoning_level = ReasoningLevel::Max;
 
         // Act
         let rows = manager.settings_rows();
 
         // Assert
-        assert_eq!(rows[1].1, "xhigh");
+        assert_eq!(rows[1].1, "max");
     }
 
     #[test]

--- a/crates/agentty/src/domain/composer.rs
+++ b/crates/agentty/src/domain/composer.rs
@@ -1236,7 +1236,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         // Assert
-        assert_eq!(labels, vec!["low", "medium", "high", "xhigh"]);
+        assert_eq!(labels, vec!["low", "medium", "high", "xhigh", "max"]);
     }
 
     #[test]

--- a/crates/agentty/src/ui/page/session_list.rs
+++ b/crates/agentty/src/ui/page/session_list.rs
@@ -338,7 +338,7 @@ fn reasoning_level_color(reasoning_level: ReasoningLevel) -> Color {
         ReasoningLevel::Low => style::palette::success(),
         ReasoningLevel::Medium => style::palette::warning(),
         ReasoningLevel::High => style::palette::warning_soft(),
-        ReasoningLevel::XHigh => style::palette::danger(),
+        ReasoningLevel::XHigh | ReasoningLevel::Max => style::palette::danger(),
     }
 }
 
@@ -678,6 +678,7 @@ mod tests {
             (ReasoningLevel::Medium, style::palette::warning()),
             (ReasoningLevel::High, style::palette::warning_soft()),
             (ReasoningLevel::XHigh, style::palette::danger()),
+            (ReasoningLevel::Max, style::palette::danger()),
         ];
 
         // Act & Assert

--- a/crates/agentty/tests/e2e/setting.rs
+++ b/crates/agentty/tests/e2e/setting.rs
@@ -202,7 +202,7 @@ fn settings_jk_navigation() {
 /// Verify that selector settings are edited through dropdowns.
 ///
 /// Opens the Settings tab, moves to the project reasoning row, opens the
-/// dropdown, and selects the next value. Captures before, during, and after
+/// dropdown, and selects the maximum value. Captures before, during, and after
 /// to show the dropdown workflow in the GIF.
 #[test]
 fn settings_dropdown_selects_value() {
@@ -228,6 +228,7 @@ fn settings_dropdown_selects_value() {
                     .wait_for_stable_frame(200, 3000)
                     .viewing_pause_ms(1500)
                     .capture_labeled("dropdown", "Reasoning Level dropdown")
+                    .press_key("j")
                     .press_key("j")
                     .wait_for_stable_frame(200, 3000)
                     .press_key("Enter")
@@ -257,10 +258,11 @@ fn settings_dropdown_selects_value() {
                     &dropdown_full,
                 );
                 assertion::assert_text_in_region(&dropdown_frame, "xhigh", &dropdown_full);
+                assertion::assert_text_in_region(&dropdown_frame, "max", &dropdown_full);
 
                 let after_frame = common::frame_from_capture(&report.captures[2]);
                 let after_full = Region::full(after_frame.cols(), after_frame.rows());
-                assertion::assert_text_in_region(&after_frame, "xhigh", &after_full);
+                assertion::assert_text_in_region(&after_frame, "max", &after_full);
             },
         )
         .expect("feature test failed");

--- a/docs/site/content/docs/agents/backends.md
+++ b/docs/site/content/docs/agents/backends.md
@@ -86,10 +86,11 @@ model ids tied to the selected Gemini or Antigravity provider. Stored defaults t
 point at an unavailable backend fall back to the first available backend default.
 
 <a id="backends-reasoning-level"></a> For Codex and Claude sessions, the **Settings**
-tab also exposes `Default Reasoning Level` (`low`, `medium`, `high`, `xhigh`). The
-selected level is persisted per project and is sent with turns unless a session-specific
-override is active. For Claude, `xhigh` maps to `--effort max`, which is currently only
-supported by `claude-opus-4-8`.
+tab also exposes `Default Reasoning Level` (`low`, `medium`, `high`, `xhigh`, `max`).
+The selected level is persisted per project and is sent with turns unless a
+session-specific override is active. Codex receives `max` as a distinct reasoning
+effort. For Claude, both `xhigh` and `max` map to `--effort max`, which is currently
+only supported by `claude-opus-4-8`.
 
 ## Available Models
 


### PR DESCRIPTION
- Add `max` as a selectable and persisted reasoning level.
- Map `xhigh` and `max` to Claude’s maximum effort while preserving distinct Codex values.
- Update settings, UI, E2E coverage, and backend documentation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)