### PR TITLE
Clarify Mermaid fence recognition

### DIFF
--- a/crates/ag-protocol/src/envelope.rs
+++ b/crates/ag-protocol/src/envelope.rs
@@ -291,6 +291,7 @@ mod tests {
         assert!(rendered_prompt.contains("```mermaid"));
         assert!(rendered_prompt.contains("put the diagram only in `answer`"));
         assert!(normalized_rendered_prompt.contains("start the opening fence at column 1"));
+        assert!(rendered_prompt.contains("recognizes Mermaid diagrams only in this fenced"));
         assert!(rendered_prompt.contains("Do not emit Mermaid as plain text"));
         assert!(rendered_prompt.contains("Supported mermaid syntax"));
         assert!(normalized_rendered_prompt.contains("Do not create commits"));

--- a/crates/ag-protocol/src/template/protocol_instruction_session_turn_usage.md
+++ b/crates/ag-protocol/src/template/protocol_instruction_session_turn_usage.md
@@ -5,12 +5,12 @@ commits or suggest creating commits at the end of the turn. The session chat ren
 when a flow, process, architecture, or relationship is clearer as a diagram than as
 prose. When including Mermaid, put the diagram only in `answer`, start the opening fence
 at column 1 with exactly three backticks followed immediately by `mermaid`, and close it
-with exactly three backticks. Do not emit Mermaid as plain text, an indented code block,
-or a code fence without the `mermaid` info string. Supported mermaid syntax:
-`graph`/`flowchart` with a `TD`, `TB`, or `LR` direction, `erDiagram` relationship
-statements, and simple `sequenceDiagram` participant and message lines. Keep every node,
-participant, and message label within 32 plain-ASCII characters; longer sequence labels
-are truncated with an ellipsis, and over-long flowchart labels drop the diagram preview.
-Keep diagrams small and acyclic unless using a compact two-node `LR` feedback loop;
-unsupported, other cyclic, or oversized diagrams fall back to the plain fenced-code
-presentation.
+with exactly three backticks. Agentty recognizes Mermaid diagrams only in this fenced
+form. Do not emit Mermaid as plain text, an indented code block, or a code fence without
+the `mermaid` info string. Supported mermaid syntax: `graph`/`flowchart` with a `TD`,
+`TB`, or `LR` direction, `erDiagram` relationship statements, and simple
+`sequenceDiagram` participant and message lines. Keep every node, participant, and
+message label within 32 plain-ASCII characters; longer sequence labels are truncated
+with an ellipsis, and over-long flowchart labels drop the diagram preview. Keep diagrams
+small and acyclic unless using a compact two-node `LR` feedback loop; unsupported, other
+cyclic, or oversized diagrams fall back to the plain fenced-code presentation.


### PR DESCRIPTION
- State that Agentty recognizes Mermaid diagrams only in fenced `mermaid` blocks.
- Verify the session prompt includes the recognition rule.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)