### PR TITLE
Manage app-server lifetimes and process groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "askama",
  "base64",
  "mockall",
+ "rustix",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/ag-agent/Cargo.toml
+++ b/crates/ag-agent/Cargo.toml
@@ -13,6 +13,7 @@ ag-protocol.workspace = true
 agent-client-protocol.workspace = true
 askama.workspace = true
 base64.workspace = true
+rustix.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/ag-agent/src/agent/app_server/client.rs
+++ b/crates/ag-agent/src/agent/app_server/client.rs
@@ -22,6 +22,9 @@ pub(crate) trait RuntimeClientProvider: Send + Sync + 'static {
     /// Returns whether prompts should include transport-level schema text.
     fn schema_instruction_mode() -> ProtocolSchemaInstructionMode;
 
+    /// Returns whether successful runtimes remain alive between turns.
+    fn retain_runtime_after_turn() -> bool;
+
     /// Starts and bootstraps one provider runtime for a request.
     fn start_runtime(
         request: AppServerTurnRequest,
@@ -85,6 +88,7 @@ impl<Provider: RuntimeClientProvider> ProviderRuntimeClient<Provider> {
                 matches_request: Self::matches_request,
                 pid: Self::pid,
                 provider_conversation_id: Self::provider_conversation_id,
+                retain_runtime_after_turn: Provider::retain_runtime_after_turn(),
                 restored_context: Self::restored_context,
             },
             Provider::schema_instruction_mode(),
@@ -182,6 +186,10 @@ mod tests {
 
         fn schema_instruction_mode() -> ProtocolSchemaInstructionMode {
             ProtocolSchemaInstructionMode::TransportSchema
+        }
+
+        fn retain_runtime_after_turn() -> bool {
+            true
         }
 
         fn start_runtime(

--- a/crates/ag-agent/src/agent/app_server/codex/client.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/client.rs
@@ -31,6 +31,10 @@ impl RuntimeClientProvider for CodexRuntimeProvider {
         agent::protocol_schema_instruction_mode(AgentKind::Codex)
     }
 
+    fn retain_runtime_after_turn() -> bool {
+        true
+    }
+
     fn start_runtime(
         request: AppServerTurnRequest,
     ) -> AppServerFuture<Result<Self::Runtime, AppServerError>> {
@@ -66,7 +70,7 @@ impl RuntimeClientProvider for CodexRuntimeProvider {
 
 /// Active Codex app-server session runtime.
 pub(crate) struct CodexSessionRuntime {
-    child: tokio::process::Child,
+    child: app_server_transport::AppServerRuntimeChild,
     state: CodexRuntimeState,
     transport: AppServerStdioTransport,
 }

--- a/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
@@ -47,7 +47,7 @@ pub(super) async fn start_runtime(
     request: &AppServerTurnRequest,
 ) -> Result<
     (
-        tokio::process::Child,
+        app_server_transport::AppServerRuntimeChild,
         AppServerStdioTransport,
         CodexRuntimeState,
     ),
@@ -81,7 +81,7 @@ pub(super) async fn start_runtime_with_built_command(
     request: &AppServerTurnRequest,
 ) -> Result<
     (
-        tokio::process::Child,
+        app_server_transport::AppServerRuntimeChild,
         AppServerStdioTransport,
         CodexRuntimeState,
     ),

--- a/crates/ag-agent/src/agent/app_server/gemini/client.rs
+++ b/crates/ag-agent/src/agent/app_server/gemini/client.rs
@@ -30,6 +30,10 @@ impl RuntimeClientProvider for GeminiRuntimeProvider {
         agent::protocol_schema_instruction_mode(AgentKind::Gemini)
     }
 
+    fn retain_runtime_after_turn() -> bool {
+        false
+    }
+
     fn start_runtime(
         request: AppServerTurnRequest,
     ) -> AppServerFuture<Result<Self::Runtime, AppServerError>> {
@@ -64,7 +68,7 @@ impl RuntimeClientProvider for GeminiRuntimeProvider {
 
 /// Active Gemini ACP session runtime.
 pub(crate) struct GeminiSessionRuntime {
-    child: tokio::process::Child,
+    child: app_server_transport::AppServerRuntimeChild,
     state: GeminiRuntimeState,
     transport: AppServerStdioTransport,
 }

--- a/crates/ag-agent/src/agent/app_server/gemini/lifecycle.rs
+++ b/crates/ag-agent/src/agent/app_server/gemini/lifecycle.rs
@@ -50,7 +50,7 @@ pub(super) async fn start_runtime(
     request: &AppServerTurnRequest,
 ) -> Result<
     (
-        tokio::process::Child,
+        app_server_transport::AppServerRuntimeChild,
         AppServerStdioTransport,
         GeminiRuntimeState,
     ),

--- a/crates/ag-agent/src/app_server/retry.rs
+++ b/crates/ag-agent/src/app_server/retry.rs
@@ -23,6 +23,8 @@ pub(crate) struct RuntimeInspector<Runtime> {
     pub(crate) pid: fn(&Runtime) -> Option<u32>,
     /// Returns the provider-native conversation id, when available.
     pub(crate) provider_conversation_id: fn(&Runtime) -> Option<String>,
+    /// Whether successful runtimes remain resident between session turns.
+    pub(crate) retain_runtime_after_turn: bool,
     /// Returns `true` when the runtime bootstrapped by restoring prior context.
     pub(crate) restored_context: fn(&Runtime) -> bool,
 }
@@ -95,7 +97,7 @@ where
     )
     .await;
     if let Ok((assistant_message, input_tokens, output_tokens)) = first_attempt {
-        return store_successful_runtime_response(
+        return complete_successful_runtime_response(
             sessions,
             session_id,
             session_runtime,
@@ -137,7 +139,7 @@ where
     .await
     {
         Ok(attempt_output) => {
-            store_successful_runtime_response(
+            complete_successful_runtime_response(
                 sessions,
                 session_id,
                 restarted,
@@ -191,15 +193,15 @@ where
     Ok(session_runtime)
 }
 
-/// Stores a successful runtime back into the idle registry and builds the
-/// normalized app-server response.
+/// Completes a successful turn, either retaining or shutting down its runtime,
+/// and builds the normalized app-server response.
 ///
 /// If the registry cannot accept the runtime, this shuts the runtime down
 /// before returning the lock error so app-server child processes do not leak.
-async fn store_successful_runtime_response<Runtime, ShutdownRuntime>(
+async fn complete_successful_runtime_response<Runtime, ShutdownRuntime>(
     sessions: &AppServerSessionRegistry<Runtime>,
     session_id: String,
-    session_runtime: Runtime,
+    mut session_runtime: Runtime,
     context_reset: bool,
     attempt_output: (String, u64, u64),
     inspector: &RuntimeInspector<Runtime>,
@@ -211,6 +213,19 @@ where
     let (assistant_message, input_tokens, output_tokens) = attempt_output;
     let pid = (inspector.pid)(&session_runtime);
     let provider_conversation_id = (inspector.provider_conversation_id)(&session_runtime);
+
+    if !inspector.retain_runtime_after_turn {
+        shutdown_runtime(&mut session_runtime).await;
+
+        return Ok(AppServerTurnResponse {
+            assistant_message,
+            context_reset,
+            input_tokens,
+            output_tokens,
+            pid,
+            provider_conversation_id,
+        });
+    }
 
     if let Err((error, mut leaked)) = sessions.store_session_or_recover(session_id, session_runtime)
     {
@@ -603,6 +618,7 @@ mod tests {
                 matches_request: |runtime: &TestRuntime, request| runtime.model == request.model,
                 pid: |_runtime| Some(42),
                 provider_conversation_id: |_runtime| None,
+                retain_runtime_after_turn: true,
                 restored_context: |_runtime| false,
             },
             ProtocolSchemaInstructionMode::PromptSchema,
@@ -655,6 +671,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn successful_turn_shuts_down_runtime_when_retention_is_disabled() {
+        // Arrange
+        let sessions = AppServerSessionRegistry::new("Test");
+        let request = AppServerTurnRequest {
+            folder: PathBuf::from("/tmp"),
+            live_transcript: None,
+            main_checkout_root: None,
+            model: "model-a".to_string(),
+            prompt: "Do work".into(),
+            request_kind: session_start_request_kind(),
+            replay_transcript: None,
+            provider_conversation_id: None,
+            persisted_instruction_conversation_id: None,
+            reasoning_level: ReasoningLevel::default(),
+            session_id: "session-1".to_string(),
+        };
+        let shutdown_count = Arc::new(AtomicUsize::new(0));
+
+        // Act
+        let response = run_turn_with_restart_retry(
+            &sessions,
+            request,
+            RuntimeInspector {
+                matches_request: |runtime: &TestRuntime, request| runtime.model == request.model,
+                pid: |_runtime| Some(42),
+                provider_conversation_id: |_runtime| Some("gemini-session".to_string()),
+                retain_runtime_after_turn: false,
+                restored_context: |_runtime| false,
+            },
+            ProtocolSchemaInstructionMode::PromptSchema,
+            |request: &AppServerTurnRequest| {
+                let model = request.model.clone();
+
+                Box::pin(async move { Ok(TestRuntime { model }) })
+            },
+            |_runtime, _prompt| Box::pin(async { Ok(("done".to_string(), 7, 3)) }),
+            {
+                let shutdown_count = Arc::clone(&shutdown_count);
+                move |_runtime| {
+                    let shutdown_count = Arc::clone(&shutdown_count);
+
+                    Box::pin(async move {
+                        shutdown_count.fetch_add(1, Ordering::SeqCst);
+                    })
+                }
+            },
+        )
+        .await
+        .expect("turn should succeed");
+        let stored_runtime = sessions
+            .take_session("session-1")
+            .expect("session registry should remain available");
+
+        // Assert
+        assert_eq!(response.assistant_message, "done");
+        assert_eq!(
+            response.provider_conversation_id.as_deref(),
+            Some("gemini-session")
+        );
+        assert_eq!(shutdown_count.load(Ordering::SeqCst), 1);
+        assert!(stored_runtime.is_none());
+    }
+
+    #[tokio::test]
     async fn run_turn_with_restart_retry_restarts_once_after_first_failure() {
         // Arrange
         let sessions = AppServerSessionRegistry::new("Test");
@@ -683,6 +763,7 @@ mod tests {
                 matches_request: |runtime: &TestRuntime, request| runtime.model == request.model,
                 pid: |_runtime| Some(42),
                 provider_conversation_id: |_runtime| None,
+                retain_runtime_after_turn: true,
                 restored_context: |_runtime| false,
             },
             ProtocolSchemaInstructionMode::PromptSchema,
@@ -766,6 +847,7 @@ mod tests {
                 matches_request: |runtime: &TestRuntime, request| runtime.model == request.model,
                 pid: |_runtime| Some(42),
                 provider_conversation_id: |_runtime| None,
+                retain_runtime_after_turn: true,
                 restored_context: |_runtime| false,
             },
             ProtocolSchemaInstructionMode::PromptSchema,
@@ -838,6 +920,7 @@ mod tests {
                 matches_request: |runtime: &TestRuntime, request| runtime.model == request.model,
                 pid: |_runtime| Some(24),
                 provider_conversation_id: |_runtime| Some("thread-123".to_string()),
+                retain_runtime_after_turn: true,
                 restored_context: |_runtime| true,
             },
             ProtocolSchemaInstructionMode::PromptSchema,

--- a/crates/ag-agent/src/app_server_transport.rs
+++ b/crates/ag-agent/src/app_server_transport.rs
@@ -5,8 +5,12 @@
 //! protocol-agnostic — it operates on raw JSON values and async stdio handles
 //! without knowledge of specific method names or event shapes.
 
+#![cfg(unix)]
+
+use std::os::unix::process::CommandExt as _;
 use std::time::Duration;
 
+use rustix::process::{self, Pid, Signal};
 use serde_json::Value;
 use tokio::io::{AsyncWriteExt, BufReader, Lines};
 
@@ -60,6 +64,35 @@ pub(crate) const STARTUP_TIMEOUT: Duration = Duration::from_mins(5);
 /// with the long-running Codex behavior instead of the shorter bootstrap
 /// timeout.
 pub(crate) const TURN_TIMEOUT: Duration = Duration::from_hours(4);
+
+/// App-server child isolated in its own Unix process group.
+///
+/// The process-group handle ensures abandoning a runtime terminates both the
+/// direct CLI process and any tool or MCP descendants that it spawned.
+pub(crate) struct AppServerRuntimeChild {
+    child: tokio::process::Child,
+    process_group_id: Option<Pid>,
+}
+
+impl AppServerRuntimeChild {
+    /// Returns the direct app-server process id while it is running.
+    pub(crate) fn id(&self) -> Option<u32> {
+        self.child.id()
+    }
+
+    /// Sends `signal` to every process in the isolated runtime group.
+    fn signal_process_group(&self, signal: Signal) {
+        if let Some(process_group_id) = self.process_group_id {
+            let _ = process::kill_process_group(process_group_id, signal);
+        }
+    }
+}
+
+impl Drop for AppServerRuntimeChild {
+    fn drop(&mut self) {
+        self.signal_process_group(Signal::KILL);
+    }
+}
 
 /// Writes one JSON-RPC payload as a newline-delimited line to `stdin`.
 ///
@@ -156,19 +189,25 @@ pub(crate) fn extract_json_error_message(response_value: &Value) -> Option<Strin
 
 /// Gracefully shuts down a child process by closing stdin, waiting briefly,
 /// then killing if the process has not exited.
-pub(crate) async fn shutdown_child(child: &mut tokio::process::Child) {
+pub(crate) async fn shutdown_child(child: &mut AppServerRuntimeChild) {
     // Closing stdin signals the child to exit cleanly.
-    drop(child.stdin.take());
+    drop(child.child.stdin.take());
 
-    if tokio::time::timeout(Duration::from_secs(1), child.wait())
+    if tokio::time::timeout(Duration::from_secs(1), child.child.wait())
         .await
         .is_err()
     {
+        child.signal_process_group(Signal::KILL);
+        // Best-effort fallback for a runtime that failed to enter its process group.
+        let _ = child.child.kill().await;
         // Best-effort: process may have already exited.
-        let _ = child.kill().await;
-        // Best-effort: process may have already exited.
-        let _ = child.wait().await;
+        let _ = child.child.wait().await;
     }
+
+    // A cooperative parent may still have left tool processes in its group.
+    // Kill any stragglers before relinquishing the group identifier.
+    child.signal_process_group(Signal::KILL);
+    child.process_group_id = None;
 }
 
 /// Spawns one app-server child process with piped stdin/stdout and hidden
@@ -187,12 +226,14 @@ pub(crate) fn spawn_runtime_command(
     runtime_name: &str,
 ) -> Result<
     (
-        tokio::process::Child,
+        AppServerRuntimeChild,
         tokio::process::ChildStdin,
         tokio::process::ChildStdout,
     ),
     AppServerError,
 > {
+    let mut command = command;
+    command.process_group(0);
     let mut command = tokio::process::Command::from(command);
     command
         .stdin(std::process::Stdio::piped())
@@ -200,40 +241,45 @@ pub(crate) fn spawn_runtime_command(
         .stderr(std::process::Stdio::null())
         .kill_on_drop(true);
 
-    let mut child = command.spawn().map_err(|error| {
+    let child = command.spawn().map_err(|error| {
         AppServerError::Provider(format!("Failed to spawn `{runtime_name}`: {error}"))
     })?;
-    let stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| AppServerError::Provider(format!("{runtime_name} stdin is unavailable")))?;
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| AppServerError::Provider(format!("{runtime_name} stdout is unavailable")))?;
+    let process_group_id = child
+        .id()
+        .and_then(|pid| i32::try_from(pid).ok())
+        .and_then(Pid::from_raw);
+    let mut child = AppServerRuntimeChild {
+        child,
+        process_group_id,
+    };
+    let stdin =
+        child.child.stdin.take().ok_or_else(|| {
+            AppServerError::Provider(format!("{runtime_name} stdin is unavailable"))
+        })?;
+    let stdout =
+        child.child.stdout.take().ok_or_else(|| {
+            AppServerError::Provider(format!("{runtime_name} stdout is unavailable"))
+        })?;
 
     Ok((child, stdin, stdout))
 }
 
 #[cfg(test)]
 mod tests {
-    use std::process::Stdio;
-
     use tokio::io::AsyncBufReadExt;
 
     use super::*;
 
     /// Spawns a simple echo process that mirrors stdin to stdout for transport
     /// write tests.
-    fn spawn_cat_process() -> tokio::process::Child {
-        let mut command = tokio::process::Command::new("cat");
-        command
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .kill_on_drop(true);
+    fn spawn_cat_process() -> (
+        AppServerRuntimeChild,
+        tokio::process::ChildStdin,
+        tokio::process::ChildStdout,
+    ) {
+        let command = std::process::Command::new("cat");
 
-        command.spawn().expect("failed to spawn `cat`")
+        spawn_runtime_command(command, "cat").expect("failed to spawn `cat`")
     }
 
     #[test]
@@ -319,9 +365,7 @@ mod tests {
     #[tokio::test]
     async fn write_json_line_writes_serialized_payload_with_newline() {
         // Arrange
-        let mut child = spawn_cat_process();
-        let mut stdin = child.stdin.take().expect("`cat` stdin should be piped");
-        let stdout = child.stdout.take().expect("`cat` stdout should be piped");
+        let (mut child, mut stdin, stdout) = spawn_cat_process();
         let payload = serde_json::json!({
             "id": "req-1",
             "method": "initialize",
@@ -442,18 +486,49 @@ mod tests {
         );
     }
 
-    /// Verifies `shutdown_child()` closes stdin and waits for a cooperative
-    /// child process to exit.
+    /// Verifies `shutdown_child()` closes stdin and reaps a cooperative child.
     #[tokio::test]
-    async fn shutdown_child_exits_cleanly_after_closing_stdin() {
+    async fn shutdown_child_reaps_process_after_closing_stdin() {
         // Arrange
-        let mut child = spawn_cat_process();
+        let (mut child, stdin, _stdout) = spawn_cat_process();
 
         // Act
+        drop(stdin);
         shutdown_child(&mut child).await;
-        let exit_status = child.wait().await.expect("child wait should succeed");
 
         // Assert
-        assert!(exit_status.success());
+        assert!(child.id().is_none());
+    }
+
+    /// Verifies forced shutdown reaches descendants spawned by an app-server.
+    #[tokio::test]
+    async fn shutdown_child_terminates_runtime_process_group() {
+        // Arrange
+        let mut command = std::process::Command::new("sh");
+        command.args([
+            "-c",
+            "trap '' TERM; sleep 60 & echo ready; cat >/dev/null; wait",
+        ]);
+        let (mut child, stdin, stdout) =
+            spawn_runtime_command(command, "process-group fixture").expect("fixture should spawn");
+        let mut stdout_lines = BufReader::new(stdout).lines();
+        let readiness_line = stdout_lines
+            .next_line()
+            .await
+            .expect("fixture readiness read should succeed")
+            .expect("fixture readiness line should be present");
+        assert_eq!(readiness_line, "ready");
+
+        // Act
+        drop(stdin);
+        shutdown_child(&mut child).await;
+        let stdout_closed =
+            tokio::time::timeout(Duration::from_secs(2), stdout_lines.next_line()).await;
+
+        // Assert
+        assert!(
+            matches!(stdout_closed, Ok(Ok(None))),
+            "runtime descendant should release inherited stdout when its process group terminates"
+        );
     }
 }

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -233,7 +233,7 @@ flowchart TD
   cli_channel["CliAgentChannel<br/>Antigravity/Claude; subprocess per turn"]
   app_server_mode["transport_mode() -> AppServer"]
   app_server_client["create_app_server_client()"]
-  app_server_channel["AppServerAgentChannel<br/>Codex/Gemini; persistent runtime per session"]
+  app_server_channel["AppServerAgentChannel<br/>Codex/Gemini"]
   client_trait["AppServerClient"]
   codex_client["RealCodexAppServerClient"]
   gemini_client["RealGeminiAcpClient"]
@@ -268,6 +268,12 @@ with prompt payloads owned by `ag-protocol` and re-exported through
 with an instruction-bootstrap marker, so later turns and runtime restarts can resume the
 native provider context and choose between resending the full prompt contract and a
 compact reminder.
+
+Codex keeps its app-server runtime resident between turns. Gemini ACP shuts down after
+each completed turn and replays the persisted transcript when a follow-up starts, so
+review-ready sessions do not accumulate idle Gemini processes. Both app-server providers
+run in isolated process groups; shutdown terminates the runtime and any tool or MCP
+descendants it spawned.
 
 <a id="architecture-session-isolation-guards"></a> Session isolation guards:
 


### PR DESCRIPTION
- Keep Codex runtimes resident between turns and shut down Gemini runtimes after successful turns.
- Isolate app-server children in Unix process groups so shutdown terminates tool and MCP descendants.
- Add `rustix` support, regression coverage, and runtime-flow documentation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)