### PR TITLE
Session refreshes preserve review publish progress

### DIFF
--- a/crates/agentty/src/app/session/state.rs
+++ b/crates/agentty/src/app/session/state.rs
@@ -105,9 +105,26 @@ impl SessionState {
             .and_then(|session_index| self.sessions.get(session_index))
     }
 
-    /// Replaces the full session snapshot list and rebuilds the cached
-    /// identifier index in one step.
-    pub(crate) fn replace_sessions(&mut self, sessions: Vec<Session>) {
+    /// Replaces persisted session snapshots while retaining in-process
+    /// transient output for sessions that remain loaded.
+    ///
+    /// Database refreshes can observe intermediate workflow persistence, such
+    /// as a published upstream branch before its review-request URL is ready.
+    /// Carrying transient output across that refresh keeps active loaders
+    /// visible until their owning reducer resolves them.
+    pub(crate) fn replace_sessions(&mut self, mut sessions: Vec<Session>) {
+        let transient_messages_by_session_id: HashMap<SessionId, _> = self
+            .sessions
+            .iter()
+            .map(|session| (session.id.clone(), session.transient_messages.clone()))
+            .collect();
+        for session in &mut sessions {
+            if let Some(transient_messages) = transient_messages_by_session_id.get(&session.id) {
+                session.transient_messages.clone_from(transient_messages);
+                session.reconcile_transient_messages();
+            }
+        }
+
         self.session_index_by_id = Self::build_session_index_by_id(&sessions);
         self.sessions = sessions;
     }
@@ -409,7 +426,10 @@ mod tests {
     use crate::domain::selection::SelectionState;
     use crate::domain::session::{Session, SessionHandles, SessionSize, SessionStats, Status};
     use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
-    use crate::domain::transient_message::TransientMessageStore;
+    use crate::domain::transient_message::{
+        TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
+        TransientMessageSlot, TransientMessageStore,
+    };
     use crate::test_support::SessionFixtureBuilder;
 
     struct FixedClock {
@@ -758,6 +778,53 @@ mod tests {
         // Assert
         assert_eq!(state.session_index_for_id("session-1"), None);
         assert_eq!(state.session_index_for_id("session-2"), Some(0));
+    }
+
+    #[test]
+    /// Verifies persisted refreshes retain active workflow loaders.
+    fn replace_sessions_preserves_active_transient_messages() {
+        // Arrange
+        let mut initial_session = SessionFixtureBuilder::new()
+            .id("session-1")
+            .status(Status::Review)
+            .build();
+        initial_session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading("Publishing review request...".to_string()),
+            lifecycle: TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::BranchPublish,
+            turn_position: None,
+        });
+        let mut refreshed_session = SessionFixtureBuilder::new()
+            .id("session-1")
+            .status(Status::Review)
+            .build();
+        refreshed_session.published_upstream_ref = Some("origin/wt/session-1".to_string());
+        let mut state = SessionState::new(
+            HashMap::new(),
+            vec![initial_session],
+            SelectionState::default(),
+            Arc::new(FixedClock::new()),
+            0,
+            0,
+        );
+
+        // Act
+        state.replace_sessions(vec![refreshed_session]);
+
+        // Assert
+        let refreshed_session = &state.sessions[0];
+        assert_eq!(
+            refreshed_session.published_upstream_ref.as_deref(),
+            Some("origin/wt/session-1")
+        );
+        assert_eq!(
+            refreshed_session
+                .transient_messages
+                .get(TransientMessageSlot::BranchPublish)
+                .map(|message| message.body.text()),
+            Some("Publishing review request...")
+        );
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -444,12 +444,14 @@ fn seed_rebase_transcript_session(env: &BuilderEnv) -> Result<(), Box<dyn std::e
     Ok(())
 }
 
-/// Seeds a review-ready worktree whose delayed successful push keeps the manual
-/// publish task visible long enough to verify session-chat responsiveness.
+/// Seeds a review-ready worktree whose delayed successful publish keeps the
+/// manual task active beyond the upstream-ref refresh observed by the feature
+/// scenario.
 fn seed_slow_successful_review_request_publish(
     env: &BuilderEnv,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    seed_review_ready_session_with_review_request(env)?;
+    seed_review_ready_session(env)?;
+    seed_review_worktree_with_diff(env)?;
     let session_worktree = env.agentty_root.join("wt").join("review-s");
     run_git(&session_worktree, &["branch", "-m", "wt/review-s"])?;
 
@@ -471,6 +473,40 @@ exec '{}' "$@"
     std::fs::write(&git_path, script)?;
     #[cfg(unix)]
     std::fs::set_permissions(&git_path, std::fs::Permissions::from_mode(0o755))?;
+
+    let gh_path = env.stub_bin.join("gh");
+    std::fs::write(
+        &gh_path,
+        r#"#!/bin/sh
+marker_path="${0}.created"
+case "$*" in
+  *"auth status"*)
+    exit 0
+    ;;
+  *"api"*"/pulls"*)
+    if [ -f "$marker_path" ]; then
+      printf '%s\n' '[{"number":42}]'
+    else
+      printf '%s\n' '[]'
+    fi
+    ;;
+  *"pr create"*)
+    # Exceeds both 3 s scenario wait budgets plus the 5.5 s mid-flight pause.
+    sleep 15
+    touch "$marker_path"
+    ;;
+  *"pr view"*)
+    printf '%s\n' '{"number":42,"title":"Review-ready session shortcuts","state":"OPEN","url":"https://github.com/agentty-xyz/agentty/pull/42","baseRefName":"main","headRefName":"wt/review-s","isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"REVIEW_REQUIRED","mergedAt":null}'
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 1
+    ;;
+esac
+"#,
+    )?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&gh_path, std::fs::Permissions::from_mode(0o755))?;
 
     Ok(())
 }
@@ -3494,7 +3530,12 @@ fn review_request_publish_runs_in_background() -> E2eResult {
                         "Session help remains available while publishing",
                     )
                     .press_key("q")
-                    .wait_for_text("[Review Request] Created PR", 10000)
+                    .viewing_pause_ms(5500)
+                    .capture_labeled(
+                        "background_publish_waiting_for_url",
+                        "Review-request publish progress remains until its URL is ready",
+                    )
+                    .wait_for_text("[Review Request] Created PR", 20000)
                     .capture_labeled(
                         "background_publish_finished",
                         "Review-request link recorded in session transcript history",
@@ -3513,6 +3554,14 @@ fn review_request_publish_runs_in_background() -> E2eResult {
                 let help_frame = common::frame_from_capture(&report.captures[1]);
                 let help_full = Region::full(help_frame.cols(), help_frame.rows());
                 assertion::assert_text_in_region(&help_frame, "Keybindings", &help_full);
+
+                let waiting_frame = common::frame_from_capture(&report.captures[2]);
+                let waiting_full = Region::full(waiting_frame.cols(), waiting_frame.rows());
+                assertion::assert_text_in_region(
+                    &waiting_frame,
+                    "Publishing review request...",
+                    &waiting_full,
+                );
 
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -343,13 +343,14 @@ publish popup for the linked forge review request:
 - Agentty publishes with `git push --force-with-lease`, then creates or refreshes the
   linked review request. After confirmation, the popup closes and publishing continues
   in the background while session chat remains interactive. Inline progress is replaced
-  by a one-line `[Review Request] Created PR URL` or `[Review Request] Created MR URL`
-  transcript notice recorded at that point in session history, or by failure details
-  when the task finishes; `p` stays hidden while that publish is active. Later turns do
-  not move or reconstruct the creation notice. GitHub projects publish pull requests;
-  GitLab projects publish merge requests. Manual publishing and completed-turn auto-push
-  share one per-session branch-operation lock, so whichever starts later waits instead
-  of force-pushing the same branch concurrently.
+  only after the forge URL is ready, including across intermediate session refreshes. It
+  becomes a one-line `[Review Request] Created PR URL` or
+  `[Review Request] Created MR URL` transcript notice recorded at that point in session
+  history, or failure details when the task finishes; `p` stays hidden while that
+  publish is active. Later turns do not move or reconstruct the creation notice. GitHub
+  projects publish pull requests; GitLab projects publish merge requests. Manual
+  publishing and completed-turn auto-push share one per-session branch-operation lock,
+  so whichever starts later waits instead of force-pushing the same branch concurrently.
 - Stacked child review requests target the parent review branch while the parent link is
   active.
 - When no review request is linked yet, only an open request for the same branch is


### PR DESCRIPTION
- Retain active transient loaders across persisted session refreshes.
- Extend review-request E2E coverage through URL creation.
- Document progress visibility during background publishing.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)