### PR TITLE
Group issues by assignment

### DIFF
--- a/crates/agentty/src/ui/page/issue_list.rs
+++ b/crates/agentty/src/ui/page/issue_list.rs
@@ -100,17 +100,9 @@ fn render_issue_table(
         Constraint::Length(28),
         Constraint::Length(12),
     ];
-    let rows = items.iter().map(|issue| {
-        let issue_label = format!("{} {}", issue.display_id, issue.title);
-        let issue_text = inline_text(&issue_label);
-
-        Row::new([
-            Cell::from(issue_text),
-            Cell::from(issue.repository.as_str()),
-            Cell::from(issue.updated_at.as_deref().map_or("", issue_updated_date)),
-        ])
-    });
-    table_state.select(selected_issue_index);
+    let table_rows = issue_table_rows(items);
+    let rows = table_rows.iter().map(IssueTableRow::render);
+    table_state.select(selected_render_row(&table_rows, selected_issue_index));
     let table = Table::new(rows, constraints)
         .column_spacing(TABLE_COLUMN_SPACING)
         .header(header)
@@ -118,6 +110,76 @@ fn render_issue_table(
         .row_highlight_style(Style::default().bg(style::palette::surface_selection()));
 
     frame.render_stateful_widget(table, area, table_state);
+}
+
+/// Intermediate row model shared by grouped rendering and selection mapping.
+enum IssueTableRow<'a> {
+    /// Non-selectable issue group heading.
+    Section(&'static str),
+    /// Selectable assigned-issue row.
+    Issue {
+        /// Issue rendered on this table row.
+        item: &'a AssignedIssue,
+        /// Original issue index in the loaded list.
+        item_index: usize,
+    },
+}
+
+impl IssueTableRow<'_> {
+    /// Converts this row model into a Ratatui table row.
+    fn render(&self) -> Row<'_> {
+        match self {
+            Self::Section(label) => Row::new([
+                Cell::from(*label).style(Style::default().fg(style::palette::accent())),
+                Cell::from(""),
+                Cell::from(""),
+            ]),
+            Self::Issue { item, .. } => {
+                let issue_label = format!("{} {}", item.display_id, item.title);
+                let issue_text = inline_text(&issue_label);
+
+                Row::new([
+                    Cell::from(issue_text),
+                    Cell::from(item.repository.as_str()),
+                    Cell::from(item.updated_at.as_deref().map_or("", issue_updated_date)),
+                ])
+            }
+        }
+    }
+}
+
+/// Builds the non-empty assigned-issue group with global indexes for
+/// navigation.
+fn issue_table_rows(items: &[AssignedIssue]) -> Vec<IssueTableRow<'_>> {
+    let mut rows = Vec::with_capacity(items.len() + 1);
+    if items.is_empty() {
+        return rows;
+    }
+
+    rows.push(IssueTableRow::Section("Assigned to you"));
+    rows.extend(
+        items
+            .iter()
+            .enumerate()
+            .map(|(item_index, item)| IssueTableRow::Issue { item, item_index }),
+    );
+
+    rows
+}
+
+/// Maps an issue selection to its rendered row after group headings are added.
+fn selected_render_row(
+    rows: &[IssueTableRow<'_>],
+    selected_issue_index: Option<usize>,
+) -> Option<usize> {
+    let selected_issue_index = selected_issue_index?;
+
+    rows.iter().position(|row| {
+        matches!(
+            row,
+            IssueTableRow::Issue { item_index, .. } if *item_index == selected_issue_index
+        )
+    })
 }
 
 /// Returns the calendar-date prefix from a provider timestamp when available.
@@ -135,17 +197,74 @@ fn render_message(frame: &mut Frame, area: Rect, message: &str) {
     );
 }
 
-/// Builds the assigned-issue list block.
+/// Builds the issue-list block.
 fn issue_block() -> Block<'static> {
     Block::default()
         .borders(Borders::ALL)
-        .title("Assigned GitHub Issues")
+        .title("Issues")
         .border_style(style::border_style())
 }
 
 #[cfg(test)]
 mod tests {
+    use ratatui::backend::TestBackend;
+
     use super::*;
+    use crate::domain::theme::ColorTheme;
+
+    #[test]
+    fn test_render_loaded_issues_shows_title_and_non_empty_group() {
+        // Arrange
+        let _theme_scope = style::scoped_active_theme(ColorTheme::Current);
+        let backend = TestBackend::new(100, 10);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+        let mut table_state = TableState::default();
+        let state = AssignedIssueState::Loaded {
+            items: vec![assigned_issue("#124", "Keep issue list compact")],
+            project_id: 1,
+        };
+
+        // Act
+        terminal
+            .draw(|frame| {
+                IssueListPage::new(&state, Some(0), &mut table_state).render(frame, frame.area());
+            })
+            .expect("failed to draw");
+
+        // Assert
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(text.contains("Issues"));
+        assert!(text.contains("Assigned to you"));
+        assert!(text.contains("#124 Keep issue list compact"));
+    }
+
+    #[test]
+    fn test_selected_render_row_skips_group_headings() {
+        // Arrange
+        let items = vec![
+            assigned_issue("#124", "First issue"),
+            assigned_issue("#125", "Second issue"),
+        ];
+        let rows = issue_table_rows(&items);
+
+        // Act
+        let first_row = selected_render_row(&rows, Some(0));
+        let second_row = selected_render_row(&rows, Some(1));
+        let out_of_range_row = selected_render_row(&rows, Some(2));
+
+        // Assert
+        assert_eq!(first_row, Some(1));
+        assert_eq!(second_row, Some(2));
+        assert_eq!(out_of_range_row, None);
+        assert_eq!(rows.len(), 3);
+    }
 
     #[test]
     fn test_issue_updated_date_uses_iso_calendar_prefix() {
@@ -157,5 +276,16 @@ mod tests {
 
         // Assert
         assert_eq!(date, "2026-07-09");
+    }
+
+    /// Builds one assigned-issue fixture for render tests.
+    fn assigned_issue(display_id: &str, title: &str) -> AssignedIssue {
+        AssignedIssue {
+            display_id: display_id.to_string(),
+            repository: "agentty-xyz/agentty".to_string(),
+            title: title.to_string(),
+            updated_at: Some("2026-07-09T18:30:00Z".to_string()),
+            web_url: format!("https://example.com/{display_id}"),
+        }
     }
 }

--- a/crates/agentty/tests/e2e/navigation.rs
+++ b/crates/agentty/tests/e2e/navigation.rs
@@ -325,11 +325,7 @@ fn tab_cycles_through_all_tabs() -> E2eResult {
 
                 let issues_frame = common::frame_from_capture(&report.captures[2]);
                 let issues_full = Region::full(issues_frame.cols(), issues_frame.rows());
-                assertion::assert_text_in_region(
-                    &issues_frame,
-                    "Assigned GitHub Issues",
-                    &issues_full,
-                );
+                assertion::assert_text_in_region(&issues_frame, "Issues", &issues_full);
 
                 let settings_frame = common::frame_from_capture(&report.captures[3]);
                 let settings_full = Region::full(settings_frame.cols(), settings_frame.rows());
@@ -471,11 +467,8 @@ fn test_assigned_github_issues() -> E2eResult {
                 assert_eq!(report.captures.len(), 2);
                 let issues_frame = common::frame_from_capture(&report.captures[0]);
                 let issues_full = Region::full(issues_frame.cols(), issues_frame.rows());
-                assertion::assert_text_in_region(
-                    &issues_frame,
-                    "Assigned GitHub Issues",
-                    &issues_full,
-                );
+                assertion::assert_text_in_region(&issues_frame, "Issues", &issues_full);
+                assertion::assert_text_in_region(&issues_frame, "Assigned to you", &issues_full);
                 assertion::assert_text_in_region(
                     &issues_frame,
                     "#124 Keep issue list compact",
@@ -609,11 +602,7 @@ fn backtab_cycles_tabs_reverse() -> E2eResult {
 
                 let issues_frame = common::frame_from_capture(&report.captures[1]);
                 let issues_full = Region::full(issues_frame.cols(), issues_frame.rows());
-                assertion::assert_text_in_region(
-                    &issues_frame,
-                    "Assigned GitHub Issues",
-                    &issues_full,
-                );
+                assertion::assert_text_in_region(&issues_frame, "Issues", &issues_full);
 
                 let inbox_frame = common::frame_from_capture(&report.captures[2]);
                 let inbox_full = Region::full(inbox_frame.cols(), inbox_frame.rows());

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -31,10 +31,11 @@ tabs. Press `Tab` to move forward or `Shift+Tab` to move backward:
   request your review in the active project, including drafts. Press `s` to refresh and
   `Enter` to open a read-only detail page with the description and comment threads.
 - **Issues**: Open GitHub issues assigned to the user authenticated with `gh` in the
-  active project repository. Press `s` to refresh, use `j` / `k` to move through the
-  first `100` results, and press `Enter` to load a read-only detail page with base
-  metadata and the description. Comments are not loaded in this iteration. Install the
-  GitHub CLI and run `gh auth login` to enable this tab.
+  active project repository. The table labels the non-empty result group **Assigned to
+  you**. Press `s` to refresh, use `j` / `k` to move through the first `100` results,
+  and press `Enter` to load a read-only detail page with base metadata and the
+  description. Comments are not loaded in this iteration. Install the GitHub CLI and run
+  `gh auth login` to enable this tab.
 - **Settings**: Configure the color theme, default reasoning level, smart/fast/review
   model defaults, the optional `Last used model as default` mode, the session commit
   coauthor trailer, and `Launch Configurations` for the active project.


### PR DESCRIPTION
- Render headings only for non-empty groups while preserving selection mapping.
- Update UI tests, E2E assertions, and workflow documentation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)