### PR TITLE
Run coverage checks in presubmit and postsubmit

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -76,10 +76,11 @@ jobs:
           cargo-llvm-cov: "true"
           llvm-tools-preview: "true"
 
-      - name: Generate coverage report
-        run: prek run coverage-lcov --all-files --hook-stage manual
+      - name: Generate and check coverage report
+        run: prek run coverage --all-files --hook-stage manual
 
       - name: Summarize coverage
+        if: ${{ !cancelled() && hashFiles('coverage.lcov') != '' }}
         run: |
           # Summarize LCOV totals in the GitHub Actions run summary.
           awk '
@@ -109,6 +110,7 @@ jobs:
           ' coverage.lcov >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage report
+        if: ${{ !cancelled() && hashFiles('coverage.lcov') != '' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -9,6 +9,36 @@ permissions:
   contents: read
 
 jobs:
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust and `prek`
+        uses: ./.github/actions/setup-rust-prek
+        with:
+          cargo-llvm-cov: "true"
+          llvm-tools-preview: "true"
+
+      - name: Generate and check coverage report
+        run: prek run coverage --all-files --hook-stage manual
+
+      - name: Upload coverage report
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && hashFiles('coverage.lcov') != '' }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          fail_ci_if_error: true
+          files: coverage.lcov
+          use_oidc: true
+
   e2e:
     name: End-to-end feature tests
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -165,23 +165,14 @@ repos:
         stages: [manual]
       - id: coverage
         name: coverage
-        description: Verify source-test coverage meets workspace ratchet thresholds with `cargo-llvm-cov` and Nextest.
+        description: Verify source-test coverage meets workspace ratchet thresholds and write the CI LCOV report.
         entry: >-
           cargo llvm-cov nextest --workspace --lib --bins --locked --profile ci
           --fail-under-lines 91 --fail-under-functions 91
-        language: system
-        types: [rust]
-        pass_filenames: false
-        stages: [manual]
-      - id: coverage-lcov
-        name: coverage lcov
-        description: Generate the postsubmit Nextest LCOV report uploaded to Codecov, excluding `crates/agentty/tests`.
-        entry: >-
-          cargo llvm-cov nextest --workspace --lib --bins --locked --profile ci
           --lcov --ignore-filename-regex '^crates/agentty/tests/'
           --output-path coverage.lcov
         language: system
-        always_run: true
+        types: [rust]
         pass_filenames: false
         stages: [manual]
       - id: cargo-machete

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,8 +375,8 @@ Use slower hygiene hooks only in CI or when making broader changes. Consult
 
 - Run local broad checks when relevant: coverage summary, member source tests,
   `zola-check`, `cargo-machete`, and `cargo-audit`.
-- Do not run GitHub-only `coverage-lcov` or the full `test-agentty-e2e` suite locally;
-  `.github/workflows/postsubmit.yml` owns those after merge to `main`.
+- Do not run the full `test-agentty-e2e` suite locally; GitHub presubmit and postsubmit
+  workflows own it.
 
 ### Test Failure Protocol
 


### PR DESCRIPTION
- Enforce coverage thresholds and generate the LCOV report through one `prek` hook.
- Upload pull request coverage reports to Codecov with OIDC authentication.
- Guard coverage summaries and uploads when the report is unavailable.
- Reuse the combined coverage command in postsubmit.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)