### PR TITLE
Support bare-repository worktree layouts for sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- agentty: support projects backed by a bare-repository worktree layout (a container
+  folder holding per-branch worktrees). Previously, starting a session turn in such a
+  project failed with a git status `must be run in a work tree` error.
+
 ## [v0.12.8] - 2026-07-09
 
 ### Removed

--- a/crates/ag-git/src/client.rs
+++ b/crates/ag-git/src/client.rs
@@ -16,10 +16,11 @@ use super::{
     fetch_remote, find_git_repo_root, get_ahead_behind, get_ref_ahead_behind, has_commits_since,
     has_unmerged_paths, head_commit_message, head_hash, head_short_hash, in_progress_operation,
     is_rebase_in_progress, is_worktree_clean, list_conflicted_files, list_local_commit_titles,
-    list_staged_conflict_marker_files, list_upstream_commit_titles, main_repo_root, pull_rebase,
-    push_current_branch, push_current_branch_to_remote_branch, rebase, rebase_continue,
-    rebase_onto_start, rebase_start, ref_hash, remote_branch_exists, remove_worktree, repo_url,
-    squash_merge, squash_merge_diff, stage_all, tracked_worktree_status, worktree_status,
+    list_staged_conflict_marker_files, list_upstream_commit_titles, main_checkout_working_tree,
+    main_repo_root, pull_rebase, push_current_branch, push_current_branch_to_remote_branch, rebase,
+    rebase_continue, rebase_onto_start, rebase_start, ref_hash, remote_branch_exists,
+    remove_worktree, repo_url, squash_merge, squash_merge_diff, stage_all, tracked_worktree_status,
+    worktree_status,
 };
 
 /// Boxed async result used by [`GitClient`] trait methods.
@@ -397,6 +398,18 @@ pub trait GitClient: Send + Sync {
     /// # Errors
     /// Returns an error when the main repository cannot be resolved.
     fn main_repo_root(&self, repo_path: PathBuf) -> GitFuture<Result<PathBuf, GitError>>;
+
+    /// Resolves the main working checkout for a repository or worktree path.
+    ///
+    /// Returns `None` when the shared repository is bare, because a bare
+    /// repository has no main working checkout.
+    ///
+    /// # Errors
+    /// Returns an error when the shared repository cannot be resolved.
+    fn main_checkout_working_tree(
+        &self,
+        repo_path: PathBuf,
+    ) -> GitFuture<Result<Option<PathBuf>, GitError>>;
 }
 
 /// Production [`GitClient`] implementation backed by real git commands.
@@ -672,6 +685,13 @@ impl GitClient for RealGitClient {
 
     fn main_repo_root(&self, repo_path: PathBuf) -> GitFuture<Result<PathBuf, GitError>> {
         Box::pin(async move { main_repo_root(repo_path).await })
+    }
+
+    fn main_checkout_working_tree(
+        &self,
+        repo_path: PathBuf,
+    ) -> GitFuture<Result<Option<PathBuf>, GitError>> {
+        Box::pin(async move { main_checkout_working_tree(repo_path).await })
     }
 }
 

--- a/crates/ag-git/src/lib.rs
+++ b/crates/ag-git/src/lib.rs
@@ -30,7 +30,7 @@ pub(crate) use rebase::{
     list_conflicted_files, list_staged_conflict_marker_files, rebase, rebase_continue,
     rebase_onto_start, rebase_start,
 };
-pub(crate) use repo::{main_repo_root, repo_url};
+pub(crate) use repo::{main_checkout_working_tree, main_repo_root, repo_url};
 #[cfg(test)]
 pub(crate) use sleeper::MockSleeper;
 pub(crate) use sleeper::{Sleeper, ThreadSleeper};

--- a/crates/ag-git/src/repo.rs
+++ b/crates/ag-git/src/repo.rs
@@ -120,6 +120,10 @@ pub(super) enum SharedRepo {
 pub(super) fn resolve_shared_repo_sync(repo_path: &Path) -> Result<SharedRepo, GitError> {
     let (git_dir, git_common_dir) = git_directory_paths(repo_path)?;
 
+    // NOTE: `to_string_lossy` replaces non-UTF-8 bytes with U+FFFD, which would
+    // produce a path git cannot find on exotic systems. The rest of this file
+    // follows the same String-based convention, so this is consistent, but
+    // callers on non-UTF-8 paths will get a generic git failure.
     let git_common_dir_arg = git_common_dir.to_string_lossy();
     let is_bare = run_git_command_sync(
         repo_path,

--- a/crates/ag-git/src/repo.rs
+++ b/crates/ag-git/src/repo.rs
@@ -50,15 +50,101 @@ pub(crate) async fn main_repo_root(repo_path: PathBuf) -> Result<PathBuf, GitErr
     spawn_blocking(move || main_repo_root_sync(&repo_path)).await?
 }
 
+/// Resolves the main working checkout for a repository or linked worktree.
+///
+/// Returns `Some(path)` with the main working checkout root for non-bare shared
+/// repositories, and `None` when the shared repository is bare because a bare
+/// repository has no main working checkout.
+///
+/// # Arguments
+/// * `repo_path` - Path to a git repository or worktree
+///
+/// # Returns
+/// Ok(Some(path)) with the main working checkout, Ok(None) when the shared
+/// repository is bare, Err([`GitError`]) on failure.
+///
+/// # Errors
+/// Returns an error if git metadata cannot be queried from `repo_path`.
+pub(crate) async fn main_checkout_working_tree(
+    repo_path: PathBuf,
+) -> Result<Option<PathBuf>, GitError> {
+    spawn_blocking(move || main_checkout_working_tree_sync(&repo_path)).await?
+}
+
 /// Resolves the main repository root for `repo_path` in synchronous code.
+///
+/// Returns the administrative root: the main working checkout for non-bare
+/// shared repositories and the bare common git directory for bare shared
+/// repositories. Both are valid working directories for `git worktree` and
+/// branch administration commands.
 pub(super) fn main_repo_root_sync(repo_path: &Path) -> Result<PathBuf, GitError> {
+    match resolve_shared_repo_sync(repo_path)? {
+        SharedRepo::Working(path) | SharedRepo::Bare(path) => Ok(path),
+    }
+}
+
+/// Resolves the main working checkout for `repo_path` in synchronous code.
+///
+/// Returns `Some(path)` for non-bare shared repositories and `None` for bare
+/// shared repositories, which have no main working checkout.
+pub(super) fn main_checkout_working_tree_sync(
+    repo_path: &Path,
+) -> Result<Option<PathBuf>, GitError> {
+    match resolve_shared_repo_sync(repo_path)? {
+        SharedRepo::Working(path) => Ok(Some(path)),
+        SharedRepo::Bare(_) => Ok(None),
+    }
+}
+
+/// Classifies the shared repository backing a worktree.
+pub(super) enum SharedRepo {
+    /// Non-bare shared repository. The path is the main working checkout root.
+    Working(PathBuf),
+    /// Bare shared repository. The path is the bare common git directory, which
+    /// has no main working checkout but is a valid administrative working
+    /// directory for `git worktree` and branch commands.
+    Bare(PathBuf),
+}
+
+/// Resolves the shared repository backing `repo_path`.
+///
+/// Reads the git and common git directories, detects whether the shared
+/// repository is bare by querying `git --git-dir <common> rev-parse
+/// --is-bare-repository`, and returns [`SharedRepo::Bare`] with the bare common
+/// git directory when bare. Otherwise returns [`SharedRepo::Working`] with the
+/// main working checkout root, matching the historical `main_repo_root_sync`
+/// resolution for non-bare layouts.
+///
+/// # Errors
+/// Returns an error if git metadata cannot be queried from `repo_path`.
+pub(super) fn resolve_shared_repo_sync(repo_path: &Path) -> Result<SharedRepo, GitError> {
     let (git_dir, git_common_dir) = git_directory_paths(repo_path)?;
 
-    if git_dir == git_common_dir {
-        return repo_root_from_git_dir(repo_path, &git_dir);
+    let git_common_dir_arg = git_common_dir.to_string_lossy();
+    let is_bare = run_git_command_sync(
+        repo_path,
+        &[
+            "--git-dir",
+            &git_common_dir_arg,
+            "rev-parse",
+            "--is-bare-repository",
+        ],
+        "Git rev-parse --is-bare-repository failed",
+    )?;
+    if is_bare.trim() == "true" {
+        return Ok(SharedRepo::Bare(git_common_dir));
     }
 
-    repo_root_from_git_dir(repo_path, &git_common_dir)
+    if git_dir == git_common_dir {
+        return Ok(SharedRepo::Working(repo_root_from_git_dir(
+            repo_path, &git_dir,
+        )?));
+    }
+
+    Ok(SharedRepo::Working(repo_root_from_git_dir(
+        repo_path,
+        &git_common_dir,
+    )?))
 }
 
 /// Resolves the git directory path for a repository root or worktree root.
@@ -472,6 +558,118 @@ mod tests {
                 if command.starts_with("git rev-parse")
                     && stderr.contains("Git rev-parse failed")),
             "unexpected error: {error:?}"
+        );
+    }
+
+    /// Runs a setup git command in `cwd`, asserting success and returning
+    /// trimmed stdout.
+    fn run_setup_git(cwd: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("failed to run setup git command");
+        assert!(
+            output.status.success(),
+            "git command {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn test_bare_layout_resolves_bare_admin_root_and_no_working_checkout() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let root = temp_dir.path();
+        let bare_dir = root.join(".bare");
+        run_setup_git(root, &["init", "--bare", ".bare"]);
+        run_setup_git(&bare_dir, &["config", "user.name", "Test User"]);
+        run_setup_git(&bare_dir, &["config", "user.email", "test@example.com"]);
+        let empty_tree =
+            run_setup_git(&bare_dir, &["hash-object", "-w", "-t", "tree", "/dev/null"]);
+        let commit = run_setup_git(&bare_dir, &["commit-tree", &empty_tree, "-m", "init"]);
+        run_setup_git(&bare_dir, &["update-ref", "refs/heads/main", &commit]);
+        run_setup_git(&bare_dir, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+        let main_worktree = root.join("main");
+        let session_worktree = root.join("session");
+        run_setup_git(
+            &bare_dir,
+            &[
+                "worktree",
+                "add",
+                main_worktree.to_str().expect("main worktree path is utf-8"),
+                "main",
+            ],
+        );
+        run_setup_git(
+            &bare_dir,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "session",
+                session_worktree
+                    .to_str()
+                    .expect("session worktree path is utf-8"),
+                "main",
+            ],
+        );
+
+        // Act
+        let admin_root =
+            main_repo_root_sync(&session_worktree).expect("failed to resolve admin root");
+        let working_checkout = main_checkout_working_tree_sync(&session_worktree)
+            .expect("failed to resolve working checkout");
+
+        // Assert
+        assert_eq!(
+            admin_root,
+            fs::canonicalize(&bare_dir).expect("failed to canonicalize bare dir")
+        );
+        assert_eq!(working_checkout, None);
+    }
+
+    #[test]
+    fn test_non_bare_layout_resolves_main_working_checkout_for_linked_worktree() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let root = temp_dir.path();
+        let main_checkout = root.join("main");
+        fs::create_dir_all(&main_checkout).expect("failed to create main checkout dir");
+        run_setup_git(&main_checkout, &["init", "-b", "main"]);
+        run_setup_git(&main_checkout, &["config", "user.name", "Test User"]);
+        run_setup_git(
+            &main_checkout,
+            &["config", "user.email", "test@example.com"],
+        );
+        fs::write(main_checkout.join("README.md"), "test repo").expect("failed to write file");
+        run_setup_git(&main_checkout, &["add", "README.md"]);
+        run_setup_git(&main_checkout, &["commit", "-m", "Initial commit"]);
+        let session_worktree = root.join("session");
+        run_setup_git(
+            &main_checkout,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "session",
+                session_worktree
+                    .to_str()
+                    .expect("session worktree path is utf-8"),
+                "main",
+            ],
+        );
+
+        // Act
+        let working_checkout = main_checkout_working_tree_sync(&session_worktree)
+            .expect("failed to resolve working checkout");
+
+        // Assert
+        assert_eq!(
+            working_checkout,
+            Some(fs::canonicalize(&main_checkout).expect("failed to canonicalize main checkout"))
         );
     }
 

--- a/crates/ag-git/src/repo.rs
+++ b/crates/ag-git/src/repo.rs
@@ -109,30 +109,25 @@ pub(super) enum SharedRepo {
 /// Resolves the shared repository backing `repo_path`.
 ///
 /// Reads the git and common git directories, detects whether the shared
-/// repository is bare by querying `git --git-dir <common> rev-parse
-/// --is-bare-repository`, and returns [`SharedRepo::Bare`] with the bare common
-/// git directory when bare. Otherwise returns [`SharedRepo::Working`] with the
-/// main working checkout root, matching the historical `main_repo_root_sync`
-/// resolution for non-bare layouts.
+/// repository is bare by running `git rev-parse --is-bare-repository` inside
+/// the common git directory, and returns [`SharedRepo::Bare`] with the bare
+/// common git directory when bare. Otherwise returns [`SharedRepo::Working`]
+/// with the main working checkout root, matching the historical
+/// `main_repo_root_sync` resolution for non-bare layouts.
 ///
 /// # Errors
 /// Returns an error if git metadata cannot be queried from `repo_path`.
 pub(super) fn resolve_shared_repo_sync(repo_path: &Path) -> Result<SharedRepo, GitError> {
     let (git_dir, git_common_dir) = git_directory_paths(repo_path)?;
 
-    // NOTE: `to_string_lossy` replaces non-UTF-8 bytes with U+FFFD, which would
-    // produce a path git cannot find on exotic systems. The rest of this file
-    // follows the same String-based convention, so this is consistent, but
-    // callers on non-UTF-8 paths will get a generic git failure.
-    let git_common_dir_arg = git_common_dir.to_string_lossy();
+    // Probe the common git directory directly by running git there, so the
+    // shared repository's bareness is detected even from a linked worktree
+    // (where `--is-bare-repository` reports the worktree, not the shared repo).
+    // Passing the directory through `current_dir` keeps non-UTF-8 paths intact,
+    // unlike converting it to a `--git-dir` string argument.
     let is_bare = run_git_command_sync(
-        repo_path,
-        &[
-            "--git-dir",
-            &git_common_dir_arg,
-            "rev-parse",
-            "--is-bare-repository",
-        ],
+        &git_common_dir,
+        &["rev-parse", "--is-bare-repository"],
         "Git rev-parse --is-bare-repository failed",
     )?;
     if is_bare.trim() == "true" {

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -168,6 +168,16 @@ fn allow_detect_git_info_with_head_hash(mock: &mut git::MockGitClient, allow_hea
 
         Box::pin(async move { Ok(repo_root) })
     });
+    mock.expect_main_checkout_working_tree()
+        .times(0..)
+        .returning(|path| {
+            let repo_root = path
+                .parent()
+                .map(std::path::Path::to_path_buf)
+                .unwrap_or(path);
+
+            Box::pin(async move { Ok(Some(repo_root)) })
+        });
     mock.expect_worktree_status()
         .times(0..)
         .returning(|_| Box::pin(async { Ok(String::new()) }));
@@ -348,6 +358,22 @@ fn setup_mock_worktree_expectations(mock: &mut git::MockGitClient, repo_root: Pa
     mock.expect_repo_url()
         .times(0..)
         .returning(|_| Box::pin(async { Ok("https://example.invalid/repo.git".to_string()) }));
+    expect_shared_repo_resolvers(mock, repo_root);
+}
+
+/// Registers the admin-root and main-working-checkout resolver expectations
+/// backed by the same `repo_root`, treating the shared repository as non-bare.
+fn expect_shared_repo_resolvers(mock: &mut git::MockGitClient, repo_root: PathBuf) {
+    mock.expect_main_checkout_working_tree()
+        .times(0..)
+        .returning({
+            let repo_root = repo_root.clone();
+
+            move |_| {
+                let repo_root = repo_root.clone();
+                Box::pin(async move { Ok(Some(repo_root)) })
+            }
+        });
     mock.expect_main_repo_root().times(0..).returning(move |_| {
         let repo_root = repo_root.clone();
         Box::pin(async move { Ok(repo_root) })

--- a/crates/agentty/src/app/session/workflow/isolation.rs
+++ b/crates/agentty/src/app/session/workflow/isolation.rs
@@ -11,16 +11,20 @@ use crate::infra::fs::FsClient;
 /// Validated git metadata for one session worktree.
 #[derive(Debug)]
 pub(super) struct SessionWorktreeValidation {
-    /// Canonical main repository checkout that must remain unchanged.
-    pub(super) main_repo_root: PathBuf,
+    /// Canonical main repository checkout that must remain unchanged, or
+    /// `None` when the shared repository is bare and therefore has no main
+    /// working checkout to guard against.
+    pub(super) main_checkout: Option<PathBuf>,
 }
 
 /// Verifies that `folder` is an isolated linked worktree for `session_id`.
 ///
-/// The guard checks the folder exists, the checked-out branch matches
-/// `wt/<session-id-prefix>`, and git resolves a distinct main repository
-/// checkout. This prevents stale or replaced session directories from being
-/// reused as provider working directories.
+/// The guard checks the folder exists and the checked-out branch matches
+/// `wt/<session-id-prefix>`. When git resolves a main working checkout it must
+/// be distinct from `folder`, preventing stale or replaced session directories
+/// from being reused as provider working directories. When the shared
+/// repository is bare there is no main working checkout, so any valid linked
+/// worktree passes with `main_checkout` set to `None`.
 ///
 /// # Errors
 /// Returns [`SessionError::Workflow`] when the folder is missing, branch
@@ -56,10 +60,15 @@ pub(super) async fn validate_session_worktree(
         )));
     }
 
-    let main_repo_root = git_client
-        .main_repo_root(folder.to_path_buf())
+    let Some(main_repo_root) = git_client
+        .main_checkout_working_tree(folder.to_path_buf())
         .await
-        .map_err(|error| main_repo_root_error(&error))?;
+        .map_err(|error| main_checkout_error(&error))?
+    else {
+        return Ok(SessionWorktreeValidation {
+            main_checkout: None,
+        });
+    };
     ensure_main_repo_root_exists(fs_client, &main_repo_root)?;
     let session_folder = canonicalize_for_isolation(fs_client, folder).await?;
     let main_repo_root = canonicalize_for_isolation(fs_client, &main_repo_root).await?;
@@ -70,7 +79,9 @@ pub(super) async fn validate_session_worktree(
         )));
     }
 
-    Ok(SessionWorktreeValidation { main_repo_root })
+    Ok(SessionWorktreeValidation {
+        main_checkout: Some(main_repo_root),
+    })
 }
 
 /// Verifies git resolved an existing main checkout before canonicalization.
@@ -104,8 +115,8 @@ async fn canonicalize_for_isolation(
         })
 }
 
-/// Converts main-repository resolution failures into workflow errors.
-fn main_repo_root_error(error: &GitError) -> SessionError {
+/// Converts main-checkout resolution failures into workflow errors.
+fn main_checkout_error(error: &GitError) -> SessionError {
     isolation_error(&format!(
         "failed to resolve main repository checkout: {error}"
     ))
@@ -164,9 +175,9 @@ mod tests {
             .once()
             .returning(|_| Box::pin(async { Some("wt/session".to_string()) }));
         git_client
-            .expect_main_repo_root()
+            .expect_main_checkout_working_tree()
             .once()
-            .returning(|_| Box::pin(async { Ok(PathBuf::from("/tmp/project")) }));
+            .returning(|_| Box::pin(async { Ok(Some(PathBuf::from("/tmp/project"))) }));
 
         // Act
         let validation =
@@ -175,7 +186,34 @@ mod tests {
                 .expect("linked worktree should validate");
 
         // Assert
-        assert_eq!(validation.main_repo_root, repo_root);
+        assert_eq!(validation.main_checkout, Some(repo_root));
+    }
+
+    #[tokio::test]
+    async fn validate_session_worktree_accepts_bare_shared_repo_without_main_checkout() {
+        // Arrange
+        let session_folder = PathBuf::from("/tmp/session");
+        let mut fs_client = fs::MockFsClient::new();
+        fs_client.expect_is_dir().once().return_const(true);
+        fs_client.expect_canonicalize().times(0);
+        let mut git_client = git::MockGitClient::new();
+        git_client
+            .expect_detect_git_info()
+            .once()
+            .returning(|_| Box::pin(async { Some("wt/session".to_string()) }));
+        git_client
+            .expect_main_checkout_working_tree()
+            .once()
+            .returning(|_| Box::pin(async { Ok(None) }));
+
+        // Act
+        let validation =
+            validate_session_worktree(&fs_client, &git_client, session_folder.as_path(), "session")
+                .await
+                .expect("bare shared repo worktree should validate");
+
+        // Assert
+        assert_eq!(validation.main_checkout, None);
     }
 
     #[tokio::test]
@@ -189,7 +227,7 @@ mod tests {
             .expect_detect_git_info()
             .once()
             .returning(|_| Box::pin(async { Some("main".to_string()) }));
-        git_client.expect_main_repo_root().times(0);
+        git_client.expect_main_checkout_working_tree().times(0);
 
         // Act
         let error =
@@ -217,9 +255,9 @@ mod tests {
             .once()
             .returning(|_| Box::pin(async { Some("wt/session".to_string()) }));
         git_client
-            .expect_main_repo_root()
+            .expect_main_checkout_working_tree()
             .once()
-            .returning(|_| Box::pin(async { Ok(PathBuf::from("/tmp/project")) }));
+            .returning(|_| Box::pin(async { Ok(Some(PathBuf::from("/tmp/project"))) }));
 
         // Act
         let error =

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -3583,9 +3583,9 @@ mod tests {
             .once()
             .returning(|_| Box::pin(async { Some("wt/session-".to_string()) }));
         mock_git_client
-            .expect_main_repo_root()
+            .expect_main_checkout_working_tree()
             .once()
-            .returning(|_| Box::pin(async { Ok(PathBuf::from("/tmp/project")) }));
+            .returning(|_| Box::pin(async { Ok(Some(PathBuf::from("/tmp/project"))) }));
         mock_git_client.expect_create_worktree().times(0);
         mock_git_client.expect_find_git_repo_root().times(0);
         let services = test_services_with_fs_client(

--- a/crates/agentty/src/app/session/workflow/turn.rs
+++ b/crates/agentty/src/app/session/workflow/turn.rs
@@ -61,10 +61,14 @@ struct MainCheckoutSnapshot {
 impl MainCheckoutSnapshot {
     /// Captures the main repository checkout status before a provider turn.
     ///
+    /// Returns `None` when the shared repository is bare and therefore has no
+    /// main working checkout to snapshot; the session worktree is still
+    /// validated in that case.
+    ///
     /// # Errors
     /// Returns a workflow error when the session folder is not a valid linked
     /// worktree or the main-checkout tracked status cannot be read.
-    async fn capture(context: &SessionWorkerContext) -> Result<Self, SessionError> {
+    async fn capture(context: &SessionWorkerContext) -> Result<Option<Self>, SessionError> {
         let validation = isolation::validate_session_worktree(
             context.fs_client.as_ref(),
             context.git_client.as_ref(),
@@ -72,16 +76,19 @@ impl MainCheckoutSnapshot {
             &context.session_id,
         )
         .await?;
+        let Some(main_repo_root) = validation.main_checkout else {
+            return Ok(None);
+        };
         let tracked_status_output = context
             .git_client
-            .tracked_worktree_status(validation.main_repo_root.clone())
+            .tracked_worktree_status(main_repo_root.clone())
             .await
             .map_err(|error| Self::status_error(&error))?;
 
-        Ok(Self {
-            main_repo_root: validation.main_repo_root,
+        Ok(Some(Self {
+            main_repo_root,
             tracked_status_output,
-        })
+        }))
     }
 
     /// Builds a warning when the main checkout tracked-file status changed and
@@ -190,7 +197,9 @@ pub(super) async fn run_channel_turn(
     let req = TurnRequest {
         folder: context.folder.clone(),
         live_transcript: Some(live_transcript_source(&context.transcript)),
-        main_checkout_root: Some(main_checkout_snapshot.main_repo_root.clone()),
+        main_checkout_root: main_checkout_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.main_repo_root.clone()),
         model: turn_metadata
             .session_agent
             .model()
@@ -231,7 +240,7 @@ pub(super) async fn run_channel_turn(
     let _ = consumer.await;
 
     let turn_result =
-        add_main_checkout_warning(context, &main_checkout_snapshot, turn_result).await;
+        add_main_checkout_warning(context, main_checkout_snapshot.as_ref(), turn_result).await;
     let post_turn_context = post_turn::PostTurnContext::from_worker(context);
     let finalizer_context = post_turn::TurnFinalizerContext::from_worker(context);
     let result = post_turn::apply_turn_result(&post_turn_context, turn_metadata, turn_result).await;
@@ -474,12 +483,18 @@ fn set_child_pid(child_pid: &Mutex<Option<u32>>, pid: Option<u32>) {
 
 /// Converts post-turn main-checkout tracked-file changes into transcript
 /// warnings while preserving the successful provider result.
+///
+/// When no main checkout was captured (bare shared repository), the provider
+/// result passes through unchanged because there is no main checkout to guard.
 async fn add_main_checkout_warning(
     context: &SessionWorkerContext,
-    main_checkout_snapshot: &MainCheckoutSnapshot,
+    main_checkout_snapshot: Option<&MainCheckoutSnapshot>,
     turn_result: Result<TurnResult, AgentError>,
 ) -> Result<TurnResult, AgentError> {
     let result = turn_result?;
+    let Some(main_checkout_snapshot) = main_checkout_snapshot else {
+        return Ok(result);
+    };
     match main_checkout_snapshot.dirty_warning(context).await {
         Ok(Some(warning)) => {
             append_main_checkout_warning(context, warning).await;

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -221,8 +221,9 @@ struct SessionWorkerRebaseAssistClient {
     /// Session worktree folder where the utility prompt runs.
     folder: PathBuf,
     /// Main repository checkout that must remain read-only during assist
-    /// turns.
-    main_checkout_root: PathBuf,
+    /// turns, or `None` when the shared repository is bare and has no main
+    /// working checkout.
+    main_checkout_root: Option<PathBuf>,
     /// Per-app session update versions for targeted refresh events.
     session_update_versions: SessionUpdateVersionMap,
     /// Session identifier whose provider conversation is reused.
@@ -235,7 +236,7 @@ struct SessionWorkerRebaseAssistClient {
 
 impl SessionWorkerRebaseAssistClient {
     /// Clones the worker fields needed to run a rebase-assist utility turn.
-    fn from_context(context: &SessionWorkerContext, main_checkout_root: PathBuf) -> Self {
+    fn from_context(context: &SessionWorkerContext, main_checkout_root: Option<PathBuf>) -> Self {
         Self {
             app_event_tx: context.app_event_tx.clone(),
             cancel_token: Arc::clone(&context.cancel_token),
@@ -276,7 +277,7 @@ impl SessionWorkerRebaseAssistClient {
         let req = TurnRequest {
             folder: self.folder.clone(),
             live_transcript: Some(turn::live_transcript_source(&self.transcript)),
-            main_checkout_root: Some(self.main_checkout_root.clone()),
+            main_checkout_root: self.main_checkout_root.clone(),
             model: self.session_agent.model().provider_model_str().to_string(),
             request_kind: AgentRequestKind::UtilityPrompt,
             replay_transcript: None,
@@ -882,7 +883,7 @@ impl SessionWorkerService {
         .await?;
         let assist_client = Arc::new(SessionWorkerRebaseAssistClient::from_context(
             context,
-            validation.main_repo_root,
+            validation.main_checkout,
         ));
         SessionManager::run_rebase_command(RebaseCommandInput {
             app_event_tx: context.app_event_tx.clone(),
@@ -1095,7 +1096,7 @@ mod tests {
     }
 
     /// Builds one git client mock that detects the `wt/sess1` worktree and
-    /// resolves the given main repository root.
+    /// resolves the given main working checkout.
     fn mock_git_client_detecting_main_repo(main_repo_root: PathBuf) -> MockGitClient {
         let mut mock_git_client = MockGitClient::new();
         mock_git_client
@@ -1103,12 +1104,12 @@ mod tests {
             .once()
             .returning(|_| Box::pin(async { Some("wt/sess1".to_string()) }));
         mock_git_client
-            .expect_main_repo_root()
+            .expect_main_checkout_working_tree()
             .once()
             .returning(move |_| {
                 let main_repo_root = main_repo_root.clone();
 
-                Box::pin(async move { Ok(main_repo_root) })
+                Box::pin(async move { Ok(Some(main_repo_root)) })
             });
 
         mock_git_client
@@ -1156,12 +1157,12 @@ mod tests {
             .once()
             .returning(|_| Box::pin(async { Some("wt/sess1".to_string()) }));
         mock_git_client
-            .expect_main_repo_root()
+            .expect_main_checkout_working_tree()
             .once()
             .returning(move |_| {
                 let main_repo_root = main_repo_root.clone();
 
-                Box::pin(async move { Ok(main_repo_root) })
+                Box::pin(async move { Ok(Some(main_repo_root)) })
             });
         mock_git_client
             .expect_tracked_worktree_status()
@@ -1908,6 +1909,98 @@ mod tests {
         assert!(
             result.is_ok(),
             "unchanged dirty tracked status should complete"
+        );
+        let output_text = transcript_text(&transcript);
+        assert!(!output_text.contains("[Main Checkout Warning]"));
+        assert!(output_text.contains("done"));
+    }
+
+    #[tokio::test]
+    /// Verifies a bare shared repository (no main working checkout) skips the
+    /// main-checkout status snapshot: `tracked_worktree_status` is never called
+    /// and the turn proceeds with `main_checkout_root` set to `None`.
+    async fn test_run_channel_turn_skips_main_checkout_snapshot_for_bare_repo() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let db = AppRepositories::in_memory().await;
+        insert_in_progress_test_session(&db).await;
+
+        let mut mock_channel = MockAgentChannel::new();
+        mock_channel
+            .expect_run_turn()
+            .once()
+            .withf(|_session_id, request, _events| request.main_checkout_root.is_none())
+            .returning(|_session_id, _req, _events| {
+                Box::pin(async {
+                    Ok(TurnResult {
+                        assistant_message: AgentResponse {
+                            answer: "done".to_string(),
+                            questions: Vec::new(),
+                            summary: None,
+                        },
+                        context_reset: false,
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        provider_conversation_id: None,
+                    })
+                })
+            });
+
+        let mut mock_git_client = MockGitClient::new();
+        mock_git_client
+            .expect_detect_git_info()
+            .once()
+            .returning(|_| Box::pin(async { Some("wt/sess1".to_string()) }));
+        mock_git_client
+            .expect_main_checkout_working_tree()
+            .once()
+            .returning(|_| Box::pin(async { Ok(None) }));
+        mock_git_client.expect_tracked_worktree_status().times(0);
+        mock_git_client
+            .expect_diff()
+            .returning(|_, _| Box::pin(async { Ok(String::new()) }));
+        mock_git_client
+            .expect_is_worktree_clean()
+            .returning(|_| Box::pin(async { Ok(true) }));
+
+        let transcript = empty_transcript();
+        let context = SessionWorkerContext {
+            app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
+            cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
+            channel: Arc::new(mock_channel),
+            child_pid: Arc::new(Mutex::new(None)),
+            clock: Arc::new(crate::infra::clock::RealClock),
+            db: db.clone(),
+            folder: base_dir.path().to_path_buf(),
+            fs_client: Arc::new(mock_fs_client_with_existing_directories()),
+            git_client: Arc::new(mock_git_client),
+            transcript: Arc::clone(&transcript),
+            queued_messages: Arc::new(Mutex::new(VecDeque::new())),
+            review_request_client: Arc::new(forge::MockReviewRequestClient::new()),
+            session_update_versions: Arc::default(),
+            session_id: "sess1".into(),
+            session_agent: AgentSelection::new(
+                crate::domain::agent::AgentKind::Antigravity,
+                AgentModel::Gemini3FlashPreview,
+            ),
+            status: Arc::new(Mutex::new(Status::InProgress)),
+        };
+
+        // Act
+        let result = run_channel_turn(
+            &context,
+            default_turn_metadata(),
+            AgentRequestKind::SessionStart,
+            None,
+            "test prompt".into(),
+        )
+        .await;
+
+        // Assert
+        assert!(
+            result.is_ok(),
+            "bare shared repository turn should complete without a main-checkout snapshot"
         );
         let output_text = transcript_text(&transcript);
         assert!(!output_text.contains("[Main Checkout Warning]"));
@@ -3522,12 +3615,12 @@ mod tests {
             .in_sequence(&mut sequence)
             .returning(|_| Box::pin(async { Some("wt/sess1".to_string()) }));
         mock_git_client
-            .expect_main_repo_root()
+            .expect_main_checkout_working_tree()
             .times(1)
             .in_sequence(&mut sequence)
             .returning(move |_| {
                 let main_checkout_root = main_checkout_root.clone();
-                Box::pin(async move { Ok(main_checkout_root) })
+                Box::pin(async move { Ok(Some(main_checkout_root)) })
             });
         mock_git_client
             .expect_is_worktree_clean()
@@ -4069,6 +4162,17 @@ mod tests {
             .times(0..)
             .returning(|_| Box::pin(async { Some("wt/sess1".to_string()) }));
         mock_git_client
+            .expect_main_checkout_working_tree()
+            .times(0..)
+            .returning({
+                let main_repo_root = main_repo_root.clone();
+
+                move |_| {
+                    let main_repo_root = main_repo_root.clone();
+                    Box::pin(async move { Ok(Some(main_repo_root)) })
+                }
+            });
+        mock_git_client
             .expect_main_repo_root()
             .times(0..)
             .returning(move |_| {
@@ -4254,14 +4358,17 @@ mod tests {
             .expect_detect_git_info()
             .times(2)
             .returning(|_| Box::pin(async { Some("wt/sess1".to_string()) }));
-        mock_git_client.expect_main_repo_root().times(1).returning({
-            let main_repo_root = main_repo_root.clone();
-
-            move |_| {
+        mock_git_client
+            .expect_main_checkout_working_tree()
+            .times(1)
+            .returning({
                 let main_repo_root = main_repo_root.clone();
-                Box::pin(async move { Ok(main_repo_root) })
-            }
-        });
+
+                move |_| {
+                    let main_repo_root = main_repo_root.clone();
+                    Box::pin(async move { Ok(Some(main_repo_root)) })
+                }
+            });
         mock_git_client
             .expect_tracked_worktree_status()
             .times(2)

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -820,6 +820,84 @@ printf '{"type":"result","subtype":"success","result":"{\"answer\":\"%s\",\"ques
     seed_project_default_model(env, "claude-haiku-4-5-20251001")
 }
 
+/// Answer text emitted by the bare-layout success stub once its turn completes.
+const BARE_LAYOUT_ANSWER_TEXT: &str = "Bare worktree turn completed";
+
+/// Rewrites the test project into a bare-repository worktree layout and
+/// installs a Claude stub that completes one turn successfully.
+///
+/// Creates a bare shared repository as a sibling of the project directory,
+/// seeds an initial `main` commit without a main working checkout, adds a
+/// sibling `main` worktree, and adds `env.workdir` as the `feature` linked
+/// worktree that Agentty opens as the project. This reproduces the
+/// container-of-worktrees layout where the shared repository is bare and there
+/// is no main working checkout for the dirty-status snapshot, which previously
+/// failed the first turn with `this operation must be run in a work tree`.
+fn seed_bare_repo_worktree_project(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    let container = env
+        .workdir
+        .parent()
+        .ok_or_else(|| std::io::Error::other("workdir has no parent container"))?
+        .to_path_buf();
+    let bare_dir = container.join("project.bare");
+    std::fs::create_dir_all(&bare_dir)?;
+
+    run_git(&bare_dir, &["init", "--bare", "."])?;
+    run_git(&bare_dir, &["config", "user.email", "test@test.com"])?;
+    run_git(&bare_dir, &["config", "user.name", "Test"])?;
+
+    let empty_tree = run_git_stdout(&bare_dir, &["hash-object", "-w", "-t", "tree", "/dev/null"])?;
+    let init_commit = run_git_stdout(&bare_dir, &["commit-tree", &empty_tree, "-m", "init"])?;
+    run_git(&bare_dir, &["update-ref", "refs/heads/main", &init_commit])?;
+    run_git(&bare_dir, &["symbolic-ref", "HEAD", "refs/heads/main"])?;
+
+    // Sibling main worktree so the shared repo genuinely holds per-branch
+    // worktrees as siblings, then the project worktree Agentty opens.
+    let main_worktree = container.join("main").to_string_lossy().into_owned();
+    run_git(
+        &bare_dir,
+        &["worktree", "add", main_worktree.as_str(), "main"],
+    )?;
+    let project_path = env.workdir.to_string_lossy().into_owned();
+    run_git(
+        &bare_dir,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature",
+            project_path.as_str(),
+            "main",
+        ],
+    )?;
+
+    install_bare_layout_success_claude_stub(env)
+}
+
+/// Installs a Claude stub that completes one turn with a fixed successful
+/// answer so the bare-layout scenario can drive a turn without a live backend.
+fn install_bare_layout_success_claude_stub(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let claude_path = env.stub_bin.join("claude");
+    let script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
+cat > /dev/null 2>&1
+printf '%s\n' '{{"type":"system","subtype":"init"}}'
+printf '{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"{BARE_LAYOUT_ANSWER_TEXT}"}}]}}}}\n'
+printf '{{"type":"result","subtype":"success","result":"{{\"answer\":\"{BARE_LAYOUT_ANSWER_TEXT}\",\"questions\":[],\"summary\":null}}","usage":{{"input_tokens":5,"output_tokens":9}}}}\n'
+"#
+    );
+
+    std::fs::write(&claude_path, script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o755))?;
+
+    seed_project_default_model(env, "claude-haiku-4-5-20251001")
+}
+
 /// Seeds one review-ready session with a linked review request.
 fn seed_review_ready_session_with_review_request(
     env: &BuilderEnv,
@@ -1785,6 +1863,52 @@ fn claude_session_launch_allows_web_tools() -> E2eResult {
     let full = Region::full(frame.cols(), frame.rows());
     assertion::assert_text_in_region(&frame, "Claude web tools enabled", &full);
     assertion::assert_not_visible(&frame, "Claude web tools missing");
+
+    Ok(())
+}
+
+/// Verify that Agentty can create a session and drive one turn to review when
+/// the project is a linked worktree of a bare shared repository.
+///
+/// The bare layout has no main working checkout, so the pre-fix dirty-status
+/// snapshot failed the first turn with `this operation must be run in a work
+/// tree`. This test drives a full successful turn and asserts the session
+/// reaches the review-ready state instead of surfacing that error.
+#[test]
+fn bare_repo_worktree_layout_supports_session_turn() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("bare_repo_worktree_layout")
+        .setup(seed_bare_repo_worktree_project)
+        .zola(
+            "Bare repository worktree layout",
+            "Run sessions from a project that is a linked worktree of a bare shared repository.",
+            45,
+        )
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("Summarize the bare worktree layout")
+                    .wait_for_text("Summarize the bare worktree layout", 3000)
+                    .press_key("Enter")
+                    .wait_for_text(BARE_LAYOUT_ANSWER_TEXT, 30000)
+                    .wait_for_text("Enter: reply", 5000)
+                    .capture_labeled(
+                        "bare_layout_review",
+                        "Session reaches review after one turn in a bare worktree layout",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, BARE_LAYOUT_ANSWER_TEXT, &full);
+                assertion::assert_text_in_region(frame, "Enter: reply", &full);
+                assertion::assert_not_visible(frame, "this operation must be run in a work tree");
+            },
+        )?;
 
     Ok(())
 }

--- a/docs/site/content/docs/getting-started/overview.md
+++ b/docs/site/content/docs/getting-started/overview.md
@@ -48,6 +48,9 @@ live session starts:
 - Before each turn, Agentty verifies that the session folder still exists, is on its
   expected `wt/<hash>` branch, and resolves to a linked worktree rather than the main
   checkout.
+- Projects backed by a bare repository (a container folder holding per-branch worktrees,
+  with no main working checkout) are supported. When there is no main checkout, the
+  per-turn dirty-state guard that inspects the main checkout is skipped.
 - Agent prompts repeat that the session worktree is the only writable root for normal
   turns.
 - If worktree creation fails (e.g., git is not installed or permissions are

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -260,7 +260,9 @@ During normal turns, the agent prompt names the session worktree as the only wri
 root. After a turn, if Agentty detects that the main checkout's tracked-file status
 changed and remains dirty, it appends a `[Main Checkout Warning]` notice to the
 transcript. Clean `HEAD` movement, such as another session landing on the base branch,
-and unchanged pre-existing tracked changes do not emit this warning.
+and unchanged pre-existing tracked changes do not emit this warning. Projects backed by
+a bare repository have no main working checkout, so this main-checkout dirty-state guard
+is skipped there.
 
 ### Continuing a Done Session
 


### PR DESCRIPTION
## Problem

Sessions launched from a project backed by a **bare shared repository** — a container folder holding per-branch worktrees as siblings, with no main working checkout — failed on the first turn with:

```
git status --porcelain=v1 ... failed: fatal: this operation must be run in a work tree
```

The pre-turn main-checkout dirty-status snapshot resolved a "main repository root" that assumed a working tree existed and ran `git status` against a bare path.

## Fix

- Resolve the shared repository into a `SharedRepo::Working` or `SharedRepo::Bare` classification, detecting bareness through the git **common directory** (`git --git-dir <common> rev-parse --is-bare-repository`) so linked worktrees resolve correctly.
- Keep `main_repo_root` returning a valid administrative working directory (the bare common directory when bare), so `git worktree`/branch admin — including worktree removal — keeps working.
- Add `main_checkout_working_tree`, which returns `None` when there is no main working checkout.
- Skip the pre-turn main-checkout dirty-status snapshot when there is no main checkout, so `git status` no longer runs against a bare path. The non-bare path is unchanged.

## Testing

- `ag-git`: 87 lib tests pass (incl. new real-git bare/non-bare fixture tests); clippy `-D warnings` clean.
- `agentty`: full suite **1876 lib + 3 bin pass, 0 failed**, incl. new unit tests asserting the snapshot is skipped and `main_checkout_root` is `None` for bare repos.
- New E2E feature test `bare_repo_worktree_layout_supports_session_turn` reproduces the container-of-worktrees layout and passes in check mode.

## Follow-ups

- **Feature-page GIF** must be generated in an unsandboxed terminal and committed: `TESTTY_GIF_MODE=force cargo nextest run --locked --profile ci -p agentty --test e2e bare_repo_worktree_layout_supports_session_turn`.
- Two related bare-layout edges are intentionally **out of scope** here: `find_git_repo_root` (worktree creation) and `merge.rs` clean-check are not yet bare-aware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
