### PR TITLE
Order tied sessions by creation time

### DIFF
--- a/crates/agentty/migrations/059_extend_session_project_ordering_index.sql
+++ b/crates/agentty/migrations/059_extend_session_project_ordering_index.sql
@@ -1,0 +1,4 @@
+DROP INDEX idx_session_project_updated_at;
+
+CREATE INDEX idx_session_project_updated_at
+ON session (project_id, updated_at DESC, created_at DESC, id);

--- a/crates/agentty/src/infra/db/session.rs
+++ b/crates/agentty/src/infra/db/session.rs
@@ -1187,7 +1187,7 @@ SELECT session.base_branch AS base_branch,
 FROM session
 LEFT JOIN session_review_request
 ON session_review_request.session_id = session.id
-ORDER BY session.updated_at DESC, session.id
+ORDER BY session.updated_at DESC, session.created_at DESC, session.id
 ",
         )
         .fetch_all(&self.0)
@@ -1238,7 +1238,7 @@ FROM session
 LEFT JOIN session_review_request
 ON session_review_request.session_id = session.id
 WHERE session.project_id = ?
-ORDER BY session.updated_at DESC, session.id
+ORDER BY session.updated_at DESC, session.created_at DESC, session.id
 ",
         )
         .bind(project_id)
@@ -2655,6 +2655,57 @@ WHERE id = ?
         assert_eq!(fork_reset_row.in_progress_started_at, None);
         assert_eq!(fork_reset_row.in_progress_total_seconds, 0);
         assert_eq!(fork_review_request, None);
+    }
+
+    #[tokio::test]
+    async fn test_load_sessions_uses_created_at_to_break_updated_at_ties() {
+        // Arrange
+        let (database, pool) = AppRepositories::in_memory_with_pool().await;
+        let project_id = database
+            .projects()
+            .upsert_project("/tmp/project", None)
+            .await
+            .expect("failed to upsert project");
+        for session_id in ["a-older", "z-newer"] {
+            database
+                .sessions()
+                .insert_session(session_id, "gpt-5.5", "main", "Review", project_id)
+                .await
+                .expect("failed to insert session");
+        }
+        sqlx::query(
+            r"
+UPDATE session
+SET created_at = CASE id WHEN 'a-older' THEN 100 ELSE 200 END,
+    updated_at = 300
+WHERE id IN ('a-older', 'z-newer')
+",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to set session timestamps");
+
+        // Act
+        let all_session_ids = database
+            .sessions()
+            .load_sessions()
+            .await
+            .expect("failed to load sessions")
+            .into_iter()
+            .map(|session| session.id)
+            .collect::<Vec<_>>();
+        let project_session_ids = database
+            .sessions()
+            .load_sessions_for_project(project_id)
+            .await
+            .expect("failed to load project sessions")
+            .into_iter()
+            .map(|session| session.id)
+            .collect::<Vec<_>>();
+
+        // Assert
+        assert_eq!(all_session_ids, ["z-newer", "a-older"]);
+        assert_eq!(project_session_ids, ["z-newer", "a-older"]);
     }
 
     #[tokio::test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -534,6 +534,52 @@ fn seed_session_with_reasoning_level(env: &BuilderEnv) -> Result<(), Box<dyn std
     Ok(())
 }
 
+/// Seeds sessions whose matching update times require creation-time ordering.
+fn seed_sessions_with_matching_update_times(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    common::seed_session(
+        env,
+        SessionSeed::regular("a-older", "gpt-5.5", "main", "Review")
+            .with_title("Older created session"),
+    )?;
+    common::seed_session(
+        env,
+        SessionSeed::regular("z-newer", "gpt-5.5", "main", "Review")
+            .with_title("Newer created session"),
+    )?;
+
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let db_path = env.agentty_root.join(DB_DIR).join(DB_FILE);
+        let mut connection = SqliteConnectOptions::new()
+            .filename(&db_path)
+            .connect()
+            .await?;
+        let query = sqlx::query(
+            r"
+UPDATE session
+SET created_at = CASE id WHEN 'a-older' THEN 100 ELSE 200 END,
+    updated_at = 300
+WHERE id IN ('a-older', 'z-newer')
+",
+        );
+        connection.execute(query).await?;
+        connection.close().await?;
+
+        Result::<(), Box<dyn std::error::Error>>::Ok(())
+    })?;
+
+    for session_id in ["a-older", "z-newer"] {
+        std::fs::create_dir_all(test_support::session_folder(
+            &env.agentty_root.join("wt"),
+            session_id,
+        ))?;
+    }
+
+    Ok(())
+}
+
 /// Adds a Gemini CLI stub that intentionally exits with failure.
 ///
 /// Picker tests only need the executable to exist on `PATH`; using a failing
@@ -1038,6 +1084,45 @@ fn session_list_model_reasoning_level() -> E2eResult {
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "gpt-5.5 [medium]", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify matching update times fall back to newest creation time first.
+#[test]
+fn session_list_matching_update_times_use_creation_order() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_list_creation_order")
+        .with_git()
+        .setup(seed_sessions_with_matching_update_times)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .wait_for_text("Newer created session", 5000)
+                    .capture_labeled(
+                        "creation_order",
+                        "Matching update times ordered by creation time",
+                    )
+            },
+            |frame, _report| {
+                let newer_row = frame
+                    .find_text("Newer created session")
+                    .first()
+                    .expect("missing newer session row")
+                    .rect
+                    .row;
+                let older_row = frame
+                    .find_text("Older created session")
+                    .first()
+                    .expect("missing older session row")
+                    .rect
+                    .row;
+
+                assert!(newer_row < older_row);
             },
         )?;
 


### PR DESCRIPTION
- Order global and project sessions by `created_at` when `updated_at` matches.
- Extend the project session ordering index to cover the secondary key.
- Cover the ordering with unit and E2E tests.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)