### PR TITLE
Run branch publishing in the background

### DIFF
--- a/crates/agentty/src/app/branch_publish.rs
+++ b/crates/agentty/src/app/branch_publish.rs
@@ -11,7 +11,6 @@ use crate::app::review_request;
 use crate::domain::session::{PublishBranchAction, ReviewRequest, Session, SessionId, Status};
 use crate::infra::clock::Clock;
 use crate::infra::db;
-use crate::presentation::app_mode::ConfirmationViewMode;
 
 /// Session snapshot cloned into a branch-publish background task.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -49,27 +48,33 @@ impl BranchPublishTaskSession {
     }
 }
 
+/// Session snapshot and shared operation lock moved into one publish task.
+pub(crate) struct BranchPublishTaskContext {
+    /// Serializes manual publishing with other branch mutations for the same
+    /// session.
+    pub(crate) branch_operation_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Immutable session data used throughout the background workflow.
+    pub(crate) session: BranchPublishTaskSession,
+}
+
 /// Final reducer payload for a completed branch-publish background action.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct BranchPublishActionUpdate {
-    /// Restore-view payload used to rebuild the previous session UI.
-    pub(crate) restore_view: ConfirmationViewMode,
     /// Branch-publish task result routed through the reducer.
     pub(crate) result: BranchPublishTaskResult,
     /// Session id targeted by the completed action.
     pub(crate) session_id: SessionId,
 }
 
-/// Error payload shown inside the session-view info popup for branch-publish
-/// failures.
+/// Error payload shown inline in session chat for branch-publish failures.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct BranchPublishTaskFailure {
     /// Whether the failure represents a blocked state (e.g. auth required)
     /// rather than an execution error.
     pub(crate) is_blocked: bool,
-    /// Popup body text describing the failure.
+    /// Inline body text describing the failure.
     pub(crate) message: String,
-    /// Popup title shown for the failure.
+    /// Inline title shown for the failure.
     pub(crate) title: String,
 }
 
@@ -153,38 +158,7 @@ pub(crate) struct ReviewRequestCreationInfo {
     pub(crate) web_url: Option<String>,
 }
 
-/// Returns the loading popup title for one branch-publish action.
-pub(crate) fn branch_publish_loading_title(publish_branch_action: PublishBranchAction) -> String {
-    match publish_branch_action {
-        PublishBranchAction::Push => "Pushing branch".to_string(),
-        PublishBranchAction::PublishPullRequest => "Publishing review request".to_string(),
-    }
-}
-
-/// Returns the loading popup body for one branch-publish action.
-pub(crate) fn branch_publish_loading_message(
-    publish_branch_action: PublishBranchAction,
-    remote_branch_name: Option<&str>,
-) -> String {
-    match (publish_branch_action, remote_branch_name) {
-        (PublishBranchAction::Push, Some(remote_branch_name)) => format!(
-            "Publishing the session branch to `{remote_branch_name}` on the configured Git remote."
-        ),
-        (PublishBranchAction::Push, None) => {
-            "Publishing the session branch to the configured Git remote.".to_string()
-        }
-        (PublishBranchAction::PublishPullRequest, Some(remote_branch_name)) => format!(
-            "Pushing the session branch to `{remote_branch_name}` and creating or refreshing the \
-             active forge review request."
-        ),
-        (PublishBranchAction::PublishPullRequest, None) => {
-            "Pushing the session branch and creating or refreshing the active forge review request."
-                .to_string()
-        }
-    }
-}
-
-/// Returns the loading spinner label for one branch-publish action.
+/// Returns the inline loading label for one branch-publish action.
 pub(crate) fn branch_publish_loading_label(publish_branch_action: PublishBranchAction) -> String {
     match publish_branch_action {
         PublishBranchAction::Push => "Pushing branch...".to_string(),
@@ -192,7 +166,7 @@ pub(crate) fn branch_publish_loading_label(publish_branch_action: PublishBranchA
     }
 }
 
-/// Returns the success popup title for a completed branch-publish action.
+/// Returns the inline success title for a completed branch-publish action.
 pub(crate) fn branch_publish_success_title(publish_branch_action: PublishBranchAction) -> String {
     match publish_branch_action {
         PublishBranchAction::Push => "Branch pushed".to_string(),
@@ -228,7 +202,7 @@ pub(crate) fn branch_push_success_message(
     }
 }
 
-/// Returns the success popup title for one completed review-request publish.
+/// Returns the inline success title for one completed review-request publish.
 pub(crate) fn review_request_publish_success_title(review_request: &ReviewRequest) -> String {
     format!(
         "{} published",
@@ -239,13 +213,13 @@ pub(crate) fn review_request_publish_success_title(review_request: &ReviewReques
     )
 }
 
-/// Returns the success popup body for one completed review-request publish.
+/// Returns the inline success body for one completed review-request publish.
 pub(crate) fn pull_request_publish_success_message(
     branch_name: &str,
     review_request: &ReviewRequest,
 ) -> String {
     format!(
-        "Published session branch `{branch_name}`.\n\n{} {} is ready:\n{}",
+        "Successfully published session branch `{branch_name}`.\n\n{} {}:\n{}",
         review_request
             .summary
             .forge_kind
@@ -255,16 +229,23 @@ pub(crate) fn pull_request_publish_success_message(
     )
 }
 
-/// Executes one background branch-publish action for a session snapshot.
+/// Executes one background branch-publish action while holding the session's
+/// shared branch-operation lock.
 pub(crate) async fn run_branch_publish_action(
     publish_branch_action: PublishBranchAction,
-    branch_publish_session: BranchPublishTaskSession,
+    branch_publish_context: BranchPublishTaskContext,
     db: db::AppRepositories,
     clock: Arc<dyn Clock>,
     git_client: Arc<dyn GitClient>,
     review_request_client: Arc<dyn forge::ReviewRequestClient>,
     remote_branch_name: Option<String>,
 ) -> BranchPublishTaskResult {
+    let BranchPublishTaskContext {
+        branch_operation_lock,
+        session: branch_publish_session,
+    } = branch_publish_context;
+    let _branch_operation_guard = branch_operation_lock.lock_owned().await;
+
     match publish_branch_action {
         PublishBranchAction::Push => {
             push_session_branch(
@@ -1218,7 +1199,8 @@ mod tests {
 
         // Assert
         assert_eq!(title, "GitLab merge request published");
-        assert!(message.contains("GitLab merge request !24 is ready"));
+        assert!(message.contains("Successfully published session branch `wt/session-1`."));
+        assert!(message.contains("GitLab merge request !24"));
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/core/draw.rs
+++ b/crates/agentty/src/app/core/draw.rs
@@ -3,7 +3,7 @@
 use super::state::{App, UpdateStatus};
 use crate::app::tab::Tab;
 use crate::domain::session::{Session, Status};
-use crate::domain::transient_message::TransientMessageSlot;
+use crate::domain::transient_message::{TransientMessageBody, TransientMessageSlot};
 use crate::presentation::app_mode::{AppMode, ConfirmationViewMode, HelpContext};
 
 impl App {
@@ -131,9 +131,11 @@ impl App {
                 session.status,
                 Status::AgentReview | Status::InProgress | Status::Merging | Status::Rebasing
             )
-            || session
-                .transient_messages
-                .get(TransientMessageSlot::PublishedBranchSync)
-                .is_some()
+            || session.transient_messages.messages().iter().any(|message| {
+                matches!(
+                    message.slot,
+                    TransientMessageSlot::BranchPublish | TransientMessageSlot::PublishedBranchSync
+                ) && matches!(&message.body, TransientMessageBody::Loading(_))
+            })
     }
 }

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -8,8 +8,6 @@ use std::sync::Arc;
 use app::branch_publish::{
     BranchPublishActionUpdate, BranchPublishTaskResult, BranchPublishTaskSuccess,
     branch_publish_loading_label as branch_publish_loading_label_text,
-    branch_publish_loading_message as branch_publish_loading_message_text,
-    branch_publish_loading_title as branch_publish_loading_title_text,
     branch_publish_success_title as branch_publish_success_title_text,
     detected_forge_kind_from_git_push_error, git_push_authentication_message,
     is_git_push_authentication_error,
@@ -37,6 +35,7 @@ use crate::domain::session::{
     PublishBranchAction, PublishedBranchSyncStatus, SessionHandles, SessionId, SessionSize, Status,
 };
 use crate::domain::transcript_notice::TranscriptNotice;
+use crate::domain::transient_message::TransientMessageBody;
 use crate::presentation::app_mode::{AppMode, ChatFocus, ConfirmationViewMode};
 use crate::presentation::prompt::PromptAtMentionState;
 
@@ -155,7 +154,6 @@ pub(crate) enum AppEvent {
     },
     /// Indicates completion of a session-view branch-publish action.
     BranchPublishActionCompleted {
-        restore_view: ConfirmationViewMode,
         result: Box<BranchPublishTaskResult>,
         session_id: SessionId,
     },
@@ -223,7 +221,7 @@ pub(super) struct AppEventBatch {
     pub(super) applied_turns: HashMap<SessionId, TurnAppliedState>,
     pub(super) agent_cli_updates: Option<Vec<AgentCliInfo>>,
     pub(super) at_mention_entries_updates: HashMap<SessionId, Vec<FileEntry>>,
-    pub(super) branch_publish_action_update: Option<BranchPublishActionUpdate>,
+    pub(super) branch_publish_action_updates: Vec<BranchPublishActionUpdate>,
     pub(super) git_status_update: Option<GitStatusBatchUpdate>,
     pub(super) latest_available_version_update: Option<LatestAvailableVersionUpdate>,
     pub(super) published_branch_sync_updates: Vec<(SessionId, PublishedBranchSyncUpdate)>,
@@ -412,11 +410,9 @@ impl AppEventBatch {
                 self.session_title_generation_finished
                     .insert(session_id, generation);
             }
-            AppEvent::BranchPublishActionCompleted {
-                restore_view,
-                result,
-                session_id,
-            } => self.collect_branch_publish_action_completed(restore_view, *result, session_id),
+            AppEvent::BranchPublishActionCompleted { result, session_id } => {
+                self.collect_branch_publish_action_completed(*result, session_id);
+            }
             AppEvent::ReviewPrepared {
                 diff_hash,
                 review_text,
@@ -636,10 +632,9 @@ impl AppEventBatch {
         self.sync_main_conflicted_files = Some(conflicted_files);
     }
 
-    /// Stores the latest branch-publish action result for this reducer batch.
+    /// Stores one branch-publish action result for this reducer batch.
     fn collect_branch_publish_action_completed(
         &mut self,
-        restore_view: ConfirmationViewMode,
         result: BranchPublishTaskResult,
         session_id: SessionId,
     ) {
@@ -647,11 +642,8 @@ impl AppEventBatch {
             self.should_refresh_git_status = true;
         }
 
-        self.branch_publish_action_update = Some(BranchPublishActionUpdate {
-            restore_view,
-            result,
-            session_id,
-        });
+        self.branch_publish_action_updates
+            .push(BranchPublishActionUpdate { result, session_id });
     }
 
     /// Stores a successful focused-review preparation result.
@@ -841,7 +833,7 @@ impl App {
         self.persist_focused_review_updates(focused_review_persistence)
             .await;
 
-        if let Some(branch_publish_action_update) = event_batch.branch_publish_action_update {
+        for branch_publish_action_update in event_batch.branch_publish_action_updates {
             self.apply_branch_publish_action_update(branch_publish_action_update);
         }
 
@@ -1245,7 +1237,7 @@ impl App {
             || event_batch.update_status.is_some()
             || !event_batch.applied_turns.is_empty()
             || !event_batch.at_mention_entries_updates.is_empty()
-            || event_batch.branch_publish_action_update.is_some()
+            || !event_batch.branch_publish_action_updates.is_empty()
             || !event_batch.published_branch_sync_updates.is_empty()
             || !event_batch.review_request_status_updates.is_empty()
             || event_batch.requested_reviews.is_some()
@@ -1611,18 +1603,14 @@ impl App {
         .await;
     }
 
-    /// Applies one completed branch-publish action and updates the popup.
+    /// Applies one completed branch-publish action to the session chat.
     pub(super) fn apply_branch_publish_action_update(
         &mut self,
         branch_publish_action_update: BranchPublishActionUpdate,
     ) {
-        let BranchPublishActionUpdate {
-            restore_view,
-            result,
-            session_id,
-        } = branch_publish_action_update;
+        let BranchPublishActionUpdate { result, session_id } = branch_publish_action_update;
 
-        let popup_mode = match result {
+        let result_message = match result {
             Ok(BranchPublishTaskSuccess::Pushed {
                 branch_name,
                 review_request_creation,
@@ -1631,16 +1619,14 @@ impl App {
                 self.sessions
                     .apply_published_upstream_ref(&session_id, upstream_reference);
 
-                Self::view_info_popup_mode(
+                TransientMessageBody::Markdown(format!(
+                    "**{}**\n\n{}",
                     Self::branch_publish_success_title(PublishBranchAction::Push),
                     Self::branch_publish_success_message(
                         &branch_name,
                         review_request_creation.as_ref(),
-                    ),
-                    false,
-                    String::new(),
-                    restore_view,
-                )
+                    )
+                ))
             }
             Ok(BranchPublishTaskSuccess::PullRequestPublished {
                 branch_name,
@@ -1652,23 +1638,19 @@ impl App {
                 self.sessions
                     .apply_review_request(&session_id, review_request.clone());
 
-                Self::view_info_popup_mode(
+                TransientMessageBody::Markdown(format!(
+                    "**{}**\n\n{}",
                     Self::review_request_publish_success_title(&review_request),
-                    Self::pull_request_publish_success_message(&branch_name, &review_request),
-                    false,
-                    String::new(),
-                    restore_view,
-                )
+                    Self::pull_request_publish_success_message(&branch_name, &review_request)
+                ))
             }
-            Err(failure) => Self::view_info_popup_mode(
-                failure.title,
-                failure.message,
-                false,
-                String::new(),
-                restore_view,
-            ),
+            Err(failure) => TransientMessageBody::Markdown(format!(
+                "**{}**\n\n{}",
+                failure.title, failure.message
+            )),
         };
-        self.mode = popup_mode;
+        self.sessions
+            .finish_branch_publish(&session_id, result_message);
     }
 
     /// Applies one background review-request status refresh.
@@ -1869,29 +1851,14 @@ impl App {
         }
     }
 
-    /// Returns the loading popup title for one branch-publish action.
-    pub(super) fn branch_publish_loading_title(
-        publish_branch_action: PublishBranchAction,
-    ) -> String {
-        branch_publish_loading_title_text(publish_branch_action)
-    }
-
-    /// Returns the loading popup body for one branch-publish action.
-    pub(super) fn branch_publish_loading_message(
-        publish_branch_action: PublishBranchAction,
-        remote_branch_name: Option<&str>,
-    ) -> String {
-        branch_publish_loading_message_text(publish_branch_action, remote_branch_name)
-    }
-
-    /// Returns the loading spinner label for one branch-publish action.
+    /// Returns the inline loading label for one branch-publish action.
     pub(super) fn branch_publish_loading_label(
         publish_branch_action: PublishBranchAction,
     ) -> String {
         branch_publish_loading_label_text(publish_branch_action)
     }
 
-    /// Returns the success popup title for a completed branch-publish action.
+    /// Returns the inline success title for a completed branch-publish action.
     pub(super) fn branch_publish_success_title(
         publish_branch_action: PublishBranchAction,
     ) -> String {

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -14,9 +14,11 @@ use ag_forge::{
 use ag_git::{GitClient, GitError, RealGitClient};
 #[cfg(test)]
 use app::branch_publish::detected_forge_kind_from_git_push_error;
+use app::branch_publish::{
+    BranchPublishTaskContext, BranchPublishTaskSession, run_branch_publish_action,
+};
 #[cfg(test)]
 use app::branch_publish::{BranchPublishTaskFailure, branch_push_failure, push_session_branch};
-use app::branch_publish::{BranchPublishTaskSession, run_branch_publish_action};
 use app::merge_queue::{MergeQueue, MergeQueueProgress};
 use app::project::ProjectManager;
 use app::review::{
@@ -1369,7 +1371,7 @@ impl App {
         publish_branch_action: PublishBranchAction,
         remote_branch_name: Option<String>,
     ) {
-        let Some(branch_publish_session) = self.branch_publish_task_session(session_id) else {
+        let Some(branch_publish_context) = self.branch_publish_task_context(session_id) else {
             self.mode = Self::view_info_popup_mode(
                 "Branch push failed".to_string(),
                 "Session is no longer available.".to_string(),
@@ -1381,32 +1383,22 @@ impl App {
             return;
         };
 
-        let loading_title = Self::branch_publish_loading_title(publish_branch_action);
-        let loading_message = Self::branch_publish_loading_message(
-            publish_branch_action,
-            remote_branch_name.as_deref(),
-        );
         let loading_label = Self::branch_publish_loading_label(publish_branch_action);
         let clock = self.services.clock();
         let db = self.services.db().clone();
         let event_sender = self.services.event_sender();
         let git_client = self.services.git_client();
         let review_request_client = self.services.review_request_client();
-        let background_restore_view = restore_view.clone();
-        let event_session_id = branch_publish_session.id.clone();
+        let event_session_id = branch_publish_context.session.id.clone();
 
-        self.mode = Self::view_info_popup_mode(
-            loading_title,
-            loading_message,
-            true,
-            loading_label,
-            restore_view,
-        );
+        self.sessions
+            .start_branch_publish(session_id, loading_label);
+        self.mode = restore_view.into_view_mode();
 
         tokio::spawn(async move {
             let result = run_branch_publish_action(
                 publish_branch_action,
-                branch_publish_session,
+                branch_publish_context,
                 db,
                 clock,
                 git_client,
@@ -1416,7 +1408,6 @@ impl App {
             .await;
             // Fire-and-forget: receiver may be dropped during shutdown.
             let _ = event_sender.send(AppEvent::BranchPublishActionCompleted {
-                restore_view: background_restore_view,
                 result: Box::new(result),
                 session_id: event_session_id,
             });
@@ -2072,17 +2063,16 @@ impl App {
         });
     }
 
-    /// Builds one background-task snapshot for a branch-publish action.
-    fn branch_publish_task_session(&self, session_id: &str) -> Option<BranchPublishTaskSession> {
-        let session = self
-            .sessions
-            .sessions()
-            .iter()
-            .find(|session| session.id == session_id)?;
+    /// Builds one branch-publish task snapshot with its shared operation lock.
+    fn branch_publish_task_context(&self, session_id: &str) -> Option<BranchPublishTaskContext> {
+        let (session, handles) = self.sessions.session_and_handles_or_err(session_id).ok()?;
         let mut branch_publish_session = BranchPublishTaskSession::from_session(session);
         branch_publish_session.base_branch = self.review_target_branch_for_session(session);
 
-        Some(branch_publish_session)
+        Some(BranchPublishTaskContext {
+            branch_operation_lock: Arc::clone(&handles.branch_operation_lock),
+            session: branch_publish_session,
+        })
     }
 
     /// Resolves the forge review-request target branch for one session.

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -25,7 +25,6 @@ use crate::domain::setting::SettingName;
 use crate::infra::db::AppRepositories;
 use crate::infra::project_discovery::{HOME_PROJECT_SCAN_MAX_RESULTS, RealProjectDiscoveryClient};
 use crate::infra::tmux::{MockTmuxClient, TmuxClient};
-use crate::presentation::app_mode::ConfirmationViewMode;
 
 /// Builds one reducer-ready turn projection for tests.
 fn test_turn_applied_state(
@@ -48,15 +47,6 @@ fn test_turn_applied_state(
         questions,
         summary: summary.and_then(|summary| serde_json::to_string(&summary).ok()),
         token_usage_delta,
-    }
-}
-
-/// Builds a restore-view snapshot used by branch-publish event-batch
-/// tests.
-fn test_confirmation_view_mode(session_id: &str) -> ConfirmationViewMode {
-    ConfirmationViewMode {
-        scroll_offset: None,
-        session_id: session_id.into(),
     }
 }
 
@@ -1006,20 +996,8 @@ async fn new_test_app_with_selected_session(
 }
 
 #[test]
-fn branch_publish_popup_helpers_format_copy() {
-    // Arrange
-    let expected_restore_view = ConfirmationViewMode {
-        scroll_offset: Some(2),
-        session_id: "session-1".into(),
-    };
-
+fn branch_publish_inline_helpers_format_copy() {
     // Act
-    let loading_title = App::branch_publish_loading_title(PublishBranchAction::Push);
-    let loading_message = App::branch_publish_loading_message(PublishBranchAction::Push, None);
-    let custom_loading_message = App::branch_publish_loading_message(
-        PublishBranchAction::Push,
-        Some("review/custom-branch"),
-    );
     let loading_label = App::branch_publish_loading_label(PublishBranchAction::Push);
     let success_title = App::branch_publish_success_title(PublishBranchAction::Push);
     let success_message = App::branch_publish_success_message(
@@ -1032,32 +1010,12 @@ fn branch_publish_popup_helpers_format_copy() {
         }),
     );
     let fallback_success_message = App::branch_publish_success_message("wt/session-1", None);
-    let pull_request_loading_title =
-        App::branch_publish_loading_title(PublishBranchAction::PublishPullRequest);
-    let pull_request_loading_message =
-        App::branch_publish_loading_message(PublishBranchAction::PublishPullRequest, None);
     let pull_request_loading_label =
         App::branch_publish_loading_label(PublishBranchAction::PublishPullRequest);
     let pull_request_success_title =
         App::branch_publish_success_title(PublishBranchAction::PublishPullRequest);
-    let popup_mode = App::view_info_popup_mode(
-        "Working".to_string(),
-        "Publishing branch".to_string(),
-        true,
-        "Pushing branch...".to_string(),
-        expected_restore_view.clone(),
-    );
 
     // Assert
-    assert_eq!(loading_title, "Pushing branch");
-    assert_eq!(
-        loading_message,
-        "Publishing the session branch to the configured Git remote."
-    );
-    assert_eq!(
-        custom_loading_message,
-        "Publishing the session branch to `review/custom-branch` on the configured Git remote."
-    );
     assert_eq!(loading_label, "Pushing branch...");
     assert_eq!(success_title, "Branch pushed");
     assert!(success_message.contains("Pushed session branch `wt/session-1`."));
@@ -1067,26 +1025,8 @@ fn branch_publish_popup_helpers_format_copy() {
             .contains("https://github.com/org/repo/compare/main...wt%2Fsession-1?expand=1")
     );
     assert!(fallback_success_message.contains("Create the review request manually"));
-    assert_eq!(pull_request_loading_title, "Publishing review request");
-    assert_eq!(
-        pull_request_loading_message,
-        "Pushing the session branch and creating or refreshing the active forge review request."
-    );
     assert_eq!(pull_request_loading_label, "Publishing review request...");
     assert_eq!(pull_request_success_title, "Review request published");
-    assert!(matches!(
-        popup_mode,
-        AppMode::ViewInfoPopup {
-            is_loading: true,
-            ref loading_label,
-            ref message,
-            ref restore_view,
-            ref title,
-        } if title == "Working"
-            && message == "Publishing branch"
-            && loading_label == "Pushing branch..."
-            && restore_view == &expected_restore_view
-    ));
 }
 
 /// Verifies generic and authentication-related branch-push failures map
@@ -1274,7 +1214,10 @@ async fn branch_publish_task_helpers_reject_unsupported_session_states() {
     // Act
     let push_result = run_branch_publish_action(
         PublishBranchAction::Push,
-        done_snapshot.clone(),
+        BranchPublishTaskContext {
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
+            session: done_snapshot.clone(),
+        },
         app.services.db().clone(),
         app.services.clock(),
         app.services.git_client(),
@@ -1309,7 +1252,61 @@ async fn branch_publish_task_helpers_reject_unsupported_session_states() {
 }
 
 #[tokio::test]
-async fn branch_publish_task_session_targets_stacked_parent_review_source_branch() {
+async fn manual_branch_publish_waits_for_existing_branch_operation() {
+    // Arrange
+    let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    let mut review_session =
+        crate::test_support::session_fixture_with_folder(PathBuf::from("/tmp/review-session"));
+    review_session.status = Status::Done;
+    app.sessions.push_session(review_session);
+    app.sessions
+        .session_handles_mut()
+        .insert("session-1".into(), SessionHandles::new(Status::Done));
+    let branch_operation_lock = Arc::clone(
+        &app.sessions
+            .session_handles_or_err("session-1")
+            .expect("expected session handles")
+            .branch_operation_lock,
+    );
+    let existing_operation_guard = Arc::clone(&branch_operation_lock).lock_owned().await;
+    let branch_publish_context = app
+        .branch_publish_task_context("session-1")
+        .expect("expected branch-publish context");
+
+    // Act
+    let publish_task = tokio::spawn(run_branch_publish_action(
+        PublishBranchAction::Push,
+        branch_publish_context,
+        app.services.db().clone(),
+        app.services.clock(),
+        app.services.git_client(),
+        app.services.review_request_client(),
+        None,
+    ));
+    tokio::task::yield_now().await;
+    let waited_for_existing_operation = !publish_task.is_finished();
+    drop(existing_operation_guard);
+    let result = tokio::time::timeout(Duration::from_secs(1), publish_task)
+        .await
+        .expect("manual publish should resume after the existing branch operation")
+        .expect("manual publish task should not panic");
+
+    // Assert
+    assert!(waited_for_existing_operation);
+    assert_eq!(
+        result,
+        Err(BranchPublishTaskFailure::failed(
+            PublishBranchAction::Push,
+            "Session must be in review to push the branch.".to_string(),
+        ))
+    );
+}
+
+#[tokio::test]
+async fn branch_publish_task_context_targets_stacked_parent_review_source_branch() {
     // Arrange
     let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
         Arc::new(MockTmuxClient::new()),
@@ -1338,18 +1335,33 @@ async fn branch_publish_task_session_targets_stacked_parent_review_source_branch
     child_session.parent_session_id = Some("parent-session".into());
     app.sessions.push_session(parent_session);
     app.sessions.push_session(child_session);
+    app.sessions
+        .session_handles_mut()
+        .insert("child-session".into(), SessionHandles::new(Status::Review));
 
     // Act
-    let branch_publish_session = app
-        .branch_publish_task_session("child-session")
-        .expect("expected branch-publish snapshot");
+    let branch_publish_context = app
+        .branch_publish_task_context("child-session")
+        .expect("expected branch-publish context");
 
     // Assert
-    assert_eq!(branch_publish_session.base_branch, "review/parent-session");
+    assert_eq!(
+        branch_publish_context.session.base_branch,
+        "review/parent-session"
+    );
+    let session_lock = &app
+        .sessions
+        .session_handles_or_err("child-session")
+        .expect("expected child session handles")
+        .branch_operation_lock;
+    assert!(Arc::ptr_eq(
+        &branch_publish_context.branch_operation_lock,
+        session_lock
+    ));
 }
 
 #[tokio::test]
-async fn branch_publish_task_session_targets_stacked_parent_upstream_branch() {
+async fn branch_publish_task_context_targets_stacked_parent_upstream_branch() {
     // Arrange
     let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
         Arc::new(MockTmuxClient::new()),
@@ -1366,14 +1378,20 @@ async fn branch_publish_task_session_targets_stacked_parent_upstream_branch() {
     child_session.parent_session_id = Some("parent-session".into());
     app.sessions.push_session(parent_session);
     app.sessions.push_session(child_session);
+    app.sessions
+        .session_handles_mut()
+        .insert("child-session".into(), SessionHandles::new(Status::Review));
 
     // Act
-    let branch_publish_session = app
-        .branch_publish_task_session("child-session")
-        .expect("expected branch-publish snapshot");
+    let branch_publish_context = app
+        .branch_publish_task_context("child-session")
+        .expect("expected branch-publish context");
 
     // Assert
-    assert_eq!(branch_publish_session.base_branch, "review/parent-custom");
+    assert_eq!(
+        branch_publish_context.session.base_branch,
+        "review/parent-custom"
+    );
 }
 
 #[tokio::test]
@@ -1493,7 +1511,7 @@ async fn push_session_branch_succeeds_without_review_request_link_for_unsupporte
 }
 
 #[tokio::test]
-async fn apply_branch_publish_action_update_sets_success_popup() {
+async fn apply_branch_publish_action_update_sets_inline_success() {
     // Arrange
     let session_folder = tempdir().expect("failed to create temp dir");
     let mut app = new_test_app_with_selected_session(
@@ -1502,14 +1520,10 @@ async fn apply_branch_publish_action_update_sets_success_popup() {
         Arc::new(MockTmuxClient::new()),
     )
     .await;
-    let expected_restore_view = ConfirmationViewMode {
-        scroll_offset: Some(1),
-        session_id: "session-1".into(),
-    };
+    app.mode = AppMode::List;
 
     // Act
     app.apply_branch_publish_action_update(BranchPublishActionUpdate {
-        restore_view: expected_restore_view.clone(),
         result: Ok(BranchPublishTaskSuccess::Pushed {
             branch_name: "wt/session-1".to_string(),
             review_request_creation: Some(crate::app::branch_publish::ReviewRequestCreationInfo {
@@ -1525,19 +1539,20 @@ async fn apply_branch_publish_action_update_sets_success_popup() {
     });
 
     // Assert
-    assert!(matches!(
-        app.mode,
-        AppMode::ViewInfoPopup {
-            is_loading: false,
-            ref message,
-            ref restore_view,
-            ref title,
-            ..
-        } if title == "Branch pushed"
-            && message.contains("Pushed session branch `wt/session-1`.")
-            && message.contains("https://github.com/agentty-xyz/agentty/compare/main...wt%2Fsession-1?expand=1")
-            && restore_view == &expected_restore_view
-    ));
+    assert!(matches!(app.mode, AppMode::List));
+    let publish_message = app.sessions.state().sessions()[0]
+        .transient_messages
+        .get(crate::domain::transient_message::TransientMessageSlot::BranchPublish)
+        .expect("branch publish result should be visible inline")
+        .body
+        .text();
+    assert!(publish_message.contains("Branch pushed"));
+    assert!(publish_message.contains("Pushed session branch `wt/session-1`."));
+    assert!(
+        publish_message.contains(
+            "https://github.com/agentty-xyz/agentty/compare/main...wt%2Fsession-1?expand=1"
+        )
+    );
     assert_eq!(
         app.sessions
             .state()
@@ -1549,7 +1564,7 @@ async fn apply_branch_publish_action_update_sets_success_popup() {
 }
 
 #[tokio::test]
-async fn apply_branch_publish_action_update_sets_pull_request_success_popup() {
+async fn apply_branch_publish_action_update_sets_inline_pull_request_success() {
     // Arrange
     let session_folder = tempdir().expect("failed to create temp dir");
     let mut app = new_test_app_with_selected_session(
@@ -1558,10 +1573,7 @@ async fn apply_branch_publish_action_update_sets_pull_request_success_popup() {
         Arc::new(MockTmuxClient::new()),
     )
     .await;
-    let expected_restore_view = ConfirmationViewMode {
-        scroll_offset: Some(1),
-        session_id: "session-1".into(),
-    };
+    app.mode = AppMode::List;
     let review_request = crate::domain::session::ReviewRequest {
         last_refreshed_at: 55,
         summary: crate::domain::session::ReviewRequestSummary {
@@ -1572,7 +1584,6 @@ async fn apply_branch_publish_action_update_sets_pull_request_success_popup() {
 
     // Act
     app.apply_branch_publish_action_update(BranchPublishActionUpdate {
-        restore_view: expected_restore_view.clone(),
         result: Ok(BranchPublishTaskSuccess::PullRequestPublished {
             branch_name: "wt/session-1".to_string(),
             review_request: review_request.clone(),
@@ -1582,20 +1593,17 @@ async fn apply_branch_publish_action_update_sets_pull_request_success_popup() {
     });
 
     // Assert
-    assert!(matches!(
-        app.mode,
-        AppMode::ViewInfoPopup {
-            is_loading: false,
-            ref message,
-            ref restore_view,
-            ref title,
-            ..
-        } if title == "GitHub pull request published"
-            && message.contains("Published session branch `wt/session-1`.")
-            && message.contains("GitHub pull request #42 is ready")
-            && message.contains("https://github.com/agentty-xyz/agentty/pull/42")
-            && restore_view == &expected_restore_view
-    ));
+    assert!(matches!(app.mode, AppMode::List));
+    let publish_message = app.sessions.state().sessions()[0]
+        .transient_messages
+        .get(crate::domain::transient_message::TransientMessageSlot::BranchPublish)
+        .expect("review request publish result should be visible inline")
+        .body
+        .text();
+    assert!(publish_message.contains("GitHub pull request published"));
+    assert!(publish_message.contains("Successfully published session branch `wt/session-1`."));
+    assert!(publish_message.contains("GitHub pull request #42"));
+    assert!(publish_message.contains("https://github.com/agentty-xyz/agentty/pull/42"));
     assert_eq!(
         app.sessions
             .state()
@@ -1607,7 +1615,7 @@ async fn apply_branch_publish_action_update_sets_pull_request_success_popup() {
 }
 
 #[tokio::test]
-async fn apply_branch_publish_action_update_sets_gitlab_merge_request_success_popup() {
+async fn apply_branch_publish_action_update_sets_inline_gitlab_merge_request_success() {
     // Arrange
     let session_folder = tempdir().expect("failed to create temp dir");
     let mut app = new_test_app_with_selected_session(
@@ -1616,10 +1624,7 @@ async fn apply_branch_publish_action_update_sets_gitlab_merge_request_success_po
         Arc::new(MockTmuxClient::new()),
     )
     .await;
-    let expected_restore_view = ConfirmationViewMode {
-        scroll_offset: Some(2),
-        session_id: "session-1".into(),
-    };
+    app.mode = AppMode::List;
     let review_request = crate::domain::session::ReviewRequest {
         last_refreshed_at: 77,
         summary: crate::domain::session::ReviewRequestSummary {
@@ -1636,7 +1641,6 @@ async fn apply_branch_publish_action_update_sets_gitlab_merge_request_success_po
 
     // Act
     app.apply_branch_publish_action_update(BranchPublishActionUpdate {
-        restore_view: expected_restore_view.clone(),
         result: Ok(BranchPublishTaskSuccess::PullRequestPublished {
             branch_name: "wt/session-1".to_string(),
             review_request,
@@ -1646,20 +1650,52 @@ async fn apply_branch_publish_action_update_sets_gitlab_merge_request_success_po
     });
 
     // Assert
-    assert!(matches!(
-        app.mode,
-        AppMode::ViewInfoPopup {
-            is_loading: false,
-            ref message,
-            ref restore_view,
-            ref title,
-            ..
-        } if title == "GitLab merge request published"
-            && message.contains("Published session branch `wt/session-1`.")
-            && message.contains("GitLab merge request !24 is ready")
-            && message.contains("https://gitlab.com/agentty-xyz/agentty/-/merge_requests/24")
-            && restore_view == &expected_restore_view
-    ));
+    assert!(matches!(app.mode, AppMode::List));
+    let publish_message = app.sessions.state().sessions()[0]
+        .transient_messages
+        .get(crate::domain::transient_message::TransientMessageSlot::BranchPublish)
+        .expect("merge request publish result should be visible inline")
+        .body
+        .text();
+    assert!(publish_message.contains("GitLab merge request published"));
+    assert!(publish_message.contains("Successfully published session branch `wt/session-1`."));
+    assert!(publish_message.contains("GitLab merge request !24"));
+    assert!(publish_message.contains("https://gitlab.com/agentty-xyz/agentty/-/merge_requests/24"));
+}
+
+#[tokio::test]
+async fn apply_branch_publish_action_update_keeps_active_mode_on_failure() {
+    // Arrange
+    let session_folder = tempdir().expect("failed to create temp dir");
+    let mut app = new_test_app_with_selected_session(
+        session_folder.path().to_path_buf(),
+        "",
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    app.mode = AppMode::List;
+
+    // Act
+    app.apply_branch_publish_action_update(BranchPublishActionUpdate {
+        result: Err(BranchPublishTaskFailure::failed(
+            PublishBranchAction::PublishPullRequest,
+            "remote rejected".to_string(),
+        )),
+        session_id: "session-1".into(),
+    });
+
+    // Assert
+    assert!(matches!(app.mode, AppMode::List));
+    let publish_message = app.sessions.state().sessions()[0]
+        .transient_messages
+        .get(crate::domain::transient_message::TransientMessageSlot::BranchPublish)
+        .expect("review request publish failure should be visible inline");
+    assert_eq!(
+        publish_message.body,
+        TransientMessageBody::Markdown(
+            "**Review request publish failed**\n\nremote rejected".to_string()
+        )
+    );
 }
 
 #[tokio::test]
@@ -2256,7 +2292,7 @@ fn app_event_batch_collect_event_keeps_latest_same_session_updates() {
 }
 
 #[test]
-fn app_event_batch_collect_event_uses_final_wins_for_review_and_branch_publish() {
+fn app_event_batch_collect_event_keeps_publish_results_and_latest_reviews() {
     // Arrange
     let mut event_batch = AppEventBatch::default();
 
@@ -2277,12 +2313,10 @@ fn app_event_batch_collect_event_uses_final_wins_for_review_and_branch_publish()
         session_id: "session-b".into(),
     });
     event_batch.collect_event(AppEvent::BranchPublishActionCompleted {
-        restore_view: test_confirmation_view_mode("session-a"),
         result: Box::new(Ok(test_pushed_branch_result("feature/first"))),
         session_id: "session-a".into(),
     });
     event_batch.collect_event(AppEvent::BranchPublishActionCompleted {
-        restore_view: test_confirmation_view_mode("session-b"),
         result: Box::new(Ok(test_pushed_branch_result("feature/final"))),
         session_id: "session-b".into(),
     });
@@ -2303,12 +2337,17 @@ fn app_event_batch_collect_event_uses_final_wins_for_review_and_branch_publish()
         })
     );
     assert_eq!(
-        event_batch.branch_publish_action_update,
-        Some(BranchPublishActionUpdate {
-            restore_view: test_confirmation_view_mode("session-b"),
-            result: Ok(test_pushed_branch_result("feature/final")),
-            session_id: "session-b".into(),
-        })
+        event_batch.branch_publish_action_updates,
+        vec![
+            BranchPublishActionUpdate {
+                result: Ok(test_pushed_branch_result("feature/first")),
+                session_id: "session-a".into(),
+            },
+            BranchPublishActionUpdate {
+                result: Ok(test_pushed_branch_result("feature/final")),
+                session_id: "session-b".into(),
+            },
+        ]
     );
     assert!(event_batch.should_refresh_git_status);
 }

--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -442,6 +442,42 @@ impl SessionManager {
         }
     }
 
+    /// Shows one manual branch-publish action as an inline session-chat task.
+    pub(crate) fn start_branch_publish(&mut self, session_id: &str, loading_label: String) {
+        if let Some(session) = self
+            .state
+            .sessions
+            .iter_mut()
+            .find(|session| session.id == session_id)
+        {
+            session.transient_messages.upsert(TransientMessage {
+                anchor: TransientMessageAnchor::Tail,
+                body: TransientMessageBody::Loading(loading_label),
+                lifecycle: TransientMessageLifecycle::UntilResolved,
+                slot: TransientMessageSlot::BranchPublish,
+                turn_position: session.latest_user_prompt_position(),
+            });
+        }
+    }
+
+    /// Replaces manual branch-publish progress with its inline final result.
+    pub(crate) fn finish_branch_publish(&mut self, session_id: &str, body: TransientMessageBody) {
+        if let Some(session) = self
+            .state
+            .sessions
+            .iter_mut()
+            .find(|session| session.id == session_id)
+        {
+            session.transient_messages.upsert(TransientMessage {
+                anchor: TransientMessageAnchor::AfterCompletedTurn,
+                body,
+                lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+                slot: TransientMessageSlot::BranchPublish,
+                turn_position: session.latest_user_prompt_position(),
+            });
+        }
+    }
+
     /// Marks one session branch as currently auto-syncing to its published
     /// upstream reference.
     pub(crate) fn start_published_branch_sync(

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -750,8 +750,12 @@ impl Session {
     /// Returns the review-request publish action currently available in session
     /// view.
     pub fn publish_pull_request_action(&self) -> Option<PublishBranchAction> {
-        self.status
-            .allows_review_actions()
+        let is_publish_active = self
+            .transient_messages
+            .get(TransientMessageSlot::BranchPublish)
+            .is_some_and(|message| matches!(&message.body, TransientMessageBody::Loading(_)));
+
+        (self.status.allows_review_actions() && !is_publish_active)
             .then_some(PublishBranchAction::PublishPullRequest)
     }
 
@@ -1942,6 +1946,25 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
 
         // Assert
         assert_eq!(action, Some(PublishBranchAction::PublishPullRequest));
+    }
+
+    #[test]
+    fn test_publish_pull_request_action_returns_none_while_publish_is_active() {
+        // Arrange
+        let mut session = crate::test_support::session_fixture("session-id", Status::Review);
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading("Publishing review request...".to_string()),
+            lifecycle: TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::BranchPublish,
+            turn_position: None,
+        });
+
+        // Act
+        let action = session.publish_pull_request_action();
+
+        // Assert
+        assert_eq!(action, None);
     }
 
     #[test]

--- a/crates/agentty/src/domain/transient_message.rs
+++ b/crates/agentty/src/domain/transient_message.rs
@@ -9,6 +9,8 @@ pub(crate) enum TransientMessageSlot {
     Review,
     /// Short-lived workflow feedback produced while finalizing a turn.
     WorkflowNotice,
+    /// Manual branch or review-request publish progress and result.
+    BranchPublish,
     /// Published-branch auto-push progress replaced by its durable result.
     PublishedBranchSync,
 }
@@ -190,7 +192,7 @@ mod tests {
             anchor: TransientMessageAnchor::AfterCompletedTurn,
             body: TransientMessageBody::Loading("Pushing...".to_string()),
             lifecycle: TransientMessageLifecycle::UntilResolved,
-            slot: TransientMessageSlot::PublishedBranchSync,
+            slot: TransientMessageSlot::BranchPublish,
             turn_position: Some(2),
         });
 
@@ -201,10 +203,6 @@ mod tests {
         assert!(store.get(TransientMessageSlot::Summary).is_none());
         assert!(store.get(TransientMessageSlot::Review).is_some());
         assert!(store.get(TransientMessageSlot::WorkflowNotice).is_none());
-        assert!(
-            store
-                .get(TransientMessageSlot::PublishedBranchSync)
-                .is_some()
-        );
+        assert!(store.get(TransientMessageSlot::BranchPublish).is_some());
     }
 }

--- a/crates/agentty/src/runtime/key_handler.rs
+++ b/crates/agentty/src/runtime/key_handler.rs
@@ -1591,7 +1591,7 @@ mod tests {
             publish_branch_action: crate::domain::session::PublishBranchAction::PublishPullRequest,
             restore_view: ConfirmationViewMode {
                 scroll_offset: Some(4),
-                session_id: session_id.into(),
+                session_id: session_id.clone().into(),
             },
         };
 
@@ -1605,14 +1605,22 @@ mod tests {
         assert!(matches!(event_result, EventResult::Continue));
         assert!(matches!(
             app.mode,
-            AppMode::ViewInfoPopup {
-                is_loading: true,
-                ref message,
-                ref title,
-                ..
-            } if title == "Publishing review request"
-                && message.contains("`review/custom`")
+            AppMode::View {
+                session_id: ref viewed_session_id,
+                scroll_offset: Some(4),
+            } if viewed_session_id == &session_id
         ));
+        assert_eq!(
+            app.sessions
+                .session_at(0)
+                .and_then(|session| {
+                    session
+                        .transient_messages
+                        .get(crate::domain::transient_message::TransientMessageSlot::BranchPublish)
+                })
+                .map(|message| message.body.text()),
+            Some("Publishing review request...")
+        );
     }
 
     #[tokio::test]

--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -191,11 +191,10 @@ impl TranscriptFingerprint {
 pub(crate) struct SessionOutputLayout {
     /// Index of the active Tachyon loader row within `lines`, when present.
     pub(crate) active_loader_line_index: Option<usize>,
+    /// Index of the branch-operation loader row within `lines`, when present.
+    pub(crate) branch_operation_loader_line_index: Option<usize>,
     /// Number of rendered lines, saturated for scroll metric arithmetic.
     pub(crate) line_count: u16,
-    /// Index of the published-branch sync loader row within `lines`, when
-    /// present.
-    pub(crate) published_loader_line_index: Option<usize>,
     /// Rendered lines shared between scroll metrics and frame painting.
     pub(crate) lines: Arc<[Line<'static>]>,
 }
@@ -210,16 +209,16 @@ struct SessionOutputResolvedLayout {
 /// Fully assembled session-output lines plus metadata derived during assembly.
 struct SessionOutputLines {
     active_loader_line_index: Option<usize>,
+    branch_operation_loader_line_index: Option<usize>,
     lines: Vec<Line<'static>>,
-    published_loader_line_index: Option<usize>,
 }
 
 /// Cached stable output body shared across status-tail changes such as a
 /// review-ready session entering the rebase workflow.
 #[derive(Clone)]
 struct SessionOutputBody {
+    branch_operation_loader_line_index: Option<usize>,
     lines: Arc<[Line<'static>]>,
-    published_loader_line_index: Option<usize>,
 }
 
 /// One logical output block in the assembled session transcript panel.
@@ -268,11 +267,11 @@ struct SessionOutputAssembly<'a> {
     active_progress: Option<&'a str>,
     active_turn_has_visible_text: bool,
     active_turn_section: SessionOutputTranscriptSection<'a>,
+    branch_operation_loader_line_index: Option<usize>,
     completed_turn_section: SessionOutputTranscriptSection<'a>,
     inner_width: usize,
     lines: Vec<Line<'static>>,
     markdown_render_cache: Option<&'a markdown::MarkdownRenderCache>,
-    published_loader_line_index: Option<usize>,
     session: &'a Session,
     status: Status,
     trailing_notice_section: SessionOutputTranscriptSection<'a>,
@@ -315,8 +314,8 @@ impl SessionOutputAssembly<'_> {
 
         SessionOutputLines {
             active_loader_line_index: self.active_loader_line_index,
+            branch_operation_loader_line_index: self.branch_operation_loader_line_index,
             lines: self.lines,
-            published_loader_line_index: self.published_loader_line_index,
         }
     }
 
@@ -332,8 +331,8 @@ impl SessionOutputAssembly<'_> {
         }
 
         SessionOutputBody {
+            branch_operation_loader_line_index: self.branch_operation_loader_line_index,
             lines: Arc::from(self.lines),
-            published_loader_line_index: self.published_loader_line_index,
         }
     }
 
@@ -393,7 +392,7 @@ impl SessionOutputAssembly<'_> {
                 self.inner_width,
                 self.markdown_render_cache,
             ) {
-                self.published_loader_line_index = Some(self.lines.len().saturating_sub(1));
+                self.branch_operation_loader_line_index = Some(self.lines.len().saturating_sub(1));
             }
         }
     }
@@ -779,8 +778,8 @@ impl<'a> SessionOutput<'a> {
 
         SessionOutputLayout {
             active_loader_line_index: output_lines.active_loader_line_index,
+            branch_operation_loader_line_index: output_lines.branch_operation_loader_line_index,
             line_count,
-            published_loader_line_index: output_lines.published_loader_line_index,
             lines: Arc::<[Line<'static>]>::from(output_lines.lines),
         }
     }
@@ -813,8 +812,8 @@ impl<'a> SessionOutput<'a> {
 
         SessionOutputLayout {
             active_loader_line_index,
+            branch_operation_loader_line_index: body.branch_operation_loader_line_index,
             line_count,
-            published_loader_line_index: body.published_loader_line_index,
             lines: Arc::from(lines),
         }
     }
@@ -937,12 +936,12 @@ impl<'a> SessionOutput<'a> {
             active_loader_line_index: None,
             active_progress,
             active_turn_has_visible_text,
+            branch_operation_loader_line_index: None,
             active_turn_section: transcript_sections.active_turn,
             completed_turn_section: transcript_sections.completed_turn,
             inner_width,
             lines: Vec::new(),
             markdown_render_cache,
-            published_loader_line_index: None,
             session,
             status,
             trailing_notice_section: transcript_sections.trailing_notice,
@@ -1029,6 +1028,7 @@ impl<'a> SessionOutput<'a> {
                         session_format::format_review_markdown(markdown)
                     }
                     TransientMessageSlot::WorkflowNotice
+                    | TransientMessageSlot::BranchPublish
                     | TransientMessageSlot::PublishedBranchSync => markdown.clone(),
                 };
                 Self::append_markdown_lines(lines, &markdown, inner_width, markdown_render_cache);
@@ -1053,8 +1053,10 @@ impl<'a> SessionOutput<'a> {
             }
         }
 
-        message.slot == TransientMessageSlot::PublishedBranchSync
-            && matches!(message.body, TransientMessageBody::Loading(_))
+        matches!(
+            message.slot,
+            TransientMessageSlot::BranchPublish | TransientMessageSlot::PublishedBranchSync
+        ) && matches!(&message.body, TransientMessageBody::Loading(_))
     }
 
     /// Returns transcript sections from draft-preview text or typed message
@@ -1626,9 +1628,9 @@ impl Component for SessionOutput<'_> {
         } else {
             None
         };
-        let published_loader_area = Self::loader_area(
+        let branch_operation_loader_area = Self::loader_area(
             output_area,
-            layout.published_loader_line_index,
+            layout.branch_operation_loader_line_index,
             final_scroll,
         );
 
@@ -1659,7 +1661,7 @@ impl Component for SessionOutput<'_> {
         if let Some(loader_area) = active_loader_area {
             self.apply_tachyon_loader_effect(f.buffer_mut(), loader_area, spinner_frame);
         }
-        if let Some(loader_area) = published_loader_area {
+        if let Some(loader_area) = branch_operation_loader_area {
             TachyonLoaderEffect::apply_stateless(f.buffer_mut(), loader_area, spinner_frame);
         }
     }
@@ -1903,6 +1905,40 @@ mod tests {
         // Assert
         assert_eq!(first_layout.line_count, second_layout.line_count);
         assert!(Arc::ptr_eq(&first_layout.lines, &second_layout.lines));
+    }
+
+    #[test]
+    fn test_output_layout_cache_tracks_manual_branch_publish_loader() {
+        // Arrange
+        let mut session = session_fixture();
+        session.status = Status::Review;
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading("Publishing review request...".to_string()),
+            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::BranchPublish,
+            turn_position: None,
+        });
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+        let output_layout_cache = SessionOutputLayoutCache::default();
+
+        // Act
+        let layout = output_layout_cache.layout(
+            &session,
+            Rect::new(0, 0, 80, 8),
+            line_context(),
+            Some(&markdown_render_cache),
+        );
+        let loader_line_index = layout
+            .branch_operation_loader_line_index
+            .expect("manual publish loader should be tracked through the layout cache");
+
+        // Assert
+        assert!(
+            layout.lines[loader_line_index]
+                .to_string()
+                .contains("Publishing review request...")
+        );
     }
 
     /// Verifies workflow-only status changes reuse the stable transcript body
@@ -2848,6 +2884,40 @@ mod tests {
         assert!(text.contains(review_status_message));
     }
 
+    /// Verifies a manual review-request publish renders as an animated
+    /// session-chat row instead of requiring a modal loading popup.
+    #[test]
+    fn test_output_lines_tracks_manual_branch_publish_loader() {
+        // Arrange
+        let mut session = session_fixture();
+        session.status = Status::Review;
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading("Publishing review request...".to_string()),
+            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::BranchPublish,
+            turn_position: None,
+        });
+
+        // Act
+        let lines = SessionOutput::output_lines_with_metadata(
+            &session,
+            Rect::new(0, 0, 80, 8),
+            line_context(),
+            None,
+        );
+        let loader_line_index = lines
+            .branch_operation_loader_line_index
+            .expect("manual publish loader should be tracked");
+
+        // Assert
+        assert!(
+            lines.lines[loader_line_index]
+                .to_string()
+                .contains("Publishing review request...")
+        );
+    }
+
     /// Verifies completed published-branch pushes render through transcript
     /// notices instead of appending a sticky synthetic status row.
     #[test]
@@ -2879,7 +2949,7 @@ mod tests {
             .join("\n");
 
         // Assert
-        assert_eq!(lines.published_loader_line_index, None);
+        assert_eq!(lines.branch_operation_loader_line_index, None);
         assert!(text.contains("[Branch Push]"));
         assert_eq!(
             text.matches("Auto-pushed published branch after completed turn.")

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -444,6 +444,37 @@ fn seed_rebase_transcript_session(env: &BuilderEnv) -> Result<(), Box<dyn std::e
     Ok(())
 }
 
+/// Seeds a review-ready worktree whose delayed successful push keeps the manual
+/// publish task visible long enough to verify session-chat responsiveness.
+fn seed_slow_successful_review_request_publish(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    seed_review_ready_session_with_review_request(env)?;
+    let session_worktree = env.agentty_root.join("wt").join("review-s");
+    run_git(&session_worktree, &["branch", "-m", "wt/review-s"])?;
+
+    let real_git = std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
+        .map(|path| path.join("git"))
+        .find(|path| path.is_file())
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "git not found"))?;
+    let git_path = env.stub_bin.join("git");
+    let script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "push" ]; then
+  sleep 3
+  exit 0
+fi
+exec '{}' "$@"
+"#,
+        real_git.display()
+    );
+    std::fs::write(&git_path, script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&git_path, std::fs::Permissions::from_mode(0o755))?;
+
+    Ok(())
+}
+
 /// Seeds one published review-ready session whose latest auto-push completion
 /// is persisted as transcript output.
 fn seed_session_with_published_branch_push_notice(
@@ -3412,6 +3443,80 @@ fn review_request_publish_shortcut_opens_publish_popup() -> E2eResult {
                     "Leave blank to push as `wt/review-s`",
                     &full,
                 );
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that confirming review-request publish returns to an interactive
+/// session chat while the push runs in the background.
+#[test]
+fn review_request_publish_runs_in_background() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("review_request_background_publish")
+        .with_git()
+        .zola(
+            "Background review-request publish",
+            "Publish a review request in the background and receive its link in session chat.",
+            41,
+        )
+        .setup(seed_slow_successful_review_request_publish)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .compose(&common::open_selected_session_view())
+                    .press_key("p")
+                    .wait_for_stable_frame(300, 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Publishing review request...", 3000)
+                    .capture_labeled(
+                        "background_publish_started",
+                        "Review-request publish progress shown inline in session chat",
+                    )
+                    .press_key("?")
+                    .wait_for_text("Keybindings", 3000)
+                    .capture_labeled(
+                        "background_publish_help",
+                        "Session help remains available while publishing",
+                    )
+                    .press_key("q")
+                    .wait_for_text("GitHub pull request published", 10000)
+                    .capture_labeled(
+                        "background_publish_finished",
+                        "Successful publish and review-request link shown in session chat",
+                    )
+            },
+            |frame, report| {
+                let loading_frame = common::frame_from_capture(&report.captures[0]);
+                let loading_full = Region::full(loading_frame.cols(), loading_frame.rows());
+                assertion::assert_text_in_region(
+                    &loading_frame,
+                    "Publishing review request...",
+                    &loading_full,
+                );
+                assertion::assert_text_in_region(&loading_frame, "q: back", &loading_full);
+
+                let help_frame = common::frame_from_capture(&report.captures[1]);
+                let help_full = Region::full(help_frame.cols(), help_frame.rows());
+                assertion::assert_text_in_region(&help_frame, "Keybindings", &help_full);
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "GitHub pull request published", &full);
+                assertion::assert_text_in_region(
+                    frame,
+                    "Successfully published session branch wt/review-s.",
+                    &full,
+                );
+                assertion::assert_text_in_region(frame, "GitHub pull request #42", &full);
+                assertion::assert_text_in_region(
+                    frame,
+                    "https://github.com/agentty-xyz/agentty/pull/42",
+                    &full,
+                );
+                assertion::assert_text_in_region(frame, "q: back", &full);
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -132,8 +132,15 @@ ordered `session_message` rows (typed `UserPrompt`, `AssistantAnswer`, `Workflow
 rows). Replaceable output lives in the session's typed transient-message slots instead
 of render-time visibility predicates. Each slot has stable identity, typed content, an
 output anchor, and an explicit lifecycle. Reducer paths upsert or retract summary,
-focused-review, workflow-feedback, and published-branch-sync slots; starting a later
-turn clears older turn-scoped slots in one place.
+focused-review, workflow-feedback, manual-branch-publish, and published-branch-sync
+slots; starting a later turn clears older turn-scoped slots in one place.
+
+Manual branch and review-request publishing returns from its branch-name popup to
+`AppMode::View` before spawning the task. Its session-scoped transient slot renders the
+animated progress row, then the terminal reducer event replaces that row with inline
+success or failure output without changing whichever app mode is active at completion.
+The manual task holds the same per-session branch-operation lock as completed-turn
+auto-push for its full push and forge-metadata workflow.
 
 Published-branch auto-push completion sends one terminal reducer event carrying its
 `WorkflowNotice`. After accepting the current operation identifier, the reducer persists
@@ -406,8 +413,10 @@ their triggers:
   for the mention picker, falling back to the project root for unstarted drafts.
 - **Session-size refresh** (`Enter` on a session in list mode): recomputes the diff-size
   bucket off the key-handling path.
-- **Branch-publish action** (session view `p`): pushes with `--force-with-lease` and
-  creates or refreshes the forge review request.
+- **Branch-publish action** (session view `p`): returns to interactive session chat,
+  then pushes with `--force-with-lease` and creates or refreshes the forge review
+  request in the background; progress and completion render inline for that session,
+  while the shared per-session branch-operation lock serializes it with auto-push.
 - **Deferred session cleanup** (session delete): removes the worktree folder and branch
   after database deletion.
 - **Session fork** (root session view `F`): creates a new worktree branch from the
@@ -441,7 +450,9 @@ orchestration paths:
   owns staging and `git rebase --continue`.
 - Review-request publish: push with `--force-with-lease`, then create or refresh the
   forge review request through `ReviewRequestClient`; only open same-branch requests are
-  reused.
+  reused. The task does not own the active app mode, so its completion cannot interrupt
+  later navigation. It holds the same branch-operation lock as post-turn auto-push, so
+  overlapping requests queue rather than running concurrent force-pushes.
 - Background review-request sync: review-ready sessions with a published branch or
   linked request are polled; merged requests move the session to `Done`, closed requests
   to `Canceled`. Externally merged worktree and branch cleanup runs as a tracked

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -165,14 +165,14 @@ Publish (`p`), sync (`r`), and stacked behavior are described in
 
 ## Publish Popup
 
-| Key                               | Action                                 |
-| --------------------------------- | -------------------------------------- |
-| `Enter`                           | Publish typed or default branch target |
-| `Esc` / `q`                       | Cancel and return to session view      |
-| `Left` / `Right` / `Home` / `End` | Move cursor                            |
-| `Up` / `Down`                     | Move cursor across wrapped lines       |
-| `Backspace` / `Delete`            | Delete character                       |
-| text keys                         | Edit remote branch name                |
+| Key                               | Action                             |
+| --------------------------------- | ---------------------------------- |
+| `Enter`                           | Start publishing in the background |
+| `Esc` / `q`                       | Cancel and return to session view  |
+| `Left` / `Right` / `Home` / `End` | Move cursor                        |
+| `Up` / `Down`                     | Move cursor across wrapped lines   |
+| `Backspace` / `Delete`            | Delete character                   |
+| text keys                         | Edit remote branch name            |
 
 ## Launch Configuration Selector
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -341,8 +341,13 @@ publish popup for the linked forge review request:
 - Leave the field empty to keep the default branch target, or type a custom remote
   branch name. After the first publish, the popup is locked to that same remote branch.
 - Agentty publishes with `git push --force-with-lease`, then creates or refreshes the
-  linked review request and shows the resulting URL. GitHub projects publish pull
-  requests; GitLab projects publish merge requests.
+  linked review request. After confirmation, the popup closes and publishing continues
+  in the background while session chat remains interactive. Inline progress is replaced
+  by an explicit success message with the review-request URL, or by failure details,
+  when the task finishes; `p` stays hidden while that publish is active. GitHub projects
+  publish pull requests; GitLab projects publish merge requests. Manual publishing and
+  completed-turn auto-push share one per-session branch-operation lock, so whichever
+  starts later waits instead of force-pushing the same branch concurrently.
 - Stacked child review requests target the parent review branch while the parent link is
   active.
 - When no review request is linked yet, only an open request for the same branch is


### PR DESCRIPTION
- Return to interactive session view before starting manual branch and review-request publishing.
- Render progress and terminal success or failure inline without changing the active app mode.
- Serialize manual publishing with completed-turn auto-push using the per-session branch-operation lock.
- Preserve multiple completion events and document the updated workflow and keybindings.
- Add unit and E2E coverage for responsive publishing.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)