### PR TITLE
Handle Codex server requests

### DIFF
--- a/crates/ag-agent/src/agent/app_server/codex/client.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/client.rs
@@ -433,6 +433,130 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_turn_event_loop_answers_user_input_request_without_blocking() {
+        // Arrange
+        let folder = tempdir().expect("temporary folder should be created");
+        let turn_start_id = Arc::new(Mutex::new(None));
+        let mut transport = MockCodexRuntimeTransport::new();
+        let mut sequence = Sequence::new();
+        let (stream_tx, _stream_rx) = mpsc::unbounded_channel();
+
+        expect_user_input_request_turn(&mut transport, &mut sequence, turn_start_id);
+
+        // Act
+        let result = lifecycle::execute_turn_event_loop(
+            &mut transport,
+            folder.path(),
+            AgentModel::Gpt55.as_str(),
+            "thread-1",
+            "Implement the task",
+            ReasoningLevel::default(),
+            stream_tx,
+        )
+        .await;
+
+        // Assert
+        assert_eq!(result.expect("turn should complete"), (String::new(), 0, 0));
+    }
+
+    /// Expects a user-input request to receive an empty response before turn
+    /// completion.
+    fn expect_user_input_request_turn(
+        transport: &mut MockCodexRuntimeTransport,
+        sequence: &mut Sequence,
+        turn_start_id: Arc<Mutex<Option<String>>>,
+    ) {
+        transport
+            .expect_write_json_line()
+            .times(1)
+            .in_sequence(sequence)
+            .withf(|payload| payload.get("method").and_then(Value::as_str) == Some("turn/start"))
+            .returning({
+                let turn_start_id = Arc::clone(&turn_start_id);
+
+                move |payload| {
+                    remember_request_id(&turn_start_id, &payload);
+
+                    Box::pin(async { Ok(()) })
+                }
+            });
+        transport
+            .expect_next_stdout()
+            .times(1)
+            .in_sequence(sequence)
+            .return_once(move || {
+                let response_id = turn_start_id
+                    .lock()
+                    .expect("turn/start mutex should lock")
+                    .clone()
+                    .expect("turn/start id should be recorded");
+
+                Box::pin(async move {
+                    Ok(Some(
+                        serde_json::json!({
+                            "id": response_id,
+                            "result": {"turn": {"id": "turn-123"}}
+                        })
+                        .to_string(),
+                    ))
+                })
+            });
+        transport
+            .expect_next_stdout()
+            .times(1)
+            .in_sequence(sequence)
+            .return_once(|| {
+                Box::pin(async {
+                    Ok(Some(
+                        serde_json::json!({
+                            "id": "user-input-1",
+                            "method": "item/tool/requestUserInput",
+                            "params": {
+                                "questions": [{
+                                    "id": "approval",
+                                    "question": "Allow this action?"
+                                }]
+                            }
+                        })
+                        .to_string(),
+                    ))
+                })
+            });
+        transport
+            .expect_write_json_line()
+            .times(1)
+            .in_sequence(sequence)
+            .withf(|payload| {
+                payload
+                    == &serde_json::json!({
+                        "id": "user-input-1",
+                        "result": {"answers": {}}
+                    })
+            })
+            .returning(|_| Box::pin(async { Ok(()) }));
+        transport
+            .expect_next_stdout()
+            .times(1)
+            .in_sequence(sequence)
+            .return_once(|| {
+                Box::pin(async {
+                    Ok(Some(
+                        serde_json::json!({
+                            "method": "turn/completed",
+                            "params": {
+                                "turn": {
+                                    "id": "turn-123",
+                                    "status": "completed"
+                                }
+                            }
+                        })
+                        .to_string(),
+                    ))
+                })
+            });
+    }
+
+    #[tokio::test]
     async fn run_turn_with_runtime_compacts_proactively_before_turn_start() {
         // Arrange
         let mut state = build_runtime_state(
@@ -609,7 +733,7 @@ mod tests {
 
         // Act
         let approval_response =
-            policy::build_pre_action_approval_response(&response_value, session_folder)
+            policy::build_server_request_response(&response_value, session_folder)
                 .expect("approval response should be generated");
 
         // Assert
@@ -665,7 +789,7 @@ mod tests {
 
         // Act
         let approval_response =
-            policy::build_pre_action_approval_response(&response_value, session_folder)
+            policy::build_server_request_response(&response_value, session_folder)
                 .expect("approval response should be generated");
 
         // Assert
@@ -694,7 +818,7 @@ mod tests {
 
         // Act
         let approval_response =
-            policy::build_pre_action_approval_response(&response_value, session_folder)
+            policy::build_server_request_response(&response_value, session_folder)
                 .expect("approval response should be generated");
 
         // Assert
@@ -704,6 +828,65 @@ mod tests {
                 .and_then(|result| result.get("decision"))
                 .and_then(Value::as_str),
             Some("reject")
+        );
+    }
+
+    #[test]
+    fn build_server_request_response_grants_no_additional_permissions() {
+        // Arrange
+        let response_value = serde_json::json!({
+            "id": "permission-1",
+            "method": "item/permissions/requestApproval",
+            "params": {
+                "permissions": {
+                    "network": { "enabled": true }
+                }
+            }
+        });
+        let session_folder = Path::new("/tmp/session");
+
+        // Act
+        let response = policy::build_server_request_response(&response_value, session_folder)
+            .expect("permission response should be generated");
+
+        // Assert
+        assert_eq!(
+            response,
+            serde_json::json!({
+                "id": "permission-1",
+                "result": {
+                    "permissions": {},
+                    "scope": "turn"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn build_server_request_response_declines_mcp_elicitation() {
+        // Arrange
+        let response_value = serde_json::json!({
+            "id": "elicitation-1",
+            "method": "mcpServer/elicitation/request",
+            "params": {
+                "message": "Allow this MCP action?"
+            }
+        });
+        let session_folder = Path::new("/tmp/session");
+
+        // Act
+        let response = policy::build_server_request_response(&response_value, session_folder)
+            .expect("elicitation response should be generated");
+
+        // Assert
+        assert_eq!(
+            response,
+            serde_json::json!({
+                "id": "elicitation-1",
+                "result": {
+                    "action": "decline"
+                }
+            })
         );
     }
 

--- a/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
@@ -540,10 +540,10 @@ impl CodexTurnEventLoopState {
             return Ok(None);
         }
 
-        if let Some(approval_response) =
-            policy::build_pre_action_approval_response(&response_value, folder)
+        if let Some(server_request_response) =
+            policy::build_server_request_response(&response_value, folder)
         {
-            transport.write_json_line(approval_response).await?;
+            transport.write_json_line(server_request_response).await?;
 
             return Ok(None);
         }

--- a/crates/ag-agent/src/agent/app_server/codex/policy.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/policy.rs
@@ -154,16 +154,48 @@ pub(super) fn web_search_mode() -> &'static str {
     permission_mode_policy(PermissionMode::default()).web_search_mode
 }
 
-/// Builds a JSON-RPC approval response for known pre-action request methods.
+/// Builds a JSON-RPC response for known approval-like server requests.
 ///
-/// Returns `None` when the input line is not a supported approval request or
-/// does not include a request id.
-pub(super) fn build_pre_action_approval_response(
+/// Agentty declines requests that require interactive user input and grants no
+/// additional permissions. Pre-action command and file-change requests retain
+/// the scoped auto-edit decisions used by older Codex app-server versions.
+/// Returns `None` when the input line is not a supported request or does not
+/// include a request id.
+pub(super) fn build_server_request_response(
     response_value: &Value,
     session_folder: &Path,
 ) -> Option<Value> {
     let method = response_value.get("method")?.as_str()?;
     let request_id = response_value.get("id")?.clone();
+
+    if method == "item/permissions/requestApproval" {
+        return Some(serde_json::json!({
+            "id": request_id,
+            "result": {
+                "permissions": {},
+                "scope": "turn"
+            }
+        }));
+    }
+
+    if method == "mcpServer/elicitation/request" {
+        return Some(serde_json::json!({
+            "id": request_id,
+            "result": {
+                "action": "decline"
+            }
+        }));
+    }
+
+    if method == "item/tool/requestUserInput" {
+        return Some(serde_json::json!({
+            "id": request_id,
+            "result": {
+                "answers": {}
+            }
+        }));
+    }
+
     let approval_kind = PreActionApprovalKind::from_method(method)?;
     let decision = scoped_pre_action_decision(response_value, session_folder, &approval_kind);
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -279,7 +279,10 @@ compact reminder.
 - Merge and `sync main` workflows require a clean target checkout before changing
   base-branch state.
 - Provider permission policies are scoped per transport: Codex turns run with a
-  non-interactive approval policy and workspace-write sandbox, Claude turns receive
+  non-interactive approval policy and workspace-write sandbox. Agentty immediately
+  declines MCP elicitations and grants no additional permission requests so an
+  app-server request cannot leave the turn waiting for interactive input. Codex tool
+  input requests receive an empty answer set for the same reason. Claude turns receive
   session-scoped settings that deny writes to the known main checkout, Gemini ACP
   requests prefer one-shot allow options, and CLI-backed providers run from the session
   worktree process directory.


### PR DESCRIPTION
- Decline MCP elicitations and grant no additional permissions.
- Answer Codex tool input requests with an empty response so turns stay non-interactive.
- Preserve scoped pre-action responses and document the server-request policy.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)