### PR TITLE
Bounds provider protocol schemas and error output

### DIFF
--- a/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
@@ -3,7 +3,9 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use ag_protocol::{TurnPrompt, TurnPromptContentPart, agent_response_output_schema};
+use ag_protocol::{
+    SchemaRequiredPolicy, TurnPrompt, TurnPromptContentPart, agent_response_output_schema,
+};
 use serde_json::Value;
 use tokio::sync::mpsc;
 
@@ -703,7 +705,7 @@ pub(super) fn build_turn_start_payload(
             "effort": reasoning_level.codex(),
             "summary": Value::Null,
             "personality": Value::Null,
-            "outputSchema": agent_response_output_schema()
+            "outputSchema": agent_response_output_schema(SchemaRequiredPolicy::AllProperties)
         }
     })
 }

--- a/crates/ag-agent/src/agent/claude.rs
+++ b/crates/ag-agent/src/agent/claude.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::process::{Command, Stdio};
 
-use ag_protocol::agent_response_output_schema_json;
+use ag_protocol::{SchemaRequiredPolicy, agent_response_output_schema_json};
 
 use super::backend::{AgentBackend, AgentBackendError, BuildCommandRequest};
 use super::prompt::{CliPromptAccessRootMode, append_cli_prompt_access_directories};
@@ -66,7 +66,9 @@ impl AgentBackend for ClaudeBackend {
         command.arg("--output-format").arg("stream-json");
         command
             .arg("--json-schema")
-            .arg(agent_response_output_schema_json());
+            .arg(agent_response_output_schema_json(
+                SchemaRequiredPolicy::MinimumProtocolKeys,
+            ));
         command
             .env("ANTHROPIC_MODEL", model)
             .current_dir(folder)

--- a/crates/ag-agent/src/agent/cli/error.rs
+++ b/crates/ag-agent/src/agent/cli/error.rs
@@ -103,10 +103,36 @@ fn cli_stream_section(label: &str, output: &str) -> String {
     format!("{label}:\n```text\n{formatted_output}\n```")
 }
 
+/// Maximum stream lines kept in one CLI exit error section.
+///
+/// Turn errors are appended to the session transcript, so an unbounded stream
+/// section paints a screenful of provider event lines into the chat. The tail
+/// carries the failure, so the newest lines are the ones worth keeping.
+const CLI_STREAM_DETAIL_MAX_LINES: usize = 12;
+
 /// Formats one captured stream, summarizing JSONL provider event lines while
 /// preserving plain-text provider diagnostics.
+///
+/// Only the last [`CLI_STREAM_DETAIL_MAX_LINES`] lines are kept, prefixed with
+/// a note when earlier lines were dropped.
 fn format_cli_stream_output(output: &str) -> String {
-    format_json_line_stream(output).unwrap_or_else(|| output.to_string())
+    let formatted_output =
+        format_json_line_stream(output).unwrap_or_else(|| output.trim_end().to_string());
+
+    truncate_stream_detail_to_tail(&formatted_output)
+}
+
+/// Keeps only the trailing stream lines that fit the error-detail budget.
+fn truncate_stream_detail_to_tail(formatted_output: &str) -> String {
+    let lines: Vec<&str> = formatted_output.lines().collect();
+    let dropped_line_count = lines.len().saturating_sub(CLI_STREAM_DETAIL_MAX_LINES);
+    if dropped_line_count == 0 {
+        return formatted_output.to_string();
+    }
+
+    let tail = lines[dropped_line_count..].join("\n");
+
+    format!("[{dropped_line_count} earlier lines omitted]\n{tail}")
 }
 
 /// Converts each JSON object line in a provider stream into readable text.
@@ -291,6 +317,26 @@ fn format_cli_stream_detail(detail: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    /// A long provider stream is reduced to its tail so a failing turn cannot
+    /// paint every event line into the session transcript.
+    fn test_format_agent_cli_exit_error_bounds_long_stream_detail() {
+        // Arrange
+        let stdout = (0..40)
+            .map(|index| format!(r#"{{"type":"system","subtype":"event_{index}"}}"#))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Act
+        let error =
+            format_agent_cli_exit_error(AgentKind::Claude, "Agent command", Some(1), &stdout, "");
+
+        // Assert
+        assert!(error.contains("earlier lines omitted"));
+        assert!(!error.contains("system | event_0"));
+        assert!(error.contains("system | event_39"));
+    }
 
     // --- format_agent_cli_exit_error ---
 

--- a/crates/ag-agent/src/agent/provider.rs
+++ b/crates/ag-agent/src/agent/provider.rs
@@ -77,8 +77,9 @@ pub(crate) fn protocol_schema_instruction_mode(kind: AgentKind) -> ProtocolSchem
 ///
 /// # Errors
 /// Returns a descriptive error when provider output does not match the
-/// required protocol JSON, including parse diagnostics that help explain why
-/// the payload was rejected.
+/// required protocol JSON. The error carries the parse reason and derived
+/// diagnostics only: turn errors are rendered into the session transcript, so
+/// quoting the payload would print raw provider output into the chat.
 pub(crate) fn parse_turn_response(
     kind: AgentKind,
     response_text: &str,
@@ -87,8 +88,7 @@ pub(crate) fn parse_turn_response(
     let response = parse_agent_response_strict(response_text).map_err(|error| {
         format!(
             "Agent output did not match the required JSON schema from {kind}: \
-             {error}\nprotocol_profile: \
-             {protocol_profile:?}\ndebug_details:\n{}\nresponse:\n{response_text}",
+             {error}\nprotocol_profile: {protocol_profile:?}\ndebug_details:\n{}",
             format_protocol_parse_debug_details(response_text)
         )
     })?;

--- a/crates/ag-agent/src/agent/submission.rs
+++ b/crates/ag-agent/src/agent/submission.rs
@@ -236,13 +236,14 @@ pub async fn submit_one_shot_with_backend(
 /// Parses one one-shot response strictly against the shared protocol schema.
 ///
 /// # Errors
-/// Returns an error when the response is empty or not valid protocol JSON,
-/// including parse diagnostics that help explain the mismatch.
+/// Returns an error when the response is empty or not valid protocol JSON. The
+/// error carries the parse reason and derived diagnostics only, never the
+/// provider payload itself.
 fn parse_one_shot_response(content: &str) -> Result<AgentResponse, String> {
     parse_agent_response_strict(content).map_err(|error| {
         format!(
             "One-shot agent output did not match the required JSON schema: \
-             {error}\ndebug_details:\n{}\nresponse:\n{content}",
+             {error}\ndebug_details:\n{}",
             format_protocol_parse_debug_details(content)
         )
     })

--- a/crates/ag-agent/src/channel/app_server.rs
+++ b/crates/ag-agent/src/channel/app_server.rs
@@ -194,8 +194,10 @@ struct AppServerParsedTurnResult {
 /// the returned metadata reflects the repair turn's provider conversation id
 /// and token usage so the caller can propagate them correctly.
 ///
-/// When repair is attempted, a [`TurnEvent::ThoughtDelta`] is emitted with
-/// the original parse error so the user can see what went wrong.
+/// When repair is attempted, a concise [`TurnEvent::ThoughtDelta`] is emitted
+/// so the user can see that schema repair is in progress. The parse error is
+/// deliberately excluded: thought updates render as live loader lines, and the
+/// error carries provider diagnostics that must not reach the UI.
 async fn parse_or_repair_app_server_response(
     kind: AgentKind,
     response: &crate::app_server::AppServerTurnResponse,
@@ -218,7 +220,7 @@ async fn parse_or_repair_app_server_response(
         };
 
     let _ = events.send(TurnEvent::ThoughtDelta(format!(
-        "Protocol parse error — retrying: {parse_error}"
+        "Protocol parse error; retrying schema repair for {kind}."
     )));
 
     let repair_prompt = build_protocol_repair_prompt(&parse_error, &response.assistant_message);
@@ -255,9 +257,7 @@ async fn parse_or_repair_app_server_response(
         agent::parse_turn_response(kind, &repair_result.assistant_message, protocol_profile)
             .map_err(|error| {
                 AgentError::Backend(format!(
-                    "{parse_error}\nprotocol repair retry also failed: \
-                     {error}\nrepair_response:\n{}",
-                    repair_result.assistant_message
+                    "{parse_error}\nprotocol repair retry also failed: {error}"
                 ))
             })?;
 
@@ -725,7 +725,7 @@ mod tests {
         // Assert
         let error_message = error.to_string();
         assert!(error_message.contains("did not match the required JSON schema"));
-        assert!(error_message.contains("response:\nplain non-json response"));
+        assert!(!error_message.contains("plain non-json response"));
     }
 
     #[tokio::test]
@@ -813,7 +813,9 @@ mod tests {
         mock_client
             .expect_run_turn()
             .times(2)
-            .returning(|_request, _stream_tx| Box::pin(async { Ok(make_ok_response("plain")) }));
+            .returning(|_request, _stream_tx| {
+                Box::pin(async { Ok(make_ok_response("plain-text-payload")) })
+            });
         let channel = AppServerAgentChannel::new(Arc::new(mock_client), AgentKind::Codex);
         let (events_tx, _events_rx) = mpsc::unbounded_channel();
 
@@ -826,7 +828,7 @@ mod tests {
         // Assert
         let error_message = error.to_string();
         assert!(error_message.contains("did not match the required JSON schema"));
-        assert!(error_message.contains("response:\nplain"));
+        assert!(!error_message.contains("plain-text-payload"));
     }
 
     #[tokio::test]

--- a/crates/ag-agent/src/channel/cli.rs
+++ b/crates/ag-agent/src/channel/cli.rs
@@ -273,8 +273,7 @@ async fn parse_or_repair_cli_response(
             }
 
             Err(AgentError::Backend(format!(
-                "{parse_error}\nprotocol repair retry also failed: \
-                 {repair_error}\nrepair_response:\n{repair_content}"
+                "{parse_error}\nprotocol repair retry also failed: {repair_error}"
             )))
         }
     }
@@ -884,7 +883,7 @@ mod tests {
         // Assert
         let error_message = error.to_string();
         assert!(error_message.contains("did not match the required JSON schema"));
-        assert!(error_message.contains("response:\nplain non-json response"));
+        assert!(!error_message.contains("plain non-json response"));
     }
 
     #[tokio::test]

--- a/crates/ag-protocol/src/lib.rs
+++ b/crates/ag-protocol/src/lib.rs
@@ -29,6 +29,6 @@ pub use prompt::{
 };
 pub use question::QuestionItem;
 pub use schema::{
-    agent_response_json_schema_json, agent_response_output_schema,
+    SchemaRequiredPolicy, agent_response_json_schema_json, agent_response_output_schema,
     agent_response_output_schema_json,
 };

--- a/crates/ag-protocol/src/parse.rs
+++ b/crates/ag-protocol/src/parse.rs
@@ -100,6 +100,11 @@ pub fn parse_agent_response_strict(raw: &str) -> Result<AgentResponse, AgentResp
 /// The report summarizes response sizing, markdown wrapping, JSON parse
 /// diagnostics, and any visible top-level keys so schema mismatch errors
 /// include enough context to diagnose malformed provider output quickly.
+///
+/// Every line is *derived* metadata: sizes, parser locations, and key names.
+/// No provider payload text is reproduced. Turn errors are rendered into the
+/// session transcript, so quoting the payload here would print raw provider
+/// output into the chat.
 pub fn format_protocol_parse_debug_details(raw: &str) -> String {
     let trimmed = raw.trim();
     let mut detail_lines = vec![
@@ -133,11 +138,6 @@ pub fn format_protocol_parse_debug_details(raw: &str) -> String {
     } else {
         detail_lines.push("embedded_json_candidate: none".to_string());
     }
-
-    detail_lines.push(format!(
-        "response_preview:\n{}",
-        format_debug_preview(trimmed, 240)
-    ));
 
     detail_lines.join("\n")
 }
@@ -359,23 +359,26 @@ fn format_debug_list(items: &[String]) -> String {
     items.join(", ")
 }
 
-/// Truncates a debug preview while preserving the original leading content.
-fn format_debug_preview(raw: &str, max_chars: usize) -> String {
-    let preview = raw.chars().take(max_chars).collect::<String>();
-    let total_chars = raw.chars().count();
-    if total_chars <= max_chars {
-        return preview;
-    }
-
-    format!(
-        "{preview}\n... [truncated {} chars]",
-        total_chars - max_chars
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    /// The debug report describes the payload without reproducing any of it,
+    /// so a turn error cannot print raw provider output into the transcript.
+    fn test_format_protocol_parse_debug_details_never_quotes_payload() {
+        // Arrange
+        let raw = format!("{} SECRETTAIL", "payload-filler ".repeat(40));
+
+        // Act
+        let details = format_protocol_parse_debug_details(&raw);
+
+        // Assert
+        assert!(!details.contains("payload-filler"));
+        assert!(!details.contains("SECRETTAIL"));
+        assert!(details.contains(&format!("response_len: {} chars", raw.chars().count())));
+        assert!(details.contains("direct_json_error"));
+    }
 
     #[test]
     /// Strict parsing accepts a complete schema payload.

--- a/crates/ag-protocol/src/schema.rs
+++ b/crates/ag-protocol/src/schema.rs
@@ -5,14 +5,31 @@ use serde_json::Value;
 
 use super::model::{AgentResponse, questions_field_description};
 
+/// Selects how a provider transport lists `required` schema properties.
+///
+/// Providers disagree on what a valid schema looks like. Codex rejects schemas
+/// whose `properties` contain keys missing from `required`, so it needs every
+/// key listed. Validators that enforce `required` literally, such as Claude,
+/// must only demand `answer`; listing optional keys there rejects ordinary
+/// replies that omit `questions` or `summary`, even though the parser accepts
+/// them through `#[serde(default)]`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SchemaRequiredPolicy {
+    /// Lists every `properties` key in `required` for Codex compatibility.
+    AllProperties,
+    /// Lists only the minimum protocol keys the parser insists on.
+    MinimumProtocolKeys,
+}
+
 /// Returns the JSON Schema used for structured assistant output.
 ///
 /// The returned value is passed directly to providers that support enforced
 /// output schemas. It starts from the self-descriptive response schema and then
 /// applies compatibility normalization required by schema-enforcing agents.
-pub fn agent_response_output_schema() -> Value {
+/// `required_policy` selects how strictly optional protocol keys are demanded.
+pub fn agent_response_output_schema(required_policy: SchemaRequiredPolicy) -> Value {
     let mut value = agent_response_json_schema();
-    normalize_schema_for_transport(&mut value);
+    normalize_schema_for_transport(&mut value, required_policy);
 
     value
 }
@@ -35,8 +52,8 @@ pub fn agent_response_json_schema_json() -> String {
 /// `outputSchema` at transport level and must be guided by in-prompt schema
 /// text instead, or by native schema-validation flags that accept a serialized
 /// schema document.
-pub fn agent_response_output_schema_json() -> String {
-    let schema = agent_response_output_schema();
+pub fn agent_response_output_schema_json(required_policy: SchemaRequiredPolicy) -> String {
+    let schema = agent_response_output_schema(required_policy);
 
     stringify_schema_json(&schema)
 }
@@ -149,18 +166,21 @@ fn stringify_schema_json(schema: &Value) -> String {
 /// cannot resolve that meta-schema. Codex rejects schemas that use `oneOf` for
 /// enum-like constants. Schemars can emit both shapes, so this normalizer
 /// strips transport-only metadata and rewrites enum fragments to string `enum`
-/// definitions.
-fn normalize_schema_for_transport(value: &mut Value) {
+/// definitions. `required_policy` decides whether optional properties are also
+/// forced into `required`.
+fn normalize_schema_for_transport(value: &mut Value, required_policy: SchemaRequiredPolicy) {
     match value {
         Value::Object(object) => {
             object.remove("$schema");
 
             for nested_value in object.values_mut() {
-                normalize_schema_for_transport(nested_value);
+                normalize_schema_for_transport(nested_value, required_policy);
             }
 
             normalize_ref_object_for_codex(object);
-            normalize_required_for_codex(object);
+            if required_policy == SchemaRequiredPolicy::AllProperties {
+                normalize_required_for_codex(object);
+            }
 
             let one_of_values = object
                 .get("oneOf")
@@ -192,7 +212,7 @@ fn normalize_schema_for_transport(value: &mut Value) {
         }
         Value::Array(array) => {
             for nested_value in array {
-                normalize_schema_for_transport(nested_value);
+                normalize_schema_for_transport(nested_value, required_policy);
             }
         }
         _ => {}
@@ -255,7 +275,7 @@ mod tests {
     /// Builds a schema object with required top-level response fields.
     fn test_agent_response_output_schema_contains_required_fields() {
         // Arrange / Act
-        let schema = agent_response_output_schema();
+        let schema = agent_response_output_schema(SchemaRequiredPolicy::AllProperties);
         let required_fields = schema
             .get("required")
             .and_then(Value::as_array)
@@ -291,7 +311,7 @@ mod tests {
     /// `required`.
     fn test_agent_response_output_schema_all_properties_are_required() {
         // Arrange / Act
-        let schema = agent_response_output_schema();
+        let schema = agent_response_output_schema(SchemaRequiredPolicy::AllProperties);
 
         // Assert
         assert!(
@@ -301,11 +321,32 @@ mod tests {
     }
 
     #[test]
+    /// Ensures the minimum-key policy demands only `answer`, so validators that
+    /// enforce `required` literally still accept replies that omit optional
+    /// protocol keys.
+    fn test_agent_response_output_schema_minimum_policy_requires_only_answer() {
+        // Arrange / Act
+        let schema = agent_response_output_schema(SchemaRequiredPolicy::MinimumProtocolKeys);
+        let required_fields = schema
+            .get("required")
+            .and_then(Value::as_array)
+            .expect("schema required fields should exist");
+
+        // Assert
+        assert_eq!(
+            required_fields,
+            &vec![Value::String("answer".to_string())],
+            "only `answer` should be required; demanding `questions` or `summary` rejects \
+             ordinary replies that omit them"
+        );
+    }
+
+    #[test]
     /// Ensures generated schema avoids `oneOf` so Codex `outputSchema`
     /// validation accepts the payload.
     fn test_agent_response_output_schema_does_not_contain_one_of() {
         // Arrange / Act
-        let schema = agent_response_output_schema();
+        let schema = agent_response_output_schema(SchemaRequiredPolicy::AllProperties);
 
         // Assert
         assert!(!contains_schema_key(&schema, "oneOf"));
@@ -316,7 +357,7 @@ mod tests {
     /// native schema validation does not need a bundled meta-schema resolver.
     fn test_agent_response_output_schema_does_not_contain_schema_metadata() {
         // Arrange / Act
-        let schema = agent_response_output_schema();
+        let schema = agent_response_output_schema(SchemaRequiredPolicy::MinimumProtocolKeys);
 
         // Assert
         assert!(!contains_schema_key(&schema, "$schema"));
@@ -385,7 +426,7 @@ mod tests {
     /// Ensures no schema object uses `$ref` with sibling keys.
     fn test_agent_response_output_schema_ref_objects_have_no_sibling_keywords() {
         // Arrange / Act
-        let schema = agent_response_output_schema();
+        let schema = agent_response_output_schema(SchemaRequiredPolicy::AllProperties);
 
         // Assert
         assert!(!contains_ref_with_sibling_keywords(&schema));
@@ -569,10 +610,11 @@ mod tests {
     /// schema enforcement.
     fn test_agent_response_output_schema_json_is_parseable_value() {
         // Arrange / Act
-        let schema_json = agent_response_output_schema_json();
+        let schema_json =
+            agent_response_output_schema_json(SchemaRequiredPolicy::MinimumProtocolKeys);
         let parsed_schema: Value =
             serde_json::from_str(&schema_json).expect("schema string should parse as JSON");
-        let schema_value = agent_response_output_schema();
+        let schema_value = agent_response_output_schema(SchemaRequiredPolicy::MinimumProtocolKeys);
 
         // Assert
         assert_eq!(parsed_schema, schema_value);

--- a/crates/agentty/src/app/session/workflow/post_turn.rs
+++ b/crates/agentty/src/app/session/workflow/post_turn.rs
@@ -318,9 +318,19 @@ pub(super) fn status_update_after_turn_result(
     }
 }
 
+/// Maximum characters of one turn error kept in the session transcript.
+///
+/// Transcript notices are rendered as chat content, so an unbounded error text
+/// paints raw provider output into the session. Providers already bound their
+/// own failure messages; this is the backstop that holds for every error path.
+const TURN_ERROR_NOTICE_MAX_CHARS: usize = 800;
+
 /// Appends one terminal turn error to the live and persisted transcript.
+///
+/// The notice is truncated to [`TURN_ERROR_NOTICE_MAX_CHARS`] so no failure can
+/// dump a screenful of provider diagnostics into the chat.
 async fn append_turn_error(context: &PostTurnContext, error_text: &str) {
-    let message = format!("\n{}\n", error_text.trim());
+    let message = format!("\n{}\n", truncate_turn_error_notice(error_text));
     SessionTaskService::append_workflow_notice(
         &context.transcript,
         &context.db,
@@ -330,6 +340,21 @@ async fn append_turn_error(context: &PostTurnContext, error_text: &str) {
         &message,
     )
     .await;
+}
+
+/// Truncates one turn error to the transcript notice budget.
+fn truncate_turn_error_notice(error_text: &str) -> String {
+    let mut characters = error_text.trim().chars();
+    let mut notice: String = characters
+        .by_ref()
+        .take(TURN_ERROR_NOTICE_MAX_CHARS)
+        .collect();
+
+    if characters.next().is_some() {
+        notice.push_str("\n[error truncated]");
+    }
+
+    notice
 }
 
 /// Persists the successful turn payload, emits the reducer projection, and
@@ -562,6 +587,34 @@ mod tests {
 
     use super::*;
     use crate::domain::agent::{AgentKind, AgentModel, AgentSelection};
+
+    #[test]
+    fn test_truncate_turn_error_notice_keeps_short_errors_intact() {
+        // Arrange
+        let error_text = "  Agent command failed with exit code 1.  ";
+
+        // Act
+        let notice = truncate_turn_error_notice(error_text);
+
+        // Assert
+        assert_eq!(notice, "Agent command failed with exit code 1.");
+    }
+
+    #[test]
+    fn test_truncate_turn_error_notice_bounds_long_provider_dumps() {
+        // Arrange
+        let error_text = "x".repeat(TURN_ERROR_NOTICE_MAX_CHARS + 50);
+
+        // Act
+        let notice = truncate_turn_error_notice(&error_text);
+
+        // Assert
+        assert_eq!(
+            notice.chars().count(),
+            TURN_ERROR_NOTICE_MAX_CHARS + "\n[error truncated]".chars().count()
+        );
+        assert!(notice.ends_with("\n[error truncated]"));
+    }
 
     #[tokio::test]
     async fn test_unfinished_rebase_check_fails_closed_when_operation_query_fails() {

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -646,6 +646,47 @@ WHERE id IN ('a-older', 'z-newer')
     Ok(())
 }
 
+/// Filler repeated through the stub's non-protocol payload.
+const PROTOCOL_FAILURE_PAYLOAD_FILLER: &str = "not-json-filler";
+
+/// Marker placed at the far end of the stub's non-protocol payload.
+///
+/// Neither this nor the filler may reach the chat: a protocol failure must
+/// report why the payload was rejected without reproducing the payload.
+const PROTOCOL_FAILURE_TAIL_MARKER: &str = "TAILOFPAYLOAD";
+
+/// Installs a Claude stub whose final payload is not protocol JSON.
+///
+/// The payload is far longer than the excerpt budget and carries a marker at
+/// each end, so the resulting transcript notice can be checked for a bounded
+/// failure message instead of a raw provider dump.
+fn seed_invalid_protocol_output_project(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let payload = format!(
+        "{} {PROTOCOL_FAILURE_TAIL_MARKER}",
+        format!("{PROTOCOL_FAILURE_PAYLOAD_FILLER} ").repeat(40)
+    );
+    let claude_path = env.stub_bin.join("claude");
+    let script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
+cat > /dev/null 2>&1
+printf '%s\n' '{{"type":"system","subtype":"init"}}'
+printf '%s\n' '{{"type":"result","subtype":"success","result":"{payload}"}}'
+"#
+    );
+    std::fs::write(&claude_path, script)?;
+
+    #[cfg(unix)]
+    std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o755))?;
+
+    seed_project_default_model(env, "claude-haiku-4-5-20251001")?;
+
+    Ok(())
+}
+
 /// Adds a Gemini CLI stub that intentionally exits with failure.
 ///
 /// Picker tests only need the executable to exist on `PATH`; using a failing
@@ -1282,6 +1323,42 @@ fn session_list_empty_state() -> E2eResult {
                 assertion::assert_not_visible(frame, "Merge queue");
                 assertion::assert_not_visible(frame, "Archive");
                 assertion::assert_not_visible(frame, "No sessions");
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that provider output which fails protocol validation surfaces a
+/// bounded failure notice instead of dumping the raw payload into the chat.
+#[test]
+fn test_session_invalid_protocol_output_is_bounded() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_invalid_protocol_output_is_bounded")
+        .with_git()
+        .setup(seed_invalid_protocol_output_project)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("Return invalid protocol output")
+                    .wait_for_text("Return invalid protocol output", 3000)
+                    .press_key("Enter")
+                    .wait_for_text("embedded_json_candidate", 60000)
+                    .capture_labeled(
+                        "invalid_protocol_output",
+                        "Invalid provider output reports a failure without raw payload",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "embedded_json_candidate", &full);
+                assertion::assert_not_visible(frame, PROTOCOL_FAILURE_TAIL_MARKER);
+                assertion::assert_not_visible(frame, PROTOCOL_FAILURE_PAYLOAD_FILLER);
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -328,10 +328,23 @@ one structured response protocol (`answer`, `questions`, optional `summary`):
    envelopes, repair prompts, and turn prompt payloads.
 1. Channels emit transient loader updates as `TurnEvent::ThoughtDelta` values while the
    turn runs; assistant transcript output is appended once from the final parsed result.
+1. Transports that enforce the schema natively receive it through
+   `SchemaRequiredPolicy`. Codex needs every property listed in `required`; validators
+   that enforce `required` literally, such as Claude's `--json-schema`, receive
+   `MinimumProtocolKeys` so only `answer` is mandatory and a reply that omits
+   `questions` or `summary` still validates.
 1. Final output must parse as the shared protocol JSON object. Claude, Gemini, and Codex
    session turns fail closed on invalid output; Antigravity tries one protocol-repair
-   retry and then preserves non-empty plain text as `answer`. Rejected payloads surface
-   parse diagnostics (response sizing, parser location, visible top-level keys).
+   retry and then preserves non-empty plain text as `answer`.
+1. Turn errors are rendered into the session transcript, so no failure surface
+   reproduces provider output. A rejected payload surfaces the parse reason plus
+   *derived* diagnostics only (response sizing, parser location, visible top-level
+   keys); the payload text itself is never quoted. Live `TurnEvent::ThoughtDelta`
+   updates carry no provider output either. The transcript notice is length-capped as a
+   backstop. The one deliberate exception is a CLI process that exits non-zero: its
+   error keeps a bounded tail of the provider stream, because a crashed provider's own
+   stderr (authentication failure, missing binary) is the only thing that explains the
+   exit.
 1. Provider-specific transport, stdin-vs-argv prompt delivery, strict parsing policy,
    and thought-phase handling are centralized in the provider registry
    (`crates/ag-agent/src/agent/provider.rs`).


### PR DESCRIPTION
- Adds `SchemaRequiredPolicy` so Codex requires all schema properties while Claude requires only `answer`.
- Removes raw provider payloads from parse, repair, and transcript error surfaces while keeping derived diagnostics.
- Truncates long CLI stream details and turn error notices before they reach the session transcript.
- Covers invalid protocol output with unit and E2E tests and documents provider schema policy and bounded error surfaces in runtime flow.