### PR TITLE
Key output caches by transient message content

### DIFF
--- a/crates/agentty/src/domain/transient_message.rs
+++ b/crates/agentty/src/domain/transient_message.rs
@@ -1,7 +1,11 @@
 //! Explicit lifecycle state for non-durable session-output messages.
 
+use std::hash::{Hash, Hasher};
+
+use rustc_hash::FxHasher;
+
 /// Stable identity for one replaceable session-output message.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) enum TransientMessageSlot {
     /// Published session summary for the latest completed turn.
     Summary,
@@ -16,7 +20,7 @@ pub(crate) enum TransientMessageSlot {
 }
 
 /// Placement of one transient message relative to durable transcript content.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum TransientMessageAnchor {
     /// Immediately after durable content from the latest completed turn.
     AfterCompletedTurn,
@@ -25,7 +29,7 @@ pub(crate) enum TransientMessageAnchor {
 }
 
 /// Removal policy for one transient message.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum TransientMessageLifecycle {
     /// Remove when a later user turn becomes active.
     ClearOnNewTurn,
@@ -34,7 +38,7 @@ pub(crate) enum TransientMessageLifecycle {
 }
 
 /// Typed content for one transient message.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum TransientMessageBody {
     /// Markdown content rendered through the shared markdown cache.
     Markdown(String),
@@ -54,7 +58,7 @@ impl TransientMessageBody {
 }
 
 /// One replaceable session-output message with explicit placement and lifetime.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct TransientMessage {
     pub(crate) anchor: TransientMessageAnchor,
     pub(crate) body: TransientMessageBody,
@@ -66,11 +70,14 @@ pub(crate) struct TransientMessage {
 
 /// Per-session slot store for non-durable output messages.
 ///
-/// `version` is the cache key and changes only when observable slot content
-/// changes. Slots use canonical enum order rather than async event arrival
-/// order, so status replacement does not move surrounding output.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+/// `version` changes only when observable slot content changes. `fingerprint`
+/// gives render caches a content identity that remains valid when refreshes
+/// reconstruct an equivalent store with a new local version sequence. Slots
+/// use canonical enum order rather than async event arrival order, so status
+/// replacement does not move surrounding output.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct TransientMessageStore {
+    fingerprint: u64,
     messages: Vec<TransientMessage>,
     version: u64,
 }
@@ -79,6 +86,12 @@ impl TransientMessageStore {
     /// Returns the monotonic observable-content version.
     pub(crate) fn version(&self) -> u64 {
         self.version
+    }
+
+    /// Returns a content-derived cache identity that remains stable when
+    /// equivalent messages are reconstructed in a refreshed session snapshot.
+    pub(crate) fn fingerprint(&self) -> u64 {
+        self.fingerprint
     }
 
     /// Returns all current messages in stable display order.
@@ -142,6 +155,27 @@ impl TransientMessageStore {
 
     fn bump_version(&mut self) {
         self.version = self.version.wrapping_add(1);
+        self.fingerprint = Self::calculate_fingerprint(&self.messages);
+    }
+
+    fn calculate_fingerprint(messages: &[TransientMessage]) -> u64 {
+        let mut hasher = FxHasher::default();
+        messages.hash(&mut hasher);
+
+        hasher.finish()
+    }
+}
+
+impl Default for TransientMessageStore {
+    fn default() -> Self {
+        let messages = Vec::new();
+        let fingerprint = Self::calculate_fingerprint(&messages);
+
+        Self {
+            fingerprint,
+            messages,
+            version: 0,
+        }
     }
 }
 
@@ -204,5 +238,48 @@ mod tests {
         assert!(store.get(TransientMessageSlot::Review).is_some());
         assert!(store.get(TransientMessageSlot::WorkflowNotice).is_none());
         assert!(store.get(TransientMessageSlot::BranchPublish).is_some());
+    }
+
+    #[test]
+    fn fingerprint_distinguishes_reconstructed_stores_with_matching_versions() {
+        // Arrange
+        let mut loading_store = TransientMessageStore::default();
+        loading_store.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading("Reviewing changes".to_string()),
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::Review,
+            turn_position: Some(1),
+        });
+        let mut ready_store = TransientMessageStore::default();
+        ready_store.upsert(message(
+            TransientMessageSlot::Review,
+            "## Review\nFinding",
+            1,
+        ));
+
+        // Act
+        let loading_fingerprint = loading_store.fingerprint();
+        let ready_fingerprint = ready_store.fingerprint();
+
+        // Assert
+        assert_eq!(loading_store.version(), ready_store.version());
+        assert_ne!(loading_fingerprint, ready_fingerprint);
+    }
+
+    #[test]
+    fn fingerprint_matches_fresh_store_after_last_message_is_retracted() {
+        // Arrange
+        let fresh_store = TransientMessageStore::default();
+        let mut emptied_store = TransientMessageStore::default();
+        emptied_store.upsert(message(TransientMessageSlot::Review, "review", 1));
+
+        // Act
+        let retracted_message = emptied_store.retract(TransientMessageSlot::Review);
+
+        // Assert
+        assert!(retracted_message.is_some());
+        assert!(emptied_store.messages().is_empty());
+        assert_eq!(emptied_store.fingerprint(), fresh_store.fingerprint());
     }
 }

--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -48,9 +48,9 @@ const USER_PROMPT_TAB_WIDTH: usize = 4;
 /// The key is intentionally tied to the session identifier plus observable
 /// update version and `updated_at` timestamp instead of hashing the full
 /// transcript on every frame. Width, active prompt, queued messages, review
-/// text/status, progress text, and markdown style version cover the transient
-/// inputs that can alter rendered lines without changing the stored session
-/// row.
+/// state fingerprint, progress text, and markdown style version cover the
+/// transient inputs that can alter rendered lines without changing the stored
+/// session row.
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct SessionOutputLayoutCacheKey {
     active_progress: TextFingerprint,
@@ -66,6 +66,7 @@ struct SessionOutputLayoutCacheKey {
     session_updated_at: i64,
     status: Status,
     theme_cache_version: u64,
+    transient_message_fingerprint: u64,
     transient_message_version: u64,
     transcript: TranscriptFingerprint,
 }
@@ -82,6 +83,7 @@ struct SessionOutputBodyCacheKey {
     queued_messages: TextFingerprint,
     session_id: SessionId,
     theme_cache_version: u64,
+    transient_message_fingerprint: u64,
     transient_message_version: u64,
     transcript: TranscriptFingerprint,
 }
@@ -843,6 +845,7 @@ impl<'a> SessionOutput<'a> {
             session_updated_at: session.updated_at,
             status: session.status,
             theme_cache_version: style::active_theme_cache_version(),
+            transient_message_fingerprint: session.transient_messages.fingerprint(),
             transient_message_version: session.transient_messages.version(),
             transcript: TranscriptFingerprint::from_session(session),
         }
@@ -869,6 +872,7 @@ impl<'a> SessionOutput<'a> {
             ),
             session_id: session.id.clone(),
             theme_cache_version: style::active_theme_cache_version(),
+            transient_message_fingerprint: session.transient_messages.fingerprint(),
             transient_message_version: session.transient_messages.version(),
             transcript: TranscriptFingerprint::from_session(session),
         }
@@ -2253,6 +2257,77 @@ mod tests {
         // Assert
         assert!(review_layout.line_count > base_layout.line_count);
         assert!(!Arc::ptr_eq(&base_layout.lines, &review_layout.lines));
+    }
+
+    #[test]
+    fn test_output_cache_distinguishes_rebuilt_review_states_with_matching_versions() {
+        // Arrange
+        let mut loading_session = session_fixture();
+        loading_session.status = Status::AgentReview;
+        loading_session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading("Reviewing changes".to_string()),
+            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::Review,
+            turn_position: None,
+        });
+        let mut ready_session = session_fixture();
+        ready_session.status = Status::Review;
+        set_review_transient(
+            &mut ready_session,
+            TransientMessageBody::Markdown("## Review\n\n- Stable finding".to_string()),
+        );
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+        let loading_then_ready_cache = SessionOutputLayoutCache::default();
+        let ready_then_loading_cache = SessionOutputLayoutCache::default();
+        let output_area = Rect::new(0, 0, 80, 8);
+
+        // Act
+        loading_then_ready_cache.layout(
+            &loading_session,
+            output_area,
+            line_context(),
+            Some(&markdown_render_cache),
+        );
+        let refreshed_ready_layout = loading_then_ready_cache.layout(
+            &ready_session,
+            output_area,
+            line_context(),
+            Some(&markdown_render_cache),
+        );
+        ready_then_loading_cache.layout(
+            &ready_session,
+            output_area,
+            line_context(),
+            Some(&markdown_render_cache),
+        );
+        let regenerated_loading_layout = ready_then_loading_cache.layout(
+            &loading_session,
+            output_area,
+            line_context(),
+            Some(&markdown_render_cache),
+        );
+        let refreshed_ready_text = refreshed_ready_layout
+            .lines
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let regenerated_loading_text = regenerated_loading_layout
+            .lines
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Assert
+        assert_eq!(loading_session.id, ready_session.id);
+        assert_eq!(
+            loading_session.transient_messages.version(),
+            ready_session.transient_messages.version()
+        );
+        assert!(refreshed_ready_text.contains("Stable finding"));
+        assert!(!regenerated_loading_text.contains("Stable finding"));
     }
 
     #[test]


### PR DESCRIPTION
- Add content-derived fingerprints to transient message stores.
- Include transient fingerprints in session output cache keys.
- Cover rebuilt loading and review states with regression tests.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)