### PR TITLE
Keeps focused review output visible across refreshes

### DIFF
--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -904,7 +904,11 @@ impl App {
             self.settings.default_review_selection,
         )
         .await;
-        app::review::hydrate_review_transients(&self.review_cache, self.sessions.state_mut());
+        app::review::hydrate_review_transients(
+            &self.review_cache,
+            self.sessions.state_mut(),
+            self.settings.default_review_selection.model(),
+        );
 
         if let Some(sync_main_result) = event_batch.sync_main_result {
             let sync_popup_context = self.sync_popup_context();

--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -151,7 +151,11 @@ impl App {
         )
         .await;
         let review_cache = Self::load_focused_review_cache(&repositories, active_project_id).await;
-        review::hydrate_review_transients(&review_cache, sessions.state_mut());
+        review::hydrate_review_transients(
+            &review_cache,
+            sessions.state_mut(),
+            settings.default_review_selection.model(),
+        );
 
         let sync_context = Self::sync_context_for(&projects, &services, &sessions);
         let sync_handle = sync::SyncHandle::spawn(event_tx.clone(), sync_context);

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -20,8 +20,8 @@ use app::branch_publish::{BranchPublishTaskSession, run_branch_publish_action};
 use app::merge_queue::{MergeQueue, MergeQueueProgress};
 use app::project::ProjectManager;
 use app::review::{
-    ReviewCacheEntry, mark_session_agent_review, review_loading_message, review_view_text,
-    start_review_assist as spawn_review_assist,
+    ReviewCacheEntry, mark_session_agent_review, review_failure_message, review_loading_message,
+    review_view_text, start_review_assist as spawn_review_assist,
 };
 use app::service::AppServices;
 use app::session::SessionManager;
@@ -1043,9 +1043,7 @@ impl App {
             Some(ReviewCacheEntry::Loading { .. }) => Some(review_loading_message(
                 self.settings.default_review_selection.model(),
             )),
-            Some(ReviewCacheEntry::Failed { error, .. }) => {
-                Some(format!("Review assist unavailable: {}", error.trim()))
-            }
+            Some(ReviewCacheEntry::Failed { error, .. }) => Some(review_failure_message(error)),
             Some(ReviewCacheEntry::Ready { .. } | ReviewCacheEntry::Suppressed) | None => None,
         };
 
@@ -1569,9 +1567,19 @@ impl App {
     /// Returns `true` when the fallback poll refreshed render-visible session
     /// state.
     pub async fn refresh_sessions_if_needed(&mut self) -> bool {
-        self.sessions
+        let refreshed = self
+            .sessions
             .refresh_sessions_if_needed(&mut self.mode, &self.projects, &self.services)
-            .await
+            .await;
+        if refreshed {
+            app::review::hydrate_review_transients(
+                &self.review_cache,
+                self.sessions.state_mut(),
+                self.settings.default_review_selection.model(),
+            );
+        }
+
+        refreshed
     }
 
     /// Forces immediate session list reload.
@@ -1579,6 +1587,11 @@ impl App {
         self.sessions
             .refresh_sessions_now(&mut self.mode, &self.projects, &self.services)
             .await;
+        app::review::hydrate_review_transients(
+            &self.review_cache,
+            self.sessions.state_mut(),
+            self.settings.default_review_selection.model(),
+        );
         self.restart_git_status_task();
     }
 

--- a/crates/agentty/src/app/review.rs
+++ b/crates/agentty/src/app/review.rs
@@ -115,6 +115,11 @@ pub(crate) fn review_loading_message(review_model: AgentModel) -> String {
     format!("{REVIEW_LOADING_MESSAGE_PREFIX} {}", review_model.as_str())
 }
 
+/// Formats a focused-review failure for the session output panel.
+pub(crate) fn review_failure_message(error: &str) -> String {
+    format!("Review assist unavailable: {}", error.trim())
+}
+
 /// Returns focused-review markdown available to prompt actions for one
 /// session.
 pub(crate) fn review_view_text<'a>(
@@ -131,10 +136,11 @@ pub(crate) fn review_view_text<'a>(
     }
 }
 
-/// Rehydrates persisted focused-review markdown into explicit display slots.
+/// Rehydrates cached focused-review states into explicit display slots.
 pub(crate) fn hydrate_review_transients(
     review_cache: &HashMap<SessionId, ReviewCacheEntry>,
     session_state: &mut SessionState,
+    review_model: AgentModel,
 ) {
     for session in session_state.sessions_mut() {
         if !matches!(
@@ -147,13 +153,28 @@ pub(crate) fn hydrate_review_transients(
 
             continue;
         }
-        let Some(ReviewCacheEntry::Ready { text, .. }) = review_cache.get(&session.id) else {
+        let Some(cache_entry) = review_cache.get(&session.id) else {
             continue;
+        };
+        let (anchor, body) = match cache_entry {
+            ReviewCacheEntry::Loading { .. } => (
+                TransientMessageAnchor::Tail,
+                TransientMessageBody::Loading(review_loading_message(review_model)),
+            ),
+            ReviewCacheEntry::Ready { text, .. } => (
+                TransientMessageAnchor::AfterCompletedTurn,
+                TransientMessageBody::Markdown(text.clone()),
+            ),
+            ReviewCacheEntry::Failed { error, .. } => (
+                TransientMessageAnchor::AfterCompletedTurn,
+                TransientMessageBody::Plain(review_failure_message(error)),
+            ),
+            ReviewCacheEntry::Suppressed => continue,
         };
 
         session.transient_messages.upsert(TransientMessage {
-            anchor: TransientMessageAnchor::AfterCompletedTurn,
-            body: TransientMessageBody::Markdown(text.clone()),
+            anchor,
+            body,
             lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
             slot: TransientMessageSlot::Review,
             turn_position: session.latest_user_prompt_position(),
@@ -381,9 +402,7 @@ fn apply_review_update(
     {
         let body = match &result {
             Ok(review_text) => TransientMessageBody::Markdown(review_text.clone()),
-            Err(error) => {
-                TransientMessageBody::Plain(format!("Review assist unavailable: {}", error.trim()))
-            }
+            Err(error) => TransientMessageBody::Plain(review_failure_message(error)),
         };
         session.transient_messages.upsert(TransientMessage {
             anchor: TransientMessageAnchor::AfterCompletedTurn,
@@ -574,7 +593,7 @@ mod tests {
         );
 
         // Act
-        hydrate_review_transients(&review_cache, &mut session_state);
+        hydrate_review_transients(&review_cache, &mut session_state, AgentModel::Gpt55);
 
         // Assert
         assert!(

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -19,6 +19,7 @@ use tempfile::tempdir;
 use tokio::sync::{Barrier, Notify};
 
 use super::*;
+use crate::app::review::{review_failure_message, review_loading_message};
 use crate::app::{App, AppEvent, ReviewCacheEntry, SyncSessionStartError, Tab};
 use crate::domain::agent::{
     AgentKind, AgentModel, AgentSelection, AgentSelectionMetadata, ReasoningLevel,
@@ -29,7 +30,9 @@ use crate::domain::session::{
 };
 use crate::domain::session_message::SessionTranscript;
 use crate::domain::setting::SettingName;
-use crate::domain::transient_message::{TransientMessageSlot, TransientMessageStore};
+use crate::domain::transient_message::{
+    TransientMessageBody, TransientMessageSlot, TransientMessageStore,
+};
 use crate::infra::clock::RealClock;
 use crate::infra::db::AppRepositories;
 use crate::infra::fs::{self as fs, FsClient};
@@ -3114,6 +3117,103 @@ async fn test_refresh_sessions_if_needed_reloads_and_preserves_selection() {
         .selected_session_index()
         .expect("missing selection");
     assert_eq!(app.sessions.sessions()[selected_index].id, "alpha000");
+}
+
+#[tokio::test]
+async fn test_periodic_session_refresh_preserves_focused_review_states() {
+    // Arrange
+    let dir = tempdir().expect("failed to create temp dir");
+    let db = AppRepositories::in_memory().await;
+    let project_id = db
+        .projects()
+        .upsert_project("/tmp/test", None)
+        .await
+        .expect("failed to upsert project");
+    let ready_session_id = "ready000";
+    let loading_session_id = "loading0";
+    let failed_session_id = "failed00";
+    let review_text = "## Review\nPersisted focused review finding.";
+    let review_error = "empty provider response";
+    for session_id in [ready_session_id, loading_session_id, failed_session_id] {
+        db.sessions()
+            .insert_session(
+                session_id,
+                "gemini-3-flash-preview",
+                "main",
+                &Status::Review.to_string(),
+                project_id,
+            )
+            .await
+            .expect("failed to insert review session");
+        let data_dir = session_folder(dir.path(), session_id).join(SESSION_DATA_DIR);
+        std::fs::create_dir_all(data_dir).expect("failed to create session data dir");
+    }
+    db.sessions()
+        .update_session_focused_review(
+            ready_session_id,
+            Some("42".to_string()),
+            Some(review_text.to_string()),
+        )
+        .await
+        .expect("failed to persist focused review");
+    let mut app = new_test_app_with_db(
+        dir.path().to_path_buf(),
+        PathBuf::from("/tmp/test"),
+        None,
+        db.clone(),
+    )
+    .await;
+    app.review_cache.insert(
+        loading_session_id.into(),
+        ReviewCacheEntry::Loading { diff_hash: 43 },
+    );
+    app.review_cache.insert(
+        failed_session_id.into(),
+        ReviewCacheEntry::Failed {
+            diff_hash: 44,
+            error: review_error.to_string(),
+        },
+    );
+    let review_model = app.settings.default_review_selection.model();
+    crate::app::review::hydrate_review_transients(
+        &app.review_cache,
+        app.sessions.state_mut(),
+        review_model,
+    );
+    let clock = Arc::new(TestClock::new(Instant::now(), SystemTime::now()));
+    app.sessions.state_mut().clock = clock.clone();
+    app.sessions.state_mut().refresh_deadline = clock.now_instant() + SESSION_REFRESH_INTERVAL;
+    db.sessions()
+        .update_session_updated_at(ready_session_id, 4_000_000_000)
+        .await
+        .expect("failed to update session timestamp");
+    clock.advance(SESSION_REFRESH_INTERVAL);
+
+    // Act
+    let refreshed = app.refresh_sessions_if_needed().await;
+
+    // Assert
+    assert!(refreshed);
+    let ready_message = review_message_body(&app, ready_session_id);
+    assert_eq!(ready_message.text(), review_text);
+
+    let loading_message = review_message_body(&app, loading_session_id);
+    assert!(matches!(loading_message, TransientMessageBody::Loading(_)));
+    assert_eq!(loading_message.text(), review_loading_message(review_model));
+
+    let failed_message = review_message_body(&app, failed_session_id);
+    assert!(matches!(failed_message, TransientMessageBody::Plain(_)));
+    assert_eq!(failed_message.text(), review_failure_message(review_error));
+}
+
+fn review_message_body<'a>(app: &'a App, session_id: &str) -> &'a TransientMessageBody {
+    &app.sessions
+        .session_or_err(session_id)
+        .expect("review session should remain loaded")
+        .transient_messages
+        .get(TransientMessageSlot::Review)
+        .expect("review output should remain visible after refresh")
+        .body
 }
 
 #[tokio::test]

--- a/crates/agentty/src/domain/review.rs
+++ b/crates/agentty/src/domain/review.rs
@@ -3,7 +3,7 @@
 /// Extracts actionable suggestion content from focused-review markdown.
 ///
 /// Returns `None` when the `### Suggestions` section is missing, empty, or
-/// explicitly reports `- None`.
+/// reports `- None` with optional trailing punctuation.
 #[must_use]
 pub fn review_suggestions(review_text: &str) -> Option<String> {
     let suggestions_header = "### Suggestions";
@@ -13,11 +13,21 @@ pub fn review_suggestions(review_text: &str) -> Option<String> {
     let section_end = content.find("\n### ").unwrap_or(content.len());
     let suggestions = content[..section_end].trim();
 
-    if suggestions.is_empty() || suggestions == "- None" {
+    if suggestions.is_empty() || is_no_suggestions_sentinel(suggestions) {
         return None;
     }
 
     Some(suggestions.to_string())
+}
+
+/// Returns whether a suggestions section contains only the required `None`
+/// sentinel plus optional trailing punctuation.
+fn is_no_suggestions_sentinel(suggestions: &str) -> bool {
+    suggestions.strip_prefix("- None").is_some_and(|suffix| {
+        suffix
+            .chars()
+            .all(|character| character.is_ascii_punctuation())
+    })
 }
 
 /// Returns whether focused-review markdown contains suggestions that `/apply`
@@ -64,6 +74,18 @@ mod tests {
 ### Suggestions
 
 - None";
+
+        // Act
+        let suggestions = review_suggestions(review_text);
+
+        // Assert
+        assert_eq!(suggestions, None);
+    }
+
+    #[test]
+    fn test_review_suggestions_returns_none_for_punctuated_no_suggestions() {
+        // Arrange
+        let review_text = "## Review\n\n### Suggestions\n\n- None.";
 
         // Act
         let suggestions = review_suggestions(review_text);

--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -807,7 +807,7 @@ impl<'a> SessionOutput<'a> {
                         session_format::session_output_summary_markdown(markdown)
                     }
                     TransientMessageSlot::Review => {
-                        session_format::annotate_review_suggestions_header(markdown)
+                        session_format::format_review_markdown(markdown)
                     }
                     TransientMessageSlot::WorkflowNotice
                     | TransientMessageSlot::PublishedBranchSync => markdown.clone(),
@@ -2396,7 +2396,8 @@ mod tests {
         );
         session.summary = Some(summary_fixture());
         session.status = Status::Review;
-        let review_text = "## Review\n\n### Project Impact\n\n- Documentation-only change.";
+        let review_text = "## Review\n\n### Project Impact\n\n- Documentation-only change.\n\n### \
+                           Suggestions\n\n- None.";
         session.reconcile_transient_messages();
         set_review_transient(
             &mut session,
@@ -2425,6 +2426,9 @@ mod tests {
         assert!(output_index < summary_index);
         assert!(summary_index < review_index);
         assert!(review_index < merge_error_index);
+        assert!(text.contains("Project Impact\n- Documentation-only change."));
+        assert!(text.contains("Suggestions\n- None."));
+        assert!(!text.contains("type \"/apply\" to verify and apply"));
     }
 
     /// Verifies focused-review failures remain visible after the transient

--- a/crates/agentty/src/ui/layout.rs
+++ b/crates/agentty/src/ui/layout.rs
@@ -1097,42 +1097,50 @@ mod tests {
     }
 
     #[test]
-    fn test_annotate_review_suggestions_header_appends_apply_hint_to_exact_header() {
+    fn test_format_review_markdown_compacts_sections_and_appends_apply_hint() {
         // Arrange
-        let review_markdown = "## Review\n### Project Impact\n- None\n### Suggestions\n- Fix typo.";
+        let review_markdown =
+            "## Review\n\n### Project Impact\n\n- None\n\n### Suggestions\n\n- Fix typo.";
 
         // Act
-        let annotated = annotate_review_suggestions_header(review_markdown);
+        let formatted = format_review_markdown(review_markdown);
 
         // Assert
-        assert!(annotated.contains("### Suggestions (type \"/apply\" to verify and apply)"));
-        assert!(!annotated.contains("### Suggestions\n"));
-        assert!(annotated.contains("- Fix typo."));
+        assert!(formatted.starts_with("## Review\n\n### Project Impact\n- None"));
+        assert!(
+            formatted
+                .contains("### Suggestions (type \"/apply\" to verify and apply)\n- Fix typo.")
+        );
+        assert!(!formatted.contains("### Suggestions\n"));
     }
 
     #[test]
-    fn test_annotate_review_suggestions_header_leaves_non_matching_lines_untouched() {
+    fn test_format_review_markdown_leaves_non_matching_lines_untouched() {
         // Arrange
         let review_markdown = "### Suggestions extra\n- keep as-is";
 
         // Act
-        let annotated = annotate_review_suggestions_header(review_markdown);
+        let formatted = format_review_markdown(review_markdown);
 
         // Assert
-        assert_eq!(annotated, review_markdown);
+        assert_eq!(formatted, review_markdown);
     }
 
     #[test]
-    fn test_annotate_review_suggestions_header_skips_empty_suggestions() {
+    fn test_format_review_markdown_compacts_empty_suggestions_without_hint() {
         // Arrange
-        let review_markdown = "## Review\n### Suggestions\n- None\n### Project Impact\n- None";
+        let review_markdown =
+            "## Review\n\n### Suggestions\n\n- None\n\n### Project Impact\n\n- None";
 
         // Act
-        let annotated = annotate_review_suggestions_header(review_markdown);
+        let formatted = format_review_markdown(review_markdown);
 
         // Assert
-        assert_eq!(annotated, review_markdown);
-        assert!(!annotated.contains("(type \"/apply\" to verify and apply)"));
+        assert_eq!(
+            formatted,
+            "## Review\n\n### Suggestions\n- None\n\n### Project Impact\n- None"
+        );
+        assert!(!formatted.contains("(type \"/apply\" to verify and apply)"));
     }
 
     #[test]

--- a/crates/agentty/src/ui/session_format.rs
+++ b/crates/agentty/src/ui/session_format.rs
@@ -13,6 +13,7 @@ use crate::presentation::help_action::{self, ViewHelpState};
 use crate::ui::icon::Icon;
 use crate::ui::{markdown, style};
 
+const REVIEW_PROJECT_IMPACT_HEADER: &str = "### Project Impact";
 const REVIEW_SUGGESTIONS_HEADER: &str = "### Suggestions";
 const REVIEW_SUGGESTIONS_HEADER_WITH_HINT: &str =
     "### Suggestions (type \"/apply\" to verify and apply)";
@@ -189,23 +190,40 @@ pub(crate) fn session_output_summary_markdown(summary_text: &str) -> String {
     )
 }
 
-/// Adds the verification-gated `/apply` hint to an actionable focused-review
-/// suggestions header.
-pub(crate) fn annotate_review_suggestions_header(review_markdown: &str) -> String {
-    if !review::has_actionable_review_suggestions(Some(review_markdown)) {
-        return review_markdown.to_string();
-    }
+/// Formats focused-review section headings with compact spacing and adds the
+/// verification-gated `/apply` hint when suggestions are actionable.
+pub(crate) fn format_review_markdown(review_markdown: &str) -> String {
+    let has_actionable_suggestions =
+        review::has_actionable_review_suggestions(Some(review_markdown));
+    let mut formatted_lines = Vec::with_capacity(review_markdown.lines().count());
+    let mut skip_section_spacing = false;
 
-    let mut annotated_lines = Vec::with_capacity(review_markdown.lines().count());
     for line in review_markdown.lines() {
-        if line.trim_end() == REVIEW_SUGGESTIONS_HEADER {
-            annotated_lines.push(REVIEW_SUGGESTIONS_HEADER_WITH_HINT.to_string());
+        if skip_section_spacing && line.trim().is_empty() {
+            continue;
+        }
+        skip_section_spacing = false;
+
+        let trimmed_line = line.trim_end();
+        if trimmed_line == REVIEW_PROJECT_IMPACT_HEADER {
+            formatted_lines.push(line.to_string());
+            skip_section_spacing = true;
+        } else if matches!(
+            trimmed_line,
+            REVIEW_SUGGESTIONS_HEADER | REVIEW_SUGGESTIONS_HEADER_WITH_HINT
+        ) {
+            if has_actionable_suggestions {
+                formatted_lines.push(REVIEW_SUGGESTIONS_HEADER_WITH_HINT.to_string());
+            } else {
+                formatted_lines.push(line.to_string());
+            }
+            skip_section_spacing = true;
         } else {
-            annotated_lines.push(line.to_string());
+            formatted_lines.push(line.to_string());
         }
     }
 
-    annotated_lines.join("\n")
+    formatted_lines.join("\n")
 }
 
 /// Returns borders used for the session output panel.

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -721,7 +721,11 @@ fn seed_review_ready_session_with_persisted_focused_review(
             .update_session_focused_review(
                 "review-shortcut-0001",
                 Some("42".to_string()),
-                Some("## Review\nPersisted focused review finding.".to_string()),
+                Some(
+                    "## Review\n\n### Project Impact\n\n- Persisted focused review \
+                     finding.\n\n### Suggestions\n\n- None."
+                        .to_string(),
+                ),
             )
             .await
     })?;
@@ -3329,6 +3333,30 @@ fn persisted_focused_review_survives_reload() -> E2eResult {
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "Persisted focused review finding.", &full);
+                let impact_header = frame
+                    .find_text("Project Impact")
+                    .into_iter()
+                    .next()
+                    .expect("project impact header should render");
+                let impact_finding = frame
+                    .find_text("Persisted focused review finding.")
+                    .into_iter()
+                    .next()
+                    .expect("project impact finding should render");
+                let suggestions_header = frame
+                    .find_text("Suggestions")
+                    .into_iter()
+                    .next()
+                    .expect("suggestions header should render");
+                let empty_suggestion = frame
+                    .find_text("- None.")
+                    .into_iter()
+                    .next()
+                    .expect("empty suggestion should render");
+
+                assert_eq!(impact_finding.rect.row, impact_header.rect.row + 1);
+                assert_eq!(empty_suggestion.rect.row, suggestions_header.rect.row + 1);
+                assertion::assert_not_visible(frame, "type \"/apply\" to verify and apply");
             },
         )?;
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -197,14 +197,16 @@ competing published-branch auto-push.
 When a session enters **Review**, Agentty starts generating a focused review in the
 background and temporarily shows **AgentReview**. Press `f` to append the cached review
 into the session output, or to see a loading message while generation is still running.
-The appended review stays visible across diff mode and question mode, and is cleared
-when you submit the next prompt. Focused review includes the saved user and agent chat
-history for context. It uses inspection-only context: it may read files, search, inspect
-git history, and browse when needed, but it recommends verification commands instead of
-running checks itself. `Project Impact` renders as concise bullets, and `Suggestions`
-renders as bullets formatted `[Severity]: Issue details`, using `[High]` or `[Medium]`
-when follow-up work is needed. A turn stopped with `Ctrl+c` does not start a focused
-review automatically; press `f` for a manual one.
+The appended review stays visible across diff mode, question mode, and background
+session metadata refreshes, and is cleared when you submit the next prompt. Focused
+review includes the saved user and agent chat history for context. It uses
+inspection-only context: it may read files, search, inspect git history, and browse when
+needed, but it recommends verification commands instead of running checks itself.
+`Project Impact` renders concise bullets directly beneath its heading. `Suggestions`
+uses the same compact spacing and formats its bullets as `[Severity]: Issue details`,
+using `[High]` or `[Medium]` when follow-up work is needed. Empty `Suggestions` output
+does not offer the `/apply` action. A turn stopped with `Ctrl+c` does not start a
+focused review automatically; press `f` for a manual one.
 
 ### Session Output Markdown
 


### PR DESCRIPTION
- Formats `Project Impact` and `Suggestions` with compact spacing.
- Adds the verification-gated `/apply` hint only when suggestions are actionable.
- Rehydrates loading, ready, and failed focused-review states after session refreshes.
- Treats punctuated `- None` suggestions as empty.
- Expands unit and E2E coverage and documents refresh persistence and section spacing.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)