### PR TITLE
Serialize running-session sync through the active worker

### DIFF
--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -16,7 +16,7 @@ use ag_protocol::{
     parse_agent_response_strict,
 };
 use tempfile::tempdir;
-use tokio::sync::Barrier;
+use tokio::sync::{Barrier, Notify};
 
 use super::*;
 use crate::app::{App, AppEvent, ReviewCacheEntry, SyncSessionStartError, Tab};
@@ -3561,6 +3561,123 @@ async fn test_spawn_integration() {
     }
 }
 
+/// Verifies sync requested during a running turn stays on the existing
+/// worker, does not cancel that turn, and runs before later queued chat.
+#[tokio::test]
+async fn test_running_turn_finishes_before_queued_sync_and_later_chat() {
+    // Arrange
+    let dir = tempdir().expect("failed to create temp dir");
+    let mut app = new_test_app_with_git(dir.path()).await;
+    let release_first_turn = Arc::new(Notify::new());
+    let release_first_turn_for_channel = Arc::clone(&release_first_turn);
+    let turn_count = Arc::new(Mutex::new(0usize));
+    let turn_count_for_channel = Arc::clone(&turn_count);
+    let (turn_started_tx, mut turn_started_rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut mock_channel = MockAgentChannel::new();
+    mock_channel
+        .expect_run_turn()
+        .times(2)
+        .returning(move |_, request, _| {
+            let turn_index = {
+                let mut turn_count = turn_count_for_channel
+                    .lock()
+                    .expect("turn count lock should not be poisoned");
+                let turn_index = *turn_count;
+                *turn_count += 1;
+
+                turn_index
+            };
+            let release_first_turn = Arc::clone(&release_first_turn_for_channel);
+            let turn_started_tx = turn_started_tx.clone();
+
+            Box::pin(async move {
+                turn_started_tx
+                    .send(turn_index)
+                    .expect("turn start receiver should remain available");
+                if turn_index == 0 {
+                    assert_eq!(request.prompt.text, "Initial running turn");
+                    release_first_turn.notified().await;
+
+                    return Ok(TurnResult {
+                        assistant_message: AgentResponse::plain("Initial turn completed"),
+                        context_reset: false,
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        provider_conversation_id: None,
+                    });
+                }
+
+                assert_eq!(request.prompt.text, "Queued after sync");
+
+                Ok(TurnResult {
+                    assistant_message: AgentResponse::plain("Queued turn completed"),
+                    context_reset: false,
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    provider_conversation_id: None,
+                })
+            })
+        });
+    mock_channel
+        .expect_shutdown_session()
+        .returning(|_| Box::pin(async { Ok(()) }));
+    let session_id = app
+        .create_session()
+        .await
+        .expect("failed to create session");
+    app.sessions
+        .worker_service
+        .test_agent_channels
+        .insert(session_id.clone().into(), Arc::new(mock_channel));
+    app.sessions
+        .reply(&app.services, &session_id, "Initial running turn")
+        .await;
+    assert_eq!(turn_started_rx.recv().await, Some(0));
+    app.sessions.sync_from_handles();
+
+    // Act
+    app.rebase_session(&session_id)
+        .await
+        .expect("running sync should queue on the active worker");
+    app.enqueue_message(&session_id, "Queued after sync")
+        .expect("later chat message should queue");
+
+    // Assert
+    app.sessions.sync_from_handles();
+    assert_eq!(app.sessions.sessions()[0].status, Status::InProgress);
+    let active_turn_was_cancelled = app
+        .sessions
+        .session_handles()
+        .get(session_id.as_str())
+        .expect("missing session handles")
+        .cancel_token
+        .lock()
+        .expect("cancel token lock should not be poisoned")
+        .is_cancelled();
+    assert!(!active_turn_was_cancelled);
+    assert!(!session_replay_text(&app.sessions.sessions()[0]).contains("Successfully synced"));
+
+    // Act
+    release_first_turn.notify_one();
+    assert_eq!(turn_started_rx.recv().await, Some(1));
+    wait_for_output_contains(&mut app, &session_id, "Queued turn completed", 300).await;
+
+    // Assert
+    app.sessions.sync_from_handles();
+    let transcript = session_replay_text(&app.sessions.sessions()[0]);
+    let initial_answer_index = transcript
+        .find("Initial turn completed")
+        .expect("missing completed initial turn");
+    let sync_completion_index = transcript
+        .find("[Sync] Successfully synced")
+        .expect("missing queued sync completion");
+    let queued_prompt_index = transcript
+        .find("Queued after sync")
+        .expect("missing later queued prompt");
+    assert!(initial_answer_index < sync_completion_index);
+    assert!(sync_completion_index < queued_prompt_index);
+}
+
 #[tokio::test]
 /// Verifies that the first reply after a model switch replays the full
 /// session transcript and subsequent replies omit the replay snapshot.
@@ -4486,6 +4603,43 @@ async fn test_rebase_session_accepts_in_progress_status_before_worktree_validati
             .expect_err("should be error")
             .to_string()
             .contains("No git worktree")
+    );
+}
+
+/// Verifies stale `InProgress` state cannot create a new worker and start
+/// session sync without an active turn owner.
+#[tokio::test]
+async fn test_rebase_in_progress_requires_existing_session_worker() {
+    // Arrange
+    let dir = tempdir().expect("failed to create temp dir");
+    let mut app = new_test_app_with_git(dir.path()).await;
+    let session_id = app
+        .create_session()
+        .await
+        .expect("failed to create session");
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::InProgress);
+
+    // Act
+    let result = app.rebase_session(&session_id).await;
+
+    // Assert
+    let error = result.expect_err("sync should reject stale in-progress state");
+    assert!(
+        error
+            .to_string()
+            .contains("active session worker is unavailable")
+    );
+    let unfinished_operations = app
+        .services
+        .db()
+        .operations()
+        .load_unfinished_session_operations()
+        .await
+        .expect("failed to load session operations");
+    assert!(
+        unfinished_operations
+            .iter()
+            .all(|operation| operation.kind != "rebase")
     );
 }
 

--- a/crates/agentty/src/app/session/workflow/merge.rs
+++ b/crates/agentty/src/app/session/workflow/merge.rs
@@ -835,7 +835,8 @@ impl SessionMergeService {
             }
 
             manager
-                .enqueue_session_command(services, &persisted_session_id, command)
+                .worker_service_mut()
+                .enqueue_existing_session_command(services, &persisted_session_id, command)
                 .await?;
             SessionTaskService::emit_session_workflow_notice(
                 &services.event_sender(),

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -595,29 +595,38 @@ impl SessionWorkerService {
         runtime: SessionWorkerRuntime,
         command: SessionCommand,
     ) -> Result<(), SessionError> {
-        let operation_id = command.operation_id().to_string();
         let session_id = runtime.session_id.clone();
-        services
-            .db()
-            .operations()
-            .insert_session_operation(&operation_id, &session_id, command.kind())
-            .await?;
-
         let sender = self.ensure_session_worker(services, &runtime);
-        if sender.send(command).is_err() {
-            // Best-effort: operation tracking metadata is non-critical.
-            let _ = services
-                .db()
-                .operations()
-                .mark_session_operation_failed(&operation_id, "Session worker is not available")
-                .await;
 
-            return Err(SessionError::Workflow(
-                "Session worker is not available".to_string(),
-            ));
-        }
+        self.persist_and_send_command(services, &session_id, sender, command)
+            .await
+    }
 
-        Ok(())
+    /// Persists and enqueues a command only when the session already owns a
+    /// worker sender.
+    ///
+    /// Running-session actions use this path so a stale `InProgress` status
+    /// can never create a second worker that executes concurrently with the
+    /// original turn.
+    ///
+    /// # Errors
+    /// Returns an error without persisting the operation when the active
+    /// worker sender is unavailable, or when persistence or delivery fails.
+    pub(super) async fn enqueue_existing_session_command(
+        &mut self,
+        services: &AppServices,
+        session_id: &SessionId,
+        command: SessionCommand,
+    ) -> Result<(), SessionError> {
+        let sender = self.workers.get(session_id).cloned().ok_or_else(|| {
+            SessionError::Workflow(
+                "Cannot queue session sync because the active session worker is unavailable"
+                    .to_string(),
+            )
+        })?;
+
+        self.persist_and_send_command(services, session_id, sender, command)
+            .await
     }
 
     /// Drops the in-memory worker sender for a session.
@@ -680,6 +689,38 @@ impl SessionWorkerService {
         sender
     }
 
+    /// Persists one operation and sends its command to the selected worker.
+    async fn persist_and_send_command(
+        &mut self,
+        services: &AppServices,
+        session_id: &SessionId,
+        sender: mpsc::UnboundedSender<SessionCommand>,
+        command: SessionCommand,
+    ) -> Result<(), SessionError> {
+        let operation_id = command.operation_id().to_string();
+        services
+            .db()
+            .operations()
+            .insert_session_operation(&operation_id, session_id, command.kind())
+            .await?;
+
+        if sender.send(command).is_err() {
+            self.workers.remove(session_id);
+            // Best-effort: operation tracking metadata is non-critical.
+            let _ = services
+                .db()
+                .operations()
+                .mark_session_operation_failed(&operation_id, "Session worker is not available")
+                .await;
+
+            return Err(SessionError::Workflow(
+                "Session worker is not available".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Spawns the background loop that executes queued session commands.
     ///
     /// After each command completes the worker drains
@@ -696,14 +737,23 @@ impl SessionWorkerService {
     ) {
         tokio::spawn(async move {
             while let Some(command) = receiver.recv().await {
-                let result = Self::process_session_command(&context, command).await;
-                if matches!(result, Some(Err(SessionError::StoppedByUser(_)))) {
-                    context.clear_queued_messages();
-                    Self::emit_queue_session_updated(&context);
-                    continue;
-                }
+                let mut next_command = Some(command);
+                while let Some(command) = next_command.take() {
+                    let result = Self::process_session_command(&context, command).await;
+                    if matches!(result, Some(Err(SessionError::StoppedByUser(_)))) {
+                        context.clear_queued_messages();
+                        Self::emit_queue_session_updated(&context);
 
-                Self::drain_queued_messages(&context).await;
+                        break;
+                    }
+
+                    next_command = receiver.try_recv().ok();
+                    if next_command.is_some() {
+                        continue;
+                    }
+
+                    next_command = Self::drain_queued_messages(&context, &mut receiver).await;
+                }
             }
 
             // Best-effort: session transport may already be torn down.
@@ -766,22 +816,28 @@ impl SessionWorkerService {
     }
 
     /// Pops queued prompts and dispatches them as follow-up `SessionResume`
-    /// turns until the queue is empty or the session enters `Question`
-    /// state.
+    /// turns until the queue is empty, the session enters `Question` state,
+    /// or a worker command is pending.
     ///
     /// Each drained turn is persisted as its own `reply` operation with a
     /// fresh identifier so cancellation, retry, and operation tracking
-    /// behave the same as a normal reply. The drain stops on the first
-    /// user-stopped turn and clears the remaining queue so `Ctrl+C` cancels
-    /// the queued work cleanly.
-    async fn drain_queued_messages(context: &SessionWorkerContext) {
+    /// behave the same as a normal reply. Worker commands are checked before
+    /// every queued turn, so a command received during an active turn waits
+    /// for that turn to finish and then preempts the remaining chat queue.
+    /// The drain stops on the first user-stopped turn and clears the remaining
+    /// queue so `Ctrl+C` cancels the queued work cleanly.
+    async fn drain_queued_messages(
+        context: &SessionWorkerContext,
+        receiver: &mut mpsc::UnboundedReceiver<SessionCommand>,
+    ) -> Option<SessionCommand> {
         loop {
             if matches!(context.current_status(), Status::Question) {
-                return;
+                return None;
             }
-            let Some(prompt) = context.pop_queued_prompt() else {
-                return;
-            };
+            if let Ok(command) = receiver.try_recv() {
+                return Some(command);
+            }
+            let prompt = context.pop_queued_prompt()?;
 
             // Mirror the queue change into render snapshots so the inline
             // "queued" rows disappear as soon as drainage starts the
@@ -814,7 +870,7 @@ impl SessionWorkerService {
                 context.clear_queued_messages();
                 Self::emit_queue_session_updated(context);
 
-                return;
+                return None;
             }
         }
     }
@@ -1067,6 +1123,7 @@ mod tests {
     use mockall::Sequence;
     use serde_json;
     use tempfile::tempdir;
+    use tokio::sync::Notify;
 
     use super::super::post_turn::{
         PostTurnContext, apply_turn_result, build_assistant_message_content,
@@ -4313,15 +4370,79 @@ mod tests {
         let queued = VecDeque::from([TurnPrompt::from_text("queued reply".to_string())]);
         let (context, _db, queue_handle, _base_dir) =
             queue_test_context(mock_channel, queued, Status::Question).await;
+        let (_command_tx, mut command_rx) = mpsc::unbounded_channel();
 
         // Act
-        SessionWorkerService::drain_queued_messages(&context).await;
+        let next_command =
+            SessionWorkerService::drain_queued_messages(&context, &mut command_rx).await;
 
         // Assert — queued prompt remains untouched until status becomes
         // runnable again.
+        assert!(next_command.is_none());
         let queue = queue_handle.lock().expect("queue lock");
         assert_eq!(queue.len(), 1);
         assert_eq!(queue.front().expect("queued head").text, "queued reply");
+    }
+
+    #[tokio::test]
+    /// Verifies a worker command received during one drained chat turn runs
+    /// before the remaining queued chat instead of waiting for the full batch.
+    async fn test_drain_queued_messages_yields_to_command_between_turns() {
+        // Arrange
+        let turn_started = Arc::new(Notify::new());
+        let turn_started_for_channel = Arc::clone(&turn_started);
+        let release_turn = Arc::new(Notify::new());
+        let release_turn_for_channel = Arc::clone(&release_turn);
+        let mut mock_channel = MockAgentChannel::new();
+        mock_channel
+            .expect_run_turn()
+            .times(1)
+            .withf(|_, request, _| request.prompt.text == "queued first")
+            .returning(move |_, _, _| {
+                let turn_started = Arc::clone(&turn_started_for_channel);
+                let release_turn = Arc::clone(&release_turn_for_channel);
+
+                Box::pin(async move {
+                    turn_started.notify_one();
+                    release_turn.notified().await;
+
+                    Ok(successful_turn_result("First queued turn completed."))
+                })
+            });
+        let queued = VecDeque::from([
+            TurnPrompt::from_text("queued first".to_string()),
+            TurnPrompt::from_text("queued second".to_string()),
+        ]);
+        let (context, _db, queue_handle, _base_dir) =
+            queue_test_context(mock_channel, queued, Status::InProgress).await;
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+
+        // Act
+        let drain_future = SessionWorkerService::drain_queued_messages(&context, &mut command_rx);
+        let enqueue_command_future = async {
+            turn_started.notified().await;
+            command_tx
+                .send(SessionCommand::Rebase {
+                    base_branch: "main".to_string(),
+                    operation_id: "queued-rebase".to_string(),
+                })
+                .expect("worker command receiver should remain available");
+            release_turn.notify_one();
+        };
+        let (next_command, ()) = tokio::join!(drain_future, enqueue_command_future);
+
+        // Assert
+        assert!(matches!(
+            next_command,
+            Some(SessionCommand::Rebase { operation_id, .. })
+                if operation_id == "queued-rebase"
+        ));
+        let queue = queue_handle.lock().expect("queue lock");
+        assert_eq!(queue.len(), 1);
+        assert_eq!(
+            queue.front().expect("remaining queued prompt").text,
+            "queued second"
+        );
     }
 
     #[tokio::test]
@@ -4340,6 +4461,7 @@ mod tests {
         let queued = VecDeque::from([TurnPrompt::from_text("queued reply".to_string())]);
         let (mut context, db, queue_handle, base_dir) =
             queue_test_context(mock_channel, queued, Status::InProgress).await;
+        let (_command_tx, mut command_rx) = mpsc::unbounded_channel();
         db.sessions()
             .update_session_published_upstream_ref(
                 "sess1",
@@ -4391,7 +4513,8 @@ mod tests {
         context.git_client = Arc::new(mock_git_client);
 
         // Act
-        SessionWorkerService::drain_queued_messages(&context).await;
+        let next_command =
+            SessionWorkerService::drain_queued_messages(&context, &mut command_rx).await;
         let sync_events = tokio::time::timeout(Duration::from_secs(1), async {
             let mut sync_events = Vec::new();
             while sync_events.len() < 2 {
@@ -4413,6 +4536,7 @@ mod tests {
         .expect("timed out waiting for sync events");
 
         // Assert
+        assert!(next_command.is_none());
         assert!(queue_handle.lock().expect("queue lock").is_empty());
         assert_eq!(sync_events[0].2, PublishedBranchSyncStatus::InProgress);
         assert_eq!(sync_events[1].2, PublishedBranchSyncStatus::Succeeded);
@@ -4448,12 +4572,15 @@ mod tests {
         ]);
         let (context, _db, queue_handle, _base_dir) =
             queue_test_context(mock_channel, queued, Status::InProgress).await;
+        let (_command_tx, mut command_rx) = mpsc::unbounded_channel();
 
         // Act
-        SessionWorkerService::drain_queued_messages(&context).await;
+        let next_command =
+            SessionWorkerService::drain_queued_messages(&context, &mut command_rx).await;
 
         // Assert — first prompt was dispatched, the StoppedByUser result
         // propagated, and the remaining queued prompt was cleared.
+        assert!(next_command.is_none());
         let queue = queue_handle.lock().expect("queue lock");
         assert!(queue.is_empty(), "queue should be cleared on Ctrl+C");
     }

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -860,6 +860,32 @@ printf '%s\n' '{{"type":"result","subtype":"success","result":"{{\"answer\":\"Ne
     seed_project_default_model(env, "claude-haiku-4-5-20251001")
 }
 
+/// Answer emitted before the queued session sync is allowed to start.
+const QUEUED_SYNC_TURN_ANSWER: &str = "Running turn completed before sync";
+
+/// Installs a delayed Claude turn so the scenario can queue sync while the
+/// worker is still active, then observe the answer before the rebase result.
+fn install_delayed_sync_claude_stub(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    let claude_path = env.stub_bin.join("claude");
+    let script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
+cat > /dev/null 2>&1
+sleep 10
+printf '%s\n' '{{"type":"system","subtype":"init"}}'
+printf '%s\n' '{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"{QUEUED_SYNC_TURN_ANSWER}"}}]}}}}'
+printf '%s\n' '{{"type":"result","subtype":"success","result":"{{\"answer\":\"{QUEUED_SYNC_TURN_ANSWER}\",\"questions\":[],\"summary\":null}}","usage":{{"input_tokens":5,"output_tokens":9}}}}'
+"#
+    );
+
+    std::fs::write(&claude_path, script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o755))?;
+
+    seed_project_default_model(env, "claude-haiku-4-5-20251001")
+}
+
 /// Installs a Claude stub that reports whether Agentty passed web-capable
 /// Claude Code tools to the non-interactive session launch.
 fn install_web_tool_reporting_claude_stub(
@@ -1854,27 +1880,27 @@ fn session_queue_chat_messages_during_in_progress_turn() -> E2eResult {
     Ok(())
 }
 
-/// Verify running sessions advertise `r` sync as a queued action alongside
-/// the stop shortcut.
+/// Verify running sessions queue `r` sync without interrupting the active
+/// turn, then rebase before returning to review.
 #[test]
 fn session_running_turn_shows_sync_shortcut() -> E2eResult {
     // Arrange, Act, Assert
     FeatureTest::new("session_running_sync_shortcut")
         .with_git()
-        .setup(seed_running_stop_session)
+        .setup(install_delayed_sync_claude_stub)
         .run(
             |scenario| {
                 scenario
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("Keep the active turn running")
+                    .wait_for_text("Keep the active turn running", 3000)
                     .press_key("Enter")
                     .wait_for_text("Ctrl+c: stop", 5000)
                     .wait_for_text("r: sync", 5000)
-                    .viewing_pause_ms(1000)
-                    .capture_labeled(
-                        "running_sync_shortcut",
-                        "Running session view with queued sync shortcut",
-                    )
                     .press_key("r")
                     .wait_for_text("will rebase after the current turn finishes", 5000)
                     .viewing_pause_ms(1000)
@@ -1882,24 +1908,43 @@ fn session_running_turn_shows_sync_shortcut() -> E2eResult {
                         "running_sync_queued",
                         "Running session view after queueing sync",
                     )
+                    .wait_for_text(QUEUED_SYNC_TURN_ANSWER, 30000)
+                    .wait_for_text("[Sync] Successfully synced", 10000)
+                    .wait_for_text("Enter: reply", 5000)
+                    .capture_labeled(
+                        "running_sync_completed",
+                        "Running turn completes before queued sync",
+                    )
             },
             |frame, report| {
-                let shortcut_frame = common::frame_from_capture(&report.captures[0]);
-                let shortcut_full = Region::full(shortcut_frame.cols(), shortcut_frame.rows());
+                let queued_frame = common::frame_from_capture(&report.captures[0]);
+                let queued_full = Region::full(queued_frame.cols(), queued_frame.rows());
                 assertion::assert_text_in_region(
-                    &shortcut_frame,
-                    "Running session stop",
-                    &shortcut_full,
+                    &queued_frame,
+                    "will rebase after the current turn finishes",
+                    &queued_full,
                 );
-                assertion::assert_text_in_region(&shortcut_frame, "Ctrl+c: stop", &shortcut_full);
-                assertion::assert_text_in_region(&shortcut_frame, "r: sync", &shortcut_full);
+                assertion::assert_text_in_region(&queued_frame, "Ctrl+c: stop", &queued_full);
 
                 let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(
-                    frame,
-                    "will rebase after the current turn finishes",
-                    &full,
-                );
+                assertion::assert_text_in_region(frame, QUEUED_SYNC_TURN_ANSWER, &full);
+                assertion::assert_text_in_region(frame, "[Sync] Successfully synced", &full);
+                assertion::assert_text_in_region(frame, "Enter: reply", &full);
+                assertion::assert_not_visible(frame, "[Stopped]");
+
+                let answer_row = frame
+                    .find_text(QUEUED_SYNC_TURN_ANSWER)
+                    .first()
+                    .expect("missing completed turn answer")
+                    .rect
+                    .row;
+                let sync_row = frame
+                    .find_text("[Sync] Successfully synced")
+                    .first()
+                    .expect("missing queued sync result")
+                    .rect
+                    .row;
+                assert!(answer_row < sync_row);
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -160,6 +160,10 @@ render twice per frame.
    `session_operation` and enqueues it on the per-session worker.
 1. The worker marks the operation `running`, checks cancel flags, verifies worktree
    isolation, and delegates to `workflow/turn.rs` or the queued session-sync workflow.
+   An **InProgress** sync request can enqueue only through the sender already owned by
+   that worker; it cannot lazily create another worker. The receiver is checked between
+   every pair of retractable queued-chat turns, so a command received during one chat
+   turn waits for that turn and then runs before the remaining chat queue.
 1. `workflow/turn.rs` builds a `TurnRequest` and calls `AgentChannel::run_turn()`, which
    streams `TurnEvent` values (loader updates) and returns a `TurnResult`.
 1. `workflow/post_turn.rs` appends the final assistant transcript output, then

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -182,11 +182,15 @@ focus toggle is available while answering clarification questions.
 
 Pressing `r` during a running turn queues session sync on the same session worker. The
 session stays **InProgress** while the active turn runs, then moves to **Rebasing** when
-the queued sync command starts. Agentty shows a `[Sync]` notice in the session output
-while the rebase is queued, and repeated `r` presses keep the single queued rebase
-instead of adding duplicates. Session sync reserves branch-publish ownership before it
-queues or starts, and retains that ownership through its post-rebase push. A completed
-turn or subsequent sync therefore cannot start a competing published-branch auto-push.
+the queued sync command starts. The existing worker must accept the request; Agentty
+never creates a second worker from an **InProgress** status just to start sync. If sync
+arrives while Agentty is draining queued chat, the active chat turn finishes before sync
+runs, and sync runs before the remaining queued messages. Agentty shows a `[Sync]`
+notice in the session output while the rebase is queued, and repeated `r` presses keep
+the single queued rebase instead of adding duplicates. Session sync reserves
+branch-publish ownership before it queues or starts, and retains that ownership through
+its post-rebase push. A completed turn or subsequent sync therefore cannot start a
+competing published-branch auto-push.
 
 ### Focused Review
 


### PR DESCRIPTION
- Require an existing worker for running-session sync so stale `InProgress` state cannot start a duplicate worker.
- Let the active turn finish, then process queued sync before later chat messages.
- Add regression and E2E coverage and document the worker and ordering rules.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)