### PR TITLE
Hide empty session groups

### DIFF
--- a/crates/agentty/src/domain/session_order.rs
+++ b/crates/agentty/src/domain/session_order.rs
@@ -28,8 +28,6 @@ pub enum SessionTreePosition {
 pub enum GroupedSessionRow<'a> {
     /// Non-selectable row that labels the following group.
     GroupLabel(SessionGroup),
-    /// Non-selectable placeholder shown when a group has no sessions.
-    EmptyGroupPlaceholder,
     /// Selectable session row in raw-session-index terms.
     Session {
         /// Raw index into the ungrouped session snapshot.
@@ -103,15 +101,15 @@ pub fn selectable_session_indexes(sessions: &[Session]) -> Vec<usize> {
         .into_iter()
         .filter_map(|row| match row {
             GroupedSessionRow::Session { index, .. } => Some(index),
-            GroupedSessionRow::GroupLabel(_) | GroupedSessionRow::EmptyGroupPlaceholder => None,
+            GroupedSessionRow::GroupLabel(_) => None,
         })
         .collect()
 }
 
-/// Returns grouped display rows with merge queue, active, then archive
-/// sessions.
+/// Returns populated grouped display rows with merge queue, active, then
+/// archive sessions.
 pub fn grouped_session_rows(sessions: &[Session]) -> Vec<GroupedSessionRow<'_>> {
-    let mut rows = Vec::with_capacity(sessions.len() + 6);
+    let mut rows = Vec::with_capacity(sessions.len() + 3);
     let stacked_children = stacked_child_index(sessions);
     append_group_rows(
         &mut rows,
@@ -149,19 +147,22 @@ fn stacked_child_index(sessions: &[Session]) -> StackedChildIndex<'_> {
     children_by_parent
 }
 
-/// Adds one group label row and either its sessions or an empty placeholder.
+/// Adds one populated group and its sessions.
 fn append_group_rows<'a>(
     rows: &mut Vec<GroupedSessionRow<'a>>,
     sessions: &'a [Session],
     stacked_children: &StackedChildIndex<'a>,
     group: SessionGroup,
 ) {
-    rows.push(GroupedSessionRow::GroupLabel(group));
-
     let mut group_has_sessions = false;
     for (index, session) in sessions_for_group(sessions, group) {
         if has_loaded_parent_session_in_group(sessions, session, group) {
             continue;
+        }
+
+        if !group_has_sessions {
+            rows.push(GroupedSessionRow::GroupLabel(group));
+            group_has_sessions = true;
         }
 
         rows.push(GroupedSessionRow::Session {
@@ -170,11 +171,6 @@ fn append_group_rows<'a>(
             tree_position: SessionTreePosition::Root,
         });
         append_stacked_child_rows(rows, stacked_children, session.id.as_str(), group);
-        group_has_sessions = true;
-    }
-
-    if !group_has_sessions {
-        rows.push(GroupedSessionRow::EmptyGroupPlaceholder);
     }
 }
 
@@ -419,7 +415,6 @@ mod tests {
             .into_iter()
             .map(|row| match row {
                 GroupedSessionRow::GroupLabel(group) => format!("{group:?}"),
-                GroupedSessionRow::EmptyGroupPlaceholder => "empty".to_string(),
                 GroupedSessionRow::Session { session, .. } => session.id.to_string(),
             })
             .collect::<Vec<_>>();
@@ -442,7 +437,7 @@ mod tests {
     }
 
     #[test]
-    fn test_grouped_session_rows_includes_placeholder_for_groups_without_sessions() {
+    fn test_grouped_session_rows_omits_groups_without_sessions() {
         // Arrange
         let sessions = vec![
             crate::test_support::titled_session_fixture("active-1", Status::Review),
@@ -454,7 +449,6 @@ mod tests {
             .into_iter()
             .map(|row| match row {
                 GroupedSessionRow::GroupLabel(group) => format!("{group:?}"),
-                GroupedSessionRow::EmptyGroupPlaceholder => "empty".to_string(),
                 GroupedSessionRow::Session { session, .. } => session.id.to_string(),
             })
             .collect::<Vec<_>>();
@@ -463,15 +457,23 @@ mod tests {
         assert_eq!(
             labels_and_ids,
             vec![
-                "MergeQueue".to_string(),
-                "empty".to_string(),
                 "Active".to_string(),
                 "active-1".to_string(),
                 "active-2".to_string(),
-                "Archive".to_string(),
-                "empty".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn test_grouped_session_rows_returns_no_rows_without_sessions() {
+        // Arrange
+        let sessions = Vec::new();
+
+        // Act
+        let rows = grouped_session_rows(&sessions);
+
+        // Assert
+        assert!(rows.is_empty());
     }
 
     #[test]
@@ -498,7 +500,7 @@ mod tests {
                     tree_position,
                     ..
                 } => Some((session.id.to_string(), tree_position)),
-                GroupedSessionRow::GroupLabel(_) | GroupedSessionRow::EmptyGroupPlaceholder => None,
+                GroupedSessionRow::GroupLabel(_) => None,
             })
             .collect::<Vec<_>>();
 
@@ -536,7 +538,6 @@ mod tests {
             .into_iter()
             .map(|row| match row {
                 GroupedSessionRow::GroupLabel(group) => format!("{group:?}"),
-                GroupedSessionRow::EmptyGroupPlaceholder => "empty".to_string(),
                 GroupedSessionRow::Session {
                     session,
                     tree_position,
@@ -549,8 +550,6 @@ mod tests {
         assert_eq!(
             labels_positions_and_ids,
             vec![
-                "MergeQueue".to_string(),
-                "empty".to_string(),
                 "Active".to_string(),
                 "parent-1:Root".to_string(),
                 "Archive".to_string(),
@@ -576,7 +575,6 @@ mod tests {
             .into_iter()
             .map(|row| match row {
                 GroupedSessionRow::GroupLabel(group) => format!("{group:?}"),
-                GroupedSessionRow::EmptyGroupPlaceholder => "empty".to_string(),
                 GroupedSessionRow::Session {
                     session,
                     tree_position,
@@ -589,10 +587,6 @@ mod tests {
         assert_eq!(
             labels_positions_and_ids,
             vec![
-                "MergeQueue".to_string(),
-                "empty".to_string(),
-                "Active".to_string(),
-                "empty".to_string(),
                 "Archive".to_string(),
                 "parent-1:Root".to_string(),
                 "child-1:Child { is_last: true }".to_string(),

--- a/crates/agentty/src/ui/page/session_list.rs
+++ b/crates/agentty/src/ui/page/session_list.rs
@@ -16,8 +16,8 @@ use crate::ui::{Page, layout, markdown, style};
 const ROW_HIGHLIGHT_SYMBOL: &str = "";
 /// Horizontal spacing between table columns in the session list.
 const TABLE_COLUMN_SPACING: u16 = 2;
-/// Placeholder text rendered under group headers with no sessions.
-const GROUP_EMPTY_PLACEHOLDER: &str = "No sessions...";
+/// Guidance rendered when the project has no sessions.
+const EMPTY_SESSIONS_HINT: &str = "No sessions. Press 'a' to start one.";
 /// Tree branch prefix for child rows that have siblings after them.
 const TREE_BRANCH_MIDDLE: &str = "├ ";
 /// Tree branch prefix for the final child row in a stack.
@@ -86,14 +86,17 @@ impl Page for SessionListPage<'_> {
         let table_rows = session_order::grouped_session_rows(self.sessions);
         let selected_session_id = selected_session_id(self.sessions, self.table_state.selected());
         let selected_row = selected_render_row(&table_rows, selected_session_id);
-        let rows = table_rows.iter().map(|table_row| {
-            render_table_row(
-                table_row,
-                title_column_width,
-                self.default_reasoning_level,
-                self.wall_clock_unix_seconds,
-            )
-        });
+        let rows = table_rows
+            .iter()
+            .map(|table_row| {
+                render_table_row(
+                    table_row,
+                    title_column_width,
+                    self.default_reasoning_level,
+                    self.wall_clock_unix_seconds,
+                )
+            })
+            .chain(table_rows.is_empty().then(render_empty_sessions_hint_row));
         let table = Table::new(rows, column_constraints)
             .column_spacing(TABLE_COLUMN_SPACING)
             .header(header)
@@ -130,9 +133,9 @@ fn session_list_help_line(selected_session: Option<&Session>) -> Line<'static> {
 /// Prepares list table state for grouped row rendering.
 ///
 /// The app stores selection as an index in the raw session slice, while the
-/// table is rendered with extra group label and placeholder rows. Resetting
-/// the offset before selecting a grouped row avoids stale deep offsets hiding
-/// top group sections after scrolling back up.
+/// table is rendered with extra group label rows. Resetting the offset before
+/// selecting a grouped row avoids stale deep offsets hiding top group sections
+/// after scrolling back up.
 fn prepare_grouped_table_state(table_state: &mut TableState, selected_row: Option<usize>) {
     *table_state.offset_mut() = 0;
     table_state.select(selected_row);
@@ -176,7 +179,7 @@ fn selected_render_row(
     let selected_session_id = selected_session_id?;
 
     rows.iter().position(|row| match row {
-        GroupedSessionRow::GroupLabel(_) | GroupedSessionRow::EmptyGroupPlaceholder => false,
+        GroupedSessionRow::GroupLabel(_) => false,
         GroupedSessionRow::Session { session, .. } => session.id == selected_session_id,
     })
 }
@@ -190,7 +193,6 @@ fn render_table_row(
 ) -> Row<'static> {
     match row {
         GroupedSessionRow::GroupLabel(group) => render_group_label_row(*group),
-        GroupedSessionRow::EmptyGroupPlaceholder => render_empty_group_placeholder_row(),
         GroupedSessionRow::Session {
             session,
             tree_position,
@@ -217,11 +219,10 @@ fn render_group_label_row(group: SessionGroup) -> Row<'static> {
     Row::new(cells).height(1)
 }
 
-/// Renders a non-selectable placeholder row for empty groups.
-fn render_empty_group_placeholder_row() -> Row<'static> {
+/// Renders guidance when no grouped sessions exist.
+fn render_empty_sessions_hint_row() -> Row<'static> {
     let cells = vec![
-        Cell::from(GROUP_EMPTY_PLACEHOLDER)
-            .style(Style::default().fg(style::palette::text_subtle())),
+        Cell::from(EMPTY_SESSIONS_HINT).style(Style::default().fg(style::palette::text_subtle())),
         Cell::from(""),
         Cell::from(""),
         Cell::from(""),
@@ -593,6 +594,30 @@ mod tests {
         // Assert
         let border_cell_count = foreground_symbol_cell_count(terminal.backend().buffer(), "┌");
         assert_eq!(border_cell_count, 1);
+    }
+
+    #[test]
+    fn test_render_empty_session_list_shows_creation_hint_without_group_labels() {
+        // Arrange
+        let backend = ratatui::backend::TestBackend::new(100, 12);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+        let mut table_state = TableState::default();
+        let sessions = Vec::new();
+
+        // Act
+        terminal
+            .draw(|frame| {
+                SessionListPage::new(&sessions, &mut table_state, ReasoningLevel::default(), 0)
+                    .render(frame, frame.area());
+            })
+            .expect("failed to draw");
+
+        // Assert
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(text.contains(EMPTY_SESSIONS_HINT));
+        assert!(!text.contains("Merge queue"));
+        assert!(!text.contains("Active sessions"));
+        assert!(!text.contains("Archive"));
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -959,19 +959,18 @@ fn seed_active_loader_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error
     Ok(())
 }
 
-/// Verify that the Sessions tab shows an empty-state message when no
-/// sessions exist.
+/// Verify that the Sessions tab hides empty groups and guides session creation.
 ///
-/// Starts agentty in a fresh temp directory (no database, no sessions),
-/// switches to the Sessions tab, and asserts that the placeholder text
-/// is visible.
+/// Starts Agentty with no sessions, then creates an active session and verifies
+/// that only the populated group is visible.
 #[test]
 fn session_list_empty_state() -> E2eResult {
     // Arrange, Act, Assert
     FeatureTest::new("session_empty")
+        .with_git()
         .zola(
             "Empty session state",
-            "A clean slate when no sessions exist yet.",
+            "See how Agentty guides session creation and hides empty groups.",
             40,
         )
         .run(
@@ -982,10 +981,29 @@ fn session_list_empty_state() -> E2eResult {
                     .compose(&common::switch_to_tab("Sessions"))
                     .viewing_pause_ms(2000)
                     .capture_labeled("sessions_tab", "Sessions tab with no sessions")
+                    .compose(&common::create_session_with_prompt_and_return_to_list(
+                        "Keep only populated groups",
+                    ))
+                    .viewing_pause_ms(2000)
+                    .capture_labeled("active_group", "Only the populated group is visible")
             },
-            |frame, _report| {
+            |frame, report| {
+                let empty_frame = common::frame_from_capture(&report.captures[0]);
+                let empty_full = Region::full(empty_frame.cols(), empty_frame.rows());
+                assertion::assert_text_in_region(
+                    &empty_frame,
+                    "No sessions. Press 'a' to start one.",
+                    &empty_full,
+                );
+                assertion::assert_not_visible(&empty_frame, "Merge queue");
+                assertion::assert_not_visible(&empty_frame, "Active sessions");
+                assertion::assert_not_visible(&empty_frame, "Archive");
+
                 let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(frame, "No sessions", &full);
+                assertion::assert_text_in_region(frame, "Active sessions", &full);
+                assertion::assert_not_visible(frame, "Merge queue");
+                assertion::assert_not_visible(frame, "Archive");
+                assertion::assert_not_visible(frame, "No sessions");
             },
         )?;
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -22,7 +22,9 @@ tabs, all accessible with `Tab`:
   versions are listed here too.
 - **Sessions**: List, create, and manage agent sessions for the active project. Rows
   show a size marker prefix (for example `[XL]`), the current `agent/model` with its
-  reasoning level, and a live active-work `Timer` column.
+  reasoning level, and a live active-work `Timer` column. The list shows only populated
+  merge queue, active, and archive groups. When there are no sessions, it prompts you to
+  press `a` to start one.
 - **Inbox**: Read-only list of open GitHub pull requests or GitLab merge requests that
   request your review in the active project, including drafts. Press `s` to refresh and
   `Enter` to open a read-only detail page with the description and comment threads.

--- a/docs/site/content/features/session_empty.md
+++ b/docs/site/content/features/session_empty.md
@@ -1,6 +1,6 @@
 +++
 title = "Empty session state"
-description = "A clean slate when no sessions exist yet."
+description = "See how Agentty guides session creation and hides empty groups."
 weight = 40
 [extra]
 gif = "session_empty.gif"


### PR DESCRIPTION
- Remove placeholder rows from grouped session ordering.
- Show a creation hint only when no sessions exist.
- Cover populated-group rendering in unit and E2E tests and document the behavior.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)