### PR TITLE
Persist session state before publishing turn updates

### DIFF
--- a/crates/agentty/src/app/assist.rs
+++ b/crates/agentty/src/app/assist.rs
@@ -107,7 +107,7 @@ pub(super) async fn append_assist_header(
     let assist_header = notice.format(format!(
         "Attempt {assist_attempt}/{max_assist_attempts}. {assist_action}\n{detail}"
     ));
-    SessionTaskService::append_workflow_notice(
+    let _ = SessionTaskService::append_workflow_notice(
         &context.transcript,
         &context.db,
         &context.app_event_tx,

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -1927,7 +1927,26 @@ impl App {
 
         let status_transition =
             StatusTransition::from_services(&self.services, handles, session_id);
-        let _ = status_transition.apply(Status::Canceled).await;
+        match status_transition.apply(Status::Canceled).await {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::warn!(
+                    session_id,
+                    "skipping stacked-child cancellation because parent status changed"
+                );
+
+                return;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    session_id,
+                    error = %error,
+                    "skipping stacked-child cancellation because parent cancellation failed"
+                );
+
+                return;
+            }
+        }
         self.sessions
             .cancel_stacked_child_sessions(&self.services, session_id)
             .await;

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -1858,7 +1858,7 @@ impl App {
         let handles = self.sessions.session_handles_or_err(session_id)?;
         let status_transition =
             StatusTransition::from_services(&self.services, handles, session_id);
-        let status_updated = status_transition.apply(Status::Queued).await;
+        let status_updated = status_transition.apply(Status::Queued).await?;
 
         if !status_updated {
             return Err(AppError::Workflow(
@@ -2071,7 +2071,8 @@ mod fork_tests {
 
         persist_fork_source_runtime_linkage(app, &source_session_id).await;
         persist_fork_source_transcript(app, &source_session_id).await;
-        crate::test_support::set_session_status_for_test(app, &source_session_id, Status::Review);
+        crate::test_support::set_session_status_for_test(app, &source_session_id, Status::Review)
+            .await;
 
         source_session_id
     }

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -5155,6 +5155,113 @@ async fn test_apply_review_request_status_update_closed_cancels_stacked_child() 
 }
 
 #[tokio::test]
+async fn test_closed_review_does_not_cancel_stacked_child_when_parent_update_fails() {
+    // Arrange
+    let base_dir = tempdir().expect("failed to create temp dir");
+    let base_path = base_dir.path().to_path_buf();
+    let (database, pool) = AppRepositories::in_memory_with_pool().await;
+    let mut app = App::new_with_clients(
+        base_path.clone(),
+        base_path,
+        None,
+        database,
+        crate::test_support::test_app_clients(),
+    )
+    .await
+    .expect("failed to build app");
+    let project_id = app.active_project_id();
+    let session_id = "session-closed-failure";
+    let child_session_id = "session-child-preserved";
+    app.services
+        .db()
+        .sessions()
+        .insert_session(
+            session_id,
+            "gemini-3-flash-preview",
+            "main",
+            &Status::Review.to_string(),
+            project_id,
+        )
+        .await
+        .expect("failed to insert parent session");
+    app.services
+        .db()
+        .sessions()
+        .insert_stacked_draft_session(
+            child_session_id,
+            "gemini-3-flash-preview",
+            "wt/session",
+            &Status::Draft.to_string(),
+            session_id,
+            project_id,
+        )
+        .await
+        .expect("failed to insert child session");
+    let session_data_dir = app
+        .services
+        .base_path()
+        .join(session_id.chars().take(8).collect::<String>())
+        .join(SESSION_DATA_DIR);
+    fs::create_dir_all(session_data_dir).expect("failed to create session data dir");
+    app.refresh_sessions_now().await;
+    sqlx::query(
+        r"
+CREATE TRIGGER fail_external_parent_cancel
+BEFORE UPDATE OF status ON session
+WHEN OLD.id = 'session-closed-failure' AND NEW.status = 'Canceled'
+BEGIN
+    SELECT RAISE(FAIL, 'injected parent cancellation failure');
+END
+",
+    )
+    .execute(&pool)
+    .await
+    .expect("failed to install parent cancellation failure trigger");
+    let update = ReviewRequestStatusUpdate {
+        generation: 0,
+        result: Ok(SyncReviewRequestTaskResult {
+            outcome: session::SyncReviewRequestOutcome::Closed {
+                display_id: "#8".to_string(),
+            },
+            summary: Some(test_review_request_summary(
+                "#8",
+                ReviewRequestState::Closed,
+            )),
+        }),
+        session_id: session_id.into(),
+    };
+
+    // Act
+    app.apply_review_request_status_update(update).await;
+    app.process_pending_app_events().await;
+
+    // Assert
+    let parent_session = app
+        .sessions
+        .session_or_err(session_id)
+        .expect("expected parent session to remain loaded");
+    let child_session = app
+        .sessions
+        .session_or_err(child_session_id)
+        .expect("expected child session to remain loaded");
+    assert_eq!(parent_session.status, Status::Review);
+    assert_eq!(child_session.status, Status::Draft);
+    let persisted_sessions = app
+        .services
+        .db()
+        .sessions()
+        .load_sessions()
+        .await
+        .expect("failed to load persisted sessions");
+    assert!(persisted_sessions.iter().any(|session| {
+        session.id == session_id && session.status == Status::Review.to_string()
+    }));
+    assert!(persisted_sessions.iter().any(|session| {
+        session.id == child_session_id && session.status == Status::Draft.to_string()
+    }));
+}
+
+#[tokio::test]
 async fn test_apply_review_request_status_update_merged_marks_session_done() {
     // Arrange
     let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -2129,7 +2129,7 @@ async fn test_start_staged_session_clears_draft_flag() {
 }
 
 #[tokio::test]
-async fn test_start_staged_session_succeeds_when_clearing_draft_flag_fails() {
+async fn test_start_staged_session_rolls_back_when_clearing_draft_flag_fails() {
     // Arrange
     let dir = tempdir().expect("failed to create temp dir");
     let (db, pool) = AppRepositories::in_memory_with_pool().await;
@@ -2159,14 +2159,15 @@ END
     let result = app.start_staged_session(&session_id).await;
 
     // Assert
-    assert!(result.is_ok());
+    assert!(result.is_err());
     let session = app
         .sessions
         .sessions()
         .iter()
         .find(|session| session.id == session_id)
-        .expect("missing started session");
+        .expect("missing draft session");
     assert!(session.is_draft);
+    assert_eq!(session.status, Status::Draft);
     let db_sessions = app
         .services
         .db()
@@ -2175,6 +2176,16 @@ END
         .await
         .expect("failed to load sessions");
     assert!(db_sessions[0].is_draft);
+    assert_eq!(db_sessions[0].status, "Draft");
+    assert!(
+        app.services
+            .db()
+            .operations()
+            .load_unfinished_session_operations()
+            .await
+            .expect("failed to load operations")
+            .is_empty()
+    );
 }
 
 #[tokio::test]
@@ -2183,7 +2194,8 @@ async fn test_start_staged_session_launches_stacked_draft_child() {
     let dir = tempdir().expect("failed to create temp dir");
     let mut app = new_test_app_with_git(dir.path()).await;
     let parent_session_id = app.create_session().await.expect("failed to create parent");
-    crate::test_support::set_session_status_for_test(&mut app, &parent_session_id, Status::Review);
+    crate::test_support::set_session_status_for_test(&mut app, &parent_session_id, Status::Review)
+        .await;
     let child_session_id = app
         .create_stacked_draft_session(&parent_session_id)
         .await
@@ -2455,7 +2467,8 @@ async fn test_parent_turn_completion_rebases_review_ready_stacked_child() {
         .create_dir_all(child_folder)
         .await
         .expect("failed to materialize child worktree folder");
-    crate::test_support::set_session_status_for_test(&mut app, &child_session_id, Status::Review);
+    crate::test_support::set_session_status_for_test(&mut app, &child_session_id, Status::Review)
+        .await;
     app.services
         .db()
         .sessions()
@@ -2498,7 +2511,8 @@ async fn test_enqueue_message_pushes_prompt_onto_in_memory_queue() {
     create_and_start_session(&mut app, "Initial").await;
     let session_id = app.sessions.sessions()[0].id.clone();
     wait_for_status(&mut app, &session_id, Status::Review).await;
-    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::InProgress);
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::InProgress)
+        .await;
 
     // Act
     app.enqueue_message(&session_id, "queued reply")
@@ -2537,7 +2551,11 @@ async fn test_enqueue_message_survives_refresh_sessions_reducer_pass() {
     create_and_start_session(&mut app, "Initial").await;
     let session_id = app.sessions.sessions()[0].id.clone();
     wait_for_status(&mut app, &session_id, Status::Review).await;
-    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::InProgress);
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::InProgress)
+        .await;
+    app.sessions
+        .worker_service_mut()
+        .clear_session_worker(&session_id);
     app.enqueue_message(&session_id, "queued reply")
         .expect("enqueue_message should succeed for InProgress session");
 
@@ -2570,7 +2588,8 @@ async fn test_enqueue_message_rejects_empty_payload() {
     create_and_start_session(&mut app, "Initial").await;
     let session_id = app.sessions.sessions()[0].id.clone();
     wait_for_status(&mut app, &session_id, Status::Review).await;
-    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::InProgress);
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::InProgress)
+        .await;
 
     // Act
     let outcome = app.enqueue_message(&session_id, "");
@@ -3543,10 +3562,10 @@ async fn test_spawn_integration() {
 /// worker in `InProgress` and correctly polls until `Review`. Without this,
 /// `wait_for_status` would return immediately because the initial status
 /// is already `Review` before the worker runs.
-async fn test_reply_with_backend_replays_history_once_after_model_switch() {
+async fn test_reply_with_backend_retries_history_replay_after_persistence_failure() {
     // Arrange
     let dir = tempdir().expect("failed to create temp dir");
-    let db = AppRepositories::in_memory().await;
+    let (db, pool) = AppRepositories::in_memory_with_pool().await;
     let mut app = new_test_app_with_git_and_db(dir.path(), db).await;
 
     let session_id = app
@@ -3562,15 +3581,11 @@ async fn test_reply_with_backend_replays_history_once_after_model_switch() {
     {
         session.transcript = Some(crate::test_support::assistant_transcript(&initial_output));
         session.prompt = "Initial prompt".to_string();
-        session.status = Status::Review;
     }
-    if let Some(handles) = app.sessions.session_handles().get(session_id.as_str()) {
-        if let Ok(mut transcript) = handles.transcript.lock() {
-            *transcript = crate::test_support::assistant_transcript(&initial_output);
-        }
-        if let Ok(mut status) = handles.status.lock() {
-            *status = Status::Review;
-        }
+    if let Some(handles) = app.sessions.session_handles().get(session_id.as_str())
+        && let Ok(mut transcript) = handles.transcript.lock()
+    {
+        *transcript = crate::test_support::assistant_transcript(&initial_output);
     }
 
     // Persist the prompt so that `RefreshSessions` reloads from DB with the
@@ -3584,6 +3599,7 @@ async fn test_reply_with_backend_replays_history_once_after_model_switch() {
         .update_session_prompt(&session_id, "Initial prompt")
         .await
         .expect("failed to persist initial prompt");
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::Review).await;
 
     app.set_session_model(
         &session_id,
@@ -3634,7 +3650,20 @@ async fn test_reply_with_backend_replays_history_once_after_model_switch() {
         .test_agent_channels
         .insert(session_id.clone().into(), Arc::new(mock_channel));
 
-    // Act — first reply after model switch: history should be replayed.
+    configure_replay_reply_start_failure(&pool, true).await;
+
+    // Act — a failed reply start must retain the pending replay marker.
+    let failed_reply_enqueued = app
+        .sessions
+        .reply(&app.services, &session_id, "Failed switch reply")
+        .await;
+
+    // Assert
+    assert!(!failed_reply_enqueued);
+
+    configure_replay_reply_start_failure(&pool, false).await;
+
+    // Act — the retry after model switch should still replay history.
     app.sessions
         .reply(&app.services, &session_id, "Switch reply")
         .await;
@@ -3665,6 +3694,25 @@ async fn test_reply_with_backend_replays_history_once_after_model_switch() {
         outputs[1].is_none(),
         "second reply should not replay history"
     );
+}
+
+async fn configure_replay_reply_start_failure(pool: &sqlx::SqlitePool, enabled: bool) {
+    let statement = if enabled {
+        r"
+CREATE TRIGGER fail_replay_reply_start
+BEFORE UPDATE OF status ON session
+BEGIN
+    SELECT RAISE(FAIL, 'injected reply start failure');
+END
+"
+    } else {
+        "DROP TRIGGER fail_replay_reply_start"
+    };
+
+    sqlx::query(statement)
+        .execute(pool)
+        .await
+        .expect("failed to configure reply start failure trigger");
 }
 
 /// Ensures resumed review sessions replay persisted transcript output on
@@ -4197,6 +4245,25 @@ async fn test_merge_session_no_git() {
     let dir = tempdir().expect("failed to create temp dir");
     let mut app = new_test_app(dir.path().to_path_buf()).await;
     add_manual_session(&mut app, dir.path(), "manual01", "Test");
+    let project_id = app
+        .services
+        .db()
+        .projects()
+        .upsert_project("/tmp/project", Some("main".to_string()))
+        .await
+        .expect("failed to insert project");
+    app.services
+        .db()
+        .sessions()
+        .insert_session("manual01", "gpt-5.5", "main", "Review", project_id)
+        .await
+        .expect("failed to insert session");
+    let mut mock_git_client = git::MockGitClient::new();
+    mock_git_client
+        .expect_find_git_repo_root()
+        .times(1)
+        .returning(|_| Box::pin(async { None }));
+    install_mock_git_client(&mut app, mock_git_client);
 
     // Act
     let result = app.merge_session("manual01").await;
@@ -4207,7 +4274,7 @@ async fn test_merge_session_no_git() {
         result
             .expect_err("should be error")
             .to_string()
-            .contains("No git worktree")
+            .contains("Failed to find git repository root")
     );
 }
 
@@ -4239,7 +4306,7 @@ async fn test_merge_session_removes_worktree_and_branch_after_success() {
         .create_session()
         .await
         .expect("failed to create merge session");
-    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::Review);
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::Review).await;
     let session_folder = app
         .sessions
         .sessions()
@@ -4285,7 +4352,8 @@ async fn test_merge_session_restacks_stacked_child_after_success() {
     app.stage_draft_message(&child_session_id, "Ready after parent merge")
         .await
         .expect("failed to stage child draft message");
-    crate::test_support::set_session_status_for_test(&mut app, &parent_session_id, Status::Review);
+    crate::test_support::set_session_status_for_test(&mut app, &parent_session_id, Status::Review)
+        .await;
     let mock_git = create_mock_git_client_for_successful_noop_merges(1, dir.path().to_path_buf());
     app.sessions.git_client = Arc::new(mock_git);
 
@@ -4319,7 +4387,7 @@ async fn test_merge_session_marks_done_when_changes_are_already_in_base() {
         .create_session()
         .await
         .expect("failed to create merge session");
-    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::Review);
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::Review).await;
     let mock_git = create_mock_git_client_for_successful_noop_merges(1, dir.path().to_path_buf());
     app.sessions.git_client = Arc::new(mock_git);
 
@@ -4353,8 +4421,10 @@ async fn test_merge_session_queue_processes_sessions_in_fifo_order() {
         .create_session()
         .await
         .expect("failed to create second queue session");
-    crate::test_support::set_session_status_for_test(&mut app, &first_session_id, Status::Review);
-    crate::test_support::set_session_status_for_test(&mut app, &second_session_id, Status::Review);
+    crate::test_support::set_session_status_for_test(&mut app, &first_session_id, Status::Review)
+        .await;
+    crate::test_support::set_session_status_for_test(&mut app, &second_session_id, Status::Review)
+        .await;
     let mock_git = create_mock_git_client_for_successful_noop_merges(2, dir.path().to_path_buf());
     app.sessions.git_client = Arc::new(mock_git);
 
@@ -4445,7 +4515,8 @@ async fn test_rebase_session_accepts_in_progress_status_before_worktree_validati
     let dir = tempdir().expect("failed to create temp dir");
     let mut app = new_test_app(dir.path().to_path_buf()).await;
     add_manual_session(&mut app, dir.path(), "manual01", "Test");
-    crate::test_support::set_session_status_for_test(&mut app, "manual01", Status::InProgress);
+    crate::test_support::set_session_status_for_test(&mut app, "manual01", Status::InProgress)
+        .await;
 
     // Act
     let result = app.rebase_session("manual01").await;
@@ -4538,12 +4609,7 @@ async fn test_rebase_session_updates_session_worktree_to_base_head() {
         .create_session()
         .await
         .expect("failed to create session");
-    app.sessions.sessions_mut()[0].status = Status::Review;
-    if let Some(handles) = app.sessions.session_handles().get(session_id.as_str())
-        && let Ok(mut session_status) = handles.status.lock()
-    {
-        *session_status = Status::Review;
-    }
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::Review).await;
 
     // Act
     let result = app.rebase_session(&session_id).await;
@@ -4571,7 +4637,8 @@ async fn test_rebase_session_cancels_pending_focused_review() {
         )
         .await
         .expect("failed to seed persisted focused review");
-    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::AgentReview);
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::AgentReview)
+        .await;
     app.mode = AppMode::View {
         session_id: session_id.clone().into(),
         scroll_offset: None,
@@ -4624,7 +4691,8 @@ async fn test_rebase_session_cleanup_failure_does_not_start_sync() {
         )
         .await
         .expect("failed to seed persisted focused review");
-    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::AgentReview);
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::AgentReview)
+        .await;
     app.mode = AppMode::View {
         session_id: session_id.clone().into(),
         scroll_offset: None,
@@ -4729,12 +4797,7 @@ async fn test_rebase_session_auto_commits_uncommitted_changes() {
         .await
         .expect("failed to create session");
     let session_folder = app.sessions.sessions()[0].folder.clone();
-    app.sessions.sessions_mut()[0].status = Status::Review;
-    if let Some(handles) = app.sessions.session_handles().get(session_id.as_str())
-        && let Ok(mut session_status) = handles.status.lock()
-    {
-        *session_status = Status::Review;
-    }
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::Review).await;
 
     // Create an uncommitted change in the session worktree
     std::fs::write(session_folder.join("dirty.txt"), "uncommitted content")
@@ -4942,7 +5005,7 @@ async fn test_cancel_session() {
         .expect("missing session")
         .folder
         .clone();
-    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::Review);
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::Review).await;
 
     // Act
     app.sessions
@@ -5035,7 +5098,8 @@ async fn test_cancel_session_cascades_to_stacked_child() {
         .create_stacked_draft_session(&parent_session_id)
         .await
         .expect("failed to create stacked draft session");
-    crate::test_support::set_session_status_for_test(&mut app, &parent_session_id, Status::Review);
+    crate::test_support::set_session_status_for_test(&mut app, &parent_session_id, Status::Review)
+        .await;
 
     // Act
     app.sessions
@@ -5091,7 +5155,8 @@ async fn test_cancel_running_session_stops_turn_and_cancels_session() {
         .create_session()
         .await
         .expect("failed to create session");
-    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::InProgress);
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::InProgress)
+        .await;
     app.services
         .db()
         .operations()
@@ -5305,7 +5370,8 @@ async fn test_done_status_triggers_app_server_shutdown() {
         &session_id,
         Status::Merging,
     )
-    .await;
+    .await
+    .expect("merging status persistence should succeed");
     assert!(
         transitioned_to_merging,
         "status transition to Merging should succeed"
@@ -5319,7 +5385,8 @@ async fn test_done_status_triggers_app_server_shutdown() {
         &session_id,
         Status::Done,
     )
-    .await;
+    .await
+    .expect("done status persistence should succeed");
     assert!(
         transitioned_to_done,
         "status transition to Done should succeed"

--- a/crates/agentty/src/app/session/error.rs
+++ b/crates/agentty/src/app/session/error.rs
@@ -1,3 +1,5 @@
+use crate::domain::session::Status;
+
 /// Typed error returned by session-layer workflow operations.
 ///
 /// Wraps infrastructure errors from git, database, app-server, and forge
@@ -21,6 +23,17 @@ pub enum SessionError {
     /// A database operation failed.
     #[error("{0}")]
     Db(#[from] crate::infra::db::DbError),
+
+    /// Durable terminal status persistence failed after the provider turn
+    /// completed, so the owning operation must remain recoverable.
+    #[error("Failed to persist terminal session status `{target_status}`: {source}")]
+    TerminalStatusPersistence {
+        /// Terminal status that still needs to be persisted.
+        target_status: Status,
+        /// Database failure returned by the status transition.
+        #[source]
+        source: crate::infra::db::DbError,
+    },
 
     /// A filesystem boundary operation failed.
     #[error("{0}")]

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -13,7 +13,6 @@ use tokio::sync::mpsc;
 use tracing::warn;
 use uuid::Uuid;
 
-use super::task::SessionTranscriptMessageAppend;
 use super::worker::{SessionCommand, TurnMetadata};
 use super::{
     SessionTaskService, StatusTransition, draft, isolation, session_branch, session_folder,
@@ -32,7 +31,9 @@ use crate::domain::session::{
     can_reply_to_session_in_stack as stack_can_reply_to_session,
     can_start_staged_session_in_stack as stack_can_start_staged_session,
 };
-use crate::domain::session_message::{SessionMessageKind, SessionTranscript};
+#[cfg(test)]
+use crate::domain::session_message::SessionMessageKind;
+use crate::domain::session_message::SessionTranscript;
 use crate::domain::session_order;
 use crate::domain::setting::SettingName;
 use crate::domain::transcript_notice::TranscriptNotice;
@@ -69,8 +70,45 @@ struct BuildSessionCommandInput {
     session_agent: AgentSelection,
 }
 
+/// Inputs for committing and publishing a first runnable turn.
+struct FirstTurnPublishInput<'a> {
+    message_content: &'a str,
+    operation_id: &'a str,
+    operation_kind: &'a str,
+    prompt: &'a str,
+    session_id: &'a str,
+    session_index: usize,
+    status: &'a Arc<Mutex<Status>>,
+    title: &'a str,
+    transcript: &'a Arc<Mutex<SessionTranscript>>,
+}
+
+/// Owned inputs for starting a first-message reply.
+struct FirstReplyInput {
+    prompt: TurnPrompt,
+    published_upstream_ref: Option<String>,
+    replay_transcript: Option<String>,
+    session_agent: AgentSelection,
+    session_id: SessionId,
+    session_index: usize,
+    status: Arc<Mutex<Status>>,
+    title: String,
+    transcript: Arc<Mutex<SessionTranscript>>,
+}
+
+/// Inputs for committing and publishing one follow-up turn start.
+struct ReplyStartPublishInput<'a> {
+    expected_status: Status,
+    message_content: &'a str,
+    operation_id: &'a str,
+    operation_kind: &'a str,
+    session_id: &'a str,
+    status: &'a Arc<Mutex<Status>>,
+    transcript: &'a Arc<Mutex<SessionTranscript>>,
+}
+
 /// Intermediate values captured while preparing a session reply.
-type ReplyContext = (Option<String>, bool, SessionId, Option<String>);
+type ReplyContext = (Option<String>, bool, SessionId, Option<String>, Status);
 
 /// Cleanup payload for a deleted session's git and filesystem resources.
 struct DeletedSessionCleanup {
@@ -674,39 +712,6 @@ impl SessionManager {
         Ok(())
     }
 
-    /// Clears the persisted and in-memory draft flag once a draft session
-    /// starts its first live turn.
-    ///
-    /// The flag only means "still staging draft prompts", so it must not
-    /// outlive the session start; a sticky flag would keep draft-only
-    /// restrictions, such as the fork gate, active for the session's whole
-    /// life. Non-draft sessions skip the write.
-    ///
-    /// # Errors
-    /// Returns an error if the session is missing or persistence fails.
-    async fn clear_session_draft_flag(
-        &mut self,
-        services: &AppServices,
-        session_id: &str,
-    ) -> Result<(), SessionError> {
-        if !self.session_or_err(session_id)?.is_draft_session() {
-            return Ok(());
-        }
-
-        services
-            .db()
-            .sessions()
-            .clear_session_draft_flag(session_id)
-            .await?;
-
-        let session_index = self.session_index_or_err(session_id)?;
-        if let Some(session) = self.session_at_mut(session_index) {
-            session.is_draft = false;
-        }
-
-        Ok(())
-    }
-
     /// Persists the parent tip used by a stacked draft's newly materialized
     /// worktree.
     ///
@@ -1096,10 +1101,7 @@ impl SessionManager {
                 .session_at_mut(session_index)
                 .ok_or(SessionError::NotFound)?;
 
-            session.prompt.clone_from(&prompt.text);
-
             let title = prompt.text.clone();
-            session.title = Some(title.clone());
             let session_agent = session.agent;
 
             (session.id.clone(), session_agent, title)
@@ -1107,37 +1109,28 @@ impl SessionManager {
 
         let handles = self.session_handles_or_err(&persisted_session_id)?;
         let transcript = Arc::clone(&handles.transcript);
-        let status_transition =
-            StatusTransition::from_services(services, handles, persisted_session_id.clone());
-        let app_event_tx = services.event_sender();
-
-        self.persist_first_message_metadata(services, &persisted_session_id, &prompt.text, &title)
-            .await;
+        let status = Arc::clone(&handles.status);
 
         let prompt_transcript_text = prompt.transcript_text();
         let initial_output = Self::formatted_prompt_output(&prompt, false);
-        SessionTaskService::append_session_transcript_message(
-            &transcript,
-            services.db(),
-            &app_event_tx,
-            &services.session_update_versions(),
-            &persisted_session_id,
-            SessionTranscriptMessageAppend {
-                kind: SessionMessageKind::UserPrompt,
-                raw_content: &prompt_transcript_text,
+        let operation_id = Uuid::new_v4().to_string();
+        self.persist_and_publish_first_turn(
+            services,
+            FirstTurnPublishInput {
+                message_content: &prompt_transcript_text,
+                operation_id: &operation_id,
+                operation_kind: "start_prompt",
+                prompt: &prompt.text,
+                session_id: &persisted_session_id,
+                session_index,
+                status: &status,
+                title: &title,
+                transcript: &transcript,
             },
         )
-        .await;
+        .await?;
         self.set_active_prompt_output(&persisted_session_id, initial_output);
 
-        if !status_transition.apply(Status::InProgress).await {
-            warn!(
-                session_id = %persisted_session_id,
-                "skipped session start status update because the in-memory status did not transition to in-progress"
-            );
-        }
-
-        let operation_id = Uuid::new_v4().to_string();
         let command = SessionCommand::Run {
             operation_id,
             request_kind: AgentRequestKind::SessionStart,
@@ -1149,21 +1142,13 @@ impl SessionManager {
             },
         };
         if let Err(error) = self
-            .enqueue_session_command(services, &persisted_session_id, command)
+            .enqueue_persisted_session_command(services, &persisted_session_id, command)
             .await
         {
             self.cleanup_prompt_attachment_files(services, &prompt)
                 .await;
 
             return Err(error);
-        }
-
-        if let Err(error) = self.clear_session_draft_flag(services, session_id).await {
-            warn!(
-                session_id,
-                %error,
-                "failed to clear draft flag after session start"
-            );
         }
 
         Ok(())
@@ -1231,6 +1216,7 @@ impl SessionManager {
         if let Ok(mut guard) = handles.queued_messages.lock() {
             guard.push_back(prompt);
         }
+        self.worker_service.wake_queued_messages(session_id);
 
         self.state.sync_session_from_handle(session_id);
 
@@ -1792,63 +1778,59 @@ impl SessionManager {
             return false;
         };
         let should_replay_history = self.should_replay_history(session_id);
-        let (replay_transcript, is_first_message, persisted_session_id, title_to_save) =
-            match self.prepare_reply_context(session_index, &prompt, should_replay_history) {
-                Ok(Some(reply_context)) => reply_context,
-                Ok(None) => return false,
-                Err(error) => {
-                    self.append_reply_status_error(services, session_id, &error)
-                        .await;
+        let (
+            replay_transcript,
+            is_first_message,
+            persisted_session_id,
+            title_to_save,
+            expected_status,
+        ) = match self.prepare_reply_context(session_index, &prompt, should_replay_history) {
+            Ok(Some(reply_context)) => reply_context,
+            Ok(None) => return false,
+            Err(error) => {
+                self.append_reply_status_error(services, session_id, &error)
+                    .await;
 
-                    return false;
-                }
-            };
-
-        if should_replay_history {
-            self.clear_history_replay_pending(&persisted_session_id);
-        }
-
-        let app_event_tx = services.event_sender();
+                return false;
+            }
+        };
 
         let Ok(handles) = self.session_handles_or_err(&persisted_session_id) else {
             return false;
         };
 
         let transcript = Arc::clone(&handles.transcript);
-        let status_transition =
-            StatusTransition::from_services(services, handles, persisted_session_id.clone());
+        let status = Arc::clone(&handles.status);
 
         let effective_prompt = prompt;
-
-        if let Some(title) = title_to_save {
-            self.persist_first_message_metadata(
-                services,
-                &persisted_session_id,
-                &effective_prompt.text,
-                &title,
-            )
-            .await;
-
-            if !status_transition.apply(Status::InProgress).await {
-                warn!(
-                    session_id = %persisted_session_id,
-                    "skipped reply status update because the in-memory status did not transition to in-progress"
-                );
-            }
-        }
-
-        self.append_reply_prompt_line(
-            services,
-            &transcript,
-            &app_event_tx,
-            &persisted_session_id,
-            &effective_prompt,
-        )
-        .await;
         let published_upstream_ref = self
             .session_or_err(&persisted_session_id)
             .ok()
             .and_then(|session| session.published_upstream_ref.clone());
+
+        if let Some(title) = title_to_save {
+            let enqueued = self
+                .start_first_reply(
+                    services,
+                    FirstReplyInput {
+                        prompt: effective_prompt,
+                        published_upstream_ref,
+                        replay_transcript,
+                        session_agent,
+                        session_id: persisted_session_id.clone(),
+                        session_index,
+                        status,
+                        title,
+                        transcript,
+                    },
+                )
+                .await;
+            if enqueued && should_replay_history {
+                self.clear_history_replay_pending(&persisted_session_id);
+            }
+
+            return enqueued;
+        }
 
         let command = Self::build_session_command(BuildSessionCommandInput {
             is_first_message,
@@ -1857,14 +1839,47 @@ impl SessionManager {
             replay_transcript,
             session_agent,
         });
-        self.enqueue_reply_command(
-            services,
-            &transcript,
+        let operation_id = command.operation_id().to_string();
+        let prompt_transcript_text = effective_prompt.transcript_text();
+        if let Err(error) = self
+            .persist_and_publish_reply_start(
+                services,
+                ReplyStartPublishInput {
+                    expected_status,
+                    message_content: &prompt_transcript_text,
+                    operation_id: &operation_id,
+                    operation_kind: command.kind(),
+                    session_id: &persisted_session_id,
+                    status: &status,
+                    transcript: &transcript,
+                },
+            )
+            .await
+        {
+            self.append_reply_status_error(services, session_id, &error)
+                .await;
+
+            return false;
+        }
+        self.set_active_prompt_output(
             &persisted_session_id,
-            &effective_prompt,
-            command,
-        )
-        .await
+            Self::formatted_prompt_output(&effective_prompt, true),
+        );
+
+        let enqueued = self
+            .enqueue_persisted_reply_command(
+                services,
+                &transcript,
+                &persisted_session_id,
+                &effective_prompt,
+                command,
+            )
+            .await;
+        if enqueued && should_replay_history {
+            self.clear_history_replay_pending(&persisted_session_id);
+        }
+
+        enqueued
     }
 
     /// Validates reply eligibility and gathers per-session values needed for
@@ -1907,13 +1922,7 @@ impl SessionManager {
             ));
         }
 
-        let mut title_to_save = None;
-        if is_first_message {
-            session.prompt.clone_from(&prompt.text);
-            let title = prompt.text.clone();
-            session.title = Some(title.clone());
-            title_to_save = Some(title);
-        }
+        let title_to_save = is_first_message.then(|| prompt.text.clone());
 
         let replay_transcript = if !is_first_message
             && (should_replay_history
@@ -1932,73 +1941,145 @@ impl SessionManager {
             is_first_message,
             session.id.clone(),
             title_to_save,
+            session.status,
         )))
     }
 
-    /// Persists first-message prompt/title metadata before queueing execution.
-    ///
-    /// This writes the initial prompt/title.
-    ///
-    /// Title generation itself is triggered once from the start-turn worker
-    /// path as soon as the first turn starts running.
-    async fn persist_first_message_metadata(
-        &self,
-        services: &AppServices,
-        session_id: &str,
-        prompt: &str,
-        title: &str,
-    ) {
-        if let Err(error) = services
-            .db()
-            .sessions()
-            .update_session_title(session_id, title)
-            .await
-        {
-            warn!(
-                session_id = session_id,
-                error = %error,
-                "failed to persist first-message session title"
-            );
-        }
-
-        if let Err(error) = services
-            .db()
-            .sessions()
-            .update_session_prompt(session_id, prompt)
-            .await
-        {
-            warn!(
-                session_id = session_id,
-                error = %error,
-                "failed to persist first-message session prompt"
-            );
-        }
-    }
-
-    /// Appends the user reply marker line to session output.
-    async fn append_reply_prompt_line(
+    /// Commits and publishes one follow-up prompt, status transition,
+    /// question clear, and operation as a single use case.
+    async fn persist_and_publish_reply_start(
         &mut self,
         services: &AppServices,
-        transcript: &Arc<Mutex<SessionTranscript>>,
-        app_event_tx: &mpsc::UnboundedSender<AppEvent>,
-        session_id: &str,
-        prompt: &TurnPrompt,
-    ) {
-        let prompt_transcript_text = prompt.transcript_text();
-        let reply_line = Self::formatted_prompt_output(prompt, true);
-        SessionTaskService::append_session_transcript_message(
-            transcript,
-            services.db(),
-            app_event_tx,
+        input: ReplyStartPublishInput<'_>,
+    ) -> Result<(), SessionError> {
+        let timestamp_seconds = unix_timestamp_from_system_time(services.clock().now_system_time());
+        let expected_status = input.expected_status.to_string();
+        let persisted_status = Status::InProgress.to_string();
+        let persisted = services
+            .db()
+            .sessions()
+            .persist_session_reply_start(db::SessionReplyStartPersistence {
+                expected_status: &expected_status,
+                id: input.session_id,
+                message_content: input.message_content,
+                operation_id: input.operation_id,
+                operation_kind: input.operation_kind,
+                status: &persisted_status,
+                timestamp_seconds,
+            })
+            .await?;
+        if !persisted {
+            return Err(SessionError::Workflow(
+                "Session status changed before the reply could start".to_string(),
+            ));
+        }
+
+        SessionTaskService::publish_persisted_turn_start(
+            input.status,
+            input.transcript,
+            &services.event_sender(),
             &services.session_update_versions(),
-            session_id,
-            SessionTranscriptMessageAppend {
-                kind: SessionMessageKind::UserPrompt,
-                raw_content: &prompt_transcript_text,
-            },
+            input.session_id,
+            input.message_content,
+        );
+
+        Ok(())
+    }
+
+    /// Commits and publishes one first-message turn as a single use case.
+    async fn persist_and_publish_first_turn(
+        &mut self,
+        services: &AppServices,
+        input: FirstTurnPublishInput<'_>,
+    ) -> Result<(), SessionError> {
+        let timestamp_seconds = unix_timestamp_from_system_time(services.clock().now_system_time());
+        let expected_status = Status::Draft.to_string();
+        let persisted_status = Status::InProgress.to_string();
+        let persisted = services
+            .db()
+            .sessions()
+            .persist_first_session_turn(db::FirstSessionTurnPersistence {
+                expected_status: &expected_status,
+                id: input.session_id,
+                message_content: input.message_content,
+                operation_id: input.operation_id,
+                operation_kind: input.operation_kind,
+                prompt: input.prompt,
+                status: &persisted_status,
+                timestamp_seconds,
+                title: input.title,
+            })
+            .await?;
+        if !persisted {
+            return Err(SessionError::Workflow(
+                "Session status changed before the first turn could start".to_string(),
+            ));
+        }
+
+        let session = self
+            .session_at_mut(input.session_index)
+            .ok_or(SessionError::NotFound)?;
+        session.prompt = input.prompt.to_string();
+        session.title = Some(input.title.to_string());
+        session.is_draft = false;
+        SessionTaskService::publish_persisted_turn_start(
+            input.status,
+            input.transcript,
+            &services.event_sender(),
+            &services.session_update_versions(),
+            input.session_id,
+            input.message_content,
+        );
+
+        Ok(())
+    }
+
+    /// Commits and enqueues one first-message reply.
+    async fn start_first_reply(&mut self, services: &AppServices, input: FirstReplyInput) -> bool {
+        let command = Self::build_session_command(BuildSessionCommandInput {
+            is_first_message: true,
+            published_upstream_ref: input.published_upstream_ref,
+            prompt: input.prompt.clone(),
+            replay_transcript: input.replay_transcript,
+            session_agent: input.session_agent,
+        });
+        let operation_id = command.operation_id().to_string();
+        let prompt_transcript_text = input.prompt.transcript_text();
+        if let Err(error) = self
+            .persist_and_publish_first_turn(
+                services,
+                FirstTurnPublishInput {
+                    message_content: &prompt_transcript_text,
+                    operation_id: &operation_id,
+                    operation_kind: command.kind(),
+                    prompt: &input.prompt.text,
+                    session_id: &input.session_id,
+                    session_index: input.session_index,
+                    status: &input.status,
+                    title: &input.title,
+                    transcript: &input.transcript,
+                },
+            )
+            .await
+        {
+            self.append_reply_status_error(services, &input.session_id, &error)
+                .await;
+
+            return false;
+        }
+        self.set_active_prompt_output(
+            &input.session_id,
+            Self::formatted_prompt_output(&input.prompt, true),
+        );
+
+        self.enqueue_persisted_reply_command(
+            services,
+            &input.transcript,
+            &input.session_id,
+            &input.prompt,
+            command,
         )
-        .await;
-        self.set_active_prompt_output(session_id, reply_line);
+        .await
     }
 
     /// Formats one user prompt block for persisted session output.
@@ -2125,7 +2206,7 @@ impl SessionManager {
         };
         let app_event_tx = services.event_sender();
 
-        SessionTaskService::append_workflow_notice(
+        let _ = SessionTaskService::append_workflow_notice(
             &handles.transcript,
             services.db(),
             &app_event_tx,
@@ -2136,9 +2217,8 @@ impl SessionManager {
         .await;
     }
 
-    /// Returns `true` when the command reached the session worker queue and
-    /// `false` when enqueueing failed and a reply-error notice was appended.
-    async fn enqueue_reply_command(
+    /// Enqueues a reply whose operation row is already durable.
+    async fn enqueue_persisted_reply_command(
         &mut self,
         services: &AppServices,
         transcript: &Arc<Mutex<SessionTranscript>>,
@@ -2147,14 +2227,14 @@ impl SessionManager {
         command: SessionCommand,
     ) -> bool {
         if let Err(error) = self
-            .enqueue_session_command(services, persisted_session_id, command)
+            .enqueue_persisted_session_command(services, persisted_session_id, command)
             .await
         {
             self.cleanup_prompt_attachment_files(services, prompt).await;
 
             let error_line = TranscriptNotice::ReplyError.format(error);
             let app_event_tx = services.event_sender();
-            SessionTaskService::append_workflow_notice(
+            let _ = SessionTaskService::append_workflow_notice(
                 transcript,
                 services.db(),
                 &app_event_tx,
@@ -2556,7 +2636,7 @@ impl SessionManager {
         };
         let app_event_tx = services.event_sender();
 
-        SessionTaskService::append_workflow_notice(
+        let _ = SessionTaskService::append_workflow_notice(
             &handles.transcript,
             services.db(),
             &app_event_tx,
@@ -2633,7 +2713,7 @@ impl SessionManager {
             Self::signal_running_session_cancellation(services, handles, session_id).await;
         }
 
-        let status_updated = status_transition.apply(Status::Canceled).await;
+        let status_updated = status_transition.apply(Status::Canceled).await?;
 
         if status_updated {
             Self::spawn_canceled_session_cleanup(
@@ -4074,8 +4154,9 @@ mod tests {
     }
 
     #[test]
-    /// Ensures first replies persist the full prompt as the one-time title.
-    fn test_prepare_reply_context_first_message_sets_title_from_prompt() {
+    /// Ensures first-reply validation does not publish metadata before
+    /// persistence succeeds.
+    fn test_prepare_reply_context_first_message_defers_snapshot_metadata() {
         // Arrange
         let prompt = "Implement optimistic retry path";
         let turn_prompt = TurnPrompt::from_text(prompt.to_string());
@@ -4093,10 +4174,89 @@ mod tests {
         assert!(context.1);
         assert_eq!(context.2, "session-id");
         assert_eq!(context.3, Some(prompt.to_string()));
-        assert_eq!(session_manager.sessions()[0].prompt, prompt);
-        assert_eq!(
-            session_manager.sessions()[0].title,
-            Some(prompt.to_string())
+        assert!(session_manager.sessions()[0].prompt.is_empty());
+        assert_eq!(session_manager.sessions()[0].title, None);
+    }
+
+    #[tokio::test]
+    async fn test_reply_first_message_preserves_draft_snapshot_on_metadata_failure() {
+        // Arrange
+        let session = test_session("", Status::Draft, None, "");
+        let session_agent = session.agent;
+        let mut session_manager = session_manager_with_one_session(session);
+        let (database, pool) = AppRepositories::in_memory_with_pool().await;
+        let services = test_services(
+            &database,
+            Arc::new(git::MockGitClient::new()),
+            Arc::new(forge::MockReviewRequestClient::new()),
+        );
+        pool.close().await;
+
+        // Act
+        let reply_enqueued = session_manager
+            .reply_impl(
+                &services,
+                "session-id",
+                TurnPrompt::from_text("Retryable first prompt".to_string()),
+                session_agent,
+            )
+            .await;
+
+        // Assert
+        assert!(!reply_enqueued);
+        assert_eq!(session_manager.sessions()[0].status, Status::Draft);
+        assert!(session_manager.sessions()[0].prompt.is_empty());
+        assert_eq!(session_manager.sessions()[0].title, None);
+    }
+
+    #[tokio::test]
+    async fn test_reply_first_message_aborts_when_persisted_status_is_stale() {
+        // Arrange
+        let session = test_session("", Status::Draft, None, "");
+        let session_agent = session.agent;
+        let database = database_with_session(&session).await;
+        database
+            .sessions()
+            .update_session_status_with_timing_at("session-id", "Canceled", 10)
+            .await
+            .expect("failed to make persisted status stale");
+        let services = test_services(
+            &database,
+            Arc::new(git::MockGitClient::new()),
+            Arc::new(forge::MockReviewRequestClient::new()),
+        );
+        let mut session_manager = session_manager_with_one_session(session);
+
+        // Act
+        let reply_enqueued = session_manager
+            .reply_impl(
+                &services,
+                "session-id",
+                TurnPrompt::from_text("Must not run".to_string()),
+                session_agent,
+            )
+            .await;
+
+        // Assert
+        assert!(!reply_enqueued);
+        assert_eq!(session_manager.sessions()[0].status, Status::Draft);
+        assert!(session_manager.sessions()[0].prompt.is_empty());
+        assert!(
+            database
+                .sessions()
+                .load_session_messages("session-id")
+                .await
+                .expect("failed to load messages")
+                .iter()
+                .all(|message| message.kind != SessionMessageKind::UserPrompt.as_str())
+        );
+        assert!(
+            database
+                .operations()
+                .load_unfinished_session_operations()
+                .await
+                .expect("failed to load operations")
+                .is_empty()
         );
     }
 

--- a/crates/agentty/src/app/session/workflow/merge.rs
+++ b/crates/agentty/src/app/session/workflow/merge.rs
@@ -704,11 +704,17 @@ impl SessionMergeService {
     /// Restores a failed merge-start attempt to `Review` status without
     /// masking the original error.
     async fn restore_review_status(context: &MergeStartRestoreContext<'_>) {
-        if !context.status_transition.apply(Status::Review).await {
-            warn!(
+        match context.status_transition.apply(Status::Review).await {
+            Ok(true) => {}
+            Ok(false) => warn!(
                 session_id = context.session_id,
                 "skipped restoring review status because the in-memory status was already current"
-            );
+            ),
+            Err(error) => warn!(
+                session_id = context.session_id,
+                error = %error,
+                "failed to persist restored review status"
+            ),
         }
     }
 
@@ -1457,7 +1463,7 @@ impl SessionManager {
             }
             Err(error) => {
                 let merge_error = TranscriptNotice::MergeError.format(error);
-                SessionTaskService::append_workflow_notice(
+                let _ = SessionTaskService::append_workflow_notice(
                     transcript,
                     db,
                     app_event_tx,
@@ -1466,12 +1472,18 @@ impl SessionManager {
                     &merge_error,
                 )
                 .await;
-                if !status_transition.apply(Status::Review).await {
-                    warn!(
+                match status_transition.apply(Status::Review).await {
+                    Ok(true) => {}
+                    Ok(false) => warn!(
                         session_id = id,
                         "skipped restoring review status after merge error because the in-memory \
                          status was already current"
-                    );
+                    ),
+                    Err(error) => warn!(
+                        session_id = id,
+                        error = %error,
+                        "failed to persist restored review status after merge error"
+                    ),
                 }
             }
         }
@@ -2096,7 +2108,7 @@ impl SessionManager {
         match rebase_result {
             Ok(message) => {
                 let rebase_message = TranscriptNotice::Rebase.format(message);
-                SessionTaskService::append_workflow_notice(
+                let _ = SessionTaskService::append_workflow_notice(
                     transcript,
                     db,
                     app_event_tx,
@@ -2123,7 +2135,7 @@ impl SessionManager {
             }
             Err(error) => {
                 let rebase_error = TranscriptNotice::RebaseError.format(error);
-                SessionTaskService::append_workflow_notice(
+                let _ = SessionTaskService::append_workflow_notice(
                     transcript,
                     db,
                     app_event_tx,
@@ -2135,7 +2147,17 @@ impl SessionManager {
             }
         }
 
-        let restored_review_status = status_transition.apply(Status::Review).await;
+        let restored_review_status = match status_transition.apply(Status::Review).await {
+            Ok(status_updated) => status_updated,
+            Err(error) => {
+                warn!(
+                    session_id = id,
+                    error = %error,
+                    "failed to persist restored review status after rebase"
+                );
+                false
+            }
+        };
         if !restored_review_status {
             warn!(
                 session_id = id,

--- a/crates/agentty/src/app/session/workflow/post_turn.rs
+++ b/crates/agentty/src/app/session/workflow/post_turn.rs
@@ -268,7 +268,7 @@ pub(super) async fn apply_turn_result(
 pub(super) async fn finalize_channel_turn(
     context: &TurnFinalizerContext,
     result: &Result<Status, SessionError>,
-) {
+) -> Result<(), SessionError> {
     if let Some((session_size, added_lines, deleted_lines)) =
         SessionTaskService::refresh_persisted_session_diff_stats(
             &context.db,
@@ -289,7 +289,6 @@ pub(super) async fn finalize_channel_turn(
     }
 
     if let Some(target_status) = status_update_after_turn_result(result) {
-        // Best-effort: status transition failure is non-critical.
         let status_transition = StatusTransition::from_parts(
             context.app_event_tx.clone(),
             Arc::clone(&context.clock),
@@ -298,8 +297,37 @@ pub(super) async fn finalize_channel_turn(
             Arc::clone(&context.session_update_versions),
             Arc::clone(&context.status),
         );
-        let _ = status_transition.apply(target_status).await;
+        match status_transition.apply(target_status).await {
+            Ok(true) => {}
+            Ok(false) => {
+                return Err(SessionError::Workflow(format!(
+                    "Session status changed before the turn could finalize as {target_status}"
+                )));
+            }
+            Err(SessionError::Db(source)) => {
+                return Err(SessionError::TerminalStatusPersistence {
+                    target_status,
+                    source,
+                });
+            }
+            Err(error) => return Err(error),
+        }
     }
+
+    if result
+        .as_ref()
+        .is_ok_and(|status| status.allows_review_actions())
+        && has_review_ready_stacked_children(&context.db, &context.session_id).await
+    {
+        // Fire-and-forget: receiver may be dropped during shutdown.
+        let _ = context
+            .app_event_tx
+            .send(AppEvent::StackedParentTurnCompleted {
+                session_id: context.session_id.clone(),
+            });
+    }
+
+    Ok(())
 }
 
 /// Returns the status transition the worker should emit after a turn result.
@@ -321,7 +349,7 @@ pub(super) fn status_update_after_turn_result(
 /// Appends one terminal turn error to the live and persisted transcript.
 async fn append_turn_error(context: &PostTurnContext, error_text: &str) {
     let message = format!("\n{}\n", error_text.trim());
-    SessionTaskService::append_workflow_notice(
+    let _ = SessionTaskService::append_workflow_notice(
         &context.transcript,
         &context.db,
         &context.app_event_tx,
@@ -360,7 +388,7 @@ async fn apply_successful_turn_result(
                 raw_content: message.as_str(),
             },
         )
-        .await;
+        .await?;
     }
     let turn_applied_state = match (TurnPersistence {
         context,
@@ -405,34 +433,16 @@ async fn apply_successful_turn_result(
     .await;
     let review_request_commit_message = commit_outcome.map(|outcome| outcome.commit_message);
     start_published_branch_auto_push(context, turn_metadata, review_request_commit_message).await;
-    if target_status.allows_review_actions() && has_review_ready_stacked_children(context).await {
-        let _ = context
-            .app_event_tx
-            .send(AppEvent::StackedParentTurnCompleted {
-                session_id: context.session_id.clone(),
-            });
-    }
-
     Ok(target_status)
 }
 
 /// Returns whether the completed session has materialized stacked children
 /// whose persisted statuses parse to review-action-ready states.
-async fn has_review_ready_stacked_children(context: &PostTurnContext) -> bool {
-    let Ok(Some(project_id)) = context
-        .db
-        .sessions()
-        .load_session_project_id(&context.session_id)
-        .await
-    else {
+async fn has_review_ready_stacked_children(db: &AppRepositories, session_id: &SessionId) -> bool {
+    let Ok(Some(project_id)) = db.sessions().load_session_project_id(session_id).await else {
         return false;
     };
-    let Ok(sessions) = context
-        .db
-        .sessions()
-        .load_sessions_for_project(project_id)
-        .await
-    else {
+    let Ok(sessions) = db.sessions().load_sessions_for_project(project_id).await else {
         return false;
     };
 
@@ -440,7 +450,7 @@ async fn has_review_ready_stacked_children(context: &PostTurnContext) -> bool {
         session
             .parent_session_id
             .as_deref()
-            .is_some_and(|parent_session_id| parent_session_id == context.session_id.as_str())
+            .is_some_and(|parent_session_id| parent_session_id == session_id.as_str())
             && session
                 .status
                 .parse::<Status>()
@@ -492,7 +502,7 @@ async fn handle_turn_persistence_failure(context: &PostTurnContext, error: &Sess
     let message = TranscriptNotice::TurnMetadataError.format(format!(
         "Failed to persist completed turn metadata: {error}"
     ));
-    SessionTaskService::append_workflow_notice(
+    let _ = SessionTaskService::append_workflow_notice(
         &context.transcript,
         &context.db,
         &context.app_event_tx,
@@ -562,6 +572,123 @@ mod tests {
 
     use super::*;
     use crate::domain::agent::{AgentKind, AgentModel, AgentSelection};
+
+    #[tokio::test]
+    async fn test_completed_turn_surfaces_terminal_status_persistence_failure() {
+        // Arrange
+        let (db, pool) = AppRepositories::in_memory_with_pool().await;
+        let project_id = db
+            .projects()
+            .upsert_project("/tmp/project", Some("main".to_string()))
+            .await
+            .expect("failed to upsert project");
+        db.sessions()
+            .insert_session("session-id", "gpt-5.5", "main", "InProgress", project_id)
+            .await
+            .expect("failed to insert session");
+        insert_review_ready_stacked_child(&db, project_id).await;
+        db.sessions()
+            .append_session_message(
+                "session-id",
+                SessionMessageKind::AssistantAnswer,
+                "Completed answer",
+            )
+            .await
+            .expect("failed to persist assistant answer");
+        db.sessions()
+            .persist_session_turn_metadata(
+                "session-id",
+                &SessionTurnMetadata {
+                    instruction_conversation_id: None,
+                    model: "gpt-5.5".to_string(),
+                    provider_conversation_id: None,
+                    questions_json: String::new(),
+                    summary: "completed summary".to_string(),
+                    token_usage_delta: SessionStats::default(),
+                },
+            )
+            .await
+            .expect("failed to persist completed turn metadata");
+        sqlx::query(
+            r"
+CREATE TRIGGER fail_completed_turn_status
+BEFORE UPDATE OF status ON session
+BEGIN
+    SELECT RAISE(FAIL, 'injected terminal status failure');
+END
+",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to install status failure trigger");
+        let mut fs_client = crate::infra::fs::MockFsClient::new();
+        fs_client.expect_is_dir().returning(|_| false);
+        let status = Arc::new(Mutex::new(Status::InProgress));
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let context = TurnFinalizerContext {
+            app_event_tx,
+            clock: Arc::new(crate::infra::clock::RealClock),
+            db: db.clone(),
+            folder: PathBuf::new(),
+            fs_client: Arc::new(fs_client),
+            git_client: Arc::new(MockGitClient::new()),
+            session_update_versions: Arc::default(),
+            session_id: "session-id".into(),
+            status: Arc::clone(&status),
+        };
+        let turn_result = Ok(Status::Review);
+
+        // Act
+        let result = finalize_channel_turn(&context, &turn_result).await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(SessionError::TerminalStatusPersistence {
+                target_status: Status::Review,
+                ..
+            })
+        ));
+        assert_eq!(*status.lock().expect("status lock"), Status::InProgress);
+        let session = db
+            .sessions()
+            .load_sessions()
+            .await
+            .expect("failed to load sessions")
+            .into_iter()
+            .find(|session| session.id == "session-id")
+            .expect("missing session");
+        assert_eq!(session.status, "InProgress");
+        assert_eq!(session.summary.as_deref(), Some("completed summary"));
+        assert_eq!(
+            db.sessions()
+                .load_session_messages("session-id")
+                .await
+                .expect("failed to load messages")
+                .len(),
+            1
+        );
+        while let Ok(event) = app_event_rx.try_recv() {
+            assert!(!matches!(
+                event,
+                AppEvent::StackedParentTurnCompleted { .. }
+            ));
+        }
+    }
+
+    async fn insert_review_ready_stacked_child(db: &AppRepositories, project_id: i64) {
+        db.sessions()
+            .insert_stacked_draft_session(
+                "child-id",
+                "gpt-5.5",
+                "child-branch",
+                "Review",
+                "session-id",
+                project_id,
+            )
+            .await
+            .expect("failed to insert stacked child");
+    }
 
     #[tokio::test]
     async fn test_unfinished_rebase_check_fails_closed_when_operation_query_fails() {

--- a/crates/agentty/src/app/session/workflow/published_branch.rs
+++ b/crates/agentty/src/app/session/workflow/published_branch.rs
@@ -152,7 +152,7 @@ async fn run_published_branch_auto_push_task(input: PublishedBranchAutoPushInput
 
             let message = TranscriptNotice::BranchPush
                 .format("Auto-pushed published branch after completed turn.");
-            SessionTaskService::append_workflow_notice(
+            let _ = SessionTaskService::append_workflow_notice(
                 &input.transcript,
                 &input.db,
                 &input.app_event_tx,
@@ -172,7 +172,7 @@ async fn run_published_branch_auto_push_task(input: PublishedBranchAutoPushInput
         }
         Err(failure) => {
             let message = TranscriptNotice::BranchPushError.format(failure.message);
-            SessionTaskService::append_workflow_notice(
+            let _ = SessionTaskService::append_workflow_notice(
                 &input.transcript,
                 &input.db,
                 &input.app_event_tx,
@@ -355,7 +355,7 @@ async fn append_review_request_sync_warning(
     let message = TranscriptNotice::ReviewRequestSyncWarning.format(format!(
         "Failed to update linked review-request metadata: {error}"
     ));
-    SessionTaskService::append_workflow_notice(
+    let _ = SessionTaskService::append_workflow_notice(
         &input.transcript,
         &input.db,
         &input.app_event_tx,

--- a/crates/agentty/src/app/session/workflow/refresh.rs
+++ b/crates/agentty/src/app/session/workflow/refresh.rs
@@ -28,6 +28,7 @@ impl SessionManager {
         }
 
         self.state.refresh_deadline = self.next_refresh_deadline();
+        self.worker_service.wake_all_queued_messages();
 
         let Ok(sessions_metadata) = services.db().sessions().load_sessions_metadata().await else {
             return false;

--- a/crates/agentty/src/app/session/workflow/task.rs
+++ b/crates/agentty/src/app/session/workflow/task.rs
@@ -115,8 +115,11 @@ impl StatusTransition {
     }
 
     /// Applies a status transition using the bound session dependencies.
-    pub(crate) async fn apply(&self, status: Status) -> bool {
-        SessionTaskService::update_status(
+    ///
+    /// # Errors
+    /// Returns an error when the durable status update fails.
+    pub(crate) async fn apply(&self, status: Status) -> Result<bool, SessionError> {
+        Ok(SessionTaskService::update_status(
             self.status.as_ref(),
             self.clock.as_ref(),
             &self.db,
@@ -125,7 +128,7 @@ impl StatusTransition {
             self.session_id.as_str(),
             status,
         )
-        .await
+        .await?)
     }
 
     /// Applies a status transition or returns a workflow error for invalid
@@ -134,7 +137,7 @@ impl StatusTransition {
         &self,
         status: Status,
     ) -> Result<(), SessionError> {
-        if self.apply(status).await {
+        if self.apply(status).await? {
             return Ok(());
         }
 
@@ -337,7 +340,7 @@ impl SessionTaskService {
             }
             Err(commit_error) => {
                 let message = TranscriptNotice::CommitError.format(&commit_error);
-                Self::append_workflow_notice(
+                let _ = Self::append_workflow_notice(
                     &context.transcript,
                     &context.db,
                     &context.app_event_tx,
@@ -921,7 +924,7 @@ impl SessionTaskService {
                     raw_content: &answer_text,
                 },
             )
-            .await;
+            .await?;
         }
 
         if let Err(error) = db
@@ -990,10 +993,11 @@ impl SessionTaskService {
             .map_err(SessionError::Workflow)
     }
 
-    /// Applies a status transition to memory and database when valid.
+    /// Applies a valid status transition to durable storage and then memory.
     ///
     /// This bumps the session-update version, emits
-    /// [`AppEvent::SessionUpdated`] for targeted snapshot sync, and emits
+    /// [`AppEvent::SessionUpdated`] for targeted snapshot sync only after
+    /// persistence succeeds, and emits
     /// session/project refresh events for transitions that affect list
     /// snapshots or project session aggregates.
     pub(crate) async fn update_status(
@@ -1004,45 +1008,79 @@ impl SessionTaskService {
         session_update_versions: &SessionUpdateVersionMap,
         id: &str,
         new: Status,
-    ) -> bool {
-        let should_update = if let Ok(mut current) = status.lock() {
-            if (*current).can_transition_to(new) {
-                *current = new;
-                true
-            } else {
-                false
-            }
-        } else {
-            false
+    ) -> Result<bool, crate::infra::db::DbError> {
+        let Some(current) = status.lock().ok().map(|current| *current) else {
+            return Ok(false);
         };
-        if !should_update {
-            return false;
+        if !current.can_transition_to(new) {
+            return Ok(false);
         }
 
         let timestamp_seconds = unix_timestamp_from_system_time(clock.now_system_time());
 
-        if let Err(error) = db
+        let status_persisted = match db
             .sessions()
-            .update_session_status_with_timing_at(id, &new.to_string(), timestamp_seconds)
+            .transition_session_status_with_timing_at(
+                id,
+                &current.to_string(),
+                &new.to_string(),
+                timestamp_seconds,
+            )
             .await
         {
-            warn!(
-                session_id = id,
-                status = %new,
-                error = %error,
-                "failed to persist session status update"
-            );
+            Ok(status_persisted) => status_persisted,
+            Err(error) => {
+                warn!(
+                    session_id = id,
+                    status = %new,
+                    error = %error,
+                    "failed to persist session status update"
+                );
+
+                return Err(error);
+            }
+        };
+        if !status_persisted {
+            return Ok(false);
+        }
+        if let Ok(mut current) = status.lock() {
+            *current = new;
         }
         Self::emit_session_updated(app_event_tx, session_update_versions, id);
         if Self::status_requires_full_refresh(new) {
             Self::send_session_and_project_refresh_events(app_event_tx, id);
         }
 
-        true
+        Ok(true)
     }
 
-    /// Appends one formatted workflow notice to the in-memory transcript and
-    /// durable message store.
+    /// Publishes a runnable turn snapshot after its use-case transaction
+    /// commits.
+    pub(crate) fn publish_persisted_turn_start(
+        status: &Mutex<Status>,
+        transcript: &Arc<Mutex<SessionTranscript>>,
+        app_event_tx: &mpsc::UnboundedSender<AppEvent>,
+        session_update_versions: &SessionUpdateVersionMap,
+        id: &str,
+        message_content: &str,
+    ) {
+        Self::append_live_transcript_message(
+            transcript,
+            id,
+            SessionMessageKind::UserPrompt,
+            message_content,
+        );
+        if let Ok(mut current) = status.lock() {
+            *current = Status::InProgress;
+        }
+        Self::emit_session_updated(app_event_tx, session_update_versions, id);
+        Self::send_session_and_project_refresh_events(app_event_tx, id);
+    }
+
+    /// Persists one formatted workflow notice, then appends it to memory.
+    ///
+    /// # Errors
+    /// Returns an error when the durable transcript append fails.
     pub(crate) async fn append_workflow_notice(
         transcript: &Arc<Mutex<SessionTranscript>>,
         db: &AppRepositories,
@@ -1050,13 +1088,7 @@ impl SessionTaskService {
         session_update_versions: &SessionUpdateVersionMap,
         id: &str,
         message: &str,
-    ) {
-        Self::append_live_transcript_message(
-            transcript,
-            id,
-            SessionMessageKind::WorkflowNotice,
-            message,
-        );
+    ) -> Result<(), crate::infra::db::DbError> {
         if let Err(error) = db
             .sessions()
             .append_session_message(id, SessionMessageKind::WorkflowNotice, message)
@@ -1067,12 +1099,24 @@ impl SessionTaskService {
                 error = %error,
                 "failed to persist workflow notice"
             );
+
+            return Err(error);
         }
+        Self::append_live_transcript_message(
+            transcript,
+            id,
+            SessionMessageKind::WorkflowNotice,
+            message,
+        );
         Self::emit_session_updated(app_event_tx, session_update_versions, id);
+
+        Ok(())
     }
 
-    /// Appends one raw user/assistant message to the in-memory transcript and
-    /// durable message store.
+    /// Persists one raw user/assistant message, then appends it to memory.
+    ///
+    /// # Errors
+    /// Returns an error when the durable transcript append fails.
     pub(crate) async fn append_session_transcript_message(
         transcript: &Arc<Mutex<SessionTranscript>>,
         db: &AppRepositories,
@@ -1080,8 +1124,7 @@ impl SessionTaskService {
         session_update_versions: &SessionUpdateVersionMap,
         id: &str,
         message: SessionTranscriptMessageAppend<'_>,
-    ) {
-        Self::append_live_transcript_message(transcript, id, message.kind, message.raw_content);
+    ) -> Result<(), crate::infra::db::DbError> {
         if let Err(error) = db
             .sessions()
             .append_session_message(id, message.kind, message.raw_content)
@@ -1092,8 +1135,13 @@ impl SessionTaskService {
                 error = %error,
                 "failed to persist session transcript message"
             );
+
+            return Err(error);
         }
+        Self::append_live_transcript_message(transcript, id, message.kind, message.raw_content);
         Self::emit_session_updated(app_event_tx, session_update_versions, id);
+
+        Ok(())
     }
 
     /// Appends one typed message to the live transcript snapshot.
@@ -1427,7 +1475,8 @@ mod tests {
             "session-id",
             "\n[Commit] No changes to commit.\n",
         )
-        .await;
+        .await
+        .expect("workflow notice persistence should succeed");
 
         // Assert
         assert_eq!(
@@ -1480,7 +1529,8 @@ mod tests {
                 raw_content: "    hello ",
             },
         )
-        .await;
+        .await
+        .expect("transcript message persistence should succeed");
 
         // Assert
         assert_eq!(
@@ -1510,6 +1560,47 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].kind, "user_prompt");
         assert_eq!(messages[0].content, "    hello");
+    }
+
+    #[tokio::test]
+    async fn test_append_session_transcript_message_preserves_memory_on_database_failure() {
+        // Arrange
+        let (database, pool) = AppRepositories::in_memory_with_pool().await;
+        insert_review_session(&database, AgentModel::Gpt55.as_str()).await;
+        pool.close().await;
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let transcript = Arc::new(Mutex::new(SessionTranscript::default()));
+        let session_update_versions = Arc::default();
+
+        // Act
+        let result = SessionTaskService::append_session_transcript_message(
+            &transcript,
+            &database,
+            &app_event_tx,
+            &session_update_versions,
+            "session-id",
+            SessionTranscriptMessageAppend {
+                kind: SessionMessageKind::UserPrompt,
+                raw_content: "hello",
+            },
+        )
+        .await;
+
+        // Assert
+        assert!(result.is_err());
+        assert!(
+            transcript
+                .lock()
+                .expect("transcript lock should not be poisoned")
+                .is_empty()
+        );
+        assert!(app_event_rx.try_recv().is_err());
+        assert!(
+            session_update_versions
+                .lock()
+                .expect("session update versions lock should not be poisoned")
+                .is_empty()
+        );
     }
 
     #[test]
@@ -1613,13 +1704,151 @@ mod tests {
             .expect("missing session row");
 
         // Assert
-        assert!(entered_first_interval);
-        assert!(left_first_interval);
-        assert!(entered_second_interval);
-        assert!(left_second_interval);
+        assert!(entered_first_interval.expect("first interval should start"));
+        assert!(left_first_interval.expect("first interval should end"));
+        assert!(entered_second_interval.expect("second interval should start"));
+        assert!(left_second_interval.expect("second interval should end"));
         assert_eq!(session_row.status, "Question");
         assert_eq!(session_row.in_progress_started_at, None);
         assert_eq!(session_row.in_progress_total_seconds, 150);
+    }
+
+    #[tokio::test]
+    async fn test_update_status_preserves_memory_on_database_failure() {
+        // Arrange
+        let (database, pool) = AppRepositories::in_memory_with_pool().await;
+        let project_id = database
+            .projects()
+            .upsert_project("/tmp/project", Some("main".to_string()))
+            .await
+            .expect("failed to upsert project");
+        database
+            .sessions()
+            .insert_session(
+                "session-id",
+                "gpt-5.5",
+                "main",
+                &Status::Draft.to_string(),
+                project_id,
+            )
+            .await
+            .expect("failed to insert session");
+        pool.close().await;
+        let status = Mutex::new(Status::Draft);
+        let clock = StaticClock::new(SystemTime::UNIX_EPOCH + Duration::from_secs(10));
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let session_update_versions = Arc::default();
+
+        // Act
+        let result = SessionTaskService::update_status(
+            &status,
+            &clock,
+            &database,
+            &app_event_tx,
+            &session_update_versions,
+            "session-id",
+            Status::InProgress,
+        )
+        .await;
+
+        // Assert
+        assert!(result.is_err());
+        assert_eq!(
+            *status.lock().expect("status lock should not be poisoned"),
+            Status::Draft
+        );
+        assert!(app_event_rx.try_recv().is_err());
+        assert!(
+            session_update_versions
+                .lock()
+                .expect("session update versions lock should not be poisoned")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_status_compare_and_swap_serializes_concurrent_transitions() {
+        // Arrange
+        let (database, pool) = AppRepositories::in_memory_with_pool().await;
+        let project_id = database
+            .projects()
+            .upsert_project("/tmp/project", Some("main".to_string()))
+            .await
+            .expect("failed to upsert project");
+        database
+            .sessions()
+            .insert_session(
+                "session-id",
+                "gpt-5.5",
+                "main",
+                &Status::Draft.to_string(),
+                project_id,
+            )
+            .await
+            .expect("failed to insert session");
+        let status = Arc::new(Mutex::new(Status::Draft));
+        let clock = Arc::new(StaticClock::new(
+            SystemTime::UNIX_EPOCH + Duration::from_secs(10),
+        ));
+        let (app_event_tx, _app_event_rx) = mpsc::unbounded_channel();
+        let session_update_versions = Arc::default();
+        let mut connection = pool.acquire().await.expect("failed to acquire connection");
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *connection)
+            .await
+            .expect("failed to hold status write lock");
+
+        // Act
+        let spawn_update = |new_status| {
+            let app_event_tx = app_event_tx.clone();
+            let clock = Arc::clone(&clock);
+            let database = database.clone();
+            let session_update_versions = Arc::clone(&session_update_versions);
+            let status = Arc::clone(&status);
+
+            tokio::spawn(async move {
+                SessionTaskService::update_status(
+                    status.as_ref(),
+                    clock.as_ref(),
+                    &database,
+                    &app_event_tx,
+                    &session_update_versions,
+                    "session-id",
+                    new_status,
+                )
+                .await
+            })
+        };
+        let in_progress_task = spawn_update(Status::InProgress);
+        let canceled_task = spawn_update(Status::Canceled);
+        tokio::task::yield_now().await;
+        sqlx::query("COMMIT")
+            .execute(&mut *connection)
+            .await
+            .expect("failed to release status write lock");
+        drop(connection);
+        let in_progress_updated = in_progress_task
+            .await
+            .expect("in-progress task should join")
+            .expect("in-progress update should not fail");
+        let canceled_updated = canceled_task
+            .await
+            .expect("canceled task should join")
+            .expect("canceled update should not fail");
+        let live_status = *status.lock().expect("status lock should not be poisoned");
+        let persisted_status = database
+            .sessions()
+            .load_sessions()
+            .await
+            .expect("failed to load sessions")
+            .into_iter()
+            .find(|row| row.id == "session-id")
+            .expect("missing session row")
+            .status;
+
+        // Assert
+        assert_ne!(in_progress_updated, canceled_updated);
+        assert_eq!(persisted_status, live_status.to_string());
     }
 
     /// Verifies the status-transition context updates both live handles and
@@ -1651,7 +1880,10 @@ mod tests {
         let status_transition = StatusTransition::from_services(&services, &handles, "session-id");
 
         // Act
-        let status_updated = status_transition.apply(Status::InProgress).await;
+        let status_updated = status_transition
+            .apply(Status::InProgress)
+            .await
+            .expect("status persistence should succeed");
         let live_status = handles
             .status
             .lock()

--- a/crates/agentty/src/app/session/workflow/turn.rs
+++ b/crates/agentty/src/app/session/workflow/turn.rs
@@ -153,7 +153,7 @@ pub(super) async fn run_channel_turn(
     // `run_turn_with_cancellation` for the duration of this turn.
     let turn_cancel_token = fresh_turn_cancel_token(context)?;
 
-    prepare_resume_turn(context, &request_kind).await;
+    prepare_resume_turn(context, &request_kind).await?;
 
     let main_checkout_snapshot = match MainCheckoutSnapshot::capture(context).await {
         Ok(snapshot) => snapshot,
@@ -171,7 +171,7 @@ pub(super) async fn run_channel_turn(
                 Err(AgentError::Backend(error.to_string())),
             )
             .await;
-            post_turn::finalize_channel_turn(&finalizer_context, &result).await;
+            post_turn::finalize_channel_turn(&finalizer_context, &result).await?;
 
             return result.map(|_| ());
         }
@@ -244,22 +244,19 @@ pub(super) async fn run_channel_turn(
     let post_turn_context = post_turn::PostTurnContext::from_worker(context);
     let finalizer_context = post_turn::TurnFinalizerContext::from_worker(context);
     let result = post_turn::apply_turn_result(&post_turn_context, turn_metadata, turn_result).await;
-    post_turn::finalize_channel_turn(&finalizer_context, &result).await;
+    post_turn::finalize_channel_turn(&finalizer_context, &result).await?;
 
     result.map(|_| ())
 }
 
 /// Applies best-effort state cleanup before a resume turn starts.
-async fn prepare_resume_turn(context: &SessionWorkerContext, request_kind: &AgentRequestKind) {
+async fn prepare_resume_turn(
+    context: &SessionWorkerContext,
+    request_kind: &AgentRequestKind,
+) -> Result<(), SessionError> {
     if !matches!(request_kind, AgentRequestKind::SessionResume) {
-        return;
+        return Ok(());
     }
-
-    let _ = context
-        .db
-        .sessions()
-        .update_session_questions(&context.session_id, "")
-        .await;
 
     let status_transition = StatusTransition::from_parts(
         context.app_event_tx.clone(),
@@ -269,7 +266,13 @@ async fn prepare_resume_turn(context: &SessionWorkerContext, request_kind: &Agen
         Arc::clone(&context.session_update_versions),
         Arc::clone(&context.status),
     );
-    let _ = status_transition.apply(Status::InProgress).await;
+    if !status_transition.apply(Status::InProgress).await? {
+        return Err(SessionError::Workflow(
+            "Session status changed before the reply could start".to_string(),
+        ));
+    }
+
+    Ok(())
 }
 
 /// Runs one agent turn with cancellation support.
@@ -497,7 +500,7 @@ async fn add_main_checkout_warning(
     };
     match main_checkout_snapshot.dirty_warning(context).await {
         Ok(Some(warning)) => {
-            append_main_checkout_warning(context, warning).await;
+            append_main_checkout_warning_best_effort(context, warning).await;
 
             Ok(result)
         }
@@ -543,9 +546,13 @@ fn fresh_turn_cancel_token(
     Ok(guard.clone())
 }
 
-/// Appends one main-checkout warning to the live and persisted transcript.
-async fn append_main_checkout_warning(context: &SessionWorkerContext, warning: String) {
-    SessionTaskService::append_workflow_notice(
+/// Best-effort appends one informational main-checkout warning without
+/// converting an otherwise successful provider turn into a failure.
+pub(super) async fn append_main_checkout_warning_best_effort(
+    context: &SessionWorkerContext,
+    warning: String,
+) {
+    if let Err(error) = SessionTaskService::append_workflow_notice(
         &context.transcript,
         &context.db,
         &context.app_event_tx,
@@ -553,7 +560,14 @@ async fn append_main_checkout_warning(context: &SessionWorkerContext, warning: S
         &context.session_id,
         &warning,
     )
-    .await;
+    .await
+    {
+        tracing::warn!(
+            session_id = %context.session_id,
+            error = %error,
+            "failed to persist informational main-checkout warning"
+        );
+    }
 }
 
 /// Spawns first-turn session title generation from the initial user prompt.

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -85,16 +85,34 @@ pub(super) enum SessionCommand {
     },
 }
 
+/// Internal messages consumed by one per-session worker loop.
+enum SessionWorkerMessage {
+    /// Executes one persisted session operation.
+    Command(SessionCommand),
+    /// Retries queued-prompt drainage after an earlier persistence failure.
+    DrainQueued,
+}
+
+/// Result of attempting to drain the in-memory queued-prompt list.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum QueueDrainOutcome {
+    /// Drainage completed, paused for questions, or stopped after a prompt
+    /// persistence failure that a later wake-up may retry.
+    Complete,
+    /// A queued turn completed but its terminal status could not be persisted.
+    TerminalStatusRecoveryPending,
+}
+
 impl SessionCommand {
     /// Returns the persisted operation identifier for this command.
-    fn operation_id(&self) -> &str {
+    pub(super) fn operation_id(&self) -> &str {
         match self {
             Self::Rebase { operation_id, .. } | Self::Run { operation_id, .. } => operation_id,
         }
     }
 
     /// Returns the operation kind persisted in the operations table.
-    fn kind(&self) -> &'static str {
+    pub(super) fn kind(&self) -> &'static str {
         match self {
             Self::Rebase { .. } => REBASE_OPERATION_KIND,
             Self::Run {
@@ -170,6 +188,20 @@ impl SessionWorkerContext {
             .lock()
             .ok()
             .and_then(|mut guard| guard.pop_front())
+    }
+
+    /// Restores one undispatched prompt to the front of the shared queue.
+    fn requeue_prompt_front(&self, prompt: TurnPrompt) {
+        // Sync critical section (single push, no `.await`); `std::sync::Mutex`
+        // is the correct choice per CLAUDE.md §"Mutex Selection".
+        let mut guard = self.queued_messages.lock().unwrap_or_else(|error| {
+            tracing::warn!(
+                session_id = %self.session_id,
+                "queued-message mutex poisoned while restoring prompt; recovering queue state"
+            );
+            error.into_inner()
+        });
+        guard.push_front(prompt);
     }
 
     /// Removes every queued prompt without dispatching it.
@@ -301,7 +333,7 @@ impl SessionWorkerRebaseAssistClient {
         let turn_result = turn_result.map_err(turn::session_error_from_agent_error)?;
 
         self.append_assist_answer(&turn_result.assistant_message)
-            .await;
+            .await?;
         self.persist_assist_turn_metadata(&turn_result).await?;
 
         Ok(())
@@ -374,10 +406,13 @@ impl SessionWorkerRebaseAssistClient {
     }
 
     /// Appends the utility prompt answer to the session transcript.
-    async fn append_assist_answer(&self, assistant_message: &AgentResponse) {
+    async fn append_assist_answer(
+        &self,
+        assistant_message: &AgentResponse,
+    ) -> Result<(), SessionError> {
         let answer_text = assistant_message.to_answer_display_text();
         if answer_text.trim().is_empty() {
-            return;
+            return Ok(());
         }
 
         SessionTaskService::append_session_transcript_message(
@@ -391,7 +426,9 @@ impl SessionWorkerRebaseAssistClient {
                 raw_content: &answer_text,
             },
         )
-        .await;
+        .await?;
+
+        Ok(())
     }
 
     /// Persists token usage and updated provider conversation identifiers.
@@ -499,7 +536,7 @@ pub(crate) struct SessionWorkerService {
     /// default factory, enabling deterministic command execution without
     /// spawning real provider processes.
     pub(in crate::app::session) test_agent_channels: HashMap<SessionId, Arc<dyn AgentChannel>>,
-    workers: HashMap<SessionId, mpsc::UnboundedSender<SessionCommand>>,
+    workers: HashMap<SessionId, mpsc::UnboundedSender<SessionWorkerMessage>>,
 }
 
 impl SessionWorkerService {
@@ -537,22 +574,36 @@ impl SessionWorkerService {
             .collect();
 
         for session_id in interrupted_session_ids {
-            // Best-effort: status persistence failure is non-critical.
-            let _ = db
+            if let Err(error) = db
                 .sessions()
                 .update_session_status_with_timing_at(
                     &session_id,
                     &Status::Review.to_string(),
                     timestamp_seconds,
                 )
-                .await;
-        }
+                .await
+            {
+                tracing::warn!(
+                    session_id,
+                    error = %error,
+                    "retaining unfinished operations because startup status recovery failed"
+                );
 
-        // Best-effort: operation tracking metadata is non-critical.
-        let _ = db
-            .operations()
-            .fail_unfinished_session_operations(RESTART_FAILURE_REASON)
-            .await;
+                continue;
+            }
+
+            if let Err(error) = db
+                .operations()
+                .fail_unfinished_session_operations_for_session(&session_id, RESTART_FAILURE_REASON)
+                .await
+            {
+                tracing::warn!(
+                    session_id,
+                    error = %error,
+                    "failed to finalize startup-recovered session operations"
+                );
+            }
+        }
     }
 
     /// Aborts stale git rebase state left by interrupted worker operations.
@@ -603,8 +654,25 @@ impl SessionWorkerService {
             .insert_session_operation(&operation_id, &session_id, command.kind())
             .await?;
 
+        self.enqueue_persisted_session_command(services, runtime, command)
+            .await
+    }
+
+    /// Enqueues a command whose operation row committed with its owning use
+    /// case transaction.
+    ///
+    /// # Errors
+    /// Returns an error when the session worker is no longer available.
+    pub(super) async fn enqueue_persisted_session_command(
+        &mut self,
+        services: &AppServices,
+        runtime: SessionWorkerRuntime,
+        command: SessionCommand,
+    ) -> Result<(), SessionError> {
+        let operation_id = command.operation_id().to_string();
+
         let sender = self.ensure_session_worker(services, &runtime);
-        if sender.send(command).is_err() {
+        if sender.send(SessionWorkerMessage::Command(command)).is_err() {
             // Best-effort: operation tracking metadata is non-critical.
             let _ = services
                 .db()
@@ -621,8 +689,29 @@ impl SessionWorkerService {
     }
 
     /// Drops the in-memory worker sender for a session.
-    pub(super) fn clear_session_worker(&mut self, session_id: &str) {
+    pub(in crate::app::session) fn clear_session_worker(&mut self, session_id: &str) {
         self.workers.remove(session_id);
+    }
+
+    /// Wakes an active worker to retry queued-prompt drainage.
+    ///
+    /// Queue submissions can arrive while the worker is still executing a
+    /// turn. Their wake-up messages remain ordered behind that command and
+    /// provide one bounded retry if the inline drain cannot persist the next
+    /// prompt. A later submission supplies another retry without polling.
+    pub(super) fn wake_queued_messages(&self, session_id: &str) {
+        if let Some(sender) = self.workers.get(session_id) {
+            let _ = sender.send(SessionWorkerMessage::DrainQueued);
+        }
+    }
+
+    /// Wakes every active worker during the low-frequency session fallback
+    /// poll so restored prompts receive another persistence retry without
+    /// requiring a new user submission.
+    pub(super) fn wake_all_queued_messages(&self) {
+        for sender in self.workers.values() {
+            let _ = sender.send(SessionWorkerMessage::DrainQueued);
+        }
     }
 
     /// Drops worker queues for sessions no longer present in the active list.
@@ -636,7 +725,7 @@ impl SessionWorkerService {
         &mut self,
         services: &AppServices,
         runtime: &SessionWorkerRuntime,
-    ) -> mpsc::UnboundedSender<SessionCommand> {
+    ) -> mpsc::UnboundedSender<SessionWorkerMessage> {
         if let Some(sender) = self.workers.get(&runtime.session_id) {
             return sender.clone();
         }
@@ -692,18 +781,39 @@ impl SessionWorkerService {
     /// into the next session activity.
     fn spawn_session_worker(
         context: SessionWorkerContext,
-        mut receiver: mpsc::UnboundedReceiver<SessionCommand>,
+        mut receiver: mpsc::UnboundedReceiver<SessionWorkerMessage>,
     ) {
         tokio::spawn(async move {
-            while let Some(command) = receiver.recv().await {
+            let mut terminal_status_recovery_pending = false;
+            while let Some(message) = receiver.recv().await {
+                if terminal_status_recovery_pending {
+                    continue;
+                }
+                let SessionWorkerMessage::Command(command) = message else {
+                    terminal_status_recovery_pending = matches!(
+                        Self::drain_queued_messages(&context).await,
+                        QueueDrainOutcome::TerminalStatusRecoveryPending
+                    );
+                    continue;
+                };
                 let result = Self::process_session_command(&context, command).await;
                 if matches!(result, Some(Err(SessionError::StoppedByUser(_)))) {
                     context.clear_queued_messages();
                     Self::emit_queue_session_updated(&context);
                     continue;
                 }
+                if matches!(
+                    result,
+                    Some(Err(SessionError::TerminalStatusPersistence { .. }))
+                ) {
+                    terminal_status_recovery_pending = true;
+                    continue;
+                }
 
-                Self::drain_queued_messages(&context).await;
+                terminal_status_recovery_pending = matches!(
+                    Self::drain_queued_messages(&context).await,
+                    QueueDrainOutcome::TerminalStatusRecoveryPending
+                );
             }
 
             // Best-effort: session transport may already be torn down.
@@ -752,6 +862,14 @@ impl SessionWorkerService {
                     .mark_session_operation_done(&operation_id)
                     .await;
             }
+            Err(error @ SessionError::TerminalStatusPersistence { .. }) => {
+                tracing::warn!(
+                    operation_id,
+                    session_id = %context.session_id,
+                    error = %error,
+                    "retaining unfinished operation for terminal-status recovery"
+                );
+            }
             Err(error) => {
                 // Best-effort: operation tracking metadata is non-critical.
                 let _ = context
@@ -774,13 +892,13 @@ impl SessionWorkerService {
     /// behave the same as a normal reply. The drain stops on the first
     /// user-stopped turn and clears the remaining queue so `Ctrl+C` cancels
     /// the queued work cleanly.
-    async fn drain_queued_messages(context: &SessionWorkerContext) {
+    async fn drain_queued_messages(context: &SessionWorkerContext) -> QueueDrainOutcome {
         loop {
             if matches!(context.current_status(), Status::Question) {
-                return;
+                return QueueDrainOutcome::Complete;
             }
             let Some(prompt) = context.pop_queued_prompt() else {
-                return;
+                return QueueDrainOutcome::Complete;
             };
 
             // Mirror the queue change into render snapshots so the inline
@@ -791,14 +909,39 @@ impl SessionWorkerService {
             Self::emit_queue_session_updated(context);
 
             let operation_id = Uuid::new_v4().to_string();
-            // Best-effort: operation tracking metadata is non-critical.
-            let _ = context
+            if let Err(error) = context
                 .db
                 .operations()
                 .insert_session_operation(&operation_id, &context.session_id, "reply")
-                .await;
+                .await
+            {
+                context.requeue_prompt_front(prompt);
+                Self::emit_queue_session_updated(context);
+                tracing::warn!(
+                    session_id = %context.session_id,
+                    error = %error,
+                    "failed to persist drained queued prompt operation"
+                );
+
+                return QueueDrainOutcome::Complete;
+            }
             let published_upstream_ref = context.load_published_upstream_ref().await;
-            append_drained_prompt_to_transcript(context, &prompt).await;
+            if let Err(error) = append_drained_prompt_to_transcript(context, &prompt).await {
+                context.requeue_prompt_front(prompt);
+                Self::emit_queue_session_updated(context);
+                let _ = context
+                    .db
+                    .operations()
+                    .mark_session_operation_failed(&operation_id, &error.to_string())
+                    .await;
+                tracing::warn!(
+                    session_id = %context.session_id,
+                    error = %error,
+                    "failed to persist drained queued prompt"
+                );
+
+                return QueueDrainOutcome::Complete;
+            }
             let command = SessionCommand::Run {
                 operation_id,
                 request_kind: AgentRequestKind::SessionResume,
@@ -814,7 +957,13 @@ impl SessionWorkerService {
                 context.clear_queued_messages();
                 Self::emit_queue_session_updated(context);
 
-                return;
+                return QueueDrainOutcome::Complete;
+            }
+            if matches!(
+                result,
+                Some(Err(SessionError::TerminalStatusPersistence { .. }))
+            ) {
+                return QueueDrainOutcome::TerminalStatusRecoveryPending;
             }
         }
     }
@@ -979,6 +1128,23 @@ impl SessionManager {
             .await
     }
 
+    /// Enqueues a command whose operation row is already durable.
+    ///
+    /// # Errors
+    /// Returns an error when no worker is available.
+    pub(super) async fn enqueue_persisted_session_command(
+        &mut self,
+        services: &AppServices,
+        session_id: &str,
+        command: SessionCommand,
+    ) -> Result<(), SessionError> {
+        let runtime = self.session_worker_runtime_or_err(services, session_id)?;
+
+        self.worker_service_mut()
+            .enqueue_persisted_session_command(services, runtime, command)
+            .await
+    }
+
     /// Drops the in-memory worker sender for a session.
     pub(super) fn clear_session_worker(&mut self, session_id: &str) {
         self.worker_service_mut().clear_session_worker(session_id);
@@ -1041,7 +1207,10 @@ impl SessionManager {
 /// Appends one drained queued prompt to the typed session transcript so it
 /// renders alongside the normal reply prompt line once the queued turn starts
 /// running.
-async fn append_drained_prompt_to_transcript(context: &SessionWorkerContext, prompt: &TurnPrompt) {
+async fn append_drained_prompt_to_transcript(
+    context: &SessionWorkerContext,
+    prompt: &TurnPrompt,
+) -> Result<(), SessionError> {
     let prompt_transcript_text = prompt.transcript_text();
 
     SessionTaskService::append_session_transcript_message(
@@ -1055,7 +1224,9 @@ async fn append_drained_prompt_to_transcript(context: &SessionWorkerContext, pro
             raw_content: &prompt_transcript_text,
         },
     )
-    .await;
+    .await?;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1073,7 +1244,8 @@ mod tests {
         persisted_session_summary_payload, status_update_after_turn_result,
     };
     use super::super::turn::{
-        consume_turn_events, run_channel_turn, run_turn_with_cancellation, terminate_child_process,
+        append_main_checkout_warning_best_effort, consume_turn_events, run_channel_turn,
+        run_turn_with_cancellation, terminate_child_process,
     };
     use super::*;
     use crate::domain::agent::{AgentKind, AgentModel, ReasoningLevel};
@@ -1409,6 +1581,14 @@ mod tests {
         );
     }
 
+    struct TerminalStatusFailureHarness {
+        context: SessionWorkerContext,
+        db: AppRepositories,
+        queued_messages: Arc<Mutex<VecDeque<TurnPrompt>>>,
+        shutdown_rx: tokio::sync::oneshot::Receiver<()>,
+        status: Arc<Mutex<Status>>,
+    }
+
     #[tokio::test]
     /// Verifies process-only events do not append transcript content.
     async fn test_consume_turn_events_ignores_pid_only_events_for_transcript_messages() {
@@ -1580,9 +1760,11 @@ mod tests {
             .returning(|_| Box::pin(async { Ok(String::new()) }));
         mock_git_client
             .expect_diff()
+            .times(0..)
             .returning(|_, _| Box::pin(async { Ok(String::new()) }));
         mock_git_client
             .expect_is_worktree_clean()
+            .times(0..)
             .returning(|_| Box::pin(async { Ok(true) }));
 
         // Pre-cancel the token to simulate a previous turn's cancellation.
@@ -1681,9 +1863,11 @@ mod tests {
             });
         mock_git_client
             .expect_diff()
+            .times(0..)
             .returning(|_, _| Box::pin(async { Ok(String::new()) }));
         mock_git_client
             .expect_is_worktree_clean()
+            .times(0..)
             .returning(|_| Box::pin(async { Ok(true) }));
 
         let transcript = empty_transcript();
@@ -1726,6 +1910,182 @@ mod tests {
         assert!(output_text.contains("[Main Checkout Warning]"));
         assert!(output_text.contains("tracked-file status changed"));
         assert!(output_text.contains("done"));
+    }
+
+    #[tokio::test]
+    /// Verifies an informational warning write failure does not escape into
+    /// the otherwise successful provider-turn path.
+    async fn test_main_checkout_warning_persistence_is_best_effort() {
+        // Arrange
+        let (context, _db, _queue_handle, pool, _base_dir) =
+            queue_test_context(MockAgentChannel::new(), VecDeque::new(), Status::InProgress).await;
+        pool.close().await;
+
+        // Act
+        append_main_checkout_warning_best_effort(
+            &context,
+            "[Main Checkout Warning] test warning".to_string(),
+        )
+        .await;
+
+        // Assert
+        assert!(
+            context
+                .transcript
+                .lock()
+                .expect("transcript lock")
+                .is_empty(),
+            "persist-first warning append must leave memory unchanged when persistence fails"
+        );
+    }
+
+    #[tokio::test]
+    /// Verifies a completed provider turn whose terminal status cannot be
+    /// persisted keeps its operation unfinished for startup recovery.
+    async fn test_worker_retains_terminal_status_failure_for_recovery() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let harness = terminal_status_failure_harness(base_dir.path()).await;
+        let command = SessionCommand::Run {
+            operation_id: "op-terminal-status".to_string(),
+            request_kind: AgentRequestKind::SessionStart,
+            replay_transcript: None,
+            prompt: "test prompt".into(),
+            turn_metadata: default_turn_metadata(),
+        };
+
+        // Act
+        let (sender, receiver) = mpsc::unbounded_channel();
+        SessionWorkerService::spawn_session_worker(harness.context, receiver);
+        sender
+            .send(SessionWorkerMessage::Command(command))
+            .expect("failed to send worker command");
+        sender
+            .send(SessionWorkerMessage::DrainQueued)
+            .expect("failed to send queued drain wake-up");
+        drop(sender);
+        tokio::time::timeout(Duration::from_secs(1), harness.shutdown_rx)
+            .await
+            .expect("timed out waiting for worker shutdown")
+            .expect("worker dropped shutdown signal");
+        let unfinished_operations = harness
+            .db
+            .operations()
+            .load_unfinished_session_operations()
+            .await
+            .expect("failed to load unfinished operations");
+
+        // Assert
+        assert_eq!(unfinished_operations.len(), 1);
+        assert_eq!(unfinished_operations[0].id, "op-terminal-status");
+        assert_eq!(unfinished_operations[0].session_id, "sess1");
+        assert_eq!(unfinished_operations[0].kind, "start_prompt");
+        assert_eq!(unfinished_operations[0].status, "running");
+        assert_eq!(
+            *harness.queued_messages.lock().expect("queue lock"),
+            VecDeque::from([TurnPrompt::from_text("must wait for recovery".to_string())])
+        );
+        assert_eq!(
+            harness
+                .db
+                .sessions()
+                .load_sessions()
+                .await
+                .expect("failed to load sessions")[0]
+                .status,
+            Status::InProgress.to_string()
+        );
+        assert_eq!(
+            *harness.status.lock().expect("status lock"),
+            Status::InProgress
+        );
+    }
+
+    async fn terminal_status_failure_harness(base_dir: &Path) -> TerminalStatusFailureHarness {
+        let (db, pool) = AppRepositories::in_memory_with_pool().await;
+        insert_in_progress_test_session(&db).await;
+        db.operations()
+            .insert_session_operation("op-terminal-status", "sess1", "start_prompt")
+            .await
+            .expect("failed to insert operation");
+        sqlx::query(
+            r"
+CREATE TRIGGER fail_worker_terminal_status
+BEFORE UPDATE OF status ON session
+BEGIN
+    SELECT RAISE(FAIL, 'injected worker terminal status failure');
+END
+",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to install status failure trigger");
+
+        let mut mock_channel = MockAgentChannel::new();
+        mock_channel
+            .expect_run_turn()
+            .once()
+            .returning(|_, _, _| Box::pin(async { Ok(successful_turn_result("done")) }));
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let shutdown_tx = Arc::new(Mutex::new(Some(shutdown_tx)));
+        mock_channel
+            .expect_shutdown_session()
+            .once()
+            .returning(move |_| {
+                let shutdown_tx = shutdown_tx.lock().expect("shutdown sender lock").take();
+                Box::pin(async move {
+                    if let Some(shutdown_tx) = shutdown_tx {
+                        let _ = shutdown_tx.send(());
+                    }
+
+                    Ok(())
+                })
+            });
+        let mut mock_git_client = mock_git_client_detecting_main_repo(base_dir.join("main"));
+        mock_git_client
+            .expect_tracked_worktree_status()
+            .times(2)
+            .returning(|_| Box::pin(async { Ok(String::new()) }));
+        mock_git_client
+            .expect_diff()
+            .returning(|_, _| Box::pin(async { Ok(String::new()) }));
+        mock_git_client
+            .expect_is_worktree_clean()
+            .returning(|_| Box::pin(async { Ok(true) }));
+        let queued_messages = Arc::new(Mutex::new(VecDeque::from([TurnPrompt::from_text(
+            "must wait for recovery".to_string(),
+        )])));
+        let status = Arc::new(Mutex::new(Status::InProgress));
+        let context = SessionWorkerContext {
+            app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
+            cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
+            channel: Arc::new(mock_channel),
+            child_pid: Arc::new(Mutex::new(None)),
+            clock: Arc::new(crate::infra::clock::RealClock),
+            db: db.clone(),
+            folder: base_dir.to_path_buf(),
+            fs_client: Arc::new(mock_fs_client_with_existing_directories()),
+            git_client: Arc::new(mock_git_client),
+            transcript: empty_transcript(),
+            queued_messages: Arc::clone(&queued_messages),
+            review_request_client: Arc::new(forge::MockReviewRequestClient::new()),
+            session_update_versions: Arc::default(),
+            session_id: "sess1".into(),
+            session_agent: AgentSelection::new(
+                crate::domain::agent::AgentKind::Antigravity,
+                AgentModel::Gemini3FlashPreview,
+            ),
+            status: Arc::clone(&status),
+        };
+
+        TerminalStatusFailureHarness {
+            context,
+            db,
+            queued_messages,
+            shutdown_rx,
+            status,
+        }
     }
 
     #[tokio::test]
@@ -3244,7 +3604,7 @@ mod tests {
     async fn test_apply_turn_result_refreshes_when_turn_metadata_persistence_fails() {
         // Arrange
         let base_dir = tempdir().expect("failed to create temp dir");
-        let db = AppRepositories::in_memory().await;
+        let (db, pool) = AppRepositories::in_memory_with_pool().await;
         let project_id = db
             .projects()
             .upsert_project("/tmp/project", Some("main".to_string()))
@@ -3260,10 +3620,18 @@ mod tests {
             )
             .await
             .expect("failed to insert session");
-        db.sessions()
-            .delete_session("sess1")
-            .await
-            .expect("failed to delete session");
+        sqlx::query(
+            r"
+CREATE TRIGGER fail_session_turn_metadata
+BEFORE UPDATE OF summary ON session
+BEGIN
+    SELECT RAISE(FAIL, 'injected turn metadata failure');
+END
+",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to install metadata failure trigger");
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
         let context = SessionWorkerContext {
             app_event_tx,
@@ -3318,11 +3686,7 @@ mod tests {
         let output = transcript_text(&context.transcript);
 
         // Assert
-        assert!(
-            error
-                .to_string()
-                .contains("no rows returned by a query that expected to return at least one row")
-        );
+        assert!(error.to_string().contains("injected turn metadata failure"));
         assert!(output.contains("Implemented the change."));
         assert!(
             output.contains("[Turn Metadata Error] Failed to persist completed turn metadata:")
@@ -3839,6 +4203,93 @@ mod tests {
     }
 
     #[tokio::test]
+    /// Verifies startup recovery retains an unfinished operation until its
+    /// owning session's `Review` status is durably repaired.
+    async fn test_startup_recovery_retains_operation_when_status_write_fails() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let (db, pool) = AppRepositories::in_memory_with_pool().await;
+        insert_in_progress_test_session(&db).await;
+        db.operations()
+            .insert_session_operation("op-recovery", "sess1", "reply")
+            .await
+            .expect("failed to insert session operation");
+        sqlx::query(
+            r"
+CREATE TRIGGER fail_startup_review_status
+BEFORE UPDATE OF status ON session
+WHEN NEW.status = 'Review'
+BEGIN
+    SELECT RAISE(FAIL, 'injected startup status recovery failure');
+END
+",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to install startup recovery failure trigger");
+        let mut failed_recovery_git_client = MockGitClient::new();
+        failed_recovery_git_client
+            .expect_is_rebase_in_progress()
+            .times(0);
+        failed_recovery_git_client.expect_abort_rebase().times(0);
+
+        // Act
+        SessionWorkerService::fail_unfinished_operations_from_previous_run_at(
+            &db,
+            base_dir.path(),
+            Arc::new(failed_recovery_git_client),
+            300,
+        )
+        .await;
+
+        // Assert
+        let failed_recovery_session = db
+            .sessions()
+            .load_sessions()
+            .await
+            .expect("failed to load session after failed recovery");
+        assert_eq!(failed_recovery_session[0].status, "InProgress");
+        assert!(
+            db.operations()
+                .is_session_operation_unfinished("op-recovery")
+                .await
+                .expect("failed to inspect retained operation")
+        );
+
+        // Arrange recovery
+        sqlx::query("DROP TRIGGER fail_startup_review_status")
+            .execute(&pool)
+            .await
+            .expect("failed to remove startup recovery failure trigger");
+        let mut recovered_git_client = MockGitClient::new();
+        recovered_git_client.expect_is_rebase_in_progress().times(0);
+        recovered_git_client.expect_abort_rebase().times(0);
+
+        // Act recovery
+        SessionWorkerService::fail_unfinished_operations_from_previous_run_at(
+            &db,
+            base_dir.path(),
+            Arc::new(recovered_git_client),
+            600,
+        )
+        .await;
+
+        // Assert recovery
+        let recovered_session = db
+            .sessions()
+            .load_sessions()
+            .await
+            .expect("failed to load recovered session");
+        assert_eq!(recovered_session[0].status, "Review");
+        assert!(
+            !db.operations()
+                .is_session_operation_unfinished("op-recovery")
+                .await
+                .expect("failed to inspect recovered operation")
+        );
+    }
+
+    #[tokio::test]
     /// Verifies restart recovery aborts stale rebase metadata for interrupted
     /// rebase operations before restoring review state.
     async fn test_fail_unfinished_operations_from_previous_run_aborts_interrupted_rebase() {
@@ -4134,11 +4585,12 @@ mod tests {
         SessionWorkerContext,
         AppRepositories,
         Arc<Mutex<VecDeque<TurnPrompt>>>,
+        sqlx::SqlitePool,
         tempfile::TempDir,
     ) {
         // Arrange
         let base_dir = tempdir().expect("failed to create temp dir");
-        let db = AppRepositories::in_memory().await;
+        let (db, pool) = AppRepositories::in_memory_with_pool().await;
         let project_id = db
             .projects()
             .upsert_project("/tmp/project", Some("main".to_string()))
@@ -4185,9 +4637,11 @@ mod tests {
             .returning(|_| Box::pin(async { Ok(String::new()) }));
         mock_git_client
             .expect_diff()
+            .times(0..)
             .returning(|_, _| Box::pin(async { Ok(String::new()) }));
         mock_git_client
             .expect_is_worktree_clean()
+            .times(0..)
             .returning(|_| Box::pin(async { Ok(true) }));
 
         let queue_handle = Arc::new(Mutex::new(queued_messages));
@@ -4214,7 +4668,7 @@ mod tests {
             status: Arc::new(Mutex::new(status)),
         };
 
-        (context, db, queue_handle, base_dir)
+        (context, db, queue_handle, pool, base_dir)
     }
 
     /// Builds one [`SessionWorkerContext`] whose only meaningful state is the
@@ -4267,6 +4721,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_requeue_prompt_front_recovers_poisoned_queue_without_losing_prompt() {
+        // Arrange
+        let queue = Arc::new(Mutex::new(VecDeque::from([TurnPrompt::from_text(
+            "queued second".to_string(),
+        )])));
+        let queue_to_poison = Arc::clone(&queue);
+        let poison_result = std::panic::catch_unwind(move || {
+            let _guard = queue_to_poison.lock().expect("initial queue lock");
+            std::panic::resume_unwind(Box::new("poison queued-message mutex"));
+        });
+        assert!(poison_result.is_err(), "test setup must poison the mutex");
+        let context = queue_helper_context(Arc::clone(&queue)).await;
+
+        // Act
+        context.requeue_prompt_front(TurnPrompt::from_text("queued first".to_string()));
+
+        // Assert
+        let queue = queue
+            .lock()
+            .expect_err("queued-message mutex should remain marked poisoned")
+            .into_inner();
+        assert_eq!(queue.len(), 2);
+        assert_eq!(queue[0].text, "queued first");
+        assert_eq!(queue[1].text, "queued second");
+    }
+
+    #[tokio::test]
     async fn test_clear_queued_messages_drops_all_pending_prompts() {
         // Arrange
         let queue: Arc<Mutex<VecDeque<TurnPrompt>>> = Arc::new(Mutex::new(VecDeque::from([
@@ -4312,7 +4793,7 @@ mod tests {
             Box::pin(async { unreachable!("drain must not dispatch while status is Question") })
         });
         let queued = VecDeque::from([TurnPrompt::from_text("queued reply".to_string())]);
-        let (context, _db, queue_handle, _base_dir) =
+        let (context, _db, queue_handle, _pool, _base_dir) =
             queue_test_context(mock_channel, queued, Status::Question).await;
 
         // Act
@@ -4323,6 +4804,280 @@ mod tests {
         let queue = queue_handle.lock().expect("queue lock");
         assert_eq!(queue.len(), 1);
         assert_eq!(queue.front().expect("queued head").text, "queued reply");
+    }
+
+    #[tokio::test]
+    async fn test_drain_queued_messages_restores_prompt_when_transcript_persistence_fails() {
+        // Arrange
+        let mut mock_channel = MockAgentChannel::new();
+        mock_channel.expect_run_turn().never().returning(|_, _, _| {
+            Box::pin(async { unreachable!("failed transcript append must not dispatch") })
+        });
+        let queued = VecDeque::from([
+            TurnPrompt::from_text("queued first".to_string()),
+            TurnPrompt::from_text("queued second".to_string()),
+        ]);
+        let (context, _db, queue_handle, pool, _base_dir) =
+            queue_test_context(mock_channel, queued, Status::InProgress).await;
+        pool.close().await;
+
+        // Act
+        SessionWorkerService::drain_queued_messages(&context).await;
+
+        // Assert
+        let queue = queue_handle.lock().expect("queue lock");
+        assert_eq!(queue.len(), 2);
+        assert_eq!(queue[0].text, "queued first");
+        assert_eq!(queue[1].text, "queued second");
+        assert!(
+            context
+                .transcript
+                .lock()
+                .expect("transcript lock")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    /// Verifies a drained prompt remains queued and unpersisted until its
+    /// owning operation row can be inserted successfully.
+    async fn test_drain_queued_messages_retries_after_operation_insert_failure() {
+        // Arrange
+        let mut mock_channel = MockAgentChannel::new();
+        mock_channel
+            .expect_run_turn()
+            .once()
+            .withf(|_, request, _| request.prompt.text == "queued reply")
+            .returning(|_, _, _| {
+                Box::pin(async {
+                    Err(AgentError::Backend(
+                        "stop after operation insert recovery".to_string(),
+                    ))
+                })
+            });
+        let queued = VecDeque::from([TurnPrompt::from_text("queued reply".to_string())]);
+        let (context, db, queue_handle, pool, _base_dir) =
+            queue_test_context(mock_channel, queued, Status::InProgress).await;
+        sqlx::query(
+            r"
+CREATE TRIGGER fail_drained_operation_insert
+BEFORE INSERT ON session_operation
+BEGIN
+    SELECT RAISE(FAIL, 'injected drained operation insert failure');
+END
+",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to install operation insert failure trigger");
+
+        // Act
+        SessionWorkerService::drain_queued_messages(&context).await;
+
+        // Assert
+        assert_eq!(queue_handle.lock().expect("queue lock").len(), 1);
+        assert!(
+            context
+                .transcript
+                .lock()
+                .expect("transcript lock")
+                .is_empty()
+        );
+        assert!(
+            db.sessions()
+                .load_session_messages("sess1")
+                .await
+                .expect("failed to load session messages")
+                .is_empty()
+        );
+
+        // Arrange recovery
+        sqlx::query("DROP TRIGGER fail_drained_operation_insert")
+            .execute(&pool)
+            .await
+            .expect("failed to remove operation insert failure trigger");
+
+        // Act recovery
+        SessionWorkerService::drain_queued_messages(&context).await;
+
+        // Assert recovery
+        assert!(queue_handle.lock().expect("queue lock").is_empty());
+        assert!(transcript_text(&context.transcript).contains("queued reply"));
+    }
+
+    #[tokio::test]
+    /// Verifies terminal-status persistence failure inside a queued turn
+    /// propagates to the worker and leaves later prompts untouched.
+    async fn test_drain_queued_messages_propagates_terminal_status_recovery() {
+        // Arrange
+        let executed_prompts = Arc::new(Mutex::new(Vec::new()));
+        let executed_prompts_for_channel = Arc::clone(&executed_prompts);
+        let mut mock_channel = MockAgentChannel::new();
+        mock_channel
+            .expect_run_turn()
+            .once()
+            .returning(move |_, request, _| {
+                executed_prompts_for_channel
+                    .lock()
+                    .expect("executed prompts lock")
+                    .push(request.prompt.text);
+                Box::pin(async { Ok(successful_turn_result("queued turn complete")) })
+            });
+        let queued = VecDeque::from([
+            TurnPrompt::from_text("queued first".to_string()),
+            TurnPrompt::from_text("queued second".to_string()),
+        ]);
+        let (context, db, queue_handle, pool, _base_dir) =
+            queue_test_context(mock_channel, queued, Status::InProgress).await;
+        sqlx::query(
+            r"
+CREATE TRIGGER fail_drained_turn_terminal_status
+BEFORE UPDATE OF status ON session
+WHEN NEW.status = 'Review'
+BEGIN
+    SELECT RAISE(FAIL, 'injected drained turn terminal status failure');
+END
+",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to install terminal status failure trigger");
+
+        // Act
+        let outcome = SessionWorkerService::drain_queued_messages(&context).await;
+        let unfinished_operations = db
+            .operations()
+            .load_unfinished_session_operations()
+            .await
+            .expect("failed to load unfinished operations");
+
+        // Assert
+        assert_eq!(outcome, QueueDrainOutcome::TerminalStatusRecoveryPending);
+        assert_eq!(
+            *executed_prompts.lock().expect("executed prompts lock"),
+            vec!["queued first".to_string()]
+        );
+        {
+            let queue = queue_handle.lock().expect("queue lock");
+            assert_eq!(queue.len(), 1);
+            assert_eq!(queue[0].text, "queued second");
+        }
+        assert_eq!(unfinished_operations.len(), 1);
+        assert_eq!(unfinished_operations[0].status, "running");
+        assert_eq!(
+            db.sessions()
+                .load_sessions()
+                .await
+                .expect("failed to load sessions")[0]
+                .status,
+            Status::InProgress.to_string()
+        );
+    }
+
+    #[tokio::test]
+    /// Verifies the periodic recovery wake retries a restored prompt after
+    /// both submission-time drain attempts fail, without new user input.
+    async fn test_periodic_worker_wake_recovers_after_two_prompt_write_failures() {
+        // Arrange
+        let executed_prompts = Arc::new(Mutex::new(Vec::new()));
+        let executed_prompts_for_channel = Arc::clone(&executed_prompts);
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let shutdown_tx = Arc::new(Mutex::new(Some(shutdown_tx)));
+        let shutdown_tx_for_channel = Arc::clone(&shutdown_tx);
+        let mut mock_channel = MockAgentChannel::new();
+        mock_channel
+            .expect_run_turn()
+            .times(2)
+            .returning(move |_, request, _| {
+                executed_prompts_for_channel
+                    .lock()
+                    .expect("executed prompts lock")
+                    .push(request.prompt.text);
+                Box::pin(async {
+                    Err(AgentError::Backend(
+                        "stop after recording queued prompt".to_string(),
+                    ))
+                })
+            });
+        mock_channel
+            .expect_shutdown_session()
+            .once()
+            .returning(move |_| {
+                let shutdown_tx = shutdown_tx_for_channel
+                    .lock()
+                    .expect("shutdown sender lock")
+                    .take();
+                Box::pin(async move {
+                    if let Some(shutdown_tx) = shutdown_tx {
+                        let _ = shutdown_tx.send(());
+                    }
+
+                    Ok(())
+                })
+            });
+        let queued = VecDeque::from([
+            TurnPrompt::from_text("queued first".to_string()),
+            TurnPrompt::from_text("queued second".to_string()),
+        ]);
+        let (context, _db, queue_handle, pool, _base_dir) =
+            queue_test_context(mock_channel, queued, Status::InProgress).await;
+        let transcript = Arc::clone(&context.transcript);
+        sqlx::query(
+            r"
+CREATE TRIGGER fail_queued_prompt_append
+BEFORE INSERT ON session_message
+BEGIN
+    SELECT RAISE(FAIL, 'injected queued prompt append failure');
+END
+",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to install queued prompt failure trigger");
+        SessionWorkerService::drain_queued_messages(&context).await;
+        let (sender, receiver) = mpsc::unbounded_channel();
+        SessionWorkerService::spawn_session_worker(context, receiver);
+        let mut worker_service = SessionWorkerService::new();
+        worker_service.workers.insert("sess1".into(), sender);
+        worker_service.wake_queued_messages("sess1");
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let failed_operation_count = sqlx::query_scalar::<_, i64>(
+                    "SELECT COUNT(*) FROM session_operation WHERE status = 'failed'",
+                )
+                .fetch_one(&pool)
+                .await
+                .expect("failed to count failed operations");
+                if failed_operation_count >= 2 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("timed out waiting for both queued prompt append failures");
+        sqlx::query("DROP TRIGGER fail_queued_prompt_append")
+            .execute(&pool)
+            .await
+            .expect("failed to remove queued prompt failure trigger");
+
+        // Act
+        worker_service.wake_all_queued_messages();
+        drop(worker_service);
+        tokio::time::timeout(Duration::from_secs(1), shutdown_rx)
+            .await
+            .expect("timed out waiting for worker shutdown")
+            .expect("worker dropped shutdown signal");
+
+        // Assert
+        assert!(queue_handle.lock().expect("queue lock").is_empty());
+        assert_eq!(
+            *executed_prompts.lock().expect("executed prompts lock"),
+            vec!["queued first".to_string(), "queued second".to_string()]
+        );
+        let transcript = transcript_text(&transcript);
+        assert!(transcript.contains("queued first"));
+        assert!(transcript.contains("queued second"));
     }
 
     #[tokio::test]
@@ -4339,7 +5094,7 @@ mod tests {
             })
             .returning(|_, _, _| Box::pin(async { Ok(successful_turn_result("Queued done.")) }));
         let queued = VecDeque::from([TurnPrompt::from_text("queued reply".to_string())]);
-        let (mut context, db, queue_handle, base_dir) =
+        let (mut context, db, queue_handle, _pool, base_dir) =
             queue_test_context(mock_channel, queued, Status::InProgress).await;
         db.sessions()
             .update_session_published_upstream_ref(
@@ -4446,7 +5201,7 @@ mod tests {
             TurnPrompt::from_text("queued first".to_string()),
             TurnPrompt::from_text("queued second".to_string()),
         ]);
-        let (context, _db, queue_handle, _base_dir) =
+        let (context, _db, queue_handle, _pool, _base_dir) =
             queue_test_context(mock_channel, queued, Status::InProgress).await;
 
         // Act

--- a/crates/agentty/src/infra/db.rs
+++ b/crates/agentty/src/infra/db.rs
@@ -25,9 +25,9 @@ pub(crate) use review::SqliteReviewRepository;
 pub use review::{ReviewRepository, SessionReviewRequestRow};
 pub(crate) use session::SqliteSessionRepository;
 pub use session::{
-    ForkSessionSnapshot, PersistedSessionCreation, SessionDetailRow, SessionFocusedReviewRow,
-    SessionFollowUpTaskRow, SessionListRow, SessionMessageRow, SessionRepository, SessionRow,
-    SessionTurnMetadata,
+    FirstSessionTurnPersistence, ForkSessionSnapshot, PersistedSessionCreation, SessionDetailRow,
+    SessionFocusedReviewRow, SessionFollowUpTaskRow, SessionListRow, SessionMessageRow,
+    SessionReplyStartPersistence, SessionRepository, SessionRow, SessionTurnMetadata,
 };
 pub(crate) use setting::{SettingRepository, SqliteSettingRepository};
 pub(crate) use usage::SqliteUsageRepository;

--- a/crates/agentty/src/infra/db/connection_test.rs
+++ b/crates/agentty/src/infra/db/connection_test.rs
@@ -11,7 +11,8 @@ use crate::domain::session::{
 use crate::domain::session_message::SessionMessageKind;
 use crate::domain::setting::SettingName;
 use crate::infra::db::{
-    SessionFocusedReviewRow, SessionOperationRow, SessionRow, SessionTurnMetadata,
+    FirstSessionTurnPersistence, SessionFocusedReviewRow, SessionOperationRow,
+    SessionReplyStartPersistence, SessionRow, SessionTurnMetadata,
 };
 /// Environment flag used to run the DST regression helper in an isolated
 /// subprocess with a fixed timezone.
@@ -297,6 +298,171 @@ async fn test_append_session_message_writes_message_rows() {
         SessionMessageKind::WorkflowNotice.as_str()
     );
     assert_eq!(messages[2].content, "\n[Sync Error] failed\n");
+}
+
+/// Asserts that a failed later step rolls the complete first-turn transaction
+/// back to its draft state.
+async fn assert_first_turn_transaction_rolls_back(trigger_sql: &'static str) {
+    let (database, pool) = AppRepositories::in_memory_with_pool().await;
+    let project_id = database
+        .projects()
+        .upsert_project("/tmp/project", Some("main".to_string()))
+        .await
+        .expect("failed to insert project");
+    database
+        .sessions()
+        .insert_draft_session("session-a", "gpt-5.5", "main", "Draft", project_id)
+        .await
+        .expect("failed to insert draft session");
+    sqlx::query(trigger_sql)
+        .execute(&pool)
+        .await
+        .expect("failed to install failure trigger");
+
+    let result = database
+        .sessions()
+        .persist_first_session_turn(FirstSessionTurnPersistence {
+            expected_status: "Draft",
+            id: "session-a",
+            message_content: "first prompt",
+            operation_id: "operation-a",
+            operation_kind: "start_prompt",
+            prompt: "first prompt",
+            status: "InProgress",
+            timestamp_seconds: 10,
+            title: "first prompt",
+        })
+        .await;
+
+    assert!(result.is_err());
+    let session = database
+        .sessions()
+        .load_sessions()
+        .await
+        .expect("failed to load sessions")
+        .into_iter()
+        .find(|session| session.id == "session-a")
+        .expect("missing session");
+    assert_eq!(session.status, "Draft");
+    assert!(session.prompt.is_empty());
+    assert_eq!(session.title, None);
+    assert!(session.is_draft);
+    assert!(
+        database
+            .sessions()
+            .load_session_messages("session-a")
+            .await
+            .expect("failed to load messages")
+            .is_empty()
+    );
+    assert!(
+        database
+            .operations()
+            .load_unfinished_session_operations()
+            .await
+            .expect("failed to load operations")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn test_first_turn_transaction_rolls_back_when_transcript_insert_fails() {
+    // Arrange / Act / Assert
+    assert_first_turn_transaction_rolls_back(
+        r"
+CREATE TRIGGER fail_first_turn_message
+BEFORE INSERT ON session_message
+BEGIN
+    SELECT RAISE(FAIL, 'injected transcript failure');
+END
+",
+    )
+    .await;
+}
+
+#[tokio::test]
+/// Verifies cancellation winning the reply-start status race preserves the
+/// unanswered question, transcript, and operation state.
+async fn test_reply_start_transaction_preserves_questions_after_stale_cancellation() {
+    // Arrange
+    let database = Database::open_in_memory()
+        .await
+        .expect("failed to open in-memory db");
+    let project_id = database
+        .projects()
+        .upsert_project("/tmp/project", Some("main".to_string()))
+        .await
+        .expect("failed to insert project");
+    insert_session_fixture(&database, "session-a", "main", "Question", project_id).await;
+    database
+        .sessions()
+        .update_session_questions("session-a", r#"["Need detail?"]"#)
+        .await
+        .expect("failed to persist question state");
+    database
+        .sessions()
+        .update_session_status_with_timing_at("session-a", "Canceled", 20)
+        .await
+        .expect("failed to persist concurrent cancellation");
+
+    // Act
+    let persisted = database
+        .sessions()
+        .persist_session_reply_start(SessionReplyStartPersistence {
+            expected_status: "Question",
+            id: "session-a",
+            message_content: "The missing detail",
+            operation_id: "operation-a",
+            operation_kind: "reply",
+            status: "InProgress",
+            timestamp_seconds: 30,
+        })
+        .await
+        .expect("stale reply transaction should return a CAS miss");
+
+    // Assert
+    assert!(!persisted);
+    let session = database
+        .sessions()
+        .load_sessions()
+        .await
+        .expect("failed to load canceled session")
+        .into_iter()
+        .find(|session| session.id == "session-a")
+        .expect("missing canceled session");
+    assert_eq!(session.status, "Canceled");
+    assert_eq!(session.questions.as_deref(), Some(r#"["Need detail?"]"#));
+    assert!(
+        database
+            .sessions()
+            .load_session_messages("session-a")
+            .await
+            .expect("failed to load session messages")
+            .is_empty()
+    );
+    assert!(
+        database
+            .operations()
+            .load_unfinished_session_operations()
+            .await
+            .expect("failed to load session operations")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn test_first_turn_transaction_rolls_back_when_operation_insert_fails() {
+    // Arrange / Act / Assert
+    assert_first_turn_transaction_rolls_back(
+        r"
+CREATE TRIGGER fail_first_turn_operation
+BEFORE INSERT ON session_operation
+BEGIN
+    SELECT RAISE(FAIL, 'injected operation failure');
+END
+",
+    )
+    .await;
 }
 
 /// Verifies legacy transcript checkpoints keep their old collapse semantics

--- a/crates/agentty/src/infra/db/operation.rs
+++ b/crates/agentty/src/infra/db/operation.rs
@@ -23,8 +23,13 @@ pub struct SessionOperationRow {
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait OperationRepository: Send + Sync {
-    /// Marks unfinished operations as failed after process restart.
-    async fn fail_unfinished_session_operations(&self, reason: &str) -> Result<(), DbError>;
+    /// Marks one session's unfinished operations as failed after its status
+    /// has been durably recovered from an interrupted process run.
+    async fn fail_unfinished_session_operations_for_session(
+        &self,
+        session_id: &str,
+        reason: &str,
+    ) -> Result<(), DbError>;
 
     /// Returns whether cancellation is requested for a specific operation.
     async fn is_cancel_requested_for_operation(&self, operation_id: &str) -> Result<bool, DbError>;
@@ -86,7 +91,11 @@ struct RequiredBoolValueRow {
 
 #[async_trait]
 impl OperationRepository for SqliteOperationRepository {
-    async fn fail_unfinished_session_operations(&self, reason: &str) -> Result<(), DbError> {
+    async fn fail_unfinished_session_operations_for_session(
+        &self,
+        session_id: &str,
+        reason: &str,
+    ) -> Result<(), DbError> {
         let now = unix_timestamp_now();
 
         sqlx::query(
@@ -97,12 +106,14 @@ SET status = 'failed',
     heartbeat_at = ?,
     last_error = ?,
     cancel_requested = 1
-WHERE status IN ('queued', 'running')
+WHERE session_id = ?
+  AND status IN ('queued', 'running')
 ",
         )
         .bind(now)
         .bind(now)
         .bind(reason)
+        .bind(session_id)
         .execute(&self.0)
         .await?;
 

--- a/crates/agentty/src/infra/db/session.rs
+++ b/crates/agentty/src/infra/db/session.rs
@@ -10,6 +10,55 @@ use crate::domain::session::{SessionFollowUpTask, SessionId, SessionStats};
 use crate::domain::session_message::{SessionMessageKind, stored_message_content};
 use crate::infra::db::DbError;
 
+/// Atomic persistence payload for the first runnable session turn.
+pub struct FirstSessionTurnPersistence<'a> {
+    /// Persisted status that must still own the transition.
+    pub(crate) expected_status: &'a str,
+    /// Stable session identifier.
+    pub(crate) id: &'a str,
+    /// Canonical user-prompt transcript content.
+    pub(crate) message_content: &'a str,
+    /// Queued operation identifier dispatched after commit.
+    pub(crate) operation_id: &'a str,
+    /// Stable operation kind stored for recovery.
+    pub(crate) operation_kind: &'a str,
+    /// First prompt saved on the session row.
+    pub(crate) prompt: &'a str,
+    /// Runnable status published after commit.
+    pub(crate) status: &'a str,
+    /// Wall-clock timestamp used for timing and operation ordering.
+    pub(crate) timestamp_seconds: i64,
+    /// Initial display title derived from the first prompt.
+    pub(crate) title: &'a str,
+}
+
+/// Atomic persistence payload for starting a follow-up session turn.
+pub struct SessionReplyStartPersistence<'a> {
+    /// Persisted status that must still own the transition.
+    pub(crate) expected_status: &'a str,
+    /// Stable session identifier.
+    pub(crate) id: &'a str,
+    /// Canonical user-prompt transcript content.
+    pub(crate) message_content: &'a str,
+    /// Queued operation identifier dispatched after commit.
+    pub(crate) operation_id: &'a str,
+    /// Stable operation kind stored for recovery.
+    pub(crate) operation_kind: &'a str,
+    /// Runnable status published after commit.
+    pub(crate) status: &'a str,
+    /// Wall-clock timestamp used for timing and operation ordering.
+    pub(crate) timestamp_seconds: i64,
+}
+
+/// Shared values committed after a turn-start status update succeeds.
+struct TurnStartPersistence<'a> {
+    id: &'a str,
+    message_content: &'a str,
+    operation_id: &'a str,
+    operation_kind: &'a str,
+    timestamp_seconds: i64,
+}
+
 /// Transactional turn-metadata payload persisted after one completed agent
 /// turn.
 ///
@@ -388,6 +437,20 @@ pub trait SessionRepository: Send + Sync {
         turn_metadata: &SessionTurnMetadata,
     ) -> Result<(), DbError>;
 
+    /// Persists the first prompt metadata, transcript row, runnable status,
+    /// and queued operation in one transaction.
+    async fn persist_first_session_turn(
+        &self,
+        persistence: FirstSessionTurnPersistence<'_>,
+    ) -> Result<bool, DbError>;
+
+    /// Persists a follow-up prompt, question clearing, runnable status, and
+    /// queued operation in one expected-status transaction.
+    async fn persist_session_reply_start(
+        &self,
+        persistence: SessionReplyStartPersistence<'_>,
+    ) -> Result<bool, DbError>;
+
     /// Replaces the persisted follow-up task list for one session inside one
     /// transaction so task deletion and reinsertion commit atomically.
     async fn replace_session_follow_up_tasks(
@@ -494,6 +557,16 @@ pub trait SessionRepository: Send + Sync {
         timestamp_seconds: i64,
     ) -> Result<(), DbError>;
 
+    /// Atomically updates status and timing only when the persisted status
+    /// still matches `expected_status`.
+    async fn transition_session_status_with_timing_at(
+        &self,
+        id: &str,
+        expected_status: &str,
+        status: &str,
+        timestamp_seconds: i64,
+    ) -> Result<bool, DbError>;
+
     /// Updates the persisted session summary text for a session row.
     async fn update_session_summary(&self, id: &str, summary: &str) -> Result<(), DbError>;
 
@@ -534,6 +607,48 @@ impl SqliteSessionRepository {
     /// Creates a session repository backed by the provided pool.
     pub(crate) fn new(pool: SqlitePool) -> Self {
         Self(pool)
+    }
+
+    /// Commits the transcript and operation rows shared by first-turn and
+    /// follow-up turn-start transactions.
+    async fn commit_turn_start(
+        mut transaction: sqlx::Transaction<'_, sqlx::Sqlite>,
+        persistence: TurnStartPersistence<'_>,
+    ) -> Result<(), DbError> {
+        let message_content =
+            stored_message_content(SessionMessageKind::UserPrompt, persistence.message_content);
+        sqlx::query(
+            r"
+INSERT INTO session_message (session_id, position, kind, content, created_at)
+SELECT ?, COALESCE(MAX(position), -1) + 1, ?, ?, ?
+FROM session_message
+WHERE session_id = ?
+",
+        )
+        .bind(persistence.id)
+        .bind(SessionMessageKind::UserPrompt.as_str())
+        .bind(message_content)
+        .bind(persistence.timestamp_seconds)
+        .bind(persistence.id)
+        .execute(&mut *transaction)
+        .await?;
+
+        sqlx::query(
+            r"
+INSERT INTO session_operation (id, session_id, kind, status, queued_at)
+VALUES (?, ?, ?, 'queued', ?)
+",
+        )
+        .bind(persistence.operation_id)
+        .bind(persistence.id)
+        .bind(persistence.operation_kind)
+        .bind(persistence.timestamp_seconds)
+        .execute(&mut *transaction)
+        .await?;
+
+        transaction.commit().await?;
+
+        Ok(())
     }
 }
 
@@ -1595,6 +1710,98 @@ ON CONFLICT(session_id, model) DO UPDATE SET
         Ok(())
     }
 
+    async fn persist_first_session_turn(
+        &self,
+        persistence: FirstSessionTurnPersistence<'_>,
+    ) -> Result<bool, DbError> {
+        let mut transaction = self.0.begin().await?;
+        let update_result = sqlx::query(
+            r"
+UPDATE session
+SET prompt = ?,
+    title = ?,
+    status = ?,
+    is_draft = 0,
+    in_progress_started_at = COALESCE(in_progress_started_at, ?),
+    updated_at = ?
+WHERE id = ?
+  AND status = ?
+",
+        )
+        .bind(persistence.prompt)
+        .bind(persistence.title)
+        .bind(persistence.status)
+        .bind(persistence.timestamp_seconds)
+        .bind(persistence.timestamp_seconds)
+        .bind(persistence.id)
+        .bind(persistence.expected_status)
+        .execute(&mut *transaction)
+        .await?;
+        if update_result.rows_affected() == 0 {
+            transaction.rollback().await?;
+
+            return Ok(false);
+        }
+
+        Self::commit_turn_start(
+            transaction,
+            TurnStartPersistence {
+                id: persistence.id,
+                message_content: persistence.message_content,
+                operation_id: persistence.operation_id,
+                operation_kind: persistence.operation_kind,
+                timestamp_seconds: persistence.timestamp_seconds,
+            },
+        )
+        .await?;
+
+        Ok(true)
+    }
+
+    async fn persist_session_reply_start(
+        &self,
+        persistence: SessionReplyStartPersistence<'_>,
+    ) -> Result<bool, DbError> {
+        let mut transaction = self.0.begin().await?;
+        let update_result = sqlx::query(
+            r"
+UPDATE session
+SET questions = '',
+    status = ?,
+    in_progress_started_at = COALESCE(in_progress_started_at, ?),
+    updated_at = ?
+WHERE id = ?
+  AND status = ?
+",
+        )
+        .bind(persistence.status)
+        .bind(persistence.timestamp_seconds)
+        .bind(persistence.timestamp_seconds)
+        .bind(persistence.id)
+        .bind(persistence.expected_status)
+        .execute(&mut *transaction)
+        .await?;
+        if update_result.rows_affected() == 0 {
+            transaction.rollback().await?;
+
+            return Ok(false);
+        }
+
+        Self::commit_turn_start(
+            transaction,
+            TurnStartPersistence {
+                id: persistence.id,
+                message_content: persistence.message_content,
+                operation_id: persistence.operation_id,
+                operation_kind: persistence.operation_kind,
+                timestamp_seconds: persistence.timestamp_seconds,
+            },
+        )
+        .await?;
+
+        Ok(true)
+    }
+
     async fn replace_session_follow_up_tasks(
         &self,
         session_id: &str,
@@ -1968,6 +2175,42 @@ WHERE id = ?
         .await?;
 
         Ok(())
+    }
+
+    async fn transition_session_status_with_timing_at(
+        &self,
+        id: &str,
+        expected_status: &str,
+        status: &str,
+        timestamp_seconds: i64,
+    ) -> Result<bool, DbError> {
+        let update_result = sqlx::query(
+            r"
+UPDATE session
+SET status = ?,
+    in_progress_total_seconds = CASE
+        WHEN ? = 'InProgress' OR in_progress_started_at IS NULL THEN in_progress_total_seconds
+        ELSE in_progress_total_seconds + MAX(0, ? - in_progress_started_at)
+    END,
+    in_progress_started_at = CASE
+        WHEN ? = 'InProgress' THEN COALESCE(in_progress_started_at, ?)
+        ELSE NULL
+    END
+WHERE id = ?
+  AND status = ?
+",
+        )
+        .bind(status)
+        .bind(status)
+        .bind(timestamp_seconds)
+        .bind(status)
+        .bind(timestamp_seconds)
+        .bind(id)
+        .bind(expected_status)
+        .execute(&self.0)
+        .await?;
+
+        Ok(update_result.rows_affected() == 1)
     }
 
     async fn update_session_summary(&self, id: &str, summary: &str) -> Result<(), DbError> {

--- a/crates/agentty/src/runtime/key_handler.rs
+++ b/crates/agentty/src/runtime/key_handler.rs
@@ -1208,7 +1208,8 @@ mod tests {
             &mut app,
             &session_id,
             crate::domain::session::Status::Review,
-        );
+        )
+        .await;
         app.mode = AppMode::Confirmation {
             confirmation_intent: ConfirmationIntent::CancelSession,
             confirmation_message: "Cancel session \"test\"?".to_string(),
@@ -1386,7 +1387,8 @@ mod tests {
             &mut app,
             &source_session_id,
             crate::domain::session::Status::Done,
-        );
+        )
+        .await;
         app.mode = AppMode::Confirmation {
             confirmation_intent: ConfirmationIntent::ContinueSession,
             confirmation_message: "Create a new draft session with initial context from this \
@@ -1516,7 +1518,8 @@ mod tests {
             &mut app,
             &session_id,
             crate::domain::session::Status::Review,
-        );
+        )
+        .await;
         app.mode = AppMode::PublishBranchInput {
             default_branch_name: "wt/session".to_string(),
             input: crate::domain::input::InputState::with_text("review/custom".to_string()),

--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -1063,6 +1063,30 @@ mod tests {
     /// Fake terminal size used by tests that don't exercise scrolling.
     const TEST_TERMINAL_SIZE: Rect = Rect::new(0, 0, 80, 24);
 
+    /// Inserts one persisted question session for tests that exercise durable
+    /// question-mode status transitions.
+    async fn insert_question_session(app: &App, session_id: &str) {
+        let project_id = app
+            .services
+            .db()
+            .projects()
+            .upsert_project("/tmp/test", None)
+            .await
+            .expect("failed to upsert project");
+        app.services
+            .db()
+            .sessions()
+            .insert_session(
+                session_id,
+                "gemini-3-flash-preview",
+                "main",
+                "Question",
+                project_id,
+            )
+            .await
+            .expect("failed to insert question session");
+    }
+
     #[tokio::test]
     async fn test_question_view_metrics_uses_default_review_model_for_loading_fallback() {
         // Arrange
@@ -1167,6 +1191,7 @@ mod tests {
         // Arrange — two unanswered questions. Ctrl+C should cancel the
         // question turn and transition to View without sending a reply.
         let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        insert_question_session(&app, "session-ctrl-c").await;
         app.review_cache.insert(
             "session-ctrl-c".into(),
             crate::app::ReviewCacheEntry::Ready {
@@ -1218,6 +1243,7 @@ mod tests {
         // Arrange — answer focus with no at-mention overlay. Esc must mirror
         // Ctrl+C and cancel the question turn without sending a reply.
         let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        insert_question_session(&app, "session-esc").await;
         app.review_cache.insert(
             "session-esc".into(),
             crate::app::ReviewCacheEntry::Ready {
@@ -1406,6 +1432,7 @@ mod tests {
 
         let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
         let session_id = "session-review-check";
+        insert_question_session(&app, session_id).await;
         app.sessions.push_session(Session {
             base_branch: "main".to_string(),
             created_at: 0,
@@ -1482,6 +1509,7 @@ mod tests {
 
         let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
         let session_id = "session-handle-review";
+        insert_question_session(&app, session_id).await;
         app.sessions.push_session(Session {
             base_branch: "main".to_string(),
             created_at: 0,

--- a/crates/agentty/src/test_support.rs
+++ b/crates/agentty/src/test_support.rs
@@ -530,10 +530,17 @@ pub(crate) fn session_manager_with_sessions(sessions: Vec<Session>) -> SessionMa
     session_manager_with_handles(sessions, std::collections::HashMap::new())
 }
 
-/// Sets a session status in both the session snapshot and its live handles,
-/// when either exists.
+/// Persists a session status, then updates both the session snapshot and its
+/// live handles when either exists.
 #[cfg(test)]
-pub(crate) fn set_session_status_for_test(app: &mut App, session_id: &str, status: Status) {
+pub(crate) async fn set_session_status_for_test(app: &mut App, session_id: &str, status: Status) {
+    app.services
+        .db()
+        .sessions()
+        .update_session_status_with_timing_at(session_id, &status.to_string(), 0)
+        .await
+        .expect("failed to persist test session status");
+
     if let Some(session) = app
         .sessions
         .sessions_mut()

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -173,10 +173,12 @@ render twice per frame.
    After a successful push, linked review-request and commit metadata are resolved and
    refreshed; lookup failures append the existing warning notice instead of being
    discarded. The push result is appended as a durable transcript notice.
-1. Completed stacked-parent turns fan out `SessionCommand::Rebase` to review-ready
-   materialized children so child branches replay onto the latest parent branch.
 1. The session size is refreshed and the final status becomes `Review` or `Question`
    (failures return to `Review`).
+1. After the terminal status commits, completed stacked-parent turns fan out
+   `SessionCommand::Rebase` to review-ready materialized children so child branches
+   replay onto the latest parent branch. A failed terminal-status write emits no child
+   synchronization event.
 
 ### Operation Lifecycle and Recovery
 
@@ -184,12 +186,26 @@ render twice per frame.
 restart-safe:
 
 - Before enqueue: insert `session_operation` row (`queued`).
+- Queued-prompt drainage restores the prompt and waits for a recovery wake-up when its
+  operation row cannot be inserted; transcript persistence and dispatch begin only after
+  that operation exists.
 - Worker transitions: `queued -> running -> done/failed/canceled`.
+- If a completed turn cannot persist its terminal status, the worker leaves the
+  operation `running` instead of marking it failed, so startup recovery can reset the
+  session to `Review` rather than overlooking a persistent `InProgress` session. That
+  worker stops dispatching later messages until recovery so it cannot execute more work
+  from the inconsistent status.
 - Cancel requests are persisted and checked before command execution.
-- On startup, unfinished operations are failed with reason `Interrupted by app restart`,
-  interrupted rebase operations abort stale in-progress git rebase metadata, and
-  impacted sessions are reset to `Review`. Pending post-merge stacked-child syncs are
-  requeued.
+- On startup, interrupted rebase operations abort stale in-progress git rebase metadata.
+  Each impacted session is durably reset to `Review` before its unfinished operations
+  are failed with reason `Interrupted by app restart`; a failed status repair retains
+  those operations for the next recovery pass. Pending post-merge stacked-child syncs
+  are requeued.
+- Prompts queued behind an active turn send ordered drain wake-ups to the same worker.
+  If transcript persistence fails, the prompt returns to the front of the queue and the
+  next pending wake-up retries it before later prompts. The existing low-frequency
+  session fallback poll supplies further recovery wake-ups after transient storage
+  failures, preserving FIFO order without requiring another user submission.
 
 ### Status Transition Rules
 
@@ -420,6 +436,26 @@ runtime flow:
   startup.
 - Session snapshots in memory are authoritative for rendering; DB is authoritative for
   restart recovery.
+- Durable session mutations commit before shared handles change or `SessionUpdated` is
+  emitted. Failed status or transcript writes therefore leave the render snapshot and
+  reducer event stream unchanged.
+- Status transitions use the validated current status as a SQLite compare-and-swap
+  condition, so concurrent stale transitions cannot both commit. The initial prompt,
+  title, user transcript row, runnable status/timing, draft flag, and queued operation
+  commit together before the first-turn snapshot is published or dispatched. Follow-up
+  replies likewise commit their expected-status transition, question clear, user
+  transcript row, and queued operation atomically, so cancellation winning the status
+  race leaves the unanswered question and transcript unchanged.
+- The one-time transcript replay marker used after an agent or model switch is consumed
+  only after the reply transaction commits and its command reaches the worker. A failed
+  reply start therefore retries with the same replay context.
+- Externally closed review requests cancel stacked children only after the parent
+  cancellation commits; a failed or stale parent transition leaves the entire stack
+  unchanged.
+- Status and active-work timing, transcript messages and ordering metadata, and
+  completed-turn metadata each commit through transaction-scoped repository methods;
+  app-layer callers receive persistence errors instead of publishing best-effort
+  snapshots.
 - System logs are process-local only: a bounded in-memory buffer, never written to
   SQLite or disk.
 - Shared session handles provide low-latency updates between DB reloads.


### PR DESCRIPTION
- Commits session status, prompt/title, transcript, draft state, timing, and queued operations before publishing snapshots, refresh events, or dispatching turns.
- Shares transactional first-turn and follow-up persistence while propagating critical failures through lifecycle, turn finalization, merge, assist, and queued-message workflows.
- Uses compare-and-swap status transitions to preserve recoverable state under database failures and concurrent transitions.
- Retains unfinished operations until status recovery succeeds and retries queued prompts in FIFO order after transcript or terminal-status persistence failures.
- Adds rollback, database-failure, concurrent-transition, and queue-recovery coverage and documents persistence ordering.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)