### PR TITLE
Require Clippy and pre-commit hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,8 +340,8 @@ the full suite.
 
 - **Markdown and docs:** Run `mdformat`, then the default hooks for touched paths.
 - **`docs/site/` content:** Add `zola-check`; use `djlint-reformat` for HTML templates.
-- **Rust sources:** Run `rustfmt-fix` while iterating, then `cargo-check`; add focused
-  tests for the changed crate and affected dependents.
+- **Rust sources:** Run `rustfmt-fix` while iterating, then `cargo-check` and `clippy`;
+  add focused tests for the changed crate and affected dependents.
 - **Workspace crate source tests:** Use the narrowest matching member source-test hook.
 - **Cargo manifests and lockfile:** Run `cargo-check`, `clippy`, and affected crate
   tests; use `test-workspace` when dependency impact is broad or uncertain.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ name = "ag-git"
 version = "0.12.9"
 dependencies = [
  "mockall",
+ "rustix",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ percent-encoding = "2"
 portable-pty = "0.9"
 ratatui = { version = "0.30.1", default-features = false, features = ["crossterm", "layout-cache", "std", "underline-color"] }
 rustc-hash = "2"
-rustix = { version = "1.1", features = ["event", "process"] }
+rustix = { version = "1.1", features = ["event", "fs", "process"] }
 schemars = { version = "1", features = ["derive"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/ag-git/Cargo.toml
+++ b/crates/ag-git/Cargo.toml
@@ -13,6 +13,7 @@ test-utils = ["dep:mockall"]
 
 [dependencies]
 mockall = { workspace = true, optional = true }
+rustix.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 

--- a/crates/ag-git/src/error.rs
+++ b/crates/ag-git/src/error.rs
@@ -21,6 +21,18 @@ pub enum GitError {
     #[error("{0}")]
     Io(#[from] std::io::Error),
 
+    /// A repository declares pre-commit validation but its Git hook is
+    /// unavailable.
+    #[error(
+        "pre-commit validation is configured by `{config_file}`, but the Git pre-commit hook is \
+         not installed or executable; install it with the project's hook manager before committing"
+    )]
+    PreCommitHookMissing {
+        /// Repository-root-relative configuration file that declares
+        /// validation.
+        config_file: String,
+    },
+
     /// A `tokio::task::spawn_blocking` join failed.
     #[error("Join error: {0}")]
     Join(#[from] tokio::task::JoinError),
@@ -78,5 +90,21 @@ mod tests {
         // Assert
         assert!(matches!(error, GitError::Io(_)));
         assert!(error.to_string().contains("file missing"));
+    }
+
+    #[test]
+    fn pre_commit_hook_missing_display_explains_required_setup() {
+        // Arrange
+        let error = GitError::PreCommitHookMissing {
+            config_file: ".pre-commit-config.yaml".to_string(),
+        };
+
+        // Act
+        let display = error.to_string();
+
+        // Assert
+        assert!(display.contains(".pre-commit-config.yaml"));
+        assert!(display.contains("not installed or executable"));
+        assert!(display.contains("project's hook manager"));
     }
 }

--- a/crates/ag-git/src/sync.rs
+++ b/crates/ag-git/src/sync.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Output;
 
+#[cfg(unix)]
+use rustix::fs::{self as rustix_fs, Access};
 use tokio::task::spawn_blocking;
 
 use super::error::GitError;
@@ -15,6 +17,7 @@ use super::repo::{
 pub type BranchTrackingMap = HashMap<String, Option<(u32, u32)>>;
 
 const COMMIT_ALL_HOOK_RETRY_ATTEMPTS: usize = 5;
+const PRE_COMMIT_CONFIG_FILES: [&str; 2] = [".pre-commit-config.yaml", ".pre-commit-config.yml"];
 
 /// Controls how single-commit session branches treat the commit message when
 /// amending `HEAD`.
@@ -993,6 +996,10 @@ async fn commit_all_with_retry(
     amend_existing_commit: bool,
 ) -> Result<(), GitError> {
     spawn_blocking(move || {
+        if !no_verify {
+            ensure_pre_commit_hook_ready(&repo_path)?;
+        }
+
         stage_all_sync(&repo_path)?;
 
         for _ in 0..COMMIT_ALL_HOOK_RETRY_ATTEMPTS {
@@ -1043,6 +1050,71 @@ async fn commit_all_with_retry(
         })
     })
     .await?
+}
+
+/// Ensures repositories declaring pre-commit validation have an executable
+/// hook.
+fn ensure_pre_commit_hook_ready(repo_path: &Path) -> Result<(), GitError> {
+    let Some(config_file) = PRE_COMMIT_CONFIG_FILES
+        .iter()
+        .find(|config_file| repo_path.join(config_file).is_file())
+    else {
+        return Ok(());
+    };
+    let hook_path = resolve_pre_commit_hook_path(repo_path)?;
+
+    if is_executable_hook(&hook_path) {
+        return Ok(());
+    }
+
+    Err(GitError::PreCommitHookMissing {
+        config_file: (*config_file).to_string(),
+    })
+}
+
+/// Resolves the pre-commit hook using `core.hooksPath` or Git's default path.
+fn resolve_pre_commit_hook_path(repo_path: &Path) -> Result<PathBuf, GitError> {
+    let hooks_path_output =
+        run_git_command_output_sync(repo_path, &["config", "--path", "--get", "core.hooksPath"])?;
+    let hooks_path = if hooks_path_output.status.success() {
+        PathBuf::from(String::from_utf8_lossy(&hooks_path_output.stdout).trim())
+    } else if hooks_path_output.status.code() == Some(1) {
+        let default_hook_path = run_git_command_sync(
+            repo_path,
+            &["rev-parse", "--git-path", "hooks/pre-commit"],
+            "Failed to resolve Git pre-commit hook path",
+        )?;
+
+        return Ok(resolve_repo_path(
+            repo_path,
+            PathBuf::from(default_hook_path.trim()),
+        ));
+    } else {
+        return Err(GitError::CommandFailed {
+            command: "git config --path --get core.hooksPath".to_string(),
+            stderr: command_output_detail(&hooks_path_output.stdout, &hooks_path_output.stderr),
+        });
+    };
+
+    Ok(resolve_repo_path(repo_path, hooks_path).join("pre-commit"))
+}
+
+fn resolve_repo_path(repo_path: &Path, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        return path;
+    }
+
+    repo_path.join(path)
+}
+
+#[cfg(unix)]
+fn is_executable_hook(hook_path: &Path) -> bool {
+    hook_path.is_file() && rustix_fs::access(hook_path, Access::EXEC_OK).is_ok()
+}
+
+#[cfg(not(unix))]
+fn is_executable_hook(hook_path: &Path) -> bool {
+    hook_path.is_file()
 }
 
 /// Returns the canonical git no-changes error used by app auto-commit flows.
@@ -1195,6 +1267,8 @@ pub(super) fn is_no_upstream_error(detail: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::path::Path;
     use std::process::{Command, Output};
 
@@ -1248,6 +1322,161 @@ mod tests {
         fs::write(repo_path.join("README.md"), "base\n").expect("failed to write base file");
         run_git_command(repo_path, &["add", "README.md"]);
         run_git_command(repo_path, &["commit", "-m", "Initial commit"]);
+    }
+
+    #[cfg(unix)]
+    fn write_executable_pre_commit_hook(hook_path: &Path) {
+        fs::create_dir_all(
+            hook_path
+                .parent()
+                .expect("pre-commit hook should have a parent directory"),
+        )
+        .expect("failed to create hooks directory");
+        fs::write(hook_path, "#!/bin/sh\nexit 0\n").expect("failed to write pre-commit hook");
+        let mut permissions = fs::metadata(hook_path)
+            .expect("failed to read pre-commit hook metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(hook_path, permissions)
+            .expect("failed to make pre-commit hook executable");
+    }
+
+    #[test]
+    fn ensure_pre_commit_hook_ready_allows_repositories_without_configuration() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        setup_test_git_repo(temp_dir.path());
+
+        // Act
+        let result = ensure_pre_commit_hook_ready(temp_dir.path());
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn ensure_pre_commit_hook_ready_rejects_missing_hook() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        setup_test_git_repo(temp_dir.path());
+        fs::write(
+            temp_dir.path().join(".pre-commit-config.yaml"),
+            "repos: []\n",
+        )
+        .expect("failed to write pre-commit configuration");
+
+        // Act
+        let result = ensure_pre_commit_hook_ready(temp_dir.path());
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(GitError::PreCommitHookMissing { ref config_file })
+                if config_file == ".pre-commit-config.yaml"
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_pre_commit_hook_ready_accepts_default_executable_hook() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        setup_test_git_repo(temp_dir.path());
+        fs::write(
+            temp_dir.path().join(".pre-commit-config.yaml"),
+            "repos: []\n",
+        )
+        .expect("failed to write pre-commit configuration");
+        let hook_path = temp_dir.path().join(git_command_stdout(
+            temp_dir.path(),
+            &["rev-parse", "--git-path", "hooks/pre-commit"],
+        ));
+        write_executable_pre_commit_hook(&hook_path);
+
+        // Act
+        let result = ensure_pre_commit_hook_ready(temp_dir.path());
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_pre_commit_hook_ready_accepts_custom_executable_hook() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        setup_test_git_repo(temp_dir.path());
+        fs::write(
+            temp_dir.path().join(".pre-commit-config.yaml"),
+            "repos: []\n",
+        )
+        .expect("failed to write pre-commit configuration");
+        run_git_command(
+            temp_dir.path(),
+            &["config", "core.hooksPath", ".custom-hooks"],
+        );
+        write_executable_pre_commit_hook(&temp_dir.path().join(".custom-hooks").join("pre-commit"));
+
+        // Act
+        let result = ensure_pre_commit_hook_ready(temp_dir.path());
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_pre_commit_hook_ready_rejects_hook_inaccessible_to_owner() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        setup_test_git_repo(temp_dir.path());
+        fs::write(
+            temp_dir.path().join(".pre-commit-config.yaml"),
+            "repos: []\n",
+        )
+        .expect("failed to write pre-commit configuration");
+        let hook_path = temp_dir.path().join(git_command_stdout(
+            temp_dir.path(),
+            &["rev-parse", "--git-path", "hooks/pre-commit"],
+        ));
+        fs::write(&hook_path, "#!/bin/sh\nexit 0\n").expect("failed to write pre-commit hook");
+        fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o011))
+            .expect("failed to set mismatched execute permissions");
+
+        // Act
+        let result = ensure_pre_commit_hook_ready(temp_dir.path());
+
+        // Assert
+        assert!(matches!(result, Err(GitError::PreCommitHookMissing { .. })));
+    }
+
+    #[tokio::test]
+    async fn commit_all_rejects_configured_validation_without_hook() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        setup_test_git_repo(temp_dir.path());
+        fs::write(
+            temp_dir.path().join(".pre-commit-config.yaml"),
+            "repos: []\n",
+        )
+        .expect("failed to write pre-commit configuration");
+        fs::write(temp_dir.path().join("README.md"), "changed\n")
+            .expect("failed to write worktree change");
+
+        // Act
+        let result = commit_all(
+            temp_dir.path().to_path_buf(),
+            "Change README".to_string(),
+            false,
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(result, Err(GitError::PreCommitHookMissing { .. })));
+        assert_eq!(
+            git_command_stdout(temp_dir.path(), &["log", "-1", "--pretty=%s"]),
+            "Initial commit"
+        );
     }
 
     #[test]

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -4729,7 +4729,7 @@ async fn test_rebase_session_auto_commits_uncommitted_changes() {
     mock_git_client
         .expect_commit_all_preserving_single_commit()
         .times(1)
-        .withf(|_, _, _, _, no_verify| *no_verify)
+        .withf(|_, _, _, _, no_verify| !*no_verify)
         .returning(|_, _, _, _, _| Box::pin(async { Ok(()) }));
     mock_git_client
         .expect_head_short_hash()

--- a/crates/agentty/src/app/session/workflow/merge.rs
+++ b/crates/agentty/src/app/session/workflow/merge.rs
@@ -1968,7 +1968,7 @@ impl SessionManager {
             &input.folder,
             input.rebase_plan.target_label(),
             auto_commit_agent,
-            true,
+            false,
             include_coauthored_by_agentty,
         )
         .await

--- a/crates/agentty/src/app/session/workflow/task.rs
+++ b/crates/agentty/src/app/session/workflow/task.rs
@@ -493,6 +493,11 @@ impl SessionTaskService {
                 Err(commit_error) if commit_error.to_string().contains("Nothing to commit") => {
                     return Ok(None);
                 }
+                Err(
+                    commit_error @ SessionError::Git(git::GitError::PreCommitHookMissing { .. }),
+                ) => {
+                    return Err(commit_error);
+                }
                 Err(commit_error) => {
                     // Keep test execution deterministic and offline by skipping
                     // model-assisted commit retries.

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -93,6 +93,37 @@ duration: 283ms
     Ok(())
 }
 
+/// Seeds configured pre-commit validation without installing its Git hook and
+/// installs a Claude stub that leaves one worktree change for auto-commit.
+fn seed_missing_pre_commit_hook_project(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    std::fs::write(env.workdir.join(".pre-commit-config.yaml"), "repos: []\n")?;
+    run_git(&env.workdir, &["add", ".pre-commit-config.yaml"])?;
+    run_git(
+        &env.workdir,
+        &["commit", "-m", "configure pre-commit validation"],
+    )?;
+
+    let claude_path = env.stub_bin.join("claude");
+    let script = r#"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
+cat > /dev/null 2>&1
+printf 'pending change\n' > generated.txt
+printf '%s\n' '{"type":"system","subtype":"init"}'
+printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Created pending worktree change"}]}}'
+printf '%s\n' '{"type":"result","subtype":"success","result":"{\"answer\":\"Created pending worktree change\",\"questions\":[],\"summary\":null}","usage":{"input_tokens":5,"output_tokens":9}}'
+"#;
+    std::fs::write(&claude_path, script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o755))?;
+
+    seed_project_default_model(env, "claude-haiku-4-5-20251001")?;
+
+    Ok(())
+}
+
 /// Seeds one review-ready session whose transcript contains a markdown table.
 fn seed_session_with_markdown_table(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
@@ -1168,6 +1199,47 @@ fn session_list_empty_state() -> E2eResult {
                 assertion::assert_not_visible(frame, "Merge queue");
                 assertion::assert_not_visible(frame, "Archive");
                 assertion::assert_not_visible(frame, "No sessions");
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that configured validation without an installed hook surfaces an
+/// actionable auto-commit error in the session transcript.
+#[test]
+fn test_session_missing_pre_commit_hook_error() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_missing_pre_commit_hook_error")
+        .with_git()
+        .setup(seed_missing_pre_commit_hook_project)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("Create one worktree change")
+                    .wait_for_text("Create one worktree change", 3000)
+                    .press_key("Enter")
+                    .wait_for_text("Created pending worktree change", 30000)
+                    .wait_for_text("[Commit Error]", 30000)
+                    .capture_labeled(
+                        "missing_hook",
+                        "Session auto-commit reports a missing pre-commit hook",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "[Commit Error]", &full);
+                assertion::assert_text_in_region(
+                    frame,
+                    "pre-commit validation is configured",
+                    &full,
+                );
+                assertion::assert_text_in_region(frame, "not installed or executable", &full);
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -163,7 +163,9 @@ render twice per frame.
 1. Auto-commit keeps one evolving commit on the session branch: the first file-changing
    turn creates it, later turns regenerate the message from the cumulative diff with the
    project's `Default Fast Model` and amend `HEAD`; an empty amend drops the reverted
-   commit. The session title is synced from the commit text.
+   commit. Repositories declaring pre-commit configuration must have an installed,
+   executable Git pre-commit hook; a missing hook fails immediately without entering
+   model-assisted commit recovery. The session title is synced from the commit text.
 1. If the session already tracks a published upstream branch and no chat message or sync
    operation is queued, a per-session branch-operation guard transfers to the detached
    auto-push until it finishes. Every sync request holds the same guard through status

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -261,6 +261,12 @@ amends `HEAD`, and refreshes the session title from the commit text. If a later 
 reverts every change, the empty session commit is dropped. Commit and merge notices
 appear as transient status rows rather than persisted transcript messages.
 
+When a project contains `.pre-commit-config.yaml` or `.pre-commit-config.yml`, Agentty
+requires the Git pre-commit hook to be installed and executable before auto-commit. A
+missing hook stops the commit with an actionable error instead of allowing validation to
+surface for the first time in CI. Install it with the project's configured hook manager,
+such as `prek install` for `prek`.
+
 When a session merges, Agentty reuses the session branch `HEAD` commit message for the
 final squash commit on the base branch. Merging requires a clean main checkout and
 returns the session to **Review** if the preparatory rebase or squash-merge fails.


### PR DESCRIPTION
- Run Clippy alongside compile checks for Rust sources.
- Require an installed, executable Git pre-commit hook when pre-commit configuration exists.
- Surface missing-hook errors without model-assisted commit recovery and document hook-manager setup.
- Cover hook validation with unit and E2E tests.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)