### PR TITLE
Rename hacker theme to green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- agentty: rename the green color theme's internal and persisted name from `hacker` to
+  `green`, migrating existing settings so users keep their selected theme.
+
 ### Added
 
 - agentty: add a `p` project switcher popup to the Sessions view that lists registered

--- a/crates/agentty/migrations/060_migrate_hacker_theme_to_green.sql
+++ b/crates/agentty/migrations/060_migrate_hacker_theme_to_green.sql
@@ -1,0 +1,4 @@
+UPDATE setting
+SET value = 'green'
+WHERE name = 'Theme'
+  AND value = 'hacker';

--- a/crates/agentty/src/app/setting.rs
+++ b/crates/agentty/src/app/setting.rs
@@ -2011,7 +2011,7 @@ mod tests {
         services
             .db()
             .settings()
-            .upsert_setting(SettingName::Theme, ColorTheme::Hacker.as_str())
+            .upsert_setting(SettingName::Theme, ColorTheme::Green.as_str())
             .await
             .expect("failed to persist theme setting");
 
@@ -2033,7 +2033,7 @@ mod tests {
         );
         assert_eq!(manager.launch_configuration, "nvim .");
         assert_eq!(manager.reasoning_level, ReasoningLevel::Low);
-        assert_eq!(manager.theme, ColorTheme::Hacker);
+        assert_eq!(manager.theme, ColorTheme::Green);
         assert!(!manager.include_coauthored_by_agentty);
         assert!(manager.use_last_used_model_as_default);
     }
@@ -2416,7 +2416,7 @@ mod tests {
     fn settings_rows_show_theme_value() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.theme = ColorTheme::Hacker;
+        manager.theme = ColorTheme::Green;
 
         // Act
         let rows = manager.settings_rows();
@@ -2707,10 +2707,10 @@ mod tests {
             .expect("failed to load theme setting");
 
         // Assert
-        assert_eq!(selected_theme, ColorTheme::Hacker);
+        assert_eq!(selected_theme, ColorTheme::Green);
         assert_eq!(
             persisted_theme,
-            Some(ColorTheme::Hacker.as_str().to_string())
+            Some(ColorTheme::Green.as_str().to_string())
         );
     }
 

--- a/crates/agentty/src/domain/theme.rs
+++ b/crates/agentty/src/domain/theme.rs
@@ -9,21 +9,21 @@ pub enum ColorTheme {
     #[default]
     Current,
     /// A green-on-dark palette shown as `Agentty Green`.
-    Hacker,
+    Green,
     /// A warm dark palette inspired by the Horizon editor theme.
     DarkHorizon,
 }
 
 impl ColorTheme {
     /// All selectable color themes in settings display order.
-    pub const ALL: [Self; 3] = [Self::Current, Self::Hacker, Self::DarkHorizon];
+    pub const ALL: [Self; 3] = [Self::Current, Self::Green, Self::DarkHorizon];
 
     /// Returns the persisted wire value for this theme.
     #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Current => "current",
-            Self::Hacker => "hacker",
+            Self::Green => "green",
             Self::DarkHorizon => "dark_horizon",
         }
     }
@@ -33,7 +33,7 @@ impl ColorTheme {
     pub fn label(self) -> &'static str {
         match self {
             Self::Current => "Agentty Default",
-            Self::Hacker => "Agentty Green",
+            Self::Green => "Agentty Green",
             Self::DarkHorizon => "Dark Horizon",
         }
     }
@@ -46,7 +46,7 @@ impl ColorTheme {
     pub fn parse_persisted(value: &str) -> Option<Self> {
         match value {
             "current" => Some(Self::Current),
-            "hacker" => Some(Self::Hacker),
+            "green" => Some(Self::Green),
             "dark_horizon" => Some(Self::DarkHorizon),
             _ => None,
         }
@@ -88,15 +88,15 @@ mod tests {
     }
 
     #[test]
-    fn parse_persisted_returns_hacker_theme() {
+    fn parse_persisted_returns_green_theme() {
         // Arrange
-        let stored_value = "hacker";
+        let stored_value = "green";
 
         // Act
         let theme = ColorTheme::parse_persisted(stored_value);
 
         // Assert
-        assert_eq!(theme, Some(ColorTheme::Hacker));
+        assert_eq!(theme, Some(ColorTheme::Green));
     }
 
     #[test]
@@ -115,17 +115,17 @@ mod tests {
     fn next_cycles_between_available_themes() {
         // Arrange
         let current_theme = ColorTheme::Current;
-        let hacker_theme = ColorTheme::Hacker;
+        let green_theme = ColorTheme::Green;
         let dark_horizon_theme = ColorTheme::DarkHorizon;
 
         // Act
         let next_theme = current_theme.next();
-        let after_hacker_theme = hacker_theme.next();
+        let after_green_theme = green_theme.next();
         let wrapped_theme = dark_horizon_theme.next();
 
         // Assert
-        assert_eq!(next_theme, ColorTheme::Hacker);
-        assert_eq!(after_hacker_theme, ColorTheme::DarkHorizon);
+        assert_eq!(next_theme, ColorTheme::Green);
+        assert_eq!(after_green_theme, ColorTheme::DarkHorizon);
         assert_eq!(wrapped_theme, ColorTheme::Current);
     }
 

--- a/crates/agentty/src/infra/db/connection_test.rs
+++ b/crates/agentty/src/infra/db/connection_test.rs
@@ -10,6 +10,7 @@ use crate::domain::session::{
 };
 use crate::domain::session_message::SessionMessageKind;
 use crate::domain::setting::SettingName;
+use crate::domain::theme::ColorTheme;
 use crate::infra::db::{
     SessionFocusedReviewRow, SessionOperationRow, SessionRow, SessionTurnMetadata,
 };
@@ -1499,6 +1500,35 @@ async fn test_setting_round_trip_supports_default_smart_fast_and_review_models()
         default_review_model,
         Some(AgentModel::ClaudeOpus48.as_str().to_string())
     );
+}
+
+#[tokio::test]
+async fn test_migrate_hacker_theme_to_green_preserves_theme_selection() {
+    // Arrange
+    let database = Database::open_in_memory()
+        .await
+        .expect("failed to open in-memory db");
+    database
+        .settings()
+        .upsert_setting(SettingName::Theme, "hacker")
+        .await
+        .expect("failed to persist legacy theme setting");
+
+    // Act
+    sqlx::raw_sql(include_str!(
+        "../../../migrations/060_migrate_hacker_theme_to_green.sql"
+    ))
+    .execute(database.pool())
+    .await
+    .expect("failed to run theme setting migration");
+    let theme = database
+        .settings()
+        .get_setting(SettingName::Theme)
+        .await
+        .expect("failed to load migrated theme setting");
+
+    // Assert
+    assert_eq!(theme, Some(ColorTheme::Green.as_str().to_string()));
 }
 
 #[tokio::test]

--- a/crates/agentty/src/runtime/mode/list.rs
+++ b/crates/agentty/src/runtime/mode/list.rs
@@ -981,7 +981,7 @@ mod tests {
 
         // Assert
         assert!(matches!(event_result, EventResult::Continue));
-        assert_eq!(app.settings.theme, ColorTheme::Hacker);
+        assert_eq!(app.settings.theme, ColorTheme::Green);
         assert!(!app.settings.is_selector_dropdown_open());
     }
 

--- a/crates/agentty/src/ui/component/chat_input.rs
+++ b/crates/agentty/src/ui/component/chat_input.rs
@@ -441,9 +441,9 @@ mod tests {
     }
 
     #[test]
-    fn test_render_hacker_theme_uses_session_list_text_color_for_input_text() {
+    fn test_render_green_theme_uses_session_list_text_color_for_input_text() {
         // Arrange
-        let _theme_scope = style::scoped_active_theme(ColorTheme::Hacker);
+        let _theme_scope = style::scoped_active_theme(ColorTheme::Green);
         let width = 48;
         let backend = ratatui::backend::TestBackend::new(width, 5);
         let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");

--- a/crates/agentty/src/ui/component/info_overlay.rs
+++ b/crates/agentty/src/ui/component/info_overlay.rs
@@ -400,9 +400,9 @@ mod tests {
     }
 
     #[test]
-    fn test_info_overlay_hacker_theme_uses_session_list_text_color_for_body_text() {
+    fn test_info_overlay_green_theme_uses_session_list_text_color_for_body_text() {
         // Arrange
-        let _theme_scope = style::scoped_active_theme(ColorTheme::Hacker);
+        let _theme_scope = style::scoped_active_theme(ColorTheme::Green);
         let backend = ratatui::backend::TestBackend::new(100, 20);
         let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
         let overlay = InfoOverlay::new("Sync blocked", "Use the session list text color.");

--- a/crates/agentty/src/ui/component/publish_branch_overlay.rs
+++ b/crates/agentty/src/ui/component/publish_branch_overlay.rs
@@ -229,9 +229,9 @@ mod tests {
     }
 
     #[test]
-    fn test_publish_branch_overlay_hacker_theme_uses_session_list_text_color_for_locked_branch() {
+    fn test_publish_branch_overlay_green_theme_uses_session_list_text_color_for_locked_branch() {
         // Arrange
-        let _theme_scope = style::scoped_active_theme(ColorTheme::Hacker);
+        let _theme_scope = style::scoped_active_theme(ColorTheme::Green);
         let backend = ratatui::backend::TestBackend::new(120, 40);
         let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
         let input = InputState::with_text("review/custom".to_string());

--- a/crates/agentty/src/ui/layout.rs
+++ b/crates/agentty/src/ui/layout.rs
@@ -526,7 +526,7 @@ mod tests {
     #[test]
     fn test_session_header_lines_use_theme_status_color() {
         // Arrange
-        let _theme_scope = style::scoped_active_theme(ColorTheme::Hacker);
+        let _theme_scope = style::scoped_active_theme(ColorTheme::Green);
         let mut session = session_fixture();
         session.status = Status::Canceled;
         session.title = Some("Canceled session".to_string());

--- a/crates/agentty/src/ui/style.rs
+++ b/crates/agentty/src/ui/style.rs
@@ -252,7 +252,7 @@ const CURRENT_PALETTE: ThemePalette = ThemePalette {
 
 /// Green phosphor terminal palette with restrained surfaces and muted status
 /// tones.
-const HACKER_PALETTE: ThemePalette = ThemePalette {
+const GREEN_PALETTE: ThemePalette = ThemePalette {
     accent: Color::Rgb(86, 184, 105),
     accent_soft: Color::Rgb(68, 145, 80),
     border: Color::Rgb(74, 132, 78),
@@ -421,7 +421,7 @@ pub fn forge_indicator_color(state: Option<ReviewRequestState>) -> Color {
 #[must_use]
 fn active_palette() -> ThemePalette {
     match active_theme() {
-        ColorTheme::Hacker => HACKER_PALETTE,
+        ColorTheme::Green => GREEN_PALETTE,
         ColorTheme::DarkHorizon => DARK_HORIZON_PALETTE,
         ColorTheme::Current => CURRENT_PALETTE,
     }
@@ -431,7 +431,7 @@ fn active_palette() -> ThemePalette {
 #[must_use]
 fn active_theme() -> ColorTheme {
     match ACTIVE_THEME.load(Ordering::Relaxed) {
-        1 => ColorTheme::Hacker,
+        1 => ColorTheme::Green,
         2 => ColorTheme::DarkHorizon,
         _ => ColorTheme::Current,
     }
@@ -452,7 +452,7 @@ fn token_color(selector: impl FnOnce(ThemePalette) -> Color) -> Color {
 const fn theme_index(theme: ColorTheme) -> u8 {
     match theme {
         ColorTheme::Current => 0,
-        ColorTheme::Hacker => 1,
+        ColorTheme::Green => 1,
         ColorTheme::DarkHorizon => 2,
     }
 }
@@ -534,15 +534,15 @@ mod tests {
     }
 
     #[test]
-    fn status_color_uses_hacker_palette_when_active() {
+    fn status_color_uses_green_palette_when_active() {
         // Arrange
-        let _theme_scope = scoped_active_theme(ColorTheme::Hacker);
+        let _theme_scope = scoped_active_theme(ColorTheme::Green);
 
         // Act
         let color = status_color(Status::Merging);
 
         // Assert
-        assert_eq!(color, HACKER_PALETTE.accent);
+        assert_eq!(color, GREEN_PALETTE.accent);
     }
 
     #[test]
@@ -562,9 +562,9 @@ mod tests {
     }
 
     #[test]
-    fn active_palette_returns_hacker_terminal_green_tones() {
+    fn active_palette_returns_green_terminal_tones() {
         // Arrange
-        let _theme_scope = scoped_active_theme(ColorTheme::Hacker);
+        let _theme_scope = scoped_active_theme(ColorTheme::Green);
 
         // Act
         let palette = palette::active();
@@ -579,9 +579,9 @@ mod tests {
     }
 
     #[test]
-    fn active_palette_returns_muted_hacker_status_tones() {
+    fn active_palette_returns_muted_green_status_tones() {
         // Arrange
-        let _theme_scope = scoped_active_theme(ColorTheme::Hacker);
+        let _theme_scope = scoped_active_theme(ColorTheme::Green);
 
         // Act
         let palette = palette::active();
@@ -706,13 +706,13 @@ mod tests {
     #[test]
     fn border_style_uses_active_palette_border_color() {
         // Arrange
-        let _theme_scope = scoped_active_theme(ColorTheme::Hacker);
+        let _theme_scope = scoped_active_theme(ColorTheme::Green);
 
         // Act
         let style = border_style();
 
         // Assert
-        assert_eq!(style.fg, Some(HACKER_PALETTE.border));
+        assert_eq!(style.fg, Some(GREEN_PALETTE.border));
     }
 
     #[test]

--- a/docs/site/content/docs/contributing/managing-docs-with-zola.md
+++ b/docs/site/content/docs/contributing/managing-docs-with-zola.md
@@ -39,7 +39,7 @@ documentation maintainable as it grows.
 - Use `--color-text` for primary content, `--color-muted` for supporting prose, and
   `--color-dim` only for short metadata. Interactive boundaries should use
   `--color-border-strong`, and keyboard focus should use `--color-focus`.
-- Preserve the shared `:focus-visible` treatment and test both the `hacker` and `dark`
+- Preserve the shared `:focus-visible` treatment and test both the `green` and `dark`
   themes when adding controls.
 - Keep animated feature images behind the `data-motion-demo` loader so off-screen media
   remains deferred. Pair each GIF with a same-named PNG poster so

--- a/docs/site/templates/base.html
+++ b/docs/site/templates/base.html
@@ -33,8 +33,8 @@
         <!-- Apply saved theme before paint to avoid flash of unstyled content -->
         <script>
             (function () {
-                var t = localStorage.getItem('agentty-theme') || 'hacker';
-                if (t === 'dark') document.documentElement.classList.add('theme-dark');
+                var theme = localStorage.getItem('agentty-theme') || 'green';
+                if (theme === 'dark') document.documentElement.classList.add('theme-dark');
             })();
         </script>
     </head>
@@ -133,8 +133,8 @@
                     <fieldset class="site-theme-switch">
                         <legend class="sr-only">Color theme</legend>
                         <button class="theme-btn site-theme-btn"
-                                data-theme="hacker"
-                                aria-pressed="true">hacker</button>
+                                data-theme="green"
+                                aria-pressed="true">green</button>
                         <span class="site-theme-separator">/</span>
                         <button class="theme-btn site-theme-btn"
                                 data-theme="dark"
@@ -200,7 +200,7 @@
       var reducedMotionQuery = globalThis.matchMedia('(prefers-reduced-motion: reduce)');
 
       /**
-       * Apply a theme by name (`hacker` or `dark`), update button states,
+       * Apply a theme by name (`green` or `dark`), update button states,
        * persist the choice, and notify any page-level renderers that depend on
        * theme colors.
        */
@@ -448,7 +448,8 @@
       }
 
       // Sync button states with the theme already applied by the <head> script.
-      applyTheme(localStorage.getItem(STORAGE_KEY) || 'hacker');
+      var savedTheme = localStorage.getItem(STORAGE_KEY);
+      applyTheme(savedTheme === 'dark' ? 'dark' : 'green');
       void loadGithubMetadata();
       syncResponsiveDetails();
       hydrateMotionDemos();


### PR DESCRIPTION
- Rename the color theme variant, palette, and persisted value to `green`.
- Migrate existing `hacker` theme settings so users retain their selected theme.
- Update settings, UI tests, documentation, and website theme defaults.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)