### PR TITLE
Persist reasoning levels per session

### DIFF
--- a/crates/agentty/migrations/058_backfill_session_reasoning_level.sql
+++ b/crates/agentty/migrations/058_backfill_session_reasoning_level.sql
@@ -1,0 +1,12 @@
+UPDATE session
+SET reasoning_level = COALESCE(
+    (
+        SELECT project_setting.value
+        FROM project_setting
+        WHERE project_setting.project_id = session.project_id
+          AND project_setting.name = 'ReasoningLevel'
+          AND project_setting.value IN ('low', 'medium', 'high', 'xhigh', 'max')
+    ),
+    'high'
+)
+WHERE reasoning_level IS NULL;

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -74,9 +74,9 @@ pub(crate) enum AppEvent {
         session_id: SessionId,
         session_agent: crate::domain::agent::AgentSelection,
     },
-    /// Indicates a session reasoning override selection has been persisted.
+    /// Indicates a session reasoning-level selection has been persisted.
     SessionReasoningLevelUpdated {
-        reasoning_level_override: Option<crate::domain::agent::ReasoningLevel>,
+        reasoning_level: crate::domain::agent::ReasoningLevel,
         session_id: SessionId,
     },
     /// Requests a DB-backed session list refresh.
@@ -215,7 +215,7 @@ pub(super) struct AppEventBatch {
     pub(super) session_update_versions: HashMap<SessionId, u64>,
     pub(super) session_model_updates: HashMap<SessionId, crate::domain::agent::AgentSelection>,
     pub(super) session_reasoning_level_updates:
-        HashMap<SessionId, Option<crate::domain::agent::ReasoningLevel>>,
+        HashMap<SessionId, crate::domain::agent::ReasoningLevel>,
     pub(super) session_progress_updates: HashMap<SessionId, Option<String>>,
     pub(super) session_size_updates: HashMap<SessionId, (u64, u64, SessionSize)>,
     pub(super) stacked_parent_merge_child_rebases: HashSet<SessionId>,
@@ -319,9 +319,9 @@ impl AppEventBatch {
                 session_agent,
             } => self.collect_session_model_updated(session_id, session_agent),
             AppEvent::SessionReasoningLevelUpdated {
-                reasoning_level_override,
+                reasoning_level,
                 session_id,
-            } => self.collect_session_reasoning_level_updated(session_id, reasoning_level_override),
+            } => self.collect_session_reasoning_level_updated(session_id, reasoning_level),
             AppEvent::RefreshSessions => self.collect_refresh_sessions(),
             AppEvent::RefreshProjects => self.collect_refresh_projects(),
             AppEvent::RefreshGitStatus => self.collect_refresh_git_status(),
@@ -478,10 +478,10 @@ impl AppEventBatch {
     fn collect_session_reasoning_level_updated(
         &mut self,
         session_id: SessionId,
-        reasoning_level_override: Option<crate::domain::agent::ReasoningLevel>,
+        reasoning_level: crate::domain::agent::ReasoningLevel,
     ) {
         self.session_reasoning_level_updates
-            .insert(session_id, reasoning_level_override);
+            .insert(session_id, reasoning_level);
     }
 
     /// Stores a workflow notice update and marks its session as touched.
@@ -1396,11 +1396,11 @@ impl App {
                 .apply_session_model_updated(&session_id, session_agent);
         }
 
-        for (session_id, reasoning_level_override) in
+        for (session_id, reasoning_level) in
             std::mem::take(&mut event_batch.session_reasoning_level_updates)
         {
             self.sessions
-                .apply_session_reasoning_level_updated(&session_id, reasoning_level_override);
+                .apply_session_reasoning_level_updated(&session_id, reasoning_level);
         }
 
         for (session_id, (added_lines, deleted_lines, session_size)) in

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -988,17 +988,17 @@ impl App {
         Ok(())
     }
 
-    /// Persists and applies a reasoning override for a session.
+    /// Persists and applies a reasoning level for a session.
     ///
     /// # Errors
     /// Returns an error if persistence fails.
     pub async fn set_session_reasoning_level(
         &mut self,
         session_id: &str,
-        reasoning_level_override: Option<ReasoningLevel>,
+        reasoning_level: ReasoningLevel,
     ) -> Result<(), AppError> {
         self.sessions
-            .set_session_reasoning_level(&self.services, session_id, reasoning_level_override)
+            .set_session_reasoning_level(&self.services, session_id, reasoning_level)
             .await?;
         self.process_pending_app_events().await;
 

--- a/crates/agentty/src/app/prompt_intent.rs
+++ b/crates/agentty/src/app/prompt_intent.rs
@@ -143,7 +143,7 @@ impl App {
                 let selected_reasoning_level = self
                     .session_at(context.session_index)
                     .map_or(self.settings.reasoning_level, |session| {
-                        session.effective_reasoning_level(self.settings.reasoning_level)
+                        session.effective_reasoning_level()
                     });
                 let selected_index = ReasoningLevel::ALL
                     .iter()
@@ -405,7 +405,7 @@ impl App {
         }
     }
 
-    /// Persists one slash-selected reasoning override and logs any failure
+    /// Persists one slash-selected reasoning level and logs any failure
     /// with session context.
     async fn update_prompt_session_reasoning_level(
         &mut self,
@@ -413,7 +413,7 @@ impl App {
         reasoning_level: ReasoningLevel,
     ) {
         if let Err(error) = self
-            .set_session_reasoning_level(&context.session_id, Some(reasoning_level))
+            .set_session_reasoning_level(&context.session_id, reasoning_level)
             .await
         {
             warn!(

--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -389,12 +389,12 @@ impl SessionManager {
         }
     }
 
-    /// Applies one persisted reasoning override update to the matching
+    /// Applies one persisted reasoning-level update to the matching
     /// in-memory session snapshot.
     pub(crate) fn apply_session_reasoning_level_updated(
         &mut self,
         session_id: &str,
-        reasoning_level_override: Option<ReasoningLevel>,
+        reasoning_level: ReasoningLevel,
     ) {
         if let Some(session) = self
             .state
@@ -402,7 +402,7 @@ impl SessionManager {
             .iter_mut()
             .find(|session| session.id == session_id)
         {
-            session.reasoning_level_override = reasoning_level_override;
+            session.reasoning_level_override = Some(reasoning_level);
         }
     }
 

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -810,11 +810,10 @@ fn test_apply_session_reasoning_level_updated_updates_only_matching_session() {
     let mut session_manager = test_session_manager("session-id", Some(ReasoningLevel::Low));
 
     // Act
-    session_manager
-        .apply_session_reasoning_level_updated("other-session", Some(ReasoningLevel::High));
+    session_manager.apply_session_reasoning_level_updated("other-session", ReasoningLevel::High);
     let reasoning_level_after_non_matching_update =
         session_manager.state.sessions[0].reasoning_level_override;
-    session_manager.apply_session_reasoning_level_updated("session-id", None);
+    session_manager.apply_session_reasoning_level_updated("session-id", ReasoningLevel::Medium);
 
     // Assert
     assert_eq!(
@@ -823,7 +822,7 @@ fn test_apply_session_reasoning_level_updated_updates_only_matching_session() {
     );
     assert_eq!(
         session_manager.state.sessions[0].reasoning_level_override,
-        None
+        Some(ReasoningLevel::Medium)
     );
 }
 
@@ -1383,6 +1382,12 @@ async fn test_create_session() {
     // Arrange
     let dir = tempdir().expect("failed to create temp dir");
     let mut app = new_test_app_with_git(dir.path()).await;
+    app.services
+        .db()
+        .settings()
+        .set_project_reasoning_level(app.projects.active_project_id(), ReasoningLevel::Low)
+        .await
+        .expect("failed to set project reasoning level");
 
     // Act
     let session_id = app
@@ -1433,7 +1438,30 @@ async fn test_create_session() {
     );
     assert!(!db_sessions[0].is_draft);
     assert_eq!(db_sessions[0].status, "Draft");
+    assert_eq!(
+        db_sessions[0].reasoning_level_override.as_deref(),
+        Some(ReasoningLevel::Low.as_str())
+    );
     assert_eq!(activity_timestamps.len(), 1);
+}
+
+#[tokio::test]
+async fn test_create_session_propagates_project_reasoning_read_failure() {
+    // Arrange
+    let dir = tempdir().expect("failed to create temp dir");
+    let (database, pool) = AppRepositories::in_memory_with_pool().await;
+    let mut app = new_test_app_with_git_and_db(dir.path(), database).await;
+    sqlx::query("DROP TABLE project_setting")
+        .execute(&pool)
+        .await
+        .expect("failed to drop project settings table");
+
+    // Act
+    let result = app.create_session().await;
+
+    // Assert
+    assert!(result.is_err());
+    assert!(app.sessions.sessions().is_empty());
 }
 
 #[tokio::test]

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -252,6 +252,11 @@ impl SessionManager {
             .resolve_default_session_agent(services, project_id)
             .await;
         let session_model = session_agent.model();
+        let reasoning_level = services
+            .db()
+            .settings()
+            .load_project_reasoning_level(project_id)
+            .await?;
         self.default_session_model = session_model;
 
         let session_id = Uuid::new_v4().to_string();
@@ -262,38 +267,23 @@ impl SessionManager {
             )));
         }
 
-        let insert_result = if let Some(parent_session_id) = parent_session_id {
-            let session_agent_kind = session_agent.kind().to_string();
-            services
-                .db()
-                .sessions()
-                .insert_stacked_draft_session_with_agent(
-                    &session_id,
-                    db::PersistedSessionAgentModel {
-                        agent: &session_agent_kind,
-                        model: session_model.as_str(),
-                    },
-                    base_branch,
-                    &Status::Draft.to_string(),
-                    parent_session_id,
-                    project_id,
-                )
-                .await
-        } else {
-            let session_agent_kind = session_agent.kind().to_string();
-            services
-                .db()
-                .sessions()
-                .insert_draft_session_with_agent(
-                    &session_id,
-                    &session_agent_kind,
-                    session_model.as_str(),
-                    base_branch,
-                    &Status::Draft.to_string(),
-                    project_id,
-                )
-                .await
-        };
+        let session_agent_kind = session_agent.kind().to_string();
+        let status = Status::Draft.to_string();
+        let insert_result = services
+            .db()
+            .sessions()
+            .insert_session_with_agent(db::PersistedSessionCreation {
+                agent: &session_agent_kind,
+                base_branch,
+                id: &session_id,
+                is_draft: true,
+                model: session_model.as_str(),
+                parent_session_id,
+                project_id,
+                reasoning_level,
+                status: &status,
+            })
+            .await;
 
         insert_result.map_err(|error| {
             SessionError::Workflow(format!("Failed to save session metadata: {error}"))
@@ -438,6 +428,11 @@ impl SessionManager {
             .resolve_default_session_agent(services, projects.active_project_id())
             .await;
         let session_model = session_agent.model();
+        let reasoning_level = services
+            .db()
+            .settings()
+            .load_project_reasoning_level(projects.active_project_id())
+            .await?;
         self.default_session_model = session_model;
 
         let session_id = Uuid::new_v4().to_string();
@@ -470,17 +465,21 @@ impl SessionManager {
         .await?;
 
         let session_agent_kind = session_agent.kind().to_string();
+        let status = Status::Draft.to_string();
         if let Err(error) = services
             .db()
             .sessions()
-            .insert_session_with_agent(
-                &session_id,
-                &session_agent_kind,
-                session_model.as_str(),
+            .insert_session_with_agent(db::PersistedSessionCreation {
+                agent: &session_agent_kind,
                 base_branch,
-                &Status::Draft.to_string(),
-                projects.active_project_id(),
-            )
+                id: &session_id,
+                is_draft: false,
+                model: session_model.as_str(),
+                parent_session_id: None,
+                project_id: projects.active_project_id(),
+                reasoning_level,
+                status: &status,
+            })
             .await
         {
             self.rollback_failed_session_creation(
@@ -1334,10 +1333,7 @@ impl SessionManager {
         Ok(())
     }
 
-    /// Updates and persists the reasoning override for a single session.
-    ///
-    /// Passing `None` clears the override so future turns inherit the active
-    /// project default reasoning level.
+    /// Updates and persists the reasoning level for a single session.
     ///
     /// # Errors
     /// Returns an error if the session is missing or persistence fails.
@@ -1345,22 +1341,18 @@ impl SessionManager {
         &mut self,
         services: &AppServices,
         session_id: &str,
-        reasoning_level_override: Option<ReasoningLevel>,
+        reasoning_level: ReasoningLevel,
     ) -> Result<(), SessionError> {
         self.session_index_or_err(session_id)?;
 
         services
             .db()
             .sessions()
-            .update_session_reasoning_level(
-                session_id,
-                reasoning_level_override
-                    .map(|reasoning_level| reasoning_level.as_str().to_string()),
-            )
+            .update_session_reasoning_level(session_id, reasoning_level)
             .await?;
 
         services.emit_app_event(AppEvent::SessionReasoningLevelUpdated {
-            reasoning_level_override,
+            reasoning_level,
             session_id: SessionId::from(session_id),
         });
 
@@ -3282,9 +3274,9 @@ mod tests {
     }
 
     #[tokio::test]
-    /// Ensures `set_session_reasoning_level()` persists the override and
+    /// Ensures `set_session_reasoning_level()` persists the level and
     /// emits the matching reducer event.
-    async fn test_set_session_reasoning_level_persists_override_and_emits_event() {
+    async fn test_set_session_reasoning_level_persists_level_and_emits_event() {
         // Arrange
         let session = test_session("Prompt", Status::Review, Some("Title"), "");
         let database = database_with_session(&session).await;
@@ -3297,24 +3289,24 @@ mod tests {
 
         // Act
         session_manager
-            .set_session_reasoning_level(&services, "session-id", Some(ReasoningLevel::High))
+            .set_session_reasoning_level(&services, "session-id", ReasoningLevel::High)
             .await
             .expect("reasoning level update should succeed");
         let persisted_reasoning_level = database
             .sessions()
-            .load_session_reasoning_level_override("session-id")
+            .load_session_reasoning_level("session-id")
             .await
-            .expect("reasoning override should load");
+            .expect("reasoning level should load");
         let emitted_event = event_rx
             .try_recv()
             .expect("expected reasoning update event");
 
         // Assert
-        assert_eq!(persisted_reasoning_level, Some(ReasoningLevel::High));
+        assert_eq!(persisted_reasoning_level, ReasoningLevel::High);
         assert_eq!(
             emitted_event,
             AppEvent::SessionReasoningLevelUpdated {
-                reasoning_level_override: Some(ReasoningLevel::High),
+                reasoning_level: ReasoningLevel::High,
                 session_id: "session-id".into(),
             }
         );

--- a/crates/agentty/src/app/session/workflow/turn.rs
+++ b/crates/agentty/src/app/session/workflow/turn.rs
@@ -171,8 +171,7 @@ pub(super) async fn run_channel_turn(
     };
 
     let session_project_id = load_session_project_id(&context.db, &context.session_id).await;
-    let reasoning_level =
-        load_session_reasoning_level(&context.db, &context.session_id, session_project_id).await;
+    let reasoning_level = load_session_reasoning_level(&context.db, &context.session_id).await;
     let provider_conversation_id = context
         .db
         .sessions()
@@ -362,22 +361,9 @@ pub(super) async fn load_session_project_id(db: &AppRepositories, session_id: &s
 pub(super) async fn load_session_reasoning_level(
     db: &AppRepositories,
     session_id: &str,
-    project_id: Option<i64>,
 ) -> ReasoningLevel {
-    if let Ok(Some(reasoning_level)) = db
-        .sessions()
-        .load_session_reasoning_level_override(session_id)
-        .await
-    {
-        return reasoning_level;
-    }
-
-    let Some(project_id) = project_id else {
-        return ReasoningLevel::default();
-    };
-
-    db.settings()
-        .load_project_reasoning_level(project_id)
+    db.sessions()
+        .load_session_reasoning_level(session_id)
         .await
         .unwrap_or_default()
 }

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -258,10 +258,7 @@ impl SessionWorkerRebaseAssistClient {
     /// cannot be persisted.
     async fn run_assist_turn(&self, prompt: String) -> Result<(), SessionError> {
         let turn_cancel_token = self.fresh_turn_cancel_token()?;
-        let session_project_id = turn::load_session_project_id(&self.db, &self.session_id).await;
-        let reasoning_level =
-            turn::load_session_reasoning_level(&self.db, &self.session_id, session_project_id)
-                .await;
+        let reasoning_level = turn::load_session_reasoning_level(&self.db, &self.session_id).await;
         let provider_conversation_id = self
             .db
             .sessions()

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -632,19 +632,9 @@ impl Session {
         self.in_progress_total_seconds > 0 || self.in_progress_started_at.is_some()
     }
 
-    /// Returns the reasoning level that will be used for the next turn.
-    pub fn effective_reasoning_level(
-        &self,
-        default_reasoning_level: ReasoningLevel,
-    ) -> ReasoningLevel {
-        self.reasoning_level_override
-            .unwrap_or(default_reasoning_level)
-    }
-
-    /// Returns whether this session currently inherits the project default
-    /// reasoning level.
-    pub fn uses_default_reasoning_level(&self) -> bool {
-        self.reasoning_level_override.is_none()
+    /// Returns the session-persisted reasoning level used for the next turn.
+    pub fn effective_reasoning_level(&self) -> ReasoningLevel {
+        self.reasoning_level_override.unwrap_or_default()
     }
 
     /// Returns cumulative active-work time including any open `InProgress`
@@ -1665,19 +1655,16 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
     }
 
     #[test]
-    /// Ensures sessions without an override inherit the provided default
-    /// reasoning level.
-    fn test_effective_reasoning_level_uses_default_when_override_is_missing() {
+    /// Ensures invalid rows without a stored value use the stable application
+    /// fallback rather than the current project setting.
+    fn test_effective_reasoning_level_uses_stable_fallback_when_value_is_missing() {
         // Arrange
         let session = test_session(None);
 
         // Act
-        let effective_reasoning_level = session.effective_reasoning_level(ReasoningLevel::Medium);
-        let uses_default_reasoning_level = session.uses_default_reasoning_level();
-
+        let effective_reasoning_level = session.effective_reasoning_level();
         // Assert
-        assert_eq!(effective_reasoning_level, ReasoningLevel::Medium);
-        assert!(uses_default_reasoning_level);
+        assert_eq!(effective_reasoning_level, ReasoningLevel::High);
     }
 
     #[test]
@@ -1688,29 +1675,22 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
         let session = test_session(Some(ReasoningLevel::High));
 
         // Act
-        let effective_reasoning_level = session.effective_reasoning_level(ReasoningLevel::Low);
-        let uses_default_reasoning_level = session.uses_default_reasoning_level();
-
+        let effective_reasoning_level = session.effective_reasoning_level();
         // Assert
         assert_eq!(effective_reasoning_level, ReasoningLevel::High);
-        assert!(!uses_default_reasoning_level);
     }
 
     #[test]
-    /// Ensures clearing a session override restores inheritance from the
-    /// provided default reasoning level.
-    fn test_effective_reasoning_level_returns_to_default_after_override_is_cleared() {
+    /// Ensures clearing a session value uses the stable application fallback.
+    fn test_effective_reasoning_level_uses_stable_fallback_after_value_is_cleared() {
         // Arrange
         let mut session = test_session(Some(ReasoningLevel::XHigh));
         session.reasoning_level_override = None;
 
         // Act
-        let effective_reasoning_level = session.effective_reasoning_level(ReasoningLevel::Low);
-        let uses_default_reasoning_level = session.uses_default_reasoning_level();
-
+        let effective_reasoning_level = session.effective_reasoning_level();
         // Assert
-        assert_eq!(effective_reasoning_level, ReasoningLevel::Low);
-        assert!(uses_default_reasoning_level);
+        assert_eq!(effective_reasoning_level, ReasoningLevel::High);
     }
 
     #[test]

--- a/crates/agentty/src/infra/db.rs
+++ b/crates/agentty/src/infra/db.rs
@@ -25,7 +25,7 @@ pub(crate) use review::SqliteReviewRepository;
 pub use review::{ReviewRepository, SessionReviewRequestRow};
 pub(crate) use session::SqliteSessionRepository;
 pub use session::{
-    ForkSessionSnapshot, PersistedSessionAgentModel, SessionDetailRow, SessionFocusedReviewRow,
+    ForkSessionSnapshot, PersistedSessionCreation, SessionDetailRow, SessionFocusedReviewRow,
     SessionFollowUpTaskRow, SessionListRow, SessionMessageRow, SessionRepository, SessionRow,
     SessionTurnMetadata,
 };

--- a/crates/agentty/src/infra/db/session.rs
+++ b/crates/agentty/src/infra/db/session.rs
@@ -34,12 +34,27 @@ pub struct SessionTurnMetadata {
     pub(crate) token_usage_delta: SessionStats,
 }
 
-/// Borrowed persisted agent/model pair for newly inserted session rows.
-pub struct PersistedSessionAgentModel<'a> {
+/// Borrowed values used to persist a newly created session with explicit
+/// provider identity and reasoning configuration.
+pub struct PersistedSessionCreation<'a> {
     /// Persisted agent provider kind for the session.
     pub agent: &'a str,
+    /// Base branch or parent branch used for future worktree materialization.
+    pub base_branch: &'a str,
+    /// Stable session identifier.
+    pub id: &'a str,
+    /// Whether the row was created through explicit draft staging.
+    pub is_draft: bool,
     /// Persisted model identifier for the session.
     pub model: &'a str,
+    /// Optional parent session id for one-level stacked drafts.
+    pub parent_session_id: Option<&'a str>,
+    /// Owning project identifier.
+    pub project_id: i64,
+    /// Reasoning level captured from the project default at creation.
+    pub reasoning_level: ReasoningLevel,
+    /// Initial lifecycle status string.
+    pub status: &'a str,
 }
 
 /// Borrowed identifiers used to persist one forked session snapshot.
@@ -249,35 +264,11 @@ pub trait SessionRepository: Send + Sync {
         project_id: i64,
     ) -> Result<(), DbError>;
 
-    /// Inserts a newly created draft-session row with explicit provider
-    /// identity.
-    async fn insert_draft_session_with_agent(
-        &self,
-        id: &str,
-        agent: &str,
-        model: &str,
-        base_branch: &str,
-        status: &str,
-        project_id: i64,
-    ) -> Result<(), DbError>;
-
     /// Inserts a newly created stacked draft-session row.
     async fn insert_stacked_draft_session(
         &self,
         id: &str,
         model: &str,
-        base_branch: &str,
-        status: &str,
-        parent_session_id: &str,
-        project_id: i64,
-    ) -> Result<(), DbError>;
-
-    /// Inserts a newly created stacked draft-session row with explicit provider
-    /// identity.
-    async fn insert_stacked_draft_session_with_agent(
-        &self,
-        id: &str,
-        agent_model: PersistedSessionAgentModel<'_>,
         base_branch: &str,
         status: &str,
         parent_session_id: &str,
@@ -297,12 +288,7 @@ pub trait SessionRepository: Send + Sync {
     /// Inserts a newly created session row with explicit provider identity.
     async fn insert_session_with_agent(
         &self,
-        id: &str,
-        agent: &str,
-        model: &str,
-        base_branch: &str,
-        status: &str,
-        project_id: i64,
+        session: PersistedSessionCreation<'_>,
     ) -> Result<(), DbError>;
 
     /// Inserts a new session by snapshotting source metadata and ordered
@@ -379,11 +365,11 @@ pub trait SessionRepository: Send + Sync {
         parent_commit_hash: Option<String>,
     ) -> Result<Vec<String>, DbError>;
 
-    /// Loads the persisted session-specific reasoning override, when present.
-    async fn load_session_reasoning_level_override(
+    /// Loads the persisted session reasoning level.
+    async fn load_session_reasoning_level(
         &self,
         session_id: &str,
-    ) -> Result<Option<ReasoningLevel>, DbError>;
+    ) -> Result<ReasoningLevel, DbError>;
 
     /// Loads the persisted summary text associated with one session.
     async fn load_session_summary(&self, session_id: &str) -> Result<Option<String>, DbError>;
@@ -480,11 +466,11 @@ pub trait SessionRepository: Send + Sync {
     /// Updates the model clarification questions for a session row.
     async fn update_session_questions(&self, id: &str, questions: &str) -> Result<(), DbError>;
 
-    /// Updates the persisted session-specific reasoning override.
+    /// Updates the persisted session reasoning level.
     async fn update_session_reasoning_level(
         &self,
         id: &str,
-        reasoning_level: Option<String>,
+        reasoning_level: ReasoningLevel,
     ) -> Result<(), DbError>;
 
     /// Updates the persisted upstream reference for a published session
@@ -1035,31 +1021,7 @@ WHERE id = ?
                 model,
                 parent_session_id: None,
                 project_id,
-                status,
-            },
-        )
-        .await
-    }
-
-    async fn insert_draft_session_with_agent(
-        &self,
-        id: &str,
-        agent: &str,
-        model: &str,
-        base_branch: &str,
-        status: &str,
-        project_id: i64,
-    ) -> Result<(), DbError> {
-        insert_session_with_draft_mode(
-            &self.0,
-            InsertSessionRow {
-                agent,
-                base_branch,
-                id,
-                is_draft: true,
-                model,
-                parent_session_id: None,
-                project_id,
+                reasoning_level: ReasoningLevel::default(),
                 status,
             },
         )
@@ -1087,33 +1049,7 @@ WHERE id = ?
                 model,
                 parent_session_id: Some(parent_session_id),
                 project_id,
-                status,
-            },
-        )
-        .await
-    }
-
-    async fn insert_stacked_draft_session_with_agent(
-        &self,
-        id: &str,
-        agent_model: PersistedSessionAgentModel<'_>,
-        base_branch: &str,
-        status: &str,
-        parent_session_id: &str,
-        project_id: i64,
-    ) -> Result<(), DbError> {
-        let PersistedSessionAgentModel { agent, model } = agent_model;
-
-        insert_session_with_draft_mode(
-            &self.0,
-            InsertSessionRow {
-                agent,
-                base_branch,
-                id,
-                is_draft: true,
-                model,
-                parent_session_id: Some(parent_session_id),
-                project_id,
+                reasoning_level: ReasoningLevel::default(),
                 status,
             },
         )
@@ -1140,6 +1076,7 @@ WHERE id = ?
                 model,
                 parent_session_id: None,
                 project_id,
+                reasoning_level: ReasoningLevel::default(),
                 status,
             },
         )
@@ -1148,23 +1085,31 @@ WHERE id = ?
 
     async fn insert_session_with_agent(
         &self,
-        id: &str,
-        agent: &str,
-        model: &str,
-        base_branch: &str,
-        status: &str,
-        project_id: i64,
+        session: PersistedSessionCreation<'_>,
     ) -> Result<(), DbError> {
+        let PersistedSessionCreation {
+            agent,
+            base_branch,
+            id,
+            is_draft,
+            model,
+            parent_session_id,
+            project_id,
+            reasoning_level,
+            status,
+        } = session;
+
         insert_session_with_draft_mode(
             &self.0,
             InsertSessionRow {
                 agent,
                 base_branch,
                 id,
-                is_draft: false,
+                is_draft,
                 model,
-                parent_session_id: None,
+                parent_session_id,
                 project_id,
+                reasoning_level,
                 status,
             },
         )
@@ -1487,10 +1432,10 @@ WHERE id = ?
         Ok(row.flatten())
     }
 
-    async fn load_session_reasoning_level_override(
+    async fn load_session_reasoning_level(
         &self,
         session_id: &str,
-    ) -> Result<Option<ReasoningLevel>, DbError> {
+    ) -> Result<ReasoningLevel, DbError> {
         let value = sqlx::query_scalar!(
             r"SELECT reasoning_level FROM session WHERE id = ?",
             session_id
@@ -1499,7 +1444,9 @@ WHERE id = ?
         .await?
         .flatten();
 
-        Ok(value.and_then(|value| value.parse::<ReasoningLevel>().ok()))
+        Ok(value
+            .and_then(|value| value.parse::<ReasoningLevel>().ok())
+            .unwrap_or_default())
     }
 
     async fn restack_child_sessions_after_parent_merge(
@@ -1931,7 +1878,7 @@ WHERE id = ?
     async fn update_session_reasoning_level(
         &self,
         id: &str,
-        reasoning_level: Option<String>,
+        reasoning_level: ReasoningLevel,
     ) -> Result<(), DbError> {
         sqlx::query!(
             r#"
@@ -1939,7 +1886,7 @@ UPDATE session
 SET reasoning_level = ?
 WHERE id = ?
             "#,
-            reasoning_level,
+            reasoning_level.as_str(),
             id
         )
         .execute(&self.0)
@@ -2152,6 +2099,8 @@ struct InsertSessionRow<'a> {
     parent_session_id: Option<&'a str>,
     /// Owning project identifier.
     project_id: i64,
+    /// Reasoning level captured from the project default at creation.
+    reasoning_level: ReasoningLevel,
     /// Initial lifecycle status string.
     status: &'a str,
 }
@@ -2170,6 +2119,7 @@ async fn insert_session_with_draft_mode(
         model,
         parent_session_id,
         project_id,
+        reasoning_level,
         status,
     } = row;
 
@@ -2184,9 +2134,10 @@ INSERT INTO session (
     is_draft,
     parent_session_id,
     project_id,
+    reasoning_level,
     prompt
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ",
     )
     .bind(id)
@@ -2197,6 +2148,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     .bind(is_draft)
     .bind(parent_session_id)
     .bind(project_id)
+    .bind(reasoning_level.as_str())
     .bind("")
     .execute(pool)
     .await?;

--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -1727,10 +1727,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_prompt_slash_submit_prefills_reasoning_selection_from_default_setting() {
+    async fn test_handle_prompt_slash_submit_prefills_reasoning_selection_from_session_value() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("/reasoning", None).await;
         app.settings.reasoning_level = ReasoningLevel::Medium;
+        app.sessions.sessions_mut()[0].reasoning_level_override = Some(ReasoningLevel::Low);
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
@@ -1741,7 +1742,7 @@ mod tests {
         if let AppMode::Prompt { slash_state, .. } = &app.mode {
             assert_eq!(slash_state.stage, PromptSlashStage::Reasoning);
             assert_eq!(slash_state.selected_agent, None);
-            assert_eq!(slash_state.selected_index, 1);
+            assert_eq!(slash_state.selected_index, 0);
         }
     }
 

--- a/crates/agentty/src/ui/page/session_list.rs
+++ b/crates/agentty/src/ui/page/session_list.rs
@@ -306,9 +306,9 @@ pub(crate) fn model_column_width(
 /// Formats model name together with the effective reasoning level label.
 fn session_model_and_reasoning_level(
     session: &Session,
-    default_reasoning_level: ReasoningLevel,
+    _default_reasoning_level: ReasoningLevel,
 ) -> String {
-    let reasoning_level = session.effective_reasoning_level(default_reasoning_level);
+    let reasoning_level = session.effective_reasoning_level();
 
     format!(
         "{} [{}]",
@@ -320,9 +320,9 @@ fn session_model_and_reasoning_level(
 /// Builds a styled model column cell where the reasoning label is colorized.
 fn session_model_and_reasoning_level_line(
     session: &Session,
-    default_reasoning_level: ReasoningLevel,
+    _default_reasoning_level: ReasoningLevel,
 ) -> Line<'static> {
-    let reasoning_level = session.effective_reasoning_level(default_reasoning_level);
+    let reasoning_level = session.effective_reasoning_level();
     let color = reasoning_level_color(reasoning_level);
 
     Line::from(vec![
@@ -679,6 +679,7 @@ mod tests {
             crate::domain::agent::AgentKind::Claude,
             AgentModel::ClaudeSonnet5,
         );
+        default_session.reasoning_level_override = Some(ReasoningLevel::Low);
         let mut medium_session =
             crate::test_support::titled_session_fixture("active-2", Status::Review);
         medium_session.agent = crate::domain::agent::AgentSelection::new(
@@ -779,7 +780,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_session_row_shows_model_with_default_reasoning_level() {
+    fn test_render_session_row_shows_model_with_persisted_reasoning_level() {
         // Arrange
         let backend = ratatui::backend::TestBackend::new(100, 12);
         let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
@@ -790,12 +791,13 @@ mod tests {
             crate::domain::agent::AgentKind::Codex,
             AgentModel::Gpt55,
         );
+        session.reasoning_level_override = Some(ReasoningLevel::Medium);
         let sessions = vec![session];
 
         // Act
         terminal
             .draw(|frame| {
-                SessionListPage::new(&sessions, &mut table_state, ReasoningLevel::Medium, 0)
+                SessionListPage::new(&sessions, &mut table_state, ReasoningLevel::XHigh, 0)
                     .render(frame, frame.area());
             })
             .expect("failed to draw");

--- a/crates/agentty/src/ui/session_format.rs
+++ b/crates/agentty/src/ui/session_format.rs
@@ -139,7 +139,7 @@ fn session_header_metadata_lines(
 /// single-line metadata renderers.
 fn session_metadata_base_text(
     session: &Session,
-    default_reasoning_level: ReasoningLevel,
+    _default_reasoning_level: ReasoningLevel,
     wall_clock_unix_seconds: i64,
 ) -> String {
     let added_lines = session.stats.added_lines;
@@ -147,7 +147,7 @@ fn session_metadata_base_text(
     let timer = text_util::format_duration_compact(
         session.in_progress_duration_seconds(wall_clock_unix_seconds),
     );
-    let reasoning_level = session.effective_reasoning_level(default_reasoning_level);
+    let reasoning_level = session.effective_reasoning_level();
     let input_tokens = text_util::format_token_count(session.stats.input_tokens);
     let output_tokens = text_util::format_token_count(session.stats.output_tokens);
     format!(

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -517,7 +517,7 @@ fn seed_child_worktree_for_onto_rebase(
     Ok(parent_tip)
 }
 
-/// Seeds one review-ready session with a persisted reasoning-level override.
+/// Seeds one review-ready session with a persisted reasoning level.
 fn seed_session_with_reasoning_level(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     seed_review_ready_session(env)?;
 
@@ -527,10 +527,7 @@ fn seed_session_with_reasoning_level(env: &BuilderEnv) -> Result<(), Box<dyn std
         let database = common::open_database(env).await?;
         database
             .sessions()
-            .update_session_reasoning_level(
-                "review-shortcut-0001",
-                Some(ReasoningLevel::Medium.as_str().to_string()),
-            )
+            .update_session_reasoning_level("review-shortcut-0001", ReasoningLevel::Medium)
             .await
     })?;
 
@@ -633,6 +630,15 @@ fn seed_running_stop_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error:
     // runtime expects for this session id.
     let worktree_name = &RUNNING_STOP_SESSION_ID[..8];
     std::fs::create_dir_all(env.agentty_root.join("wt").join(worktree_name))?;
+
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        database
+            .sessions()
+            .update_session_reasoning_level(RUNNING_STOP_SESSION_ID, ReasoningLevel::High)
+            .await
+    })?;
 
     Ok(())
 }
@@ -1032,6 +1038,44 @@ fn session_list_model_reasoning_level() -> E2eResult {
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "gpt-5.5 [medium]", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that changing the project reasoning default does not relabel a turn
+/// that is already in progress.
+#[test]
+fn existing_session_keeps_persisted_reasoning_label() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_persisted_reasoning_label")
+        .with_git()
+        .setup(seed_running_stop_session)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .wait_for_text("gpt-5.5 [high]", 5000)
+                    .compose(&common::switch_to_tab("Inbox"))
+                    .compose(&common::switch_to_tab("Settings"))
+                    .press_key("j")
+                    .press_key("Enter")
+                    .press_key("j")
+                    .press_key("Enter")
+                    .wait_for_text("xhigh", 5000)
+                    .press_key("BackTab")
+                    .press_key("BackTab")
+                    .wait_for_text("gpt-5.5 [high]", 5000)
+                    .capture_labeled(
+                        "active_reasoning",
+                        "Existing session retains persisted reasoning",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "gpt-5.5 [high]", &full);
             },
         )?;
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -42,7 +42,9 @@ In session chat view, the status-colored session title renders in a header row a
 output panel, with a metadata row showing the size bucket, `+added` / `-deleted` line
 totals, the cumulative active-work timer, the current model, the effective reasoning
 level, and token usage. A linked pull-request or merge-request URL appears in the header
-when present. The timer ticks only while the session is actively working.
+when present. The timer ticks only while the session is actively working. Each session
+stores the project reasoning default when it is created, so later default changes affect
+new sessions without relabeling existing ones.
 
 The top status bar shows the current version and update status, and rotates short
 page-scoped `FYI:` messages once per minute in the **Sessions** list and session chat


### PR DESCRIPTION
- Store the project reasoning level when creating sessions and backfill missing session values.
- Use the persisted session level for turn execution and UI labels so later project default changes affect only new sessions.
- Cover creation, fallback, and retained-label behavior with unit and E2E tests and workflow documentation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)