### PR TITLE
Move presentation state out of app orchestration

### DIFF
--- a/crates/agentty/src/app.rs
+++ b/crates/agentty/src/app.rs
@@ -5,6 +5,7 @@
 
 mod assigned_issue;
 mod assist;
+pub(crate) mod at_mention_task;
 mod branch_publish;
 mod core;
 mod error;
@@ -21,8 +22,10 @@ pub mod session_state;
 pub(crate) mod setting;
 mod startup;
 mod sync;
+pub(crate) mod sync_message;
 pub(crate) mod tab;
 mod task;
+mod view;
 
 #[cfg(test)]
 pub(crate) use core::AppClients;
@@ -35,6 +38,7 @@ pub use project::ProjectManager;
 pub(crate) use requested_review::RequestedReviewState;
 pub(crate) use review::{
     ReviewCacheEntry, diff_content_hash, is_review_loading_status_message, review_loading_message,
+    review_view_state,
 };
 #[cfg(test)]
 pub(crate) use service::AppServiceDeps;
@@ -46,3 +50,4 @@ pub use setting::SettingsManager;
 #[cfg(test)]
 pub(crate) use sync::MockSyncMainRunner;
 pub use tab::{Tab, TabManager};
+pub(crate) use view::AppViewSnapshot;

--- a/crates/agentty/src/app/at_mention_task.rs
+++ b/crates/agentty/src/app/at_mention_task.rs
@@ -1,0 +1,46 @@
+//! Application-owned registry for pending `@`-mention indexing tasks.
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+use tokio::task::JoinHandle;
+
+use crate::domain::session::SessionId;
+
+static PENDING_AT_MENTION_LOADS: LazyLock<Mutex<HashMap<SessionId, PendingAtMentionLoad>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+struct PendingAtMentionLoad {
+    handle: JoinHandle<()>,
+    request_id: u64,
+}
+
+/// Aborts and removes any pending debounced load for one session.
+pub(crate) fn clear_pending_load(session_id: &str) {
+    if let Ok(mut pending_loads) = PENDING_AT_MENTION_LOADS.lock()
+        && let Some(pending_load) = pending_loads.remove(session_id)
+    {
+        pending_load.handle.abort();
+    }
+}
+
+/// Stores the latest task and aborts any stale debounced predecessor.
+pub(crate) fn track_pending_load(session_id: SessionId, request_id: u64, handle: JoinHandle<()>) {
+    if let Ok(mut pending_loads) = PENDING_AT_MENTION_LOADS.lock()
+        && let Some(previous_task) =
+            pending_loads.insert(session_id, PendingAtMentionLoad { handle, request_id })
+    {
+        previous_task.handle.abort();
+    }
+}
+
+/// Clears a task entry when the completing request is still current.
+pub(crate) fn finish_pending_load(session_id: &str, request_id: u64) {
+    if let Ok(mut pending_loads) = PENDING_AT_MENTION_LOADS.lock()
+        && pending_loads
+            .get(session_id)
+            .is_some_and(|task| task.request_id == request_id)
+    {
+        pending_loads.remove(session_id);
+    }
+}

--- a/crates/agentty/src/app/branch_publish.rs
+++ b/crates/agentty/src/app/branch_publish.rs
@@ -11,7 +11,7 @@ use crate::app::review_request;
 use crate::domain::session::{PublishBranchAction, ReviewRequest, Session, SessionId, Status};
 use crate::infra::clock::Clock;
 use crate::infra::db;
-use crate::ui::state::app_mode::ConfirmationViewMode;
+use crate::presentation::app_mode::ConfirmationViewMode;
 
 /// Session snapshot cloned into a branch-publish background task.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/agentty/src/app/core/draw.rs
+++ b/crates/agentty/src/app/core/draw.rs
@@ -1,17 +1,9 @@
 //! Draw helpers and render-facing accessors for the app core module.
 
-use std::collections::HashMap;
-
-use ratatui::Frame;
-
 use super::state::{App, UpdateStatus};
 use crate::app::tab::Tab;
-use crate::app::{ReviewCacheEntry, review, session};
-use crate::domain::agent::AgentModel;
-use crate::domain::session::{PublishedBranchSyncStatus, Session, SessionId, Status};
-use crate::ui;
-use crate::ui::state::app_mode::{AppMode, ConfirmationViewMode, HelpContext};
-use crate::ui::style;
+use crate::domain::session::{PublishedBranchSyncStatus, Session, Status};
+use crate::presentation::app_mode::{AppMode, ConfirmationViewMode, HelpContext};
 
 impl App {
     /// Returns the active project identifier.
@@ -42,8 +34,8 @@ impl App {
 
     /// Builds prompt slash-menu state from the cached machine-scoped agent
     /// availability snapshot.
-    pub(crate) fn prompt_slash_state(&self) -> crate::ui::state::prompt::PromptSlashState {
-        crate::ui::state::prompt::PromptSlashState::with_available_agent_kinds(
+    pub(crate) fn prompt_slash_state(&self) -> crate::presentation::prompt::PromptSlashState {
+        crate::presentation::prompt::PromptSlashState::with_available_agent_kinds(
             self.services.available_agent_kinds(),
         )
     }
@@ -97,81 +89,6 @@ impl App {
         }
     }
 
-    /// Renders a complete UI frame by applying the active color theme,
-    /// assembling a [`ui::RenderContext`] from current app state, and
-    /// dispatching to the UI render pipeline.
-    pub fn draw(&mut self, frame: &mut Frame) {
-        let current_tab = self.tabs.current();
-        let available_agent_clis = self.services.available_agent_clis();
-        let latest_available_version = self.latest_available_version.as_deref();
-        let session_progress_messages = &self.session_progress_messages;
-        let update_status = self.update_status.as_ref();
-        let wall_clock_unix_seconds =
-            session::unix_timestamp_from_system_time(self.sessions.state().now_system_time());
-        let status_bar_fyi_rotation_index =
-            u64::try_from(wall_clock_unix_seconds.div_euclid(60)).unwrap_or_default();
-        let review_comment_cache = self.services.review_comment_cache();
-        let requested_review_selected_index = self.requested_review_selected_index();
-        let assigned_issue_selected_index = self.assigned_issue_selected_index();
-        let mode = &self.mode;
-        let session_review_snapshot = visible_session_review_snapshot(
-            mode,
-            &self.review_cache,
-            self.settings.default_review_selection.model(),
-        );
-        let requested_review_table_state = &mut self.requested_review_table_state;
-        let assigned_issue_table_state = &mut self.assigned_issue_table_state;
-        let project_render_parts = self.projects.render_parts();
-        let session_render_parts = self.sessions.render_parts();
-        let render_cache_store = &self.render_cache_store;
-        let settings = &mut self.settings;
-        let _theme_scope = style::scoped_active_theme(settings.theme);
-
-        ui::render(
-            frame,
-            ui::RenderContext {
-                assigned_issues: &self.assigned_issues,
-                assigned_issue_selected_index,
-                assigned_issue_table_state,
-                active_project_id: project_render_parts.active_project_id,
-                available_agent_clis: &available_agent_clis,
-                current_tab,
-                git_branch: project_render_parts.git_branch,
-                diff_layout_cache: render_cache_store.diff_layout_cache(),
-                git_upstream_ref: project_render_parts.git_upstream_ref,
-                git_status: project_render_parts.git_status,
-                latest_available_version,
-                markdown_render_cache: render_cache_store.markdown_render_cache(),
-                update_status,
-                mode,
-                output_layout_cache: render_cache_store.session_output_layout_cache(),
-                project_table_state: project_render_parts.table_state,
-                projects: project_render_parts.project_items,
-                review_comment_cache: &review_comment_cache,
-                session_review_snapshot: session_review_snapshot.as_ref(),
-                requested_reviews: &self.requested_reviews,
-                requested_review_selected_index,
-                requested_review_table_state,
-                active_prompt_outputs: session_render_parts.active_prompt_outputs,
-                session_branch_names: session_render_parts.session_branch_names,
-                session_git_statuses: session_render_parts.session_git_statuses,
-                session_index_by_id: session_render_parts.session_index_by_id,
-                session_progress_messages,
-                session_update_versions: &self.last_seen_session_update_versions,
-                session_worktree_availability: session_render_parts.session_worktree_availability,
-                settings,
-                system_log_tail_offset: self.system_log_tail_offset,
-                system_logs: &self.system_logs,
-                stats_activity: session_render_parts.stats_activity,
-                sessions: session_render_parts.sessions,
-                status_bar_fyi_rotation_index,
-                table_state: session_render_parts.table_state,
-                working_dir: project_render_parts.working_dir,
-                wall_clock_unix_seconds,
-            },
-        );
-    }
-
     /// Returns whether the currently visible list background contains any
     /// spinner or timer-driven session rows.
     fn list_background_has_tick_driven_ui(&self) -> bool {
@@ -212,43 +129,4 @@ impl App {
             )
             || session.published_branch_sync_status == PublishedBranchSyncStatus::InProgress
     }
-}
-
-/// Projects focused-review cache state for the session currently visible behind
-/// the active mode without cloning the cached review body during rendering.
-fn visible_session_review_snapshot<'a>(
-    mode: &'a AppMode,
-    review_cache: &'a HashMap<SessionId, ReviewCacheEntry>,
-    review_model: AgentModel,
-) -> Option<ui::SessionReviewSnapshot<'a>> {
-    let session_id = match mode {
-        AppMode::View { session_id, .. }
-        | AppMode::Prompt { session_id, .. }
-        | AppMode::Question { session_id, .. }
-        | AppMode::Diff { session_id, .. }
-        | AppMode::Help {
-            context: HelpContext::View { session_id, .. } | HelpContext::Diff { session_id, .. },
-            ..
-        } => session_id,
-        AppMode::Confirmation {
-            restore_view: Some(restore_view),
-            ..
-        }
-        | AppMode::LaunchConfigurationSelector { restore_view, .. }
-        | AppMode::PublishBranchInput { restore_view, .. }
-        | AppMode::ViewInfoPopup { restore_view, .. } => &restore_view.session_id,
-        AppMode::List
-        | AppMode::ReviewDetail { .. }
-        | AppMode::SessionCreation { .. }
-        | AppMode::Confirmation { .. }
-        | AppMode::SyncBlockedPopup { .. }
-        | AppMode::Help { .. } => return None,
-    };
-    let (status_message, text) = review::review_view_state(review_cache, session_id, review_model);
-
-    Some(ui::SessionReviewSnapshot {
-        session_id: session_id.as_str(),
-        status_message,
-        text,
-    })
 }

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -27,18 +27,18 @@ use crate::app::session::{
     StatusTransition, SyncMainOutcome, SyncSessionStartError, TurnAppliedState,
 };
 use crate::app::session_state::SessionGitStatus;
-use crate::app::{self, session};
+use crate::app::{self, session, sync_message};
 use crate::domain::agent::AgentCliInfo;
-use crate::domain::file_entry::FileEntry;
+use crate::domain::file_entry::{FileEntry, at_mention_lookup_root};
 use crate::domain::input::InputState;
+use crate::domain::question::default_option_index;
 use crate::domain::session::{
     PublishBranchAction, PublishedBranchSyncStatus, SessionId, SessionSize, Status,
 };
 use crate::domain::system_log::{SystemLogCategory, SystemLogEvent, SystemLogLevel};
 use crate::domain::transcript_notice::TranscriptNotice;
-use crate::runtime::mode::{at_mention, question, sync_blocked};
-use crate::ui::state::app_mode::{AppMode, ConfirmationViewMode, QuestionFocus};
-use crate::ui::state::prompt::PromptAtMentionState;
+use crate::presentation::app_mode::{AppMode, ConfirmationViewMode, QuestionFocus};
+use crate::presentation::prompt::PromptAtMentionState;
 
 /// Internal app events emitted by background workers and workflows.
 ///
@@ -1079,7 +1079,6 @@ impl App {
             match result {
                 Ok(items) => self.replace_assigned_issues(project_id, items),
                 Err(message) => {
-                    self.reset_assigned_issue_table_state();
                     self.assigned_issue_selected_index = None;
                     self.assigned_issues = app::AssignedIssueState::Failed {
                         message,
@@ -1100,7 +1099,6 @@ impl App {
                     self.replace_requested_reviews(project_id, items);
                 }
                 Err(message) => {
-                    self.reset_requested_review_table_state();
                     self.requested_review_selected_index = None;
 
                     self.requested_reviews = app::RequestedReviewState::Failed {
@@ -1532,7 +1530,7 @@ impl App {
         if self.is_viewing_session(session_id) {
             self.mode = AppMode::Question {
                 at_mention_state: None,
-                selected_option_index: question::default_option_index(&questions, 0),
+                selected_option_index: default_option_index(&questions, 0),
                 session_id: session_id.into(),
                 questions,
                 responses: Vec::new(),
@@ -1638,7 +1636,7 @@ impl App {
                 let session_folder = session.folder.clone();
                 let has_session_folder = self.services.fs_client().is_dir(session_folder.clone());
 
-                at_mention::lookup_root(
+                at_mention_lookup_root(
                     project_working_dir,
                     Some(session_folder),
                     has_session_folder,
@@ -2082,7 +2080,7 @@ impl App {
         let conflict_summary =
             Self::sync_conflict_summary(&sync_main_outcome.resolved_conflict_files);
 
-        sync_blocked::format_sync_success_message(
+        sync_message::format_sync_success_message(
             &pulled_summary,
             &pulled_titles,
             &pushed_summary,

--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -165,13 +165,12 @@ impl App {
         let system_logs = Self::startup_system_logs(clock.as_ref(), projects.project_name());
 
         Ok(Self {
-            mode: crate::ui::state::app_mode::AppMode::List,
+            mode: crate::presentation::app_mode::AppMode::List,
             needs_redraw: true,
             settings,
             tabs: crate::app::tab::TabManager::new(initial_tab),
             assigned_issue_generation: 0,
             assigned_issue_selected_index: None,
-            assigned_issue_table_state: ratatui::widgets::TableState::default(),
             assigned_issues: crate::app::AssignedIssueState::default(),
             projects,
             services,
@@ -181,13 +180,11 @@ impl App {
             requested_review_generation: 0,
             requested_review_comment_fetches: std::collections::HashSet::new(),
             requested_review_selected_index: None,
-            requested_review_table_state: ratatui::widgets::TableState::default(),
             requested_reviews: crate::app::RequestedReviewState::default(),
             event_rx,
             review_cache,
             latest_available_version: None,
             last_seen_session_update_versions: std::collections::HashMap::new(),
-            render_cache_store: crate::ui::RenderCacheStore::default(),
             merge_queue: crate::app::merge_queue::MergeQueue::default(),
             session_progress_messages: std::collections::HashMap::new(),
             system_log_tail_offset: 0,

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -29,7 +29,6 @@ use app::setting::SettingsManager;
 use app::sync::SyncMainRunner;
 use app::tab::{Tab, TabManager};
 use app::{sync, task};
-use ratatui::widgets::TableState;
 use session::StatusTransition;
 #[cfg(test)]
 use session::{SyncMainOutcome, SyncSessionStartError, TurnAppliedState};
@@ -38,6 +37,7 @@ use tokio::sync::mpsc;
 use super::events::AppEvent;
 #[cfg(test)]
 use super::events::{AppEventBatch, ReviewRequestStatusUpdate};
+use crate::app;
 use crate::app::{AppError, AssignedIssueState, RequestedReviewState, session};
 #[cfg(test)]
 use crate::domain::agent::AgentCliInfo;
@@ -45,7 +45,7 @@ use crate::domain::agent::AgentCliInfo;
 use crate::domain::agent::AgentSelection;
 use crate::domain::agent::{AgentKind, ReasoningLevel};
 use crate::domain::input::InputState;
-use crate::domain::question::{QuestionItem, QuestionProgress};
+use crate::domain::question::{QuestionItem, QuestionProgress, default_option_index};
 use crate::domain::session::{FollowUpTaskAction, PublishBranchAction, Session, SessionId, Status};
 use crate::domain::session_message::SessionTranscript;
 use crate::domain::setting::SettingName;
@@ -59,9 +59,7 @@ use crate::infra::db;
 use crate::infra::fs::{FsClient, RealFsClient};
 use crate::infra::project_discovery::{ProjectDiscoveryClient, RealProjectDiscoveryClient};
 use crate::infra::tmux::{RealTmuxClient, TmuxClient};
-use crate::runtime::mode::{at_mention, question};
-use crate::ui::state::app_mode::{AppMode, ConfirmationViewMode, QuestionFocus};
-use crate::{app, ui};
+use crate::presentation::app_mode::{AppMode, ConfirmationViewMode, QuestionFocus};
 
 /// Relative directory name used for session git worktrees within the
 /// `agentty` home directory.
@@ -204,10 +202,8 @@ pub struct App {
     pub(super) assigned_issue_generation: u64,
     /// Selected assigned-issue item index for the top-level `Issues` tab.
     pub(super) assigned_issue_selected_index: Option<usize>,
-    /// Persistent table viewport state for the top-level `Issues` tab.
-    pub(super) assigned_issue_table_state: TableState,
     /// Caches open GitHub issues assigned to the authenticated user.
-    pub(super) assigned_issues: AssignedIssueState,
+    pub(crate) assigned_issues: AssignedIssueState,
     /// Saves partially answered clarification progress per session so
     /// already-submitted answers survive leaving question mode with `q` and
     /// reopening the session. Entries are consumed on restore and cleared
@@ -248,11 +244,9 @@ pub struct App {
     pub(super) requested_review_comment_fetches: HashSet<RequestedReviewCommentFetchKey>,
     /// Selected requested-review item index for the active project's
     /// top-level `Review` tab, excluding non-selectable section headers.
-    pub(super) requested_review_selected_index: Option<usize>,
-    /// Persistent table viewport state for the top-level `Review` tab.
-    pub(super) requested_review_table_state: TableState,
+    pub(crate) requested_review_selected_index: Option<usize>,
     /// Caches requested PR/MR reviews for the active project's `Review` tab.
-    pub(super) requested_reviews: RequestedReviewState,
+    pub(crate) requested_reviews: RequestedReviewState,
     /// Number of log output lines between the visible window and the newest
     /// log lines. `0` keeps the logs page tailed to the newest events.
     pub(crate) system_log_tail_offset: u16,
@@ -260,22 +254,20 @@ pub struct App {
     pub(super) event_rx: mpsc::UnboundedReceiver<AppEvent>,
     /// Stores the latest available stable `agentty` version when one is
     /// detected.
-    pub(super) latest_available_version: Option<String>,
+    pub(crate) latest_available_version: Option<String>,
     /// Serializes local merge requests so only one merge workflow runs at a
     /// time.
     pub(super) merge_queue: MergeQueue,
     /// Tracks per-session thinking text rendered while background work is
     /// active.
-    pub(super) session_progress_messages: HashMap<SessionId, String>,
+    pub(crate) session_progress_messages: HashMap<SessionId, String>,
     /// Interacts with tmux panes for session-specific terminal workflows.
     pub(super) tmux_client: Arc<dyn TmuxClient>,
-    /// Owns UI render caches used by frame rendering and scroll-metric paths.
-    pub(super) render_cache_store: ui::RenderCacheStore,
     /// Tracks the last reduced observable-handle version for each session so
     /// stale `SessionUpdated` events do not trigger redundant redraws.
-    pub(super) last_seen_session_update_versions: HashMap<SessionId, u64>,
+    pub(crate) last_seen_session_update_versions: HashMap<SessionId, u64>,
     /// Stores the current auto-update progress state when an update is running.
-    pub(super) update_status: Option<UpdateStatus>,
+    pub(crate) update_status: Option<UpdateStatus>,
 }
 
 impl App {
@@ -365,7 +357,6 @@ impl App {
         mut items: Vec<RequestedReview>,
     ) {
         items.sort_by_key(|item| Self::requested_review_audience_order(item.audience));
-        self.reset_requested_review_table_state();
         self.requested_review_selected_index = (!items.is_empty()).then_some(0);
         self.requested_reviews = RequestedReviewState::Loaded { items, project_id };
     }
@@ -379,7 +370,6 @@ impl App {
     /// Replaces the assigned-issue list and selects the first issue when
     /// available.
     pub(crate) fn replace_assigned_issues(&mut self, project_id: i64, items: Vec<AssignedIssue>) {
-        self.reset_assigned_issue_table_state();
         self.assigned_issue_selected_index = (!items.is_empty()).then_some(0);
         self.assigned_issues = AssignedIssueState::Loaded { items, project_id };
     }
@@ -415,12 +405,6 @@ impl App {
             Some(0) | None => item_count - 1,
             Some(index) => index - 1,
         });
-    }
-
-    /// Clears the persisted review-list table viewport after loading state,
-    /// project, or result changes.
-    pub(super) fn reset_requested_review_table_state(&mut self) {
-        self.requested_review_table_state = TableState::default();
     }
 
     /// Moves selection to the next requested review in the `Inbox` tab.
@@ -645,7 +629,6 @@ impl App {
 
         self.requested_review_generation = self.requested_review_generation.saturating_add(1);
         let generation = self.requested_review_generation;
-        self.reset_requested_review_table_state();
         self.requested_review_selected_index = None;
         self.clear_requested_review_comment_fetches_for_project(project_id);
         self.requested_reviews = RequestedReviewState::Loading {
@@ -687,7 +670,6 @@ impl App {
 
         self.assigned_issue_generation = self.assigned_issue_generation.saturating_add(1);
         let generation = self.assigned_issue_generation;
-        self.reset_assigned_issue_table_state();
         self.assigned_issue_selected_index = None;
         self.assigned_issues = AssignedIssueState::Loading {
             generation,
@@ -702,11 +684,6 @@ impl App {
             self.services.review_request_client(),
         );
         self.mark_dirty();
-    }
-
-    /// Clears the persisted issue-list table viewport after state changes.
-    pub(super) fn reset_assigned_issue_table_state(&mut self) {
-        self.assigned_issue_table_state = TableState::default();
     }
 
     /// Returns the loaded assigned-issue row count when a row can be selected.
@@ -848,8 +825,8 @@ impl App {
 
         self.mode = AppMode::Prompt {
             at_mention_state: None,
-            attachment_state: crate::ui::state::prompt::PromptAttachmentState::default(),
-            history_state: crate::ui::state::prompt::PromptHistoryState::new(Vec::new()),
+            attachment_state: crate::presentation::prompt::PromptAttachmentState::default(),
+            history_state: crate::presentation::prompt::PromptHistoryState::new(Vec::new()),
             slash_state: self.prompt_slash_state(),
             session_id: SessionId::from(session_id.as_str()),
             input: InputState::default(),
@@ -1141,12 +1118,6 @@ impl App {
             .unwrap_or_default()
     }
 
-    /// Returns the UI-owned render cache store used by scroll metrics and
-    /// frame rendering.
-    pub(crate) fn render_cache_store(&self) -> &ui::RenderCacheStore {
-        &self.render_cache_store
-    }
-
     /// Returns the selected follow-up task action for one session, if that
     /// session currently exposes follow-up tasks.
     pub(crate) fn selected_follow_up_task_action(
@@ -1220,7 +1191,7 @@ impl App {
             .await;
 
         if let Some(session_id) = session_id {
-            at_mention::clear_pending_load(&session_id);
+            app::at_mention_task::clear_pending_load(&session_id);
             self.review_cache.remove(&session_id);
         }
 
@@ -1238,7 +1209,7 @@ impl App {
             .await;
 
         if let Some(session_id) = session_id {
-            at_mention::clear_pending_load(&session_id);
+            app::at_mention_task::clear_pending_load(&session_id);
             self.review_cache.remove(&session_id);
         }
 
@@ -1836,7 +1807,7 @@ impl App {
                 0,
                 InputState::default(),
                 Vec::new(),
-                question::default_option_index(&questions, 0),
+                default_option_index(&questions, 0),
             ),
         };
 

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -25,7 +25,7 @@ use crate::domain::setting::SettingName;
 use crate::infra::db::AppRepositories;
 use crate::infra::project_discovery::{HOME_PROJECT_SCAN_MAX_RESULTS, RealProjectDiscoveryClient};
 use crate::infra::tmux::{MockTmuxClient, TmuxClient};
-use crate::ui::state::app_mode::ConfirmationViewMode;
+use crate::presentation::app_mode::ConfirmationViewMode;
 
 /// Builds one reducer-ready turn projection for tests.
 fn test_turn_applied_state(
@@ -878,7 +878,7 @@ async fn test_new_with_clients_falls_back_from_stale_active_project_and_loads_cu
         .expect("failed to create current session folder");
 
     // Act
-    let mut app = App::new_with_clients(
+    let app = App::new_with_clients(
         agentty_home.clone(),
         current_project_path.clone(),
         Some("main".to_string()),

--- a/crates/agentty/src/app/project.rs
+++ b/crates/agentty/src/app/project.rs
@@ -2,9 +2,8 @@
 
 use std::path::{Path, PathBuf};
 
-use ratatui::widgets::TableState;
-
 use crate::domain::project::ProjectListItem;
+use crate::domain::selection::SelectionState;
 
 /// Borrowed project state required to draw one UI frame.
 pub(crate) struct ProjectRenderParts<'a> {
@@ -18,8 +17,8 @@ pub(crate) struct ProjectRenderParts<'a> {
     pub(crate) git_upstream_ref: Option<&'a str>,
     /// Project rows available for rendering.
     pub(crate) project_items: &'a [ProjectListItem],
-    /// Table selection state for the projects list.
-    pub(crate) table_state: &'a mut TableState,
+    /// Selected project row index.
+    pub(crate) selected_index: Option<usize>,
     /// Working directory for the active project.
     pub(crate) working_dir: &'a Path,
 }
@@ -32,7 +31,7 @@ pub struct ProjectManager {
     git_status: Option<(u32, u32)>,
     git_upstream_ref: Option<String>,
     project_items: Vec<ProjectListItem>,
-    table_state: TableState,
+    table_state: SelectionState,
     working_dir: PathBuf,
 }
 
@@ -53,7 +52,7 @@ impl ProjectManager {
             git_status: None,
             git_upstream_ref,
             project_items,
-            table_state: TableState::default(),
+            table_state: SelectionState::default(),
             working_dir,
         };
         manager.select_active_project_row();
@@ -61,20 +60,20 @@ impl ProjectManager {
         manager
     }
 
-    /// Returns project rows, active-project context, and list table state
+    /// Returns project rows, active-project context, and semantic selection
     /// required for one frame.
     ///
     /// The render parts borrow disjoint manager fields directly so
-    /// [`crate::app::App::draw`] can avoid cloning the project list on the
-    /// render hot path.
-    pub(crate) fn render_parts(&mut self) -> ProjectRenderParts<'_> {
+    /// [`crate::ui::render_app`] can avoid cloning the project list on the
+    /// render hot path while runtime retains the concrete table viewport.
+    pub(crate) fn render_parts(&self) -> ProjectRenderParts<'_> {
         ProjectRenderParts {
             active_project_id: self.active_project_id,
             git_branch: self.git_branch.as_deref(),
             git_status: self.git_status,
             git_upstream_ref: self.git_upstream_ref.as_deref(),
             project_items: &self.project_items,
-            table_state: &mut self.table_state,
+            selected_index: self.table_state.selected(),
             working_dir: self.working_dir.as_path(),
         }
     }

--- a/crates/agentty/src/app/prompt_intent.rs
+++ b/crates/agentty/src/app/prompt_intent.rs
@@ -10,8 +10,8 @@ use crate::domain::session::{SessionId, Status};
 use crate::domain::transcript_notice::TranscriptNotice;
 use crate::domain::turn_prompt::{TurnPrompt, TurnPromptAttachment, TurnPromptTextSource};
 use crate::infra::clipboard_image;
-use crate::ui::state::app_mode::AppMode;
-use crate::ui::state::prompt::{
+use crate::presentation::app_mode::AppMode;
+use crate::presentation::prompt::{
     PromptSlashStage, PromptSuggestionSelection, drain_prompt_submission,
     insert_prompt_local_image, resolve_prompt_slash_selection,
 };

--- a/crates/agentty/src/app/review.rs
+++ b/crates/agentty/src/app/review.rs
@@ -391,10 +391,9 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    use ratatui::widgets::TableState;
-
     use super::*;
     use crate::app::session_state::SessionState;
+    use crate::domain::selection::SelectionState;
     use crate::infra::clock::RealClock;
 
     /// Builds empty session state for review reducer tests that only need mode
@@ -403,7 +402,7 @@ mod tests {
         SessionState::new(
             HashMap::new(),
             Vec::new(),
-            TableState::default(),
+            SelectionState::default(),
             Arc::new(RealClock),
             0,
             0,

--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use ag_git as git;
-use ratatui::widgets::TableState;
 use tokio::task::{JoinHandle, JoinSet};
 
 use super::workflow::merge::SessionMergeService;
@@ -55,8 +54,8 @@ pub(crate) struct SessionRenderParts<'a> {
     pub(crate) sessions: &'a [Session],
     /// Daily session activity series used by dashboard activity summaries.
     pub(crate) stats_activity: &'a [DailyActivity],
-    /// Table selection state for the session list.
-    pub(crate) table_state: &'a mut TableState,
+    /// Selected session row index.
+    pub(crate) selected_index: Option<usize>,
 }
 
 /// Reducer-facing snapshot derived from one persisted turn result.
@@ -252,13 +251,13 @@ impl SessionManager {
         setting::load_default_smart_model_setting(services, project_id, fallback_model).await
     }
 
-    /// Returns session snapshots, render caches, and list table state required
-    /// for one frame.
+    /// Returns session snapshots, render caches, and semantic selection
+    /// required for one frame.
     ///
     /// The render parts borrow disjoint manager fields directly so
-    /// [`crate::app::App::draw`] can avoid cloning session maps or active
-    /// prompt output blocks on the render hot path.
-    pub(crate) fn render_parts(&mut self) -> SessionRenderParts<'_> {
+    /// [`crate::ui::render_app`] can avoid cloning session maps or active
+    /// prompt output blocks while runtime retains the concrete table viewport.
+    pub(crate) fn render_parts(&self) -> SessionRenderParts<'_> {
         SessionRenderParts {
             active_prompt_outputs: &self.active_prompt_outputs,
             session_branch_names: &self.state.session_branch_names,
@@ -267,7 +266,7 @@ impl SessionManager {
             session_worktree_availability: &self.state.session_worktree_availability,
             sessions: &self.state.sessions,
             stats_activity: &self.stats_activity,
-            table_state: &mut self.state.table_state,
+            selected_index: self.state.table_state.selected(),
         }
     }
 

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -23,6 +23,7 @@ use crate::app::{App, AppEvent, ReviewCacheEntry, SyncSessionStartError, Tab};
 use crate::domain::agent::{
     AgentKind, AgentModel, AgentSelection, AgentSelectionMetadata, ReasoningLevel,
 };
+use crate::domain::selection::SelectionState;
 use crate::domain::session::{
     DailyActivity, SESSION_DATA_DIR, Session, SessionHandles, SessionSize, SessionStats, Status,
 };
@@ -31,8 +32,8 @@ use crate::domain::setting::SettingName;
 use crate::infra::clock::RealClock;
 use crate::infra::db::AppRepositories;
 use crate::infra::fs::{self as fs, FsClient};
+use crate::presentation::app_mode::AppMode;
 use crate::ui::activity_heatmap;
-use crate::ui::state::app_mode::AppMode;
 
 /// Builds a filesystem mock that delegates operations to local disk.
 fn create_passthrough_mock_fs_client() -> fs::MockFsClient {
@@ -717,7 +718,7 @@ fn test_session_manager_with_clock(
             updated_at: 0,
             workflow_notice: None,
         }],
-        ratatui::widgets::TableState::default(),
+        crate::domain::selection::SelectionState::default(),
         clock,
         1,
         0,
@@ -1905,7 +1906,7 @@ async fn test_replace_title_generation_task_aborts_superseded_task() {
     let state = SessionState::new(
         HashMap::new(),
         Vec::new(),
-        TableState::default(),
+        SelectionState::default(),
         Arc::new(RealClock),
         1,
         0,
@@ -1962,7 +1963,7 @@ async fn test_clear_title_generation_task_if_matches_ignores_stale_generation() 
     let state = SessionState::new(
         HashMap::new(),
         Vec::new(),
-        TableState::default(),
+        SelectionState::default(),
         Arc::new(RealClock),
         1,
         0,
@@ -1997,7 +1998,7 @@ async fn test_clear_title_generation_task_if_matches_removes_matching_generation
     let state = SessionState::new(
         HashMap::new(),
         Vec::new(),
-        TableState::default(),
+        SelectionState::default(),
         Arc::new(RealClock),
         1,
         0,

--- a/crates/agentty/src/app/session/state.rs
+++ b/crates/agentty/src/app/session/state.rs
@@ -2,9 +2,8 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Instant, SystemTime};
 
-use ratatui::widgets::TableState;
-
 use crate::app::session::{Clock, SESSION_REFRESH_INTERVAL};
+use crate::domain::selection::SelectionState;
 use crate::domain::session::{Session, SessionHandles, SessionId, SessionSize};
 
 /// Cached ahead/behind snapshots for one session branch.
@@ -29,7 +28,7 @@ pub struct SessionState {
     /// Cached session list positions keyed by stable session id.
     pub(super) session_index_by_id: HashMap<SessionId, usize>,
     pub(super) sessions: Vec<Session>,
-    pub(super) table_state: TableState,
+    pub(super) table_state: SelectionState,
     pub(super) clock: Arc<dyn Clock>,
     pub(super) refresh_deadline: Instant,
     pub(super) row_count: i64,
@@ -45,7 +44,7 @@ impl SessionState {
     pub(crate) fn new(
         handles: HashMap<SessionId, SessionHandles>,
         sessions: Vec<Session>,
-        table_state: TableState,
+        table_state: SelectionState,
         clock: Arc<dyn Clock>,
         row_count: i64,
         updated_at_max: i64,
@@ -404,9 +403,8 @@ mod tests {
     use std::sync::Arc;
     use std::time::{Duration, Instant, SystemTime};
 
-    use ratatui::widgets::TableState;
-
     use super::*;
+    use crate::domain::selection::SelectionState;
     use crate::domain::session::{Session, SessionHandles, SessionSize, SessionStats, Status};
     use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
     use crate::test_support::SessionFixtureBuilder;
@@ -490,7 +488,7 @@ mod tests {
         let mut state = SessionState::new(
             handles,
             vec![session],
-            TableState::default(),
+            SelectionState::default(),
             Arc::new(FixedClock::new()),
             0,
             0,
@@ -665,7 +663,7 @@ mod tests {
         let mut state = SessionState::new(
             HashMap::new(),
             vec![session],
-            TableState::default(),
+            SelectionState::default(),
             Arc::new(FixedClock::new()),
             0,
             0,
@@ -751,7 +749,7 @@ mod tests {
         let mut state = SessionState::new(
             HashMap::new(),
             vec![initial_session],
-            TableState::default(),
+            SelectionState::default(),
             Arc::new(FixedClock::new()),
             0,
             0,
@@ -837,7 +835,7 @@ mod tests {
         let mut state = SessionState::new(
             HashMap::new(),
             vec![first_session, second_session],
-            TableState::default(),
+            SelectionState::default(),
             Arc::new(FixedClock::new()),
             0,
             0,
@@ -912,7 +910,7 @@ mod tests {
         let mut state = SessionState::new(
             HashMap::new(),
             Vec::new(),
-            TableState::default(),
+            SelectionState::default(),
             Arc::new(FixedClock::new()),
             0,
             0,
@@ -1035,7 +1033,7 @@ mod tests {
         let mut state = SessionState::new(
             HashMap::new(),
             vec![surviving_session, taskless_session],
-            TableState::default(),
+            SelectionState::default(),
             Arc::new(FixedClock::new()),
             0,
             0,

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -2994,13 +2994,13 @@ mod tests {
     use std::sync::Arc;
 
     use ag_forge as forge;
-    use ratatui::widgets::TableState;
     use tokio::sync::mpsc;
 
     use super::*;
     use crate::app::session::SessionDefaults;
     use crate::app::{AppEvent, AppServices, SessionState};
     use crate::domain::agent::{AgentKind, AgentModel, ReasoningLevel};
+    use crate::domain::selection::SelectionState;
     use crate::domain::session::{
         ForgeKind, ReviewRequestState, ReviewRequestSummary, SessionHandles,
     };
@@ -3023,7 +3023,7 @@ mod tests {
         let state = SessionState::new(
             handles,
             vec![session],
-            TableState::default(),
+            SelectionState::default(),
             Arc::new(RealClock),
             1,
             0,
@@ -4305,7 +4305,7 @@ mod tests {
         let state = SessionState::new(
             handles,
             sessions,
-            TableState::default(),
+            SelectionState::default(),
             Arc::new(RealClock),
             row_count,
             0,

--- a/crates/agentty/src/app/session/workflow/refresh.rs
+++ b/crates/agentty/src/app/session/workflow/refresh.rs
@@ -9,7 +9,7 @@ use super::SESSION_REFRESH_INTERVAL;
 use crate::app::session::SessionError;
 use crate::app::{AppServices, ProjectManager, SessionManager};
 use crate::domain::session::{ForgeKind, ReviewRequest, SessionId};
-use crate::ui::state::app_mode::{AppMode, ConfirmationViewMode};
+use crate::presentation::app_mode::{AppMode, ConfirmationViewMode};
 
 impl SessionManager {
     /// Reloads session rows when the metadata cache indicates a change.
@@ -308,7 +308,6 @@ mod tests {
 
     use ag_forge as forge;
     use ag_git as git;
-    use ratatui::widgets::TableState;
     use tempfile::tempdir;
     use tokio::sync::mpsc;
 
@@ -316,6 +315,7 @@ mod tests {
     use crate::app::session::{Clock, SessionDefaults};
     use crate::app::{AppServices, SessionState};
     use crate::domain::agent::AgentKind;
+    use crate::domain::selection::SelectionState;
     use crate::domain::session::{
         ForgeKind, ReviewRequest, ReviewRequestState, ReviewRequestSummary, Session,
         SessionHandles, Status,
@@ -423,7 +423,14 @@ mod tests {
                 model: AgentKind::Antigravity.default_model(),
             },
             Arc::new(git::MockGitClient::new()),
-            SessionState::new(handles, vec![session], TableState::default(), clock, 1, 0),
+            SessionState::new(
+                handles,
+                vec![session],
+                SelectionState::default(),
+                clock,
+                1,
+                0,
+            ),
             Vec::new(),
         )
     }
@@ -729,7 +736,7 @@ mod tests {
             SessionState::new(
                 HashMap::new(),
                 Vec::new(),
-                TableState::default(),
+                SelectionState::default(),
                 clock,
                 0,
                 0,

--- a/crates/agentty/src/app/setting.rs
+++ b/crates/agentty/src/app/setting.rs
@@ -1,4 +1,3 @@
-use ratatui::widgets::TableState;
 use tracing::warn;
 
 use crate::app::AppServices;
@@ -6,6 +5,7 @@ use crate::domain::agent::{
     self, AgentKind, AgentModel, AgentSelection, AgentSelectionMetadata, ReasoningLevel,
 };
 use crate::domain::input::InputState;
+use crate::domain::selection::SelectionState;
 use crate::domain::setting::SettingName;
 use crate::domain::theme::ColorTheme;
 use crate::infra::db::AppRepositories;
@@ -313,8 +313,8 @@ pub struct SettingsManager {
     ///
     /// Currently applied to Codex and Claude turns.
     pub reasoning_level: ReasoningLevel,
-    /// Table selection state for the settings page.
-    pub table_state: TableState,
+    /// Frontend-neutral selected-row state for the settings page.
+    pub table_state: SelectionState,
     /// Active terminal color theme for the whole application.
     pub theme: ColorTheme,
     available_agent_kinds: Vec<AgentKind>,
@@ -383,7 +383,7 @@ impl SettingsManager {
         .await;
         let theme = load_theme_setting(services).await;
 
-        let mut table_state = TableState::default();
+        let mut table_state = SelectionState::default();
         table_state.select(Some(0));
 
         Self {
@@ -1613,11 +1613,11 @@ mod tests {
     use ag_agent::MockAppServerClient;
     use ag_forge as forge;
     use ag_git as git;
-    use ratatui::widgets::TableState;
     use tokio::sync::mpsc;
 
     use super::*;
     use crate::db::AppRepositories;
+    use crate::domain::selection::SelectionState;
     use crate::infra::fs;
 
     /// Builds app services backed by an in-memory database for settings tests.
@@ -1654,7 +1654,7 @@ mod tests {
     }
 
     fn new_settings_manager() -> SettingsManager {
-        let mut table_state = TableState::default();
+        let mut table_state = SelectionState::default();
         table_state.select(Some(0));
 
         SettingsManager {

--- a/crates/agentty/src/app/startup.rs
+++ b/crates/agentty/src/app/startup.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use ag_agent::AgentAvailabilityProbe;
 use ag_git::GitClient;
-use ratatui::widgets::TableState;
 use tokio::sync::mpsc;
 
 use super::core::{AGENTTY_WT_DIR, AppEvent};
@@ -18,6 +17,7 @@ use crate::app::tab::Tab;
 use crate::app::{AppError, session};
 use crate::domain::agent::{AgentKind, AgentModel};
 use crate::domain::project::{Project, ProjectListItem, project_name_from_path};
+use crate::domain::selection::SelectionState;
 use crate::domain::session_order;
 use crate::domain::setting::SettingName;
 use crate::infra::db::AppRepositories;
@@ -204,7 +204,7 @@ impl AppStartup {
             default_session_model,
             startup_working_dir,
         } = context;
-        let mut table_state = TableState::default();
+        let mut table_state = SelectionState::default();
         let mut handles = std::collections::HashMap::new();
         let fs_client = services.fs_client();
         let (sessions, stats_activity, session_worktree_availability) =

--- a/crates/agentty/src/app/sync_message.rs
+++ b/crates/agentty/src/app/sync_message.rs
@@ -1,0 +1,36 @@
+//! Application result formatting for synchronization summaries.
+
+const SYNC_SUCCESS_HEADER: &str = "Successfully synchronized with its upstream.";
+
+/// Builds synchronization completion copy with separated markdown sections.
+pub(crate) fn format_sync_success_message(
+    pulled_summary: &str,
+    pulled_titles: &str,
+    pushed_summary: &str,
+    pushed_titles: &str,
+    conflict_summary: &str,
+) -> String {
+    let pull_section = sync_success_section(&format!("## 1. {pulled_summary}"), pulled_titles);
+    let push_section = sync_success_section(&format!("## 2. {pushed_summary}"), pushed_titles);
+    let conflict_section = sync_success_section(&format!("## 3. {conflict_summary}"), "");
+
+    [
+        SYNC_SUCCESS_HEADER,
+        &pull_section,
+        &push_section,
+        &conflict_section,
+    ]
+    .join("\n\n")
+}
+
+fn sync_success_section(title: &str, details: &str) -> String {
+    let mut lines = Vec::with_capacity(2);
+
+    lines.push(title.to_string());
+
+    if !details.is_empty() {
+        lines.push(details.to_string());
+    }
+
+    lines.join("\n")
+}

--- a/crates/agentty/src/app/view.rs
+++ b/crates/agentty/src/app/view.rs
@@ -1,0 +1,149 @@
+//! Immutable application view projection consumed by frontends.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::app::session_state::SessionGitStatus;
+use crate::app::{
+    App, AssignedIssueState, RequestedReviewState, SettingsManager, Tab, UpdateStatus,
+    review_view_state, session,
+};
+use crate::domain::agent::AgentCliInfo;
+use crate::domain::project::ProjectListItem;
+use crate::domain::session::{DailyActivity, Session, SessionId};
+use crate::domain::system_log::SystemLogBuffer;
+use crate::infra::review_comment_cache::ReviewCommentCache;
+use crate::presentation::app_mode::{AppMode, HelpContext};
+
+/// Focused-review display state for the visible session.
+pub(crate) struct SessionReviewView<'a> {
+    pub(crate) session_id: &'a str,
+    pub(crate) status_message: Option<String>,
+    pub(crate) text: Option<&'a str>,
+}
+
+/// Borrowed immutable application data required by one frontend frame.
+pub(crate) struct AppViewSnapshot<'a> {
+    pub(crate) active_project_id: i64,
+    pub(crate) active_prompt_outputs: &'a HashMap<SessionId, String>,
+    pub(crate) assigned_issue_selected_index: Option<usize>,
+    pub(crate) assigned_issues: &'a AssignedIssueState,
+    pub(crate) available_agent_clis: Vec<AgentCliInfo>,
+    pub(crate) current_tab: Tab,
+    pub(crate) git_branch: Option<&'a str>,
+    pub(crate) git_status: Option<(u32, u32)>,
+    pub(crate) git_upstream_ref: Option<&'a str>,
+    pub(crate) latest_available_version: Option<&'a str>,
+    pub(crate) mode: &'a AppMode,
+    pub(crate) project_selected_index: Option<usize>,
+    pub(crate) projects: &'a [ProjectListItem],
+    pub(crate) requested_review_selected_index: Option<usize>,
+    pub(crate) requested_reviews: &'a RequestedReviewState,
+    pub(crate) review_comment_cache: ReviewCommentCache,
+    pub(crate) session_branch_names: &'a HashMap<SessionId, String>,
+    pub(crate) session_git_statuses: &'a HashMap<SessionId, SessionGitStatus>,
+    pub(crate) session_index_by_id: &'a HashMap<SessionId, usize>,
+    pub(crate) session_progress_messages: &'a HashMap<SessionId, String>,
+    pub(crate) session_review: Option<SessionReviewView<'a>>,
+    pub(crate) session_selected_index: Option<usize>,
+    pub(crate) session_update_versions: &'a HashMap<SessionId, u64>,
+    pub(crate) session_worktree_availability: &'a HashMap<SessionId, bool>,
+    pub(crate) sessions: &'a [Session],
+    pub(crate) settings: &'a SettingsManager,
+    pub(crate) stats_activity: &'a [DailyActivity],
+    pub(crate) status_bar_fyi_rotation_index: u64,
+    pub(crate) system_log_tail_offset: u16,
+    pub(crate) system_logs: &'a SystemLogBuffer,
+    pub(crate) update_status: Option<&'a UpdateStatus>,
+    pub(crate) wall_clock_unix_seconds: i64,
+    pub(crate) working_dir: &'a Path,
+}
+
+impl App {
+    /// Projects immutable application state for one frontend frame.
+    pub(crate) fn view_snapshot(&self) -> AppViewSnapshot<'_> {
+        let wall_clock_unix_seconds =
+            session::unix_timestamp_from_system_time(self.sessions.state().now_system_time());
+        let status_bar_fyi_rotation_index =
+            u64::try_from(wall_clock_unix_seconds.div_euclid(60)).unwrap_or_default();
+        let visible_session_id = visible_review_session_id(&self.mode);
+        let session_review = visible_session_id.map(|session_id| {
+            let (status_message, text) = review_view_state(
+                &self.review_cache,
+                session_id,
+                self.settings.default_review_selection.model(),
+            );
+
+            SessionReviewView {
+                session_id,
+                status_message,
+                text,
+            }
+        });
+        let project = self.projects.render_parts();
+        let sessions = self.sessions.render_parts();
+
+        AppViewSnapshot {
+            active_project_id: project.active_project_id,
+            active_prompt_outputs: sessions.active_prompt_outputs,
+            assigned_issue_selected_index: self.assigned_issue_selected_index(),
+            assigned_issues: &self.assigned_issues,
+            available_agent_clis: self.services.available_agent_clis(),
+            current_tab: self.tabs.current(),
+            git_branch: project.git_branch,
+            git_status: project.git_status,
+            git_upstream_ref: project.git_upstream_ref,
+            latest_available_version: self.latest_available_version.as_deref(),
+            mode: &self.mode,
+            project_selected_index: project.selected_index,
+            projects: project.project_items,
+            requested_review_selected_index: self.requested_review_selected_index(),
+            requested_reviews: &self.requested_reviews,
+            review_comment_cache: self.services.review_comment_cache(),
+            session_branch_names: sessions.session_branch_names,
+            session_git_statuses: sessions.session_git_statuses,
+            session_index_by_id: sessions.session_index_by_id,
+            session_progress_messages: &self.session_progress_messages,
+            session_review,
+            session_selected_index: sessions.selected_index,
+            session_update_versions: &self.last_seen_session_update_versions,
+            session_worktree_availability: sessions.session_worktree_availability,
+            sessions: sessions.sessions,
+            settings: &self.settings,
+            stats_activity: sessions.stats_activity,
+            status_bar_fyi_rotation_index,
+            system_log_tail_offset: self.system_log_tail_offset,
+            system_logs: &self.system_logs,
+            update_status: self.update_status.as_ref(),
+            wall_clock_unix_seconds,
+            working_dir: project.working_dir,
+        }
+    }
+}
+
+/// Returns the session visible behind the active presentation mode.
+fn visible_review_session_id(mode: &AppMode) -> Option<&str> {
+    match mode {
+        AppMode::View { session_id, .. }
+        | AppMode::Prompt { session_id, .. }
+        | AppMode::Question { session_id, .. }
+        | AppMode::Diff { session_id, .. }
+        | AppMode::Help {
+            context: HelpContext::View { session_id, .. } | HelpContext::Diff { session_id, .. },
+            ..
+        } => Some(session_id),
+        AppMode::Confirmation {
+            restore_view: Some(restore_view),
+            ..
+        }
+        | AppMode::LaunchConfigurationSelector { restore_view, .. }
+        | AppMode::PublishBranchInput { restore_view, .. }
+        | AppMode::ViewInfoPopup { restore_view, .. } => Some(&restore_view.session_id),
+        AppMode::List
+        | AppMode::ReviewDetail { .. }
+        | AppMode::SessionCreation { .. }
+        | AppMode::Confirmation { .. }
+        | AppMode::SyncBlockedPopup { .. }
+        | AppMode::Help { .. } => None,
+    }
+}

--- a/crates/agentty/src/domain.rs
+++ b/crates/agentty/src/domain.rs
@@ -6,6 +6,7 @@ pub mod input;
 pub mod project;
 pub mod question;
 pub mod review;
+pub mod selection;
 pub mod session;
 pub mod session_message;
 pub mod session_order;

--- a/crates/agentty/src/domain/file_entry.rs
+++ b/crates/agentty/src/domain/file_entry.rs
@@ -1,5 +1,21 @@
 //! File-entry model shared by file indexing, prompt state, and UI layout.
 
+use std::path::PathBuf;
+
+/// Selects the directory backing an active `@`-mention lookup.
+#[must_use]
+pub fn at_mention_lookup_root(
+    project_working_dir: PathBuf,
+    session_folder: Option<PathBuf>,
+    has_session_folder: bool,
+) -> PathBuf {
+    if has_session_folder && let Some(session_folder) = session_folder {
+        return session_folder;
+    }
+
+    project_working_dir
+}
+
 /// A single file or directory entry for `@` mention dropdowns and explorer
 /// lists.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/agentty/src/domain/question.rs
+++ b/crates/agentty/src/domain/question.rs
@@ -5,6 +5,18 @@ pub use ag_protocol::QuestionItem;
 
 use crate::domain::input::InputState;
 
+/// Returns the initial highlighted option for a clarification question.
+///
+/// Questions with predefined options begin on the first option; free-text
+/// questions begin with no highlighted option.
+#[must_use]
+pub fn default_option_index(questions: &[QuestionItem], question_index: usize) -> Option<usize> {
+    questions
+        .get(question_index)
+        .filter(|item| !item.options.is_empty())
+        .map(|_| 0)
+}
+
 /// Partially answered clarification state saved when the user leaves question
 /// mode for the sessions list.
 ///

--- a/crates/agentty/src/domain/selection.rs
+++ b/crates/agentty/src/domain/selection.rs
@@ -1,0 +1,20 @@
+//! Frontend-neutral list selection state.
+
+/// Semantic selection for one ordered list.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct SelectionState {
+    selected: Option<usize>,
+}
+
+impl SelectionState {
+    /// Returns the selected row index.
+    #[must_use]
+    pub const fn selected(&self) -> Option<usize> {
+        self.selected
+    }
+
+    /// Replaces the selected row index.
+    pub fn select(&mut self, selected: Option<usize>) {
+        self.selected = selected;
+    }
+}

--- a/crates/agentty/src/lib.rs
+++ b/crates/agentty/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app;
 pub mod domain;
 pub mod infra;
+pub mod presentation;
 pub mod ui;
 
 pub mod runtime;

--- a/crates/agentty/src/presentation.rs
+++ b/crates/agentty/src/presentation.rs
@@ -1,0 +1,8 @@
+//! Frontend-neutral interaction state shared by runtime input and UI output.
+
+#[path = "ui/state/app_mode.rs"]
+pub mod app_mode;
+#[path = "ui/state/help_action.rs"]
+pub mod help_action;
+#[path = "ui/state/prompt.rs"]
+pub mod prompt;

--- a/crates/agentty/src/runtime.rs
+++ b/crates/agentty/src/runtime.rs
@@ -7,10 +7,12 @@ mod core;
 mod event;
 mod key_handler;
 pub mod mode;
+mod presentation;
 mod terminal;
 mod timing;
 
 pub(crate) use core::{EventResult, TuiTerminal, backend_err};
 pub use core::{run, run_with_backend};
 
+pub(crate) use presentation::PresentationState;
 pub(crate) use timing::FRAME_INTERVAL;

--- a/crates/agentty/src/runtime/core.rs
+++ b/crates/agentty/src/runtime/core.rs
@@ -3,6 +3,7 @@
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::time::{Duration, Instant};
@@ -13,7 +14,7 @@ use tokio::sync::mpsc;
 
 use crate::app::App;
 use crate::infra::clock::Clock;
-use crate::runtime::{FRAME_INTERVAL, event, terminal};
+use crate::runtime::{FRAME_INTERVAL, PresentationState, event, terminal};
 
 /// Fallback redraw cadence for visible spinner and timer UI when no new
 /// events arrive.
@@ -111,6 +112,7 @@ where
         clock,
         event_rx,
         last_draw_at,
+        presentation: Rc::new(PresentationState::default()),
         terminal,
         tick,
     };
@@ -124,6 +126,7 @@ struct MainLoopState<'a, B: Backend> {
     clock: Arc<dyn Clock>,
     event_rx: &'a mut mpsc::UnboundedReceiver<crossterm::event::Event>,
     last_draw_at: Instant,
+    presentation: Rc<PresentationState>,
     terminal: &'a mut Terminal<B>,
     tick: &'a mut tokio::time::Interval,
 }
@@ -147,9 +150,17 @@ where
             self.terminal,
             self.clock.as_ref(),
             &mut self.last_draw_at,
+            self.presentation.as_ref(),
         )?;
 
-        event::process_events(self.app, self.terminal, self.event_rx, self.tick).await
+        event::process_events(
+            self.app,
+            Rc::clone(&self.presentation),
+            self.terminal,
+            self.event_rx,
+            self.tick,
+        )
+        .await
     }
 }
 
@@ -182,6 +193,7 @@ fn render_frame<B: Backend>(
     terminal: &mut Terminal<B>,
     clock: &dyn Clock,
     last_draw_at: &mut Instant,
+    presentation: &PresentationState,
 ) -> io::Result<()>
 where
     B::Error: std::error::Error + Send + Sync + 'static,
@@ -192,8 +204,23 @@ where
         return Ok(());
     }
 
+    let mut assigned_issue_table_state = presentation.assigned_issue_table_state();
+    let mut project_table_state = presentation.project_table_state();
+    let mut requested_review_table_state = presentation.requested_review_table_state();
+    let mut session_table_state = presentation.session_table_state();
+    let snapshot = app.view_snapshot();
     terminal
-        .draw(|frame| app.draw(frame))
+        .draw(|frame| {
+            crate::ui::render_app(
+                &snapshot,
+                frame,
+                &mut assigned_issue_table_state,
+                &mut project_table_state,
+                presentation.render_cache_store(),
+                &mut requested_review_table_state,
+                &mut session_table_state,
+            );
+        })
         .map_err(backend_err)?;
     app.clear_redraw();
     *last_draw_at = clock.now_instant();
@@ -224,8 +251,8 @@ mod tests {
     use crate::app::AppEvent;
     use crate::domain::session::{SessionHandles, Status};
     use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
+    use crate::presentation::app_mode::AppMode;
     use crate::test_support::SessionFixtureBuilder;
-    use crate::ui::state::app_mode::AppMode;
 
     /// Test-only loop state that records call counts and scripted outcomes.
     struct TestLoopState {
@@ -562,6 +589,7 @@ mod tests {
             clock,
             event_rx: &mut event_rx,
             last_draw_at,
+            presentation: Rc::new(PresentationState::default()),
             terminal: &mut terminal,
             tick: &mut tick,
         };

--- a/crates/agentty/src/runtime/event.rs
+++ b/crates/agentty/src/runtime/event.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -12,8 +13,8 @@ use tokio::sync::mpsc;
 use tracing::debug;
 
 use crate::app::{App, AppEvent};
-use crate::runtime::{EventResult, FRAME_INTERVAL, key_handler, mode};
-use crate::ui::state::app_mode::AppMode;
+use crate::presentation::app_mode::AppMode;
+use crate::runtime::{EventResult, FRAME_INTERVAL, PresentationState, key_handler, mode};
 
 /// Maximum terminal input events processed in one foreground cycle.
 ///
@@ -94,6 +95,7 @@ fn spawn_event_reader_with_source(
 /// processing cycle.
 pub(crate) async fn process_events<B: Backend>(
     app: &mut App,
+    presentation: Rc<PresentationState>,
     terminal: &mut Terminal<B>,
     event_rx: &mut mpsc::UnboundedReceiver<Event>,
     tick: &mut tokio::time::Interval,
@@ -102,7 +104,9 @@ where
     B::Error: std::error::Error + Send + Sync + 'static,
 {
     process_events_with_handler(app, terminal, event_rx, tick, |app, terminal, event| {
-        Box::pin(process_event(app, terminal, event))
+        let presentation = Rc::clone(&presentation);
+
+        Box::pin(process_event(app, presentation, terminal, event))
     })
     .await
 }
@@ -202,6 +206,7 @@ where
 /// content is inserted as text instead of interpreted as navigation keys.
 async fn process_event<B: Backend>(
     app: &mut App,
+    presentation: Rc<PresentationState>,
     terminal: &mut Terminal<B>,
     event: Option<Event>,
 ) -> io::Result<EventResult>
@@ -209,7 +214,11 @@ where
     B::Error: std::error::Error + Send + Sync + 'static,
 {
     process_event_with_key_handler(app, terminal, event, |app, terminal, key| {
-        Box::pin(key_handler::handle_key_event(app, terminal, key))
+        let presentation = Rc::clone(&presentation);
+
+        Box::pin(async move {
+            key_handler::handle_key_event(app, presentation.as_ref(), terminal, key).await
+        })
     })
     .await
 }
@@ -280,8 +289,10 @@ mod tests {
     use crate::domain::input::InputState;
     use crate::domain::question::QuestionItem;
     use crate::domain::session::{Session, SessionSize, SessionStats, Status};
-    use crate::ui::state::app_mode::{AppMode, QuestionFocus};
-    use crate::ui::state::prompt::{PromptAttachmentState, PromptHistoryState, PromptSlashState};
+    use crate::presentation::app_mode::{AppMode, QuestionFocus};
+    use crate::presentation::prompt::{
+        PromptAttachmentState, PromptHistoryState, PromptSlashState,
+    };
 
     /// Verifies the event reader forwards one queued event before stopping on
     /// a poll error.

--- a/crates/agentty/src/runtime/key_handler.rs
+++ b/crates/agentty/src/runtime/key_handler.rs
@@ -9,9 +9,9 @@ use tracing::warn;
 use crate::app::{App, ReviewCacheEntry, diff_content_hash};
 use crate::domain::session::SessionId;
 use crate::domain::transcript_notice::TranscriptNotice;
+use crate::presentation::app_mode::{AppMode, ConfirmationIntent, ConfirmationViewMode};
 use crate::runtime::mode::confirmation::ConfirmationDecision;
-use crate::runtime::{EventResult, backend_err, mode};
-use crate::ui::state::app_mode::{AppMode, ConfirmationIntent, ConfirmationViewMode};
+use crate::runtime::{EventResult, PresentationState, backend_err, mode};
 
 /// Routes key events to the active mode handler and returns the next runtime
 /// action.
@@ -20,6 +20,7 @@ use crate::ui::state::app_mode::{AppMode, ConfirmationIntent, ConfirmationViewMo
 /// the updated UI state.
 pub(crate) async fn handle_key_event<B: Backend>(
     app: &mut App,
+    presentation: &PresentationState,
     terminal: &mut Terminal<B>,
     key: KeyEvent,
 ) -> io::Result<EventResult>
@@ -48,7 +49,12 @@ where
                 let terminal_rect = Rect::new(0, 0, size.width, size.height);
                 let content_area = content_area_for_terminal(terminal_rect);
 
-                Ok(mode::review_detail::handle(app, content_area, key))
+                Ok(mode::review_detail::handle_with_cache(
+                    app,
+                    presentation.render_cache_store(),
+                    content_area,
+                    key,
+                ))
             }
             AppMode::SessionCreation { .. } => {
                 unreachable!("session creation mode is handled before dispatch matching")
@@ -58,20 +64,39 @@ where
             AppMode::Confirmation { .. } => {
                 unreachable!("confirmation mode is handled before dispatch matching")
             }
-            AppMode::View { .. } => mode::session_view::handle(app, terminal, key).await,
+            AppMode::View { .. } => {
+                mode::session_view::handle_with_cache(
+                    app,
+                    presentation.render_cache_store(),
+                    terminal,
+                    key,
+                )
+                .await
+            }
             AppMode::Prompt { .. } => mode::prompt::handle(app, terminal, key).await,
             AppMode::Question { .. } => {
                 let size = terminal.size().map_err(backend_err)?;
                 let terminal_rect = Rect::new(0, 0, size.width, size.height);
 
-                Ok(mode::question::handle(app, terminal_rect, key).await)
+                Ok(mode::question::handle_with_cache(
+                    app,
+                    presentation.render_cache_store(),
+                    terminal_rect,
+                    key,
+                )
+                .await)
             }
             AppMode::Diff { .. } => {
                 let size = terminal.size().map_err(backend_err)?;
                 let terminal_rect = Rect::new(0, 0, size.width, size.height);
                 let content_area = content_area_for_terminal(terminal_rect);
 
-                Ok(mode::diff::handle(app, content_area, key))
+                Ok(mode::diff::handle_with_cache(
+                    app,
+                    presentation.render_cache_store(),
+                    content_area,
+                    key,
+                ))
             }
             AppMode::Help { .. } => Ok(mode::help::handle(app, key)),
             AppMode::LaunchConfigurationSelector { .. } => {
@@ -688,7 +713,7 @@ mod tests {
     use super::*;
     use crate::domain::session_message::SessionTranscript;
     use crate::infra::tmux::MockTmuxClient;
-    use crate::ui::state::app_mode::ConfirmationViewMode;
+    use crate::presentation::app_mode::ConfirmationViewMode;
 
     fn session_replay_text(session: &crate::domain::session::Session) -> String {
         session
@@ -939,6 +964,7 @@ mod tests {
         // Act
         let event_result = handle_key_event(
             &mut app,
+            &PresentationState::default(),
             &mut terminal,
             KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE),
         )

--- a/crates/agentty/src/runtime/mode/at_mention.rs
+++ b/crates/agentty/src/runtime/mode/at_mention.rs
@@ -1,28 +1,24 @@
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
+#[cfg(test)]
+use at_mention_task::clear_pending_load;
 use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
 use tracing::warn;
 
-use crate::app::AppEvent;
 use crate::app::session::SessionManager;
-use crate::domain::file_entry::FileEntry;
+use crate::app::{AppEvent, at_mention_task};
+use crate::domain::file_entry::{FileEntry, at_mention_lookup_root};
 use crate::domain::input::InputState;
 use crate::domain::session::SessionId;
 use crate::infra::file_index;
-use crate::ui::state::prompt::PromptAtMentionState;
+use crate::presentation::prompt::PromptAtMentionState;
 
 /// Delay applied before a fresh `@`-mention filesystem walk starts.
 const AT_MENTION_LOAD_DEBOUNCE: Duration = Duration::from_millis(75);
 /// Monotonic counter used to distinguish stale and current load tasks.
 static NEXT_AT_MENTION_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
-/// Per-session debounced file-index tasks keyed by session identifier.
-static PENDING_AT_MENTION_LOADS: LazyLock<Mutex<HashMap<SessionId, PendingAtMentionLoad>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Describes how one mode should update its visible `@`-mention state after an
 /// input edit or cursor move.
@@ -45,14 +41,6 @@ pub(crate) struct AtMentionSelection {
     pub text: String,
     /// Start character index of the active `@query`.
     pub at_start: usize,
-}
-
-/// Tracks one debounced background file-index load for a session.
-struct PendingAtMentionLoad {
-    /// Background task that sleeps, walks, and publishes the latest entries.
-    handle: JoinHandle<()>,
-    /// Monotonic identifier used to ignore stale completions.
-    request_id: u64,
 }
 
 /// Returns the next `@`-mention sync action for one input buffer and dropdown
@@ -131,41 +119,10 @@ pub(crate) fn start_loading_entries(
             );
         }
 
-        finish_pending_load(&task_session_id, request_id);
+        at_mention_task::finish_pending_load(&task_session_id, request_id);
     });
 
-    track_pending_load(tracked_session_id, request_id, handle);
-}
-
-/// Aborts and removes any pending debounced load for one session.
-pub(crate) fn clear_pending_load(session_id: &str) {
-    if let Ok(mut pending_loads) = PENDING_AT_MENTION_LOADS.lock()
-        && let Some(pending_load) = pending_loads.remove(session_id)
-    {
-        pending_load.handle.abort();
-    }
-}
-
-/// Stores the latest pending load task for one session and aborts any stale
-/// debounced predecessor.
-fn track_pending_load(session_id: SessionId, request_id: u64, handle: JoinHandle<()>) {
-    if let Ok(mut pending_loads) = PENDING_AT_MENTION_LOADS.lock()
-        && let Some(previous_task) =
-            pending_loads.insert(session_id, PendingAtMentionLoad { handle, request_id })
-    {
-        previous_task.handle.abort();
-    }
-}
-
-/// Clears a pending task entry when the completing request is still current.
-fn finish_pending_load(session_id: &str, request_id: u64) {
-    if let Ok(mut pending_loads) = PENDING_AT_MENTION_LOADS.lock()
-        && pending_loads
-            .get(session_id)
-            .is_some_and(|task| task.request_id == request_id)
-    {
-        pending_loads.remove(session_id);
-    }
+    at_mention_task::track_pending_load(tracked_session_id, request_id, handle);
 }
 
 /// Returns the directory that should back one active `@`-mention lookup.
@@ -178,11 +135,7 @@ pub(crate) fn lookup_root(
     session_folder: Option<PathBuf>,
     has_session_folder: bool,
 ) -> PathBuf {
-    if has_session_folder && let Some(session_folder) = session_folder {
-        return session_folder;
-    }
-
-    project_working_dir
+    at_mention_lookup_root(project_working_dir, session_folder, has_session_folder)
 }
 
 /// Returns the lookup root for an optional session folder after checking
@@ -276,13 +229,13 @@ mod tests {
     use std::sync::Arc;
 
     use ag_git as git;
-    use ratatui::widgets::TableState;
     use tempfile::TempDir;
 
     use super::*;
     use crate::app::SessionState;
     use crate::app::session::SessionDefaults;
     use crate::domain::agent::AgentModel;
+    use crate::domain::selection::SelectionState;
     use crate::domain::session::{Session, SessionHandles, SessionSize, SessionStats, Status};
     use crate::infra::clock::RealClock;
 
@@ -569,7 +522,7 @@ mod tests {
                 updated_at: 0,
                 workflow_notice: None,
             }],
-            TableState::default(),
+            SelectionState::default(),
             Arc::new(RealClock),
             1,
             0,

--- a/crates/agentty/src/runtime/mode/diff.rs
+++ b/crates/agentty/src/runtime/mode/diff.rs
@@ -2,10 +2,10 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::Rect;
 
 use crate::app::App;
+use crate::presentation::app_mode::{AppMode, DiffScrollCache, HelpContext, ViewportRect};
 use crate::runtime::EventResult;
 use crate::ui::component::file_explorer::FileExplorer;
-use crate::ui::page;
-use crate::ui::state::app_mode::{AppMode, DiffScrollCache, HelpContext};
+use crate::ui::{RenderCacheStore, page};
 
 /// Handles key input while the app is in `AppMode::Diff`.
 ///
@@ -13,7 +13,12 @@ use crate::ui::state::app_mode::{AppMode, DiffScrollCache, HelpContext};
 /// explorer entries. Leaving diff mode restores the prior question snapshot
 /// when present; otherwise it rebuilds session view with any cached focused
 /// review output for the same session.
-pub(crate) fn handle(app: &mut App, content_area: Rect, key: KeyEvent) -> EventResult {
+pub(crate) fn handle_with_cache(
+    app: &mut App,
+    render_cache_store: &RenderCacheStore,
+    content_area: Rect,
+    key: KeyEvent,
+) -> EventResult {
     if handle_help_key(app, key) {
         return EventResult::Continue;
     }
@@ -26,9 +31,14 @@ pub(crate) fn handle(app: &mut App, content_area: Rect, key: KeyEvent) -> EventR
         return EventResult::Continue;
     }
 
-    handle_navigation_key(app, content_area, key);
+    handle_navigation_key(app, render_cache_store, content_area, key);
 
     EventResult::Continue
+}
+
+#[cfg(test)]
+fn handle(app: &mut App, content_area: Rect, key: KeyEvent) -> EventResult {
+    handle_with_cache(app, &RenderCacheStore::default(), content_area, key)
 }
 
 /// Toggles the diff-mode right-hand panel between diff and comments.
@@ -110,7 +120,12 @@ fn handle_exit_key(app: &mut App, key: KeyEvent) -> bool {
 }
 
 /// Applies file-selection and scroll navigation keys in diff mode.
-fn handle_navigation_key(app: &mut App, content_area: Rect, key: KeyEvent) {
+fn handle_navigation_key(
+    app: &mut App,
+    render_cache_store: &RenderCacheStore,
+    content_area: Rect,
+    key: KeyEvent,
+) {
     let mode = std::mem::replace(&mut app.mode, AppMode::List);
     let AppMode::Diff {
         diff,
@@ -129,7 +144,7 @@ fn handle_navigation_key(app: &mut App, content_area: Rect, key: KeyEvent) {
 
     match key.code {
         KeyCode::Char('j') if is_plain_char_key(key, 'j') => {
-            let content = app.render_cache_store().diff_layout_cache().content(&diff);
+            let content = render_cache_store.diff_layout_cache().content(&diff);
             let new_index = FileExplorer::next_selected_index(
                 file_explorer_selected_index,
                 content.item_count(),
@@ -142,7 +157,7 @@ fn handle_navigation_key(app: &mut App, content_area: Rect, key: KeyEvent) {
             }
         }
         KeyCode::Char('k') if is_plain_char_key(key, 'k') => {
-            let content = app.render_cache_store().diff_layout_cache().content(&diff);
+            let content = render_cache_store.diff_layout_cache().content(&diff);
             let new_index = FileExplorer::previous_selected_index(
                 file_explorer_selected_index,
                 content.item_count(),
@@ -164,8 +179,8 @@ fn handle_navigation_key(app: &mut App, content_area: Rect, key: KeyEvent) {
                 file_explorer_selected_index,
                 &mut scroll_cache,
                 review_comment_snapshot.as_ref(),
-                app.render_cache_store().markdown_render_cache(),
-                app.render_cache_store().diff_layout_cache(),
+                render_cache_store.markdown_render_cache(),
+                render_cache_store.diff_layout_cache(),
             );
             let clamped_scroll_offset = scroll_offset.min(max_scroll_offset);
 
@@ -183,8 +198,8 @@ fn handle_navigation_key(app: &mut App, content_area: Rect, key: KeyEvent) {
                 file_explorer_selected_index,
                 &mut scroll_cache,
                 review_comment_snapshot.as_ref(),
-                app.render_cache_store().markdown_render_cache(),
-                app.render_cache_store().diff_layout_cache(),
+                render_cache_store.markdown_render_cache(),
+                render_cache_store.diff_layout_cache(),
             );
             let clamped_scroll_offset = scroll_offset.min(max_scroll_offset);
 
@@ -237,7 +252,7 @@ fn diff_max_scroll_offset(
     diff_layout_cache: &page::diff::DiffLayoutCache,
 ) -> u16 {
     if let Some(cached_scroll_limit) = scroll_cache
-        && cached_scroll_limit.content_area == content_area
+        && cached_scroll_limit.content_area == viewport_rect(content_area)
         && cached_scroll_limit.file_explorer_selected_index == selected_index
     {
         return cached_scroll_limit.max_scroll_offset;
@@ -253,12 +268,22 @@ fn diff_max_scroll_offset(
     );
 
     *scroll_cache = Some(DiffScrollCache {
-        content_area,
+        content_area: viewport_rect(content_area),
         file_explorer_selected_index: selected_index,
         max_scroll_offset,
     });
 
     max_scroll_offset
+}
+
+/// Converts terminal geometry into the frontend-neutral cached viewport key.
+fn viewport_rect(content_area: Rect) -> ViewportRect {
+    ViewportRect {
+        height: content_area.height,
+        width: content_area.width,
+        x: content_area.x,
+        y: content_area.y,
+    }
 }
 
 #[cfg(test)]
@@ -327,7 +352,7 @@ mod tests {
             file_explorer_selected_index: 0,
             restore_question: None,
             scroll_cache: None,
-            right_panel: crate::ui::state::app_mode::DiffRightPanel::Diff,
+            right_panel: crate::presentation::app_mode::DiffRightPanel::Diff,
         };
 
         // Act
@@ -367,7 +392,7 @@ mod tests {
             file_explorer_selected_index: 0,
             restore_question: None,
             scroll_cache: None,
-            right_panel: crate::ui::state::app_mode::DiffRightPanel::Diff,
+            right_panel: crate::presentation::app_mode::DiffRightPanel::Diff,
         };
 
         // Act
@@ -400,7 +425,7 @@ mod tests {
             file_explorer_selected_index: 0,
             restore_question: None,
             scroll_cache: None,
-            right_panel: crate::ui::state::app_mode::DiffRightPanel::Diff,
+            right_panel: crate::presentation::app_mode::DiffRightPanel::Diff,
         };
 
         // Act
@@ -432,7 +457,7 @@ mod tests {
             file_explorer_selected_index: 2,
             restore_question: None,
             scroll_cache: None,
-            right_panel: crate::ui::state::app_mode::DiffRightPanel::Diff,
+            right_panel: crate::presentation::app_mode::DiffRightPanel::Diff,
         };
 
         // Act
@@ -465,7 +490,7 @@ mod tests {
             file_explorer_selected_index: 0,
             restore_question: None,
             scroll_cache: None,
-            right_panel: crate::ui::state::app_mode::DiffRightPanel::Diff,
+            right_panel: crate::presentation::app_mode::DiffRightPanel::Diff,
         };
 
         // Act
@@ -497,7 +522,7 @@ mod tests {
             file_explorer_selected_index: 2,
             restore_question: None,
             scroll_cache: None,
-            right_panel: crate::ui::state::app_mode::DiffRightPanel::Diff,
+            right_panel: crate::presentation::app_mode::DiffRightPanel::Diff,
         };
 
         // Act
@@ -548,7 +573,7 @@ mod tests {
             file_explorer_selected_index: 0,
             restore_question: None,
             scroll_cache: None,
-            right_panel: crate::ui::state::app_mode::DiffRightPanel::Diff,
+            right_panel: crate::presentation::app_mode::DiffRightPanel::Diff,
         };
 
         // Act
@@ -580,7 +605,7 @@ mod tests {
             file_explorer_selected_index: 1,
             restore_question: None,
             scroll_cache: None,
-            right_panel: crate::ui::state::app_mode::DiffRightPanel::Diff,
+            right_panel: crate::presentation::app_mode::DiffRightPanel::Diff,
         };
 
         // Act
@@ -612,7 +637,7 @@ mod tests {
             file_explorer_selected_index: 1,
             restore_question: None,
             scroll_cache: None,
-            right_panel: crate::ui::state::app_mode::DiffRightPanel::Diff,
+            right_panel: crate::presentation::app_mode::DiffRightPanel::Diff,
         };
 
         // Act
@@ -644,7 +669,7 @@ mod tests {
             file_explorer_selected_index: 0,
             restore_question: None,
             scroll_cache: None,
-            right_panel: crate::ui::state::app_mode::DiffRightPanel::Diff,
+            right_panel: crate::presentation::app_mode::DiffRightPanel::Diff,
         };
 
         // Act
@@ -676,7 +701,7 @@ mod tests {
             file_explorer_selected_index: 3,
             restore_question: None,
             scroll_cache: None,
-            right_panel: crate::ui::state::app_mode::DiffRightPanel::Diff,
+            right_panel: crate::presentation::app_mode::DiffRightPanel::Diff,
         };
 
         // Act
@@ -726,7 +751,7 @@ mod tests {
             file_explorer_selected_index: 0,
             restore_question: None,
             scroll_cache: None,
-            right_panel: crate::ui::state::app_mode::DiffRightPanel::Diff,
+            right_panel: crate::presentation::app_mode::DiffRightPanel::Diff,
         };
 
         // Act
@@ -770,7 +795,7 @@ mod tests {
             file_explorer_selected_index: 0,
             restore_question: None,
             scroll_cache: None,
-            right_panel: crate::ui::state::app_mode::DiffRightPanel::Diff,
+            right_panel: crate::presentation::app_mode::DiffRightPanel::Diff,
         };
 
         // Act
@@ -833,7 +858,7 @@ mod tests {
         // Arrange — diff opened from question mode carries a snapshot.
         use crate::domain::input::InputState;
         use crate::domain::question::QuestionItem;
-        use crate::ui::state::app_mode::QuestionModeSnapshot;
+        use crate::presentation::app_mode::QuestionModeSnapshot;
 
         let (mut app, _base_dir) = crate::test_support::new_test_app().await;
         app.mode = AppMode::Diff {
@@ -855,7 +880,7 @@ mod tests {
                 session_id: "session-q".into(),
             }),
             scroll_cache: None,
-            right_panel: crate::ui::state::app_mode::DiffRightPanel::Diff,
+            right_panel: crate::presentation::app_mode::DiffRightPanel::Diff,
         };
 
         // Act
@@ -871,7 +896,7 @@ mod tests {
             app.mode,
             AppMode::Question {
                 ref session_id,
-                focus: crate::ui::state::app_mode::QuestionFocus::Answer,
+                focus: crate::presentation::app_mode::QuestionFocus::Answer,
                 ..
             } if session_id == "session-q"
         ));
@@ -882,7 +907,7 @@ mod tests {
         // Arrange — diff opened from question mode, then user opens help with `?`.
         use crate::domain::input::InputState;
         use crate::domain::question::QuestionItem;
-        use crate::ui::state::app_mode::QuestionModeSnapshot;
+        use crate::presentation::app_mode::QuestionModeSnapshot;
 
         let (mut app, _base_dir) = crate::test_support::new_test_app().await;
         let snapshot = QuestionModeSnapshot {
@@ -912,7 +937,7 @@ mod tests {
             file_explorer_selected_index: 1,
             restore_question: Some(snapshot),
             scroll_cache: None,
-            right_panel: crate::ui::state::app_mode::DiffRightPanel::Diff,
+            right_panel: crate::presentation::app_mode::DiffRightPanel::Diff,
         };
 
         // Act — open help overlay.
@@ -962,7 +987,7 @@ mod tests {
             AppMode::Question {
                 ref session_id,
                 current_index: 1,
-                focus: crate::ui::state::app_mode::QuestionFocus::Answer,
+                focus: crate::presentation::app_mode::QuestionFocus::Answer,
                 ..
             } if session_id == "session-q"
         ));
@@ -970,7 +995,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_c_toggles_diff_right_panel() {
-        use crate::ui::state::app_mode::DiffRightPanel;
+        use crate::presentation::app_mode::DiffRightPanel;
 
         // Arrange
         let (mut app, _base_dir) = crate::test_support::new_test_app().await;

--- a/crates/agentty/src/runtime/mode/help.rs
+++ b/crates/agentty/src/runtime/mode/help.rs
@@ -1,8 +1,8 @@
 use crossterm::event::{KeyCode, KeyEvent};
 
 use crate::app::App;
+use crate::presentation::app_mode::AppMode;
 use crate::runtime::EventResult;
-use crate::ui::state::app_mode::AppMode;
 
 /// Handles key input while the app is showing the help overlay.
 pub(crate) fn handle(app: &mut App, key: KeyEvent) -> EventResult {
@@ -36,8 +36,8 @@ mod tests {
     use crossterm::event::KeyModifiers;
 
     use super::*;
-    use crate::ui::state::app_mode::{DiffRightPanel, HelpContext};
-    use crate::ui::state::help_action::{HelpAction, ViewSessionState};
+    use crate::presentation::app_mode::{DiffRightPanel, HelpContext};
+    use crate::presentation::help_action::{HelpAction, ViewSessionState};
 
     #[tokio::test]
     async fn test_handle_question_mark_restores_list_mode() {

--- a/crates/agentty/src/runtime/mode/list.rs
+++ b/crates/agentty/src/runtime/mode/list.rs
@@ -5,13 +5,13 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use crate::app::{App, Tab};
 use crate::domain::input::InputState;
 use crate::domain::session::{Session, Status};
-use crate::runtime::EventResult;
-use crate::runtime::mode::confirmation::DEFAULT_OPTION_INDEX;
-use crate::ui::state::app_mode::{AppMode, ConfirmationIntent, HelpContext};
-use crate::ui::state::help_action::{
+use crate::presentation::app_mode::{AppMode, ConfirmationIntent, HelpContext};
+use crate::presentation::help_action::{
     HelpAction, project_list_actions, session_list_actions, settings_actions, system_log_actions,
 };
-use crate::ui::state::prompt::{PromptAttachmentState, PromptHistoryState};
+use crate::presentation::prompt::{PromptAttachmentState, PromptHistoryState};
+use crate::runtime::EventResult;
+use crate::runtime::mode::confirmation::DEFAULT_OPTION_INDEX;
 use crate::ui::text_util::inline_text;
 
 /// Handles key input while the app is in list mode.
@@ -328,7 +328,7 @@ fn list_keybindings(app: &App) -> Vec<HelpAction> {
     }
 
     if app.tabs.current() == Tab::Review {
-        return crate::ui::state::help_action::review_actions();
+        return crate::presentation::help_action::review_actions();
     }
 
     if app.tabs.current() == Tab::Issues {

--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -11,15 +11,15 @@ use crate::app::prompt_intent::{
 use crate::domain::agent::AgentKind;
 use crate::domain::input::InputState;
 use crate::domain::session::SessionId;
-use crate::runtime::EventResult;
-use crate::runtime::mode::{at_mention, input_key};
-use crate::ui::input_layout::{move_input_cursor_down, move_input_cursor_up};
-use crate::ui::state::app_mode::AppMode;
-use crate::ui::state::prompt::{
+use crate::presentation::app_mode::AppMode;
+use crate::presentation::prompt::{
     PromptAtMentionState, apply_prompt_delete_range as apply_prompt_delete_range_components,
     current_line_delete_range as prompt_current_line_delete_range, insert_prompt_character,
     insert_prompt_text, prompt_slash_option_count,
 };
+use crate::runtime::EventResult;
+use crate::runtime::mode::{at_mention, input_key};
+use crate::ui::input_layout::{move_input_cursor_down, move_input_cursor_up};
 
 /// Captures prompt-mode routing flags derived from the current session.
 ///
@@ -853,7 +853,7 @@ mod tests {
     use crate::domain::file_entry::FileEntry;
     use crate::domain::session_message::SessionTranscript;
     use crate::infra::db::Database;
-    use crate::ui::state::prompt::{
+    use crate::presentation::prompt::{
         PromptAtMentionState, PromptAttachmentState, PromptHistoryState, PromptSlashStage,
         PromptSlashState,
     };
@@ -1407,7 +1407,7 @@ mod tests {
     #[test]
     fn test_prompt_slash_commands_match_model() {
         // Arrange & Act
-        let suggestion_list = crate::ui::state::prompt::build_prompt_slash_suggestion_list(
+        let suggestion_list = crate::presentation::prompt::build_prompt_slash_suggestion_list(
             "/m",
             &PromptSlashState::default(),
             AgentKind::Codex,
@@ -1429,7 +1429,7 @@ mod tests {
     #[test]
     fn test_prompt_slash_commands_lists_all_commands() {
         // Arrange & Act
-        let suggestion_list = crate::ui::state::prompt::build_prompt_slash_suggestion_list(
+        let suggestion_list = crate::presentation::prompt::build_prompt_slash_suggestion_list(
             "/",
             &PromptSlashState::default(),
             AgentKind::Codex,
@@ -1449,7 +1449,7 @@ mod tests {
     #[test]
     fn test_prompt_slash_commands_no_match() {
         // Arrange & Act
-        let commands = crate::ui::state::prompt::build_prompt_slash_suggestion_list(
+        let commands = crate::presentation::prompt::build_prompt_slash_suggestion_list(
             "/x",
             &PromptSlashState::default(),
             AgentKind::Codex,

--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -4,13 +4,14 @@ use ratatui::layout::Rect;
 use crate::app::session::SessionTaskService;
 use crate::app::{self, App, AppEvent};
 use crate::domain::input::InputState;
-use crate::domain::question::{QuestionItem, QuestionProgress};
+use crate::domain::question::{QuestionItem, QuestionProgress, default_option_index};
 use crate::domain::session::{SessionId, Status};
 use crate::domain::turn_prompt::TurnPrompt;
+use crate::presentation::app_mode::{AppMode, DiffRightPanel, QuestionFocus, QuestionModeSnapshot};
+use crate::presentation::prompt::PromptAtMentionState;
 use crate::runtime::EventResult;
 use crate::runtime::mode::{at_mention, input_key, session_output_metric};
-use crate::ui::state::app_mode::{AppMode, DiffRightPanel, QuestionFocus, QuestionModeSnapshot};
-use crate::ui::state::prompt::PromptAtMentionState;
+use crate::ui::RenderCacheStore;
 
 /// Default response stored when users skip one model question.
 const NO_ANSWER: &str = "no answer";
@@ -27,7 +28,12 @@ const NO_ANSWER: &str = "no answer";
 /// saving already-submitted answers for the next visit (skipped while the
 /// user is actively typing a free-text answer so the character can still be
 /// inserted into the response).
-pub(crate) async fn handle(app: &mut App, terminal_size: Rect, key: KeyEvent) -> EventResult {
+pub(crate) async fn handle_with_cache(
+    app: &mut App,
+    render_cache_store: &RenderCacheStore,
+    terminal_size: Rect,
+    key: KeyEvent,
+) -> EventResult {
     if handle_focus_toggle(app, key) {
         return EventResult::Continue;
     }
@@ -44,7 +50,7 @@ pub(crate) async fn handle(app: &mut App, terminal_size: Rect, key: KeyEvent) ->
         return EventResult::Continue;
     }
 
-    if handle_chat_scroll(app, terminal_size, key).await {
+    if handle_chat_scroll(app, render_cache_store, terminal_size, key).await {
         return EventResult::Continue;
     }
 
@@ -68,6 +74,11 @@ pub(crate) async fn handle(app: &mut App, terminal_size: Rect, key: KeyEvent) ->
     }
 
     EventResult::Continue
+}
+
+#[cfg(test)]
+async fn handle(app: &mut App, terminal_size: Rect, key: KeyEvent) -> EventResult {
+    handle_with_cache(app, &RenderCacheStore::default(), terminal_size, key).await
 }
 
 /// Returns whether `key` is a plain `Ctrl+C` press.
@@ -159,7 +170,12 @@ fn handle_focus_toggle(app: &mut App, key: KeyEvent) -> bool {
 /// Returns `true` when the key was consumed as a scroll action. `Enter` and
 /// `Esc` switch focus back to `Answer` so they cannot accidentally submit or
 /// end the turn while scrolling. `d` opens the diff preview for the session.
-async fn handle_chat_scroll(app: &mut App, terminal_size: Rect, key: KeyEvent) -> bool {
+async fn handle_chat_scroll(
+    app: &mut App,
+    render_cache_store: &RenderCacheStore,
+    terminal_size: Rect,
+    key: KeyEvent,
+) -> bool {
     if !matches!(
         &app.mode,
         AppMode::Question {
@@ -170,7 +186,7 @@ async fn handle_chat_scroll(app: &mut App, terminal_size: Rect, key: KeyEvent) -
         return false;
     }
 
-    let metrics = question_view_metrics(app, terminal_size);
+    let metrics = question_view_metrics(app, render_cache_store, terminal_size);
 
     let AppMode::Question {
         focus,
@@ -223,7 +239,11 @@ struct QuestionViewMetrics {
 }
 
 /// Computes scroll metrics for the chat output area above the question panel.
-fn question_view_metrics(app: &App, terminal_size: Rect) -> QuestionViewMetrics {
+fn question_view_metrics(
+    app: &App,
+    render_cache_store: &RenderCacheStore,
+    terminal_size: Rect,
+) -> QuestionViewMetrics {
     let view_height = terminal_size.height.saturating_sub(5);
     let output_width = terminal_size.width.saturating_sub(2);
 
@@ -242,8 +262,9 @@ fn question_view_metrics(app: &App, terminal_size: Rect) -> QuestionViewMetrics 
 
     let (review_status_message, review_text) = app.review_view_state(session_id);
     let total_lines = session_index.map_or(0, |index| {
-        session_output_metric::rendered_output_line_count(
+        session_output_metric::rendered_output_line_count_with_cache(
             app,
+            render_cache_store,
             session_id,
             index,
             review_status_message.as_deref(),
@@ -394,20 +415,6 @@ pub(crate) fn handle_paste(app: &mut App, pasted_text: &str) {
     }
 
     sync_question_at_mention_state(app);
-}
-
-/// Returns the default selected option index for a question at the given
-/// position. Returns `Some(0)` when the question has predefined options so
-/// the UI starts in option-selection mode, or `None` when there are no
-/// predefined options so the input line opens immediately.
-pub(crate) fn default_option_index(
-    questions: &[QuestionItem],
-    question_index: usize,
-) -> Option<usize> {
-    questions
-        .get(question_index)
-        .filter(|item| !item.options.is_empty())
-        .map(|_| 0)
 }
 
 /// Semantic action emitted by one question-mode key event.
@@ -1049,9 +1056,9 @@ mod tests {
     use super::*;
     use crate::domain::agent::AgentModel;
     use crate::domain::session::Status;
+    use crate::presentation::app_mode::QuestionFocus;
     use crate::ui::component::session_output::SessionOutputLineContext;
     use crate::ui::page::session_chat::SessionChatPage;
-    use crate::ui::state::app_mode::QuestionFocus;
 
     /// Fake terminal size used by tests that don't exercise scrolling.
     const TEST_TERMINAL_SIZE: Rect = Rect::new(0, 0, 80, 24);
@@ -1085,6 +1092,7 @@ mod tests {
         };
         let terminal_size = Rect::new(0, 0, 16, 24);
         let output_width = terminal_size.width.saturating_sub(2);
+        let render_cache_store = RenderCacheStore::default();
         let session = &app.sessions.sessions()[0];
         let expected = SessionChatPage::rendered_output_line_count(
             session,
@@ -1097,12 +1105,12 @@ mod tests {
                 review_text: None,
                 session_update_version: app.session_update_version(session_id),
             },
-            app.render_cache_store().markdown_render_cache(),
-            app.render_cache_store().session_output_layout_cache(),
+            render_cache_store.markdown_render_cache(),
+            render_cache_store.session_output_layout_cache(),
         );
 
         // Act
-        let metrics = question_view_metrics(&app, terminal_size);
+        let metrics = question_view_metrics(&app, &render_cache_store, terminal_size);
 
         // Assert
         assert_eq!(metrics.total_lines, expected);

--- a/crates/agentty/src/runtime/mode/review_detail.rs
+++ b/crates/agentty/src/runtime/mode/review_detail.rs
@@ -2,12 +2,17 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::Rect;
 
 use crate::app::App;
+use crate::presentation::app_mode::AppMode;
 use crate::runtime::EventResult;
-use crate::ui::page;
-use crate::ui::state::app_mode::AppMode;
+use crate::ui::{RenderCacheStore, page};
 
 /// Handles key input while a requested-review detail page is visible.
-pub(crate) fn handle(app: &mut App, content_area: Rect, key: KeyEvent) -> EventResult {
+pub(crate) fn handle_with_cache(
+    app: &mut App,
+    render_cache_store: &RenderCacheStore,
+    content_area: Rect,
+    key: KeyEvent,
+) -> EventResult {
     if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
         app.mode = AppMode::List;
 
@@ -25,7 +30,7 @@ pub(crate) fn handle(app: &mut App, content_area: Rect, key: KeyEvent) -> EventR
             comment_error.as_deref(),
             *is_loading_comments,
             content_area,
-            app.render_cache_store().markdown_render_cache(),
+            render_cache_store.markdown_render_cache(),
         ),
         _ => 0,
     };
@@ -55,6 +60,11 @@ pub(crate) fn handle(app: &mut App, content_area: Rect, key: KeyEvent) -> EventR
     }
 
     EventResult::Continue
+}
+
+#[cfg(test)]
+fn handle(app: &mut App, content_area: Rect, key: KeyEvent) -> EventResult {
+    handle_with_cache(app, &RenderCacheStore::default(), content_area, key)
 }
 
 /// Returns the half-page scroll step for the review detail viewport.
@@ -131,12 +141,13 @@ mod tests {
         let mut app = new_test_app().await;
         let content_area = Rect::new(0, 0, 80, 8);
         let review = requested_review("line 1\nline 2\nline 3\nline 4\nline 5\nline 6");
+        let render_cache_store = RenderCacheStore::default();
         let expected_scroll_offset = page::review_detail::review_detail_max_scroll_offset(
             &review,
             None,
             false,
             content_area,
-            app.render_cache_store().markdown_render_cache(),
+            render_cache_store.markdown_render_cache(),
         );
         app.mode = AppMode::ReviewDetail {
             comment_error: None,

--- a/crates/agentty/src/runtime/mode/session_output_metric.rs
+++ b/crates/agentty/src/runtime/mode/session_output_metric.rs
@@ -1,10 +1,12 @@
 use crate::app::App;
+use crate::ui::RenderCacheStore;
 use crate::ui::component::session_output::SessionOutputLineContext;
 use crate::ui::page::session_chat::SessionChatPage;
 
 /// Returns rendered session-output line count for runtime scroll metrics.
-pub(crate) fn rendered_output_line_count(
+pub(crate) fn rendered_output_line_count_with_cache(
     app: &App,
+    render_cache_store: &RenderCacheStore,
     session_id: &str,
     session_index: usize,
     review_status_message: Option<&str>,
@@ -30,8 +32,28 @@ pub(crate) fn rendered_output_line_count(
                 review_text,
                 session_update_version: app.session_update_version(session_id),
             },
-            app.render_cache_store().markdown_render_cache(),
-            app.render_cache_store().session_output_layout_cache(),
+            render_cache_store.markdown_render_cache(),
+            render_cache_store.session_output_layout_cache(),
         )
     })
+}
+
+#[cfg(test)]
+pub(crate) fn rendered_output_line_count(
+    app: &App,
+    session_id: &str,
+    session_index: usize,
+    review_status_message: Option<&str>,
+    review_text: Option<&str>,
+    output_width: u16,
+) -> u16 {
+    rendered_output_line_count_with_cache(
+        app,
+        &RenderCacheStore::default(),
+        session_id,
+        session_index,
+        review_status_message,
+        review_text,
+        output_width,
+    )
 }

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -15,15 +15,16 @@ use crate::app::{
 use crate::domain::input::InputState;
 use crate::domain::session::{FollowUpTaskAction, PublishBranchAction, SessionId, Status};
 use crate::domain::transcript_notice::TranscriptNotice;
+use crate::presentation::app_mode::{
+    AppMode, ConfirmationIntent, ConfirmationViewMode, DiffRightPanel, HelpContext,
+};
+use crate::presentation::help_action::{self, ViewSessionState};
+use crate::presentation::prompt::{PromptAttachmentState, PromptHistoryState};
 use crate::runtime::EventResult;
 use crate::runtime::mode::confirmation::DEFAULT_OPTION_INDEX;
 use crate::runtime::mode::input_key::is_insertable_char_key;
 use crate::runtime::mode::{prompt, session_output_metric};
-use crate::ui::state::app_mode::{
-    AppMode, ConfirmationIntent, ConfirmationViewMode, DiffRightPanel, HelpContext,
-};
-use crate::ui::state::help_action::{self, ViewSessionState};
-use crate::ui::state::prompt::{PromptAttachmentState, PromptHistoryState};
+use crate::ui::RenderCacheStore;
 
 #[derive(Clone)]
 struct ViewContext {
@@ -197,8 +198,9 @@ const REVIEW_NO_DIFF_MESSAGE: &str = "No diff changes found for review.";
 /// Processes view-mode key presses and keeps shortcut availability aligned with
 /// session status (`o` disabled outside editable/review-ready local
 /// worktrees, and diff/review available for review-ready statuses).
-pub(crate) async fn handle<B: Backend>(
+pub(crate) async fn handle_with_cache<B: Backend>(
     app: &mut App,
+    render_cache_store: &RenderCacheStore,
     terminal: &mut Terminal<B>,
     key: KeyEvent,
 ) -> io::Result<EventResult>
@@ -208,7 +210,7 @@ where
     let Some(view_context) = view_context(app) else {
         return Ok(EventResult::Continue);
     };
-    let view_metrics = view_metrics(app, terminal, &view_context)?;
+    let view_metrics = view_metrics(app, render_cache_store, terminal, &view_context)?;
     let mut pending_update = ViewPendingUpdate::from_context(&view_context);
 
     let Some(view_session_snapshot) = view_session_snapshot(app, &view_context) else {
@@ -227,6 +229,18 @@ where
     apply_view_scroll_and_output_mode(app, pending_update.scroll_offset);
 
     Ok(EventResult::Continue)
+}
+
+#[cfg(test)]
+async fn handle<B: Backend>(
+    app: &mut App,
+    terminal: &mut Terminal<B>,
+    key: KeyEvent,
+) -> io::Result<EventResult>
+where
+    B::Error: std::error::Error + Send + Sync + 'static,
+{
+    handle_with_cache(app, &RenderCacheStore::default(), terminal, key).await
 }
 
 /// Applies one view-mode key press and updates pending output/scroll state.
@@ -1009,6 +1023,7 @@ fn view_context(app: &mut App) -> Option<ViewContext> {
 
 fn view_metrics<B: Backend>(
     app: &App,
+    render_cache_store: &RenderCacheStore,
     terminal: &Terminal<B>,
     view_context: &ViewContext,
 ) -> io::Result<ViewMetrics>
@@ -1019,8 +1034,9 @@ where
     let view_height = terminal_size.height.saturating_sub(5);
     let output_width = terminal_size.width.saturating_sub(2);
     let (review_status_message, review_text) = app.review_view_state(&view_context.session_id);
-    let total_lines = session_output_metric::rendered_output_line_count(
+    let total_lines = session_output_metric::rendered_output_line_count_with_cache(
         app,
+        render_cache_store,
         &view_context.session_id,
         view_context.session_index,
         review_status_message.as_deref(),
@@ -2020,6 +2036,7 @@ mod tests {
         );
         app.sessions.sessions_mut()[0].status = Status::AgentReview;
         let output_width = 14;
+        let render_cache_store = RenderCacheStore::default();
         let session = &app.sessions.sessions()[0];
         let expected = SessionChatPage::rendered_output_line_count(
             session,
@@ -2032,8 +2049,8 @@ mod tests {
                 review_text: None,
                 session_update_version: app.session_update_version(&session_id),
             },
-            app.render_cache_store().markdown_render_cache(),
-            app.render_cache_store().session_output_layout_cache(),
+            render_cache_store.markdown_render_cache(),
+            render_cache_store.session_output_layout_cache(),
         );
 
         // Act

--- a/crates/agentty/src/runtime/mode/sync_blocked.rs
+++ b/crates/agentty/src/runtime/mode/sync_blocked.rs
@@ -1,45 +1,10 @@
 use crossterm::event::{KeyCode, KeyEvent};
 
 use crate::app::App;
+#[cfg(test)]
+use crate::app::sync_message::format_sync_success_message;
+use crate::presentation::app_mode::AppMode;
 use crate::runtime::EventResult;
-use crate::ui::state::app_mode::AppMode;
-
-const SYNC_SUCCESS_HEADER: &str = "Successfully synchronized with its upstream.";
-
-/// Builds a sync completion message using markdown headers and spacing between
-/// pull/push/conflict blocks.
-pub(crate) fn format_sync_success_message(
-    pulled_summary: &str,
-    pulled_titles: &str,
-    pushed_summary: &str,
-    pushed_titles: &str,
-    conflict_summary: &str,
-) -> String {
-    let pull_section = sync_success_section(&format!("## 1. {pulled_summary}"), pulled_titles);
-    let push_section = sync_success_section(&format!("## 2. {pushed_summary}"), pushed_titles);
-    let conflict_section = sync_success_section(&format!("## 3. {conflict_summary}"), "");
-
-    [
-        SYNC_SUCCESS_HEADER,
-        &pull_section,
-        &push_section,
-        &conflict_section,
-    ]
-    .join("\n\n")
-}
-
-/// Builds one markdown sync section with a title and optional details.
-fn sync_success_section(title: &str, details: &str) -> String {
-    let mut lines = Vec::with_capacity(2);
-
-    lines.push(title.to_string());
-
-    if !details.is_empty() {
-        lines.push(details.to_string());
-    }
-
-    lines.join("\n")
-}
 
 /// Handles key input while the sync informational popup is visible.
 pub(crate) fn handle(app: &mut App, key: KeyEvent) -> EventResult {

--- a/crates/agentty/src/runtime/presentation.rs
+++ b/crates/agentty/src/runtime/presentation.rs
@@ -1,0 +1,46 @@
+use std::cell::{RefCell, RefMut};
+
+use ratatui::widgets::TableState;
+
+use crate::ui::RenderCacheStore;
+
+/// Runtime-owned state used to measure and render the terminal presentation.
+///
+/// Keeping render caches here prevents application orchestration from
+/// depending on concrete UI cache implementations or their invalidation
+/// details.
+#[derive(Default)]
+pub(crate) struct PresentationState {
+    assigned_issue_table_state: RefCell<TableState>,
+    project_table_state: RefCell<TableState>,
+    render_cache_store: RenderCacheStore,
+    requested_review_table_state: RefCell<TableState>,
+    session_table_state: RefCell<TableState>,
+}
+
+impl PresentationState {
+    /// Borrows the assigned-issue table viewport for one render pass.
+    pub(crate) fn assigned_issue_table_state(&self) -> RefMut<'_, TableState> {
+        self.assigned_issue_table_state.borrow_mut()
+    }
+
+    /// Borrows the project-list table viewport for one render pass.
+    pub(crate) fn project_table_state(&self) -> RefMut<'_, TableState> {
+        self.project_table_state.borrow_mut()
+    }
+
+    /// Returns the UI cache collection shared by input metrics and rendering.
+    pub(crate) fn render_cache_store(&self) -> &RenderCacheStore {
+        &self.render_cache_store
+    }
+
+    /// Borrows the requested-review table viewport for one render pass.
+    pub(crate) fn requested_review_table_state(&self) -> RefMut<'_, TableState> {
+        self.requested_review_table_state.borrow_mut()
+    }
+
+    /// Borrows the session-list table viewport for one render pass.
+    pub(crate) fn session_table_state(&self) -> RefMut<'_, TableState> {
+        self.session_table_state.borrow_mut()
+    }
+}

--- a/crates/agentty/src/test_support.rs
+++ b/crates/agentty/src/test_support.rs
@@ -17,8 +17,6 @@ use ag_agent::{AppServerClient, MockAppServerClient, StaticAgentAvailabilityProb
 #[cfg(test)]
 use ag_git as git;
 use ratatui::buffer::{Buffer, Cell};
-#[cfg(test)]
-use ratatui::widgets::TableState;
 
 use crate::app;
 #[cfg(test)]
@@ -29,6 +27,8 @@ use crate::domain::agent::{AgentKind, AgentModel, AgentSelection, ReasoningLevel
 #[cfg(test)]
 use crate::domain::question::QuestionItem;
 #[cfg(test)]
+use crate::domain::selection::SelectionState;
+#[cfg(test)]
 use crate::domain::session::{
     PublishedBranchSyncStatus, ReviewRequest, Session, SessionHandles, SessionId, SessionSize,
     SessionStats, Status,
@@ -37,7 +37,7 @@ use crate::domain::session::{
 use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
 use crate::domain::setting::SettingName;
 #[cfg(test)]
-use crate::ui::state::app_mode::AppMode;
+use crate::presentation::app_mode::AppMode;
 
 /// Returns the canonical session folder path for integration-test fixtures.
 pub fn session_folder(base: &Path, session_id: &str) -> PathBuf {
@@ -493,7 +493,7 @@ pub(crate) fn session_manager_with_handles(
         SessionState::new(
             handles,
             sessions,
-            TableState::default(),
+            SelectionState::default(),
             Arc::new(FixedClock::unix_epoch()),
             0,
             0,

--- a/crates/agentty/src/ui.rs
+++ b/crates/agentty/src/ui.rs
@@ -1,6 +1,8 @@
 pub mod activity_heatmap;
+mod app_render;
 pub mod component;
 pub mod diff_util;
+pub(crate) mod help_format;
 pub mod icon;
 pub mod input_layout;
 pub mod layout;
@@ -21,6 +23,7 @@ pub mod state;
 pub mod style;
 pub mod text_util;
 
+pub(crate) use app_render::render_app;
 /// A trait for UI components that enforces a standard rendering interface.
 pub use render::Component;
 /// A trait for UI pages that enforces a standard rendering interface.

--- a/crates/agentty/src/ui/app_render.rs
+++ b/crates/agentty/src/ui/app_render.rs
@@ -1,0 +1,75 @@
+//! Application snapshot projection at the UI boundary.
+
+use ratatui::Frame;
+use ratatui::widgets::TableState;
+
+use crate::app::AppViewSnapshot;
+use crate::ui::{RenderCacheStore, RenderContext, SessionReviewSnapshot, style};
+
+/// Projects application data into one terminal frame.
+pub(crate) fn render_app(
+    snapshot: &AppViewSnapshot<'_>,
+    frame: &mut Frame,
+    assigned_issue_table_state: &mut TableState,
+    project_table_state: &mut TableState,
+    render_cache_store: &RenderCacheStore,
+    requested_review_table_state: &mut TableState,
+    session_table_state: &mut TableState,
+) {
+    project_table_state.select(snapshot.project_selected_index);
+    session_table_state.select(snapshot.session_selected_index);
+    let session_review_snapshot =
+        snapshot
+            .session_review
+            .as_ref()
+            .map(|review| SessionReviewSnapshot {
+                session_id: review.session_id,
+                status_message: review.status_message.clone(),
+                text: review.text,
+            });
+    let _theme_scope = style::scoped_active_theme(snapshot.settings.theme);
+
+    super::render(
+        frame,
+        RenderContext {
+            assigned_issue_selected_index: snapshot.assigned_issue_selected_index,
+            assigned_issue_table_state,
+            assigned_issues: snapshot.assigned_issues,
+            active_project_id: snapshot.active_project_id,
+            available_agent_clis: &snapshot.available_agent_clis,
+            current_tab: snapshot.current_tab,
+            git_branch: snapshot.git_branch,
+            diff_layout_cache: render_cache_store.diff_layout_cache(),
+            git_upstream_ref: snapshot.git_upstream_ref,
+            git_status: snapshot.git_status,
+            latest_available_version: snapshot.latest_available_version,
+            markdown_render_cache: render_cache_store.markdown_render_cache(),
+            update_status: snapshot.update_status,
+            mode: snapshot.mode,
+            output_layout_cache: render_cache_store.session_output_layout_cache(),
+            project_table_state,
+            projects: snapshot.projects,
+            review_comment_cache: &snapshot.review_comment_cache,
+            session_review_snapshot: session_review_snapshot.as_ref(),
+            requested_reviews: snapshot.requested_reviews,
+            requested_review_selected_index: snapshot.requested_review_selected_index,
+            requested_review_table_state,
+            active_prompt_outputs: snapshot.active_prompt_outputs,
+            session_branch_names: snapshot.session_branch_names,
+            session_git_statuses: snapshot.session_git_statuses,
+            session_index_by_id: snapshot.session_index_by_id,
+            session_progress_messages: snapshot.session_progress_messages,
+            session_update_versions: snapshot.session_update_versions,
+            session_worktree_availability: snapshot.session_worktree_availability,
+            settings: snapshot.settings,
+            system_log_tail_offset: snapshot.system_log_tail_offset,
+            system_logs: snapshot.system_logs,
+            stats_activity: snapshot.stats_activity,
+            sessions: snapshot.sessions,
+            status_bar_fyi_rotation_index: snapshot.status_bar_fyi_rotation_index,
+            table_state: session_table_state,
+            working_dir: snapshot.working_dir,
+            wall_clock_unix_seconds: snapshot.wall_clock_unix_seconds,
+        },
+    );
+}

--- a/crates/agentty/src/ui/component/help_overlay.rs
+++ b/crates/agentty/src/ui/component/help_overlay.rs
@@ -4,7 +4,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
-use crate::ui::state::app_mode::HelpContext;
+use crate::presentation::app_mode::HelpContext;
 use crate::ui::style::palette;
 use crate::ui::{Component, overlay};
 
@@ -98,7 +98,7 @@ impl Component for HelpOverlay<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ui::state::help_action::HelpAction;
+    use crate::presentation::help_action::HelpAction;
 
     #[test]
 

--- a/crates/agentty/src/ui/help_format.rs
+++ b/crates/agentty/src/ui/help_format.rs
@@ -1,0 +1,103 @@
+//! Ratatui formatting for frontend-neutral help-action contracts.
+
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+
+use crate::presentation::help_action::HelpAction;
+use crate::ui::style;
+
+/// Renders one-line footer help with emphasized keys and muted labels.
+pub(crate) fn footer_line(actions: &[HelpAction]) -> Line<'static> {
+    let mut spans = Vec::new();
+
+    for (index, action) in actions.iter().enumerate() {
+        if index > 0 {
+            spans.push(footer_separator_span());
+        }
+
+        spans.push(footer_key_span(action.key));
+        spans.push(footer_muted_span(": "));
+        spans.push(footer_muted_span(action.footer_label));
+    }
+
+    Line::from(spans)
+}
+
+/// Returns one highlighted footer key span.
+pub(crate) fn footer_key_span(key: &'static str) -> Span<'static> {
+    Span::styled(
+        key.to_string(),
+        Style::default()
+            .fg(style::palette::accent())
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+/// Returns one muted footer text span.
+pub(crate) fn footer_muted_span(text: impl Into<String>) -> Span<'static> {
+    Span::styled(
+        text.into(),
+        Style::default().fg(style::palette::text_muted()),
+    )
+}
+
+/// Returns the separator between footer help items.
+pub(crate) fn footer_separator_span() -> Span<'static> {
+    Span::styled(" | ", Style::default().fg(style::palette::text_subtle()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn footer_line_styles_keys_labels_and_separator() {
+        // Arrange
+        let actions = vec![
+            HelpAction::new("quit", "q", "Quit"),
+            HelpAction::new("help", "?", "Help"),
+        ];
+
+        // Act
+        let line = footer_line(&actions);
+
+        // Assert
+        assert_eq!(line.to_string(), "q: quit | ?: help");
+        assert_eq!(
+            line.spans[0].style,
+            Style::default()
+                .fg(style::palette::accent())
+                .add_modifier(Modifier::BOLD)
+        );
+        assert_eq!(
+            line.spans[3].style,
+            Style::default().fg(style::palette::text_subtle())
+        );
+    }
+
+    #[test]
+    fn footer_muted_span_uses_muted_style() {
+        // Arrange & Act
+        let span = footer_muted_span("note");
+
+        // Assert
+        assert_eq!(span.content, "note");
+        assert_eq!(
+            span.style,
+            Style::default().fg(style::palette::text_muted())
+        );
+    }
+
+    #[test]
+    fn footer_separator_span_uses_subtle_style() {
+        // Arrange & Act
+        let span = footer_separator_span();
+
+        // Assert
+        assert_eq!(span.content, " | ");
+        assert_eq!(
+            span.style,
+            Style::default().fg(style::palette::text_subtle())
+        );
+    }
+}

--- a/crates/agentty/src/ui/layout.rs
+++ b/crates/agentty/src/ui/layout.rs
@@ -330,13 +330,13 @@ mod tests {
         COMMITTING_PROGRESS_LABEL, PublishedBranchSyncStatus, Session, Status,
     };
     use crate::domain::theme::ColorTheme;
+    use crate::presentation::app_mode::QuestionFocus;
+    use crate::presentation::help_action::{self, ViewActionAvailability, ViewHelpState};
+    use crate::presentation::prompt::{PromptAtMentionState, PromptSlashStage, PromptSlashState};
     use crate::ui::input_layout::*;
     use crate::ui::prompt_format::*;
     use crate::ui::question_format::*;
     use crate::ui::session_format::*;
-    use crate::ui::state::app_mode::QuestionFocus;
-    use crate::ui::state::help_action::{self, ViewActionAvailability, ViewHelpState};
-    use crate::ui::state::prompt::{PromptAtMentionState, PromptSlashStage, PromptSlashState};
     use crate::ui::style;
 
     fn session_fixture() -> Session {

--- a/crates/agentty/src/ui/overlay.rs
+++ b/crates/agentty/src/ui/overlay.rs
@@ -9,8 +9,8 @@ use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding};
 use crate::domain::agent::ReasoningLevel;
 use crate::domain::session::{Session, SessionId};
 use crate::infra::review_comment_cache::ReviewCommentCache;
+use crate::presentation::app_mode::{AppMode, ConfirmationViewMode, DiffRightPanel, HelpContext};
 use crate::ui::router::{ListBackgroundRenderContext, render_list_background};
-use crate::ui::state::app_mode::{AppMode, ConfirmationViewMode, DiffRightPanel, HelpContext};
 use crate::ui::style::palette;
 use crate::ui::{Component, Page, SessionReviewSnapshot, component, markdown, page};
 
@@ -747,7 +747,7 @@ mod tests {
             can_start_staged_session: false,
             publish_pull_request_action: None,
             session_id: "missing-session".into(),
-            session_state: crate::ui::state::help_action::ViewSessionState::Done,
+            session_state: crate::presentation::help_action::ViewSessionState::Done,
             scroll_offset: Some(0),
         };
 

--- a/crates/agentty/src/ui/page/diff.rs
+++ b/crates/agentty/src/ui/page/diff.rs
@@ -16,13 +16,13 @@ use rustc_hash::FxHasher;
 
 use crate::domain::session::{ReviewRequest, Session};
 use crate::infra::review_comment_cache::CachedReviewCommentSnapshot;
+use crate::presentation::app_mode::DiffRightPanel;
+use crate::presentation::help_action;
 use crate::ui::component::file_explorer::FileExplorer;
 use crate::ui::diff_util::{
     DiffLine, DiffLineKind, FileTreeItem, diff_header_new_path, diff_header_old_path,
     parse_diff_lines,
 };
-use crate::ui::state::app_mode::DiffRightPanel;
-use crate::ui::state::help_action;
 use crate::ui::text_util::{self, inline_text, wrap_lines_to_rows};
 use crate::ui::{Component, Page, diff_util, markdown, review_comment_format, style};
 
@@ -1081,7 +1081,7 @@ impl Page for DiffPage<'_> {
             }
         }
 
-        let help_message = Paragraph::new(help_action::footer_line(
+        let help_message = Paragraph::new(crate::ui::help_format::footer_line(
             &help_action::diff_footer_actions(self.right_panel),
         ));
         f.render_widget(help_message, areas.footer_area);

--- a/crates/agentty/src/ui/page/fyi.rs
+++ b/crates/agentty/src/ui/page/fyi.rs
@@ -1,7 +1,7 @@
 //! Shared helpers and message sets for page-scoped status-bar FYIs.
 
 use crate::app::Tab;
-use crate::ui::state::app_mode::{AppMode, HelpContext};
+use crate::presentation::app_mode::{AppMode, HelpContext};
 
 /// Rotating workflow FYI messages shown in the top status bar while the
 /// sessions list is visible.
@@ -90,7 +90,7 @@ pub(crate) fn rotating_message<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ui::state::app_mode::DiffRightPanel;
+    use crate::presentation::app_mode::DiffRightPanel;
 
     #[test]
     fn rotating_message_cycles_through_messages() {

--- a/crates/agentty/src/ui/page/inbox.rs
+++ b/crates/agentty/src/ui/page/inbox.rs
@@ -6,8 +6,8 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
 
 use crate::app::RequestedReviewState;
+use crate::presentation::help_action;
 use crate::ui::input_layout::first_table_column_width;
-use crate::ui::state::help_action;
 use crate::ui::text_util::{inline_text, truncate_spans_with_ellipsis};
 use crate::ui::{Page, layout, style};
 
@@ -158,16 +158,20 @@ fn is_at_display_limit(requested_reviews: &RequestedReviewState) -> bool {
 
 /// Builds the review footer, including read-only and truncation hints.
 fn review_footer_line(show_limit_hint: bool) -> Line<'static> {
-    let mut line = help_action::footer_line(&help_action::review_actions());
-    line.spans.push(help_action::footer_separator_span());
+    let mut line = crate::ui::help_format::footer_line(&help_action::review_actions());
     line.spans
-        .push(help_action::footer_muted_span("read-only forge list"));
+        .push(crate::ui::help_format::footer_separator_span());
+    line.spans.push(crate::ui::help_format::footer_muted_span(
+        "read-only forge list",
+    ));
 
     if show_limit_hint {
-        line.spans.push(help_action::footer_separator_span());
-        line.spans.push(help_action::footer_muted_span(format!(
-            "showing first {REQUESTED_REVIEW_DISPLAY_LIMIT}"
-        )));
+        line.spans
+            .push(crate::ui::help_format::footer_separator_span());
+        line.spans
+            .push(crate::ui::help_format::footer_muted_span(format!(
+                "showing first {REQUESTED_REVIEW_DISPLAY_LIMIT}"
+            )));
     }
 
     line

--- a/crates/agentty/src/ui/page/issue.rs
+++ b/crates/agentty/src/ui/page/issue.rs
@@ -63,17 +63,23 @@ impl Page for IssuePage<'_> {
             }
         }
 
-        let mut footer = help_action::footer_line(&help_action::issue_actions());
-        footer.spans.push(help_action::footer_separator_span());
+        let mut footer = crate::ui::help_format::footer_line(&help_action::issue_actions());
         footer
             .spans
-            .push(help_action::footer_muted_span("list only"));
+            .push(crate::ui::help_format::footer_separator_span());
+        footer
+            .spans
+            .push(crate::ui::help_format::footer_muted_span("list only"));
         if matches!(self.assigned_issues, AssignedIssueState::Loaded { items, .. } if items.len() >= ASSIGNED_ISSUE_DISPLAY_LIMIT)
         {
-            footer.spans.push(help_action::footer_separator_span());
-            footer.spans.push(help_action::footer_muted_span(format!(
-                "showing first {ASSIGNED_ISSUE_DISPLAY_LIMIT}"
-            )));
+            footer
+                .spans
+                .push(crate::ui::help_format::footer_separator_span());
+            footer
+                .spans
+                .push(crate::ui::help_format::footer_muted_span(format!(
+                    "showing first {ASSIGNED_ISSUE_DISPLAY_LIMIT}"
+                )));
         }
         frame.render_widget(Paragraph::new(footer), areas.footer_area);
     }

--- a/crates/agentty/src/ui/page/project_list.rs
+++ b/crates/agentty/src/ui/page/project_list.rs
@@ -10,12 +10,12 @@ use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState, 
 use crate::domain::agent::{AgentCliInfo, AgentCliVersion};
 use crate::domain::project::ProjectListItem;
 use crate::domain::session::DailyActivity;
+use crate::presentation::help_action;
 use crate::ui::activity_heatmap::{
     RecentActivityStats, build_activity_heatmap_grid, build_recent_activity_stats,
     build_visible_heatmap_month_row, current_day_key_local, heatmap_intensity_level,
     heatmap_max_count, visible_heatmap_week_count,
 };
-use crate::ui::state::help_action;
 use crate::ui::{Page, layout, style, text_util};
 
 const DAY_LABELS: [&str; 7] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
@@ -408,7 +408,7 @@ fn stat_value_span(text: impl Into<String>) -> Span<'static> {
 
 /// Returns the footer help content rendered below the projects table.
 fn project_list_footer_line() -> Line<'static> {
-    help_action::footer_line(&help_action::project_list_footer_actions())
+    crate::ui::help_format::footer_line(&help_action::project_list_footer_actions())
 }
 
 /// Returns project row display values for reuse and testing.
@@ -873,7 +873,8 @@ mod tests {
     #[test]
     fn test_project_list_footer_line_matches_project_shortcuts() {
         // Arrange
-        let expected_line = help_action::footer_line(&help_action::project_list_footer_actions());
+        let expected_line =
+            crate::ui::help_format::footer_line(&help_action::project_list_footer_actions());
 
         // Act
         let footer_line = project_list_footer_line();

--- a/crates/agentty/src/ui/page/review_detail.rs
+++ b/crates/agentty/src/ui/page/review_detail.rs
@@ -5,7 +5,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use crate::ui::state::help_action;
+use crate::presentation::help_action;
 use crate::ui::{Page, layout, markdown, review_comment_format, style};
 
 /// Page renderer for one requested PR or MR review summary, comments, and
@@ -454,7 +454,7 @@ fn section_label(label: &'static str) -> Line<'static> {
 
 /// Builds the review-detail footer with the currently supported action.
 fn review_detail_footer_line() -> Line<'static> {
-    help_action::footer_line(&[
+    crate::ui::help_format::footer_line(&[
         help_action::HelpAction::new("back", "q", "Back"),
         help_action::HelpAction::new("scroll", "j/k", "Scroll"),
         help_action::HelpAction::new("page", "Ctrl+d/u", "Page"),

--- a/crates/agentty/src/ui/page/session_chat.rs
+++ b/crates/agentty/src/ui/page/session_chat.rs
@@ -11,6 +11,9 @@ use crate::domain::session::{
     can_start_staged_session_in_stack,
 };
 use crate::domain::{input, review};
+use crate::presentation::app_mode::{AppMode, QuestionFocus};
+use crate::presentation::help_action::{self, ViewActionAvailability, ViewHelpState};
+use crate::presentation::prompt::PromptAtMentionState;
 use crate::ui::component::chat_input::{ChatInput, SuggestionList};
 use crate::ui::component::session_output::{
     SessionOutput, SessionOutputLayoutCache, SessionOutputLineContext,
@@ -18,9 +21,6 @@ use crate::ui::component::session_output::{
 use crate::ui::input_layout::{
     calculate_input_height, overlay_area_above, suggestion_dropdown_height,
 };
-use crate::ui::state::app_mode::{AppMode, QuestionFocus};
-use crate::ui::state::help_action::{self, ViewActionAvailability, ViewHelpState};
-use crate::ui::state::prompt::PromptAtMentionState;
 use crate::ui::{
     Component, Page, layout, markdown, prompt_format, question_format, session_format,
 };
@@ -570,8 +570,10 @@ mod tests {
     use crate::domain::question::QuestionItem;
     use crate::domain::session::Status;
     use crate::domain::session_message::SessionTranscript;
-    use crate::ui::state::app_mode::QuestionFocus;
-    use crate::ui::state::prompt::{PromptAttachmentState, PromptHistoryState, PromptSlashState};
+    use crate::presentation::app_mode::QuestionFocus;
+    use crate::presentation::prompt::{
+        PromptAttachmentState, PromptHistoryState, PromptSlashState,
+    };
 
     fn session_fixture() -> Session {
         crate::test_support::SessionFixtureBuilder::new()

--- a/crates/agentty/src/ui/page/session_list.rs
+++ b/crates/agentty/src/ui/page/session_list.rs
@@ -7,8 +7,8 @@ use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
 use crate::domain::agent::ReasoningLevel;
 use crate::domain::session::{Session, SessionSize, Status};
 use crate::domain::session_order::{self, GroupedSessionRow, SessionGroup, SessionTreePosition};
+use crate::presentation::help_action;
 use crate::ui::input_layout::first_table_column_width;
-use crate::ui::state::help_action;
 use crate::ui::text_util::{format_duration_compact, inline_text, truncate_spans_with_ellipsis};
 use crate::ui::{Page, layout, markdown, style};
 
@@ -127,7 +127,7 @@ fn session_list_help_line(selected_session: Option<&Session>) -> Line<'static> {
         can_open_selected_session,
     );
 
-    help_action::footer_line(&actions)
+    crate::ui::help_format::footer_line(&actions)
 }
 
 /// Prepares list table state for grouped row rendering.

--- a/crates/agentty/src/ui/page/setting.rs
+++ b/crates/agentty/src/ui/page/setting.rs
@@ -5,7 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState, Wrap};
 
 use crate::app::setting::{SettingsManager, SettingsSelectorDropdown};
-use crate::ui::state::help_action;
+use crate::presentation::help_action;
 use crate::ui::text_util::truncate_with_ellipsis;
 use crate::ui::{Component, Page, component, layout, overlay, style};
 
@@ -22,13 +22,13 @@ const DROPDOWN_WIDTH_PERCENT: u16 = 58;
 
 /// Renders the settings page table and inline editing hints.
 pub struct SettingsPage<'a> {
-    manager: &'a mut SettingsManager,
+    manager: &'a SettingsManager,
     project_name: Option<String>,
 }
 
 impl<'a> SettingsPage<'a> {
     /// Creates a settings page renderer bound to the active project settings.
-    pub fn new(manager: &'a mut SettingsManager, project_name: Option<String>) -> Self {
+    pub fn new(manager: &'a SettingsManager, project_name: Option<String>) -> Self {
         Self {
             manager,
             project_name,
@@ -56,9 +56,9 @@ impl Page for SettingsPage<'_> {
         let global_section_title = "Global settings".to_string();
 
         let global_table_state =
-            section_table_state(&self.manager.table_state, 0, global_row_count);
+            section_table_state(self.manager.table_state.selected(), 0, global_row_count);
         let project_table_state = section_table_state(
-            &self.manager.table_state,
+            self.manager.table_state.selected(),
             global_row_count,
             project_rows.len(),
         );
@@ -145,12 +145,12 @@ fn settings_section_height(setting_row_count: usize) -> Constraint {
 
 /// Projects the shared settings selection into a section-local table state.
 fn section_table_state(
-    table_state: &TableState,
+    selected: Option<usize>,
     section_start: usize,
     section_len: usize,
 ) -> TableState {
     let mut section_table_state = TableState::default();
-    let Some(selected) = table_state.selected() else {
+    let Some(selected) = selected else {
         return section_table_state;
     };
 
@@ -379,7 +379,7 @@ fn settings_footer_line_for_mode(uses_inline_hint: bool, footer_hint: &str) -> L
 
     let actions = help_action::settings_footer_actions();
 
-    help_action::footer_line(&actions)
+    crate::ui::help_format::footer_line(&actions)
 }
 
 /// Builds single-line settings table rows.
@@ -493,7 +493,7 @@ mod tests {
         table_state.select(Some(0));
 
         // Act
-        let section_state = section_table_state(&table_state, 0, 1);
+        let section_state = section_table_state(table_state.selected(), 0, 1);
 
         // Assert
         assert_eq!(section_state.selected(), Some(0));
@@ -506,7 +506,7 @@ mod tests {
         table_state.select(Some(3));
 
         // Act
-        let section_state = section_table_state(&table_state, 1, 6);
+        let section_state = section_table_state(table_state.selected(), 1, 6);
 
         // Assert
         assert_eq!(section_state.selected(), Some(2));
@@ -519,7 +519,7 @@ mod tests {
         table_state.select(Some(0));
 
         // Act
-        let section_state = section_table_state(&table_state, 1, 6);
+        let section_state = section_table_state(table_state.selected(), 1, 6);
 
         // Assert
         assert_eq!(section_state.selected(), None);
@@ -643,7 +643,8 @@ mod tests {
     fn test_settings_footer_line_uses_shared_actions_in_list_mode() {
         // Arrange
         let footer_hint = "unused while not editing";
-        let expected_line = help_action::footer_line(&help_action::settings_footer_actions());
+        let expected_line =
+            crate::ui::help_format::footer_line(&help_action::settings_footer_actions());
 
         // Act
         let footer_line = settings_footer_line_for_mode(false, footer_hint);

--- a/crates/agentty/src/ui/page/system_log.rs
+++ b/crates/agentty/src/ui/page/system_log.rs
@@ -12,7 +12,7 @@ use time::{OffsetDateTime, UtcOffset};
 use crate::domain::system_log::{
     SYSTEM_LOG_LIMIT, SystemLogBuffer, SystemLogEntry, SystemLogLevel,
 };
-use crate::ui::state::help_action;
+use crate::presentation::help_action;
 use crate::ui::text_util::inline_text;
 use crate::ui::{Page, layout, style};
 
@@ -141,11 +141,13 @@ fn top_scroll_offset(line_count: usize, viewport_height: u16, tail_offset: u16) 
 
 /// Builds the footer help content for the logs page.
 fn system_log_footer_line() -> Line<'static> {
-    let mut line = help_action::footer_line(&help_action::system_log_footer_actions());
-    line.spans.push(help_action::footer_separator_span());
-    line.spans.push(help_action::footer_muted_span(format!(
-        "keeps last {SYSTEM_LOG_LIMIT} entries in memory"
-    )));
+    let mut line = crate::ui::help_format::footer_line(&help_action::system_log_footer_actions());
+    line.spans
+        .push(crate::ui::help_format::footer_separator_span());
+    line.spans
+        .push(crate::ui::help_format::footer_muted_span(format!(
+            "keeps last {SYSTEM_LOG_LIMIT} entries in memory"
+        )));
 
     line
 }

--- a/crates/agentty/src/ui/prompt_format.rs
+++ b/crates/agentty/src/ui/prompt_format.rs
@@ -4,12 +4,12 @@ use ratatui::text::Line;
 
 use crate::domain::agent::AgentKind;
 use crate::infra::file_index;
-use crate::ui::component::chat_input::{SuggestionItem, SuggestionList};
-use crate::ui::state::help_action;
-use crate::ui::state::prompt::{
+use crate::presentation::help_action;
+use crate::presentation::prompt::{
     PromptAtMentionState, PromptSlashState, PromptSuggestionList,
     build_prompt_slash_suggestion_list,
 };
+use crate::ui::component::chat_input::{SuggestionItem, SuggestionList};
 
 const AT_MENTION_DEFAULT_MAX_VISIBLE: usize = 10;
 const NEW_SESSION_PROMPT_FOOTER_ACTIONS: [help_action::HelpAction; 4] = [
@@ -38,14 +38,16 @@ pub fn prompt_footer_line(
     session: &crate::domain::session::Session,
     attachment_count: usize,
 ) -> Line<'static> {
-    let mut footer_line = help_action::footer_line(prompt_footer_actions(session));
+    let mut footer_line = crate::ui::help_format::footer_line(prompt_footer_actions(session));
 
     if attachment_count > 0 {
         let suffix = if attachment_count == 1 { "" } else { "s" };
-        footer_line.spans.push(help_action::footer_separator_span());
         footer_line
             .spans
-            .push(help_action::footer_muted_span(format!(
+            .push(crate::ui::help_format::footer_separator_span());
+        footer_line
+            .spans
+            .push(crate::ui::help_format::footer_muted_span(format!(
                 "{attachment_count} image{suffix} ready"
             )));
     }

--- a/crates/agentty/src/ui/question_format.rs
+++ b/crates/agentty/src/ui/question_format.rs
@@ -3,8 +3,8 @@
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 
-use crate::ui::state::app_mode::QuestionFocus;
-use crate::ui::state::help_action;
+use crate::presentation::app_mode::QuestionFocus;
+use crate::presentation::help_action;
 use crate::ui::{style, text_util};
 
 /// Returns wrapped question-panel lines with the correct focus styling.
@@ -128,5 +128,5 @@ pub fn question_help_footer_line(
         }
     }
 
-    help_action::footer_line(&help_actions)
+    crate::ui::help_format::footer_line(&help_actions)
 }

--- a/crates/agentty/src/ui/render.rs
+++ b/crates/agentty/src/ui/render.rs
@@ -13,7 +13,7 @@ use crate::domain::project::ProjectListItem;
 use crate::domain::session::{DailyActivity, Session, SessionId};
 use crate::domain::system_log::SystemLogBuffer;
 use crate::infra::review_comment_cache::ReviewCommentCache;
-use crate::ui::state::app_mode::{AppMode, ConfirmationViewMode, HelpContext};
+use crate::presentation::app_mode::{AppMode, ConfirmationViewMode, HelpContext};
 use crate::ui::{component, markdown, page, router};
 
 /// Focused-review display state projected from the app cache for one visible
@@ -99,7 +99,7 @@ pub struct RenderContext<'a> {
     /// disk, keyed by session id.
     pub session_worktree_availability: &'a HashMap<SessionId, bool>,
     /// Mutable project-scoped settings snapshot.
-    pub settings: &'a mut SettingsManager,
+    pub settings: &'a SettingsManager,
     /// Process-local retained system log entries.
     pub system_logs: &'a SystemLogBuffer,
     /// Tail-relative scroll offset for the logs page.

--- a/crates/agentty/src/ui/router.rs
+++ b/crates/agentty/src/ui/router.rs
@@ -11,11 +11,11 @@ use crate::domain::project::ProjectListItem;
 use crate::domain::session::{DailyActivity, Session, SessionId};
 use crate::domain::system_log::SystemLogBuffer;
 use crate::infra::review_comment_cache::ReviewCommentCache;
+use crate::presentation::app_mode::{
+    AppMode, ConfirmationIntent, ConfirmationViewMode, DiffRightPanel,
+};
 use crate::ui::overlay::{
     HelpOverlayRenderContext, SyncBlockedPopupRenderContext, ViewInfoPopupRenderContext,
-};
-use crate::ui::state::app_mode::{
-    AppMode, ConfirmationIntent, ConfirmationViewMode, DiffRightPanel,
 };
 use crate::ui::{
     Component, Page, RenderContext, SessionReviewSnapshot, component, markdown, overlay, page,
@@ -68,7 +68,7 @@ pub(crate) struct RouteSharedContext<'a> {
     requested_review_table_state: &'a mut TableState,
     requested_reviews: &'a RequestedReviewState,
     sessions: &'a [Session],
-    settings: &'a mut SettingsManager,
+    settings: &'a SettingsManager,
     stats_activity: &'a [DailyActivity],
     system_log_tail_offset: u16,
     system_logs: &'a SystemLogBuffer,
@@ -896,7 +896,7 @@ pub(crate) fn render_list_background(
         Tab::Settings => {
             let active_project_name =
                 active_project_name(shared.active_project_id, shared.projects);
-            page::setting::SettingsPage::new(&mut *shared.settings, active_project_name)
+            page::setting::SettingsPage::new(shared.settings, active_project_name)
                 .render(f, chunks[1]);
         }
         Tab::Logs => {

--- a/crates/agentty/src/ui/session_format.rs
+++ b/crates/agentty/src/ui/session_format.rs
@@ -11,8 +11,8 @@ use crate::domain::review;
 use crate::domain::session::{
     COMMITTING_PROGRESS_LABEL, PublishedBranchSyncStatus, Session, Status,
 };
+use crate::presentation::help_action::{self, ViewHelpState};
 use crate::ui::icon::Icon;
-use crate::ui::state::help_action::{self, ViewHelpState};
 use crate::ui::{markdown, style, text_util};
 
 const REVIEW_SUGGESTIONS_HEADER: &str = "### Suggestions";
@@ -162,7 +162,7 @@ fn session_metadata_base_text(
 
 /// Builds the footer help line shown in session view mode.
 pub(crate) fn session_view_footer_line(view_help_state: ViewHelpState) -> Line<'static> {
-    help_action::footer_line(&help_action::view_footer_actions(view_help_state))
+    crate::ui::help_format::footer_line(&help_action::view_footer_actions(view_help_state))
 }
 
 /// Renders persisted summary payloads into display markdown.

--- a/crates/agentty/src/ui/state.rs
+++ b/crates/agentty/src/ui/state.rs
@@ -1,5 +1,3 @@
-//! Shared UI state modules.
+//! Compatibility re-exports for shared presentation state.
 
-pub mod app_mode;
-pub mod help_action;
-pub mod prompt;
+pub use crate::presentation::{app_mode, help_action, prompt};

--- a/crates/agentty/src/ui/state/app_mode.rs
+++ b/crates/agentty/src/ui/state/app_mode.rs
@@ -1,5 +1,4 @@
 use ag_forge::RequestedReview;
-use ratatui::layout::Rect;
 
 use super::help_action::{
     self, HelpAction, ViewActionAvailability, ViewHelpState, ViewSessionState,
@@ -50,9 +49,18 @@ impl ConfirmationViewMode {
 /// Cached scroll bounds for the current diff selection and content area.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct DiffScrollCache {
-    pub content_area: Rect,
+    pub content_area: ViewportRect,
     pub file_explorer_selected_index: usize,
     pub max_scroll_offset: u16,
+}
+
+/// Frontend-neutral rectangular viewport coordinates.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ViewportRect {
+    pub height: u16,
+    pub width: u16,
+    pub x: u16,
+    pub y: u16,
 }
 
 /// Selects which content pane is shown on the right side of the diff page.

--- a/crates/agentty/src/ui/state/help_action.rs
+++ b/crates/agentty/src/ui/state/help_action.rs
@@ -1,8 +1,4 @@
-use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
-
 use crate::domain::session::{PublishBranchAction, Session, Status};
-use crate::ui::style;
 
 /// Footer shortcut label for prompt image paste.
 ///
@@ -726,47 +722,6 @@ fn diff_toggle_comments_label(right_panel: super::app_mode::DiffRightPanel) -> &
         super::app_mode::DiffRightPanel::Diff => "Show comments",
         super::app_mode::DiffRightPanel::Comments => "Show diff",
     }
-}
-
-/// Renders one-line footer help as styled spans where keys are emphasized and
-/// labels are muted for faster scanning.
-pub(crate) fn footer_line(actions: &[HelpAction]) -> Line<'static> {
-    let mut spans = Vec::new();
-
-    for (index, action) in actions.iter().enumerate() {
-        if index > 0 {
-            spans.push(footer_separator_span());
-        }
-
-        spans.push(footer_key_span(action.key));
-        spans.push(footer_muted_span(": "));
-        spans.push(footer_muted_span(action.footer_label));
-    }
-
-    Line::from(spans)
-}
-
-/// Returns one highlighted footer key span.
-pub(crate) fn footer_key_span(key: &'static str) -> Span<'static> {
-    Span::styled(
-        key.to_string(),
-        Style::default()
-            .fg(style::palette::accent())
-            .add_modifier(Modifier::BOLD),
-    )
-}
-
-/// Returns one muted footer text span for labels and informational notes.
-pub(crate) fn footer_muted_span(text: impl Into<String>) -> Span<'static> {
-    Span::styled(
-        text.into(),
-        Style::default().fg(style::palette::text_muted()),
-    )
-}
-
-/// Returns the shared separator span used between footer help items.
-pub(crate) fn footer_separator_span() -> Span<'static> {
-    Span::styled(" | ", Style::default().fg(style::palette::text_subtle()))
 }
 
 /// Returns list-mode actions shared by all tabs.
@@ -1593,45 +1548,6 @@ mod tests {
     }
 
     #[test]
-    fn test_footer_line_styles_keys_labels_and_separator() {
-        // Arrange
-        let actions = vec![
-            HelpAction::new("quit", "q", "Quit"),
-            HelpAction::new("help", "?", "Help"),
-        ];
-
-        // Act
-        let line = footer_line(&actions);
-
-        // Assert
-        assert_eq!(line.to_string(), "q: quit | ?: help");
-        assert_eq!(
-            line.spans[0].style,
-            Style::default()
-                .fg(style::palette::accent())
-                .add_modifier(Modifier::BOLD)
-        );
-        assert_eq!(
-            line.spans[1].style,
-            Style::default().fg(style::palette::text_muted())
-        );
-        assert_eq!(
-            line.spans[2].style,
-            Style::default().fg(style::palette::text_muted())
-        );
-        assert_eq!(
-            line.spans[3].style,
-            Style::default().fg(style::palette::text_subtle())
-        );
-        assert_eq!(
-            line.spans[4].style,
-            Style::default()
-                .fg(style::palette::accent())
-                .add_modifier(Modifier::BOLD)
-        );
-    }
-
-    #[test]
     fn test_view_footer_actions_in_progress_shows_stop_and_hides_open() {
         // Arrange
         let state = ViewHelpState {
@@ -1698,33 +1614,5 @@ mod tests {
 
         // Assert
         assert!(!actions.iter().any(|action| action.key == "Ctrl+c"));
-    }
-
-    #[test]
-    fn test_footer_muted_span_uses_muted_footer_style() {
-        // Arrange
-        // Act
-        let span = footer_muted_span("note");
-
-        // Assert
-        assert_eq!(span.content, "note");
-        assert_eq!(
-            span.style,
-            Style::default().fg(style::palette::text_muted())
-        );
-    }
-
-    #[test]
-    fn test_footer_separator_span_uses_shared_separator_style() {
-        // Arrange
-        // Act
-        let span = footer_separator_span();
-
-        // Assert
-        assert_eq!(span.content, " | ");
-        assert_eq!(
-            span.style,
-            Style::default().fg(style::palette::text_subtle())
-        );
     }
 }

--- a/docs/site/content/docs/architecture/change-recipes.md
+++ b/docs/site/content/docs/architecture/change-recipes.md
@@ -61,8 +61,10 @@ through the correct modules without crossing layer boundaries.
 1. Add the page in `crates/agentty/src/ui/page/` or component in
    `crates/agentty/src/ui/component/`.
 1. Wire the page into `crates/agentty/src/ui/router.rs`.
-1. If a new `AppMode` is needed, extend `crates/agentty/src/ui/state/app_mode.rs` and
-   add a key handler in `crates/agentty/src/runtime/mode/`.
+1. If a new `AppMode` is needed, extend the shared presentation contract implemented in
+   `crates/agentty/src/ui/state/app_mode.rs` and exported through
+   `crates/agentty/src/presentation.rs`, then add a key handler in
+   `crates/agentty/src/runtime/mode/`.
 
 ## Contributor Checklist for Architecture-Safe Changes
 

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -66,15 +66,30 @@ For file-level detail, read the module docstrings directly.
   transport internals stay private to `crates/ag-agent/`.
 - `runtime/`: Terminal lifecycle and the event loop — terminal setup, the event-reader
   thread, key dispatch, one handler per `AppMode` under `runtime/mode/`, and shared mode
-  helpers for session-output metrics.
+  helpers for session-output metrics. Runtime owns `PresentationState`, including the
+  shared `RenderCacheStore` used by input metrics and frame rendering.
+- `presentation.rs`: Frontend-neutral interaction state shared by runtime input and UI
+  output. It exposes mode, help-action, prompt, editor, scroll, viewport, and semantic
+  list-selection contracts without importing Ratatui or `ui/` formatting.
 - `ui/`: Rendering — frame composition, mode-to-page routing, pages under `ui/page/`,
-  reusable widgets under `ui/component/`, UI state under `ui/state/`, Agentty theme
-  adapters for `ag-tui-text`, plus diff, layout, review-comment formatting, and theme
-  helpers. Render caches are owned by the shared `RenderCacheStore`.
+  reusable widgets under `ui/component/`, application-to-frame projection in
+  `ui/app_render.rs`, Agentty theme adapters for `ag-tui-text`, plus diff, layout,
+  review-comment formatting, and theme helpers. `ui/state.rs` only provides
+  compatibility re-exports for the shared presentation contracts.
 
 ## Layer Rules
 
 - Workflow and state transitions live in `app/`, not in UI rendering modules.
+- `App` does not render terminal frames or own concrete render caches; runtime passes
+  its presentation cache into the UI projection boundary.
+- `App::view_snapshot()` creates the immutable borrowed application view consumed by
+  frontends. `ui/app_render.rs` receives that snapshot plus runtime-owned Ratatui state
+  and does not access the concrete `App`, services, or managers directly.
+- Application managers retain semantic selected-row indexes through
+  `domain::selection::SelectionState`; runtime owns Ratatui table viewport state and
+  synchronizes selection at the frame projection boundary.
+- `app/` must not import runtime mode handlers. Shared interaction calculations belong
+  in `domain/` or `presentation.rs`, while application task registries belong in `app/`.
 - Business entities and enums live in `domain/`.
 - External side effects live in `infra/` behind mockable traits; see
   [Testability Boundaries](@/docs/architecture/testability-boundaries.md).

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -56,7 +56,7 @@ flowchart TD
   event_reader["event::spawn_event_reader()<br/>dedicated OS thread"]
   main_loop["run_main_loop()"]
   drain["process_pending_app_events()<br/>reduce queued AppEvent values"]
-  draw["ui::render::draw()"]
+  draw["ui::render_app()"]
   process["event::process_events()"]
   key_events["Key events<br/>mode handlers -> app/session orchestration"]
   app_events["App events<br/>App::apply_app_events reducer"]
@@ -83,6 +83,9 @@ flowchart TD
 
 - `run_main_loop()` drains one bounded batch of queued app events before draw so touched
   sessions sync from their live handles without a full list-wide sweep every frame.
+- `run_main_loop()` owns `PresentationState`; input measurement and `ui::render_app()`
+  share its bounded `RenderCacheStore`. `App` neither constructs Ratatui frames nor owns
+  render caches.
 - `process_events()` waits on terminal events, app events, or tick, then drains a
   bounded batch of queued terminal events to avoid one-key-per-frame lag.
 - Tick interval is `50ms`; metadata-based session reload fallback is `5s`.


### PR DESCRIPTION
- Share frontend-neutral interaction contracts through `presentation` and `domain` modules.
- Keep semantic selections in application state while runtime owns Ratatui table viewports and render caches.
- Project immutable app state through `App::view_snapshot()` and a dedicated UI rendering boundary.
- Move `@`-mention task tracking and synchronization formatting into focused application modules.
- Document updated layer ownership and runtime flow.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)