### PR TITLE
Use typed transient slots for session output

### DIFF
--- a/crates/agentty/src/app.rs
+++ b/crates/agentty/src/app.rs
@@ -36,10 +36,9 @@ pub(crate) use assigned_issue::AssignedIssueState;
 pub use error::AppError;
 pub use project::ProjectManager;
 pub(crate) use requested_review::RequestedReviewState;
-pub(crate) use review::{
-    ReviewCacheEntry, diff_content_hash, is_review_loading_status_message, review_loading_message,
-    review_view_state,
-};
+#[cfg(test)]
+pub(crate) use review::review_loading_message;
+pub(crate) use review::{ReviewCacheEntry, diff_content_hash};
 #[cfg(test)]
 pub(crate) use service::AppServiceDeps;
 pub use service::AppServices;

--- a/crates/agentty/src/app/core/draw.rs
+++ b/crates/agentty/src/app/core/draw.rs
@@ -2,7 +2,8 @@
 
 use super::state::{App, UpdateStatus};
 use crate::app::tab::Tab;
-use crate::domain::session::{PublishedBranchSyncStatus, Session, Status};
+use crate::domain::session::{Session, Status};
+use crate::domain::transient_message::TransientMessageSlot;
 use crate::presentation::app_mode::{AppMode, ConfirmationViewMode, HelpContext};
 
 impl App {
@@ -129,6 +130,9 @@ impl App {
                 session.status,
                 Status::AgentReview | Status::InProgress | Status::Merging | Status::Rebasing
             )
-            || session.published_branch_sync_status == PublishedBranchSyncStatus::InProgress
+            || session
+                .transient_messages
+                .get(TransientMessageSlot::PublishedBranchSync)
+                .is_some()
     }
 }

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -24,7 +24,7 @@ use super::state::{
     UpdateStatus,
 };
 use crate::app::session::{
-    StatusTransition, SyncMainOutcome, SyncSessionStartError, TurnAppliedState,
+    SessionTaskService, StatusTransition, SyncMainOutcome, SyncSessionStartError, TurnAppliedState,
 };
 use crate::app::session_state::SessionGitStatus;
 use crate::app::{self, sync_message};
@@ -196,6 +196,9 @@ pub(crate) enum AppEvent {
     /// Indicates that one published session branch started or finished a
     /// background auto-push after a completed turn.
     PublishedBranchSyncUpdated {
+        /// Durable transcript notice promoted into place for a terminal
+        /// operation, or `None` for progress-only updates.
+        persistent_notice: Option<String>,
         session_id: SessionId,
         sync_operation_id: String,
         sync_status: PublishedBranchSyncStatus,
@@ -289,6 +292,8 @@ pub(super) struct LatestAvailableVersionUpdate {
 
 /// One ordered published-branch sync update queued for one session.
 pub(super) struct PublishedBranchSyncUpdate {
+    /// Durable notice promoted while retracting the matching loading slot.
+    persistent_notice: Option<String>,
     /// Operation identifier used to ignore stale terminal auto-push updates.
     sync_operation_id: String,
     /// Auto-push state carried by this update.
@@ -450,6 +455,7 @@ impl AppEventBatch {
                 self.collect_session_workflow_notice_updated(session_id, notice);
             }
             AppEvent::PublishedBranchSyncUpdated {
+                persistent_notice,
                 session_id,
                 sync_operation_id,
                 sync_status,
@@ -457,6 +463,7 @@ impl AppEventBatch {
                 session_id,
                 sync_operation_id,
                 sync_status,
+                persistent_notice,
             ),
             AppEvent::ReviewRequestStatusUpdated {
                 generation,
@@ -702,6 +709,7 @@ impl AppEventBatch {
         session_id: SessionId,
         sync_operation_id: String,
         sync_status: PublishedBranchSyncStatus,
+        persistent_notice: Option<String>,
     ) {
         if matches!(
             sync_status,
@@ -710,9 +718,11 @@ impl AppEventBatch {
             self.should_refresh_git_status = true;
         }
 
+        self.session_ids.insert(session_id.clone());
         self.published_branch_sync_updates.push((
             session_id,
             PublishedBranchSyncUpdate {
+                persistent_notice,
                 sync_operation_id,
                 sync_status,
             },
@@ -878,7 +888,8 @@ impl App {
             self.apply_agent_response_received(&session_id, &turn_applied_state);
         }
         for (session_id, sync_update) in event_batch.published_branch_sync_updates {
-            self.apply_published_branch_sync_update(&session_id, sync_update);
+            self.apply_published_branch_sync_update(&session_id, sync_update)
+                .await;
         }
 
         if let Some(conflicted_files) = event_batch.sync_main_conflicted_files.as_deref() {
@@ -913,6 +924,7 @@ impl App {
             self.settings.default_review_selection,
         )
         .await;
+        app::review::hydrate_review_transients(&self.review_cache, self.sessions.state_mut());
 
         if let Some(sync_main_result) = event_batch.sync_main_result {
             let sync_popup_context = self.sync_popup_context();
@@ -1485,12 +1497,13 @@ impl App {
 
     /// Routes one published-branch auto-push update to the matching in-memory
     /// session snapshot.
-    fn apply_published_branch_sync_update(
+    async fn apply_published_branch_sync_update(
         &mut self,
         session_id: &str,
         sync_update: PublishedBranchSyncUpdate,
     ) {
         let PublishedBranchSyncUpdate {
+            persistent_notice,
             sync_operation_id,
             sync_status,
         } = sync_update;
@@ -1503,11 +1516,19 @@ impl App {
             PublishedBranchSyncStatus::Idle
             | PublishedBranchSyncStatus::Succeeded
             | PublishedBranchSyncStatus::Failed => {
-                self.sessions.finish_published_branch_sync(
+                let was_applied = self.sessions.finish_published_branch_sync(
                     session_id,
                     &sync_operation_id,
-                    sync_status,
+                    persistent_notice.as_deref(),
                 );
+                if was_applied && let Some(persistent_notice) = persistent_notice {
+                    SessionTaskService::persist_workflow_notice(
+                        self.services.db(),
+                        session_id,
+                        &persistent_notice,
+                    )
+                    .await;
+                }
             }
         }
     }

--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -143,7 +143,7 @@ impl App {
             AgentKind::Antigravity.default_model(),
         )
         .await;
-        let sessions = Self::load_and_restack_startup_sessions(
+        let mut sessions = Self::load_and_restack_startup_sessions(
             &services,
             active_project_id,
             default_session_model,
@@ -151,6 +151,7 @@ impl App {
         )
         .await;
         let review_cache = Self::load_focused_review_cache(&repositories, active_project_id).await;
+        review::hydrate_review_transients(&review_cache, sessions.state_mut());
 
         let sync_context = Self::sync_context_for(&projects, &services, &sessions);
         let sync_handle = sync::SyncHandle::spawn(event_tx.clone(), sync_context);

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -20,7 +20,7 @@ use app::branch_publish::{BranchPublishTaskSession, run_branch_publish_action};
 use app::merge_queue::{MergeQueue, MergeQueueProgress};
 use app::project::ProjectManager;
 use app::review::{
-    ReviewCacheEntry, cancel_pending_review, mark_session_agent_review, review_view_state,
+    ReviewCacheEntry, mark_session_agent_review, review_loading_message, review_view_text,
     start_review_assist as spawn_review_assist,
 };
 use app::service::AppServices;
@@ -50,6 +50,10 @@ use crate::domain::session::{FollowUpTaskAction, PublishBranchAction, Session, S
 use crate::domain::session_message::SessionTranscript;
 use crate::domain::setting::SettingName;
 use crate::domain::transcript_notice::TranscriptNotice;
+use crate::domain::transient_message::{
+    TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
+    TransientMessageSlot,
+};
 use crate::domain::turn_prompt::TurnPrompt;
 #[cfg(test)]
 use crate::infra::db;
@@ -940,7 +944,7 @@ impl App {
         session_id: &str,
         prompt: impl Into<TurnPrompt>,
     ) -> Result<(), AppError> {
-        self.review_cache.remove(session_id);
+        self.clear_review_output(session_id);
         self.services
             .db()
             .sessions()
@@ -978,7 +982,7 @@ impl App {
     /// Returns an error if the session is missing, has no staged drafts, or
     /// stack consistency or launch enqueueing fails.
     pub async fn start_staged_session(&mut self, session_id: &str) -> Result<(), AppError> {
-        self.review_cache.remove(session_id);
+        self.clear_review_output(session_id);
         self.services
             .db()
             .sessions()
@@ -998,7 +1002,7 @@ impl App {
     /// submission. Returns `true` when the reply command was enqueued on the
     /// session worker.
     pub async fn reply(&mut self, session_id: &str, prompt: impl Into<TurnPrompt>) -> bool {
-        self.review_cache.remove(session_id);
+        self.clear_review_output(session_id);
         let _ = self
             .services
             .db()
@@ -1035,11 +1039,77 @@ impl App {
     /// Returns the focused-review output state that should be shown when one
     /// session view is reopened.
     pub(crate) fn review_view_state(&self, session_id: &str) -> (Option<String>, Option<&str>) {
-        review_view_state(
-            &self.review_cache,
-            session_id,
-            self.settings.default_review_selection.model(),
+        let status_message = match self.review_cache.get(session_id) {
+            Some(ReviewCacheEntry::Loading { .. }) => Some(review_loading_message(
+                self.settings.default_review_selection.model(),
+            )),
+            Some(ReviewCacheEntry::Failed { error, .. }) => {
+                Some(format!("Review assist unavailable: {}", error.trim()))
+            }
+            Some(ReviewCacheEntry::Ready { .. } | ReviewCacheEntry::Suppressed) | None => None,
+        };
+
+        (
+            status_message,
+            review_view_text(&self.review_cache, session_id),
         )
+    }
+
+    /// Returns whether focused-review generation is already running for one
+    /// session without inspecting user-visible status copy.
+    pub(crate) fn review_is_loading(&self, session_id: &str) -> bool {
+        matches!(
+            self.review_cache.get(session_id),
+            Some(ReviewCacheEntry::Loading { .. })
+        )
+    }
+
+    /// Clears cached focused-review state and retracts its display slot.
+    pub(crate) fn clear_review_output(&mut self, session_id: &str) {
+        self.review_cache.remove(session_id);
+        if let Some(session) = self.sessions.state_mut().session_mut_for_id(session_id) {
+            session
+                .transient_messages
+                .retract(TransientMessageSlot::Review);
+        }
+    }
+
+    /// Stores completed focused-review text and posts it to the stable review
+    /// display slot.
+    pub(crate) fn set_review_ready_output(
+        &mut self,
+        session_id: &str,
+        diff_hash: u64,
+        text: String,
+    ) {
+        self.review_cache.insert(
+            SessionId::from(session_id),
+            ReviewCacheEntry::Ready {
+                diff_hash,
+                text: text.clone(),
+            },
+        );
+        if let Some(session) = self.sessions.state_mut().session_mut_for_id(session_id) {
+            session.transient_messages.upsert(TransientMessage {
+                anchor: TransientMessageAnchor::AfterCompletedTurn,
+                body: TransientMessageBody::Markdown(text),
+                lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+                slot: TransientMessageSlot::Review,
+                turn_position: session.latest_user_prompt_position(),
+            });
+        }
+    }
+
+    /// Suppresses automatic focused review and removes any previous review
+    /// display slot for the stopped turn.
+    pub(crate) fn suppress_review_output(&mut self, session_id: &str) {
+        self.review_cache
+            .insert(SessionId::from(session_id), ReviewCacheEntry::Suppressed);
+        if let Some(session) = self.sessions.state_mut().session_mut_for_id(session_id) {
+            session
+                .transient_messages
+                .retract(TransientMessageSlot::Review);
+        }
     }
 
     /// Persists and applies an agent/model selection for a session.
@@ -1398,7 +1468,7 @@ impl App {
                 .sessions()
                 .update_session_focused_review(session_id, None, None)
                 .await?;
-            cancel_pending_review(&mut self.review_cache, session_id);
+            self.clear_review_output(session_id);
         }
 
         self.sessions
@@ -1447,6 +1517,10 @@ impl App {
         diff_hash: u64,
         review_diff: &str,
     ) {
+        self.review_cache.insert(
+            SessionId::from(session_id),
+            ReviewCacheEntry::Loading { diff_hash },
+        );
         let session_chat_history = self
             .sessions
             .session_handles()
@@ -1467,6 +1541,17 @@ impl App {
             });
 
         mark_session_agent_review(self.sessions.state_mut(), session_id);
+        if let Some(session) = self.sessions.state_mut().session_mut_for_id(session_id) {
+            session.transient_messages.upsert(TransientMessage {
+                anchor: TransientMessageAnchor::Tail,
+                body: TransientMessageBody::Loading(review_loading_message(
+                    self.settings.default_review_selection.model(),
+                )),
+                lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+                slot: TransientMessageSlot::Review,
+                turn_position: session.latest_user_prompt_position(),
+            });
+        }
 
         spawn_review_assist(
             self.services.event_sender(),

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -2446,7 +2446,10 @@ async fn apply_app_events_session_workflow_notice_updates_session_state() {
         .find(|session| session.id == "session-1")
         .expect("session should exist");
     assert_eq!(
-        session.workflow_notice.as_deref(),
+        session
+            .transient_messages
+            .get(crate::domain::transient_message::TransientMessageSlot::WorkflowNotice)
+            .map(|message| message.body.text()),
         Some(
             "[Commit] No changes to commit.\n\n[Merge] Successfully merged wt/session-1 into main"
         )
@@ -3219,18 +3222,21 @@ async fn apply_app_events_ignores_stale_published_branch_sync_updates() {
 
     // Act
     app.apply_app_events(AppEvent::PublishedBranchSyncUpdated {
+        persistent_notice: None,
         session_id: "session-1".into(),
         sync_operation_id: "sync-1".to_string(),
         sync_status: PublishedBranchSyncStatus::InProgress,
     })
     .await;
     app.apply_app_events(AppEvent::PublishedBranchSyncUpdated {
+        persistent_notice: None,
         session_id: "session-1".into(),
         sync_operation_id: "sync-2".to_string(),
         sync_status: PublishedBranchSyncStatus::InProgress,
     })
     .await;
     app.apply_app_events(AppEvent::PublishedBranchSyncUpdated {
+        persistent_notice: Some("[Branch Push Error] stale failure".to_string()),
         session_id: "session-1".into(),
         sync_operation_id: "sync-1".to_string(),
         sync_status: PublishedBranchSyncStatus::Failed,
@@ -3239,8 +3245,17 @@ async fn apply_app_events_ignores_stale_published_branch_sync_updates() {
 
     // Assert
     assert_eq!(
-        app.sessions.sessions()[0].published_branch_sync_status,
-        PublishedBranchSyncStatus::InProgress
+        app.sessions.sessions()[0]
+            .transient_messages
+            .get(crate::domain::transient_message::TransientMessageSlot::PublishedBranchSync)
+            .map(|message| message.body.text()),
+        Some("Auto-pushing published branch after completed turn...")
+    );
+    assert!(
+        app.sessions.sessions()[0]
+            .transcript
+            .as_ref()
+            .is_none_or(|transcript| transcript.messages().is_empty())
     );
 }
 
@@ -3261,6 +3276,9 @@ async fn apply_app_events_preserves_completed_published_branch_sync_updates() {
 
     event_sender
         .send(AppEvent::PublishedBranchSyncUpdated {
+            persistent_notice: Some(
+                "[Branch Push] Auto-pushed published branch after completed turn.".to_string(),
+            ),
             session_id: "session-1".into(),
             sync_operation_id: "sync-1".to_string(),
             sync_status: PublishedBranchSyncStatus::Succeeded,
@@ -3269,6 +3287,7 @@ async fn apply_app_events_preserves_completed_published_branch_sync_updates() {
 
     // Act
     app.apply_app_events(AppEvent::PublishedBranchSyncUpdated {
+        persistent_notice: None,
         session_id: "session-1".into(),
         sync_operation_id: "sync-1".to_string(),
         sync_status: PublishedBranchSyncStatus::InProgress,
@@ -3276,9 +3295,25 @@ async fn apply_app_events_preserves_completed_published_branch_sync_updates() {
     .await;
 
     // Assert
+    let session = &app.sessions.sessions()[0];
+    assert!(
+        session
+            .transient_messages
+            .get(crate::domain::transient_message::TransientMessageSlot::PublishedBranchSync)
+            .is_none()
+    );
     assert_eq!(
-        app.sessions.sessions()[0].published_branch_sync_status,
-        PublishedBranchSyncStatus::Succeeded
+        session
+            .transcript
+            .as_ref()
+            .expect("promoted notice should update transcript")
+            .messages()
+            .iter()
+            .filter(|message| {
+                message.kind == crate::domain::session_message::SessionMessageKind::WorkflowNotice
+            })
+            .count(),
+        1
     );
 }
 
@@ -4622,13 +4657,7 @@ async fn auto_start_reviews_clears_cache_on_in_progress_transition() {
             PathBuf::from("/tmp/session-cache-clear"),
         ));
     app.sessions.sessions_mut()[0].status = Status::InProgress;
-    app.review_cache.insert(
-        session_id.to_string().into(),
-        ReviewCacheEntry::Ready {
-            diff_hash: 789,
-            text: "old review".to_string(),
-        },
-    );
+    app.set_review_ready_output(session_id, 789, "old review".to_string());
     let session_ids = HashSet::from([session_id.into()]);
 
     // Act
@@ -4636,6 +4665,12 @@ async fn auto_start_reviews_clears_cache_on_in_progress_transition() {
 
     // Assert
     assert!(!app.review_cache.contains_key(session_id));
+    assert!(
+        app.sessions.sessions()[0]
+            .transient_messages
+            .messages()
+            .is_empty()
+    );
 }
 
 #[tokio::test]
@@ -4735,18 +4770,12 @@ async fn auto_start_reviews_skips_when_auto_review_is_suppressed() {
         ));
     app.sessions.sessions_mut()[0].status = Status::Review;
 
-    let diff_text = "diff --git a/file.rs b/file.rs\n+stopped turn";
-    let hash = diff_content_hash(diff_text);
-    app.review_cache.insert(
-        session_id.to_string().into(),
-        ReviewCacheEntry::Suppressed { diff_hash: hash },
-    );
+    app.review_cache
+        .insert(session_id.to_string().into(), ReviewCacheEntry::Suppressed);
     let session_ids = HashSet::from([session_id.into()]);
 
     let mut mock_git_client = ag_git::MockGitClient::new();
-    mock_git_client
-        .expect_diff()
-        .returning(move |_, _| Box::pin(async move { Ok(diff_text.to_string()) }));
+    mock_git_client.expect_diff().times(0);
     install_mock_git_client(&mut app, mock_git_client);
 
     // Act
@@ -4755,7 +4784,7 @@ async fn auto_start_reviews_skips_when_auto_review_is_suppressed() {
     // Assert
     assert!(matches!(
         app.review_cache.get(session_id),
-        Some(ReviewCacheEntry::Suppressed { diff_hash }) if *diff_hash == hash
+        Some(ReviewCacheEntry::Suppressed)
     ));
     assert_eq!(app.sessions.sessions()[0].status, Status::Review);
 }

--- a/crates/agentty/src/app/prompt_intent.rs
+++ b/crates/agentty/src/app/prompt_intent.rs
@@ -555,7 +555,7 @@ impl App {
         let current_hash = diff_content_hash(&current_diff);
 
         if current_hash != cached_hash {
-            self.review_cache.remove(context.session_id.as_str());
+            self.clear_review_output(context.session_id.as_str());
             self.append_prompt_status_line(
                 &context.session_id,
                 TranscriptNotice::Apply,
@@ -581,7 +581,6 @@ impl App {
         let prompt = build_apply_review_prompt(&suggestions);
 
         self.cleanup_prompt_attachment_state().await;
-        self.review_cache.remove(context.session_id.as_str());
         self.reply(&context.session_id, prompt).await;
 
         self.mode = AppMode::View {

--- a/crates/agentty/src/app/review.rs
+++ b/crates/agentty/src/app/review.rs
@@ -13,6 +13,10 @@ use crate::app::session_state::SessionState;
 use crate::domain::agent::{AgentModel, AgentSelection};
 use crate::domain::session::{SessionId, Status};
 use crate::domain::session_message::SessionTranscript;
+use crate::domain::transient_message::{
+    TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
+    TransientMessageSlot,
+};
 use crate::infra::db::SessionFocusedReviewRow;
 
 /// Cached focused review state for a session.
@@ -37,23 +41,21 @@ pub(crate) enum ReviewCacheEntry {
         /// Human-readable error description.
         error: String,
     },
-    /// Automatic focused review is intentionally suppressed for this diff.
+    /// Automatic focused review is intentionally suppressed for the current
+    /// stopped turn.
     ///
     /// Manual focused review can still replace this entry with `Loading`.
-    Suppressed {
-        /// Hash of the diff text that should not auto-start review assist.
-        diff_hash: u64,
-    },
+    Suppressed,
 }
 
 impl ReviewCacheEntry {
-    /// Returns the diff content hash stored in any variant.
-    pub(crate) fn diff_hash(&self) -> u64 {
+    /// Returns the diff content hash stored by generated review states.
+    pub(crate) fn diff_hash(&self) -> Option<u64> {
         match self {
             Self::Loading { diff_hash }
             | Self::Ready { diff_hash, .. }
-            | Self::Failed { diff_hash, .. }
-            | Self::Suppressed { diff_hash } => *diff_hash,
+            | Self::Failed { diff_hash, .. } => Some(*diff_hash),
+            Self::Suppressed => None,
         }
     }
 
@@ -108,35 +110,54 @@ pub(crate) fn diff_content_hash(diff: &str) -> u64 {
     })
 }
 
-/// Returns whether one status line represents an in-flight focused review.
-pub(crate) fn is_review_loading_status_message(status_message: &str) -> bool {
-    status_message.starts_with(REVIEW_LOADING_MESSAGE_PREFIX)
-}
-
 /// Formats the focused-review loading status with the active model name.
 pub(crate) fn review_loading_message(review_model: AgentModel) -> String {
     format!("{REVIEW_LOADING_MESSAGE_PREFIX} {}", review_model.as_str())
 }
 
-/// Returns the focused-review render state that should be restored for one
-/// session when reopening session view.
-pub(crate) fn review_view_state<'a>(
+/// Returns focused-review markdown available to prompt actions for one
+/// session.
+pub(crate) fn review_view_text<'a>(
     review_cache: &'a HashMap<SessionId, ReviewCacheEntry>,
     session_id: &str,
-    review_model: AgentModel,
-) -> (Option<String>, Option<&'a str>) {
-    let Some(cache_entry) = review_cache.get(session_id) else {
-        return (None, None);
-    };
+) -> Option<&'a str> {
+    let cache_entry = review_cache.get(session_id)?;
 
     match cache_entry {
-        ReviewCacheEntry::Loading { .. } => (Some(review_loading_message(review_model)), None),
-        ReviewCacheEntry::Ready { text, .. } => (None, Some(text.as_str())),
-        ReviewCacheEntry::Failed { error, .. } => (
-            Some(format!("Review assist unavailable: {}", error.trim())),
-            None,
-        ),
-        ReviewCacheEntry::Suppressed { .. } => (None, None),
+        ReviewCacheEntry::Ready { text, .. } => Some(text.as_str()),
+        ReviewCacheEntry::Loading { .. }
+        | ReviewCacheEntry::Failed { .. }
+        | ReviewCacheEntry::Suppressed => None,
+    }
+}
+
+/// Rehydrates persisted focused-review markdown into explicit display slots.
+pub(crate) fn hydrate_review_transients(
+    review_cache: &HashMap<SessionId, ReviewCacheEntry>,
+    session_state: &mut SessionState,
+) {
+    for session in session_state.sessions_mut() {
+        if !matches!(
+            session.status,
+            Status::Review | Status::Question | Status::AgentReview
+        ) {
+            session
+                .transient_messages
+                .retract(TransientMessageSlot::Review);
+
+            continue;
+        }
+        let Some(ReviewCacheEntry::Ready { text, .. }) = review_cache.get(&session.id) else {
+            continue;
+        };
+
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::AfterCompletedTurn,
+            body: TransientMessageBody::Markdown(text.clone()),
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::Review,
+            turn_position: session.latest_user_prompt_position(),
+        });
     }
 }
 
@@ -158,24 +179,6 @@ pub(crate) fn review_cache_from_rows(
             ))
         })
         .collect()
-}
-
-/// Cancels an in-flight focused review for a session so a later stale
-/// review-assist result is ignored.
-///
-/// Returns `true` when a loading review was removed, letting callers clear any
-/// matching persisted review state from durable storage.
-pub(crate) fn cancel_pending_review(
-    review_cache: &mut HashMap<SessionId, ReviewCacheEntry>,
-    session_id: &str,
-) -> bool {
-    let Some(ReviewCacheEntry::Loading { .. }) = review_cache.get(session_id) else {
-        return false;
-    };
-
-    review_cache.remove(session_id);
-
-    true
 }
 
 /// Spawns one focused review-assist task for the provided session diff.
@@ -250,74 +253,100 @@ pub(crate) async fn auto_start_reviews(
     review_selection: AgentSelection,
 ) {
     for session_id in session_ids {
-        let Some(session) = session_state
-            .sessions()
-            .iter()
-            .find(|session| session.id == *session_id)
-        else {
-            continue;
-        };
-        let current_status = session.status;
-
-        if current_status == Status::InProgress {
-            review_cache.remove(session_id);
-
-            continue;
-        }
-
-        if current_status != Status::Review {
-            continue;
-        }
-
-        if matches!(
-            review_cache.get(session_id),
-            Some(ReviewCacheEntry::Suppressed { .. })
-        ) {
-            continue;
-        }
-
-        let base_branch = session.base_branch.clone();
-        let session_chat_history = session
-            .transcript
-            .as_ref()
-            .and_then(SessionTranscript::conversation_replay_text);
-        let session_folder = session.folder.clone();
-
-        let diff = git_client
-            .diff(session_folder.clone(), base_branch)
-            .await
-            .unwrap_or_default();
-
-        if diff.trim().is_empty() || diff.starts_with("Failed to run git diff:") {
-            continue;
-        }
-
-        let new_hash = diff_content_hash(&diff);
-
-        if review_cache
-            .get(session_id)
-            .is_some_and(|entry| entry.diff_hash() == new_hash)
-        {
-            continue;
-        }
-
-        review_cache.insert(
-            session_id.clone(),
-            ReviewCacheEntry::Loading {
-                diff_hash: new_hash,
-            },
-        );
-        mark_session_agent_review(session_state, session_id);
-        start_review_assist(
-            app_event_tx.clone(),
+        auto_start_review_for_session(
+            review_cache,
+            session_state,
+            git_client.as_ref(),
+            &app_event_tx,
             review_selection,
             session_id,
-            &session_folder,
-            new_hash,
-            &diff,
-            session_chat_history.as_deref(),
-        );
+        )
+        .await;
     }
+}
+
+/// Starts focused review generation for one eligible session snapshot.
+async fn auto_start_review_for_session(
+    review_cache: &mut HashMap<SessionId, ReviewCacheEntry>,
+    session_state: &mut SessionState,
+    git_client: &dyn GitClient,
+    app_event_tx: &mpsc::UnboundedSender<AppEvent>,
+    review_selection: AgentSelection,
+    session_id: &SessionId,
+) {
+    let Some(session) = session_state.session_for_id(session_id) else {
+        return;
+    };
+    let current_status = session.status;
+
+    if current_status == Status::InProgress {
+        review_cache.remove(session_id);
+        if let Some(session) = session_state.session_mut_for_id(session_id) {
+            session
+                .transient_messages
+                .retract(TransientMessageSlot::Review);
+        }
+
+        return;
+    }
+
+    if current_status != Status::Review
+        || matches!(
+            review_cache.get(session_id),
+            Some(ReviewCacheEntry::Suppressed)
+        )
+    {
+        return;
+    }
+
+    let base_branch = session.base_branch.clone();
+    let session_chat_history = session
+        .transcript
+        .as_ref()
+        .and_then(SessionTranscript::conversation_replay_text);
+    let session_folder = session.folder.clone();
+    let diff = git_client
+        .diff(session_folder.clone(), base_branch)
+        .await
+        .unwrap_or_default();
+
+    if diff.trim().is_empty() || diff.starts_with("Failed to run git diff:") {
+        return;
+    }
+
+    let new_hash = diff_content_hash(&diff);
+    if review_cache
+        .get(session_id)
+        .is_some_and(|entry| entry.diff_hash() == Some(new_hash))
+    {
+        return;
+    }
+
+    review_cache.insert(
+        session_id.clone(),
+        ReviewCacheEntry::Loading {
+            diff_hash: new_hash,
+        },
+    );
+    mark_session_agent_review(session_state, session_id);
+    if let Some(session) = session_state.session_mut_for_id(session_id) {
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading(review_loading_message(review_selection.model())),
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::Review,
+            turn_position: session.latest_user_prompt_position(),
+        });
+    }
+    start_review_assist(
+        app_event_tx.clone(),
+        review_selection,
+        session_id,
+        &session_folder,
+        new_hash,
+        &diff,
+        session_chat_history.as_deref(),
+    );
 }
 
 /// Applies one review assist update to cache and session review status.
@@ -331,7 +360,7 @@ fn apply_review_update(
     let cache_entry = review_cache.get(session_id)?;
 
     if !matches!(cache_entry, ReviewCacheEntry::Loading { .. })
-        || cache_entry.diff_hash() != diff_hash
+        || cache_entry.diff_hash() != Some(diff_hash)
     {
         return None;
     }
@@ -345,6 +374,25 @@ fn apply_review_update(
         SessionId::from(session_id),
         ReviewCacheEntry::from_result(diff_hash, &result),
     );
+    if let Some(session) = session_state
+        .sessions_mut()
+        .iter_mut()
+        .find(|session| session.id == session_id)
+    {
+        let body = match &result {
+            Ok(review_text) => TransientMessageBody::Markdown(review_text.clone()),
+            Err(error) => {
+                TransientMessageBody::Plain(format!("Review assist unavailable: {}", error.trim()))
+            }
+        };
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::AfterCompletedTurn,
+            body,
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::Review,
+            turn_position: session.latest_user_prompt_position(),
+        });
+    }
     restore_session_review_status(session_state, session_id);
 
     Some(persistence_update)
@@ -395,6 +443,7 @@ mod tests {
     use crate::app::session_state::SessionState;
     use crate::domain::selection::SelectionState;
     use crate::infra::clock::RealClock;
+    use crate::test_support::SessionFixtureBuilder;
 
     /// Builds empty session state for review reducer tests that only need mode
     /// field updates.
@@ -445,19 +494,7 @@ mod tests {
     }
 
     #[test]
-    fn is_review_loading_status_message_matches_model_aware_copy() {
-        // Arrange
-        let status_message = review_loading_message(AgentModel::ClaudeOpus48);
-
-        // Act
-        let is_loading = is_review_loading_status_message(&status_message);
-
-        // Assert
-        assert!(is_loading);
-    }
-
-    #[test]
-    fn review_view_state_uses_loading_message_for_cached_review_generation() {
+    fn review_view_text_hides_cached_review_generation() {
         // Arrange
         let mut review_cache = HashMap::new();
         review_cache.insert(
@@ -466,32 +503,22 @@ mod tests {
         );
 
         // Act
-        let (review_status_message, review_text) =
-            review_view_state(&review_cache, "session-id", AgentModel::ClaudeSonnet5);
+        let review_text = review_view_text(&review_cache, "session-id");
 
         // Assert
-        assert_eq!(
-            review_status_message.as_deref(),
-            Some("Reviewing changes with claude-sonnet-5")
-        );
         assert_eq!(review_text, None);
     }
 
     #[test]
-    fn review_view_state_hides_suppressed_auto_review() {
+    fn review_view_text_hides_suppressed_auto_review() {
         // Arrange
         let mut review_cache = HashMap::new();
-        review_cache.insert(
-            "session-id".into(),
-            ReviewCacheEntry::Suppressed { diff_hash: 7 },
-        );
+        review_cache.insert("session-id".into(), ReviewCacheEntry::Suppressed);
 
         // Act
-        let (review_status_message, review_text) =
-            review_view_state(&review_cache, "session-id", AgentModel::ClaudeSonnet5);
+        let review_text = review_view_text(&review_cache, "session-id");
 
         // Assert
-        assert_eq!(review_status_message, None);
         assert_eq!(review_text, None);
     }
 
@@ -513,6 +540,49 @@ mod tests {
             Some(ReviewCacheEntry::Ready { diff_hash: 42, text })
                 if text == "## Review\nPersisted finding."
         ));
+    }
+
+    #[test]
+    fn hydrate_review_transients_retracts_terminal_session_review() {
+        // Arrange
+        let session_id = SessionId::from("session-id");
+        let mut session = SessionFixtureBuilder::new()
+            .id(session_id.as_str())
+            .status(Status::Done)
+            .build();
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::AfterCompletedTurn,
+            body: TransientMessageBody::Markdown("stale review".to_string()),
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::Review,
+            turn_position: None,
+        });
+        let review_cache = HashMap::from([(
+            session_id,
+            ReviewCacheEntry::Ready {
+                diff_hash: 42,
+                text: "persisted review".to_string(),
+            },
+        )]);
+        let mut session_state = SessionState::new(
+            HashMap::new(),
+            vec![session],
+            SelectionState::default(),
+            Arc::new(RealClock),
+            0,
+            0,
+        );
+
+        // Act
+        hydrate_review_transients(&review_cache, &mut session_state);
+
+        // Assert
+        assert!(
+            session_state.sessions()[0]
+                .transient_messages
+                .get(TransientMessageSlot::Review)
+                .is_none()
+        );
     }
 
     #[test]
@@ -595,10 +665,7 @@ mod tests {
         // Arrange
         let session_id = SessionId::from("session-suppressed-review");
         let diff_hash = 23;
-        let mut review_cache = HashMap::from([(
-            session_id.clone(),
-            ReviewCacheEntry::Suppressed { diff_hash },
-        )]);
+        let mut review_cache = HashMap::from([(session_id.clone(), ReviewCacheEntry::Suppressed)]);
         let mut session_state = empty_session_state();
         let review_updates =
             successful_review_update(&session_id, diff_hash, "## Review\nShould not be rendered.");
@@ -609,8 +676,7 @@ mod tests {
         // Assert
         assert!(matches!(
             review_cache.get(session_id.as_str()),
-            Some(ReviewCacheEntry::Suppressed { diff_hash: cached_hash })
-                if *cached_hash == diff_hash
+            Some(ReviewCacheEntry::Suppressed)
         ));
     }
 }

--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -22,10 +22,15 @@ use crate::domain::agent::{AgentModel, ReasoningLevel};
 use crate::domain::file_entry::FileEntry;
 use crate::domain::question::QuestionItem;
 use crate::domain::session::{
-    DailyActivity, FollowUpTaskAction, PublishedBranchSyncStatus, ReviewRequest, Session,
-    SessionFollowUpTask, SessionId, SessionStats,
+    DailyActivity, FollowUpTaskAction, ReviewRequest, Session, SessionFollowUpTask, SessionId,
+    SessionStats,
 };
+use crate::domain::session_message::SessionMessageKind;
 use crate::domain::transcript_notice::TranscriptNotice;
+use crate::domain::transient_message::{
+    TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
+    TransientMessageSlot,
+};
 
 /// Low-frequency fallback interval for metadata-based session refresh.
 pub(crate) const SESSION_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
@@ -453,7 +458,15 @@ impl SessionManager {
             .iter_mut()
             .find(|session| session.id == session_id)
         {
-            session.published_branch_sync_status = PublishedBranchSyncStatus::InProgress;
+            session.transient_messages.upsert(TransientMessage {
+                anchor: TransientMessageAnchor::AfterCompletedTurn,
+                body: TransientMessageBody::Loading(
+                    "Auto-pushing published branch after completed turn...".to_string(),
+                ),
+                lifecycle: TransientMessageLifecycle::UntilResolved,
+                slot: TransientMessageSlot::PublishedBranchSync,
+                turn_position: session.latest_user_prompt_position(),
+            });
         }
     }
 
@@ -463,26 +476,50 @@ impl SessionManager {
         &mut self,
         session_id: &str,
         sync_operation_id: &str,
-        sync_status: PublishedBranchSyncStatus,
-    ) {
+        persistent_notice: Option<&str>,
+    ) -> bool {
         let Some(current_operation_id) = self.published_branch_sync_operations.get(session_id)
         else {
-            return;
+            return false;
         };
         if current_operation_id != sync_operation_id {
-            return;
+            return false;
         }
 
         self.published_branch_sync_operations.remove(session_id);
 
-        if let Some(session) = self
+        let appended_to_handle = persistent_notice.is_some_and(|persistent_notice| {
+            let Some(handles) = self.state.handles.get(session_id) else {
+                return false;
+            };
+            let Ok(mut transcript) = handles.transcript.lock() else {
+                return false;
+            };
+
+            transcript.append_message(SessionMessageKind::WorkflowNotice, persistent_notice);
+
+            true
+        });
+
+        let Some(session) = self
             .state
             .sessions
             .iter_mut()
             .find(|session| session.id == session_id)
-        {
-            session.published_branch_sync_status = sync_status;
+        else {
+            return false;
+        };
+        if !appended_to_handle && let Some(persistent_notice) = persistent_notice {
+            session
+                .transcript
+                .get_or_insert_default()
+                .append_message(SessionMessageKind::WorkflowNotice, persistent_notice);
         }
+        session
+            .transient_messages
+            .retract(TransientMessageSlot::PublishedBranchSync);
+
+        true
     }
 
     /// Appends transient sync-error notices to stacked children whose
@@ -507,12 +544,18 @@ impl SessionManager {
             .iter_mut()
             .find(|session| session.id == session_id)
         {
-            if let Some(workflow_notice) = &mut session.workflow_notice {
-                workflow_notice.push_str("\n\n");
-                workflow_notice.push_str(&notice);
-            } else {
-                session.workflow_notice = Some(notice);
-            }
+            let notice = session
+                .transient_messages
+                .get(TransientMessageSlot::WorkflowNotice)
+                .map(|message| format!("{}\n\n{notice}", message.body.text()))
+                .unwrap_or(notice);
+            session.transient_messages.upsert(TransientMessage {
+                anchor: TransientMessageAnchor::AfterCompletedTurn,
+                body: TransientMessageBody::Markdown(notice),
+                lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+                slot: TransientMessageSlot::WorkflowNotice,
+                turn_position: session.latest_user_prompt_position(),
+            });
         }
     }
 
@@ -537,6 +580,7 @@ impl SessionManager {
             .clone_from(&turn_applied_state.follow_up_tasks);
         session.questions.clone_from(&turn_applied_state.questions);
         session.summary.clone_from(&turn_applied_state.summary);
+        session.hydrate_summary_transient();
         session.stats.input_tokens = session
             .stats
             .input_tokens

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -29,6 +29,7 @@ use crate::domain::session::{
 };
 use crate::domain::session_message::SessionTranscript;
 use crate::domain::setting::SettingName;
+use crate::domain::transient_message::{TransientMessageSlot, TransientMessageStore};
 use crate::infra::clock::RealClock;
 use crate::infra::db::AppRepositories;
 use crate::infra::fs::{self as fs, FsClient};
@@ -672,7 +673,6 @@ fn add_manual_session_with_status(
         queued_messages: Vec::new(),
         reasoning_level_override: None,
         published_upstream_ref: None,
-        published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
         questions: Vec::new(),
         review_request: None,
         size: SessionSize::Xs,
@@ -682,7 +682,7 @@ fn add_manual_session_with_status(
         title: Some(prompt.to_string()),
         transcript: None,
         updated_at: 0,
-        workflow_notice: None,
+        transient_messages: TransientMessageStore::default(),
     });
     if app.sessions.selected_session_index().is_none() {
         app.sessions.select_session_index(Some(0));
@@ -732,7 +732,6 @@ fn test_session_manager_with_clock(
             queued_messages: Vec::new(),
             reasoning_level_override,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -742,7 +741,7 @@ fn test_session_manager_with_clock(
             title: Some("Title".to_string()),
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         }],
         crate::domain::selection::SelectionState::default(),
         clock,
@@ -780,7 +779,10 @@ fn test_append_stacked_rebase_failure_notices_updates_affected_child() {
         .find(|session| session.id.as_str() == "child-session")
         .expect("expected affected child session");
     assert_eq!(
-        child_session.workflow_notice.as_deref(),
+        child_session
+            .transient_messages
+            .get(TransientMessageSlot::WorkflowNotice)
+            .map(|message| message.body.text()),
         Some("[Sync Error] Stacked child auto-sync failed: Session handles not found")
     );
 }
@@ -3877,7 +3879,10 @@ async fn test_spawn_session_task_auto_commits_changes() {
     // state, not persisted transcript output.
     let session = &app.sessions.sessions()[0];
     let output = session_replay_text(session);
-    let workflow_notice = session.workflow_notice.as_deref();
+    let workflow_notice = session
+        .transient_messages
+        .get(crate::domain::transient_message::TransientMessageSlot::WorkflowNotice)
+        .map(|message| message.body.text());
     assert!(
         !output.contains("[Commit] committed with hash"),
         "commit completion should not be persisted, got: {output}"
@@ -4039,7 +4044,10 @@ async fn test_spawn_session_task_skips_commit_when_nothing_to_commit() {
     // Assert — no-op commit output is visible as transient workflow state.
     let session = &app.sessions.sessions()[0];
     let output = session_replay_text(session);
-    let workflow_notice = session.workflow_notice.as_deref();
+    let workflow_notice = session
+        .transient_messages
+        .get(crate::domain::transient_message::TransientMessageSlot::WorkflowNotice)
+        .map(|message| message.body.text());
     assert!(
         !output.contains("[Commit] No changes to commit."),
         "no-op commit output should not be persisted when nothing to commit"

--- a/crates/agentty/src/app/session/state.rs
+++ b/crates/agentty/src/app/session/state.rs
@@ -148,6 +148,7 @@ impl SessionState {
         };
 
         Self::sync_session_with_handles(session, session_handles);
+        session.reconcile_transient_messages();
     }
 
     /// Copies current values from runtime handles into plain `Session` fields.
@@ -164,6 +165,7 @@ impl SessionState {
             };
 
             Self::sync_session_with_handles(session, session_handles);
+            session.reconcile_transient_messages();
         }
     }
 
@@ -407,6 +409,7 @@ mod tests {
     use crate::domain::selection::SelectionState;
     use crate::domain::session::{Session, SessionHandles, SessionSize, SessionStats, Status};
     use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
+    use crate::domain::transient_message::TransientMessageStore;
     use crate::test_support::SessionFixtureBuilder;
 
     struct FixedClock {
@@ -466,7 +469,6 @@ mod tests {
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -476,7 +478,7 @@ mod tests {
             title: None,
             transcript: Some(crate::test_support::assistant_transcript("old")),
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
         let handles: HashMap<SessionId, SessionHandles> = HashMap::from([(
             session_id.into(),
@@ -526,7 +528,6 @@ mod tests {
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -536,7 +537,7 @@ mod tests {
             title: None,
             transcript: Some(crate::test_support::assistant_transcript("Old")),
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
         let handles = SessionHandles::new_with_transcript(
             Status::InProgress,
@@ -575,7 +576,6 @@ mod tests {
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -585,7 +585,7 @@ mod tests {
             title: None,
             transcript: Some(crate::test_support::assistant_transcript("first line\n")),
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
         let handles = SessionHandles::new_with_transcript(
             Status::InProgress,
@@ -648,7 +648,6 @@ mod tests {
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -658,7 +657,7 @@ mod tests {
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
         let mut state = SessionState::new(
             HashMap::new(),
@@ -702,7 +701,6 @@ mod tests {
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -712,7 +710,7 @@ mod tests {
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
         let replacement_session = Session {
             base_branch: "main".to_string(),
@@ -734,7 +732,6 @@ mod tests {
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -744,7 +741,7 @@ mod tests {
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
         let mut state = SessionState::new(
             HashMap::new(),
@@ -788,7 +785,6 @@ mod tests {
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -798,7 +794,7 @@ mod tests {
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
         let second_session = Session {
             base_branch: "main".to_string(),
@@ -820,7 +816,6 @@ mod tests {
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -830,7 +825,7 @@ mod tests {
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
         let mut state = SessionState::new(
             HashMap::new(),
@@ -877,7 +872,6 @@ mod tests {
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -887,7 +881,7 @@ mod tests {
             title: None,
             transcript: Some(crate::test_support::assistant_transcript("abc")),
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
         let handles = SessionHandles::new_with_transcript(
             Status::Review,
@@ -978,7 +972,6 @@ mod tests {
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -988,7 +981,7 @@ mod tests {
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
         surviving_session
             .follow_up_tasks
@@ -1018,7 +1011,6 @@ mod tests {
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -1028,7 +1020,7 @@ mod tests {
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
         let mut state = SessionState::new(
             HashMap::new(),

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -10,10 +10,11 @@ use crate::app::SessionManager;
 use crate::domain::agent::{AgentSelection, ReasoningLevel, parse_persisted_session_agent_model};
 use crate::domain::question::QuestionItem;
 use crate::domain::session::{
-    DailyActivity, PublishedBranchSyncStatus, ReviewRequest, ReviewRequestSummary, Session,
-    SessionFollowUpTask, SessionHandles, SessionId, SessionSize, SessionStats, Status,
+    DailyActivity, ReviewRequest, ReviewRequestSummary, Session, SessionFollowUpTask,
+    SessionHandles, SessionId, SessionSize, SessionStats, Status,
 };
 use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
+use crate::domain::transient_message::TransientMessageStore;
 use crate::infra::db::{
     AppRepositories, DbError, SessionDetailRow, SessionListRow, SessionMessageRow,
 };
@@ -289,7 +290,7 @@ impl SessionManager {
     /// Builds one in-memory session snapshot from a database row plus the
     /// transient fields computed during reload.
     fn build_loaded_session(input: LoadedSessionInput) -> Session {
-        Session {
+        let mut session = Session {
             agent: input.session_agent,
             base_branch: input.row.base_branch,
             created_at: input.row.created_at,
@@ -306,7 +307,6 @@ impl SessionManager {
             queued_messages: input.session_queued_messages,
             reasoning_level_override: input.reasoning_level_override,
             published_upstream_ref: input.row.published_upstream_ref,
-            published_branch_sync_status: PublishedBranchSyncStatus::Idle,
             questions: input.session_questions,
             review_request: input.review_request,
             size: input.size,
@@ -321,8 +321,11 @@ impl SessionManager {
             title: input.row.title,
             transcript: input.session_transcript,
             updated_at: input.row.updated_at,
-            workflow_notice: None,
-        }
+            transient_messages: TransientMessageStore::default(),
+        };
+        session.hydrate_summary_transient();
+
+        session
     }
 
     /// Applies one lazily loaded detail row and message transcript to the
@@ -351,6 +354,7 @@ impl SessionManager {
         }
         session.summary = detail.summary;
         session.transcript = session_transcript;
+        session.hydrate_summary_transient();
     }
 }
 

--- a/crates/agentty/src/app/session/workflow/merge.rs
+++ b/crates/agentty/src/app/session/workflow/merge.rs
@@ -2182,6 +2182,7 @@ impl SessionManager {
 
         if app_event_tx
             .send(AppEvent::PublishedBranchSyncUpdated {
+                persistent_notice: None,
                 session_id: SessionId::from(session_id),
                 sync_operation_id: sync_operation_id.clone(),
                 sync_status: PublishedBranchSyncStatus::InProgress,
@@ -4933,6 +4934,7 @@ mod tests {
                     session_id,
                     sync_operation_id,
                     sync_status,
+                    ..
                 } = event
                 {
                     sync_events.push((session_id, sync_operation_id, sync_status));

--- a/crates/agentty/src/app/session/workflow/published_branch.rs
+++ b/crates/agentty/src/app/session/workflow/published_branch.rs
@@ -66,6 +66,7 @@ pub(super) fn start_published_branch_auto_push(input: PublishedBranchAutoPushSta
     let _ = input
         .app_event_tx
         .send(AppEvent::PublishedBranchSyncUpdated {
+            persistent_notice: None,
             session_id: input.session_id.clone(),
             sync_operation_id: sync_operation_id.clone(),
             sync_status: PublishedBranchSyncStatus::InProgress,
@@ -152,19 +153,11 @@ async fn run_published_branch_auto_push_task(input: PublishedBranchAutoPushInput
 
             let message = TranscriptNotice::BranchPush
                 .format("Auto-pushed published branch after completed turn.");
-            SessionTaskService::append_workflow_notice(
-                &input.transcript,
-                &input.db,
-                &input.app_event_tx,
-                &input.session_update_versions,
-                &input.session_id,
-                &message,
-            )
-            .await;
 
             let _ = input
                 .app_event_tx
                 .send(AppEvent::PublishedBranchSyncUpdated {
+                    persistent_notice: Some(message),
                     session_id: input.session_id,
                     sync_operation_id: input.sync_operation_id,
                     sync_status: PublishedBranchSyncStatus::Succeeded,
@@ -172,19 +165,11 @@ async fn run_published_branch_auto_push_task(input: PublishedBranchAutoPushInput
         }
         Err(failure) => {
             let message = TranscriptNotice::BranchPushError.format(failure.message);
-            SessionTaskService::append_workflow_notice(
-                &input.transcript,
-                &input.db,
-                &input.app_event_tx,
-                &input.session_update_versions,
-                &input.session_id,
-                &message,
-            )
-            .await;
 
             let _ = input
                 .app_event_tx
                 .send(AppEvent::PublishedBranchSyncUpdated {
+                    persistent_notice: Some(message),
                     session_id: input.session_id,
                     sync_operation_id: input.sync_operation_id,
                     sync_status: PublishedBranchSyncStatus::Failed,

--- a/crates/agentty/src/app/session/workflow/task.rs
+++ b/crates/agentty/src/app/session/workflow/task.rs
@@ -1071,6 +1071,24 @@ impl SessionTaskService {
         Self::emit_session_updated(app_event_tx, session_update_versions, id);
     }
 
+    /// Persists one workflow notice without exposing it to the live transcript.
+    ///
+    /// Reducer events use this when a transient status and its durable result
+    /// must be swapped in one observable state transition.
+    pub(crate) async fn persist_workflow_notice(db: &AppRepositories, id: &str, message: &str) {
+        if let Err(error) = db
+            .sessions()
+            .append_session_message(id, SessionMessageKind::WorkflowNotice, message)
+            .await
+        {
+            warn!(
+                session_id = id,
+                error = %error,
+                "failed to persist workflow notice"
+            );
+        }
+    }
+
     /// Appends one raw user/assistant message to the in-memory transcript and
     /// durable message store.
     pub(crate) async fn append_session_transcript_message(

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -2919,6 +2919,7 @@ mod tests {
                     session_id,
                     sync_operation_id,
                     sync_status,
+                    ..
                 } = event
                 {
                     sync_events.push((session_id, sync_operation_id, sync_status));
@@ -3127,8 +3128,8 @@ mod tests {
     }
 
     #[tokio::test]
-    /// Verifies failed background auto-push attempts append a visible error
-    /// and keep the session marked as failed for the latest sync attempt.
+    /// Verifies failed background auto-push attempts emit one durable notice
+    /// for atomic reducer promotion.
     async fn test_apply_turn_result_reports_background_push_failures() {
         // Arrange
         let base_dir = tempdir().expect("failed to create temp dir");
@@ -3190,17 +3191,7 @@ mod tests {
             session_agent,
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
-        let turn_result = Ok(TurnResult {
-            assistant_message: AgentResponse {
-                answer: "Implemented the change.".to_string(),
-                questions: Vec::new(),
-                summary: None,
-            },
-            context_reset: false,
-            input_tokens: 0,
-            output_tokens: 0,
-            provider_conversation_id: None,
-        });
+        let turn_result = Ok(successful_turn_result("Implemented the change."));
 
         // Act
         let turn_metadata = TurnMetadata {
@@ -3214,8 +3205,13 @@ mod tests {
             let mut sync_events = Vec::new();
             while sync_events.len() < 2 {
                 let event = app_event_rx.recv().await.expect("missing app event");
-                if let AppEvent::PublishedBranchSyncUpdated { sync_status, .. } = event {
-                    sync_events.push(sync_status);
+                if let AppEvent::PublishedBranchSyncUpdated {
+                    persistent_notice,
+                    sync_status,
+                    ..
+                } = event
+                {
+                    sync_events.push((sync_status, persistent_notice));
                 }
             }
 
@@ -3223,19 +3219,22 @@ mod tests {
         })
         .await
         .expect("timed out waiting for sync events");
-        let output = transcript_text(&transcript);
 
         // Assert
         assert_eq!(status, Status::Review);
-        assert_eq!(
-            sync_events,
-            vec![
-                PublishedBranchSyncStatus::InProgress,
-                PublishedBranchSyncStatus::Failed,
+        assert!(matches!(
+            sync_events.as_slice(),
+            [
+                (PublishedBranchSyncStatus::InProgress, None),
+                (PublishedBranchSyncStatus::Failed, Some(_))
             ]
-        );
-        assert!(output.contains("[Branch Push Error]"));
-        assert!(output.contains("gh auth login"));
+        ));
+        let failure_notice = sync_events[1]
+            .1
+            .as_deref()
+            .expect("failed sync should promote one durable notice");
+        assert!(failure_notice.contains("[Branch Push Error]"));
+        assert!(failure_notice.contains("gh auth login"));
     }
 
     #[tokio::test]
@@ -4401,6 +4400,7 @@ mod tests {
                     session_id,
                     sync_operation_id,
                     sync_status,
+                    ..
                 } = event
                 {
                     sync_events.push((session_id, sync_operation_id, sync_status));

--- a/crates/agentty/src/app/view.rs
+++ b/crates/agentty/src/app/view.rs
@@ -6,7 +6,6 @@ use std::path::Path;
 use crate::app::session_state::SessionGitStatus;
 use crate::app::{
     App, AssignedIssueState, RequestedReviewState, SettingsManager, Tab, UpdateStatus,
-    review_view_state,
 };
 use crate::domain::agent::AgentCliInfo;
 use crate::domain::project::ProjectListItem;
@@ -17,7 +16,6 @@ use crate::presentation::app_mode::{AppMode, HelpContext};
 /// Focused-review display state for the visible session.
 pub(crate) struct SessionReviewView<'a> {
     pub(crate) session_id: &'a str,
-    pub(crate) status_message: Option<String>,
     pub(crate) text: Option<&'a str>,
 }
 
@@ -65,17 +63,9 @@ impl App {
             u64::try_from(wall_clock_unix_seconds.div_euclid(60)).unwrap_or_default();
         let visible_session_id = visible_review_session_id(&self.mode);
         let session_review = visible_session_id.map(|session_id| {
-            let (status_message, text) = review_view_state(
-                &self.review_cache,
-                session_id,
-                self.settings.default_review_selection.model(),
-            );
+            let (_, text) = self.review_view_state(session_id);
 
-            SessionReviewView {
-                session_id,
-                status_message,
-                text,
-            }
+            SessionReviewView { session_id, text }
         });
         let project = self.projects.render_parts();
         let sessions = self.sessions.render_parts();

--- a/crates/agentty/src/domain.rs
+++ b/crates/agentty/src/domain.rs
@@ -13,6 +13,7 @@ pub mod session_order;
 pub mod setting;
 pub mod theme;
 pub(crate) mod transcript_notice;
+pub(crate) mod transient_message;
 
 /// Agent provider and model metadata used by the domain layer.
 pub mod agent {

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -16,6 +16,10 @@ use tokio_util::sync::CancellationToken;
 use super::agent::{AgentSelection, ReasoningLevel};
 use super::session_message::SessionTranscript;
 use crate::domain::question::QuestionItem;
+use crate::domain::transient_message::{
+    TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
+    TransientMessageSlot, TransientMessageStore,
+};
 use crate::domain::turn_prompt::{TurnPrompt, TurnPromptAttachment};
 
 /// Folder name under a project root that stores Agentty session metadata.
@@ -503,8 +507,6 @@ pub struct Session {
     /// Upstream reference recorded after the latest successful branch publish,
     /// for example `origin/wt/session-id`.
     pub published_upstream_ref: Option<String>,
-    /// Background auto-push state for the already-published upstream branch.
-    pub published_branch_sync_status: PublishedBranchSyncStatus,
     /// Model clarification questions emitted by the agent.
     pub questions: Vec<QuestionItem>,
     /// Persisted forge review-request link for this session, when available.
@@ -527,12 +529,78 @@ pub struct Session {
     pub transcript: Option<SessionTranscript>,
     /// Last update timestamp (Unix seconds).
     pub updated_at: i64,
-    /// Transient workflow notice block shown in the output panel without
-    /// being appended to the persisted transcript.
-    pub workflow_notice: Option<String>,
+    /// Explicit non-durable output slots and their render lifecycle.
+    pub(crate) transient_messages: TransientMessageStore,
 }
 
 impl Session {
+    /// Returns the latest persisted user-prompt position for transient-message
+    /// lifecycle binding.
+    pub(crate) fn latest_user_prompt_position(&self) -> Option<i64> {
+        self.transcript
+            .as_ref()?
+            .messages()
+            .iter()
+            .rev()
+            .find_map(|message| {
+                (message.kind == crate::domain::session_message::SessionMessageKind::UserPrompt)
+                    .then_some(message.position)
+            })
+    }
+
+    /// Rebuilds the visible summary slot from the latest persisted summary.
+    pub(crate) fn hydrate_summary_transient(&mut self) {
+        if matches!(
+            self.status,
+            Status::Draft
+                | Status::InProgress
+                | Status::Queued
+                | Status::Rebasing
+                | Status::Merging
+                | Status::Canceled
+        ) {
+            self.transient_messages
+                .retract(TransientMessageSlot::Summary);
+
+            return;
+        }
+
+        let Some(summary) = self
+            .summary
+            .as_deref()
+            .map(str::trim)
+            .filter(|summary| !summary.is_empty())
+            .map(ToString::to_string)
+        else {
+            self.transient_messages
+                .retract(TransientMessageSlot::Summary);
+
+            return;
+        };
+
+        self.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::AfterCompletedTurn,
+            body: TransientMessageBody::Markdown(summary),
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::Summary,
+            turn_position: self.latest_user_prompt_position(),
+        });
+    }
+
+    /// Applies turn-bound lifecycle cleanup after reducer-owned snapshot sync.
+    pub(crate) fn reconcile_transient_messages(&mut self) {
+        if matches!(
+            self.status,
+            Status::InProgress | Status::Queued | Status::Rebasing | Status::Merging
+        ) && let Some(active_turn_position) = self.latest_user_prompt_position()
+        {
+            self.transient_messages
+                .clear_for_new_turn(active_turn_position);
+        }
+
+        self.hydrate_summary_transient();
+    }
+
     /// Returns the display title for this session.
     pub fn display_title(&self) -> &str {
         self.title.as_deref().unwrap_or("No title")
@@ -684,21 +752,6 @@ impl Session {
             self.published_upstream_ref.is_some() || self.review_request.is_some();
 
         has_forge_context && matches!(self.status, Status::Review | Status::AgentReview)
-    }
-
-    /// Returns one transient UI message describing an active
-    /// published-branch sync when the session tracks an upstream branch.
-    pub fn published_branch_sync_message(&self) -> Option<&'static str> {
-        self.published_upstream_ref.as_ref()?;
-
-        match self.published_branch_sync_status {
-            PublishedBranchSyncStatus::Idle
-            | PublishedBranchSyncStatus::Succeeded
-            | PublishedBranchSyncStatus::Failed => None,
-            PublishedBranchSyncStatus::InProgress => {
-                Some("Auto-pushing published branch after completed turn...")
-            }
-        }
     }
 
     /// Returns the review-request publish action currently available in session
@@ -1811,7 +1864,6 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -1821,7 +1873,7 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
 
         // Act
@@ -1854,7 +1906,6 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -1864,7 +1915,7 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
 
         // Act
@@ -1897,7 +1948,6 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: Some("origin/wt/session-id".to_string()),
-            published_branch_sync_status: PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -1907,7 +1957,7 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
 
         // Act
@@ -1940,7 +1990,6 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: Some("origin/wt/session-id".to_string()),
-            published_branch_sync_status: PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -1950,7 +1999,7 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
 
         // Act
@@ -1983,7 +2032,6 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -1993,7 +2041,7 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
 
         // Act
@@ -2026,7 +2074,6 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -2036,7 +2083,7 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         };
 
         // Act
@@ -2251,51 +2298,6 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
 
         // Act / Assert
         assert!(!session.can_sync_review_request());
-    }
-
-    #[test]
-    fn test_published_branch_sync_message_returns_in_progress_copy() {
-        // Arrange
-        let mut session = test_session(None);
-        session.published_upstream_ref = Some("origin/wt/session-id".to_string());
-        session.published_branch_sync_status = PublishedBranchSyncStatus::InProgress;
-
-        // Act
-        let sync_message = session.published_branch_sync_message();
-
-        // Assert
-        assert_eq!(
-            sync_message,
-            Some("Auto-pushing published branch after completed turn...")
-        );
-    }
-
-    #[test]
-    fn test_published_branch_sync_message_omits_succeeded_copy() {
-        // Arrange
-        let mut session = test_session(None);
-        session.published_upstream_ref = Some("origin/wt/session-id".to_string());
-        session.published_branch_sync_status = PublishedBranchSyncStatus::Succeeded;
-
-        // Act
-        let sync_message = session.published_branch_sync_message();
-
-        // Assert
-        assert_eq!(sync_message, None);
-    }
-
-    #[test]
-    fn test_published_branch_sync_message_omits_failed_copy() {
-        // Arrange
-        let mut session = test_session(None);
-        session.published_upstream_ref = Some("origin/wt/session-id".to_string());
-        session.published_branch_sync_status = PublishedBranchSyncStatus::Failed;
-
-        // Act
-        let sync_message = session.published_branch_sync_message();
-
-        // Assert
-        assert_eq!(sync_message, None);
     }
 
     #[test]

--- a/crates/agentty/src/domain/transient_message.rs
+++ b/crates/agentty/src/domain/transient_message.rs
@@ -1,0 +1,210 @@
+//! Explicit lifecycle state for non-durable session-output messages.
+
+/// Stable identity for one replaceable session-output message.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum TransientMessageSlot {
+    /// Published session summary for the latest completed turn.
+    Summary,
+    /// Focused review loading, result, or failure output.
+    Review,
+    /// Short-lived workflow feedback produced while finalizing a turn.
+    WorkflowNotice,
+    /// Published-branch auto-push progress replaced by its durable result.
+    PublishedBranchSync,
+}
+
+/// Placement of one transient message relative to durable transcript content.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TransientMessageAnchor {
+    /// Immediately after durable content from the latest completed turn.
+    AfterCompletedTurn,
+    /// At the end of the output, beside other active status rows.
+    Tail,
+}
+
+/// Removal policy for one transient message.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TransientMessageLifecycle {
+    /// Remove when a later user turn becomes active.
+    ClearOnNewTurn,
+    /// Retain until its owning workflow explicitly resolves it.
+    UntilResolved,
+}
+
+/// Typed content for one transient message.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum TransientMessageBody {
+    /// Markdown content rendered through the shared markdown cache.
+    Markdown(String),
+    /// Plain status or failure text that must not interpret markdown syntax.
+    Plain(String),
+    /// Animated status text with explicit loading semantics.
+    Loading(String),
+}
+
+impl TransientMessageBody {
+    /// Returns the message text independent of its render treatment.
+    pub(crate) fn text(&self) -> &str {
+        match self {
+            Self::Markdown(text) | Self::Plain(text) | Self::Loading(text) => text,
+        }
+    }
+}
+
+/// One replaceable session-output message with explicit placement and lifetime.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct TransientMessage {
+    pub(crate) anchor: TransientMessageAnchor,
+    pub(crate) body: TransientMessageBody,
+    pub(crate) lifecycle: TransientMessageLifecycle,
+    pub(crate) slot: TransientMessageSlot,
+    /// User-prompt transcript position that produced this message, when known.
+    pub(crate) turn_position: Option<i64>,
+}
+
+/// Per-session slot store for non-durable output messages.
+///
+/// `version` is the cache key and changes only when observable slot content
+/// changes. Slots use canonical enum order rather than async event arrival
+/// order, so status replacement does not move surrounding output.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct TransientMessageStore {
+    messages: Vec<TransientMessage>,
+    version: u64,
+}
+
+impl TransientMessageStore {
+    /// Returns the monotonic observable-content version.
+    pub(crate) fn version(&self) -> u64 {
+        self.version
+    }
+
+    /// Returns all current messages in stable display order.
+    pub(crate) fn messages(&self) -> &[TransientMessage] {
+        &self.messages
+    }
+
+    /// Returns one current slot value.
+    pub(crate) fn get(&self, slot: TransientMessageSlot) -> Option<&TransientMessage> {
+        self.messages.iter().find(|message| message.slot == slot)
+    }
+
+    /// Posts a new slot or replaces its content without changing its position.
+    pub(crate) fn upsert(&mut self, message: TransientMessage) {
+        if let Some(existing) = self
+            .messages
+            .iter_mut()
+            .find(|existing| existing.slot == message.slot)
+        {
+            if *existing == message {
+                return;
+            }
+
+            *existing = message;
+            self.bump_version();
+
+            return;
+        }
+
+        self.messages.push(message);
+        self.messages.sort_by_key(|message| message.slot);
+        self.bump_version();
+    }
+
+    /// Removes one slot and returns its previous value.
+    pub(crate) fn retract(&mut self, slot: TransientMessageSlot) -> Option<TransientMessage> {
+        let message_index = self
+            .messages
+            .iter()
+            .position(|message| message.slot == slot)?;
+        let message = self.messages.remove(message_index);
+        self.bump_version();
+
+        Some(message)
+    }
+
+    /// Removes turn-scoped messages with no producing turn or from before
+    /// `active_turn_position`.
+    pub(crate) fn clear_for_new_turn(&mut self, active_turn_position: i64) {
+        let previous_len = self.messages.len();
+        self.messages.retain(|message| {
+            message.lifecycle != TransientMessageLifecycle::ClearOnNewTurn
+                || message
+                    .turn_position
+                    .is_some_and(|turn_position| turn_position >= active_turn_position)
+        });
+        if self.messages.len() != previous_len {
+            self.bump_version();
+        }
+    }
+
+    fn bump_version(&mut self) {
+        self.version = self.version.wrapping_add(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message(slot: TransientMessageSlot, text: &str, turn_position: i64) -> TransientMessage {
+        TransientMessage {
+            anchor: TransientMessageAnchor::AfterCompletedTurn,
+            body: TransientMessageBody::Markdown(text.to_string()),
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+            slot,
+            turn_position: Some(turn_position),
+        }
+    }
+
+    #[test]
+    fn upsert_replaces_slot_without_moving_it() {
+        // Arrange
+        let mut store = TransientMessageStore::default();
+        store.upsert(message(TransientMessageSlot::Summary, "summary", 1));
+        store.upsert(message(TransientMessageSlot::Review, "review", 1));
+
+        // Act
+        store.upsert(message(TransientMessageSlot::Summary, "new summary", 1));
+
+        // Assert
+        assert_eq!(store.messages[0].body.text(), "new summary");
+        assert_eq!(store.messages[1].slot, TransientMessageSlot::Review);
+        assert_eq!(store.version(), 3);
+    }
+
+    #[test]
+    fn clear_for_new_turn_only_retracts_older_turn_scoped_messages() {
+        // Arrange
+        let mut store = TransientMessageStore::default();
+        store.upsert(message(TransientMessageSlot::Summary, "old", 2));
+        store.upsert(message(TransientMessageSlot::Review, "current", 3));
+        store.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::AfterCompletedTurn,
+            body: TransientMessageBody::Markdown("unbound".to_string()),
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::WorkflowNotice,
+            turn_position: None,
+        });
+        store.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::AfterCompletedTurn,
+            body: TransientMessageBody::Loading("Pushing...".to_string()),
+            lifecycle: TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::PublishedBranchSync,
+            turn_position: Some(2),
+        });
+
+        // Act
+        store.clear_for_new_turn(3);
+
+        // Assert
+        assert!(store.get(TransientMessageSlot::Summary).is_none());
+        assert!(store.get(TransientMessageSlot::Review).is_some());
+        assert!(store.get(TransientMessageSlot::WorkflowNotice).is_none());
+        assert!(
+            store
+                .get(TransientMessageSlot::PublishedBranchSync)
+                .is_some()
+        );
+    }
+}

--- a/crates/agentty/src/runtime/event.rs
+++ b/crates/agentty/src/runtime/event.rs
@@ -289,6 +289,7 @@ mod tests {
     use crate::domain::input::InputState;
     use crate::domain::question::QuestionItem;
     use crate::domain::session::{Session, SessionSize, SessionStats, Status};
+    use crate::domain::transient_message::TransientMessageStore;
     use crate::presentation::app_mode::{AppMode, ChatFocus};
     use crate::presentation::prompt::{
         PromptAttachmentState, PromptHistoryState, PromptSlashState,
@@ -451,7 +452,6 @@ mod tests {
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -461,7 +461,7 @@ mod tests {
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         });
         app.mode = AppMode::Prompt {
             at_mention_state: None,

--- a/crates/agentty/src/runtime/key_handler.rs
+++ b/crates/agentty/src/runtime/key_handler.rs
@@ -6,7 +6,9 @@ use ratatui::backend::Backend;
 use ratatui::layout::{Constraint, Layout, Rect};
 use tracing::warn;
 
-use crate::app::{App, ReviewCacheEntry, diff_content_hash};
+#[cfg(test)]
+use crate::app::ReviewCacheEntry;
+use crate::app::{App, diff_content_hash};
 use crate::domain::session::SessionId;
 use crate::domain::transcript_notice::TranscriptNotice;
 use crate::presentation::app_mode::{AppMode, ConfirmationIntent, ConfirmationViewMode};
@@ -740,7 +742,7 @@ async fn handle_regenerate_review_confirmation(
         return Ok(EventResult::Continue);
     };
 
-    app.review_cache.remove(session_id.as_str());
+    app.clear_review_output(session_id.as_str());
 
     let session = app
         .sessions
@@ -774,21 +776,13 @@ async fn handle_regenerate_review_confirmation(
         } else {
             diff
         };
-        app.review_cache.insert(
-            session_id,
-            ReviewCacheEntry::Ready {
-                diff_hash,
-                text: review_text,
-            },
-        );
+        app.set_review_ready_output(&session_id, diff_hash, review_text);
         app.mode = view_mode.into_view_mode();
 
         return Ok(EventResult::Continue);
     }
 
     let diff_hash = diff_content_hash(&diff);
-    app.review_cache
-        .insert(session_id.clone(), ReviewCacheEntry::Loading { diff_hash });
     let _ = app
         .services
         .db()

--- a/crates/agentty/src/runtime/mode/at_mention.rs
+++ b/crates/agentty/src/runtime/mode/at_mention.rs
@@ -237,6 +237,7 @@ mod tests {
     use crate::domain::agent::AgentModel;
     use crate::domain::selection::SelectionState;
     use crate::domain::session::{Session, SessionHandles, SessionSize, SessionStats, Status};
+    use crate::domain::transient_message::TransientMessageStore;
     use crate::infra::clock::RealClock;
 
     #[test]
@@ -509,8 +510,6 @@ mod tests {
                 queued_messages: Vec::new(),
                 reasoning_level_override: None,
                 published_upstream_ref: None,
-                published_branch_sync_status:
-                    crate::domain::session::PublishedBranchSyncStatus::Idle,
                 questions: Vec::new(),
                 review_request: None,
                 size: SessionSize::Xs,
@@ -520,7 +519,7 @@ mod tests {
                 title: Some("Title".to_string()),
                 transcript: None,
                 updated_at: 0,
-                workflow_notice: None,
+                transient_messages: TransientMessageStore::default(),
             }],
             SelectionState::default(),
             Arc::new(RealClock),

--- a/crates/agentty/src/runtime/mode/chat_scroll.rs
+++ b/crates/agentty/src/runtime/mode/chat_scroll.rs
@@ -40,15 +40,13 @@ impl ChatScrollMetrics {
     ) -> Self {
         let page_area = layout::app_frame_areas(terminal_size).content_area;
         let output_width = page_area.width.saturating_sub(2);
-        let (review_status_message, review_text) = app.review_view_state(session_id);
+        let (_, review_text) = app.review_view_state(session_id);
 
         let total_lines = session_output_metric::rendered_output_line_count_with_cache(
             app,
             render_cache_store,
             session_id,
             session_index,
-            review_status_message.as_deref(),
-            review_text,
             output_width,
         );
         let view_height = app.sessions.session_at(session_index).map_or_else(

--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -1000,6 +1000,7 @@ mod tests {
     use super::*;
     use crate::domain::agent::AgentModel;
     use crate::domain::session::Status;
+    use crate::domain::transient_message::TransientMessageStore;
     use crate::presentation::app_mode::ChatFocus;
     use crate::ui::component::session_output::SessionOutputLineContext;
     use crate::ui::page::session_chat::SessionChatPage;
@@ -1044,9 +1045,6 @@ mod tests {
             SessionOutputLineContext {
                 active_prompt_output: None,
                 active_progress: None,
-                review_model: AgentModel::ClaudeHaiku4520251001,
-                review_status_message: None,
-                review_text: None,
                 session_update_version: app.session_update_version(session_id),
             },
             render_cache_store.markdown_render_cache(),
@@ -1374,7 +1372,6 @@ mod tests {
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -1384,7 +1381,7 @@ mod tests {
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         });
         app.mode = AppMode::Question {
             at_mention_state: None,
@@ -1450,7 +1447,6 @@ mod tests {
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -1460,7 +1456,7 @@ mod tests {
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         });
         app.sessions.session_handles_mut().insert(
             session_id.to_string().into(),
@@ -3071,7 +3067,6 @@ mod tests {
             queued_messages: Vec::new(),
             reasoning_level_override: None,
             published_upstream_ref: None,
-            published_branch_sync_status: crate::domain::session::PublishedBranchSyncStatus::Idle,
             questions: Vec::new(),
             review_request: None,
             size: SessionSize::Xs,
@@ -3081,7 +3076,7 @@ mod tests {
             title: None,
             transcript: None,
             updated_at: 0,
-            workflow_notice: None,
+            transient_messages: TransientMessageStore::default(),
         });
 
         app.mode = AppMode::Question {

--- a/crates/agentty/src/runtime/mode/session_output_metric.rs
+++ b/crates/agentty/src/runtime/mode/session_output_metric.rs
@@ -9,8 +9,6 @@ pub(crate) fn rendered_output_line_count_with_cache(
     render_cache_store: &RenderCacheStore,
     session_id: &str,
     session_index: usize,
-    review_status_message: Option<&str>,
-    review_text: Option<&str>,
     output_width: u16,
 ) -> u16 {
     let active_progress = app.session_progress_message(session_id);
@@ -27,9 +25,6 @@ pub(crate) fn rendered_output_line_count_with_cache(
             SessionOutputLineContext {
                 active_prompt_output,
                 active_progress,
-                review_model: app.settings.default_review_selection.model(),
-                review_status_message,
-                review_text,
                 session_update_version: app.session_update_version(session_id),
             },
             render_cache_store.markdown_render_cache(),
@@ -43,8 +38,6 @@ pub(crate) fn rendered_output_line_count(
     app: &App,
     session_id: &str,
     session_index: usize,
-    review_status_message: Option<&str>,
-    review_text: Option<&str>,
     output_width: u16,
 ) -> u16 {
     rendered_output_line_count_with_cache(
@@ -52,8 +45,6 @@ pub(crate) fn rendered_output_line_count(
         &RenderCacheStore::default(),
         session_id,
         session_index,
-        review_status_message,
-        review_text,
         output_width,
     )
 }

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -10,9 +10,7 @@ use crate::app::prompt_intent::{
     PromptIntentContext, PromptIntentInputMode, PromptIntentSessionMode,
 };
 use crate::app::session::{SessionTaskService, remote_branch_name_from_upstream_ref};
-use crate::app::{
-    self, App, AppEvent, ReviewCacheEntry, diff_content_hash, is_review_loading_status_message,
-};
+use crate::app::{self, App, AppEvent, ReviewCacheEntry, diff_content_hash};
 use crate::domain::input::InputState;
 use crate::domain::session::{FollowUpTaskAction, PublishBranchAction, SessionId, Status};
 use crate::domain::transcript_notice::TranscriptNotice;
@@ -537,10 +535,7 @@ async fn open_or_regenerate_review(
     pending_update: &mut ViewPendingUpdate,
 ) {
     let (review_status_message, review_text) = app.review_view_state(&view_context.session_id);
-    let is_loading = review_status_message
-        .as_deref()
-        .is_some_and(is_review_loading_status_message);
-    if is_loading {
+    if app.review_is_loading(&view_context.session_id) {
         return;
     }
 
@@ -848,10 +843,7 @@ async fn cancel_in_progress_turn(app: &mut App, session_id: &str) {
 /// the cache, and pressing `f` still starts manual focused review because
 /// view-mode review handling replaces suppressed entries.
 fn suppress_auto_review_for_stopped_turn(app: &mut App, session_id: &str) {
-    app.review_cache.insert(
-        SessionId::from(session_id),
-        ReviewCacheEntry::Suppressed { diff_hash: 0 },
-    );
+    app.suppress_review_output(session_id);
 }
 
 /// Switches the TUI mode from session view to the prompt input.
@@ -1067,7 +1059,7 @@ fn session_prompt_history_entries(session: &crate::domain::session::Session) -> 
 /// persisted for restart hydration.
 async fn open_review_output_mode(app: &mut App, view_context: &ViewContext) {
     if let Some(cached) = app.review_cache.get(view_context.session_id.as_str())
-        && !matches!(cached, ReviewCacheEntry::Suppressed { .. })
+        && !matches!(cached, ReviewCacheEntry::Suppressed)
     {
         return;
     }
@@ -1078,12 +1070,10 @@ async fn open_review_output_mode(app: &mut App, view_context: &ViewContext) {
     let session_folder = session.folder.clone();
     let diff = load_view_session_diff(app, view_context).await;
     if diff.trim().is_empty() {
-        app.review_cache.insert(
-            view_context.session_id.clone(),
-            ReviewCacheEntry::Ready {
-                diff_hash: diff_content_hash(&diff),
-                text: REVIEW_NO_DIFF_MESSAGE.to_string(),
-            },
+        app.set_review_ready_output(
+            &view_context.session_id,
+            diff_content_hash(&diff),
+            REVIEW_NO_DIFF_MESSAGE.to_string(),
         );
 
         return;
@@ -1091,22 +1081,12 @@ async fn open_review_output_mode(app: &mut App, view_context: &ViewContext) {
 
     if diff.starts_with("Failed to run git diff:") {
         let diff_hash = diff_content_hash(&diff);
-        app.review_cache.insert(
-            view_context.session_id.clone(),
-            ReviewCacheEntry::Ready {
-                diff_hash,
-                text: diff,
-            },
-        );
+        app.set_review_ready_output(&view_context.session_id, diff_hash, diff);
 
         return;
     }
 
     let diff_hash = diff_content_hash(&diff);
-    app.review_cache.insert(
-        view_context.session_id.clone(),
-        ReviewCacheEntry::Loading { diff_hash },
-    );
     let _ = app
         .services
         .db()
@@ -1785,7 +1765,7 @@ mod tests {
 
         // Act
         let total_lines =
-            session_output_metric::rendered_output_line_count(&app, &session_id, 0, None, None, 20);
+            session_output_metric::rendered_output_line_count(&app, &session_id, 0, 20);
 
         // Assert
         assert!(total_lines > raw_line_count);
@@ -1854,8 +1834,6 @@ mod tests {
                 &app,
                 &session_id,
                 0,
-                None,
-                None,
                 20,
             ),
             view_height: 5,
@@ -1890,30 +1868,6 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_is_review_loading_status_message_matches_model_aware_message() {
-        // Arrange
-        let status_message = review_loading_message(AgentModel::ClaudeOpus48);
-
-        // Act
-        let is_loading = is_review_loading_status_message(&status_message);
-
-        // Assert
-        assert!(is_loading);
-    }
-
-    #[test]
-    fn test_is_review_loading_status_message_rejects_unrelated_message() {
-        // Arrange
-        let status_message = "Review complete.";
-
-        // Act
-        let is_loading = is_review_loading_status_message(status_message);
-
-        // Assert
-        assert!(!is_loading);
-    }
-
     #[tokio::test]
     async fn test_view_total_lines_uses_default_review_model_for_loading_fallback() {
         // Arrange
@@ -1936,9 +1890,6 @@ mod tests {
             SessionOutputLineContext {
                 active_prompt_output: None,
                 active_progress: None,
-                review_model: AgentModel::ClaudeHaiku4520251001,
-                review_status_message: None,
-                review_text: None,
                 session_update_version: app.session_update_version(&session_id),
             },
             render_cache_store.markdown_render_cache(),
@@ -1946,14 +1897,8 @@ mod tests {
         );
 
         // Act
-        let total_lines = session_output_metric::rendered_output_line_count(
-            &app,
-            &session_id,
-            0,
-            None,
-            None,
-            output_width,
-        );
+        let total_lines =
+            session_output_metric::rendered_output_line_count(&app, &session_id, 0, output_width);
 
         // Assert
         assert_eq!(total_lines, expected);

--- a/crates/agentty/src/test_support.rs
+++ b/crates/agentty/src/test_support.rs
@@ -30,12 +30,13 @@ use crate::domain::question::QuestionItem;
 use crate::domain::selection::SelectionState;
 #[cfg(test)]
 use crate::domain::session::{
-    PublishedBranchSyncStatus, ReviewRequest, Session, SessionHandles, SessionId, SessionSize,
-    SessionStats, Status,
+    ReviewRequest, Session, SessionHandles, SessionId, SessionSize, SessionStats, Status,
 };
 #[cfg(test)]
 use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
 use crate::domain::setting::SettingName;
+#[cfg(test)]
+use crate::domain::transient_message::TransientMessageStore;
 #[cfg(test)]
 use crate::presentation::app_mode::AppMode;
 
@@ -162,7 +163,6 @@ impl SessionFixtureBuilder {
                 queued_messages: Vec::new(),
                 reasoning_level_override: None,
                 published_upstream_ref: None,
-                published_branch_sync_status: PublishedBranchSyncStatus::Idle,
                 questions: Vec::new(),
                 review_request: None,
                 size: SessionSize::Xs,
@@ -172,7 +172,7 @@ impl SessionFixtureBuilder {
                 title: None,
                 transcript: None,
                 updated_at: 0,
-                workflow_notice: None,
+                transient_messages: TransientMessageStore::default(),
             },
         }
     }
@@ -286,7 +286,9 @@ impl SessionFixtureBuilder {
     }
 
     /// Consumes the builder and returns the fully populated fixture.
-    pub(crate) fn build(self) -> Session {
+    pub(crate) fn build(mut self) -> Session {
+        self.session.hydrate_summary_transient();
+
         self.session
     }
 }

--- a/crates/agentty/src/ui/app_render.rs
+++ b/crates/agentty/src/ui/app_render.rs
@@ -24,7 +24,6 @@ pub(crate) fn render_app(
             .as_ref()
             .map(|review| SessionReviewSnapshot {
                 session_id: review.session_id,
-                status_message: review.status_message.clone(),
                 text: review.text,
             });
     let _theme_scope = style::scoped_active_theme(snapshot.settings.theme);

--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -12,10 +12,11 @@ use ratatui::text::Line;
 use ratatui::widgets::{Block, Paragraph};
 use rustc_hash::FxHasher;
 
-use crate::app;
-use crate::domain::agent::AgentModel;
 use crate::domain::session::{Session, SessionId, Status};
 use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
+use crate::domain::transient_message::{
+    TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageSlot,
+};
 use crate::ui::component::tachyon_loader::TachyonLoaderEffect;
 use crate::ui::icon::{Icon, TACHYON_LOADER_WIDTH};
 use crate::ui::input_layout::{bottom_pinned_scroll_offset, panel_inner_width};
@@ -56,18 +57,13 @@ struct SessionOutputLayoutCacheKey {
     markdown_render_version: u64,
     output_width: u16,
     queued_messages: TextFingerprint,
-    /// Review model identity included so fallback loading text invalidates
-    /// correctly when the selected model changes.
-    review_model_name: &'static str,
-    review_status_message: TextFingerprint,
-    review_text: TextFingerprint,
     session_id: SessionId,
     session_update_version: u64,
     session_updated_at: i64,
     status: Status,
     theme_cache_version: u64,
+    transient_message_version: u64,
     transcript: TranscriptFingerprint,
-    workflow_notice: TextFingerprint,
 }
 
 /// Compact optional-text identity used by the layout cache key.
@@ -192,13 +188,10 @@ struct SessionOutputLines {
 enum SessionOutputBlock {
     ActiveTurn,
     CompletedTranscript,
-    PublishedBranchSync,
     QueuedMessage,
-    Review,
     SessionTail,
-    Summary,
+    Transient(TransientMessageAnchor),
     TrailingTranscriptNotice(TrailingTranscriptNoticePlacement),
-    WorkflowNotice,
 }
 
 /// Render placement for trailing transcript notices split from persisted
@@ -217,18 +210,16 @@ enum SessionOutputSeparator {
     AfterPreviousContent,
 }
 
-const SESSION_OUTPUT_BLOCK_ORDER: [SessionOutputBlock; 10] = [
+const SESSION_OUTPUT_BLOCK_ORDER: [SessionOutputBlock; 8] = [
     SessionOutputBlock::CompletedTranscript,
     SessionOutputBlock::TrailingTranscriptNotice(
         TrailingTranscriptNoticePlacement::BeforeActiveTurn,
     ),
-    SessionOutputBlock::Summary,
+    SessionOutputBlock::Transient(TransientMessageAnchor::AfterCompletedTurn),
     SessionOutputBlock::ActiveTurn,
     SessionOutputBlock::QueuedMessage,
-    SessionOutputBlock::Review,
     SessionOutputBlock::TrailingTranscriptNotice(TrailingTranscriptNoticePlacement::AfterReview),
-    SessionOutputBlock::WorkflowNotice,
-    SessionOutputBlock::PublishedBranchSync,
+    SessionOutputBlock::Transient(TransientMessageAnchor::Tail),
     SessionOutputBlock::SessionTail,
 ];
 
@@ -236,7 +227,6 @@ const SESSION_OUTPUT_BLOCK_ORDER: [SessionOutputBlock; 10] = [
 struct SessionOutputAssembly<'a> {
     active_loader_line_index: Option<usize>,
     active_progress: Option<&'a str>,
-    active_prompt_output: Option<&'a str>,
     active_turn_has_visible_text: bool,
     active_turn_section: SessionOutputTranscriptSection<'a>,
     completed_turn_section: SessionOutputTranscriptSection<'a>,
@@ -244,9 +234,6 @@ struct SessionOutputAssembly<'a> {
     lines: Vec<Line<'static>>,
     markdown_render_cache: Option<&'a markdown::MarkdownRenderCache>,
     published_loader_line_index: Option<usize>,
-    review_model: AgentModel,
-    review_status_message: Option<&'a str>,
-    review_text: Option<&'a str>,
     session: &'a Session,
     status: Status,
     trailing_notice_section: SessionOutputTranscriptSection<'a>,
@@ -301,12 +288,9 @@ impl SessionOutputAssembly<'_> {
             SessionOutputBlock::TrailingTranscriptNotice(placement) => {
                 self.append_trailing_transcript_notice(placement);
             }
-            SessionOutputBlock::Summary => self.append_summary(),
+            SessionOutputBlock::Transient(anchor) => self.append_transient_messages(anchor),
             SessionOutputBlock::ActiveTurn => self.append_active_turn(),
             SessionOutputBlock::QueuedMessage => self.append_queued_messages(),
-            SessionOutputBlock::Review => self.append_review(),
-            SessionOutputBlock::WorkflowNotice => self.append_workflow_notice(),
-            SessionOutputBlock::PublishedBranchSync => self.append_published_branch_sync(),
             SessionOutputBlock::SessionTail => self.append_session_tail(),
         }
     }
@@ -339,21 +323,23 @@ impl SessionOutputAssembly<'_> {
         );
     }
 
-    fn append_summary(&mut self) {
-        if !SessionOutput::shows_summary_block(
-            self.status,
-            self.active_prompt_output,
-            &self.active_turn_section,
-        ) {
-            return;
+    fn append_transient_messages(&mut self, anchor: TransientMessageAnchor) {
+        for message in self
+            .session
+            .transient_messages
+            .messages()
+            .iter()
+            .filter(|message| message.anchor == anchor)
+        {
+            if SessionOutput::append_transient_message_lines(
+                &mut self.lines,
+                message,
+                self.inner_width,
+                self.markdown_render_cache,
+            ) {
+                self.published_loader_line_index = Some(self.lines.len().saturating_sub(1));
+            }
         }
-
-        SessionOutput::append_summary_lines(
-            &mut self.lines,
-            self.session.summary.as_deref(),
-            self.inner_width,
-            self.markdown_render_cache,
-        );
     }
 
     fn append_active_turn(&mut self) {
@@ -369,46 +355,20 @@ impl SessionOutputAssembly<'_> {
         SessionOutput::append_queued_message_lines(&mut self.lines, &self.session.queued_messages);
     }
 
-    fn append_review(&mut self) {
-        if !SessionOutput::shows_review_lines(
-            self.status,
-            self.review_status_message,
-            self.review_text,
-        ) {
-            return;
-        }
-
-        SessionOutput::append_review_lines(
-            &mut self.lines,
-            self.review_status_message,
-            self.review_text,
-            self.inner_width,
-            self.markdown_render_cache,
-        );
-    }
-
-    fn append_workflow_notice(&mut self) {
-        SessionOutput::append_workflow_notice_lines(
-            &mut self.lines,
-            self.session.workflow_notice.as_deref(),
-            self.inner_width,
-            self.markdown_render_cache,
-        );
-    }
-
-    fn append_published_branch_sync(&mut self) {
-        if SessionOutput::append_published_branch_sync_lines(&mut self.lines, self.session) {
-            self.published_loader_line_index = Some(self.lines.len().saturating_sub(1));
-        }
-    }
-
     fn append_session_tail(&mut self) {
+        let review_loading_message = self
+            .session
+            .transient_messages
+            .get(TransientMessageSlot::Review)
+            .and_then(|message| match &message.body {
+                TransientMessageBody::Loading(message) => Some(message.as_str()),
+                TransientMessageBody::Markdown(_) | TransientMessageBody::Plain(_) => None,
+            });
         self.active_loader_line_index = SessionOutput::append_session_tail_lines(
             &mut self.lines,
             self.status,
             self.active_progress,
-            self.review_status_message,
-            self.review_model,
+            review_loading_message,
         );
     }
 }
@@ -552,10 +512,6 @@ pub struct SessionOutput<'a> {
     /// for scroll metrics and frame painting within the same session/update
     /// version.
     output_layout_cache: Option<&'a SessionOutputLayoutCache>,
-    /// Model used when an `AgentReview` session needs fallback loading text.
-    review_model: AgentModel,
-    review_status_message: Option<&'a str>,
-    review_text: Option<&'a str>,
     scroll_offset: Option<u16>,
     session: &'a Session,
     session_update_version: u64,
@@ -570,13 +526,6 @@ pub(crate) struct SessionOutputLineContext<'a> {
     pub(crate) active_prompt_output: Option<&'a str>,
     /// Transient progress text rendered in the active-status loader row.
     pub(crate) active_progress: Option<&'a str>,
-    /// Review fallback text shown while review output is unavailable.
-    pub(crate) review_status_message: Option<&'a str>,
-    /// Model used for fallback loading text when no explicit review status
-    /// exists.
-    pub(crate) review_model: AgentModel,
-    /// Review markdown generated by the agent, when available.
-    pub(crate) review_text: Option<&'a str>,
     /// Current observable update version for this session snapshot.
     pub(crate) session_update_version: u64,
 }
@@ -589,9 +538,6 @@ impl<'a> SessionOutput<'a> {
             active_progress: None,
             markdown_render_cache: None,
             output_layout_cache: None,
-            review_model: session.agent.model(),
-            review_status_message: None,
-            review_text: None,
             scroll_offset: None,
             session,
             session_update_version: 0,
@@ -625,28 +571,6 @@ impl<'a> SessionOutput<'a> {
     #[must_use]
     pub fn output_layout_cache(mut self, cache: &'a SessionOutputLayoutCache) -> Self {
         self.output_layout_cache = Some(cache);
-        self
-    }
-
-    /// Sets the review status message rendered when review text is not
-    /// available.
-    #[must_use]
-    pub fn review_status_message(mut self, status_message: Option<&'a str>) -> Self {
-        self.review_status_message = status_message;
-        self
-    }
-
-    /// Sets the review model used by fallback loading text.
-    #[must_use]
-    pub fn review_model(mut self, review_model: AgentModel) -> Self {
-        self.review_model = review_model;
-        self
-    }
-
-    /// Sets review text generated by an agent.
-    #[must_use]
-    pub fn review_text(mut self, review_text: Option<&'a str>) -> Self {
-        self.review_text = review_text;
         self
     }
 
@@ -745,16 +669,13 @@ impl<'a> SessionOutput<'a> {
             queued_messages: TextFingerprint::from_texts(
                 session.queued_messages.iter().map(String::as_str),
             ),
-            review_model_name: context.review_model.as_str(),
-            review_status_message: TextFingerprint::from_text(context.review_status_message),
-            review_text: TextFingerprint::from_text(context.review_text),
             session_id: session.id.clone(),
             session_update_version: context.session_update_version,
             session_updated_at: session.updated_at,
             status: session.status,
             theme_cache_version: style::active_theme_cache_version(),
+            transient_message_version: session.transient_messages.version(),
             transcript: TranscriptFingerprint::from_session(session),
-            workflow_notice: TextFingerprint::from_text(session.workflow_notice.as_deref()),
         }
     }
 
@@ -795,11 +716,8 @@ impl<'a> SessionOutput<'a> {
         markdown_render_cache: Option<&markdown::MarkdownRenderCache>,
     ) -> SessionOutputLines {
         let SessionOutputLineContext {
-            active_prompt_output,
             active_progress,
-            review_model,
-            review_status_message,
-            review_text,
+            active_prompt_output: _,
             session_update_version: _,
         } = context;
         let status = session.status;
@@ -810,7 +728,6 @@ impl<'a> SessionOutput<'a> {
         SessionOutputAssembly {
             active_loader_line_index: None,
             active_progress,
-            active_prompt_output,
             active_turn_has_visible_text,
             active_turn_section: transcript_sections.active_turn,
             completed_turn_section: transcript_sections.completed_turn,
@@ -818,9 +735,6 @@ impl<'a> SessionOutput<'a> {
             lines: Vec::new(),
             markdown_render_cache,
             published_loader_line_index: None,
-            review_model,
-            review_status_message,
-            review_text,
             session,
             status,
             trailing_notice_section: transcript_sections.trailing_notice,
@@ -851,13 +765,11 @@ impl<'a> SessionOutput<'a> {
         status: Status,
         active_progress: Option<&str>,
         review_status_message: Option<&str>,
-        review_model: AgentModel,
     ) -> Option<usize> {
         if let Some(status_line) = session_format::session_output_status_line(
             status,
             active_progress,
             review_status_message,
-            review_model,
         ) {
             Self::append_block_separator(lines, SessionOutputSeparator::Always);
             let active_loader_line_index =
@@ -880,39 +792,50 @@ impl<'a> SessionOutput<'a> {
         None
     }
 
-    /// Appends one automatic published-branch sync status row while the latest
-    /// completed turn is auto-pushing to a published branch.
-    fn append_published_branch_sync_lines(
+    /// Appends one explicitly typed transient message and returns whether it
+    /// owns the published-branch loader row.
+    fn append_transient_message_lines(
         lines: &mut Vec<Line<'static>>,
-        session: &Session,
-    ) -> bool {
-        let Some(sync_line) = session_format::session_output_published_branch_sync_line(session)
-        else {
-            return false;
-        };
-
-        Self::append_block_separator(lines, SessionOutputSeparator::Always);
-        lines.push(sync_line);
-
-        true
-    }
-
-    /// Appends the latest transient workflow notice without reading from or
-    /// mutating the persisted transcript text.
-    fn append_workflow_notice_lines(
-        lines: &mut Vec<Line<'static>>,
-        workflow_notice: Option<&str>,
+        message: &TransientMessage,
         inner_width: usize,
         markdown_render_cache: Option<&markdown::MarkdownRenderCache>,
-    ) {
-        let Some(workflow_notice) = workflow_notice.map(str::trim) else {
-            return;
-        };
-        if workflow_notice.is_empty() {
-            return;
+    ) -> bool {
+        match &message.body {
+            TransientMessageBody::Markdown(markdown) => {
+                let markdown = match message.slot {
+                    TransientMessageSlot::Summary => {
+                        session_format::session_output_summary_markdown(markdown)
+                    }
+                    TransientMessageSlot::Review => {
+                        session_format::annotate_review_suggestions_header(markdown)
+                    }
+                    TransientMessageSlot::WorkflowNotice
+                    | TransientMessageSlot::PublishedBranchSync => markdown.clone(),
+                };
+                Self::append_markdown_lines(lines, &markdown, inner_width, markdown_render_cache);
+            }
+            TransientMessageBody::Plain(status_message) => {
+                Self::append_block_separator(lines, SessionOutputSeparator::AfterPreviousContent);
+                Self::append_plain_status_lines(lines, status_message, inner_width);
+            }
+            TransientMessageBody::Loading(status_message) => {
+                if message.slot == TransientMessageSlot::Review {
+                    // Review loading is painted by `append_session_tail()` so
+                    // it shares the status row's tachyon animation. The Tail
+                    // anchor classifies its placement but this pass must skip
+                    // it to avoid rendering a duplicate static loading row.
+                    return false;
+                }
+
+                Self::append_block_separator(lines, SessionOutputSeparator::Always);
+                lines.push(session_format::session_output_transient_loading_line(
+                    status_message,
+                ));
+            }
         }
 
-        Self::append_markdown_lines(lines, workflow_notice, inner_width, markdown_render_cache);
+        message.slot == TransientMessageSlot::PublishedBranchSync
+            && matches!(message.body, TransientMessageBody::Loading(_))
     }
 
     /// Returns transcript sections from draft-preview text or typed message
@@ -1061,98 +984,12 @@ impl<'a> SessionOutput<'a> {
         format!("{}\n\n", formatted_lines.join("\n"))
     }
 
-    /// Returns whether the output panel should append the structured summary
-    /// block outside the persisted transcript string.
-    ///
-    /// Summary markdown is rendered alongside transcript output for completed
-    /// turns. Once a new prompt is active, the old summary is hidden until the
-    /// next turn finishes and produces fresh summary metadata.
-    /// Canceled sessions keep the raw transcript visible so interrupted turns
-    /// do not render synthetic summary content that was never finalized.
-    fn shows_summary_block(
-        status: Status,
-        active_prompt_output: Option<&str>,
-        active_turn_section: &SessionOutputTranscriptSection<'_>,
-    ) -> bool {
-        if status == Status::Canceled {
-            return false;
-        }
-
-        active_prompt_output.is_none() && active_turn_section.is_empty()
-    }
-
-    /// Returns whether focused-review output belongs in a non-terminal session
-    /// view.
-    ///
-    /// Terminal session views own their final summary or transcript display, so
-    /// they intentionally avoid appending transient focused-review summaries.
-    fn shows_review_lines(
-        status: Status,
-        review_status_message: Option<&str>,
-        review_text: Option<&str>,
-    ) -> bool {
-        if matches!(status, Status::Done | Status::Canceled) {
-            return false;
-        }
-
-        review_status_message
-            .map(str::trim)
-            .is_some_and(|status_message| !status_message.is_empty())
-            || review_text
-                .map(str::trim)
-                .is_some_and(|review_text| !review_text.is_empty())
-    }
-
-    /// Appends focused-review output or non-loading fallback text to the
-    /// transcript for the current session view.
-    ///
-    /// The `### Suggestions` header is annotated with a `/apply` hint at
-    /// render time only when the review contains actionable suggestions, so
-    /// users discover available apply behavior without polluting the persisted
-    /// review markdown consumed by suggestion extraction.
-    fn append_review_lines(
-        lines: &mut Vec<Line<'static>>,
-        review_status_message: Option<&str>,
-        review_text: Option<&str>,
-        inner_width: usize,
-        markdown_render_cache: Option<&markdown::MarkdownRenderCache>,
-    ) {
-        if let Some(review_markdown) = review_text
-            .map(str::trim)
-            .filter(|review_text| !review_text.is_empty())
-            .map(session_format::annotate_review_suggestions_header)
-        {
-            Self::append_markdown_lines(
-                lines,
-                &review_markdown,
-                inner_width,
-                markdown_render_cache,
-            );
-
-            return;
-        }
-
-        if let Some(status_message) = Self::visible_review_status_message(review_status_message) {
-            Self::append_block_separator(lines, SessionOutputSeparator::AfterPreviousContent);
-            Self::append_plain_review_status_lines(lines, status_message, inner_width);
-        }
-    }
-
-    /// Returns non-loading focused-review fallback text suitable for plain
-    /// rendering.
-    fn visible_review_status_message(review_status_message: Option<&str>) -> Option<&str> {
-        review_status_message
-            .map(str::trim)
-            .filter(|status_message| !status_message.is_empty())
-            .filter(|status_message| !app::is_review_loading_status_message(status_message))
-    }
-
-    /// Appends review fallback text without interpreting markdown
+    /// Appends transient fallback text without interpreting markdown
     /// metacharacters in status strings.
     ///
     /// The caller owns separator trimming and spacing so this helper remains
     /// purely additive.
-    fn append_plain_review_status_lines(
+    fn append_plain_status_lines(
         lines: &mut Vec<Line<'static>>,
         status_message: &str,
         inner_width: usize,
@@ -1162,29 +999,6 @@ impl<'a> SessionOutput<'a> {
             .map(|line| Line::from(line.to_string()));
 
         lines.extend(rendered_lines);
-    }
-
-    /// Appends a rendered structured-summary section without mutating the
-    /// persisted transcript string.
-    fn append_summary_lines(
-        lines: &mut Vec<Line<'static>>,
-        summary_text: Option<&str>,
-        inner_width: usize,
-        markdown_render_cache: Option<&markdown::MarkdownRenderCache>,
-    ) {
-        let Some(summary_text) = summary_text else {
-            return;
-        };
-        if summary_text.trim().is_empty() {
-            return;
-        }
-
-        Self::append_markdown_lines(
-            lines,
-            &session_format::session_output_summary_markdown(summary_text),
-            inner_width,
-            markdown_render_cache,
-        );
     }
 
     /// Appends one split transcript section while preserving typed message
@@ -1557,9 +1371,6 @@ impl Component for SessionOutput<'_> {
             SessionOutputLineContext {
                 active_prompt_output: self.active_prompt_output,
                 active_progress: self.active_progress,
-                review_model: self.review_model,
-                review_status_message: self.review_status_message,
-                review_text: self.review_text,
                 session_update_version: self.session_update_version,
             },
             self.markdown_render_cache,
@@ -1613,23 +1424,26 @@ mod tests {
     use serde_json;
 
     use super::*;
-    use crate::domain::session::PublishedBranchSyncStatus;
     use crate::domain::theme::ColorTheme;
 
     /// Builds one output-line context with defaults suitable for tests.
-    fn line_context<'a>(
-        review_status_message: Option<&'a str>,
-        review_text: Option<&'a str>,
-        active_progress: Option<&'a str>,
-    ) -> SessionOutputLineContext<'a> {
+    fn line_context() -> SessionOutputLineContext<'static> {
         SessionOutputLineContext {
             active_prompt_output: None,
-            active_progress,
-            review_model: AgentModel::Gpt55,
-            review_status_message,
-            review_text,
+            active_progress: None,
             session_update_version: 0,
         }
+    }
+
+    /// Posts one focused-review slot for renderer tests.
+    fn set_review_transient(session: &mut Session, body: TransientMessageBody) {
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::AfterCompletedTurn,
+            body,
+            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::Review,
+            turn_position: session.latest_user_prompt_position(),
+        });
     }
 
     fn summary_fixture() -> String {
@@ -1724,7 +1538,7 @@ mod tests {
         let rendered_line_count = SessionOutput::rendered_line_count(
             &session,
             20,
-            line_context(None, None, None),
+            line_context(),
             Some(&markdown_render_cache),
             Some(&output_layout_cache),
         );
@@ -1742,7 +1556,7 @@ mod tests {
         let output_layout_cache = SessionOutputLayoutCache::default();
         let context = SessionOutputLineContext {
             session_update_version: 7,
-            ..line_context(None, None, None)
+            ..line_context()
         };
 
         // Act
@@ -1783,7 +1597,7 @@ mod tests {
         );
         let markdown_render_cache = markdown::MarkdownRenderCache::default();
         let output_layout_cache = SessionOutputLayoutCache::default();
-        let context = line_context(None, None, None);
+        let context = line_context();
 
         // Act
         let current_layout = {
@@ -1823,7 +1637,7 @@ mod tests {
         session.is_draft = true;
         let markdown_render_cache = markdown::MarkdownRenderCache::default();
         let output_layout_cache = SessionOutputLayoutCache::default();
-        let context = line_context(None, None, None);
+        let context = line_context();
 
         // Act
         let empty_layout = output_layout_cache.layout(
@@ -1859,7 +1673,7 @@ mod tests {
         session.prompt = "First staged draft".to_string();
         let markdown_render_cache = markdown::MarkdownRenderCache::default();
         let output_layout_cache = SessionOutputLayoutCache::default();
-        let context = line_context(None, None, None);
+        let context = line_context();
 
         // Act
         let root_layout = output_layout_cache.layout(
@@ -1899,7 +1713,7 @@ mod tests {
         set_assistant_transcript(&mut session, " › running prompt");
         let markdown_render_cache = markdown::MarkdownRenderCache::default();
         let output_layout_cache = SessionOutputLayoutCache::default();
-        let context = line_context(None, None, None);
+        let context = line_context();
 
         // Act
         let empty_layout = output_layout_cache.layout(
@@ -1937,7 +1751,7 @@ mod tests {
         session.status = Status::Review;
         let markdown_render_cache = markdown::MarkdownRenderCache::default();
         let output_layout_cache = SessionOutputLayoutCache::default();
-        let context = line_context(None, None, None);
+        let context = line_context();
 
         // Act
         let base_layout = output_layout_cache.layout(
@@ -1946,7 +1760,13 @@ mod tests {
             context,
             Some(&markdown_render_cache),
         );
-        session.workflow_notice = Some("[Commit] No changes to commit.".to_string());
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::AfterCompletedTurn,
+            body: TransientMessageBody::Markdown("[Commit] No changes to commit.".to_string()),
+            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::WorkflowNotice,
+            turn_position: None,
+        });
         let notice_layout = output_layout_cache.layout(
             &session,
             Rect::new(0, 0, 80, 8),
@@ -1974,18 +1794,13 @@ mod tests {
     #[test]
     fn test_output_layout_cache_keys_review_text() {
         // Arrange
-        let session = session_fixture();
+        let mut session = session_fixture();
         let markdown_render_cache = markdown::MarkdownRenderCache::default();
         let output_layout_cache = SessionOutputLayoutCache::default();
         let base_context = SessionOutputLineContext {
             session_update_version: 7,
-            ..line_context(None, None, None)
+            ..line_context()
         };
-        let review_context = SessionOutputLineContext {
-            review_text: Some("## Review\n\n- Cached finding"),
-            ..base_context
-        };
-
         // Act
         let base_layout = output_layout_cache.layout(
             &session,
@@ -1993,10 +1808,17 @@ mod tests {
             base_context,
             Some(&markdown_render_cache),
         );
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::AfterCompletedTurn,
+            body: TransientMessageBody::Markdown("## Review\n\n- Cached finding".to_string()),
+            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::Review,
+            turn_position: None,
+        });
         let review_layout = output_layout_cache.layout(
             &session,
             Rect::new(0, 0, 80, 8),
-            review_context,
+            base_context,
             Some(&markdown_render_cache),
         );
 
@@ -2013,7 +1835,7 @@ mod tests {
         session.status = Status::InProgress;
         let markdown_render_cache = markdown::MarkdownRenderCache::default();
         let output_layout_cache = SessionOutputLayoutCache::default();
-        let first_frame_context = line_context(None, None, None);
+        let first_frame_context = line_context();
 
         // Act
         let first_layout = output_layout_cache.layout(
@@ -2109,7 +1931,7 @@ mod tests {
             output_layout_cache.layout(
                 &session,
                 Rect::new(0, 0, 80, 8),
-                line_context(None, None, None),
+                line_context(),
                 Some(&markdown_render_cache),
             );
 
@@ -2139,7 +1961,7 @@ mod tests {
             &format!("{} pasted transcript glyph", Icon::TachyonLoader),
         );
         session.status = Status::InProgress;
-        let context = line_context(None, None, None);
+        let context = line_context();
 
         // Act
         let output_lines = SessionOutput::output_lines_with_metadata(
@@ -2247,14 +2069,9 @@ mod tests {
         set_assistant_transcript(&mut session, "streamed output");
         session.summary = Some(summary_fixture());
         session.status = Status::Done;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 5),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 5), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -2275,12 +2092,7 @@ mod tests {
         session.prompt = "First draft\n\nSecond draft".to_string();
 
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 12),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 12), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -2306,12 +2118,7 @@ mod tests {
         session.prompt = "First draft".to_string();
 
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 12),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 12), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -2334,12 +2141,7 @@ mod tests {
         session.prompt = "Stacked draft".to_string();
 
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 12),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 12), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -2361,12 +2163,7 @@ mod tests {
         session.is_draft = true;
 
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 8),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 8), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -2387,12 +2184,7 @@ mod tests {
         session.parent_session_id = Some(SessionId::from("parent-session"));
 
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 8),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 8), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -2421,14 +2213,9 @@ mod tests {
         );
         session.summary = Some(summary_fixture());
         session.status = Status::Done;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 5),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 5), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -2475,14 +2262,9 @@ mod tests {
         );
         session.summary = Some(summary_fixture());
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 5),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 5), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -2525,14 +2307,9 @@ mod tests {
         session.summary = Some(summary_fixture());
         session.transcript = Some(transcript);
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 8),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 8), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -2620,14 +2397,14 @@ mod tests {
         session.summary = Some(summary_fixture());
         session.status = Status::Review;
         let review_text = "## Review\n\n### Project Impact\n\n- Documentation-only change.";
+        session.reconcile_transient_messages();
+        set_review_transient(
+            &mut session,
+            TransientMessageBody::Markdown(review_text.to_string()),
+        );
 
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 8),
-            line_context(None, Some(review_text), None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 8), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -2650,72 +2427,6 @@ mod tests {
         assert!(review_index < merge_error_index);
     }
 
-    /// Verifies a terminal `Done` session keeps its final summary without
-    /// appending transient focused-review output.
-    #[test]
-    fn test_output_lines_done_session_hides_review_text_when_available() {
-        // Arrange
-        let mut session = session_fixture();
-        session.summary = Some("# Summary\n\nMerged session work.".to_string());
-        session.status = Status::Done;
-        let assisted_review = "## Review\n\n- Focused finding";
-
-        // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 8),
-            line_context(
-                Some("Reviewing changes with gpt-5.5"),
-                Some(assisted_review),
-                None,
-            ),
-            None,
-        );
-        let text = lines
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        // Assert
-        assert!(text.contains("Merged session work."));
-        assert!(!text.contains("Focused finding"));
-        assert!(!text.contains("Reviewing changes with gpt-5.5"));
-    }
-
-    /// Verifies a terminal `Canceled` session keeps its interrupted transcript
-    /// without appending transient focused-review output.
-    #[test]
-    fn test_output_lines_canceled_session_hides_review_text_when_available() {
-        // Arrange
-        let mut session = session_fixture();
-        set_assistant_transcript(&mut session, "interrupted transcript");
-        session.status = Status::Canceled;
-        let assisted_review = "## Review\n\n- Focused finding";
-
-        // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 8),
-            line_context(
-                Some("Reviewing changes with gpt-5.5"),
-                Some(assisted_review),
-                None,
-            ),
-            None,
-        );
-        let text = lines
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        // Assert
-        assert!(text.contains("interrupted transcript"));
-        assert!(!text.contains("Focused finding"));
-        assert!(!text.contains("Reviewing changes with gpt-5.5"));
-    }
-
     /// Verifies focused-review failures remain visible after the transient
     /// loading status returns to `Review`.
     #[test]
@@ -2724,14 +2435,13 @@ mod tests {
         let mut session = session_fixture();
         session.status = Status::Review;
         let review_status_message = "Review assist unavailable: empty provider response";
+        set_review_transient(
+            &mut session,
+            TransientMessageBody::Plain(review_status_message.to_string()),
+        );
 
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 8),
-            line_context(Some(review_status_message), None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 8), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -2755,15 +2465,14 @@ mod tests {
                 "\n[Branch Push] Auto-pushed published branch after completed turn.\n",
             )],
         );
-        session.published_branch_sync_status = PublishedBranchSyncStatus::Succeeded;
         session.published_upstream_ref = Some("origin/wt/session-id".to_string());
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
         let lines = SessionOutput::output_lines_with_metadata(
             &session,
             Rect::new(0, 0, 80, 8),
-            line_context(None, None, None),
+            line_context(),
             None,
         );
         let text = lines
@@ -2791,14 +2500,13 @@ mod tests {
         let mut session = session_fixture();
         session.status = Status::Review;
         let review_status_message = "# Review *failed* for `tool`";
+        set_review_transient(
+            &mut session,
+            TransientMessageBody::Plain(review_status_message.to_string()),
+        );
 
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 8),
-            line_context(Some(review_status_message), None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 8), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -2816,14 +2524,9 @@ mod tests {
         set_assistant_transcript(&mut session, "implemented the feature");
         session.summary = Some(summary_fixture());
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 5),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 5), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -2844,14 +2547,9 @@ mod tests {
         let mut session = session_fixture();
         session.summary = Some(summary_fixture());
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 8),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 8), line_context(), None);
         let rendered_lines = lines.iter().map(ToString::to_string).collect::<Vec<_>>();
         let summary_header_index = rendered_lines
             .iter()
@@ -2898,7 +2596,7 @@ mod tests {
             Rect::new(0, 0, 80, 8),
             SessionOutputLineContext {
                 active_prompt_output: Some("\n › add hello world\n\n"),
-                ..line_context(None, None, None)
+                ..line_context()
             },
             None,
         );
@@ -2947,7 +2645,7 @@ mod tests {
             Rect::new(0, 0, 80, 8),
             SessionOutputLineContext {
                 active_prompt_output: Some("\n › add hello world\n\n"),
-                ..line_context(None, None, None)
+                ..line_context()
             },
             None,
         );
@@ -2998,7 +2696,7 @@ mod tests {
             Rect::new(0, 0, 80, 8),
             SessionOutputLineContext {
                 active_prompt_output: Some(" › add hello world\n\n"),
-                ..line_context(None, None, None)
+                ..line_context()
             },
             None,
         );
@@ -3041,12 +2739,7 @@ mod tests {
         session.status = Status::InProgress;
 
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 8),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 8), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -3091,7 +2784,7 @@ mod tests {
             Rect::new(0, 0, 80, 8),
             SessionOutputLineContext {
                 active_prompt_output: Some("\n › actual prompt\n\n"),
-                ..line_context(None, None, None)
+                ..line_context()
             },
             None,
         );
@@ -3118,14 +2811,9 @@ mod tests {
         let mut session = session_fixture();
         set_assistant_transcript(&mut session, "implemented the feature");
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 5),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 5), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -3159,14 +2847,9 @@ mod tests {
             ],
         );
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 12),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 12), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -3213,14 +2896,9 @@ mod tests {
             )],
         );
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 8),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 8), line_context(), None);
         let rendered_lines = lines
             .iter()
             .map(|line| line.to_string().trim_end().to_string())
@@ -3253,14 +2931,9 @@ mod tests {
             )],
         );
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 8),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 8), line_context(), None);
         let rendered_lines = lines
             .iter()
             .map(|line| line.to_string().trim_end().to_string())
@@ -3287,14 +2960,9 @@ mod tests {
         let mut session = session_fixture();
         set_conversation_transcript(&mut session, vec![(SessionMessageKind::UserPrompt, prompt)]);
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 6),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 6), line_context(), None);
         let rendered_text = lines
             .iter()
             .map(|line| line.to_string().trim_end().to_string())
@@ -3323,14 +2991,9 @@ mod tests {
             )],
         );
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 12),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 12), line_context(), None);
         let rendered_lines = lines
             .iter()
             .map(|line| line.to_string().trim_end().to_string())
@@ -3429,14 +3092,9 @@ mod tests {
             vec![(SessionMessageKind::UserPrompt, "alpha beta")],
         );
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 3, 8),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 3, 8), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -3465,14 +3123,9 @@ mod tests {
             )],
         );
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 12),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 12), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -3538,14 +3191,9 @@ mod tests {
             )],
         );
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 12),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 12), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -3582,14 +3230,9 @@ mod tests {
             ),
         );
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 8),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 8), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -3619,14 +3262,9 @@ mod tests {
             ),
         );
         session.status = Status::Review;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 12),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 12), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -3650,12 +3288,8 @@ mod tests {
         set_assistant_transcript(&mut session, "streamed output");
         session.summary = Some(summary_fixture());
         session.status = Status::Review;
-        let review_lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 8),
-            line_context(None, None, None),
-            None,
-        );
+        session.reconcile_transient_messages();
+        let review_lines = output_lines(&session, Rect::new(0, 0, 80, 8), line_context(), None);
         let review_text = review_lines
             .iter()
             .map(ToString::to_string)
@@ -3667,14 +3301,9 @@ mod tests {
                 .to_string(),
         );
         session.status = Status::Done;
-
+        session.reconcile_transient_messages();
         // Act
-        let done_lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 8),
-            line_context(None, None, None),
-            None,
-        );
+        let done_lines = output_lines(&session, Rect::new(0, 0, 80, 8), line_context(), None);
         let done_text = done_lines
             .iter()
             .map(ToString::to_string)
@@ -3697,18 +3326,13 @@ mod tests {
         let mut session = session_fixture();
         session.status = Status::AgentReview;
         let assisted_text = "## Review\n\n- Focused finding";
+        set_review_transient(
+            &mut session,
+            TransientMessageBody::Markdown(assisted_text.to_string()),
+        );
 
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 5),
-            line_context(
-                Some("Reviewing changes with gpt-5.5"),
-                Some(assisted_text),
-                None,
-            ),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 5), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -3727,14 +3351,9 @@ mod tests {
         set_assistant_transcript(&mut session, "streamed output");
         session.summary = Some(summary_fixture());
         session.status = Status::Canceled;
-
+        session.reconcile_transient_messages();
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 5),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 5), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)
@@ -3754,12 +3373,7 @@ mod tests {
         session.status = Status::InProgress;
 
         // Act
-        let lines = output_lines(
-            &session,
-            Rect::new(0, 0, 80, 5),
-            line_context(None, None, None),
-            None,
-        );
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 5), line_context(), None);
         let text = lines
             .iter()
             .map(ToString::to_string)

--- a/crates/agentty/src/ui/layout.rs
+++ b/crates/agentty/src/ui/layout.rs
@@ -359,9 +359,7 @@ mod tests {
     use crate::domain::agent::{AgentKind, AgentModel, ReasoningLevel};
     use crate::domain::file_entry::FileEntry;
     use crate::domain::input::InputState;
-    use crate::domain::session::{
-        COMMITTING_PROGRESS_LABEL, PublishedBranchSyncStatus, Session, Status,
-    };
+    use crate::domain::session::{COMMITTING_PROGRESS_LABEL, Session, Status};
     use crate::domain::theme::ColorTheme;
     use crate::presentation::app_mode::ChatFocus;
     use crate::presentation::help_action::{self, ViewActionAvailability, ViewHelpState};
@@ -1212,13 +1210,9 @@ mod tests {
         // Arrange
 
         // Act
-        let status_line = session_output_status_line(
-            Status::InProgress,
-            Some("Inspecting changed files"),
-            None,
-            AgentModel::Gpt55,
-        )
-        .expect("in-progress sessions should render a status line");
+        let status_line =
+            session_output_status_line(Status::InProgress, Some("Inspecting changed files"), None)
+                .expect("in-progress sessions should render a status line");
 
         // Assert
         assert!(
@@ -1233,13 +1227,9 @@ mod tests {
         // Arrange
 
         // Act
-        let status_line = session_output_status_line(
-            Status::InProgress,
-            Some(COMMITTING_PROGRESS_LABEL),
-            None,
-            AgentModel::ClaudeOpus48,
-        )
-        .expect("in-progress sessions should render a status line");
+        let status_line =
+            session_output_status_line(Status::InProgress, Some(COMMITTING_PROGRESS_LABEL), None)
+                .expect("in-progress sessions should render a status line");
 
         // Assert
         assert!(status_line.to_string().contains(COMMITTING_PROGRESS_LABEL));
@@ -1259,7 +1249,6 @@ mod tests {
             Status::AgentReview,
             None,
             Some("Reviewing changes with gpt-5.5"),
-            AgentModel::Gpt55,
         )
         .expect("agent-review sessions should render a status line");
 
@@ -1272,20 +1261,15 @@ mod tests {
     }
 
     #[test]
-    fn test_session_output_status_line_for_agent_review_falls_back_to_model_loader_text() {
+    fn test_session_output_status_line_for_agent_review_uses_generic_fallback() {
         // Arrange
 
         // Act
-        let status_line =
-            session_output_status_line(Status::AgentReview, None, None, AgentModel::ClaudeOpus48)
-                .expect("agent-review sessions should render a status line");
+        let status_line = session_output_status_line(Status::AgentReview, None, None)
+            .expect("agent-review sessions should render a status line");
 
         // Assert
-        assert!(
-            status_line
-                .to_string()
-                .contains("Reviewing changes with claude-opus-4-8")
-        );
+        assert!(status_line.to_string().contains("Reviewing changes..."));
     }
 
     #[test]
@@ -1293,31 +1277,11 @@ mod tests {
         // Arrange
 
         // Act
-        let status_line =
-            session_output_status_line(Status::Merging, None, None, AgentModel::Gpt55)
-                .expect("merging sessions should render a status line");
+        let status_line = session_output_status_line(Status::Merging, None, None)
+            .expect("merging sessions should render a status line");
 
         // Assert
         assert!(status_line.to_string().contains("Merging..."));
-    }
-
-    #[test]
-    fn test_session_output_published_branch_sync_line_uses_sync_message() {
-        // Arrange
-        let mut session = session_fixture();
-        session.published_upstream_ref = Some("origin/wt/session-id".to_string());
-        session.published_branch_sync_status = PublishedBranchSyncStatus::InProgress;
-
-        // Act
-        let sync_line = session_output_published_branch_sync_line(&session)
-            .expect("published branch sync should render a status line");
-
-        // Assert
-        assert!(
-            sync_line
-                .to_string()
-                .contains("Auto-pushing published branch after completed turn...")
-        );
     }
 
     #[test]

--- a/crates/agentty/src/ui/overlay.rs
+++ b/crates/agentty/src/ui/overlay.rs
@@ -290,9 +290,6 @@ pub(crate) fn render_view_info_popup(
             markdown_render_cache,
             mode: &background_mode,
             output_layout_cache,
-            review_status_message: review_snapshot
-                .filter(|snapshot| snapshot.session_id == restore_view.session_id.as_str())
-                .and_then(|snapshot| snapshot.status_message.as_deref()),
             review_text: review_snapshot
                 .filter(|snapshot| snapshot.session_id == restore_view.session_id.as_str())
                 .and_then(|snapshot| snapshot.text),
@@ -545,9 +542,6 @@ fn render_help_background(f: &mut Frame, area: Rect, context: HelpBackgroundRend
                 markdown_render_cache,
                 mode: &bg_mode,
                 output_layout_cache,
-                review_status_message: review_snapshot
-                    .filter(|snapshot| snapshot.session_id == session_id)
-                    .and_then(|snapshot| snapshot.status_message.as_deref()),
                 review_text: review_snapshot
                     .filter(|snapshot| snapshot.session_id == session_id)
                     .and_then(|snapshot| snapshot.text),

--- a/crates/agentty/src/ui/page/session_chat.rs
+++ b/crates/agentty/src/ui/page/session_chat.rs
@@ -64,7 +64,6 @@ pub struct SessionChatPage<'a> {
     /// Shared fully assembled output-layout cache for scroll metrics and
     /// frame rendering.
     pub output_layout_cache: &'a SessionOutputLayoutCache,
-    pub review_status_message: Option<&'a str>,
     pub review_text: Option<&'a str>,
     pub scroll_offset: Option<u16>,
     pub session_index: usize,
@@ -90,8 +89,6 @@ pub struct SessionChatPageInput<'a> {
     pub mode: &'a AppMode,
     /// Shared output-layout cache for this render pass.
     pub output_layout_cache: &'a SessionOutputLayoutCache,
-    /// Focused-review status text for the rendered session.
-    pub review_status_message: Option<&'a str>,
     /// Focused-review output for the rendered session.
     pub review_text: Option<&'a str>,
     /// Current vertical output scroll offset.
@@ -116,7 +113,6 @@ impl<'a> SessionChatPage<'a> {
             markdown_render_cache,
             mode,
             output_layout_cache,
-            review_status_message,
             review_text,
             scroll_offset,
             session_index,
@@ -133,7 +129,6 @@ impl<'a> SessionChatPage<'a> {
             markdown_render_cache,
             mode,
             output_layout_cache,
-            review_status_message,
             review_text,
             scroll_offset,
             session_index,
@@ -196,8 +191,6 @@ impl<'a> SessionChatPage<'a> {
             .output_layout_cache(self.output_layout_cache)
             .session_update_version(self.session_update_version);
         output = output.active_prompt_output(self.active_prompt_output);
-        output = output.review_status_message(self.review_status_message);
-        output = output.review_text(self.review_text);
         if let Some(scroll_offset) = self.scroll_offset {
             output = output.scroll_offset(scroll_offset);
         }
@@ -623,7 +616,7 @@ impl Page for SessionChatPage<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::agent::{AgentModel, ReasoningLevel};
+    use crate::domain::agent::ReasoningLevel;
     use crate::domain::input::InputState;
     use crate::domain::question::QuestionItem;
     use crate::domain::session::Status;
@@ -649,7 +642,6 @@ mod tests {
             markdown_render_cache: test_markdown_render_cache(),
             mode,
             output_layout_cache: test_output_layout_cache(),
-            review_status_message: None,
             review_text: None,
             scroll_offset: None,
             session_index: 0,
@@ -899,9 +891,6 @@ mod tests {
             SessionOutputLineContext {
                 active_prompt_output: None,
                 active_progress: None,
-                review_model: AgentModel::Gpt55,
-                review_status_message: None,
-                review_text: None,
                 session_update_version: 0,
             },
             &markdown_render_cache,
@@ -952,25 +941,19 @@ mod tests {
             selected_option_index: None,
         };
         let mut page = test_session_chat_page(&session, &mode);
-        page.review_status_message = Some("Reviewing changes with gpt-5.5");
         page.review_text = Some("Focused review");
 
         // Act
         let review_text = page.review_text;
-        let review_status_message = page.review_status_message;
 
         // Assert
         assert_eq!(review_text, Some("Focused review"));
-        assert_eq!(
-            review_status_message,
-            Some("Reviewing changes with gpt-5.5")
-        );
     }
 
     #[test]
     fn test_rendered_output_line_count_includes_question_review_output() {
         // Arrange
-        let session = session_fixture();
+        let mut session = session_fixture();
         let markdown_render_cache = markdown::MarkdownRenderCache::default();
         let output_layout_cache = SessionOutputLayoutCache::default();
         let without_review = SessionChatPage::rendered_output_line_count(
@@ -979,14 +962,24 @@ mod tests {
             SessionOutputLineContext {
                 active_prompt_output: None,
                 active_progress: None,
-                review_model: AgentModel::Gpt55,
-                review_status_message: None,
-                review_text: None,
                 session_update_version: 0,
             },
             &markdown_render_cache,
             &output_layout_cache,
         );
+        session
+            .transient_messages
+            .upsert(crate::domain::transient_message::TransientMessage {
+                anchor:
+                    crate::domain::transient_message::TransientMessageAnchor::AfterCompletedTurn,
+                body: crate::domain::transient_message::TransientMessageBody::Markdown(
+                    "## Review\n\n- Finding".to_string(),
+                ),
+                lifecycle:
+                    crate::domain::transient_message::TransientMessageLifecycle::ClearOnNewTurn,
+                slot: crate::domain::transient_message::TransientMessageSlot::Review,
+                turn_position: None,
+            });
 
         // Act
         let with_review = SessionChatPage::rendered_output_line_count(
@@ -995,9 +988,6 @@ mod tests {
             SessionOutputLineContext {
                 active_prompt_output: None,
                 active_progress: None,
-                review_model: AgentModel::Gpt55,
-                review_status_message: None,
-                review_text: Some("## Review\n\n- Finding"),
                 session_update_version: 0,
             },
             &markdown_render_cache,

--- a/crates/agentty/src/ui/render.rs
+++ b/crates/agentty/src/ui/render.rs
@@ -19,7 +19,6 @@ use crate::ui::{component, layout, markdown, page, router};
 /// session.
 pub struct SessionReviewSnapshot<'a> {
     pub session_id: &'a str,
-    pub status_message: Option<String>,
     pub text: Option<&'a str>,
 }
 

--- a/crates/agentty/src/ui/router.rs
+++ b/crates/agentty/src/ui/router.rs
@@ -831,9 +831,6 @@ fn render_session_chat(f: &mut Frame, area: Rect, context: SessionChatRenderCont
         markdown_render_cache,
         mode,
         output_layout_cache,
-        review_status_message: review_snapshot
-            .filter(|snapshot| snapshot.session_id == session_id)
-            .and_then(|snapshot| snapshot.status_message.as_deref()),
         review_text: review_snapshot
             .filter(|snapshot| snapshot.session_id == session_id)
             .and_then(|snapshot| snapshot.text),

--- a/crates/agentty/src/ui/session_format.rs
+++ b/crates/agentty/src/ui/session_format.rs
@@ -6,12 +6,9 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Borders;
 
-use crate::app;
-use crate::domain::agent::{AgentModel, ReasoningLevel};
+use crate::domain::agent::ReasoningLevel;
 use crate::domain::review;
-use crate::domain::session::{
-    COMMITTING_PROGRESS_LABEL, PublishedBranchSyncStatus, Session, Status,
-};
+use crate::domain::session::{COMMITTING_PROGRESS_LABEL, Session, Status};
 use crate::presentation::help_action::{self, ViewHelpState};
 use crate::ui::icon::Icon;
 use crate::ui::{markdown, style};
@@ -242,7 +239,6 @@ pub fn session_output_status_line(
     status: Status,
     active_progress: Option<&str>,
     review_status_message: Option<&str>,
-    review_model: AgentModel,
 ) -> Option<Line<'static>> {
     if !matches!(
         status,
@@ -256,7 +252,7 @@ pub fn session_output_status_line(
     }
 
     let status_message =
-        session_output_status_message(status, active_progress, review_status_message, review_model);
+        session_output_status_message(status, active_progress, review_status_message);
 
     Some(Line::from(vec![Span::styled(
         format!("{} {status_message}", session_output_status_icon(status)),
@@ -264,20 +260,12 @@ pub fn session_output_status_line(
     )]))
 }
 
-/// Builds the published-branch sync status line appended after transcript
-/// content while an auto-push is in progress.
-pub fn session_output_published_branch_sync_line(session: &Session) -> Option<Line<'static>> {
-    let sync_message = session.published_branch_sync_message()?;
-
-    Some(Line::from(vec![Span::styled(
-        format!(
-            "{} {sync_message}",
-            session_output_published_branch_sync_icon(session.published_branch_sync_status)
-        ),
-        Style::default().fg(session_output_published_branch_sync_color(
-            session.published_branch_sync_status,
-        )),
-    )]))
+/// Builds one animated loading row for an explicit transient workflow slot.
+pub(crate) fn session_output_transient_loading_line(message: &str) -> Line<'static> {
+    Line::from(vec![Span::styled(
+        format!("{} {}", Icon::Spinner, message.trim()),
+        Style::default().fg(style::palette::warning()),
+    )])
 }
 
 /// Returns one rendered summary section or the shared empty placeholder.
@@ -299,7 +287,6 @@ fn session_output_status_message(
     status: Status,
     active_progress: Option<&str>,
     review_status_message: Option<&str>,
-    review_model: AgentModel,
 ) -> String {
     match status {
         Status::InProgress => active_progress
@@ -318,10 +305,8 @@ fn session_output_status_message(
         Status::AgentReview => review_status_message
             .map(str::trim)
             .filter(|status_message| !status_message.is_empty())
-            .map_or_else(
-                || app::review_loading_message(review_model),
-                ToString::to_string,
-            ),
+            .unwrap_or("Reviewing changes...")
+            .to_string(),
         Status::Queued => "Waiting in merge queue...".to_string(),
         Status::Rebasing => "Rebasing...".to_string(),
         Status::Merging => "Merging...".to_string(),
@@ -346,32 +331,10 @@ fn session_output_status_icon(status: Status) -> Icon {
     }
 }
 
-/// Returns the icon used for published-branch sync status lines.
-fn session_output_published_branch_sync_icon(sync_status: PublishedBranchSyncStatus) -> Icon {
-    match sync_status {
-        PublishedBranchSyncStatus::Idle => Icon::Pending,
-        PublishedBranchSyncStatus::InProgress => Icon::Spinner,
-        PublishedBranchSyncStatus::Succeeded => Icon::Check,
-        PublishedBranchSyncStatus::Failed => Icon::Warn,
-    }
-}
-
-/// Returns the color used for published-branch sync status lines.
-fn session_output_published_branch_sync_color(
-    sync_status: PublishedBranchSyncStatus,
-) -> ratatui::style::Color {
-    match sync_status {
-        PublishedBranchSyncStatus::Idle => style::palette::text_muted(),
-        PublishedBranchSyncStatus::InProgress | PublishedBranchSyncStatus::Failed => {
-            style::palette::warning()
-        }
-        PublishedBranchSyncStatus::Succeeded => style::palette::success(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::agent::AgentModel;
     use crate::domain::session::{
         ForgeKind, ReviewRequest, ReviewRequestState, ReviewRequestSummary,
     };

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -54,9 +54,10 @@ For file-level detail, read the module docstrings directly.
   direct process, filesystem, or clock calls — everything external goes through `infra/`
   traits.
 - `domain/`: Pure business entities and logic — sessions and statuses, projects,
-  settings keys, themes, structured questions, typed transcript messages,
-  prompt-composer logic, and thin re-export modules for `ag-agent` provider models plus
-  shared protocol question and turn prompt payloads. No I/O.
+  settings keys, themes, structured questions, typed transcript messages, explicit
+  transient-message slots and lifecycles, prompt-composer logic, and thin re-export
+  modules for `ag-agent` provider models plus shared protocol question and turn prompt
+  payloads. No I/O.
 - `infra/`: External integrations behind traits — Agentty data-root resolution, SQLite
   persistence (`infra/db/` repositories), git (`GitClient`, backed by `ag-git`),
   filesystem (`FsClient`), tmux, clipboard images, version checks, project discovery,

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -129,12 +129,20 @@ loader updates), and applies side effects in stable order. Key behaviors:
 by `crates/agentty/src/ui/page/session_chat.rs` and
 `crates/agentty/src/ui/component/session_output.rs`. The durable transcript is the
 ordered `session_message` rows (typed `UserPrompt`, `AssistantAnswer`, `WorkflowNotice`,
-rows); the component layers synthetic content on top at render time: the
-`session.summary` block, focused review text, the in-progress published-branch sync row,
-and the animated loader row. Completed published-branch auto-push results are persisted
-as `WorkflowNotice` transcript rows instead of synthetic render rows. Structured
-clarification questions render in the bottom question panel (`AppMode::Question`), not
-inside the output component.
+rows). Replaceable output lives in the session's typed transient-message slots instead
+of render-time visibility predicates. Each slot has stable identity, typed content, an
+output anchor, and an explicit lifecycle. Reducer paths upsert or retract summary,
+focused-review, workflow-feedback, and published-branch-sync slots; starting a later
+turn clears older turn-scoped slots in one place.
+
+Published-branch auto-push completion sends one terminal reducer event carrying its
+`WorkflowNotice`. After accepting the current operation identifier, the reducer persists
+the notice, retracts the matching loading slot, and projects the durable transcript
+message in the same batch. Stale completions therefore cannot write a notice, and no
+frame can contain both the progress row and completed notice. The output-layout cache
+keys the transient-store version rather than maintaining a separate fingerprint for
+every temporary channel. Structured clarification questions render in the bottom
+question panel (`AppMode::Question`), not inside the output component.
 
 `App` owns one shared `RenderCacheStore` for markdown, diff, and session-output layout
 caches. Changes in this area should keep caches bounded and route layout/count helpers
@@ -172,7 +180,9 @@ render twice per frame.
    guard again, preventing a subsequent sync from starting until that publish finishes.
    After a successful push, linked review-request and commit metadata are resolved and
    refreshed; lookup failures append the existing warning notice instead of being
-   discarded. The push result is appended as a durable transcript notice.
+   discarded. The push result is persisted as a durable transcript notice and atomically
+   replaces the matching transient progress row when the reducer applies the terminal
+   sync event.
 1. Completed stacked-parent turns fan out `SessionCommand::Rebase` to review-ready
    materialized children so child branches replay onto the latest parent branch.
 1. The session size is refreshed and the final status becomes `Review` or `Question`


### PR DESCRIPTION
- Replaces synthetic summary, review, workflow-notice, and published-branch sync rendering with explicit slots and lifecycles.
- Reconciles transient output across session loading, turn transitions, focused review, and workflow updates.
- Promotes published-branch sync results into durable transcript notices while retracting progress state.
- Updates output caching, tests, and architecture documentation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)