### PR TITLE
Queue messages during session rebases

### DIFF
--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -1039,9 +1039,9 @@ impl App {
             .await
     }
 
-    /// Queues one chat prompt for an existing `InProgress` session so the
-    /// session worker dispatches it as the next turn once the running turn
-    /// finishes.
+    /// Queues one chat prompt for an existing `InProgress` or `Rebasing`
+    /// session so the session worker dispatches it as the next turn once the
+    /// active operation finishes.
     ///
     /// # Errors
     /// Returns the underlying [`crate::app::session::SessionError`] when

--- a/crates/agentty/src/app/prompt_intent.rs
+++ b/crates/agentty/src/app/prompt_intent.rs
@@ -333,7 +333,7 @@ impl App {
                 )
                 .await;
             }
-        } else if self.session_is_in_progress(&context.session_id) {
+        } else if self.session_queues_messages(&context.session_id) {
             if let Err(error) = self.enqueue_message(&context.session_id, prompt) {
                 self.append_output_for_session(
                     &context.session_id,
@@ -354,15 +354,15 @@ impl App {
         };
     }
 
-    /// Returns whether the targeted session is currently `InProgress`, used
+    /// Returns whether the targeted session is running a turn or rebase, used
     /// to route non-slash submissions into the in-memory message queue
     /// instead of the live reply path.
-    fn session_is_in_progress(&self, session_id: &str) -> bool {
+    fn session_queues_messages(&self, session_id: &str) -> bool {
         self.sessions
             .sessions()
             .iter()
             .find(|session| session.id == session_id)
-            .is_some_and(|session| session.status == Status::InProgress)
+            .is_some_and(|session| matches!(session.status, Status::InProgress | Status::Rebasing))
     }
 
     /// Clears the slash-command buffer after one prompt slash action is

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -1189,7 +1189,8 @@ impl SessionManager {
             .await
     }
 
-    /// Stages one chat prompt into the in-memory queue for the running turn.
+    /// Stages one chat prompt into the in-memory queue for the active turn or
+    /// rebase.
     ///
     /// The queue is owned by [`SessionHandles::queued_messages`] and lives
     /// only for the active app session, so queued prompts are discarded on

--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -71,8 +71,8 @@ pub enum ViewSessionState {
     /// Session is currently running; queued replies, queued sync, and stop
     /// remain available while worktree-open and diff shortcuts are hidden.
     InProgress,
-    /// Session is syncing through the rebase workflow; worktree-open, reply,
-    /// and diff shortcuts are hidden until sync finishes.
+    /// Session is syncing through the rebase workflow; queued replies remain
+    /// available while worktree-open and diff shortcuts are hidden.
     Rebasing,
     /// Session is in merge-queue processing; only read-only navigation
     /// shortcuts are available.
@@ -508,7 +508,8 @@ fn can_open_view_prompt(
     reply_to_session.is_enabled()
         && matches!(
             session_state,
-            ViewSessionState::Interactive
+            ViewSessionState::Rebasing
+                | ViewSessionState::Interactive
                 | ViewSessionState::Review
                 | ViewSessionState::AgentReview
         )
@@ -667,6 +668,9 @@ fn prompt_action_help_action(session_state: ViewSessionState) -> HelpAction {
         ViewSessionState::NewSession | ViewSessionState::StackedDraft
     ) {
         return HelpAction::new("add draft", "Enter", "Add draft");
+    }
+    if matches!(session_state, ViewSessionState::Rebasing) {
+        return HelpAction::new("queue message", "Enter", "Queue message");
     }
 
     HelpAction::new("reply", "Enter", "Reply")
@@ -851,7 +855,7 @@ mod tests {
     }
 
     #[test]
-    fn test_view_actions_rebasing_hides_open_and_stop() {
+    fn test_view_actions_rebasing_shows_queue_and_hides_open_and_stop() {
         // Arrange
         let state = ViewHelpState {
             can_fork_session: ViewActionAvailability::Enabled,
@@ -869,7 +873,11 @@ mod tests {
         let actions = view_actions(state);
 
         // Assert
-        assert!(!actions.iter().any(|action| action.key == "Enter"));
+        assert!(
+            actions
+                .iter()
+                .any(|action| { action.key == "Enter" && action.popup_label == "Queue message" })
+        );
         assert!(!actions.iter().any(|action| action.key == "o"));
         assert!(!actions.iter().any(|action| action.key == "Ctrl+c"));
         assert!(!actions.iter().any(|action| action.key == "d"));
@@ -1327,7 +1335,7 @@ mod tests {
     }
 
     #[test]
-    fn test_view_footer_actions_rebasing_hides_open_and_stop() {
+    fn test_view_footer_actions_rebasing_shows_queue_and_hides_open_and_stop() {
         // Arrange
         let state = ViewHelpState {
             can_fork_session: ViewActionAvailability::Enabled,
@@ -1348,7 +1356,11 @@ mod tests {
         assert!(!actions.iter().any(|action| action.key == "o"));
         assert!(!actions.iter().any(|action| action.key == "p"));
         assert!(!actions.iter().any(|action| action.key == "Ctrl+c"));
-        assert!(!actions.iter().any(|action| action.key == "Enter"));
+        assert!(
+            actions
+                .iter()
+                .any(|action| { action.key == "Enter" && action.footer_label == "queue message" })
+        );
     }
 
     #[test]

--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -397,14 +397,18 @@ fn prompt_context(app: &mut App) -> Option<PromptContext> {
             (false, _, _) => PromptSessionMode::Existing,
         }
     });
-    // While the session is `InProgress` the composer queues the next chat
-    // message instead of dispatching it. Demote a leading `/` to plain text
-    // so slash commands cannot run while the active turn is still in flight
-    // and so arrow-key navigation behaves as text editing rather than slash
-    // menu selection.
-    let session_is_in_progress =
-        session.is_some_and(|session| session.status == crate::domain::session::Status::InProgress);
-    let input_mode = match (is_at_mention, is_slash_command, session_is_in_progress) {
+    // While the session is `InProgress` or `Rebasing` the composer queues the
+    // next chat message instead of dispatching it. Demote a leading `/` to
+    // plain text so slash commands cannot run while the active operation is
+    // still in flight and so arrow-key navigation behaves as text editing
+    // rather than slash-menu selection.
+    let session_queues_messages = session.is_some_and(|session| {
+        matches!(
+            session.status,
+            crate::domain::session::Status::InProgress | crate::domain::session::Status::Rebasing
+        )
+    });
+    let input_mode = match (is_at_mention, is_slash_command, session_queues_messages) {
         (true, _, _) => PromptInputMode::AtMention,
         (false, true, false) => PromptInputMode::SlashCommand,
         (false, _, _) => PromptInputMode::Text,
@@ -655,9 +659,9 @@ fn advance_prompt_slash_selection(app: &mut App) {
 ///
 /// A submitted prompt clears any cached focused-review output for the session
 /// so the next turn starts from the raw transcript again. While the session
-/// is `InProgress`, slash command mode is already demoted to text in
-/// [`prompt_context`], so any leading `/` falls through to the queue path
-/// instead of executing a slash command against the running turn.
+/// is `InProgress` or `Rebasing`, slash command mode is already demoted to
+/// text in [`prompt_context`], so any leading `/` falls through to the queue
+/// path instead of executing a slash command against the active operation.
 async fn handle_prompt_submit_key(app: &mut App, prompt_context: &PromptContext) {
     app.handle_prompt_submit_intent(&prompt_context.to_intent_context())
         .await;
@@ -3030,9 +3034,29 @@ mod tests {
     }
 
     #[tokio::test]
-    /// Verifies that the slash-command gate only fires for `InProgress`
-    /// sessions: when status is `Review`, a leading `/` is still recognized
-    /// as a slash command so the existing slash submit path keeps working.
+    /// Verifies that when the active session is `Rebasing`, a leading `/`
+    /// is demoted from slash-command mode to plain text so submission queues
+    /// the prompt behind the rebase.
+    async fn test_prompt_context_demotes_slash_command_to_text_when_session_is_rebasing() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("/model", None).await;
+        app.sessions.sessions_mut()[0].status = crate::domain::session::Status::Rebasing;
+
+        // Act
+        let context = prompt_context(&mut app).expect("expected prompt context");
+
+        // Assert
+        assert!(
+            !context.is_slash_command(),
+            "slash command mode must be demoted while session is Rebasing"
+        );
+        assert_eq!(context.input_mode, PromptInputMode::Text);
+    }
+
+    #[tokio::test]
+    /// Verifies that the slash-command gate only fires for queueing statuses:
+    /// when status is `Review`, a leading `/` is still recognized as a slash
+    /// command so the existing slash submit path keeps working.
     async fn test_prompt_context_keeps_slash_command_when_session_is_review() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("/model", None).await;
@@ -3044,7 +3068,7 @@ mod tests {
         // Assert
         assert!(
             context.is_slash_command(),
-            "slash command mode must remain active when session is not InProgress"
+            "slash command mode must remain active when the session is not queueing messages"
         );
         assert_eq!(context.input_mode, PromptInputMode::SlashCommand);
     }
@@ -3086,6 +3110,41 @@ mod tests {
             app.sessions.sessions()[0].queued_messages[0],
             "/model gpt-5",
             "queued message preserves the original slash-prefixed text"
+        );
+    }
+
+    #[tokio::test]
+    /// Verifies that submitting a prompt while the session is `Rebasing`
+    /// queues it via [`App::enqueue_message`] instead of trying to start a
+    /// concurrent reply turn.
+    async fn test_handle_prompt_submit_key_queues_text_when_session_is_rebasing() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("queued after rebase", None).await;
+        let session_id = app.sessions.sessions()[0].id.clone();
+        app.sessions.session_handles_mut().insert(
+            session_id.clone(),
+            crate::domain::session::SessionHandles::new(crate::domain::session::Status::Rebasing),
+        );
+        app.sessions.sessions_mut()[0].status = crate::domain::session::Status::Rebasing;
+        let prompt_context = prompt_context(&mut app).expect("expected prompt context");
+
+        // Act
+        handle_prompt_submit_key(&mut app, &prompt_context).await;
+
+        // Assert
+        let queued_messages = app
+            .sessions
+            .session_handles()
+            .get(session_id.as_str())
+            .expect("handles for rebasing session")
+            .queued_messages
+            .lock()
+            .expect("queue lock");
+        assert_eq!(queued_messages.len(), 1);
+        assert_eq!(queued_messages[0].text, "queued after rebase");
+        assert_eq!(
+            app.sessions.sessions()[0].queued_messages,
+            vec!["queued after rebase".to_string()]
         );
     }
 

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -644,13 +644,14 @@ fn is_view_action_allowed(status: Status) -> bool {
 
 /// Returns whether `Enter` can open the chat composer.
 ///
-/// Allowing `Enter` during `InProgress` lets users queue follow-up chat
-/// messages without waiting for the running turn to return to `Review`.
+/// Allowing `Enter` during `InProgress` or `Rebasing` lets users queue
+/// follow-up chat messages without waiting for the active operation to return
+/// to `Review`.
 /// Slash-command shortcuts and other action keys still require
-/// [`is_view_action_allowed`] so terminal or rebasing sessions are not
+/// [`is_view_action_allowed`] so terminal or busy sessions are not
 /// accidentally re-driven.
 fn is_view_chat_allowed(status: Status) -> bool {
-    is_view_action_allowed(status) || matches!(status, Status::InProgress)
+    is_view_action_allowed(status) || matches!(status, Status::InProgress | Status::Rebasing)
 }
 
 /// Returns whether the `d` shortcut can open the diff view.
@@ -1321,6 +1322,27 @@ mod tests {
         assert!(review_allowed);
         assert!(!in_progress_allowed);
         assert!(!done_allowed);
+    }
+
+    #[test]
+    fn test_is_view_chat_allowed_includes_in_progress_and_rebasing() {
+        // Arrange
+        let review_status = Status::Review;
+        let in_progress_status = Status::InProgress;
+        let rebasing_status = Status::Rebasing;
+        let merging_status = Status::Merging;
+
+        // Act
+        let review_allowed = is_view_chat_allowed(review_status);
+        let in_progress_allowed = is_view_chat_allowed(in_progress_status);
+        let rebasing_allowed = is_view_chat_allowed(rebasing_status);
+        let merging_allowed = is_view_chat_allowed(merging_status);
+
+        // Assert
+        assert!(review_allowed);
+        assert!(in_progress_allowed);
+        assert!(rebasing_allowed);
+        assert!(!merging_allowed);
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -34,6 +34,9 @@ const LOADER_SESSION_ID: &str = "loader-session-0001";
 /// Stable id for the seeded running session used by stop-turn tests.
 const RUNNING_STOP_SESSION_ID: &str = "running-stop-0001";
 
+/// Stable id for the seeded rebasing session used by message-queue tests.
+const REBASING_QUEUE_SESSION_ID: &str = "rebasing-queue-0001";
+
 /// Stable id for the seeded clarification-question session used by the
 /// question-resume test.
 const QUESTION_RESUME_SESSION_ID: &str = "question-resume-0001";
@@ -900,6 +903,21 @@ fn seed_running_stop_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error:
             .update_session_reasoning_level(RUNNING_STOP_SESSION_ID, ReasoningLevel::High)
             .await
     })?;
+
+    Ok(())
+}
+
+/// Seeds one rebasing session so message queueing can be exercised without a
+/// live git operation or agent backend.
+fn seed_rebasing_queue_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    common::seed_session(
+        env,
+        SessionSeed::regular(REBASING_QUEUE_SESSION_ID, "gpt-5.5", "main", "Rebasing")
+            .with_title("Rebasing message queue"),
+    )?;
+
+    let worktree_name = &REBASING_QUEUE_SESSION_ID[..8];
+    std::fs::create_dir_all(env.agentty_root.join("wt").join(worktree_name))?;
 
     Ok(())
 }
@@ -2127,6 +2145,46 @@ fn session_queue_chat_messages_during_in_progress_turn() -> E2eResult {
                 assertion::assert_text_in_region(frame, "Enter: reply", &cleared_full);
                 assertion::assert_not_visible(frame, "Ctrl+c: stop");
                 assertion::assert_not_visible(frame, "queued ›");
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify `Enter` opens the composer while a session is `Rebasing` and the
+/// submitted follow-up renders inline as queued work without replacing the
+/// active rebase status.
+#[test]
+fn session_queue_chat_message_during_rebase() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_queue_chat_message_during_rebase")
+        .with_git()
+        .setup(seed_rebasing_queue_session)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("Enter")
+                    .wait_for_text("Rebasing...", 5000)
+                    .wait_for_text("Enter: queue message", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Type your message", 5000)
+                    .write_text("follow up after sync")
+                    .wait_for_text("follow up after sync", 3000)
+                    .press_key("Enter")
+                    .wait_for_text("queued ›", 5000)
+                    .viewing_pause_ms(1000)
+                    .capture_labeled(
+                        "message_queued_during_rebase",
+                        "Follow-up message queued inline while session sync remains active",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Rebasing...", &full);
+                assertion::assert_text_in_region(frame, "queued ›", &full);
+                assertion::assert_text_in_region(frame, "follow up after sync", &full);
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -175,9 +175,11 @@ derived data instead of recomputing the render twice per frame.
 1. The worker marks the operation `running`, checks cancel flags, verifies worktree
    isolation, and delegates to `workflow/turn.rs` or the queued session-sync workflow.
    An **InProgress** sync request can enqueue only through the sender already owned by
-   that worker; it cannot lazily create another worker. The receiver is checked between
-   every pair of retractable queued-chat turns, so a command received during one chat
-   turn waits for that turn and then runs before the remaining chat queue.
+   that worker; it cannot lazily create another worker. The same in-memory chat queue
+   accepts follow-up prompts while the worker is **InProgress** or **Rebasing**, and
+   drains them after the active operation. The receiver is checked between every pair of
+   retractable queued-chat turns, so a command received during one chat turn waits for
+   that turn and then runs before the remaining chat queue.
 1. `workflow/turn.rs` builds a `TurnRequest` and calls `AgentChannel::run_turn()`, which
    streams `TurnEvent` values (loader updates) and returns a `TurnResult`.
 1. `workflow/post_turn.rs` appends the final assistant transcript output, then

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -144,6 +144,9 @@ State-specific differences:
 - **InProgress** sessions use `Enter` to queue a follow-up message and keep `r`
   available to queue session sync behind the running turn. Each `Ctrl+c` retracts the
   newest queued message; when the queue is empty, `Ctrl+c` stops the active turn.
+- **Rebasing** sessions use `Enter` to queue a follow-up message behind the active
+  session sync. Slash commands and branch actions remain unavailable until sync
+  finishes.
 - Root **Review** and **AgentReview** sessions offer `F` to fork the current branch and
   copied transcript history into a new independent session; stacked children hide `F`.
 - **Draft** sessions use `Enter` to add a staged message and `s` to start the staged
@@ -154,8 +157,7 @@ State-specific differences:
 - Review-ready stacked parents with a materialized child keep `Enter`, `m`, and `r`
   while the stack is idle, but hide `/` until the child is terminal or no longer linked.
 - **Done** sessions offer `c` to start a continuation draft (confirmation popup).
-- **Canceled**, **Queued**, **Rebasing**, and **Merging** sessions are read-only (`q`,
-  scroll, help).
+- **Canceled**, **Queued**, and **Merging** sessions are read-only (`q`, scroll, help).
 
 `o` runs the configured `Launch Configurations` entry, or opens a selector popup when
 several are configured. Run Agentty inside `tmux` when you rely on

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -82,7 +82,7 @@ to the assist agent.
 | **AgentReview** | Focused review is generating; `r` cancels it before syncing.     |
 | **Question**    | Agent requested clarification before continuing.                 |
 | **Queued**      | Waiting in the merge queue.                                      |
-| **Rebasing**    | Session branch is rebasing onto its base branch.                 |
+| **Rebasing**    | Session is syncing; follow-up messages queue behind the sync.    |
 | **Merging**     | Changes are being merged into the base branch.                   |
 | **Done**        | Completed and merged; the worktree was removed.                  |
 | **Canceled**    | Canceled by the user; the worktree was removed.                  |
@@ -168,12 +168,13 @@ While a session is **InProgress**, an animated loader row shows transient provid
 thought and tool-status text; the transcript itself updates only after the final turn
 result is parsed and persisted.
 
-Pressing `Enter` during a running turn opens the composer and queues the message inline
-with a `queued ›` prefix. Queued messages dispatch one-by-one as new turns after the
-running turn finishes. Each `Ctrl+c` press retracts the most recently queued message
-(LIFO) without interrupting the running turn; once the queue is empty, the next `Ctrl+c`
-stops the current turn and returns the session to **Review**. The queue is in-memory
-only and is discarded if `agentty` restarts.
+Pressing `Enter` during a running turn or session sync opens the composer and queues the
+message inline with a `queued ›` prefix. Queued messages dispatch one-by-one as new
+turns after the active turn or sync finishes. During **InProgress**, each `Ctrl+c` press
+retracts the most recently queued message (LIFO) without interrupting the running turn;
+once the queue is empty, the next `Ctrl+c` stops the current turn and returns the
+session to **Review**. **Rebasing** keeps cancellation unavailable while still accepting
+queued messages. The queue is in-memory only and is discarded if `agentty` restarts.
 
 While the composer is open, `Tab` moves focus to the chat transcript above it so the
 conversation can be scrolled with `j` / `k`, `g` / `G`, and `Ctrl+D` / `Ctrl+U` without


### PR DESCRIPTION
- Accept follow-up prompts while sessions are `Rebasing` and route them through the in-memory queue.
- Expose the queue composer action while keeping unavailable commands disabled.
- Add unit and E2E coverage and update runtime, keybinding, and workflow documentation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)