### PR TITLE
Preserve pasted prompt indentation

### DIFF
--- a/crates/ag-tui-text/src/markdown.rs
+++ b/crates/ag-tui-text/src/markdown.rs
@@ -232,6 +232,49 @@ pub fn render_markdown_with_settings(
     style::with_render_settings(settings, || render_markdown_active_settings(text, width))
 }
 
+/// Returns one flag per input line indicating that leading whitespace must be
+/// preserved before Markdown parsing.
+///
+/// The mask uses the same fence, table, and horizontal-rule classifiers as
+/// [`render_markdown`], allowing callers to protect indentation on ordinary
+/// text without hiding trim-tolerant block syntax from the shared parser.
+pub fn markdown_block_preservation_mask(text: &str) -> Vec<bool> {
+    let raw_lines = text.split('\n').collect::<Vec<_>>();
+    let mut block_state = BlockState::Paragraph;
+    let mut preservation_mask = vec![false; raw_lines.len()];
+    let mut line_index = 0;
+
+    while line_index < raw_lines.len() {
+        let raw_line = raw_lines[line_index];
+        if is_fence_delimiter(raw_line) {
+            preservation_mask[line_index] = true;
+            let _ = update_fence_state(raw_line, &mut block_state);
+            line_index += 1;
+
+            continue;
+        }
+        if !matches!(block_state, BlockState::Paragraph) {
+            preservation_mask[line_index] = true;
+            line_index += 1;
+
+            continue;
+        }
+        if let Some((_, next_line_index)) = parse_markdown_table(&raw_lines, line_index) {
+            preservation_mask[line_index..next_line_index].fill(true);
+            line_index = next_line_index;
+
+            continue;
+        }
+        if is_horizontal_rule(raw_line) {
+            preservation_mask[line_index] = true;
+        }
+
+        line_index += 1;
+    }
+
+    preservation_mask
+}
+
 fn render_markdown_active_settings(text: &str, width: usize) -> Vec<Line<'static>> {
     let mut rendered_lines = Vec::new();
     let mut block_state = BlockState::Paragraph;
@@ -2552,6 +2595,31 @@ mod tests {
         assert!(lines[1].spans.iter().any(|span| {
             span.content.as_ref().contains("Name") && span.style == table_header_style()
         }));
+    }
+
+    #[test]
+    fn test_markdown_block_preservation_mask_uses_shared_block_classifiers() {
+        // Arrange
+        let input = concat!(
+            "  plain\n",
+            "  | Name | Status |\n",
+            "  | --- | ---: |\n",
+            "  | Build | passing |\n",
+            "\n",
+            "  ---\n",
+            "  ```text\n",
+            "    fenced\n",
+            "  ```",
+        );
+
+        // Act
+        let preservation_mask = markdown_block_preservation_mask(input);
+
+        // Assert
+        assert_eq!(
+            preservation_mask,
+            vec![false, true, true, true, false, true, true, true, true]
+        );
     }
 
     #[test]

--- a/crates/agentty/src/app/session/workflow/task.rs
+++ b/crates/agentty/src/app/session/workflow/task.rs
@@ -1477,7 +1477,7 @@ mod tests {
             "session-id",
             SessionTranscriptMessageAppend {
                 kind: SessionMessageKind::UserPrompt,
-                raw_content: " hello ",
+                raw_content: "    hello ",
             },
         )
         .await;
@@ -1489,7 +1489,7 @@ mod tests {
                 .expect("transcript lock should not be poisoned")
                 .replay_text()
                 .expect("transcript should have replay text"),
-            " › hello\n\n"
+            " ›     hello\n\n"
         );
         assert_eq!(
             transcript
@@ -1499,7 +1499,7 @@ mod tests {
             &[SessionMessage::conversation(
                 0,
                 SessionMessageKind::UserPrompt,
-                "hello"
+                "    hello"
             )]
         );
         let messages = database
@@ -1509,7 +1509,7 @@ mod tests {
             .expect("failed to load persisted session messages");
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].kind, "user_prompt");
-        assert_eq!(messages[0].content, "hello");
+        assert_eq!(messages[0].content, "    hello");
     }
 
     #[test]

--- a/crates/agentty/src/domain/session_message.rs
+++ b/crates/agentty/src/domain/session_message.rs
@@ -89,10 +89,11 @@ impl SessionMessage {
         }
     }
 
-    /// Creates one raw user or assistant message with outer whitespace removed.
+    /// Creates one raw user or assistant message using kind-specific storage
+    /// normalization.
     pub fn conversation(position: i64, kind: SessionMessageKind, content: impl AsRef<str>) -> Self {
         Self {
-            content: normalized_message_content(content.as_ref()),
+            content: stored_message_content(kind, content.as_ref()),
             kind,
             position,
         }
@@ -198,15 +199,16 @@ impl SessionTranscript {
 
 /// Returns the durable message content for one kind.
 ///
-/// Conversation rows store raw user/assistant text with outer whitespace
-/// removed. Workflow notices preserve exact content so status blocks keep their
-/// spacing.
+/// User prompts preserve leading horizontal whitespace so pasted indentation
+/// survives persistence while outer line breaks and trailing whitespace are
+/// normalized. Assistant rows remove outer whitespace, while workflow notices
+/// preserve exact content so status blocks keep their spacing.
 pub fn stored_message_content(kind: SessionMessageKind, content: &str) -> String {
-    if kind.is_conversation_message() {
-        return normalized_message_content(content);
+    match kind {
+        SessionMessageKind::UserPrompt => normalized_user_prompt_content(content),
+        SessionMessageKind::AssistantAnswer => normalized_message_content(content),
+        SessionMessageKind::WorkflowNotice => content.to_string(),
     }
-
-    content.to_string()
 }
 
 impl SessionMessage {
@@ -231,8 +233,8 @@ pub fn normalized_message_content(content: &str) -> String {
 
 /// Appends one raw user prompt using the session transcript marker and spacing.
 fn append_user_prompt_display_text(output: &mut String, content: &str) {
-    let content = content.trim();
-    if content.is_empty() {
+    let content = normalized_user_prompt_content(content);
+    if content.trim().is_empty() {
         return;
     }
 
@@ -261,6 +263,15 @@ fn append_user_prompt_display_text(output: &mut String, content: &str) {
         output.push('\n');
     }
     output.push('\n');
+}
+
+/// Normalizes prompt boundaries without consuming indentation on the first
+/// content line.
+fn normalized_user_prompt_content(content: &str) -> String {
+    content
+        .trim_end()
+        .trim_start_matches(['\r', '\n'])
+        .to_string()
 }
 
 /// Returns true for raw clarification question rows like `1. Q: Need tests?`.
@@ -486,10 +497,22 @@ mod tests {
     }
 
     #[test]
-    fn test_stored_message_content_normalizes_conversation_spacing() {
+    fn test_stored_message_content_preserves_user_prompt_indentation() {
         // Arrange, Act, Assert
         assert_eq!(
-            stored_message_content(SessionMessageKind::UserPrompt, "\n  hello  \n"),
+            stored_message_content(
+                SessionMessageKind::UserPrompt,
+                "\n    first\n        second  \n"
+            ),
+            "    first\n        second"
+        );
+    }
+
+    #[test]
+    fn test_stored_message_content_normalizes_assistant_spacing() {
+        // Arrange, Act, Assert
+        assert_eq!(
+            stored_message_content(SessionMessageKind::AssistantAnswer, "\n  hello  \n"),
             "hello"
         );
     }

--- a/crates/agentty/src/infra/db/connection_test.rs
+++ b/crates/agentty/src/infra/db/connection_test.rs
@@ -246,7 +246,7 @@ async fn test_append_session_message_writes_message_rows() {
     // Act
     database
         .sessions()
-        .append_session_message("session-a", SessionMessageKind::UserPrompt, " hi ")
+        .append_session_message("session-a", SessionMessageKind::UserPrompt, "    hi ")
         .await
         .expect("failed to append prompt message");
     database
@@ -284,7 +284,7 @@ async fn test_append_session_message_writes_message_rows() {
     assert_eq!(messages.len(), 3);
     assert_eq!(messages[0].position, 0);
     assert_eq!(messages[0].kind, SessionMessageKind::UserPrompt.as_str());
-    assert_eq!(messages[0].content, "hi");
+    assert_eq!(messages[0].content, "    hi");
     assert_eq!(messages[1].position, 1);
     assert_eq!(
         messages[1].kind,

--- a/crates/agentty/src/runtime/event.rs
+++ b/crates/agentty/src/runtime/event.rs
@@ -467,7 +467,7 @@ mod tests {
         let result = process_event_with_key_handler(
             &mut app,
             &mut terminal,
-            Some(Event::Paste("line 1\r\nline 2".to_string())),
+            Some(Event::Paste("    line 1\r\n        line 2".to_string())),
             |_, (), _| Box::pin(async { Err(io::Error::other("unexpected key-handler call")) }),
         )
         .await;
@@ -475,7 +475,7 @@ mod tests {
         // Assert
         assert!(matches!(result, Ok(EventResult::Continue)));
         assert!(
-            matches!(&app.mode, AppMode::Prompt { input, .. } if input.text() == "line 1\nline 2")
+            matches!(&app.mode, AppMode::Prompt { input, .. } if input.text() == "    line 1\n        line 2")
         );
     }
 

--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::Write as _;
 use std::hash::Hasher;
 use std::sync::Arc;
@@ -35,6 +35,7 @@ const DRAFT_PREVIEW_STACKED_STAGED_NOTE: &str =
     "Draft messages stay local until the parent is review-ready and you press `s` in session view \
      to start the stacked bundle from its parent branch.";
 const SESSION_OUTPUT_LAYOUT_CACHE_ENTRY_LIMIT: usize = 16;
+const USER_PROMPT_TAB_WIDTH: usize = 4;
 
 /// Cache key for one fully assembled session-output layout.
 ///
@@ -1255,11 +1256,10 @@ impl<'a> SessionOutput<'a> {
             .fg(style::palette::text_subtle())
             .add_modifier(ratatui::style::Modifier::ITALIC);
         for queued_text in queued_messages {
-            let trimmed = queued_text.trim();
-            if trimmed.is_empty() {
+            if queued_text.trim().is_empty() {
                 continue;
             }
-            for (line_index, message_line) in trimmed.split('\n').enumerate() {
+            for (line_index, message_line) in queued_text.split('\n').enumerate() {
                 let prefix = if line_index == 0 {
                     "queued › "
                 } else {
@@ -1284,8 +1284,7 @@ impl<'a> SessionOutput<'a> {
         inner_width: usize,
         markdown_render_cache: Option<&markdown::MarkdownRenderCache>,
     ) {
-        let prompt_text = prompt_text.trim();
-        if prompt_text.is_empty() {
+        if prompt_text.trim().is_empty() {
             return;
         }
 
@@ -1294,8 +1293,13 @@ impl<'a> SessionOutput<'a> {
             .saturating_sub(prompt_prefix_width)
             .saturating_sub(USER_PROMPT_RIGHT_GUTTER_WIDTH)
             .max(1);
-        let rendered_lines =
-            Self::rendered_markdown_lines(prompt_text, prompt_content_width, markdown_render_cache);
+        let (protected_prompt_text, indent_marker) =
+            Self::protect_user_prompt_indentation(prompt_text);
+        let rendered_lines = Self::rendered_markdown_lines(
+            &protected_prompt_text,
+            prompt_content_width,
+            markdown_render_cache,
+        );
         if rendered_lines.is_empty() {
             return;
         }
@@ -1323,7 +1327,7 @@ impl<'a> SessionOutput<'a> {
                 prompt_block::user_prompt_prefix_style()
             };
             lines.push(prompt_block::user_prompt_markdown_line(
-                rendered_line.spans.iter().cloned(),
+                Self::restored_user_prompt_spans(rendered_line, indent_marker),
                 prefix,
                 prefix_style,
                 inner_width,
@@ -1332,6 +1336,102 @@ impl<'a> SessionOutput<'a> {
         }
 
         lines.push(prompt_block::user_prompt_padding_line(inner_width));
+    }
+
+    /// Replaces leading prompt spaces with a visible-width non-whitespace
+    /// marker so Markdown wrapping cannot discard indentation.
+    fn protect_user_prompt_indentation(prompt_text: &str) -> (String, Option<char>) {
+        let Some(indent_marker) = Self::unused_private_use_character(prompt_text) else {
+            return (prompt_text.to_string(), None);
+        };
+
+        let mut protected_text = String::with_capacity(prompt_text.len());
+        let prompt_lines = prompt_text.split('\n').collect::<Vec<_>>();
+        let preservation_mask = markdown::markdown_block_preservation_mask(prompt_text);
+
+        for (line_index, line) in prompt_lines.into_iter().enumerate() {
+            if line_index > 0 {
+                protected_text.push('\n');
+            }
+
+            if preservation_mask[line_index] {
+                protected_text.push_str(line);
+            } else {
+                let (content_start, indentation_width) = Self::leading_indentation(line);
+                let content = &line[content_start..];
+                protected_text.extend(std::iter::repeat_n(indent_marker, indentation_width));
+                protected_text.push_str(content);
+            }
+        }
+
+        (protected_text, Some(indent_marker))
+    }
+
+    /// Chooses a private-use character absent from the prompt so literal user
+    /// content can never collide with the temporary indentation marker.
+    fn unused_private_use_character(prompt_text: &str) -> Option<char> {
+        const DEFAULT_INDENT_MARKER: char = '\u{e000}';
+
+        if !prompt_text.contains(DEFAULT_INDENT_MARKER) {
+            return Some(DEFAULT_INDENT_MARKER);
+        }
+
+        let used_characters = prompt_text
+            .chars()
+            .filter(|character| {
+                matches!(
+                    u32::from(*character),
+                    0xe000..=0xf8ff | 0x000f_0000..=0x000f_fffd | 0x0010_0000..=0x0010_fffd
+                )
+            })
+            .collect::<HashSet<_>>();
+        [
+            0xe000..=0xf8ff,
+            0x000f_0000..=0x000f_fffd,
+            0x0010_0000..=0x0010_fffd,
+        ]
+        .into_iter()
+        .flatten()
+        .filter_map(char::from_u32)
+        .find(|character| !used_characters.contains(character))
+    }
+
+    /// Returns the byte offset after leading horizontal whitespace and its
+    /// terminal width, expanding tabs to four-column tab stops.
+    fn leading_indentation(line: &str) -> (usize, usize) {
+        let mut content_start = 0;
+        let mut indentation_width = 0;
+
+        for (byte_index, character) in line.char_indices() {
+            match character {
+                ' ' => indentation_width += 1,
+                '\t' => {
+                    indentation_width +=
+                        USER_PROMPT_TAB_WIDTH - (indentation_width % USER_PROMPT_TAB_WIDTH);
+                }
+                _ => break,
+            }
+            content_start = byte_index + character.len_utf8();
+        }
+
+        (content_start, indentation_width)
+    }
+
+    /// Lazily restores protected indent markers while yielding spans to the
+    /// final prompt line, avoiding an intermediate `Line` and `Vec` allocation.
+    fn restored_user_prompt_spans<'line>(
+        rendered_line: &'line Line<'static>,
+        indent_marker: Option<char>,
+    ) -> impl Iterator<Item = ratatui::text::Span<'static>> + 'line {
+        rendered_line.spans.iter().cloned().map(move |mut span| {
+            if let Some(indent_marker) = indent_marker
+                && span.content.contains(indent_marker)
+            {
+                span.content = span.content.replace(indent_marker, " ").into();
+            }
+
+            span
+        })
     }
 
     /// Appends rendered markdown with one blank separator while trimming any
@@ -3097,6 +3197,155 @@ mod tests {
         assert!(table_header_line.spans.iter().any(|span| {
             span.content.as_ref().contains("Input")
                 && span.style.bg == Some(style::palette::surface_elevated())
+        }));
+    }
+
+    #[test]
+    fn test_output_lines_preserve_user_prompt_indentation() {
+        // Arrange
+        let mut session = session_fixture();
+        set_conversation_transcript(
+            &mut session,
+            vec![(
+                SessionMessageKind::UserPrompt,
+                "    if ready {\n        run();\n    }",
+            )],
+        );
+        session.status = Status::Review;
+
+        // Act
+        let lines = output_lines(
+            &session,
+            Rect::new(0, 0, 80, 8),
+            line_context(None, None, None),
+            None,
+        );
+        let rendered_lines = lines
+            .iter()
+            .map(|line| line.to_string().trim_end().to_string())
+            .collect::<Vec<_>>();
+
+        // Assert
+        assert!(
+            rendered_lines
+                .iter()
+                .any(|line| line == " ›     if ready {"),
+            "rendered lines: {rendered_lines:#?}"
+        );
+        assert!(
+            rendered_lines
+                .iter()
+                .any(|line| line == "           run();")
+        );
+        assert!(rendered_lines.iter().any(|line| line == "       }"));
+    }
+
+    #[test]
+    fn test_output_lines_expand_user_prompt_tab_indentation() {
+        // Arrange
+        let mut session = session_fixture();
+        set_conversation_transcript(
+            &mut session,
+            vec![(
+                SessionMessageKind::UserPrompt,
+                "\tif ready {\n\t\trun();\n\t}",
+            )],
+        );
+        session.status = Status::Review;
+
+        // Act
+        let lines = output_lines(
+            &session,
+            Rect::new(0, 0, 80, 8),
+            line_context(None, None, None),
+            None,
+        );
+        let rendered_lines = lines
+            .iter()
+            .map(|line| line.to_string().trim_end().to_string())
+            .collect::<Vec<_>>();
+
+        // Assert
+        assert!(
+            rendered_lines
+                .iter()
+                .any(|line| line == " ›     if ready {")
+        );
+        assert!(
+            rendered_lines
+                .iter()
+                .any(|line| line == "           run();")
+        );
+        assert!(rendered_lines.iter().any(|line| line == "       }"));
+    }
+
+    #[test]
+    fn test_output_lines_preserve_literal_private_use_character() {
+        // Arrange
+        let prompt = "  before \u{e000} after";
+        let mut session = session_fixture();
+        set_conversation_transcript(&mut session, vec![(SessionMessageKind::UserPrompt, prompt)]);
+        session.status = Status::Review;
+
+        // Act
+        let lines = output_lines(
+            &session,
+            Rect::new(0, 0, 80, 6),
+            line_context(None, None, None),
+            None,
+        );
+        let rendered_text = lines
+            .iter()
+            .map(|line| line.to_string().trim_end().to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Assert
+        assert!(rendered_text.contains(" ›   before \u{e000} after"));
+    }
+
+    #[test]
+    fn test_output_lines_render_indented_user_prompt_table_and_horizontal_rule() {
+        // Arrange
+        let mut session = session_fixture();
+        set_conversation_transcript(
+            &mut session,
+            vec![(
+                SessionMessageKind::UserPrompt,
+                concat!(
+                    "  | Input | Meaning |\n",
+                    "  | --- | --- |\n",
+                    "  | Prompt | Indented |\n",
+                    "\n",
+                    "  ---",
+                ),
+            )],
+        );
+        session.status = Status::Review;
+
+        // Act
+        let lines = output_lines(
+            &session,
+            Rect::new(0, 0, 80, 12),
+            line_context(None, None, None),
+            None,
+        );
+        let rendered_lines = lines
+            .iter()
+            .map(|line| line.to_string().trim_end().to_string())
+            .collect::<Vec<_>>();
+        let text = rendered_lines.join("\n");
+
+        // Assert
+        assert!(text.contains('┌'));
+        assert!(text.contains("Prompt"));
+        assert!(text.contains("Indented"));
+        assert!(!text.contains("| --- | --- |"));
+        assert!(rendered_lines.iter().any(|line| {
+            line.strip_prefix(prompt_block::user_prompt_continuation_prefix().as_str())
+                .is_some_and(|content| {
+                    content.len() > 10 && content.chars().all(|character| character == '-')
+                })
         }));
     }
 

--- a/crates/agentty/src/ui/markdown.rs
+++ b/crates/agentty/src/ui/markdown.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-pub use ag_tui_text::markdown::parse_inline_spans;
+pub use ag_tui_text::markdown::{markdown_block_preservation_mask, parse_inline_spans};
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -3157,6 +3157,40 @@ fn prompt_multiline_via_alt_enter() -> E2eResult {
     Ok(())
 }
 
+/// Verify bracketed paste keeps leading indentation after prompt submission.
+#[test]
+fn prompt_paste_indentation() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("prompt_paste_indentation")
+        .with_git()
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("\x1b[200~    indented prompt\x1b[201~")
+                    .wait_for_text("indented prompt", 3000)
+                    .press_key("Enter")
+                    .wait_for_text("q: back", 10000)
+                    .capture_labeled(
+                        "submitted_indentation",
+                        "Submitted pasted prompt retaining leading indentation",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                let text = frame.text_in_region(&full);
+
+                assert!(text.contains(" ›     indented prompt"));
+            },
+        )?;
+
+    Ok(())
+}
+
 /// Verify that CSI-u `Shift+Enter` inserts a newline in the prompt input.
 #[test]
 fn prompt_multiline_via_csi_u_shift_enter() -> E2eResult {

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -188,7 +188,9 @@ review automatically; press `f` for a manual one.
 Session output renders common Markdown blocks in agent answers and persisted user
 messages, including headings, lists, block quotes, code fences, and pipe tables. Tables
 are aligned to the output panel width so compact comparison data stays readable in the
-terminal transcript.
+terminal transcript. Leading horizontal whitespace in pasted prompts is preserved after
+submission, including nested indentation in multiline text. Tabs render at four-column
+tab stops.
 
 <a id="usage-session-mermaid"></a> Complete ```` ```mermaid ```` fenced blocks in
 session output render as Unicode diagrams. Simple `graph`/`flowchart` diagrams with


### PR DESCRIPTION
- Preserve leading whitespace in persisted and rendered user prompts, including multiline pastes and four-column tab stops.
- Protect indentation across Markdown rendering while retaining tables and horizontal rules.
- Cover the behavior with unit, database, runtime, UI, and E2E tests and document it in the workflow guide.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)