### PR TITLE
Show scrollbar for overflowing session output

### DIFF
--- a/crates/agentty/src/runtime/mode/chat_scroll.rs
+++ b/crates/agentty/src/runtime/mode/chat_scroll.rs
@@ -41,14 +41,6 @@ impl ChatScrollMetrics {
         let page_area = layout::app_frame_areas(terminal_size).content_area;
         let output_width = page_area.width.saturating_sub(2);
         let (_, review_text) = app.review_view_state(session_id);
-
-        let total_lines = session_output_metric::rendered_output_line_count_with_cache(
-            app,
-            render_cache_store,
-            session_id,
-            session_index,
-            output_width,
-        );
         let view_height = app.sessions.session_at(session_index).map_or_else(
             || Self::footer_only_view_height(page_area),
             |session| {
@@ -61,6 +53,14 @@ impl ChatScrollMetrics {
                     wall_clock_unix_seconds: app.wall_clock_unix_seconds(),
                 })
             },
+        );
+        let total_lines = session_output_metric::rendered_output_line_count_with_cache(
+            app,
+            render_cache_store,
+            session_id,
+            session_index,
+            output_width,
+            view_height,
         );
 
         Self {

--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -1037,10 +1037,15 @@ mod tests {
         let terminal_size = Rect::new(0, 0, 16, 24);
         let output_width = terminal_size.width.saturating_sub(2);
         let render_cache_store = RenderCacheStore::default();
+        // Act
+        let metrics = question_scroll_metrics(&app, &render_cache_store, terminal_size)
+            .expect("chat-focused question mode should have scroll metrics");
+
         let session = &app.sessions.sessions()[0];
         let expected = SessionChatPage::rendered_output_line_count(
             session,
             output_width,
+            metrics.view_height,
             SessionOutputLineContext {
                 active_prompt_output: None,
                 active_progress: None,
@@ -1050,13 +1055,9 @@ mod tests {
             render_cache_store.session_output_layout_cache(),
         );
 
-        // Act
-        let metrics = question_scroll_metrics(&app, &render_cache_store, terminal_size);
-
         // Assert
         assert_eq!(
-            metrics.map(|metrics| metrics.total_lines),
-            Some(expected),
+            metrics.total_lines, expected,
             "chat-focused question mode must report transcript line count"
         );
     }

--- a/crates/agentty/src/runtime/mode/session_output_metric.rs
+++ b/crates/agentty/src/runtime/mode/session_output_metric.rs
@@ -3,13 +3,15 @@ use crate::ui::RenderCacheStore;
 use crate::ui::component::session_output::SessionOutputLineContext;
 use crate::ui::page::session_chat::SessionChatPage;
 
-/// Returns rendered session-output line count for runtime scroll metrics.
+/// Returns rendered session-output line count for runtime scroll metrics,
+/// resolving conditional scrollbar width against `viewport_height`.
 pub(crate) fn rendered_output_line_count_with_cache(
     app: &App,
     render_cache_store: &RenderCacheStore,
     session_id: &str,
     session_index: usize,
     output_width: u16,
+    viewport_height: u16,
 ) -> u16 {
     let active_progress = app.session_progress_message(session_id);
     let active_prompt_output = app
@@ -22,6 +24,7 @@ pub(crate) fn rendered_output_line_count_with_cache(
         SessionChatPage::rendered_output_line_count(
             session,
             output_width,
+            viewport_height,
             SessionOutputLineContext {
                 active_prompt_output,
                 active_progress,
@@ -39,6 +42,7 @@ pub(crate) fn rendered_output_line_count(
     session_id: &str,
     session_index: usize,
     output_width: u16,
+    viewport_height: u16,
 ) -> u16 {
     rendered_output_line_count_with_cache(
         app,
@@ -46,5 +50,6 @@ pub(crate) fn rendered_output_line_count(
         session_id,
         session_index,
         output_width,
+        viewport_height,
     )
 }

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -1764,7 +1764,7 @@ mod tests {
 
         // Act
         let total_lines =
-            session_output_metric::rendered_output_line_count(&app, &session_id, 0, 20);
+            session_output_metric::rendered_output_line_count(&app, &session_id, 0, 20, 5);
 
         // Assert
         assert!(total_lines > raw_line_count);
@@ -1834,6 +1834,7 @@ mod tests {
                 &session_id,
                 0,
                 20,
+                5,
             ),
             view_height: 5,
         };
@@ -1881,11 +1882,13 @@ mod tests {
         );
         app.sessions.sessions_mut()[0].status = Status::AgentReview;
         let output_width = 14;
+        let viewport_height = 5;
         let render_cache_store = RenderCacheStore::default();
         let session = &app.sessions.sessions()[0];
         let expected = SessionChatPage::rendered_output_line_count(
             session,
             output_width,
+            viewport_height,
             SessionOutputLineContext {
                 active_prompt_output: None,
                 active_progress: None,
@@ -1896,8 +1899,13 @@ mod tests {
         );
 
         // Act
-        let total_lines =
-            session_output_metric::rendered_output_line_count(&app, &session_id, 0, output_width);
+        let total_lines = session_output_metric::rendered_output_line_count(
+            &app,
+            &session_id,
+            0,
+            output_width,
+            viewport_height,
+        );
 
         // Assert
         assert_eq!(total_lines, expected);

--- a/crates/agentty/src/ui/component.rs
+++ b/crates/agentty/src/ui/component.rs
@@ -15,3 +15,4 @@ pub mod session_output;
 pub mod status_bar;
 pub mod tab;
 pub mod tachyon_loader;
+pub mod vertical_scrollbar;

--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -18,6 +18,9 @@ use crate::domain::transient_message::{
     TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageSlot,
 };
 use crate::ui::component::tachyon_loader::TachyonLoaderEffect;
+use crate::ui::component::vertical_scrollbar::VerticalScrollbar;
+#[cfg(test)]
+use crate::ui::component::vertical_scrollbar::{SCROLLBAR_THUMB_SYMBOL, SCROLLBAR_TRACK_SYMBOL};
 use crate::ui::icon::{Icon, TACHYON_LOADER_WIDTH};
 use crate::ui::input_layout::{bottom_pinned_scroll_offset, panel_inner_width};
 use crate::ui::markdown::{self, render_markdown};
@@ -36,6 +39,7 @@ const DRAFT_PREVIEW_STAGED_NOTE: &str =
 const DRAFT_PREVIEW_STACKED_STAGED_NOTE: &str =
     "Draft messages stay local until the parent is review-ready and you press `s` in session view \
      to start the stacked bundle from its parent branch.";
+const SCROLLBAR_WIDTH: u16 = 1;
 const SESSION_OUTPUT_LAYOUT_CACHE_ENTRY_LIMIT: usize = 16;
 const USER_PROMPT_TAB_WIDTH: usize = 4;
 
@@ -194,6 +198,13 @@ pub(crate) struct SessionOutputLayout {
     pub(crate) published_loader_line_index: Option<usize>,
     /// Rendered lines shared between scroll metrics and frame painting.
     pub(crate) lines: Arc<[Line<'static>]>,
+}
+
+/// Final session-output layout selected for the current viewport and
+/// scrollbar state.
+struct SessionOutputResolvedLayout {
+    layout: SessionOutputLayout,
+    show_scrollbar: bool,
 }
 
 /// Fully assembled session-output lines plus metadata derived during assembly.
@@ -676,24 +687,66 @@ impl<'a> SessionOutput<'a> {
     /// width.
     ///
     /// This mirrors the exact wrapping and footer line rules used during
-    /// rendering so scroll math can stay in sync with what users see.
+    /// rendering, including conditional scrollbar gutter reservation, so
+    /// scroll math can stay in sync with what users see.
     pub(crate) fn rendered_line_count(
         session: &Session,
         output_width: u16,
+        viewport_height: u16,
         context: SessionOutputLineContext<'_>,
         markdown_render_cache: Option<&markdown::MarkdownRenderCache>,
         output_layout_cache: Option<&SessionOutputLayoutCache>,
     ) -> u16 {
-        let output_area = Rect::new(0, 0, output_width, 0);
+        Self::resolved_layout(
+            session,
+            Rect::new(0, 0, output_width, 0),
+            viewport_height,
+            context,
+            markdown_render_cache,
+            output_layout_cache,
+        )
+        .layout
+        .line_count
+    }
 
-        Self::rendered_layout(
+    /// Returns the full-width layout when it fits, or derives a second layout
+    /// with the scrollbar gutter reserved when the viewport overflows.
+    fn resolved_layout(
+        session: &Session,
+        output_area: Rect,
+        viewport_height: u16,
+        context: SessionOutputLineContext<'_>,
+        markdown_render_cache: Option<&markdown::MarkdownRenderCache>,
+        output_layout_cache: Option<&SessionOutputLayoutCache>,
+    ) -> SessionOutputResolvedLayout {
+        let layout_without_scrollbar = Self::rendered_layout(
             session,
             output_area,
             context,
             markdown_render_cache,
             output_layout_cache,
-        )
-        .line_count
+        );
+        if !Self::has_scrollable_overflow(layout_without_scrollbar.lines.len(), viewport_height) {
+            return SessionOutputResolvedLayout {
+                layout: layout_without_scrollbar,
+                show_scrollbar: false,
+            };
+        }
+
+        let layout_with_scrollbar = Self::rendered_layout(
+            session,
+            Self::scrollbar_layout_area(output_area),
+            context,
+            markdown_render_cache,
+            output_layout_cache,
+        );
+        let show_scrollbar =
+            Self::has_scrollable_overflow(layout_with_scrollbar.lines.len(), viewport_height);
+
+        SessionOutputResolvedLayout {
+            layout: layout_with_scrollbar,
+            show_scrollbar,
+        }
     }
 
     /// Returns the rendered output layout for the current session state,
@@ -1499,6 +1552,20 @@ impl<'a> SessionOutput<'a> {
         )
     }
 
+    /// Returns the width used to wrap output while leaving the final panel
+    /// column available for the scrollbar.
+    fn scrollbar_layout_area(output_area: Rect) -> Rect {
+        Rect {
+            width: output_area.width.saturating_sub(SCROLLBAR_WIDTH),
+            ..output_area
+        }
+    }
+
+    /// Returns whether the output extends beyond the visible transcript rows.
+    fn has_scrollable_overflow(line_count: usize, viewport_height: u16) -> bool {
+        viewport_height > 0 && line_count > usize::from(viewport_height)
+    }
+
     /// Returns whether a status row should receive the Tachyonfx loader
     /// treatment.
     fn status_uses_tachyon_loader(status: Status) -> bool {
@@ -1534,9 +1601,11 @@ impl Component for SessionOutput<'_> {
     fn render(&self, f: &mut Frame, output_area: Rect) {
         let status = self.session.status;
         let spinner_frame = Icon::current_spinner_frame();
-        let layout = Self::rendered_layout(
+        let viewport_height = Self::session_output_inner_area(output_area).height;
+        let resolved_layout = Self::resolved_layout(
             self.session,
             output_area,
+            viewport_height,
             SessionOutputLineContext {
                 active_prompt_output: self.active_prompt_output,
                 active_progress: self.active_progress,
@@ -1545,6 +1614,7 @@ impl Component for SessionOutput<'_> {
             self.markdown_render_cache,
             self.output_layout_cache,
         );
+        let layout = resolved_layout.layout;
         let final_scroll = bottom_pinned_scroll_offset(
             output_area,
             session_format::session_output_panel_borders(),
@@ -1572,6 +1642,19 @@ impl Component for SessionOutput<'_> {
             .scroll((final_scroll, 0));
 
         f.render_widget(paragraph, output_area);
+
+        if resolved_layout.show_scrollbar {
+            let scrollbar_area = Rect::new(
+                output_area
+                    .x
+                    .saturating_add(output_area.width.saturating_sub(SCROLLBAR_WIDTH)),
+                output_area.y.saturating_add(1),
+                SCROLLBAR_WIDTH,
+                viewport_height,
+            );
+
+            VerticalScrollbar::new(final_scroll, layout.lines.len()).render(f, scrollbar_area);
+        }
 
         if let Some(loader_area) = active_loader_area {
             self.apply_tachyon_loader_effect(f.buffer_mut(), loader_area, spinner_frame);
@@ -1686,6 +1769,80 @@ mod tests {
     }
 
     #[test]
+    fn test_render_shows_scrollbar_for_overflowing_output() {
+        // Arrange
+        let mut session = session_fixture();
+        let output = (0..40)
+            .map(|line_index| format!("output line {line_index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        set_assistant_transcript(&mut session, &output);
+        let backend = ratatui::backend::TestBackend::new(40, 10);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+
+        // Act
+        terminal
+            .draw(|frame| {
+                let output = SessionOutput::new(&session).scroll_offset(12);
+                output.render(frame, frame.area());
+            })
+            .expect("failed to draw session output");
+
+        // Assert
+        let rendered_text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect::<String>();
+        assert!(rendered_text.contains(SCROLLBAR_TRACK_SYMBOL));
+        assert!(rendered_text.contains(SCROLLBAR_THUMB_SYMBOL));
+    }
+
+    #[test]
+    fn test_resolved_layout_keeps_full_width_when_output_fits() {
+        // Arrange
+        let mut session = session_fixture();
+        set_assistant_transcript(&mut session, "word word");
+        let output_area = Rect::new(0, 0, 9, 3);
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+        let output_layout_cache = SessionOutputLayoutCache::default();
+        let context = line_context();
+        let full_width_layout = SessionOutput::rendered_layout(
+            &session,
+            output_area,
+            context,
+            Some(&markdown_render_cache),
+            Some(&output_layout_cache),
+        );
+        let gutter_layout = SessionOutput::rendered_layout(
+            &session,
+            SessionOutput::scrollbar_layout_area(output_area),
+            context,
+            Some(&markdown_render_cache),
+            Some(&output_layout_cache),
+        );
+        // Act
+        let resolved_layout = SessionOutput::resolved_layout(
+            &session,
+            output_area,
+            full_width_layout.line_count,
+            context,
+            Some(&markdown_render_cache),
+            Some(&output_layout_cache),
+        );
+
+        // Assert
+        assert!(gutter_layout.line_count > full_width_layout.line_count);
+        assert!(!resolved_layout.show_scrollbar);
+        assert!(Arc::ptr_eq(
+            &resolved_layout.layout.lines,
+            &full_width_layout.lines
+        ));
+    }
+
+    #[test]
     fn test_rendered_line_count_counts_wrapped_content() {
         // Arrange
         let mut session = session_fixture();
@@ -1707,6 +1864,7 @@ mod tests {
         let rendered_line_count = SessionOutput::rendered_line_count(
             &session,
             20,
+            5,
             line_context(),
             Some(&markdown_render_cache),
             Some(&output_layout_cache),

--- a/crates/agentty/src/ui/component/vertical_scrollbar.rs
+++ b/crates/agentty/src/ui/component/vertical_scrollbar.rs
@@ -1,0 +1,95 @@
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+
+use crate::ui::{Component, style};
+
+/// Symbol used to draw the scrollbar track.
+pub(crate) const SCROLLBAR_TRACK_SYMBOL: &str = "│";
+/// Symbol used to draw the scrollbar thumb.
+pub(crate) const SCROLLBAR_THUMB_SYMBOL: &str = "█";
+/// Slim vertical scrollbar rendered within a caller-provided track area.
+pub(crate) struct VerticalScrollbar {
+    scroll_offset: u16,
+    total_lines: usize,
+}
+
+impl VerticalScrollbar {
+    /// Creates a scrollbar for the current offset and full content length.
+    pub(crate) fn new(scroll_offset: u16, total_lines: usize) -> Self {
+        Self {
+            scroll_offset,
+            total_lines,
+        }
+    }
+
+    /// Returns whether the content extends beyond the visible viewport.
+    fn has_scrollable_overflow(&self, viewport_height: u16) -> bool {
+        viewport_height > 0 && self.total_lines > usize::from(viewport_height)
+    }
+
+    /// Returns the thumb offset and height for the provided track height.
+    fn thumb_geometry(&self, track_height: usize) -> (usize, usize) {
+        let thumb_height = (track_height * track_height / self.total_lines).max(1);
+        let max_scroll = self.total_lines.saturating_sub(track_height);
+        let max_thumb_offset = track_height.saturating_sub(thumb_height);
+        let thumb_offset = usize::from(self.scroll_offset)
+            .min(max_scroll)
+            .saturating_mul(max_thumb_offset)
+            .checked_div(max_scroll)
+            .unwrap_or(0);
+
+        (thumb_offset, thumb_height)
+    }
+}
+
+impl Component for VerticalScrollbar {
+    fn render(&self, f: &mut Frame, area: Rect) {
+        if !self.has_scrollable_overflow(area.height) {
+            return;
+        }
+
+        let track_height = usize::from(area.height);
+        let (thumb_offset, thumb_height) = self.thumb_geometry(track_height);
+        let mut scrollbar_lines = Vec::with_capacity(track_height);
+
+        for line_index in 0..track_height {
+            let is_thumb_line =
+                line_index >= thumb_offset && line_index < thumb_offset + thumb_height;
+            let (symbol, symbol_style) = if is_thumb_line {
+                (
+                    SCROLLBAR_THUMB_SYMBOL,
+                    Style::default().fg(style::palette::warning()),
+                )
+            } else {
+                (
+                    SCROLLBAR_TRACK_SYMBOL,
+                    Style::default().fg(style::palette::text_subtle()),
+                )
+            };
+
+            scrollbar_lines.push(Line::from(Span::styled(symbol, symbol_style)));
+        }
+
+        f.render_widget(Paragraph::new(scrollbar_lines), area);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_thumb_geometry_clamps_overscroll_to_track_bottom() {
+        // Arrange
+        let scrollbar = VerticalScrollbar::new(u16::MAX, 40);
+
+        // Act
+        let (thumb_offset, thumb_height) = scrollbar.thumb_geometry(8);
+
+        // Assert
+        assert_eq!(thumb_offset + thumb_height, 8);
+    }
+}

--- a/crates/agentty/src/ui/page/diff.rs
+++ b/crates/agentty/src/ui/page/diff.rs
@@ -14,13 +14,14 @@ use rustc_hash::FxHasher;
 use crate::domain::session::Session;
 use crate::presentation::help_action;
 use crate::ui::component::file_explorer::FileExplorer;
+use crate::ui::component::vertical_scrollbar::VerticalScrollbar;
+#[cfg(test)]
+use crate::ui::component::vertical_scrollbar::{SCROLLBAR_THUMB_SYMBOL, SCROLLBAR_TRACK_SYMBOL};
 use crate::ui::diff_util::{
     DiffLine, DiffLineKind, FileTreeItem, diff_header_new_path, parse_diff_lines,
 };
 use crate::ui::{Component, Page, diff_util, style};
 
-const SCROLLBAR_TRACK_SYMBOL: &str = "│";
-const SCROLLBAR_THUMB_SYMBOL: &str = "█";
 const WRAPPED_CHUNK_START_INDEX: usize = 0;
 const DIFF_CONTENT_CACHE_ENTRY_LIMIT: usize = 8;
 const DIFF_LAYOUT_CACHE_ENTRY_LIMIT: usize = 16;
@@ -604,13 +605,10 @@ impl<'a> DiffPage<'a> {
         f.render_widget(paragraph, area);
 
         if layout.show_scrollbar {
-            Self::render_diff_scrollbar(
-                f,
-                area,
-                layout.render_layout.viewport_height,
-                scroll_offset,
-                layout.line_count,
-            );
+            let scrollbar_area =
+                diff_util::diff_scrollbar_area(area, layout.render_layout.viewport_height);
+
+            VerticalScrollbar::new(scroll_offset, layout.line_count).render(f, scrollbar_area);
         }
     }
 
@@ -754,56 +752,6 @@ impl<'a> DiffPage<'a> {
         };
 
         format!("{old_str}│{new_str} ")
-    }
-
-    /// Renders a slim scrollbar inside the diff panel so users can see their
-    /// position in long diffs at a glance.
-    fn render_diff_scrollbar(
-        f: &mut Frame,
-        area: Rect,
-        viewport_height: u16,
-        scroll_offset: u16,
-        total_lines: usize,
-    ) {
-        if viewport_height == 0 {
-            return;
-        }
-
-        if !diff_util::diff_has_scrollable_overflow(total_lines, viewport_height) {
-            return;
-        }
-
-        let track_height = usize::from(viewport_height);
-        let thumb_height = (track_height * track_height / total_lines).max(1);
-        let max_scroll = total_lines.saturating_sub(track_height);
-        let max_thumb_offset = track_height.saturating_sub(thumb_height);
-        let thumb_offset = usize::from(scroll_offset)
-            .saturating_mul(max_thumb_offset)
-            .checked_div(max_scroll)
-            .unwrap_or(0);
-
-        let scrollbar_area = diff_util::diff_scrollbar_area(area, viewport_height);
-        let mut scrollbar_lines = Vec::with_capacity(track_height);
-
-        for line_index in 0..track_height {
-            let is_thumb_line =
-                line_index >= thumb_offset && line_index < thumb_offset + thumb_height;
-            let (symbol, symbol_style) = if is_thumb_line {
-                (
-                    SCROLLBAR_THUMB_SYMBOL,
-                    Style::default().fg(style::palette::warning()),
-                )
-            } else {
-                (
-                    SCROLLBAR_TRACK_SYMBOL,
-                    Style::default().fg(style::palette::text_subtle()),
-                )
-            };
-
-            scrollbar_lines.push(Line::from(Span::styled(symbol, symbol_style)));
-        }
-
-        f.render_widget(Paragraph::new(scrollbar_lines), scrollbar_area);
     }
 }
 

--- a/crates/agentty/src/ui/page/session_chat.rs
+++ b/crates/agentty/src/ui/page/session_chat.rs
@@ -147,14 +147,16 @@ impl<'a> SessionChatPage<'a> {
     }
 
     /// Returns the rendered output line count for chat content at a given
-    /// width.
+    /// width and viewport height.
     ///
     /// This mirrors the exact wrapping and footer line rules used during
-    /// rendering, including review text and generic active-status loaders, so
-    /// scroll math can stay in sync with what users see.
+    /// rendering, including review text, generic active-status loaders, and
+    /// conditional scrollbar gutter reservation, so scroll math can stay in
+    /// sync with what users see.
     pub(crate) fn rendered_output_line_count(
         session: &Session,
         output_width: u16,
+        viewport_height: u16,
         context: SessionOutputLineContext<'_>,
         markdown_render_cache: &markdown::MarkdownRenderCache,
         output_layout_cache: &SessionOutputLayoutCache,
@@ -162,6 +164,7 @@ impl<'a> SessionChatPage<'a> {
         SessionOutput::rendered_line_count(
             session,
             output_width,
+            viewport_height,
             context,
             Some(markdown_render_cache),
             Some(output_layout_cache),
@@ -888,6 +891,7 @@ mod tests {
         let rendered_line_count = SessionChatPage::rendered_output_line_count(
             &session,
             20,
+            5,
             SessionOutputLineContext {
                 active_prompt_output: None,
                 active_progress: None,
@@ -959,6 +963,7 @@ mod tests {
         let without_review = SessionChatPage::rendered_output_line_count(
             &session,
             40,
+            5,
             SessionOutputLineContext {
                 active_prompt_output: None,
                 active_progress: None,
@@ -985,6 +990,7 @@ mod tests {
         let with_review = SessionChatPage::rendered_output_line_count(
             &session,
             40,
+            5,
             SessionOutputLineContext {
                 active_prompt_output: None,
                 active_progress: None,

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -21,6 +21,7 @@ use agentty::test_support;
 use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::{ConnectOptions, Connection, Executor};
 use testty::assertion;
+use testty::frame::TerminalFrame;
 use testty::region::Region;
 use testty::scenario::Scenario;
 
@@ -48,6 +49,27 @@ const RECONCILE_QUESTION_TEXT: &str = "Should I add a regression test?";
 
 /// Draft text typed into the composer by the chat-focus toggle test.
 const PROMPT_FOCUS_DRAFT_TEXT: &str = "Draft kept while reading chat";
+
+/// Returns every scrollbar row and the subset occupied by its thumb in the
+/// session output's rightmost column.
+fn session_output_scrollbar_rows(frame: &TerminalFrame) -> (Vec<u16>, Vec<u16>) {
+    let scrollbar_column = frame.cols().saturating_sub(2);
+    let mut scrollbar_rows = Vec::new();
+    let mut thumb_rows = Vec::new();
+
+    for row in 0..frame.rows() {
+        match frame.cell_text(row, scrollbar_column) {
+            "█" => {
+                scrollbar_rows.push(row);
+                thumb_rows.push(row);
+            }
+            "│" => scrollbar_rows.push(row),
+            _ => {}
+        }
+    }
+
+    (scrollbar_rows, thumb_rows)
+}
 
 /// Seeds one review-ready session whose transcript contains a beautified
 /// provider command failure.
@@ -1289,6 +1311,38 @@ fn seed_active_loader_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error
     Ok(())
 }
 
+/// Seeds one review-ready session with enough output to overflow a compact
+/// transcript viewport.
+fn seed_session_with_scrollable_output(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    const SESSION_ID: &str = "scroll-output-0001";
+
+    common::seed_session(
+        env,
+        SessionSeed::regular(SESSION_ID, "gpt-5.5", "main", "Review")
+            .with_title("Scrollable output"),
+    )?;
+
+    let output = (0..60)
+        .map(|line_index| format!("Transcript line {line_index}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        database
+            .sessions()
+            .append_session_message(SESSION_ID, SessionMessageKind::AssistantAnswer, &output)
+            .await
+    })?;
+
+    std::fs::create_dir_all(test_support::session_folder(
+        &env.agentty_root.join("wt"),
+        SESSION_ID,
+    ))?;
+
+    Ok(())
+}
+
 /// Verify that the Sessions tab hides empty groups and guides session creation.
 ///
 /// Starts Agentty with no sessions, then creates an active session and verifies
@@ -1374,7 +1428,8 @@ fn test_session_missing_pre_commit_hook_error() -> E2eResult {
                     "pre-commit validation is configured",
                     &full,
                 );
-                assertion::assert_text_in_region(frame, "not installed or executable", &full);
+                assertion::assert_text_in_region(frame, "not installed or", &full);
+                assertion::assert_text_in_region(frame, "executable; install it", &full);
             },
         )?;
 
@@ -3039,6 +3094,65 @@ fn session_active_loader_uses_tachyonfx_glyph() -> E2eResult {
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "▌▌▌ Working...", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that overflowing session output shows a scrollbar in the panel's
+/// rightmost column.
+#[test]
+fn session_output_scrollbar_is_visible() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_output_scrollbar")
+        .with_terminal_size(80, 20)
+        .setup(seed_session_with_scrollable_output)
+        .zola(
+            "Session output scrollbar",
+            "Track your position while scrolling through long session transcripts.",
+            43,
+        )
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .press_key("g")
+                    .wait_for_stable_frame(300, 5000)
+                    .viewing_pause_ms(1500)
+                    .capture_labeled(
+                        "session_output_scrollbar_top",
+                        "Scrollbar thumb at the top of long session output",
+                    )
+                    .write_text("G")
+                    .wait_for_stable_frame(300, 5000)
+                    .viewing_pause_ms(1500)
+                    .capture_labeled(
+                        "session_output_scrollbar_bottom",
+                        "Scrollbar thumb at the bottom of long session output",
+                    )
+            },
+            |_frame, report| {
+                assert_eq!(report.captures.len(), 2);
+
+                let top_frame = common::frame_from_capture(&report.captures[0]);
+                let bottom_frame = common::frame_from_capture(&report.captures[1]);
+                let (top_scrollbar_rows, top_thumb_rows) =
+                    session_output_scrollbar_rows(&top_frame);
+                let (bottom_scrollbar_rows, bottom_thumb_rows) =
+                    session_output_scrollbar_rows(&bottom_frame);
+
+                assert!(top_scrollbar_rows.len() > top_thumb_rows.len());
+                assert!(bottom_scrollbar_rows.len() > bottom_thumb_rows.len());
+                assert_eq!(top_thumb_rows.first(), top_scrollbar_rows.first());
+                assert_eq!(bottom_thumb_rows.last(), bottom_scrollbar_rows.last());
+                assert!(
+                    top_thumb_rows.last() < bottom_thumb_rows.first(),
+                    "expected the scrollbar thumb to move from top to bottom"
+                );
             },
         )?;
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -178,7 +178,8 @@ only and is discarded if `agentty` restarts.
 While the composer is open, `Tab` moves focus to the chat transcript above it so the
 conversation can be scrolled with `j` / `k`, `g` / `G`, and `Ctrl+D` / `Ctrl+U` without
 losing the typed draft. Pressing `Tab` again returns focus to the composer. The same
-focus toggle is available while answering clarification questions.
+focus toggle is available while answering clarification questions. Long transcripts show
+a slim scrollbar on the right side of the output panel to indicate the current position.
 
 Pressing `r` during a running turn queues session sync on the same session worker. The
 session stays **InProgress** while the active turn runs, then moves to **Rebasing** when


### PR DESCRIPTION
- Reserves the output panel’s rightmost column for the scrollbar only when content overflows.
- Keeps rendered line counts and scroll metrics aligned with scrollbar-aware wrapping.
- Reuses a shared scrollbar component for session output and diff views.
- Covers scrollbar rendering with unit and end-to-end tests.
- Documents scrollbar position tracking in the workflow guide.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)