### PR TITLE
Coordinate branch publishing and review-request refresh

### DIFF
--- a/crates/agentty/src/app/session/workflow/merge.rs
+++ b/crates/agentty/src/app/session/workflow/merge.rs
@@ -8,6 +8,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 use ag_agent as agent;
+use ag_forge as forge;
 use ag_git::{self as git, GitClient};
 use ag_protocol::AgentResponseSummary;
 use askama::Template;
@@ -15,7 +16,7 @@ use tokio::sync::mpsc;
 use tracing::warn;
 
 use super::published_branch::{self, PublishedBranchAutoPushInput};
-use super::worker::SessionCommand;
+use super::worker::{SessionCommand, has_unfinished_rebase_operation};
 use super::{SessionTaskService, StatusTransition, session_branch};
 use crate::app::assist::{
     AssistContext, AssistPolicy, FailureTracker, append_assist_header, format_detail_lines,
@@ -28,7 +29,7 @@ use crate::domain::agent::{AgentKind, AgentModel, AgentSelection, ReasoningLevel
 use crate::domain::session::{PublishedBranchSyncStatus, SessionId, Status};
 use crate::domain::session_message::SessionTranscript;
 use crate::domain::transcript_notice::TranscriptNotice;
-use crate::infra::db::{AppRepositories, SessionOperationRow};
+use crate::infra::db::AppRepositories;
 use crate::infra::fs::{self as fs, FsClient};
 
 const REBASE_ASSIST_POLICY: AssistPolicy = AssistPolicy {
@@ -219,6 +220,9 @@ pub(super) struct RebaseCommandInput {
     pub(super) assist_mode: RebaseAssistMode,
     /// Stored base branch for the session worktree.
     pub(super) base_branch: String,
+    /// Serializes post-rebase publish ownership with other queued/running
+    /// branch operations for the same session.
+    pub(super) branch_operation_lock: Arc<tokio::sync::Mutex<()>>,
     /// Shared child-process PID slot used by cancellation.
     pub(super) child_pid: Arc<Mutex<Option<u32>>>,
     /// Clock used for persisted status timing.
@@ -233,6 +237,9 @@ pub(super) struct RebaseCommandInput {
     pub(super) git_client: Arc<dyn GitClient>,
     /// Session identifier receiving transcript/status updates.
     pub(super) id: SessionId,
+    /// Forge boundary used for optional linked PR/MR metadata refresh after
+    /// post-rebase auto-push.
+    pub(super) review_request_client: Arc<dyn forge::ReviewRequestClient>,
     /// Agent/model selection used by agent-assisted conflict prompts.
     pub(super) session_agent: AgentSelection,
     /// Per-app update versions for targeted session refresh events.
@@ -246,11 +253,16 @@ pub(super) struct RebaseCommandInput {
 /// Bundled context for finalizing one rebase task.
 struct FinalizeRebaseInput<'a> {
     app_event_tx: &'a mpsc::UnboundedSender<AppEvent>,
+    /// Serializes post-rebase publish ownership with other queued/running
+    /// branch operations for the same session.
+    branch_operation_lock: &'a Arc<tokio::sync::Mutex<()>>,
+    clock: &'a Arc<dyn Clock>,
     db: &'a AppRepositories,
     folder: &'a Path,
     git_client: &'a Arc<dyn GitClient>,
     id: &'a str,
     rebase_result: Result<String, SessionError>,
+    review_request_client: &'a Arc<dyn forge::ReviewRequestClient>,
     session_update_versions: &'a SessionUpdateVersionMap,
     /// Bound transition context for restoring `Review` after rebase cleanup.
     status_transition: &'a StatusTransition,
@@ -260,9 +272,14 @@ struct FinalizeRebaseInput<'a> {
 /// Bundled context for starting post-rebase auto-publish.
 struct RebaseAutoPushInput<'a> {
     app_event_tx: &'a mpsc::UnboundedSender<AppEvent>,
+    /// Serializes post-rebase publish ownership with other queued/running
+    /// branch operations for the same session.
+    branch_operation_lock: &'a Arc<tokio::sync::Mutex<()>>,
+    clock: &'a Arc<dyn Clock>,
     db: &'a AppRepositories,
     folder: &'a Path,
     git_client: &'a Arc<dyn GitClient>,
+    review_request_client: &'a Arc<dyn forge::ReviewRequestClient>,
     session_id: &'a str,
     session_update_versions: &'a SessionUpdateVersionMap,
     transcript: &'a Arc<Mutex<SessionTranscript>>,
@@ -794,6 +811,11 @@ impl SessionMergeService {
     ) -> Result<(), SessionError> {
         let (base_branch, current_status, persisted_session_id) =
             Self::load_rebase_start_context(manager, services, session_id).await?;
+        let branch_operation_lock = manager
+            .session_handles_or_err(session_id)
+            .map(|handles| Arc::clone(&handles.branch_operation_lock))
+            .map_err(|_| SessionError::HandlesNotFound)?;
+        let _branch_operation_guard = branch_operation_lock.lock_owned().await;
 
         let command = SessionCommand::Rebase {
             base_branch,
@@ -805,7 +827,7 @@ impl SessionMergeService {
                 .operations()
                 .load_unfinished_session_operations()
                 .await?;
-            if Self::has_unfinished_rebase_operation(
+            if has_unfinished_rebase_operation(
                 &unfinished_operations,
                 persisted_session_id.as_str(),
             ) {
@@ -844,17 +866,6 @@ impl SessionMergeService {
         }
 
         Ok(())
-    }
-
-    /// Returns whether a session already has a queued or running rebase
-    /// operation.
-    fn has_unfinished_rebase_operation(
-        operations: &[SessionOperationRow],
-        session_id: &str,
-    ) -> bool {
-        operations
-            .iter()
-            .any(|operation| operation.session_id == session_id && operation.kind == "rebase")
     }
 
     /// Starts automatic rebase commands for review-ready stacked children
@@ -1773,6 +1784,7 @@ impl SessionManager {
             app_event_tx,
             assist_mode,
             base_branch,
+            branch_operation_lock,
             child_pid,
             clock,
             db,
@@ -1780,6 +1792,7 @@ impl SessionManager {
             fs_client,
             git_client,
             id,
+            review_request_client,
             session_agent,
             session_update_versions,
             status,
@@ -1829,11 +1842,14 @@ impl SessionManager {
 
         Self::finalize_rebase_task(FinalizeRebaseInput {
             app_event_tx: &app_event_tx,
+            branch_operation_lock: &branch_operation_lock,
+            clock: &clock,
             db: &db,
             folder: &folder,
             git_client: &git_client,
             id: &id,
             rebase_result,
+            review_request_client: &review_request_client,
             session_update_versions: &session_update_versions,
             status_transition: &status_transition,
             transcript: &transcript,
@@ -2063,11 +2079,14 @@ impl SessionManager {
     async fn finalize_rebase_task(input: FinalizeRebaseInput<'_>) {
         let FinalizeRebaseInput {
             app_event_tx,
+            branch_operation_lock,
+            clock,
             db,
             folder,
             git_client,
             id,
             rebase_result,
+            review_request_client,
             session_update_versions,
             status_transition,
             transcript,
@@ -2090,9 +2109,12 @@ impl SessionManager {
 
                 Self::start_auto_push_after_rebase(RebaseAutoPushInput {
                     app_event_tx,
+                    branch_operation_lock,
+                    clock,
                     db,
                     folder,
                     git_client,
+                    review_request_client,
                     session_id: id,
                     session_update_versions,
                     transcript,
@@ -2133,14 +2155,18 @@ impl SessionManager {
     async fn start_auto_push_after_rebase(input: RebaseAutoPushInput<'_>) {
         let RebaseAutoPushInput {
             app_event_tx,
+            branch_operation_lock,
+            clock,
             db,
             folder,
             git_client,
+            review_request_client,
             session_id,
             session_update_versions,
             transcript,
         } = input;
 
+        let branch_operation_guard = Arc::clone(branch_operation_lock).lock_owned().await;
         let published_upstream_ref = db
             .sessions()
             .load_session_published_upstream_ref(session_id)
@@ -2168,6 +2194,11 @@ impl SessionManager {
                 "failed to publish branch sync start because the app event receiver is closed"
             );
         }
+        let review_request_metadata_sync = Some(published_branch::ReviewRequestMetadataSyncInput {
+            clock: Arc::clone(clock),
+            commit_message: None,
+            review_request_client: Arc::clone(review_request_client),
+        });
 
         let app_event_tx = app_event_tx.clone();
         let db = db.clone();
@@ -2181,7 +2212,7 @@ impl SessionManager {
             folder,
             git_client,
             published_upstream_ref,
-            review_request_metadata_sync: None,
+            review_request_metadata_sync,
             session_id,
             session_update_versions: session_update_versions.clone(),
             sync_operation_id,
@@ -2189,6 +2220,7 @@ impl SessionManager {
         };
 
         tokio::spawn(async move {
+            let _branch_operation_guard = branch_operation_guard;
             published_branch::run_published_branch_auto_push(auto_push_input).await;
         });
     }
@@ -2929,6 +2961,7 @@ mod tests {
     use tempfile::{TempDir, tempdir};
 
     use super::*;
+    use crate::infra::db::SessionOperationRow;
 
     /// Builds a filesystem mock that delegates operations to local disk.
     fn create_passthrough_mock_fs_client() -> fs::MockFsClient {
@@ -2986,8 +3019,7 @@ mod tests {
         ];
 
         // Act
-        let has_rebase =
-            SessionMergeService::has_unfinished_rebase_operation(&operations, "session-a");
+        let has_rebase = has_unfinished_rebase_operation(&operations, "session-a");
 
         // Assert
         assert!(has_rebase);
@@ -3002,8 +3034,7 @@ mod tests {
         ];
 
         // Act
-        let has_rebase =
-            SessionMergeService::has_unfinished_rebase_operation(&operations, "session-a");
+        let has_rebase = has_unfinished_rebase_operation(&operations, "session-a");
 
         // Assert
         assert!(!has_rebase);
@@ -4844,53 +4875,56 @@ mod tests {
             .expect("failed to set published upstream ref");
 
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let branch_operation_lock = Arc::new(tokio::sync::Mutex::new(()));
         let temp_dir = tempdir().expect("failed to create temp dir");
         let folder = temp_dir.path().join("sess-rebase");
         let session_update_versions = Arc::default();
         let status = Arc::new(Mutex::new(Status::Rebasing));
         let transcript = empty_transcript();
+        let clock: Arc<dyn Clock> = Arc::new(crate::infra::clock::RealClock);
+        let review_request_client: Arc<dyn forge::ReviewRequestClient> =
+            Arc::new(forge::MockReviewRequestClient::new());
         let status_transition = StatusTransition::from_parts(
             app_event_tx.clone(),
-            Arc::new(crate::infra::clock::RealClock),
+            Arc::clone(&clock),
             db.clone(),
             "sess-rebase",
             Arc::clone(&session_update_versions),
             Arc::clone(&status),
         );
-
-        let mut mock_git_client = git::MockGitClient::new();
-        mock_git_client
-            .expect_in_progress_operation()
-            .once()
-            .returning(|_| Box::pin(async { Ok(None) }));
-        mock_git_client
-            .expect_detect_git_info()
-            .once()
-            .returning(|_| Box::pin(async { Some("wt/sess-reb".to_string()) }));
-        mock_git_client
-            .expect_push_current_branch_to_remote_branch()
-            .once()
-            .withf(|session_folder, remote_branch_name| {
-                session_folder.ends_with("sess-rebase") && remote_branch_name == "wt/sess-rebase"
-            })
-            .returning(|_, _| Box::pin(async { Ok("origin/wt/sess-rebase".to_string()) }));
-        let git_client: Arc<dyn GitClient> = Arc::new(mock_git_client);
+        let push_started = Arc::new(tokio::sync::Notify::new());
+        let release_push = Arc::new(tokio::sync::Notify::new());
+        let git_client: Arc<dyn GitClient> = Arc::new(blocking_auto_push_git_client(
+            Arc::clone(&push_started),
+            Arc::clone(&release_push),
+        ));
 
         // Act
         SessionManager::finalize_rebase_task(FinalizeRebaseInput {
             app_event_tx: &app_event_tx,
+            branch_operation_lock: &branch_operation_lock,
+            clock: &clock,
             db: &db,
             folder: &folder,
             git_client: &git_client,
             id: "sess-rebase",
             rebase_result: Ok("Successfully synced wt/sess-rebase onto main".to_string()),
+            review_request_client: &review_request_client,
             session_update_versions: &session_update_versions,
             status_transition: &status_transition,
             transcript: &transcript,
         })
         .await;
+        tokio::time::timeout(std::time::Duration::from_secs(2), push_started.notified())
+            .await
+            .expect("timed out waiting for auto-push to start");
 
-        // Assert — collect sync events emitted by the auto-push task.
+        // Assert
+        assert!(
+            branch_operation_lock.try_lock().is_err(),
+            "post-rebase auto-push should retain branch-operation ownership"
+        );
+        release_push.notify_one();
         let sync_events = tokio::time::timeout(std::time::Duration::from_secs(2), async {
             let mut sync_events = Vec::new();
             while sync_events.len() < 2 {
@@ -4924,6 +4958,339 @@ mod tests {
         assert!(transcript_text.contains("[Sync] Successfully synced"));
     }
 
+    /// Returns a git mock whose published-branch push waits for an explicit
+    /// release after notifying the test that push execution has started.
+    fn blocking_auto_push_git_client(
+        push_started: Arc<tokio::sync::Notify>,
+        release_push: Arc<tokio::sync::Notify>,
+    ) -> git::MockGitClient {
+        let mut mock_git_client = git::MockGitClient::new();
+        mock_git_client
+            .expect_in_progress_operation()
+            .once()
+            .returning(|_| Box::pin(async { Ok(None) }));
+        mock_git_client
+            .expect_detect_git_info()
+            .once()
+            .returning(|_| Box::pin(async { Some("wt/sess-reb".to_string()) }));
+        mock_git_client
+            .expect_push_current_branch_to_remote_branch()
+            .once()
+            .withf(|session_folder, remote_branch_name| {
+                session_folder.ends_with("sess-rebase") && remote_branch_name == "wt/sess-rebase"
+            })
+            .returning(move |_, _| {
+                let push_started = Arc::clone(&push_started);
+                let release_push = Arc::clone(&release_push);
+
+                Box::pin(async move {
+                    push_started.notify_one();
+                    release_push.notified().await;
+
+                    Ok("origin/wt/sess-rebase".to_string())
+                })
+            });
+
+        mock_git_client
+    }
+
+    /// Inserts one published rebasing session linked to an open GitHub review
+    /// request.
+    async fn insert_published_rebase_session_with_review_request(db: &AppRepositories) {
+        let project_id = db
+            .projects()
+            .upsert_project("/tmp/project", Some("main".to_string()))
+            .await
+            .expect("failed to upsert project");
+        db.sessions()
+            .insert_session(
+                "sess-rebase",
+                "gemini-3-flash-preview",
+                "main",
+                "Rebasing",
+                project_id,
+            )
+            .await
+            .expect("failed to insert session");
+        db.sessions()
+            .update_session_published_upstream_ref(
+                "sess-rebase",
+                Some("origin/wt/sess-rebase".to_string()),
+            )
+            .await
+            .expect("failed to set published upstream ref");
+        db.reviews()
+            .update_session_review_request("sess-rebase", Some(linked_github_review_request()))
+            .await
+            .expect("failed to persist review request");
+    }
+
+    /// Returns one linked GitHub review request fixture for metadata-sync
+    /// tests.
+    fn linked_github_review_request() -> crate::domain::session::ReviewRequest {
+        crate::domain::session::ReviewRequest {
+            last_refreshed_at: 100,
+            summary: forge::ReviewRequestSummary {
+                display_id: "#42".to_string(),
+                forge_kind: forge::ForgeKind::GitHub,
+                source_branch: "wt/sess-rebase".to_string(),
+                state: crate::domain::session::ReviewRequestState::Open,
+                status_summary: Some("Draft".to_string()),
+                target_branch: "main".to_string(),
+                title: "Old title".to_string(),
+                web_url: "https://github.com/agentty-xyz/agentty/pull/42".to_string(),
+            },
+        }
+    }
+
+    /// Returns one git client mock for post-rebase review-request metadata
+    /// sync.
+    fn metadata_sync_git_client() -> git::MockGitClient {
+        let mut mock_git_client = git::MockGitClient::new();
+        mock_git_client
+            .expect_head_commit_message()
+            .once()
+            .withf(|session_folder| session_folder.ends_with("sess-rebase"))
+            .returning(|_| {
+                Box::pin(async {
+                    Ok(Some(
+                        "Refresh queued sync metadata\n\n- Preserve sync details.".to_string(),
+                    ))
+                })
+            });
+        mock_git_client
+            .expect_in_progress_operation()
+            .once()
+            .returning(|_| Box::pin(async { Ok(None) }));
+        mock_git_client
+            .expect_detect_git_info()
+            .once()
+            .returning(|_| Box::pin(async { Some("wt/sess-reb".to_string()) }));
+        mock_git_client
+            .expect_push_current_branch_to_remote_branch()
+            .once()
+            .withf(|session_folder, remote_branch_name| {
+                session_folder.ends_with("sess-rebase") && remote_branch_name == "wt/sess-rebase"
+            })
+            .returning(|_, _| Box::pin(async { Ok("origin/wt/sess-rebase".to_string()) }));
+        mock_git_client.expect_repo_url().once().returning(|_| {
+            Box::pin(async { Ok("https://github.com/agentty-xyz/agentty.git".to_string()) })
+        });
+
+        mock_git_client
+    }
+
+    /// Returns one GitHub forge remote fixture for metadata-sync tests.
+    fn github_forge_remote() -> forge::ForgeRemote {
+        forge::ForgeRemote {
+            command_working_directory: None,
+            forge_kind: forge::ForgeKind::GitHub,
+            host: "github.com".to_string(),
+            namespace: "agentty-xyz".to_string(),
+            project: "agentty".to_string(),
+            repo_url: "https://github.com/agentty-xyz/agentty.git".to_string(),
+            web_url: "https://github.com/agentty-xyz/agentty".to_string(),
+        }
+    }
+
+    /// Returns one review-request client mock for post-rebase metadata sync.
+    fn metadata_sync_review_request_client(folder: PathBuf) -> forge::MockReviewRequestClient {
+        let mut mock_review_request_client = forge::MockReviewRequestClient::new();
+        mock_review_request_client
+            .expect_detect_remote()
+            .once()
+            .returning(|_| Ok(github_forge_remote()));
+        mock_review_request_client
+            .expect_sync_review_request_metadata()
+            .once()
+            .withf(move |remote, display_id, input| {
+                remote.command_working_directory.as_deref() == Some(folder.as_path())
+                    && display_id == "#42"
+                    && input.title == "Refresh queued sync metadata"
+                    && input.body.as_deref() == Some("- Preserve sync details.")
+            })
+            .returning(|_, _, input| {
+                Box::pin(async move {
+                    Ok(forge::ReviewRequestSummary {
+                        display_id: "#42".to_string(),
+                        forge_kind: forge::ForgeKind::GitHub,
+                        source_branch: "wt/sess-rebase".to_string(),
+                        state: crate::domain::session::ReviewRequestState::Open,
+                        status_summary: Some("Open".to_string()),
+                        target_branch: "main".to_string(),
+                        title: input.title,
+                        web_url: "https://github.com/agentty-xyz/agentty/pull/42".to_string(),
+                    })
+                })
+            });
+
+        mock_review_request_client
+    }
+
+    /// Collects the in-progress and terminal published-branch sync states.
+    async fn collect_published_branch_sync_statuses(
+        app_event_rx: &mut mpsc::UnboundedReceiver<AppEvent>,
+    ) -> Vec<PublishedBranchSyncStatus> {
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            let mut sync_events = Vec::new();
+            while sync_events.len() < 2 {
+                let event = app_event_rx.recv().await.expect("missing app event");
+                if let AppEvent::PublishedBranchSyncUpdated { sync_status, .. } = event {
+                    sync_events.push(sync_status);
+                }
+            }
+
+            sync_events
+        })
+        .await
+        .expect("timed out waiting for sync events")
+    }
+
+    #[tokio::test]
+    /// Verifies post-rebase auto-push refreshes linked PR/MR metadata from the
+    /// latest session commit message.
+    async fn test_finalize_rebase_task_syncs_review_request_metadata_after_auto_push() {
+        // Arrange
+        let db = AppRepositories::in_memory().await;
+        insert_published_rebase_session_with_review_request(&db).await;
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let folder = temp_dir.path().join("sess-rebase");
+        let session_update_versions = Arc::default();
+        let status = Arc::new(Mutex::new(Status::Rebasing));
+        let transcript = empty_transcript();
+        let clock: Arc<dyn Clock> = Arc::new(crate::infra::clock::RealClock);
+        let status_transition = StatusTransition::from_parts(
+            app_event_tx.clone(),
+            Arc::clone(&clock),
+            db.clone(),
+            "sess-rebase",
+            Arc::clone(&session_update_versions),
+            Arc::clone(&status),
+        );
+        let git_client: Arc<dyn GitClient> = Arc::new(metadata_sync_git_client());
+        let review_request_client: Arc<dyn forge::ReviewRequestClient> =
+            Arc::new(metadata_sync_review_request_client(folder.clone()));
+
+        // Act
+        SessionManager::finalize_rebase_task(FinalizeRebaseInput {
+            app_event_tx: &app_event_tx,
+            branch_operation_lock: &Arc::new(tokio::sync::Mutex::new(())),
+            clock: &clock,
+            db: &db,
+            folder: &folder,
+            git_client: &git_client,
+            id: "sess-rebase",
+            rebase_result: Ok("Successfully synced wt/sess-rebase onto main".to_string()),
+            review_request_client: &review_request_client,
+            session_update_versions: &session_update_versions,
+            status_transition: &status_transition,
+            transcript: &transcript,
+        })
+        .await;
+        let sync_events = collect_published_branch_sync_statuses(&mut app_event_rx).await;
+        let review_request = db
+            .reviews()
+            .load_session_review_request("sess-rebase")
+            .await
+            .expect("failed to load review request")
+            .expect("review request should remain linked");
+
+        // Assert
+        assert_eq!(
+            sync_events,
+            vec![
+                PublishedBranchSyncStatus::InProgress,
+                PublishedBranchSyncStatus::Succeeded,
+            ]
+        );
+        assert_eq!(review_request.title, "Refresh queued sync metadata");
+    }
+
+    #[tokio::test]
+    /// Verifies post-rebase metadata lookup failures remain visible after the
+    /// branch itself pushes successfully.
+    async fn test_finalize_rebase_task_warns_when_commit_message_lookup_fails() {
+        // Arrange
+        let db = AppRepositories::in_memory().await;
+        insert_published_rebase_session_with_review_request(&db).await;
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let folder = temp_dir.path().join("sess-rebase");
+        let session_update_versions = Arc::default();
+        let status = Arc::new(Mutex::new(Status::Rebasing));
+        let transcript = empty_transcript();
+        let clock: Arc<dyn Clock> = Arc::new(crate::infra::clock::RealClock);
+        let status_transition = StatusTransition::from_parts(
+            app_event_tx.clone(),
+            Arc::clone(&clock),
+            db.clone(),
+            "sess-rebase",
+            Arc::clone(&session_update_versions),
+            Arc::clone(&status),
+        );
+        let mut mock_git_client = git::MockGitClient::new();
+        mock_git_client
+            .expect_in_progress_operation()
+            .once()
+            .returning(|_| Box::pin(async { Ok(None) }));
+        mock_git_client
+            .expect_detect_git_info()
+            .once()
+            .returning(|_| Box::pin(async { Some("wt/sess-reb".to_string()) }));
+        mock_git_client
+            .expect_push_current_branch_to_remote_branch()
+            .once()
+            .returning(|_, _| Box::pin(async { Ok("origin/wt/sess-rebase".to_string()) }));
+        mock_git_client
+            .expect_head_commit_message()
+            .once()
+            .returning(|_| {
+                Box::pin(async {
+                    Err(git::GitError::OutputParse(
+                        "commit message unavailable".to_string(),
+                    ))
+                })
+            });
+        let git_client: Arc<dyn GitClient> = Arc::new(mock_git_client);
+        let review_request_client: Arc<dyn forge::ReviewRequestClient> =
+            Arc::new(forge::MockReviewRequestClient::new());
+
+        // Act
+        SessionManager::finalize_rebase_task(FinalizeRebaseInput {
+            app_event_tx: &app_event_tx,
+            branch_operation_lock: &Arc::new(tokio::sync::Mutex::new(())),
+            clock: &clock,
+            db: &db,
+            folder: &folder,
+            git_client: &git_client,
+            id: "sess-rebase",
+            rebase_result: Ok("Successfully synced wt/sess-rebase onto main".to_string()),
+            review_request_client: &review_request_client,
+            session_update_versions: &session_update_versions,
+            status_transition: &status_transition,
+            transcript: &transcript,
+        })
+        .await;
+        let sync_events = collect_published_branch_sync_statuses(&mut app_event_rx).await;
+        let transcript_text = transcript
+            .lock()
+            .expect("transcript lock poisoned")
+            .replay_text()
+            .unwrap_or_default();
+
+        // Assert
+        assert_eq!(
+            sync_events,
+            vec![
+                PublishedBranchSyncStatus::InProgress,
+                PublishedBranchSyncStatus::Succeeded,
+            ]
+        );
+        assert!(transcript_text.contains("[Review Request Sync Warning]"));
+        assert!(transcript_text.contains("commit message unavailable"));
+    }
+
     #[tokio::test]
     /// Verifies that a successful rebase does not trigger auto-push when the
     /// session has no published upstream branch.
@@ -4952,9 +5319,12 @@ mod tests {
         let session_update_versions = Arc::default();
         let status = Arc::new(Mutex::new(Status::Rebasing));
         let transcript = empty_transcript();
+        let clock: Arc<dyn Clock> = Arc::new(crate::infra::clock::RealClock);
+        let review_request_client: Arc<dyn forge::ReviewRequestClient> =
+            Arc::new(forge::MockReviewRequestClient::new());
         let status_transition = StatusTransition::from_parts(
             app_event_tx.clone(),
-            Arc::new(crate::infra::clock::RealClock),
+            Arc::clone(&clock),
             db.clone(),
             "sess-no-push",
             Arc::clone(&session_update_versions),
@@ -4965,11 +5335,14 @@ mod tests {
         // Act
         SessionManager::finalize_rebase_task(FinalizeRebaseInput {
             app_event_tx: &app_event_tx,
+            branch_operation_lock: &Arc::new(tokio::sync::Mutex::new(())),
+            clock: &clock,
             db: &db,
             folder: &folder,
             git_client: &git_client,
             id: "sess-no-push",
             rebase_result: Ok("Successfully synced wt/sess-no-push onto main".to_string()),
+            review_request_client: &review_request_client,
             session_update_versions: &session_update_versions,
             status_transition: &status_transition,
             transcript: &transcript,

--- a/crates/agentty/src/app/session/workflow/post_turn.rs
+++ b/crates/agentty/src/app/session/workflow/post_turn.rs
@@ -11,9 +11,10 @@ use ag_git::GitClient;
 use ag_protocol::AgentResponse;
 use serde_json;
 use tokio::sync::mpsc;
+use tracing::warn;
 
 use super::task::SessionTranscriptMessageAppend;
-use super::worker::{SessionWorkerContext, TurnMetadata};
+use super::worker::{SessionWorkerContext, TurnMetadata, has_unfinished_rebase_operation};
 use super::{SessionTaskService, StatusTransition, published_branch};
 use crate::app::AppEvent;
 use crate::app::assist::AssistContext;
@@ -35,6 +36,8 @@ use crate::infra::fs::FsClient;
 pub(super) struct PostTurnContext {
     /// Reducer event sender used for output and post-turn projections.
     pub(super) app_event_tx: mpsc::UnboundedSender<AppEvent>,
+    /// Serializes post-turn publish ownership with queued branch operations.
+    pub(super) branch_operation_lock: Arc<tokio::sync::Mutex<()>>,
     /// Shared child-process PID slot reused by auto-commit cancellation.
     pub(super) child_pid: Arc<Mutex<Option<u32>>>,
     /// Clock used by linked review-request metadata refresh.
@@ -62,6 +65,7 @@ impl PostTurnContext {
     pub(super) fn from_worker(context: &SessionWorkerContext) -> Self {
         Self {
             app_event_tx: context.app_event_tx.clone(),
+            branch_operation_lock: Arc::clone(&context.branch_operation_lock),
             child_pid: Arc::clone(&context.child_pid),
             clock: Arc::clone(&context.clock),
             db: context.db.clone(),
@@ -84,6 +88,30 @@ impl PostTurnContext {
         self.queued_messages
             .lock()
             .map_or(true, |guard| !guard.is_empty())
+    }
+
+    /// Returns whether session sync is already queued or running on this
+    /// worker, failing closed when persisted operation state cannot be read.
+    async fn has_unfinished_rebase_operation(&self) -> bool {
+        let unfinished_operations = match self
+            .db
+            .operations()
+            .load_unfinished_session_operations()
+            .await
+        {
+            Ok(unfinished_operations) => unfinished_operations,
+            Err(error) => {
+                warn!(
+                    session_id = %self.session_id,
+                    %error,
+                    "Skipping post-turn auto-push because unfinished session operations could not be loaded"
+                );
+
+                return true;
+            }
+        };
+
+        has_unfinished_rebase_operation(&unfinished_operations, self.session_id.as_str())
     }
 }
 
@@ -376,7 +404,7 @@ async fn apply_successful_turn_result(
     })
     .await;
     let review_request_commit_message = commit_outcome.map(|outcome| outcome.commit_message);
-    start_published_branch_auto_push(context, turn_metadata, review_request_commit_message);
+    start_published_branch_auto_push(context, turn_metadata, review_request_commit_message).await;
     if target_status.allows_review_actions() && has_review_ready_stacked_children(context).await {
         let _ = context
             .app_event_tx
@@ -422,22 +450,28 @@ async fn has_review_ready_stacked_children(context: &PostTurnContext) -> bool {
 
 /// Starts the optional published-branch auto-push effect from explicit
 /// post-turn inputs.
-fn start_published_branch_auto_push(
+async fn start_published_branch_auto_push(
     context: &PostTurnContext,
     turn_metadata: TurnMetadata,
     review_request_commit_message: Option<String>,
 ) {
-    if context.has_queued_messages() {
-        return;
-    }
-
     let Some(published_upstream_ref) = turn_metadata.published_upstream_ref else {
         return;
     };
+    if context.has_queued_messages() {
+        return;
+    }
+    let branch_operation_guard = Arc::clone(&context.branch_operation_lock)
+        .lock_owned()
+        .await;
+    if context.has_unfinished_rebase_operation().await {
+        return;
+    }
 
     published_branch::start_published_branch_auto_push(
         published_branch::PublishedBranchAutoPushStartInput {
             app_event_tx: context.app_event_tx.clone(),
+            branch_operation_guard,
             clock: Arc::clone(&context.clock),
             db: context.db.clone(),
             folder: context.folder.clone(),
@@ -520,4 +554,116 @@ pub(super) fn persisted_session_summary_payload(assistant_message: &AgentRespons
 /// response.
 fn turn_applied_follow_up_tasks(_assistant_message: &AgentResponse) -> Vec<SessionFollowUpTask> {
     Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use ag_git::MockGitClient;
+
+    use super::*;
+    use crate::domain::agent::{AgentKind, AgentModel, AgentSelection};
+
+    #[tokio::test]
+    async fn test_unfinished_rebase_check_fails_closed_when_operation_query_fails() {
+        // Arrange
+        let (db, pool) = AppRepositories::in_memory_with_pool().await;
+        pool.close().await;
+        let context = PostTurnContext {
+            app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
+            child_pid: Arc::new(Mutex::new(None)),
+            clock: Arc::new(crate::infra::clock::RealClock),
+            db,
+            folder: PathBuf::new(),
+            git_client: Arc::new(MockGitClient::new()),
+            queued_messages: Arc::new(Mutex::new(VecDeque::new())),
+            review_request_client: Arc::new(forge::MockReviewRequestClient::new()),
+            session_update_versions: Arc::default(),
+            session_id: "session-id".into(),
+            transcript: Arc::new(Mutex::new(SessionTranscript::default())),
+        };
+
+        // Act
+        let should_skip_auto_push = context.has_unfinished_rebase_operation().await;
+
+        // Assert
+        assert!(
+            should_skip_auto_push,
+            "operation-query failures must suppress post-turn auto-push"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_auto_push_rechecks_queued_rebase_after_waiting_for_branch_lock() {
+        // Arrange
+        let db = AppRepositories::in_memory().await;
+        let project_id = db
+            .projects()
+            .upsert_project("/tmp/project", Some("main".to_string()))
+            .await
+            .expect("failed to upsert project");
+        db.sessions()
+            .insert_session(
+                "session-id",
+                "gemini-3-flash-preview",
+                "main",
+                "InProgress",
+                project_id,
+            )
+            .await
+            .expect("failed to insert session");
+        let branch_operation_lock = Arc::new(tokio::sync::Mutex::new(()));
+        let enqueue_guard = Arc::clone(&branch_operation_lock).lock_owned().await;
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let mut mock_git_client = MockGitClient::new();
+        mock_git_client
+            .expect_push_current_branch_to_remote_branch()
+            .never();
+        let context = Arc::new(PostTurnContext {
+            app_event_tx,
+            branch_operation_lock,
+            child_pid: Arc::new(Mutex::new(None)),
+            clock: Arc::new(crate::infra::clock::RealClock),
+            db: db.clone(),
+            folder: PathBuf::new(),
+            git_client: Arc::new(mock_git_client),
+            queued_messages: Arc::new(Mutex::new(VecDeque::new())),
+            review_request_client: Arc::new(forge::MockReviewRequestClient::new()),
+            session_update_versions: Arc::default(),
+            session_id: "session-id".into(),
+            transcript: Arc::new(Mutex::new(SessionTranscript::default())),
+        });
+        let auto_push_task = {
+            let context = Arc::clone(&context);
+
+            tokio::spawn(async move {
+                start_published_branch_auto_push(
+                    &context,
+                    TurnMetadata {
+                        published_upstream_ref: Some("origin/wt/session-id".to_string()),
+                        session_agent: AgentSelection::new(
+                            AgentKind::Antigravity,
+                            AgentModel::Gemini3FlashPreview,
+                        ),
+                    },
+                    None,
+                )
+                .await;
+            })
+        };
+        db.operations()
+            .insert_session_operation("queued-sync", "session-id", "rebase")
+            .await
+            .expect("failed to insert queued sync");
+
+        // Act
+        drop(enqueue_guard);
+        auto_push_task.await.expect("auto-push task should join");
+
+        // Assert
+        assert!(
+            app_event_rx.try_recv().is_err(),
+            "the queued sync should retain publish ownership"
+        );
+    }
 }

--- a/crates/agentty/src/app/session/workflow/published_branch.rs
+++ b/crates/agentty/src/app/session/workflow/published_branch.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 
 use ag_forge as forge;
 use ag_git::GitClient;
-use tokio::sync::mpsc;
+use tokio::sync::{OwnedMutexGuard, mpsc};
 use uuid::Uuid;
 
 use super::SessionTaskService;
@@ -25,6 +25,8 @@ use crate::infra::db::AppRepositories;
 pub(super) struct PublishedBranchAutoPushStartInput {
     /// Reducer event sender used to publish auto-push progress and completion.
     pub(super) app_event_tx: mpsc::UnboundedSender<AppEvent>,
+    /// Per-session guard retained until the detached push finishes.
+    pub(super) branch_operation_guard: OwnedMutexGuard<()>,
     /// Clock used to timestamp optional review-request metadata refresh.
     pub(super) clock: Arc<dyn Clock>,
     /// Repository bundle used to resolve and persist branch-publish state.
@@ -50,13 +52,14 @@ pub(super) struct PublishedBranchAutoPushStartInput {
 /// Starts one detached auto-push task for a session that already tracks a
 /// published upstream branch.
 pub(super) fn start_published_branch_auto_push(input: PublishedBranchAutoPushStartInput) {
+    let branch_operation_guard = input.branch_operation_guard;
     let sync_operation_id = Uuid::new_v4().to_string();
     let review_request_metadata_sync =
         input
             .review_request_commit_message
             .map(|commit_message| ReviewRequestMetadataSyncInput {
                 clock: Arc::clone(&input.clock),
-                commit_message,
+                commit_message: Some(commit_message),
                 review_request_client: Arc::clone(&input.review_request_client),
             });
 
@@ -81,6 +84,7 @@ pub(super) fn start_published_branch_auto_push(input: PublishedBranchAutoPushSta
         transcript: input.transcript,
     };
     tokio::spawn(async move {
+        let _branch_operation_guard = branch_operation_guard;
         run_published_branch_auto_push_task(auto_push_input).await;
     });
 }
@@ -114,8 +118,8 @@ pub(super) struct PublishedBranchAutoPushInput {
 pub(super) struct ReviewRequestMetadataSyncInput {
     /// Clock used to timestamp the refreshed review-request summary.
     pub(super) clock: Arc<dyn Clock>,
-    /// Latest auto-commit message used to update linked PR/MR metadata.
-    pub(super) commit_message: String,
+    /// Known auto-commit message, or `None` to resolve it after the push.
+    pub(super) commit_message: Option<String>,
     /// Forge boundary used to refresh linked PR/MR metadata after a push.
     pub(super) review_request_client: Arc<dyn forge::ReviewRequestClient>,
 }
@@ -195,11 +199,38 @@ async fn sync_linked_review_request_metadata_after_push(
     input: &PublishedBranchAutoPushInput,
     metadata_sync_input: &ReviewRequestMetadataSyncInput,
 ) {
-    let Some(update_input) = review_request_update_input(&metadata_sync_input.commit_message)
-    else {
-        return;
+    let linked_review_request = match load_open_review_request(input).await {
+        Ok(Some(linked_review_request)) => linked_review_request,
+        Ok(None) => return,
+        Err(error) => {
+            append_review_request_sync_warning(input, error).await;
+
+            return;
+        }
     };
-    let Some(linked_review_request) = load_open_review_request(input).await else {
+    let commit_message = match metadata_sync_input.commit_message.as_deref() {
+        Some(commit_message) => commit_message.to_string(),
+        None => match input
+            .git_client
+            .head_commit_message(input.folder.clone())
+            .await
+        {
+            Ok(Some(commit_message)) => commit_message,
+            Ok(None) => return,
+            Err(error) => {
+                append_review_request_sync_warning(
+                    input,
+                    SessionError::Workflow(format!(
+                        "Failed to resolve the session commit message: {error}"
+                    )),
+                )
+                .await;
+
+                return;
+            }
+        },
+    };
+    let Some(update_input) = review_request_update_input(&commit_message) else {
         return;
     };
 
@@ -227,26 +258,19 @@ fn review_request_update_input(commit_message: &str) -> Option<forge::UpdateRevi
 }
 
 /// Loads the linked review request when it is still open.
-async fn load_open_review_request(input: &PublishedBranchAutoPushInput) -> Option<ReviewRequest> {
-    let review_request = match input
+async fn load_open_review_request(
+    input: &PublishedBranchAutoPushInput,
+) -> Result<Option<ReviewRequest>, SessionError> {
+    let review_request = input
         .db
         .reviews()
         .load_session_review_request(&input.session_id)
         .await
-    {
-        Ok(Some(row)) => review_request_from_row(row),
-        Ok(None) => None,
-        Err(error) => {
-            warn_review_request_metadata_sync(
-                input,
-                &format!("failed to load linked review request: {error}"),
-            );
+        .map_err(SessionError::from)?
+        .and_then(review_request_from_row);
 
-            None
-        }
-    }?;
-
-    (review_request.summary.state == ReviewRequestState::Open).then_some(review_request)
+    Ok(review_request
+        .filter(|review_request| review_request.summary.state == ReviewRequestState::Open))
 }
 
 /// Converts one persisted review-request row into the domain model used by

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -37,6 +37,7 @@ use crate::infra::process;
 
 const RESTART_FAILURE_REASON: &str = "Interrupted by app restart";
 const CANCEL_BEFORE_EXECUTION_REASON: &str = "Session canceled before execution";
+const REBASE_OPERATION_KIND: &str = "rebase";
 
 /// Per-turn data captured at enqueue time that travels alongside the channel
 /// turn but is consumed only after turn completion.
@@ -95,7 +96,7 @@ impl SessionCommand {
     /// Returns the operation kind persisted in the operations table.
     fn kind(&self) -> &'static str {
         match self {
-            Self::Rebase { .. } => "rebase",
+            Self::Rebase { .. } => REBASE_OPERATION_KIND,
             Self::Run {
                 request_kind: AgentRequestKind::SessionStart,
                 ..
@@ -116,9 +117,21 @@ impl SessionCommand {
     }
 }
 
+/// Returns whether the session has a queued or running rebase operation.
+pub(super) fn has_unfinished_rebase_operation(
+    operations: &[SessionOperationRow],
+    session_id: &str,
+) -> bool {
+    operations.iter().any(|operation| {
+        operation.session_id == session_id && operation.kind == REBASE_OPERATION_KIND
+    })
+}
+
 /// Shared state threaded through all worker turn executions.
 pub(super) struct SessionWorkerContext {
     pub(super) app_event_tx: mpsc::UnboundedSender<AppEvent>,
+    /// Serializes post-turn publish ownership with queued branch operations.
+    pub(super) branch_operation_lock: Arc<tokio::sync::Mutex<()>>,
     /// Per-turn cancellation token shared with the UI through
     /// [`SessionHandles`]. The worker swaps in a fresh token at the start
     /// of each turn; the UI calls `cancel()` on the current token to
@@ -464,6 +477,7 @@ impl ExistingSessionRebaseAssistClient for SessionWorkerRebaseAssistClient {
 
 /// Runtime snapshot required to create or reuse one session worker.
 pub(super) struct SessionWorkerRuntime {
+    branch_operation_lock: Arc<tokio::sync::Mutex<()>>,
     cancel_token: Arc<Mutex<CancellationToken>>,
     child_pid: Arc<Mutex<Option<u32>>>,
     folder: PathBuf,
@@ -554,7 +568,7 @@ impl SessionWorkerService {
     ) {
         let mut rebase_session_ids = unfinished_operations
             .iter()
-            .filter(|operation| operation.kind == "rebase")
+            .filter(|operation| operation.kind == REBASE_OPERATION_KIND)
             .map(|operation| operation.session_id.as_str())
             .collect::<Vec<_>>();
         rebase_session_ids.sort_unstable();
@@ -643,6 +657,7 @@ impl SessionWorkerService {
 
         let context = SessionWorkerContext {
             app_event_tx: services.event_sender(),
+            branch_operation_lock: Arc::clone(&runtime.branch_operation_lock),
             cancel_token: Arc::clone(&runtime.cancel_token),
             channel,
             child_pid: Arc::clone(&runtime.child_pid),
@@ -876,6 +891,7 @@ impl SessionWorkerService {
             app_event_tx: context.app_event_tx.clone(),
             assist_mode: RebaseAssistMode::ExistingSession(assist_client),
             base_branch,
+            branch_operation_lock: Arc::clone(&context.branch_operation_lock),
             child_pid: Arc::clone(&context.child_pid),
             clock: Arc::clone(&context.clock),
             db: context.db.clone(),
@@ -883,6 +899,7 @@ impl SessionWorkerService {
             fs_client: Arc::clone(&context.fs_client),
             git_client: Arc::clone(&context.git_client),
             id: context.session_id.clone(),
+            review_request_client: Arc::clone(&context.review_request_client),
             session_agent: context.session_agent,
             session_update_versions: context.session_update_versions.clone(),
             status: Arc::clone(&context.status),
@@ -1008,6 +1025,7 @@ impl SessionManager {
         let (session, handles) = self.session_and_handles_or_err(session_id)?;
 
         Ok(SessionWorkerRuntime {
+            branch_operation_lock: Arc::clone(&handles.branch_operation_lock),
             cancel_token: Arc::clone(&handles.cancel_token),
             child_pid: Arc::clone(&handles.child_pid),
             folder: session.folder.clone(),
@@ -1451,6 +1469,7 @@ mod tests {
         let transcript = empty_transcript();
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::clone(&cancel_token),
             channel: Arc::new(mock_channel),
             child_pid: Arc::new(Mutex::new(None)),
@@ -1576,6 +1595,7 @@ mod tests {
 
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(stale_token)),
             channel: Arc::new(mock_channel),
             child_pid: Arc::new(Mutex::new(None)),
@@ -1671,6 +1691,7 @@ mod tests {
         let transcript = empty_transcript();
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(mock_channel),
             child_pid: Arc::new(Mutex::new(None)),
@@ -1769,6 +1790,7 @@ mod tests {
         let transcript = empty_transcript();
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(mock_channel),
             child_pid: Arc::new(Mutex::new(None)),
@@ -1854,6 +1876,7 @@ mod tests {
         let transcript = empty_transcript();
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(mock_channel),
             child_pid: Arc::new(Mutex::new(None)),
@@ -1929,6 +1952,7 @@ mod tests {
 
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(mock_channel),
             child_pid: Arc::new(Mutex::new(None)),
@@ -2003,6 +2027,7 @@ mod tests {
 
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(mock_channel),
             child_pid: Arc::new(Mutex::new(None)),
@@ -2074,6 +2099,7 @@ mod tests {
 
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(MockAgentChannel::new()),
             child_pid: Arc::new(Mutex::new(Some(child_pid))),
@@ -2118,6 +2144,7 @@ mod tests {
         // Arrange
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(MockAgentChannel::new()),
             child_pid: Arc::new(Mutex::new(None)),
@@ -2253,6 +2280,7 @@ mod tests {
             AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini3FlashPreview);
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(MockAgentChannel::new()),
             child_pid: Arc::new(Mutex::new(None)),
@@ -2337,6 +2365,7 @@ mod tests {
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
         let context = SessionWorkerContext {
             app_event_tx,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(MockAgentChannel::new()),
             child_pid: Arc::new(Mutex::new(None)),
@@ -2418,6 +2447,7 @@ mod tests {
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
         let context = SessionWorkerContext {
             app_event_tx,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(MockAgentChannel::new()),
             child_pid: Arc::new(Mutex::new(None)),
@@ -2750,6 +2780,7 @@ mod tests {
             .returning(|_, _| Box::pin(async { Ok("origin/wt/session-id".to_string()) }));
         let context = SessionWorkerContext {
             app_event_tx,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(MockAgentChannel::new()),
             child_pid: Arc::new(Mutex::new(None)),
@@ -2853,6 +2884,7 @@ mod tests {
             .never();
         let context = SessionWorkerContext {
             app_event_tx,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(MockAgentChannel::new()),
             child_pid: Arc::new(Mutex::new(None)),
@@ -2911,6 +2943,100 @@ mod tests {
     }
 
     #[tokio::test]
+    /// Verifies completed turns leave auto-push idle while queued sync will
+    /// publish the branch after rebasing.
+    async fn test_apply_turn_result_skips_background_push_while_sync_is_queued() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let db = AppRepositories::in_memory().await;
+        let project_id = db
+            .projects()
+            .upsert_project("/tmp/project", Some("main".to_string()))
+            .await
+            .expect("failed to upsert project");
+        db.sessions()
+            .insert_session(
+                "sess1",
+                "gemini-3-flash-preview",
+                "main",
+                "InProgress",
+                project_id,
+            )
+            .await
+            .expect("failed to insert session");
+        db.operations()
+            .insert_session_operation("queued-sync", "sess1", "rebase")
+            .await
+            .expect("failed to insert queued sync operation");
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let session_agent =
+            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini3FlashPreview);
+        let mut mock_git_client = MockGitClient::new();
+        mock_git_client
+            .expect_is_worktree_clean()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(true) }));
+        mock_git_client
+            .expect_push_current_branch_to_remote_branch()
+            .never();
+        let context = SessionWorkerContext {
+            app_event_tx,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
+            cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
+            channel: Arc::new(MockAgentChannel::new()),
+            child_pid: Arc::new(Mutex::new(None)),
+            clock: Arc::new(crate::infra::clock::RealClock),
+            db,
+            folder: base_dir.path().join("sess1"),
+            fs_client: Arc::new(fs::MockFsClient::new()),
+            git_client: Arc::new(mock_git_client),
+            transcript: empty_transcript(),
+            queued_messages: Arc::new(Mutex::new(VecDeque::new())),
+            review_request_client: Arc::new(forge::MockReviewRequestClient::new()),
+            session_update_versions: Arc::default(),
+            session_id: "sess1".into(),
+            session_agent: AgentSelection::new(
+                crate::domain::agent::AgentKind::Antigravity,
+                AgentModel::Gemini3FlashPreview,
+            ),
+            status: Arc::new(Mutex::new(Status::InProgress)),
+        };
+        let turn_result = Ok(TurnResult {
+            assistant_message: AgentResponse {
+                answer: "Implemented the change.".to_string(),
+                questions: Vec::new(),
+                summary: None,
+            },
+            context_reset: false,
+            input_tokens: 0,
+            output_tokens: 0,
+            provider_conversation_id: None,
+        });
+
+        // Act
+        let turn_metadata = TurnMetadata {
+            published_upstream_ref: Some("origin/wt/session-id".to_string()),
+            session_agent,
+        };
+        let status = apply_worker_turn_result(&context, turn_metadata, turn_result)
+            .await
+            .expect("turn result should succeed");
+        let mut emitted_sync_event = false;
+        while let Ok(event) = app_event_rx.try_recv() {
+            if matches!(event, AppEvent::PublishedBranchSyncUpdated { .. }) {
+                emitted_sync_event = true;
+            }
+        }
+
+        // Assert
+        assert_eq!(status, Status::Review);
+        assert!(
+            !emitted_sync_event,
+            "queued sync should suppress post-turn auto-push events"
+        );
+    }
+
+    #[tokio::test]
     /// Verifies failed background auto-push attempts append a visible error
     /// and keep the session marked as failed for the latest sync attempt.
     async fn test_apply_turn_result_reports_background_push_failures() {
@@ -2957,6 +3083,7 @@ mod tests {
         let transcript = empty_transcript();
         let context = SessionWorkerContext {
             app_event_tx,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(MockAgentChannel::new()),
             child_pid: Arc::new(Mutex::new(None)),
@@ -3050,6 +3177,7 @@ mod tests {
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
         let context = SessionWorkerContext {
             app_event_tx,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(MockAgentChannel::new()),
             child_pid: Arc::new(Mutex::new(None)),
@@ -3154,6 +3282,7 @@ mod tests {
         )));
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(MockAgentChannel::new()),
             child_pid: Arc::new(Mutex::new(None)),
@@ -3236,6 +3365,7 @@ mod tests {
             .returning(|_| Box::pin(async { Ok(true) }));
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(MockAgentChannel::new()),
             child_pid: Arc::new(Mutex::new(None)),
@@ -3481,6 +3611,7 @@ mod tests {
         let status = Arc::new(Mutex::new(Status::Rebasing));
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(mock_existing_session_rebase_channel(
                 expected_main_checkout_root,
@@ -3707,6 +3838,7 @@ mod tests {
 
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(mock_channel),
             child_pid: Arc::new(Mutex::new(None)),
@@ -3779,6 +3911,7 @@ mod tests {
 
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(mock_channel),
             child_pid: Arc::new(Mutex::new(None)),
@@ -3865,6 +3998,7 @@ mod tests {
 
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(mock_channel),
             child_pid: Arc::new(Mutex::new(None)),
@@ -3958,6 +4092,7 @@ mod tests {
         let queue_handle = Arc::new(Mutex::new(queued_messages));
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(channel),
             child_pid: Arc::new(Mutex::new(None)),
@@ -3987,6 +4122,7 @@ mod tests {
     async fn queue_helper_context(queue: Arc<Mutex<VecDeque<TurnPrompt>>>) -> SessionWorkerContext {
         SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             channel: Arc::new(MockAgentChannel::new()),
             child_pid: Arc::new(Mutex::new(None)),

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -10,6 +10,7 @@ pub use ag_agent::SessionStats;
 use serde::de::{self, Deserializer};
 use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex as AsyncMutex;
 use tokio_util::sync::CancellationToken;
 
 use super::agent::{AgentSelection, ReasoningLevel};
@@ -942,6 +943,11 @@ fn find_session<'a>(sessions: &'a [Session], session_id: &str) -> Option<&'a Ses
 
 /// Shared runtime handles for one active session worker.
 pub struct SessionHandles {
+    /// Serializes branch-publish ownership with queued branch operations.
+    ///
+    /// The guard is held across async persistence and push work, so this is
+    /// intentionally an async mutex rather than [`std::sync::Mutex`].
+    pub branch_operation_lock: Arc<AsyncMutex<()>>,
     /// Per-turn cancellation token shared between the UI and the worker.
     ///
     /// The worker swaps in a fresh [`CancellationToken`] at the start of
@@ -967,6 +973,7 @@ impl SessionHandles {
     /// Creates handles initialized with the given status.
     pub fn new(status: Status) -> Self {
         Self {
+            branch_operation_lock: Arc::new(AsyncMutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             child_pid: Arc::new(Mutex::new(None)),
             queued_messages: Arc::new(Mutex::new(VecDeque::new())),
@@ -978,6 +985,7 @@ impl SessionHandles {
     /// Creates handles initialized with a typed transcript snapshot.
     pub fn new_with_transcript(status: Status, transcript: SessionTranscript) -> Self {
         Self {
+            branch_operation_lock: Arc::new(AsyncMutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             child_pid: Arc::new(Mutex::new(None)),
             queued_messages: Arc::new(Mutex::new(VecDeque::new())),

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -161,10 +161,15 @@ render twice per frame.
    turn creates it, later turns regenerate the message from the cumulative diff with the
    project's `Default Fast Model` and amend `HEAD`; an empty amend drops the reverted
    commit. The session title is synced from the commit text.
-1. If the session already tracks a published upstream branch and no chat messages are
-   queued, a detached auto-push updates the remote branch and refreshes linked
-   review-request metadata when the commit message changed, then appends the push result
-   as a durable transcript notice.
+1. If the session already tracks a published upstream branch and no chat message or sync
+   operation is queued, a per-session branch-operation guard transfers to the detached
+   auto-push until it finishes. Every sync request holds the same guard through status
+   transition and operation persistence, so its rebase is observed before publish starts
+   or waits until the active publish completes. Post-rebase auto-push transfers the
+   guard again, preventing a subsequent sync from starting until that publish finishes.
+   After a successful push, linked review-request and commit metadata are resolved and
+   refreshed; lookup failures append the existing warning notice instead of being
+   discarded. The push result is appended as a durable transcript notice.
 1. Completed stacked-parent turns fan out `SessionCommand::Rebase` to review-ready
    materialized children so child branches replay onto the latest parent branch.
 1. The session size is refreshed and the final status becomes `Review` or `Question`

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -167,7 +167,9 @@ Pressing `r` during a running turn queues session sync on the same session worke
 session stays **InProgress** while the active turn runs, then moves to **Rebasing** when
 the queued sync command starts. Agentty shows a `[Sync]` notice in the session output
 while the rebase is queued, and repeated `r` presses keep the single queued rebase
-instead of adding duplicates.
+instead of adding duplicates. Session sync reserves branch-publish ownership before it
+queues or starts, and retains that ownership through its post-rebase push. A completed
+turn or subsequent sync therefore cannot start a competing published-branch auto-push.
 
 ### Focused Review
 
@@ -295,9 +297,10 @@ publish popup for the linked forge review request:
 - When no review request is linked yet, only an open request for the same branch is
   reused; merged or closed requests are left alone.
 - After the first publish, later completed turns push the same remote branch
-  automatically in the background and update the review request title and description
-  from the latest session commit message when they differ. Failed background pushes keep
-  the manual `p` flow available for retry.
+  automatically in the background when no chat message or sync is already queued, and
+  update the review request title and description from the latest session commit message
+  when they differ. Failed background pushes keep the manual `p` flow available for
+  retry.
 
 <a id="usage-review-request-prerequisites"></a> Publishing needs regular Git
 authentication (credential helper or PAT for HTTPS remotes, SSH key for SSH remotes)


### PR DESCRIPTION
- A per-session branch-operation lock serializes queued rebases, post-turn pushes, and post-rebase publishes, rechecking persisted operations after lock acquisition.
- Post-push review-request metadata refresh resolves the latest session commit message when needed.
- Failed operation-state, commit-message, or review-request metadata lookups preserve visible warnings.
- Runtime-flow and workflow docs describe ownership, and regression tests cover coordination, metadata refresh, and failed lookups.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)