### PR TITLE
Keep completed session output stable during branch workflows

### DIFF
--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -552,12 +552,7 @@ impl Session {
     pub(crate) fn hydrate_summary_transient(&mut self) {
         if matches!(
             self.status,
-            Status::Draft
-                | Status::InProgress
-                | Status::Queued
-                | Status::Rebasing
-                | Status::Merging
-                | Status::Canceled
+            Status::Draft | Status::InProgress | Status::Queued | Status::Canceled
         ) {
             self.transient_messages
                 .retract(TransientMessageSlot::Summary);
@@ -589,10 +584,8 @@ impl Session {
 
     /// Applies turn-bound lifecycle cleanup after reducer-owned snapshot sync.
     pub(crate) fn reconcile_transient_messages(&mut self) {
-        if matches!(
-            self.status,
-            Status::InProgress | Status::Queued | Status::Rebasing | Status::Merging
-        ) && let Some(active_turn_position) = self.latest_user_prompt_position()
+        if matches!(self.status, Status::InProgress | Status::Queued)
+            && let Some(active_turn_position) = self.latest_user_prompt_position()
         {
             self.transient_messages
                 .clear_for_new_turn(active_turn_position);
@@ -1587,6 +1580,32 @@ pub(crate) mod tests {
 
         // Assert
         assert!(can_transition);
+    }
+
+    #[test]
+    fn test_reconcile_transient_messages_retains_summary_during_branch_workflow() {
+        // Arrange
+        let statuses = [Status::Rebasing, Status::Merging];
+
+        // Act
+        let sessions = statuses.map(|status| {
+            let mut session = SessionFixtureBuilder::new()
+                .status(status)
+                .summary(Some("Completed summary".to_string()))
+                .build();
+            session.reconcile_transient_messages();
+
+            session
+        });
+
+        // Assert
+        for session in sessions {
+            let summary = session
+                .transient_messages
+                .get(TransientMessageSlot::Summary)
+                .expect("branch workflow should retain the completed summary");
+            assert_eq!(summary.body.text(), "Completed summary");
+        }
     }
 
     #[test]

--- a/crates/agentty/src/domain/session_message.rs
+++ b/crates/agentty/src/domain/session_message.rs
@@ -1,5 +1,8 @@
 use std::fmt;
+use std::hash::Hasher;
 use std::str::FromStr;
+
+use rustc_hash::FxHasher;
 
 const CLARIFICATION_HEADER: &str = "Clarifications:";
 const USER_PROMPT_CONTINUATION_PREFIX: &str = "   ";
@@ -103,6 +106,7 @@ impl SessionMessage {
 /// Ordered transcript view assembled from persisted session messages.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct SessionTranscript {
+    content_hash: u64,
     messages: Vec<SessionMessage>,
     total_content_len: usize,
 }
@@ -112,9 +116,11 @@ impl SessionTranscript {
     pub fn new(mut messages: Vec<SessionMessage>) -> Self {
         messages.sort_by_key(|message| message.position);
 
+        let content_hash = transcript_content_hash(&messages);
         let total_content_len = messages.iter().map(|message| message.content.len()).sum();
 
         Self {
+            content_hash,
             messages,
             total_content_len,
         }
@@ -130,13 +136,22 @@ impl SessionTranscript {
         &self.messages
     }
 
+    /// Returns the cached content identity for render and projection caches.
+    pub fn content_hash(&self) -> u64 {
+        self.content_hash
+    }
+
     /// Returns the total byte length of message content in this transcript.
     pub fn total_content_len(&self) -> usize {
         self.total_content_len
     }
 
-    /// Appends one message to the in-memory transcript snapshot using the
-    /// same content normalization as durable storage.
+    /// Appends one message after the ordered transcript tail using the same
+    /// content normalization as durable storage.
+    ///
+    /// [`Self::new`] sorts persisted input before this method derives the next
+    /// position, so the message slice and its cached content hash retain the
+    /// same ordering as a newly reconstructed transcript.
     pub fn append_message(&mut self, kind: SessionMessageKind, content: &str) {
         let content = stored_message_content(kind, content);
         if content.trim().is_empty() {
@@ -150,6 +165,7 @@ impl SessionTranscript {
         self.total_content_len = self.total_content_len.saturating_add(content.len());
         self.messages
             .push(SessionMessage::new(position, kind, content));
+        self.content_hash = transcript_content_hash(&self.messages);
     }
 
     /// Returns formatted transcript text for replay when content exists.
@@ -195,6 +211,23 @@ impl SessionTranscript {
 
         output
     }
+}
+
+/// Computes one ordered identity across message positions, kinds, and raw
+/// content so render caches can compare transcripts without rescanning them on
+/// every frame.
+fn transcript_content_hash(messages: &[SessionMessage]) -> u64 {
+    let mut hasher = FxHasher::default();
+
+    for message in messages {
+        hasher.write_i64(message.position);
+        hasher.write(message.kind.as_str().as_bytes());
+        hasher.write_u8(0xff);
+        hasher.write(message.content.as_bytes());
+        hasher.write_u8(0xfe);
+    }
+
+    hasher.finish()
 }
 
 /// Returns the durable message content for one kind.
@@ -339,6 +372,32 @@ mod tests {
     }
 
     #[test]
+    fn test_session_transcript_content_hash_tracks_exact_message_content() {
+        // Arrange
+        let original = SessionTranscript::new(vec![SessionMessage::conversation(
+            0,
+            SessionMessageKind::AssistantAnswer,
+            "alpha",
+        )]);
+        let replacement = SessionTranscript::new(vec![SessionMessage::conversation(
+            0,
+            SessionMessageKind::AssistantAnswer,
+            "bravo",
+        )]);
+
+        // Act
+        let original_hash = original.content_hash();
+        let replacement_hash = replacement.content_hash();
+
+        // Assert
+        assert_eq!(
+            original.total_content_len(),
+            replacement.total_content_len()
+        );
+        assert_ne!(original_hash, replacement_hash);
+    }
+
+    #[test]
     fn test_session_transcript_formats_multiline_user_prompt() {
         // Arrange
         let messages = vec![SessionMessage::conversation(
@@ -435,25 +494,31 @@ mod tests {
     }
 
     #[test]
-    fn test_session_transcript_append_message_uses_next_position() {
+    fn test_session_transcript_append_message_preserves_constructor_ordering() {
         // Arrange
-        let mut transcript = SessionTranscript::new(vec![SessionMessage::conversation(
-            4,
-            SessionMessageKind::UserPrompt,
-            "prompt",
-        )]);
+        let mut transcript = SessionTranscript::new(vec![
+            SessionMessage::conversation(4, SessionMessageKind::AssistantAnswer, "first answer"),
+            SessionMessage::conversation(1, SessionMessageKind::UserPrompt, "prompt"),
+        ]);
 
         // Act
-        transcript.append_message(SessionMessageKind::AssistantAnswer, " answer\n");
+        transcript.append_message(SessionMessageKind::WorkflowNotice, "[Sync] Complete.\n");
+        let reconstructed = SessionTranscript::new(transcript.messages().to_vec());
 
         // Assert
         assert_eq!(
             transcript.messages(),
             &[
-                SessionMessage::conversation(4, SessionMessageKind::UserPrompt, "prompt"),
-                SessionMessage::conversation(5, SessionMessageKind::AssistantAnswer, "answer"),
+                SessionMessage::conversation(1, SessionMessageKind::UserPrompt, "prompt"),
+                SessionMessage::conversation(
+                    4,
+                    SessionMessageKind::AssistantAnswer,
+                    "first answer",
+                ),
+                SessionMessage::new(5, SessionMessageKind::WorkflowNotice, "[Sync] Complete.\n",),
             ]
         );
+        assert_eq!(transcript.content_hash(), reconstructed.content_hash());
     }
 
     #[test]

--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -66,6 +66,22 @@ struct SessionOutputLayoutCacheKey {
     transcript: TranscriptFingerprint,
 }
 
+/// Cache key for the stable transcript body assembled above the dynamic
+/// session-status tail.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SessionOutputBodyCacheKey {
+    draft_prompt: TextFingerprint,
+    has_active_turn: bool,
+    is_stacked_child: bool,
+    markdown_render_version: u64,
+    output_width: u16,
+    queued_messages: TextFingerprint,
+    session_id: SessionId,
+    theme_cache_version: u64,
+    transient_message_version: u64,
+    transcript: TranscriptFingerprint,
+}
+
 /// Compact optional-text identity used by the layout cache key.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct TextFingerprint {
@@ -121,6 +137,7 @@ impl TextFingerprint {
 /// Compact identity for a typed transcript snapshot in the layout cache key.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct TranscriptFingerprint {
+    content_hash: u64,
     content_len: usize,
     is_some: bool,
     last_kind: &'static str,
@@ -134,6 +151,7 @@ impl TranscriptFingerprint {
     fn from_session(session: &Session) -> Self {
         let Some(transcript) = session.transcript.as_ref() else {
             return Self {
+                content_hash: 0,
                 content_len: 0,
                 is_some: false,
                 last_kind: "",
@@ -144,6 +162,7 @@ impl TranscriptFingerprint {
         let messages = transcript.messages();
         let Some(last_message) = messages.last() else {
             return Self {
+                content_hash: 0,
                 content_len: 0,
                 is_some: false,
                 last_kind: "",
@@ -153,6 +172,7 @@ impl TranscriptFingerprint {
         };
 
         Self {
+            content_hash: transcript.content_hash(),
             content_len: transcript.total_content_len(),
             is_some: true,
             last_kind: last_message.kind.as_str(),
@@ -180,6 +200,14 @@ pub(crate) struct SessionOutputLayout {
 struct SessionOutputLines {
     active_loader_line_index: Option<usize>,
     lines: Vec<Line<'static>>,
+    published_loader_line_index: Option<usize>,
+}
+
+/// Cached stable output body shared across status-tail changes such as a
+/// review-ready session entering the rebase workflow.
+#[derive(Clone)]
+struct SessionOutputBody {
+    lines: Arc<[Line<'static>]>,
     published_loader_line_index: Option<usize>,
 }
 
@@ -281,6 +309,23 @@ impl SessionOutputAssembly<'_> {
         }
     }
 
+    /// Appends the stable output body while leaving the status tail for the
+    /// current render state to assemble separately.
+    fn into_output_body(mut self) -> SessionOutputBody {
+        for block in SESSION_OUTPUT_BLOCK_ORDER {
+            if matches!(block, SessionOutputBlock::SessionTail) {
+                continue;
+            }
+
+            self.append_block(block);
+        }
+
+        SessionOutputBody {
+            lines: Arc::from(self.lines),
+            published_loader_line_index: self.published_loader_line_index,
+        }
+    }
+
     /// Appends one optional output block when its current inputs are visible.
     fn append_block(&mut self, block: SessionOutputBlock) {
         match block {
@@ -356,19 +401,11 @@ impl SessionOutputAssembly<'_> {
     }
 
     fn append_session_tail(&mut self) {
-        let review_loading_message = self
-            .session
-            .transient_messages
-            .get(TransientMessageSlot::Review)
-            .and_then(|message| match &message.body {
-                TransientMessageBody::Loading(message) => Some(message.as_str()),
-                TransientMessageBody::Markdown(_) | TransientMessageBody::Plain(_) => None,
-            });
         self.active_loader_line_index = SessionOutput::append_session_tail_lines(
             &mut self.lines,
             self.status,
             self.active_progress,
-            review_loading_message,
+            SessionOutput::review_loading_message(self.session),
         );
     }
 }
@@ -377,6 +414,12 @@ impl SessionOutputAssembly<'_> {
 struct SessionOutputLayoutCacheEntry {
     key: SessionOutputLayoutCacheKey,
     layout: SessionOutputLayout,
+}
+
+/// Cached stable output-body entry.
+struct SessionOutputBodyCacheEntry {
+    body: SessionOutputBody,
+    key: SessionOutputBodyCacheKey,
 }
 
 /// Bounded LRU cache for the fully assembled session output panel.
@@ -390,6 +433,7 @@ struct SessionOutputLayoutCacheEntry {
 /// is bounded by the same layout LRU and is removed once no cached layout
 /// remains for that session.
 pub struct SessionOutputLayoutCache {
+    body_entries: RefCell<VecDeque<SessionOutputBodyCacheEntry>>,
     entries: RefCell<VecDeque<SessionOutputLayoutCacheEntry>>,
     tachyon_loader_effects: RefCell<HashMap<SessionId, TachyonLoaderEffect>>,
 }
@@ -397,6 +441,9 @@ pub struct SessionOutputLayoutCache {
 impl Default for SessionOutputLayoutCache {
     fn default() -> Self {
         Self {
+            body_entries: RefCell::new(VecDeque::with_capacity(
+                SESSION_OUTPUT_LAYOUT_CACHE_ENTRY_LIMIT,
+            )),
             entries: RefCell::new(VecDeque::with_capacity(
                 SESSION_OUTPUT_LAYOUT_CACHE_ENTRY_LIMIT,
             )),
@@ -425,14 +472,50 @@ impl SessionOutputLayoutCache {
             return layout;
         }
 
+        let body_key = SessionOutput::body_cache_key(
+            session,
+            output_area,
+            markdown_render_cache.map_or(0, markdown::MarkdownRenderCache::version),
+        );
+        let body = self.cached_body(&body_key).unwrap_or_else(|| {
+            let body =
+                SessionOutput::derive_body(session, output_area, context, markdown_render_cache);
+            self.store_body_entry(SessionOutputBodyCacheEntry {
+                body: body.clone(),
+                key: body_key,
+            });
+
+            body
+        });
         let layout =
-            SessionOutput::derive_layout(session, output_area, context, markdown_render_cache);
+            SessionOutput::derive_layout_from_body(session, context.active_progress, &body);
         self.store_entry(SessionOutputLayoutCacheEntry {
             key,
             layout: layout.clone(),
         });
 
         layout
+    }
+
+    /// Returns a matching stable output body and promotes it in the body LRU.
+    fn cached_body(&self, key: &SessionOutputBodyCacheKey) -> Option<SessionOutputBody> {
+        let mut entries = self.body_entries.borrow_mut();
+        let entry_index = entries.iter().position(|entry| &entry.key == key)?;
+        let entry = entries.remove(entry_index)?;
+        let body = entry.body.clone();
+        entries.push_front(entry);
+
+        Some(body)
+    }
+
+    /// Stores one stable output body within the same bound as full layouts.
+    fn store_body_entry(&self, entry: SessionOutputBodyCacheEntry) {
+        let mut entries = self.body_entries.borrow_mut();
+        entries.push_front(entry);
+
+        while entries.len() > SESSION_OUTPUT_LAYOUT_CACHE_ENTRY_LIMIT {
+            entries.pop_back();
+        }
     }
 
     /// Returns cached layout for a matching entry and promotes it to the
@@ -649,6 +732,40 @@ impl<'a> SessionOutput<'a> {
         }
     }
 
+    /// Derives the stable transcript body without the dynamic status tail.
+    fn derive_body<'assembly>(
+        session: &'assembly Session,
+        output_area: Rect,
+        context: SessionOutputLineContext<'assembly>,
+        markdown_render_cache: Option<&'assembly markdown::MarkdownRenderCache>,
+    ) -> SessionOutputBody {
+        Self::output_assembly(session, output_area, context, markdown_render_cache)
+            .into_output_body()
+    }
+
+    /// Appends the current status tail to a cached transcript body.
+    fn derive_layout_from_body(
+        session: &Session,
+        active_progress: Option<&str>,
+        body: &SessionOutputBody,
+    ) -> SessionOutputLayout {
+        let mut lines = body.lines.iter().cloned().collect::<Vec<_>>();
+        let active_loader_line_index = Self::append_session_tail_lines(
+            &mut lines,
+            session.status,
+            active_progress,
+            Self::review_loading_message(session),
+        );
+        let line_count = u16::try_from(lines.len()).unwrap_or(u16::MAX);
+
+        SessionOutputLayout {
+            active_loader_line_index,
+            line_count,
+            published_loader_line_index: body.published_loader_line_index,
+            lines: Arc::from(lines),
+        }
+    }
+
     /// Builds the cache key for a fully assembled session-output layout.
     fn layout_cache_key(
         session: &Session,
@@ -673,6 +790,32 @@ impl<'a> SessionOutput<'a> {
             session_update_version: context.session_update_version,
             session_updated_at: session.updated_at,
             status: session.status,
+            theme_cache_version: style::active_theme_cache_version(),
+            transient_message_version: session.transient_messages.version(),
+            transcript: TranscriptFingerprint::from_session(session),
+        }
+    }
+
+    /// Builds the cache key for transcript content that remains stable while
+    /// workflow statuses and progress labels change below it.
+    fn body_cache_key(
+        session: &Session,
+        output_area: Rect,
+        markdown_render_version: u64,
+    ) -> SessionOutputBodyCacheKey {
+        let inner_width =
+            panel_inner_width(output_area, session_format::session_output_panel_borders());
+
+        SessionOutputBodyCacheKey {
+            draft_prompt: Self::draft_prompt_fingerprint(session),
+            has_active_turn: Self::status_has_active_turn(session.status),
+            is_stacked_child: session.is_stacked_child(),
+            markdown_render_version,
+            output_width: u16::try_from(inner_width).unwrap_or(u16::MAX),
+            queued_messages: TextFingerprint::from_texts(
+                session.queued_messages.iter().map(String::as_str),
+            ),
+            session_id: session.id.clone(),
             theme_cache_version: style::active_theme_cache_version(),
             transient_message_version: session.transient_messages.version(),
             transcript: TranscriptFingerprint::from_session(session),
@@ -709,12 +852,24 @@ impl<'a> SessionOutput<'a> {
     /// transcript notices for non-terminal review states, keeping workflow
     /// failures below the completed turn's summary/review content while
     /// terminal views keep their final transcript and summary display stable.
-    fn output_lines_with_metadata(
-        session: &Session,
+    fn output_lines_with_metadata<'assembly>(
+        session: &'assembly Session,
         output_area: Rect,
-        context: SessionOutputLineContext<'_>,
-        markdown_render_cache: Option<&markdown::MarkdownRenderCache>,
+        context: SessionOutputLineContext<'assembly>,
+        markdown_render_cache: Option<&'assembly markdown::MarkdownRenderCache>,
     ) -> SessionOutputLines {
+        Self::output_assembly(session, output_area, context, markdown_render_cache)
+            .into_output_lines()
+    }
+
+    /// Prepares one output assembly shared by full-layout and stable-body
+    /// derivation paths.
+    fn output_assembly<'assembly>(
+        session: &'assembly Session,
+        output_area: Rect,
+        context: SessionOutputLineContext<'assembly>,
+        markdown_render_cache: Option<&'assembly markdown::MarkdownRenderCache>,
+    ) -> SessionOutputAssembly<'assembly> {
         let SessionOutputLineContext {
             active_progress,
             active_prompt_output: _,
@@ -739,7 +894,6 @@ impl<'a> SessionOutput<'a> {
             status,
             trailing_notice_section: transcript_sections.trailing_notice,
         }
-        .into_output_lines()
     }
 
     /// Trims trailing blank rows before appending a block separator.
@@ -790,6 +944,18 @@ impl<'a> SessionOutput<'a> {
         lines.push(Line::from(""));
 
         None
+    }
+
+    /// Returns the focused-review loading label rendered in the shared status
+    /// row rather than in the stable transcript body.
+    fn review_loading_message(session: &Session) -> Option<&str> {
+        session
+            .transient_messages
+            .get(TransientMessageSlot::Review)
+            .and_then(|message| match &message.body {
+                TransientMessageBody::Loading(message) => Some(message.as_str()),
+                TransientMessageBody::Markdown(_) | TransientMessageBody::Plain(_) => None,
+            })
     }
 
     /// Appends one explicitly typed transient message and returns whether it
@@ -900,16 +1066,19 @@ impl<'a> SessionOutput<'a> {
 
     /// Returns the start index for the latest active user prompt message.
     fn active_prompt_message_index(status: Status, messages: &[SessionMessage]) -> Option<usize> {
-        if !matches!(
-            status,
-            Status::InProgress | Status::Queued | Status::Rebasing | Status::Merging
-        ) {
+        if !Self::status_has_active_turn(status) {
             return None;
         }
 
         messages
             .iter()
             .rposition(|message| message.kind == SessionMessageKind::UserPrompt)
+    }
+
+    /// Returns whether one status represents a live or queued agent turn whose
+    /// latest prompt must remain separate from completed transcript content.
+    fn status_has_active_turn(status: Status) -> bool {
+        matches!(status, Status::InProgress | Status::Queued)
     }
 
     /// Returns the first index of the trailing workflow-notice suffix.
@@ -1576,6 +1745,71 @@ mod tests {
         // Assert
         assert_eq!(first_layout.line_count, second_layout.line_count);
         assert!(Arc::ptr_eq(&first_layout.lines, &second_layout.lines));
+    }
+
+    /// Verifies workflow-only status changes reuse the stable transcript body
+    /// and keep completed output ahead of its summary during a rebase.
+    #[test]
+    fn test_output_layout_cache_reuses_completed_body_during_rebase() {
+        // Arrange
+        let mut session = session_fixture();
+        set_conversation_transcript(
+            &mut session,
+            vec![
+                (SessionMessageKind::UserPrompt, "implement cache reuse"),
+                (
+                    SessionMessageKind::AssistantAnswer,
+                    "Completed answer stays stable.",
+                ),
+            ],
+        );
+        session.status = Status::Review;
+        session.summary = Some(summary_fixture());
+        session.reconcile_transient_messages();
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+        let output_layout_cache = SessionOutputLayoutCache::default();
+        let review_context = SessionOutputLineContext {
+            session_update_version: 7,
+            ..line_context()
+        };
+        let review_layout = output_layout_cache.layout(
+            &session,
+            Rect::new(0, 0, 80, 8),
+            review_context,
+            Some(&markdown_render_cache),
+        );
+
+        // Act
+        session.status = Status::Rebasing;
+        let rebase_layout = output_layout_cache.layout(
+            &session,
+            Rect::new(0, 0, 80, 8),
+            SessionOutputLineContext {
+                active_progress: Some("Rebasing branch"),
+                session_update_version: 8,
+                ..line_context()
+            },
+            Some(&markdown_render_cache),
+        );
+        let rebase_text = rebase_layout
+            .lines
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let answer_index = rebase_text
+            .find("Completed answer stays stable.")
+            .expect("completed answer should remain visible");
+        let summary_index = rebase_text
+            .find("Change Summary")
+            .expect("completed summary should remain visible");
+
+        // Assert
+        assert!(!Arc::ptr_eq(&review_layout.lines, &rebase_layout.lines));
+        assert_eq!(output_layout_cache.body_entries.borrow().len(), 1);
+        assert_eq!(output_layout_cache.entries.borrow().len(), 2);
+        assert!(answer_index < summary_index);
+        assert!(rebase_text.contains("Rebasing..."));
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -371,6 +371,54 @@ fn seed_review_ready_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error:
     Ok(())
 }
 
+/// Seeds a review-ready transcript and delays its Git rebase long enough to
+/// inspect the in-progress session output ordering.
+fn seed_rebase_transcript_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    seed_review_ready_session(env)?;
+    seed_review_worktree_with_diff(env)?;
+
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        database
+            .sessions()
+            .append_session_message(
+                "review-shortcut-0001",
+                SessionMessageKind::UserPrompt,
+                "keep completed transcript stable",
+            )
+            .await?;
+        database
+            .sessions()
+            .append_session_message(
+                "review-shortcut-0001",
+                SessionMessageKind::AssistantAnswer,
+                "Completed answer before rebase summary.",
+            )
+            .await?;
+        database
+            .sessions()
+            .update_session_summary(
+                "review-shortcut-0001",
+                r#"{"turn":"Preserved transcript ordering.","session":"Rebase keeps completed output stable."}"#,
+            )
+            .await
+    })?;
+
+    let pre_rebase_hook = env
+        .agentty_root
+        .join("wt")
+        .join("review-s")
+        .join(".git")
+        .join("hooks")
+        .join("pre-rebase");
+    std::fs::write(&pre_rebase_hook, "#!/bin/sh\nsleep 5\n")?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&pre_rebase_hook, std::fs::Permissions::from_mode(0o755))?;
+
+    Ok(())
+}
+
 /// Seeds one published review-ready session whose latest auto-push completion
 /// is persisted as transcript output.
 fn seed_session_with_published_branch_push_notice(
@@ -1945,6 +1993,58 @@ fn session_running_turn_shows_sync_shortcut() -> E2eResult {
                     .rect
                     .row;
                 assert!(answer_row < sync_row);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify a manual rebase keeps the completed answer ahead of its summary
+/// while only the workflow status tail animates.
+#[test]
+fn session_rebase_keeps_completed_transcript_before_summary() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_rebase_transcript_stability")
+        .with_git()
+        .setup(seed_rebase_transcript_session)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("Enter")
+                    .wait_for_text("Completed answer before rebase summary.", 5000)
+                    .wait_for_text("Change Summary", 5000)
+                    .press_key("r")
+                    .wait_for_text("Rebasing...", 5000)
+                    .capture_labeled(
+                        "rebase_transcript_stable",
+                        "Completed transcript remains stable during rebase",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(
+                    frame,
+                    "Completed answer before rebase summary.",
+                    &full,
+                );
+                assertion::assert_text_in_region(frame, "Change Summary", &full);
+                assertion::assert_text_in_region(frame, "Rebasing...", &full);
+
+                let answer_row = frame
+                    .find_text("Completed answer before rebase summary.")
+                    .first()
+                    .expect("missing completed answer")
+                    .rect
+                    .row;
+                let summary_row = frame
+                    .find_text("Change Summary")
+                    .first()
+                    .expect("missing change summary")
+                    .rect
+                    .row;
+                assert!(answer_row < summary_row);
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -144,10 +144,13 @@ keys the transient-store version rather than maintaining a separate fingerprint 
 every temporary channel. Structured clarification questions render in the bottom
 question panel (`AppMode::Question`), not inside the output component.
 
-`App` owns one shared `RenderCacheStore` for markdown, diff, and session-output layout
-caches. Changes in this area should keep caches bounded and route layout/count helpers
-and the final paint path through the same cached derived data instead of recomputing the
-render twice per frame.
+Runtime owns one shared `RenderCacheStore` for markdown, diff, and session-output layout
+caches. The session-output cache keeps a bounded stable-body layer keyed by the typed
+transcript's cached content hash, width, theme, queued input, and transient-message
+version. Workflow-only status changes such as `Review` entering `Rebasing` reuse that
+body and append only the dynamic status tail. Changes in this area should keep caches
+bounded and route layout/count helpers and the final paint path through the same cached
+derived data instead of recomputing the render twice per frame.
 
 ## Session Turn Data Flow
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -281,7 +281,8 @@ first and rebase onto the remote base ref, unpublished sessions rebase onto the 
 local base branch. In **InProgress**, the sync request is queued behind the running turn
 before the session enters **Rebasing**. If the rebase stops on conflicts, Agentty asks
 the existing agent session to resolve only the conflicted files, then stages the edits
-and continues the rebase itself.
+and continues the rebase itself. The completed conversation and summary remain in their
+existing order while the rebase or merge status animates below them.
 
 During normal turns, the agent prompt names the session worktree as the only writable
 root. After a turn, if Agentty detects that the main checkout's tracked-file status


### PR DESCRIPTION
- Retain completed transcripts and summaries while rebase or merge status updates render below.
- Cache ordered transcript bodies separately from dynamic workflow tails.
- Add regression and E2E coverage for transcript ordering.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)