### PR TITLE
Optimize PTY proof execution and E2E validation

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,7 +6,7 @@ fail-fast = false
 slow-timeout = { period = "60s", terminate-after = 3 }
 
 [test-groups]
-agentty-e2e = { max-threads = 1 }
+agentty-e2e = { max-threads = 2 }
 
 [[profile.ci.overrides]]
 filter = 'package(agentty) and kind(test) and binary(e2e)'

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -9,6 +9,22 @@ permissions:
   contents: read
 
 jobs:
+  e2e:
+    name: End-to-end feature tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust and `prek`
+        uses: ./.github/actions/setup-rust-prek
+
+      - name: Run end-to-end feature suite
+        run: prek run test-agentty-e2e --all-files --hook-stage manual
+
   validate:
     name: Workspace checks
     uses: ./.github/workflows/workspace-validation.yml

--- a/crates/testty/src/scenario.rs
+++ b/crates/testty/src/scenario.rs
@@ -5,6 +5,7 @@
 //! in Rust and can be compiled into both PTY executor actions (for semantic
 //! assertions) and VHS tape files (for visual screenshot capture).
 
+use std::ops::RangeInclusive;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -140,7 +141,9 @@ impl Scenario {
     /// Execute this scenario in a PTY session with proof collection.
     ///
     /// Returns both the final frame and a [`ProofReport`] containing all
-    /// labeled captures encountered during execution.
+    /// labeled captures encountered during execution. Steps are executed in
+    /// batches ending at each labeled capture so input-only and VHS viewing
+    /// steps do not trigger redundant PTY frame drains.
     ///
     /// # Errors
     ///
@@ -152,17 +155,15 @@ impl Scenario {
         let mut report = ProofReport::new(&self.name);
         let mut last_frame = None;
 
-        for step in &self.steps {
-            match step {
-                Step::CaptureLabeled { label, description } => {
-                    let frame = session.capture_frame();
-                    report.add_capture(label, description, &frame);
-                    last_frame = Some(frame);
-                }
-                _ => {
-                    last_frame = Some(session.execute_steps(std::slice::from_ref(step))?);
-                }
+        for step_range in self.proof_step_ranges() {
+            let final_step_index = *step_range.end();
+            let frame = session.execute_steps(&self.steps[step_range])?;
+
+            if let Step::CaptureLabeled { label, description } = &self.steps[final_step_index] {
+                report.add_capture(label, description, &frame);
             }
+
+            last_frame = Some(frame);
         }
 
         let final_frame = last_frame.unwrap_or_else(|| session.capture_frame());
@@ -232,6 +233,29 @@ impl Scenario {
         tape.write_to(tape_path)?;
 
         Ok(tape_path.to_path_buf())
+    }
+
+    /// Group PTY proof steps so each labeled capture terminates one batch.
+    ///
+    /// Executing a whole batch avoids the implicit final-frame capture that
+    /// [`PtySession::execute_steps`] performs when called with one input-only
+    /// step while still preserving every labeled proof boundary.
+    fn proof_step_ranges(&self) -> Vec<RangeInclusive<usize>> {
+        let mut ranges = Vec::new();
+        let mut range_start = 0;
+
+        for (step_index, step) in self.steps.iter().enumerate() {
+            if matches!(step, Step::CaptureLabeled { .. }) {
+                ranges.push(range_start..=step_index);
+                range_start = step_index + 1;
+            }
+        }
+
+        if range_start < self.steps.len() {
+            ranges.push(range_start..=self.steps.len() - 1);
+        }
+
+        ranges
     }
 }
 
@@ -338,6 +362,24 @@ mod tests {
 
         // Assert
         assert_eq!(scenario.steps.len(), 2);
+    }
+
+    #[test]
+    fn proof_step_ranges_end_at_labeled_captures() {
+        // Arrange
+        let scenario = Scenario::new("proof-batches")
+            .press_key("Tab")
+            .viewing_pause_ms(500)
+            .capture_labeled("first", "First capture")
+            .write_text("hello")
+            .capture_labeled("second", "Second capture")
+            .press_key("Enter");
+
+        // Act
+        let ranges = scenario.proof_step_ranges();
+
+        // Assert
+        assert_eq!(ranges, vec![0..=2, 3..=4, 5..=5]);
     }
 
     #[test]

--- a/crates/testty/src/session.rs
+++ b/crates/testty/src/session.rs
@@ -307,29 +307,34 @@ impl PtySession {
     /// Execute a sequence of [`Step`] actions against this session.
     ///
     /// Returns the final [`TerminalFrame`] after all steps have been
-    /// executed. Capture steps record intermediate frames but the last
-    /// frame is always returned.
+    /// executed. Input and sleep steps invalidate earlier frames, causing one
+    /// final capture after the sequence. Wait and capture steps provide a
+    /// reusable current frame unless a later step invalidates it. VHS-only
+    /// viewing pauses neither capture nor invalidate a frame.
     ///
     /// # Errors
     ///
     /// Returns an error if any step fails (e.g., timeout, write failure).
     pub fn execute_steps(&mut self, steps: &[Step]) -> Result<TerminalFrame, PtySessionError> {
-        let mut last_frame = None;
+        let mut current_frame = None;
 
         for step in steps {
             match step {
                 Step::WriteText(text) => {
                     self.write_text(text)?;
+                    current_frame = None;
                 }
                 Step::PressKey(key) => {
                     self.press_key(key)?;
+                    current_frame = None;
                 }
                 Step::Sleep(duration) => {
                     thread::sleep(*duration);
+                    current_frame = None;
                 }
                 Step::WaitForText { needle, timeout_ms } => {
                     let timeout = Duration::from_millis(u64::from(*timeout_ms));
-                    last_frame = Some(self.wait_for_text(needle, timeout)?);
+                    current_frame = Some(self.wait_for_text(needle, timeout)?);
                 }
                 Step::WaitForStableFrame {
                     stable_ms,
@@ -337,17 +342,18 @@ impl PtySession {
                 } => {
                     let stable = Duration::from_millis(u64::from(*stable_ms));
                     let timeout = Duration::from_millis(u64::from(*timeout_ms));
-                    last_frame = Some(self.wait_for_stable_frame(stable, timeout)?);
+                    current_frame = Some(self.wait_for_stable_frame(stable, timeout)?);
                 }
                 Step::Eventually {
                     timeout,
                     poll,
                     predicate,
                 } => {
-                    last_frame = Some(self.run_eventually(*timeout, *poll, predicate.as_ref())?);
+                    current_frame =
+                        Some(self.run_eventually(*timeout, *poll, predicate.as_ref())?);
                 }
                 Step::Capture | Step::CaptureLabeled { .. } => {
-                    last_frame = Some(self.capture_frame());
+                    current_frame = Some(self.capture_frame());
                 }
                 Step::ViewingPause(_) => {
                     // No-op in PTY execution — only affects VHS tape output.
@@ -355,7 +361,12 @@ impl PtySession {
             }
         }
 
-        Ok(last_frame.unwrap_or_else(|| self.capture_frame()))
+        let final_frame = match current_frame {
+            Some(frame) => frame,
+            None => self.capture_frame(),
+        };
+
+        Ok(final_frame)
     }
 
     /// Return the configured number of columns.
@@ -688,6 +699,33 @@ mod tests {
 
         // Assert
         assert_eq!(bytes, vec![b'x']);
+    }
+
+    #[test]
+    fn execute_steps_captures_input_after_an_earlier_wait() {
+        // Arrange
+        let mut session = PtySessionBuilder::new("/bin/sh")
+            .args([
+                "-c",
+                "printf 'ready\\n'; read value; printf 'done:%s\\n' \"$value\"; sleep 60",
+            ])
+            .spawn()
+            .expect("failed to spawn interactive shell script");
+        let steps = [
+            Step::wait_for_text("ready", 3_000),
+            Step::write_text("hello\n"),
+        ];
+
+        // Act
+        let frame = session
+            .execute_steps(&steps)
+            .expect("step execution should succeed");
+
+        // Assert
+        assert!(
+            frame.all_text().contains("done:hello"),
+            "final frame must include output produced after the wait"
+        );
     }
 
     /// Verifies that `wait_for_stable_frame` times out when the spawned


### PR DESCRIPTION
- Batch scenario steps around labeled captures and refresh frames after invalidating steps.
- Allow two concurrent Agentty E2E test threads.
- Run the Agentty E2E feature suite during presubmit validation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)