### PR TITLE
Persist review-request creation results across turns

### DIFF
--- a/crates/agentty/src/app/branch_publish.rs
+++ b/crates/agentty/src/app/branch_publish.rs
@@ -9,6 +9,7 @@ use ag_git::GitClient;
 use super::session::{self, unix_timestamp_from_system_time};
 use crate::app::review_request;
 use crate::domain::session::{PublishBranchAction, ReviewRequest, Session, SessionId, Status};
+use crate::domain::transcript_notice::TranscriptNotice;
 use crate::infra::clock::Clock;
 use crate::infra::db;
 
@@ -202,31 +203,17 @@ pub(crate) fn branch_push_success_message(
     }
 }
 
-/// Returns the inline success title for one completed review-request publish.
-pub(crate) fn review_request_publish_success_title(review_request: &ReviewRequest) -> String {
-    format!(
-        "{} published",
+/// Returns the durable transcript notice for one completed review-request
+/// publish.
+pub(crate) fn review_request_created_notice(review_request: &ReviewRequest) -> String {
+    TranscriptNotice::ReviewRequest.format(format!(
+        "Created {} {}",
         review_request
             .summary
             .forge_kind
-            .review_request_display_name()
-    )
-}
-
-/// Returns the inline success body for one completed review-request publish.
-pub(crate) fn pull_request_publish_success_message(
-    branch_name: &str,
-    review_request: &ReviewRequest,
-) -> String {
-    format!(
-        "Successfully published session branch `{branch_name}`.\n\n{} {}:\n{}",
-        review_request
-            .summary
-            .forge_kind
-            .review_request_display_name(),
-        review_request.summary.display_id,
+            .review_request_short_name(),
         review_request.summary.web_url
-    )
+    ))
 }
 
 /// Executes one background branch-publish action while holding the session's
@@ -1177,7 +1164,7 @@ mod tests {
     }
 
     #[test]
-    fn pull_request_publish_success_message_uses_gitlab_display_copy() {
+    fn review_request_created_notice_uses_gitlab_short_name() {
         // Arrange
         let review_request = ReviewRequest {
             last_refreshed_at: 42,
@@ -1194,13 +1181,14 @@ mod tests {
         };
 
         // Act
-        let title = review_request_publish_success_title(&review_request);
-        let message = pull_request_publish_success_message("wt/session-1", &review_request);
+        let notice = review_request_created_notice(&review_request);
 
         // Assert
-        assert_eq!(title, "GitLab merge request published");
-        assert!(message.contains("Successfully published session branch `wt/session-1`."));
-        assert!(message.contains("GitLab merge request !24"));
+        assert_eq!(
+            notice,
+            "\n[Review Request] Created MR \
+             https://gitlab.com/agentty-xyz/agentty/-/merge_requests/24\n"
+        );
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -11,7 +11,7 @@ use app::branch_publish::{
     branch_publish_success_title as branch_publish_success_title_text,
     detected_forge_kind_from_git_push_error, git_push_authentication_message,
     is_git_push_authentication_error,
-    pull_request_publish_success_message as pull_request_publish_success_message_text,
+    review_request_created_notice as review_request_created_notice_text,
 };
 use app::reducer::AppEventReducer;
 use app::review::{
@@ -834,7 +834,8 @@ impl App {
             .await;
 
         for branch_publish_action_update in event_batch.branch_publish_action_updates {
-            self.apply_branch_publish_action_update(branch_publish_action_update);
+            self.apply_branch_publish_action_update(branch_publish_action_update)
+                .await;
         }
 
         let applied_review_request_status_update = event_batch
@@ -1604,13 +1605,13 @@ impl App {
     }
 
     /// Applies one completed branch-publish action to the session chat.
-    pub(super) fn apply_branch_publish_action_update(
+    pub(super) async fn apply_branch_publish_action_update(
         &mut self,
         branch_publish_action_update: BranchPublishActionUpdate,
     ) {
         let BranchPublishActionUpdate { result, session_id } = branch_publish_action_update;
 
-        let result_message = match result {
+        match result {
             Ok(BranchPublishTaskSuccess::Pushed {
                 branch_name,
                 review_request_creation,
@@ -1619,38 +1620,49 @@ impl App {
                 self.sessions
                     .apply_published_upstream_ref(&session_id, upstream_reference);
 
-                TransientMessageBody::Markdown(format!(
+                let result_message = TransientMessageBody::Markdown(format!(
                     "**{}**\n\n{}",
                     Self::branch_publish_success_title(PublishBranchAction::Push),
                     Self::branch_publish_success_message(
                         &branch_name,
                         review_request_creation.as_ref(),
                     )
-                ))
+                ));
+                self.sessions
+                    .finish_branch_publish(&session_id, result_message);
             }
             Ok(BranchPublishTaskSuccess::PullRequestPublished {
-                branch_name,
                 review_request,
                 upstream_reference,
+                ..
             }) => {
                 self.sessions
                     .apply_published_upstream_ref(&session_id, upstream_reference);
                 self.sessions
                     .apply_review_request(&session_id, review_request.clone());
 
-                TransientMessageBody::Markdown(format!(
-                    "**{}**\n\n{}",
-                    Self::review_request_publish_success_title(&review_request),
-                    Self::pull_request_publish_success_message(&branch_name, &review_request)
-                ))
+                let persistent_notice = Self::review_request_created_notice(&review_request);
+                if self
+                    .sessions
+                    .finish_review_request_publish(&session_id, &persistent_notice)
+                {
+                    SessionTaskService::persist_workflow_notice(
+                        self.services.db(),
+                        &session_id,
+                        &persistent_notice,
+                    )
+                    .await;
+                }
             }
-            Err(failure) => TransientMessageBody::Markdown(format!(
-                "**{}**\n\n{}",
-                failure.title, failure.message
-            )),
-        };
-        self.sessions
-            .finish_branch_publish(&session_id, result_message);
+            Err(failure) => {
+                let result_message = TransientMessageBody::Markdown(format!(
+                    "**{}**\n\n{}",
+                    failure.title, failure.message
+                ));
+                self.sessions
+                    .finish_branch_publish(&session_id, result_message);
+            }
+        }
     }
 
     /// Applies one background review-request status refresh.
@@ -1876,21 +1888,12 @@ impl App {
         )
     }
 
-    /// Returns the success popup title for one completed review-request
+    /// Returns the durable transcript notice for one completed review-request
     /// publish.
-    pub(super) fn review_request_publish_success_title(
+    pub(super) fn review_request_created_notice(
         review_request: &crate::domain::session::ReviewRequest,
     ) -> String {
-        crate::app::branch_publish::review_request_publish_success_title(review_request)
-    }
-
-    /// Returns the success popup body for one completed review-request
-    /// publish.
-    pub(super) fn pull_request_publish_success_message(
-        branch_name: &str,
-        review_request: &crate::domain::session::ReviewRequest,
-    ) -> String {
-        pull_request_publish_success_message_text(branch_name, review_request)
+        review_request_created_notice_text(review_request)
     }
 
     /// Builds final sync popup mode from background sync completion result.

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -20,7 +20,7 @@ use crate::domain::session::{
     ForgeKind, PublishedBranchSyncStatus, ReviewRequest, ReviewRequestState, ReviewRequestSummary,
     SESSION_DATA_DIR, SessionFollowUpTask, SessionHandles, SessionSize, SessionStats, Status,
 };
-use crate::domain::session_message::SessionTranscript;
+use crate::domain::session_message::{SessionMessageKind, SessionTranscript};
 use crate::domain::setting::SettingName;
 use crate::infra::db::AppRepositories;
 use crate::infra::project_discovery::{HOME_PROJECT_SCAN_MAX_RESULTS, RealProjectDiscoveryClient};
@@ -995,6 +995,24 @@ async fn new_test_app_with_selected_session(
     app
 }
 
+/// Inserts the selected session into the test database for durable transcript
+/// assertions.
+async fn persist_selected_session(app: &App) {
+    let project_id = app
+        .services
+        .db()
+        .projects()
+        .upsert_project("/tmp/project", Some("main".to_string()))
+        .await
+        .expect("failed to insert project");
+    app.services
+        .db()
+        .sessions()
+        .insert_session("session-1", "gpt-5.5", "main", "Review", project_id)
+        .await
+        .expect("failed to insert session");
+}
+
 #[test]
 fn branch_publish_inline_helpers_format_copy() {
     // Act
@@ -1536,7 +1554,8 @@ async fn apply_branch_publish_action_update_sets_inline_success() {
             upstream_reference: "origin/wt/session-1".to_string(),
         }),
         session_id: "session-1".into(),
-    });
+    })
+    .await;
 
     // Assert
     assert!(matches!(app.mode, AppMode::List));
@@ -1564,7 +1583,7 @@ async fn apply_branch_publish_action_update_sets_inline_success() {
 }
 
 #[tokio::test]
-async fn apply_branch_publish_action_update_sets_inline_pull_request_success() {
+async fn apply_branch_publish_action_update_persists_pull_request_notice() {
     // Arrange
     let session_folder = tempdir().expect("failed to create temp dir");
     let mut app = new_test_app_with_selected_session(
@@ -1573,6 +1592,10 @@ async fn apply_branch_publish_action_update_sets_inline_pull_request_success() {
         Arc::new(MockTmuxClient::new()),
     )
     .await;
+    persist_selected_session(&app).await;
+    app.sessions
+        .session_handles_mut()
+        .insert("session-1".into(), SessionHandles::new(Status::Review));
     app.mode = AppMode::List;
     let review_request = crate::domain::session::ReviewRequest {
         last_refreshed_at: 55,
@@ -1590,20 +1613,72 @@ async fn apply_branch_publish_action_update_sets_inline_pull_request_success() {
             upstream_reference: "origin/wt/session-1".to_string(),
         }),
         session_id: "session-1".into(),
-    });
+    })
+    .await;
 
     // Assert
     assert!(matches!(app.mode, AppMode::List));
-    let publish_message = app.sessions.state().sessions()[0]
-        .transient_messages
-        .get(crate::domain::transient_message::TransientMessageSlot::BranchPublish)
-        .expect("review request publish result should be visible inline")
-        .body
-        .text();
-    assert!(publish_message.contains("GitHub pull request published"));
-    assert!(publish_message.contains("Successfully published session branch `wt/session-1`."));
-    assert!(publish_message.contains("GitHub pull request #42"));
-    assert!(publish_message.contains("https://github.com/agentty-xyz/agentty/pull/42"));
+    assert!(
+        app.sessions.state().sessions()[0]
+            .transient_messages
+            .get(crate::domain::transient_message::TransientMessageSlot::BranchPublish)
+            .is_none()
+    );
+    let transcript = app.sessions.state().sessions()[0]
+        .transcript
+        .as_ref()
+        .expect("review request notice should be appended to transcript");
+    let transcript_notice = transcript
+        .messages()
+        .last()
+        .expect("review request notice should be present");
+    assert_eq!(transcript_notice.kind, SessionMessageKind::WorkflowNotice);
+    assert_eq!(
+        transcript_notice.content,
+        "\n[Review Request] Created PR https://github.com/agentty-xyz/agentty/pull/42\n"
+    );
+    let persisted_messages = app
+        .services
+        .db()
+        .sessions()
+        .load_session_messages("session-1")
+        .await
+        .expect("failed to load persisted session messages");
+    assert_eq!(persisted_messages.len(), 1);
+    assert_eq!(
+        persisted_messages[0].kind,
+        SessionMessageKind::WorkflowNotice.as_str()
+    );
+    assert_eq!(persisted_messages[0].content, transcript_notice.content);
+    {
+        let handles = app
+            .sessions
+            .session_handles()
+            .get("session-1")
+            .expect("session handles should exist");
+        let mut live_transcript = handles
+            .transcript
+            .lock()
+            .expect("session transcript lock should succeed");
+        live_transcript.append_message(SessionMessageKind::UserPrompt, "continue the session");
+    }
+    app.sessions
+        .state_mut()
+        .sync_session_from_handle("session-1");
+    let messages_after_new_turn = app.sessions.state().sessions()[0]
+        .transcript
+        .as_ref()
+        .expect("session transcript should remain available")
+        .messages();
+    assert_eq!(messages_after_new_turn.len(), 2);
+    assert_eq!(
+        messages_after_new_turn[0].kind,
+        SessionMessageKind::WorkflowNotice
+    );
+    assert_eq!(
+        messages_after_new_turn[1].kind,
+        SessionMessageKind::UserPrompt
+    );
     assert_eq!(
         app.sessions
             .state()
@@ -1615,7 +1690,7 @@ async fn apply_branch_publish_action_update_sets_inline_pull_request_success() {
 }
 
 #[tokio::test]
-async fn apply_branch_publish_action_update_sets_inline_gitlab_merge_request_success() {
+async fn apply_branch_publish_action_update_persists_gitlab_merge_request_notice() {
     // Arrange
     let session_folder = tempdir().expect("failed to create temp dir");
     let mut app = new_test_app_with_selected_session(
@@ -1624,6 +1699,9 @@ async fn apply_branch_publish_action_update_sets_inline_gitlab_merge_request_suc
         Arc::new(MockTmuxClient::new()),
     )
     .await;
+    persist_selected_session(&app).await;
+    app.sessions
+        .start_branch_publish("session-1", "Publishing review request...".to_string());
     app.mode = AppMode::List;
     let review_request = crate::domain::session::ReviewRequest {
         last_refreshed_at: 77,
@@ -1647,20 +1725,41 @@ async fn apply_branch_publish_action_update_sets_inline_gitlab_merge_request_suc
             upstream_reference: "origin/wt/session-1".to_string(),
         }),
         session_id: "session-1".into(),
-    });
+    })
+    .await;
 
     // Assert
     assert!(matches!(app.mode, AppMode::List));
-    let publish_message = app.sessions.state().sessions()[0]
-        .transient_messages
-        .get(crate::domain::transient_message::TransientMessageSlot::BranchPublish)
-        .expect("merge request publish result should be visible inline")
-        .body
-        .text();
-    assert!(publish_message.contains("GitLab merge request published"));
-    assert!(publish_message.contains("Successfully published session branch `wt/session-1`."));
-    assert!(publish_message.contains("GitLab merge request !24"));
-    assert!(publish_message.contains("https://gitlab.com/agentty-xyz/agentty/-/merge_requests/24"));
+    assert!(
+        app.sessions.state().sessions()[0]
+            .transient_messages
+            .get(crate::domain::transient_message::TransientMessageSlot::BranchPublish)
+            .is_none()
+    );
+    let transcript_notice = app.sessions.state().sessions()[0]
+        .transcript
+        .as_ref()
+        .and_then(|transcript| transcript.messages().last())
+        .expect("merge request notice should be appended to transcript");
+    assert_eq!(transcript_notice.kind, SessionMessageKind::WorkflowNotice);
+    assert_eq!(
+        transcript_notice.content,
+        "\n[Review Request] Created MR \
+         https://gitlab.com/agentty-xyz/agentty/-/merge_requests/24\n"
+    );
+    let persisted_messages = app
+        .services
+        .db()
+        .sessions()
+        .load_session_messages("session-1")
+        .await
+        .expect("failed to load persisted session messages");
+    assert_eq!(persisted_messages.len(), 1);
+    assert_eq!(
+        persisted_messages[0].kind,
+        SessionMessageKind::WorkflowNotice.as_str()
+    );
+    assert_eq!(persisted_messages[0].content, transcript_notice.content);
 }
 
 #[tokio::test]
@@ -1682,7 +1781,8 @@ async fn apply_branch_publish_action_update_keeps_active_mode_on_failure() {
             "remote rejected".to_string(),
         )),
         session_id: "session-1".into(),
-    });
+    })
+    .await;
 
     // Assert
     assert!(matches!(app.mode, AppMode::List));

--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -478,6 +478,39 @@ impl SessionManager {
         }
     }
 
+    /// Promotes completed review-request creation into durable transcript
+    /// history and removes its transient loading row.
+    pub(crate) fn finish_review_request_publish(
+        &mut self,
+        session_id: &str,
+        persistent_notice: &str,
+    ) -> bool {
+        let appended_to_handle =
+            self.append_workflow_notice_to_handle(session_id, persistent_notice);
+        if appended_to_handle {
+            self.state.sync_session_from_handle(session_id);
+        }
+        let Some(session) = self
+            .state
+            .sessions
+            .iter_mut()
+            .find(|session| session.id == session_id)
+        else {
+            return false;
+        };
+        if !appended_to_handle {
+            session
+                .transcript
+                .get_or_insert_default()
+                .append_message(SessionMessageKind::WorkflowNotice, persistent_notice);
+        }
+        session
+            .transient_messages
+            .retract(TransientMessageSlot::BranchPublish);
+
+        true
+    }
+
     /// Marks one session branch as currently auto-syncing to its published
     /// upstream reference.
     pub(crate) fn start_published_branch_sync(
@@ -525,17 +558,11 @@ impl SessionManager {
         self.published_branch_sync_operations.remove(session_id);
 
         let appended_to_handle = persistent_notice.is_some_and(|persistent_notice| {
-            let Some(handles) = self.state.handles.get(session_id) else {
-                return false;
-            };
-            let Ok(mut transcript) = handles.transcript.lock() else {
-                return false;
-            };
-
-            transcript.append_message(SessionMessageKind::WorkflowNotice, persistent_notice);
-
-            true
+            self.append_workflow_notice_to_handle(session_id, persistent_notice)
         });
+        if appended_to_handle {
+            self.state.sync_session_from_handle(session_id);
+        }
 
         let Some(session) = self
             .state
@@ -869,6 +896,21 @@ impl SessionManager {
             position,
             launched_session_id,
         );
+    }
+
+    /// Appends one workflow notice to a live transcript handle when the
+    /// session currently owns one.
+    fn append_workflow_notice_to_handle(&self, session_id: &str, persistent_notice: &str) -> bool {
+        let Some(handles) = self.state.handles.get(session_id) else {
+            return false;
+        };
+        let Ok(mut transcript) = handles.transcript.lock() else {
+            return false;
+        };
+
+        transcript.append_message(SessionMessageKind::WorkflowNotice, persistent_notice);
+
+        true
     }
 }
 

--- a/crates/agentty/src/domain/transcript_notice.rs
+++ b/crates/agentty/src/domain/transcript_notice.rs
@@ -48,6 +48,8 @@ pub(crate) enum TranscriptNotice {
     RebaseError,
     /// Reply submission failure.
     ReplyError,
+    /// Review-request creation result.
+    ReviewRequest,
     /// Review-request sync warning.
     ReviewRequestSyncWarning,
     /// Draft session start failure.
@@ -80,6 +82,7 @@ impl TranscriptNotice {
             Self::RebaseAssist => "[Sync Assist]",
             Self::RebaseError => "[Sync Error]",
             Self::ReplyError => "[Reply Error]",
+            Self::ReviewRequest => "[Review Request]",
             Self::ReviewRequestSyncWarning => "[Review Request Sync Warning]",
             Self::StartError => "[Start Error]",
             Self::TurnMetadataError => "[Turn Metadata Error]",

--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -2993,6 +2993,50 @@ mod tests {
         );
     }
 
+    /// Verifies persisted review-request creation renders as one logical
+    /// transcript line.
+    #[test]
+    fn test_output_lines_renders_persisted_review_request_on_one_line() {
+        // Arrange
+        let mut session = session_fixture();
+        session.status = Status::InProgress;
+        let created_message =
+            "[Review Request] Created PR https://github.com/agentty-xyz/agentty/pull/42";
+        set_conversation_transcript(
+            &mut session,
+            vec![
+                (SessionMessageKind::AssistantAnswer, "Published the changes."),
+                (
+                    SessionMessageKind::WorkflowNotice,
+                    "\n[Review Request] Created PR \
+                     https://github.com/agentty-xyz/agentty/pull/42\n",
+                ),
+                (SessionMessageKind::UserPrompt, "continue the session"),
+            ],
+        );
+
+        // Act
+        let lines = output_lines(&session, Rect::new(0, 0, 120, 8), line_context(), None);
+
+        // Assert
+        let created_message_index = lines
+            .iter()
+            .position(|line| line.to_string() == created_message)
+            .expect("review request notice should be rendered");
+        let later_prompt_index = lines
+            .iter()
+            .position(|line| line.to_string().contains("continue the session"))
+            .expect("later user prompt should be rendered");
+        assert_eq!(
+            lines
+                .iter()
+                .filter(|line| line.to_string() == created_message)
+                .count(),
+            1
+        );
+        assert!(created_message_index < later_prompt_index);
+    }
+
     /// Verifies completed published-branch pushes render through transcript
     /// notices instead of appending a sticky synthetic status row.
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -3483,10 +3483,10 @@ fn review_request_publish_runs_in_background() -> E2eResult {
                         "Session help remains available while publishing",
                     )
                     .press_key("q")
-                    .wait_for_text("GitHub pull request published", 10000)
+                    .wait_for_text("[Review Request] Created PR", 10000)
                     .capture_labeled(
                         "background_publish_finished",
-                        "Successful publish and review-request link shown in session chat",
+                        "Review-request link recorded in session transcript history",
                     )
             },
             |frame, report| {
@@ -3504,16 +3504,9 @@ fn review_request_publish_runs_in_background() -> E2eResult {
                 assertion::assert_text_in_region(&help_frame, "Keybindings", &help_full);
 
                 let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(frame, "GitHub pull request published", &full);
                 assertion::assert_text_in_region(
                     frame,
-                    "Successfully published session branch wt/review-s.",
-                    &full,
-                );
-                assertion::assert_text_in_region(frame, "GitHub pull request #42", &full);
-                assertion::assert_text_in_region(
-                    frame,
-                    "https://github.com/agentty-xyz/agentty/pull/42",
+                    "[Review Request] Created PR https://github.com/agentty-xyz/agentty/pull/42",
                     &full,
                 );
                 assertion::assert_text_in_region(frame, "q: back", &full);

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -139,8 +139,12 @@ Manual branch and review-request publishing returns from its branch-name popup t
 `AppMode::View` before spawning the task. Its session-scoped transient slot renders the
 animated progress row, then the terminal reducer event replaces that row with inline
 success or failure output without changing whichever app mode is active at completion.
-The manual task holds the same per-session branch-operation lock as completed-turn
-auto-push for its full push and forge-metadata workflow.
+Successful review-request creation retracts the transient row and appends its
+single-line URL result as a durable `WorkflowNotice` at the current transcript position.
+Later turns therefore leave the result in its original history position instead of
+reconstructing a transient between turns. The manual task holds the same per-session
+branch-operation lock as completed-turn auto-push for its full push and forge-metadata
+workflow.
 
 Published-branch auto-push completion sends one terminal reducer event carrying its
 `WorkflowNotice`. After accepting the current operation identifier, the reducer persists

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -343,11 +343,13 @@ publish popup for the linked forge review request:
 - Agentty publishes with `git push --force-with-lease`, then creates or refreshes the
   linked review request. After confirmation, the popup closes and publishing continues
   in the background while session chat remains interactive. Inline progress is replaced
-  by an explicit success message with the review-request URL, or by failure details,
-  when the task finishes; `p` stays hidden while that publish is active. GitHub projects
-  publish pull requests; GitLab projects publish merge requests. Manual publishing and
-  completed-turn auto-push share one per-session branch-operation lock, so whichever
-  starts later waits instead of force-pushing the same branch concurrently.
+  by a one-line `[Review Request] Created PR URL` or `[Review Request] Created MR URL`
+  transcript notice recorded at that point in session history, or by failure details
+  when the task finishes; `p` stays hidden while that publish is active. Later turns do
+  not move or reconstruct the creation notice. GitHub projects publish pull requests;
+  GitLab projects publish merge requests. Manual publishing and completed-turn auto-push
+  share one per-session branch-operation lock, so whichever starts later waits instead
+  of force-pushing the same branch concurrently.
 - Stacked child review requests target the parent review branch while the parent link is
   active.
 - When no review request is linked yet, only an open request for the same branch is


### PR DESCRIPTION
- Record successful PR and MR creation as one-line durable transcript notices.
- Retract transient publish rows while preserving notices at their original transcript positions.
- Cover persistence, rendering, E2E behavior, and runtime/workflow documentation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)