### PR TITLE
Forge and git commands enforce timeouts and merged cleanup runs in background

### DIFF
--- a/crates/ag-forge/src/adapter_common.rs
+++ b/crates/ag-forge/src/adapter_common.rs
@@ -489,6 +489,17 @@ pub(crate) fn map_spawn_error(
                 message: format!("failed to execute `{}`: {message}", forge_kind.cli_name()),
             }
         }
+        ForgeCommandError::TimedOut {
+            executable,
+            timeout,
+        } => ReviewRequestError::OperationFailed {
+            forge_kind,
+            message: format!(
+                "`{executable}` timed out after {} seconds while contacting {}",
+                timeout.as_secs(),
+                remote.host
+            ),
+        },
     }
 }
 
@@ -689,6 +700,28 @@ mod tests {
             ReviewRequestError::OperationFailed {
                 forge_kind: ForgeKind::GitHub,
                 message: "failed to execute `gh`: permission denied".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn map_spawn_error_reports_command_timeout() {
+        // Arrange
+        let remote = sample_remote(ForgeKind::GitHub);
+        let error = ForgeCommandError::TimedOut {
+            executable: "gh".to_string(),
+            timeout: std::time::Duration::from_secs(30),
+        };
+
+        // Act
+        let review_request_error = map_spawn_error(&remote, error);
+
+        // Assert
+        assert_eq!(
+            review_request_error,
+            ReviewRequestError::OperationFailed {
+                forge_kind: ForgeKind::GitHub,
+                message: "`gh` timed out after 30 seconds while contacting github.com".to_string(),
             }
         );
     }

--- a/crates/ag-forge/src/command.rs
+++ b/crates/ag-forge/src/command.rs
@@ -2,10 +2,15 @@
 
 use std::io::ErrorKind;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use tokio::process::Command;
+use tokio::time;
 
 use super::ForgeFuture;
+
+/// Maximum time one forge CLI command may run before it is canceled.
+const FORGE_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// One forge CLI invocation.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -87,6 +92,13 @@ pub(crate) enum ForgeCommandError {
         /// Human-readable spawn error detail.
         message: String,
     },
+    /// The process exceeded the bounded forge-command runtime.
+    TimedOut {
+        /// Executable whose process exceeded the timeout.
+        executable: String,
+        /// Configured command timeout.
+        timeout: Duration,
+    },
 }
 
 /// Async command boundary used by forge adapters.
@@ -113,8 +125,17 @@ impl ForgeCommandRunner for RealForgeCommandRunner {
 
 /// Runs one forge CLI command and captures stdout, stderr, and exit status.
 async fn run_command(command: ForgeCommand) -> Result<ForgeCommandOutput, ForgeCommandError> {
+    run_command_with_timeout(command, FORGE_COMMAND_TIMEOUT).await
+}
+
+/// Runs one forge CLI command with an explicit upper bound.
+async fn run_command_with_timeout(
+    command: ForgeCommand,
+    timeout: Duration,
+) -> Result<ForgeCommandOutput, ForgeCommandError> {
     let mut process = Command::new(command.executable);
     process.args(&command.arguments);
+    process.kill_on_drop(true);
 
     for (key, value) in &command.environment {
         process.env(key, value);
@@ -124,18 +145,24 @@ async fn run_command(command: ForgeCommand) -> Result<ForgeCommandOutput, ForgeC
         process.current_dir(working_directory);
     }
 
-    let output = process.output().await.map_err(|error| {
-        if error.kind() == ErrorKind::NotFound {
-            return ForgeCommandError::ExecutableNotFound {
-                executable: command.executable.to_string(),
-            };
-        }
-
-        ForgeCommandError::SpawnFailed {
+    let output = time::timeout(timeout, process.output())
+        .await
+        .map_err(|_| ForgeCommandError::TimedOut {
             executable: command.executable.to_string(),
-            message: error.to_string(),
-        }
-    })?;
+            timeout,
+        })?
+        .map_err(|error| {
+            if error.kind() == ErrorKind::NotFound {
+                return ForgeCommandError::ExecutableNotFound {
+                    executable: command.executable.to_string(),
+                };
+            }
+
+            ForgeCommandError::SpawnFailed {
+                executable: command.executable.to_string(),
+                message: error.to_string(),
+            }
+        })?;
 
     Ok(ForgeCommandOutput {
         exit_code: output.status.code(),
@@ -277,6 +304,27 @@ mod tests {
             error,
             ForgeCommandError::ExecutableNotFound {
                 executable: "agentty-definitely-missing-forge-command".to_string(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn command_timeout_cancels_long_running_process() {
+        // Arrange
+        let command = ForgeCommand::new("sh", vec!["-c".to_string(), "exec sleep 5".to_string()]);
+        let timeout = Duration::from_millis(25);
+
+        // Act
+        let error = run_command_with_timeout(command, timeout)
+            .await
+            .expect_err("long-running command should time out");
+
+        // Assert
+        assert_eq!(
+            error,
+            ForgeCommandError::TimedOut {
+                executable: "sh".to_string(),
+                timeout,
             }
         );
     }

--- a/crates/ag-git/src/error.rs
+++ b/crates/ag-git/src/error.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 /// Typed error returned by git infrastructure operations.
 ///
 /// Wraps command execution failures, output parsing issues, and I/O errors so
@@ -11,6 +13,15 @@ pub enum GitError {
         command: String,
         /// Human-readable detail extracted from stderr/stdout.
         stderr: String,
+    },
+
+    /// A git subprocess exceeded its configured runtime bound.
+    #[error("{command} timed out after {timeout:?}")]
+    CommandTimedOut {
+        /// Git invocation that exceeded the timeout.
+        command: String,
+        /// Configured command timeout.
+        timeout: Duration,
     },
 
     /// Git command output could not be parsed into the expected structure.
@@ -52,6 +63,24 @@ mod tests {
         assert_eq!(
             display,
             "git push origin main: fatal: could not read Username"
+        );
+    }
+
+    #[test]
+    fn command_timed_out_display_includes_command_and_timeout() {
+        // Arrange
+        let error = GitError::CommandTimedOut {
+            command: "git worktree remove --force /tmp/worktree".to_string(),
+            timeout: Duration::from_secs(30),
+        };
+
+        // Act
+        let display = error.to_string();
+
+        // Assert
+        assert_eq!(
+            display,
+            "git worktree remove --force /tmp/worktree timed out after 30s"
         );
     }
 

--- a/crates/ag-git/src/repo.rs
+++ b/crates/ag-git/src/repo.rs
@@ -1,10 +1,16 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
+use std::time::Duration;
 
+use tokio::process::Command as AsyncCommand;
 use tokio::task::spawn_blocking;
+use tokio::time;
 
 use super::error::GitError;
+
+/// Maximum time one asynchronous git subprocess may run.
+const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Returns the origin repository URL normalized to HTTPS form when possible.
 ///
@@ -47,7 +53,9 @@ pub(crate) async fn repo_url(repo_path: PathBuf) -> Result<String, GitError> {
 /// # Errors
 /// Returns an error if git metadata cannot be queried from `repo_path`.
 pub(crate) async fn main_repo_root(repo_path: PathBuf) -> Result<PathBuf, GitError> {
-    spawn_blocking(move || main_repo_root_sync(&repo_path)).await?
+    match resolve_shared_repo(&repo_path).await? {
+        SharedRepo::Working(path) | SharedRepo::Bare(path) => Ok(path),
+    }
 }
 
 /// Resolves the main working checkout for a repository or linked worktree.
@@ -69,18 +77,6 @@ pub(crate) async fn main_checkout_working_tree(
     repo_path: PathBuf,
 ) -> Result<Option<PathBuf>, GitError> {
     spawn_blocking(move || main_checkout_working_tree_sync(&repo_path)).await?
-}
-
-/// Resolves the main repository root for `repo_path` in synchronous code.
-///
-/// Returns the administrative root: the main working checkout for non-bare
-/// shared repositories and the bare common git directory for bare shared
-/// repositories. Both are valid working directories for `git worktree` and
-/// branch administration commands.
-pub(super) fn main_repo_root_sync(repo_path: &Path) -> Result<PathBuf, GitError> {
-    match resolve_shared_repo_sync(repo_path)? {
-        SharedRepo::Working(path) | SharedRepo::Bare(path) => Ok(path),
-    }
 }
 
 /// Resolves the main working checkout for `repo_path` in synchronous code.
@@ -112,8 +108,8 @@ pub(super) enum SharedRepo {
 /// repository is bare by running `git rev-parse --is-bare-repository` inside
 /// the common git directory, and returns [`SharedRepo::Bare`] with the bare
 /// common git directory when bare. Otherwise returns [`SharedRepo::Working`]
-/// with the main working checkout root, matching the historical
-/// `main_repo_root_sync` resolution for non-bare layouts.
+/// with the main working checkout root, matching the async administrative-root
+/// resolution for non-bare layouts.
 ///
 /// # Errors
 /// Returns an error if git metadata cannot be queried from `repo_path`.
@@ -194,6 +190,54 @@ pub(super) async fn run_git_command(
         run_git_command_sync(&repo_path, &argument_refs, &error_context)
     })
     .await?
+}
+
+/// Runs a cancellable git subprocess with the cleanup-safe runtime bound.
+pub(super) async fn run_git_command_cancellable(
+    repo_path: PathBuf,
+    args: Vec<String>,
+    error_context: String,
+) -> Result<String, GitError> {
+    run_git_command_with_timeout(repo_path, args, error_context, GIT_COMMAND_TIMEOUT).await
+}
+
+/// Runs a cancellable git subprocess with an explicit runtime bound.
+async fn run_git_command_with_timeout(
+    repo_path: PathBuf,
+    args: Vec<String>,
+    error_context: String,
+    timeout: Duration,
+) -> Result<String, GitError> {
+    let argument_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+    let git_invocation = format_git_invocation(&argument_refs);
+    let mut command = AsyncCommand::new("git");
+    command
+        .args(&args)
+        .current_dir(repo_path)
+        .stdin(Stdio::null())
+        .kill_on_drop(true);
+    apply_non_interactive_environment_async(&mut command);
+
+    let output = time::timeout(timeout, command.output())
+        .await
+        .map_err(|_| GitError::CommandTimedOut {
+            command: git_invocation.clone(),
+            timeout,
+        })?
+        .map_err(|error| GitError::CommandFailed {
+            command: git_invocation.clone(),
+            stderr: error.to_string(),
+        })?;
+    if !output.status.success() {
+        let detail = command_output_detail(&output.stdout, &output.stderr);
+
+        return Err(GitError::CommandFailed {
+            command: git_invocation,
+            stderr: format!("{error_context}: {detail}"),
+        });
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 /// Runs a git command in `repo_path` and returns stdout text.
@@ -311,6 +355,19 @@ fn apply_non_interactive_environment(command: &mut Command) {
         .env("GIT_SSH_COMMAND", git_ssh_command);
 }
 
+/// Applies non-interactive defaults to one async git subprocess.
+fn apply_non_interactive_environment_async(command: &mut AsyncCommand) {
+    let git_ssh_command = std::env::var("GIT_SSH_COMMAND").map_or_else(
+        |_| "ssh -o BatchMode=yes".to_string(),
+        |configured_command| format!("{configured_command} -o BatchMode=yes"),
+    );
+
+    command
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GCM_INTERACTIVE", "never")
+        .env("GIT_SSH_COMMAND", git_ssh_command);
+}
+
 /// Extracts the best human-readable error detail from command output.
 pub(super) fn command_output_detail(stdout: &[u8], stderr: &[u8]) -> String {
     let stderr_text = String::from_utf8_lossy(stderr).trim().to_string();
@@ -324,6 +381,29 @@ pub(super) fn command_output_detail(stdout: &[u8], stderr: &[u8]) -> String {
     }
 
     "Unknown git error".to_string()
+}
+
+/// Resolves the shared repository through cancellable async git commands.
+async fn resolve_shared_repo(repo_path: &Path) -> Result<SharedRepo, GitError> {
+    let (git_dir, git_common_dir) = git_directory_paths_async(repo_path).await?;
+    let is_bare = run_git_command_cancellable(
+        git_common_dir.clone(),
+        vec!["rev-parse".to_string(), "--is-bare-repository".to_string()],
+        "Git rev-parse --is-bare-repository failed".to_string(),
+    )
+    .await?;
+    if is_bare.trim() == "true" {
+        return Ok(SharedRepo::Bare(git_common_dir));
+    }
+
+    let shared_git_dir = if git_dir == git_common_dir {
+        git_dir
+    } else {
+        git_common_dir
+    };
+    let repo_root = repo_root_from_git_dir_async(repo_path, &shared_git_dir).await?;
+
+    Ok(SharedRepo::Working(repo_root))
 }
 
 /// Converts SSH-style GitHub remotes into HTTPS while preserving other URLs.
@@ -341,12 +421,37 @@ fn normalize_repo_url(remote: &str) -> String {
 }
 
 /// Reads absolute git and common git directory paths for `repo_path`.
+async fn git_directory_paths_async(repo_path: &Path) -> Result<(PathBuf, PathBuf), GitError> {
+    let stdout = run_git_command_cancellable(
+        repo_path.to_path_buf(),
+        vec![
+            "rev-parse".to_string(),
+            "--git-dir".to_string(),
+            "--git-common-dir".to_string(),
+        ],
+        "Git rev-parse failed".to_string(),
+    )
+    .await?;
+
+    parse_git_directory_paths(repo_path, &stdout)
+}
+
+/// Reads absolute git and common git directory paths synchronously.
 fn git_directory_paths(repo_path: &Path) -> Result<(PathBuf, PathBuf), GitError> {
     let stdout = run_git_command_sync(
         repo_path,
         &["rev-parse", "--git-dir", "--git-common-dir"],
         "Git rev-parse failed",
     )?;
+
+    parse_git_directory_paths(repo_path, &stdout)
+}
+
+/// Parses the two paths emitted by `git rev-parse`.
+fn parse_git_directory_paths(
+    repo_path: &Path,
+    stdout: &str,
+) -> Result<(PathBuf, PathBuf), GitError> {
     let mut lines = stdout
         .lines()
         .map(str::trim)
@@ -365,18 +470,28 @@ fn git_directory_paths(repo_path: &Path) -> Result<(PathBuf, PathBuf), GitError>
 }
 
 /// Converts a git directory path (typically `.git`) into repository root.
+async fn repo_root_from_git_dir_async(
+    repo_path: &Path,
+    git_dir: &Path,
+) -> Result<PathBuf, GitError> {
+    if let Some(repo_root) = repo_root_from_dot_git_dir(git_dir)? {
+        return Ok(repo_root);
+    }
+
+    let root = run_git_command_cancellable(
+        repo_path.to_path_buf(),
+        vec!["rev-parse".to_string(), "--show-toplevel".to_string()],
+        "Git rev-parse --show-toplevel failed".to_string(),
+    )
+    .await?;
+
+    parse_repo_root(&root)
+}
+
+/// Converts a git directory path into a repository root synchronously.
 fn repo_root_from_git_dir(repo_path: &Path, git_dir: &Path) -> Result<PathBuf, GitError> {
-    if git_dir
-        .file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name == ".git")
-    {
-        return git_dir.parent().map(Path::to_path_buf).ok_or_else(|| {
-            GitError::OutputParse(format!(
-                "Git directory has no parent: {}",
-                git_dir.display()
-            ))
-        });
+    if let Some(repo_root) = repo_root_from_dot_git_dir(git_dir)? {
+        return Ok(repo_root);
     }
 
     let root = run_git_command_sync(
@@ -384,6 +499,34 @@ fn repo_root_from_git_dir(repo_path: &Path, git_dir: &Path) -> Result<PathBuf, G
         &["rev-parse", "--show-toplevel"],
         "Git rev-parse --show-toplevel failed",
     )?;
+
+    parse_repo_root(&root)
+}
+
+/// Returns the parent of a conventional `.git` directory when applicable.
+fn repo_root_from_dot_git_dir(git_dir: &Path) -> Result<Option<PathBuf>, GitError> {
+    if git_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_none_or(|name| name != ".git")
+    {
+        return Ok(None);
+    }
+
+    git_dir
+        .parent()
+        .map(Path::to_path_buf)
+        .map(Some)
+        .ok_or_else(|| {
+            GitError::OutputParse(format!(
+                "Git directory has no parent: {}",
+                git_dir.display()
+            ))
+        })
+}
+
+/// Parses a non-empty `git rev-parse --show-toplevel` response.
+fn parse_repo_root(root: &str) -> Result<PathBuf, GitError> {
     let root = root.trim().to_string();
     if root.is_empty() {
         return Err(GitError::OutputParse(
@@ -447,6 +590,43 @@ mod tests {
                 .iter()
                 .any(|(key, value)| key == "GIT_SSH_COMMAND" && value.contains("BatchMode=yes"))
         );
+    }
+
+    #[tokio::test]
+    async fn test_async_git_command_timeout_cancels_process() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temporary repository");
+        let init_output = Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(temp_dir.path())
+            .output()
+            .expect("failed to initialize temporary repository");
+        assert!(init_output.status.success());
+        let timeout = Duration::from_millis(25);
+
+        // Act
+        let error = run_git_command_with_timeout(
+            temp_dir.path().to_path_buf(),
+            vec![
+                "-c".to_string(),
+                "alias.agentty-hang=!exec sleep 1".to_string(),
+                "agentty-hang".to_string(),
+            ],
+            "Git timeout test failed".to_string(),
+            timeout,
+        )
+        .await
+        .expect_err("long-running git command should time out");
+
+        // Assert
+        assert!(matches!(
+            error,
+            GitError::CommandTimedOut {
+                ref command,
+                timeout: actual_timeout,
+            } if command == "git -c alias.agentty-hang=!exec sleep 1 agentty-hang"
+                && actual_timeout == timeout
+        ));
     }
 
     #[test]
@@ -542,13 +722,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_main_repo_root_sync_returns_command_failed_outside_git_repository() {
+    #[tokio::test]
+    async fn test_main_repo_root_returns_command_failed_outside_git_repository() {
         // Arrange
         let temp_dir = tempdir().expect("failed to create temp dir");
 
         // Act
-        let result = main_repo_root_sync(temp_dir.path());
+        let result = main_repo_root(temp_dir.path().to_path_buf()).await;
 
         // Assert
         let error = result.expect_err("non-repo should fail");
@@ -577,8 +757,8 @@ mod tests {
         String::from_utf8_lossy(&output.stdout).trim().to_string()
     }
 
-    #[test]
-    fn test_bare_layout_resolves_bare_admin_root_and_no_working_checkout() {
+    #[tokio::test]
+    async fn test_bare_layout_resolves_bare_admin_root_and_no_working_checkout() {
         // Arrange
         let temp_dir = tempdir().expect("failed to create temp dir");
         let root = temp_dir.path();
@@ -617,8 +797,9 @@ mod tests {
         );
 
         // Act
-        let admin_root =
-            main_repo_root_sync(&session_worktree).expect("failed to resolve admin root");
+        let admin_root = main_repo_root(session_worktree.clone())
+            .await
+            .expect("failed to resolve admin root");
         let working_checkout = main_checkout_working_tree_sync(&session_worktree)
             .expect("failed to resolve working checkout");
 

--- a/crates/ag-git/src/sync.rs
+++ b/crates/ag-git/src/sync.rs
@@ -7,7 +7,8 @@ use tokio::task::spawn_blocking;
 use super::error::GitError;
 use super::rebase::{is_rebase_conflict, run_git_command_with_index_lock_retry};
 use super::repo::{
-    command_output_detail, run_git_command, run_git_command_output_sync, run_git_command_sync,
+    command_output_detail, run_git_command, run_git_command_cancellable,
+    run_git_command_output_sync, run_git_command_sync,
 };
 
 /// Map of local branch names to their ahead/behind counts relative to their
@@ -227,9 +228,10 @@ pub(crate) async fn head_commit_message(repo_path: PathBuf) -> Result<Option<Str
 /// Ok(()) on success.
 ///
 /// # Errors
-/// Returns a [`GitError`] if the branch delete command fails.
+/// Returns a [`GitError`] if the branch delete command fails or exceeds its
+/// runtime bound.
 pub(crate) async fn delete_branch(repo_path: PathBuf, branch_name: String) -> Result<(), GitError> {
-    run_git_command(
+    run_git_command_cancellable(
         repo_path,
         vec!["branch".to_string(), "-D".to_string(), branch_name],
         "Git branch deletion failed".to_string(),

--- a/crates/ag-git/src/worktree.rs
+++ b/crates/ag-git/src/worktree.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use tokio::task::spawn_blocking;
 
 use super::error::GitError;
-use super::repo::{main_repo_root_sync, resolve_git_dir, run_git_command_sync};
+use super::repo::{
+    main_repo_root, resolve_git_dir, run_git_command_cancellable, run_git_command_sync,
+};
 
 /// Detects git repository information for the given directory.
 /// Returns the current branch name if in a git repository, None otherwise.
@@ -77,21 +79,25 @@ pub(crate) async fn create_worktree(
 /// Ok(()) on success, Err([`GitError`]) on failure.
 ///
 /// # Errors
-/// Returns [`GitError::CommandFailed`] if spawning fails or the worktree
-/// remove command exits with a non-zero status.
+/// Returns [`GitError::CommandTimedOut`] when repository inspection or
+/// worktree removal exceeds its runtime bound, or [`GitError::CommandFailed`]
+/// if spawning fails or the command exits with a non-zero status.
 pub(crate) async fn remove_worktree(worktree_path: PathBuf) -> Result<(), GitError> {
-    spawn_blocking(move || {
-        let repo_root = main_repo_root_sync(&worktree_path)?;
-        let worktree_path = worktree_path.to_string_lossy().to_string();
-        run_git_command_sync(
-            &repo_root,
-            &["worktree", "remove", "--force", worktree_path.as_str()],
-            "Git worktree command failed",
-        )?;
+    let repo_root = main_repo_root(worktree_path.clone()).await?;
+    let worktree_path = worktree_path.to_string_lossy().to_string();
+    run_git_command_cancellable(
+        repo_root,
+        vec![
+            "worktree".to_string(),
+            "remove".to_string(),
+            "--force".to_string(),
+            worktree_path,
+        ],
+        "Git worktree command failed".to_string(),
+    )
+    .await?;
 
-        Ok(())
-    })
-    .await?
+    Ok(())
 }
 
 /// Returns branch information for a repository directory in synchronous code.

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -3,6 +3,7 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use app::branch_publish::{
     BranchPublishActionUpdate, BranchPublishTaskResult, BranchPublishTaskSuccess,
@@ -24,7 +25,7 @@ use super::state::{
     UpdateStatus,
 };
 use crate::app::session::{
-    StatusTransition, SyncMainOutcome, SyncSessionStartError, TurnAppliedState,
+    SessionTaskService, StatusTransition, SyncMainOutcome, SyncSessionStartError, TurnAppliedState,
 };
 use crate::app::session_state::SessionGitStatus;
 use crate::app::{self, sync_message};
@@ -33,7 +34,7 @@ use crate::domain::file_entry::{FileEntry, at_mention_lookup_root};
 use crate::domain::input::InputState;
 use crate::domain::question::default_option_index;
 use crate::domain::session::{
-    PublishBranchAction, PublishedBranchSyncStatus, SessionId, SessionSize, Status,
+    PublishBranchAction, PublishedBranchSyncStatus, SessionHandles, SessionId, SessionSize, Status,
 };
 use crate::domain::transcript_notice::TranscriptNotice;
 use crate::presentation::app_mode::{AppMode, ChatFocus, ConfirmationViewMode};
@@ -1747,6 +1748,10 @@ impl App {
         let Ok(handles) = self.sessions.session_handles_or_err(session_id) else {
             return None;
         };
+        let should_schedule_cleanup = handles
+            .status
+            .lock()
+            .is_ok_and(|status| *status != Status::Done);
 
         let mut warnings = Vec::new();
 
@@ -1769,17 +1774,6 @@ impl App {
         let source_branch = crate::app::session::session_branch(session_id);
         let app_event_tx = self.services.event_sender();
 
-        if let Err(error) = crate::app::session::SessionManager::cleanup_merged_session_worktree(
-            folder,
-            self.services.fs_client(),
-            self.services.git_client(),
-            source_branch,
-            None,
-        )
-        .await
-        {
-            warnings.push(format!("Worktree cleanup failed: {error}"));
-        }
         match crate::app::session::SessionManager::restack_child_sessions_after_parent_merge(
             self.services.db(),
             session_id,
@@ -1801,9 +1795,61 @@ impl App {
 
         let status_transition =
             StatusTransition::from_services(&self.services, handles, session_id);
-        let _ = status_transition.apply(Status::Done).await;
+        let status_applied = status_transition.apply(Status::Done).await;
+        if should_schedule_cleanup && status_applied {
+            self.spawn_externally_merged_session_cleanup(
+                session_id,
+                folder,
+                source_branch,
+                handles,
+            );
+        }
 
         (!warnings.is_empty()).then(|| warnings.join("\n"))
+    }
+
+    /// Removes an externally merged session worktree without delaying terminal
+    /// input or redraws, persisting any cleanup warning after the task
+    /// finishes.
+    fn spawn_externally_merged_session_cleanup(
+        &self,
+        session_id: &str,
+        folder: PathBuf,
+        source_branch: String,
+        handles: &SessionHandles,
+    ) {
+        let app_event_tx = self.services.event_sender();
+        let db = self.services.db().clone();
+        let fs_client = self.services.fs_client();
+        let git_client = self.services.git_client();
+        let session_id = SessionId::from(session_id);
+        let session_update_versions = self.services.session_update_versions();
+        let transcript = Arc::clone(&handles.transcript);
+        let cleanup_task = tokio::spawn(async move {
+            if let Err(error) =
+                crate::app::session::SessionManager::cleanup_merged_session_worktree(
+                    folder,
+                    fs_client,
+                    git_client,
+                    source_branch,
+                    None,
+                )
+                .await
+            {
+                let warning = TranscriptNotice::ReviewRequestSyncWarning
+                    .format(format!("Worktree cleanup failed: {error}"));
+                SessionTaskService::append_workflow_notice(
+                    &transcript,
+                    &db,
+                    &app_event_tx,
+                    &session_update_versions,
+                    session_id.as_str(),
+                    &warning,
+                )
+                .await;
+            }
+        });
+        self.services.track_cleanup_task(cleanup_task);
     }
 
     /// Transitions one externally closed review session to `Canceled`.

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -5056,7 +5056,7 @@ async fn test_apply_review_request_status_update_closed_cancels_stacked_child() 
 }
 
 #[tokio::test]
-async fn test_apply_review_request_status_update_merged_marks_session_done() {
+async fn test_apply_review_request_status_update_merged_schedules_cleanup_once() {
     // Arrange
     let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
         Arc::new(MockTmuxClient::new()),
@@ -5084,27 +5084,63 @@ async fn test_apply_review_request_status_update_merged_marks_session_done() {
         .join(SESSION_DATA_DIR);
     fs::create_dir_all(session_data_dir).expect("failed to create session data dir");
     app.refresh_sessions_now().await;
+    let (cleanup_started_tx, mut cleanup_started_rx) = tokio::sync::mpsc::unbounded_channel();
+    let cleanup_release = Arc::new(tokio::sync::Notify::new());
+    let mut mock_git_client = ag_git::MockGitClient::new();
+    mock_git_client.expect_main_repo_root().times(1).returning({
+        let cleanup_release = Arc::clone(&cleanup_release);
 
-    let task_result = SyncReviewRequestTaskResult {
-        outcome: session::SyncReviewRequestOutcome::Merged {
-            display_id: "#9".to_string(),
-            session_head_hash: Some("abc1234".to_string()),
-        },
-        summary: Some(test_review_request_summary(
-            "#9",
-            ReviewRequestState::Merged,
-        )),
-    };
+        move |_| {
+            let cleanup_release = Arc::clone(&cleanup_release);
+            let cleanup_started_tx = cleanup_started_tx.clone();
 
-    let update = ReviewRequestStatusUpdate {
+            Box::pin(async move {
+                let _ = cleanup_started_tx.send(());
+                cleanup_release.notified().await;
+
+                Ok(PathBuf::from("/tmp/repo"))
+            })
+        }
+    });
+    mock_git_client
+        .expect_remove_worktree()
+        .times(1)
+        .returning(|_| Box::pin(async { Ok(()) }));
+    mock_git_client
+        .expect_delete_branch()
+        .times(1)
+        .returning(|_, _| Box::pin(async { Ok(()) }));
+    install_mock_git_client(&mut app, mock_git_client);
+
+    let merged_update = || ReviewRequestStatusUpdate {
         generation: 0,
-        result: Ok(task_result),
+        result: Ok(SyncReviewRequestTaskResult {
+            outcome: session::SyncReviewRequestOutcome::Merged {
+                display_id: "#9".to_string(),
+                session_head_hash: Some("abc1234".to_string()),
+            },
+            summary: Some(test_review_request_summary(
+                "#9",
+                ReviewRequestState::Merged,
+            )),
+        }),
         session_id: session_id.into(),
     };
 
     // Act
-    app.apply_review_request_status_update(update).await;
+    tokio::time::timeout(
+        Duration::from_millis(250),
+        app.apply_review_request_status_update(merged_update()),
+    )
+    .await
+    .expect("foreground status update should not wait for worktree cleanup");
     app.process_pending_app_events().await;
+    tokio::time::timeout(Duration::from_secs(1), cleanup_started_rx.recv())
+        .await
+        .expect("cleanup task should start")
+        .expect("cleanup task should report startup");
+    app.apply_review_request_status_update(merged_update())
+        .await;
 
     // Assert
     let session = app
@@ -5121,6 +5157,16 @@ async fn test_apply_review_request_status_update_merged_marks_session_done() {
         .expect("failed to load merged commit hash")
         .expect("expected persisted merged commit hash");
     assert_eq!(merged_commit_hash, "abc1234");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), cleanup_started_rx.recv())
+            .await
+            .is_err(),
+        "duplicate merged updates should not schedule another cleanup task"
+    );
+
+    // Cleanup
+    cleanup_release.notify_one();
+    app.services.wait_for_cleanup_tasks().await;
 }
 
 #[tokio::test]

--- a/crates/agentty/src/app/service.rs
+++ b/crates/agentty/src/app/service.rs
@@ -3,12 +3,14 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use ag_agent::AppServerClient;
 use ag_forge::ReviewRequestClient;
 use ag_git::GitClient;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
+use tokio::time::{self, Instant};
 use tracing::{debug, warn};
 
 use crate::app::AppEvent;
@@ -22,6 +24,9 @@ use crate::infra::review_comment_cache::ReviewCommentCache;
 
 /// Shared per-app session redraw version counters keyed by session id.
 pub(crate) type SessionUpdateVersionMap = Arc<Mutex<HashMap<SessionId, u64>>>;
+
+/// Maximum graceful-shutdown wait shared by all background cleanup tasks.
+const CLEANUP_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// External clients and cached machine-scoped availability injected into
 /// [`AppServices`].
@@ -184,28 +189,14 @@ impl AppServices {
     ///
     /// The task list is drained before awaiting so the synchronous mutex guard
     /// is never held across an `.await`. The loop repeats in case a cleanup
-    /// task registers additional cleanup work before it exits.
+    /// task registers additional cleanup work before it exits. All tasks share
+    /// one shutdown deadline; unfinished tasks are canceled after it expires.
     pub(crate) async fn wait_for_cleanup_tasks(&self) {
-        loop {
-            let cleanup_task_handles = self
-                .cleanup_task_handles
-                .lock()
-                .map(|mut task_handles| task_handles.drain(..).collect::<Vec<_>>())
-                .unwrap_or_default();
-
-            if cleanup_task_handles.is_empty() {
-                break;
-            }
-
-            for cleanup_task_handle in cleanup_task_handles {
-                if let Err(error) = cleanup_task_handle.await {
-                    warn!(
-                        error = %error,
-                        "background cleanup task failed during shutdown"
-                    );
-                }
-            }
-        }
+        wait_for_cleanup_task_handles(
+            self.cleanup_task_handles.as_ref(),
+            CLEANUP_TASK_SHUTDOWN_TIMEOUT,
+        )
+        .await;
     }
 
     /// Returns a clone of the app event sender.
@@ -246,6 +237,54 @@ impl AppServices {
     }
 }
 
+/// Waits for tracked cleanup tasks until one shared deadline, then cancels
+/// every unfinished task so terminal shutdown can continue.
+async fn wait_for_cleanup_task_handles(
+    cleanup_task_handles: &Mutex<Vec<JoinHandle<()>>>,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        let task_handles = cleanup_task_handles
+            .lock()
+            .map(|mut task_handles| task_handles.drain(..).collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        if task_handles.is_empty() {
+            break;
+        }
+
+        for mut task_handle in task_handles {
+            match time::timeout_at(deadline, &mut task_handle).await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    warn!(
+                        error = %error,
+                        "background cleanup task failed during shutdown"
+                    );
+                }
+                Err(_) => {
+                    task_handle.abort();
+                    warn!(
+                        timeout_seconds = timeout.as_secs(),
+                        "background cleanup task exceeded the shutdown deadline and was canceled"
+                    );
+
+                    if let Err(error) = task_handle.await
+                        && !error.is_cancelled()
+                    {
+                        warn!(
+                            error = %error,
+                            "background cleanup task failed while being canceled"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Returns a stable instrumentation label for one app event variant.
 fn app_event_label(event: &AppEvent) -> &'static str {
     match event {
@@ -282,5 +321,40 @@ fn app_event_label(event: &AppEvent) -> &'static str {
         AppEvent::PublishedBranchSyncUpdated { .. } => "PublishedBranchSyncUpdated",
         AppEvent::ReviewRequestStatusUpdated { .. } => "ReviewRequestStatusUpdated",
         AppEvent::ReviewCommentsUpdated { .. } => "ReviewCommentsUpdated",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn cleanup_task_wait_cancels_work_after_shared_deadline() {
+        // Arrange
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let task_handle = tokio::spawn(async move {
+            let _ = started_tx.send(());
+            future::pending::<()>().await;
+        });
+        let cleanup_task_handles = Mutex::new(vec![task_handle]);
+        started_rx.await.expect("cleanup task should start");
+
+        // Act
+        time::timeout(
+            Duration::from_secs(1),
+            wait_for_cleanup_task_handles(&cleanup_task_handles, Duration::from_millis(25)),
+        )
+        .await
+        .expect("cleanup wait should honor its shared deadline");
+
+        // Assert
+        assert!(
+            cleanup_task_handles
+                .lock()
+                .expect("cleanup task mutex should remain available")
+                .is_empty()
+        );
     }
 }

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -9,6 +9,7 @@
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Command;
+use std::time::Duration;
 
 use agentty::db::{DB_DIR, DB_FILE, Database};
 use agentty::domain::agent::ReasoningLevel;
@@ -1064,6 +1065,66 @@ esac
     )?;
     #[cfg(unix)]
     std::fs::set_permissions(&gh_path, std::fs::Permissions::from_mode(0o755))?;
+
+    Ok(())
+}
+
+/// Seeds a merged GitHub review response and delays runtime worktree removal
+/// so the feature scenario can prove terminal rendering stays responsive.
+fn seed_slow_merged_review_request_status(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    seed_review_ready_session_with_review_request(env)?;
+
+    let gh_path = env.stub_bin.join("gh");
+    std::fs::write(
+        &gh_path,
+        r#"#!/bin/sh
+case "$*" in
+  *"auth status"*)
+    exit 0
+    ;;
+  *"pr view"*)
+    printf '%s\n' '{"number":42,"title":"Review-ready session shortcuts","state":"MERGED","url":"https://github.com/agentty-xyz/agentty/pull/42","baseRefName":"main","headRefName":"wt/review-s","isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","mergedAt":"2026-01-01T00:00:00Z"}'
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 1
+    ;;
+esac
+"#,
+    )?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&gh_path, std::fs::Permissions::from_mode(0o755))?;
+
+    install_delayed_worktree_remove_stub(env, 4)
+}
+
+/// Installs a git wrapper that delays worktree removal while forwarding all
+/// other commands to the real executable.
+fn install_delayed_worktree_remove_stub(
+    env: &BuilderEnv,
+    delay_seconds: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let real_git = std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
+        .map(|path| path.join("git"))
+        .find(|path| path.is_file())
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "git not found"))?;
+    let real_git = real_git.to_string_lossy().replace('\'', "'\"'\"'");
+    let git_path = env.stub_bin.join("git");
+    std::fs::write(
+        &git_path,
+        format!(
+            r#"#!/bin/sh
+if [ "$1" = "worktree" ] && [ "$2" = "remove" ]; then
+  exec sleep {delay_seconds}
+fi
+exec '{real_git}' "$@"
+"#
+        ),
+    )?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&git_path, std::fs::Permissions::from_mode(0o755))?;
 
     Ok(())
 }
@@ -2950,6 +3011,72 @@ fn review_request_sync_runs_in_background() -> E2eResult {
                 );
             },
         )?;
+
+    Ok(())
+}
+
+/// Verify that externally merged status updates reach `Done` without waiting
+/// for slow worktree cleanup and the terminal remains navigable.
+#[test]
+fn test_merged_review_request_cleanup_responsive() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("merged_review_request_cleanup_responsive")
+        .with_git()
+        .setup(seed_slow_merged_review_request_status)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .wait_for_text("Done", 2500)
+                    .capture_labeled(
+                        "merged_status",
+                        "Merged session reaches Done before worktree cleanup finishes",
+                    )
+                    .press_key("Tab")
+                    .wait_for_text("Review Requests", 1000)
+                    .capture_labeled(
+                        "responsive_navigation",
+                        "Tab navigation remains responsive during worktree cleanup",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Review Requests", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that confirming quit does not wait indefinitely for externally
+/// merged worktree cleanup.
+#[test]
+fn merged_review_request_cleanup_does_not_block_quit() -> E2eResult {
+    // Arrange
+    let _test_guard = common::acquire_e2e_test_lock();
+    let temp = tempfile::TempDir::new()?;
+    let env = BuilderEnv::new(temp.path())?;
+    env.init_git()?;
+    seed_slow_merged_review_request_status(&env)?;
+    install_delayed_worktree_remove_stub(&env, 30)?;
+    let mut session = env.builder().spawn()?;
+    let scenario = Scenario::new("merged_cleanup_quit")
+        .compose(&common::wait_for_agentty_startup())
+        .compose(&common::switch_to_tab("Sessions"))
+        .wait_for_text("Done", 2500)
+        .compose(&common::open_quit_dialog())
+        .press_key("y");
+
+    // Act
+    scenario.execute_in_pty(&mut session)?;
+    let exited_successfully = session.wait_for_exit(Duration::from_secs(8))?;
+
+    // Assert
+    assert!(
+        exited_successfully,
+        "confirmed quit should cancel cleanup after the shutdown deadline"
+    );
 
     Ok(())
 }

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -345,7 +345,8 @@ their triggers:
 - **Project sync orchestrator** (startup, project switch, ticks, list-mode `s`): owns
   one command queue per active project that serializes read-only `git fetch`,
   ahead/behind snapshots, review-request refreshes, and manual pull/rebase/push
-  commands.
+  commands. Forge CLI calls are bounded to 30 seconds and cancel their subprocess on
+  timeout so one unavailable provider cannot retain the queue indefinitely.
 - **Version check** (startup): reports npm update availability.
 - **Per-session worker loop** (first command enqueue): serializes all turn commands per
   session and manages channel lifecycle.
@@ -404,8 +405,13 @@ orchestration paths:
   reused.
 - Background review-request sync: review-ready sessions with a published branch or
   linked request are polled; merged requests move the session to `Done`, closed requests
-  to `Canceled`. The Inbox tab loads comment snapshots on demand with generation-scoped
-  deduplication.
+  to `Canceled`. Externally merged worktree and branch cleanup runs as a tracked
+  background task after the terminal transition so input and redraws do not wait for git
+  or filesystem removal. Repeated merged results for an already-`Done` session do not
+  schedule cleanup again. Cleanup-critical git subprocesses are cancellable and bounded
+  to 30 seconds; confirmed shutdown shares a five-second grace period across all tracked
+  cleanup tasks before canceling unfinished work. The Inbox tab loads comment snapshots
+  on demand with generation-scoped deduplication.
 - Assigned-issue refresh: the Issues tab resolves the active project remote and runs a
   repository-scoped, generation-scoped `gh search issues` task through
   `ReviewRequestClient`; stale completions are discarded before the list cache is


### PR DESCRIPTION
- Bounds forge CLI and cleanup-critical git subprocesses to 30 seconds and cancels timed-out processes.
- Runs externally merged session cleanup as tracked background work, avoids duplicate cleanup, and limits shutdown waiting to a five-second grace period before canceling unfinished tasks.
- Adds unit and E2E coverage for timeout handling, responsive navigation, and quit behavior.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)