### PR TITLE
Place queued sync notices after active turns

### DIFF
--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -23,7 +23,7 @@ use crate::domain::file_entry::FileEntry;
 use crate::domain::question::QuestionItem;
 use crate::domain::session::{
     DailyActivity, FollowUpTaskAction, ReviewRequest, Session, SessionFollowUpTask, SessionId,
-    SessionStats,
+    SessionStats, Status,
 };
 use crate::domain::session_message::SessionMessageKind;
 use crate::domain::transcript_notice::TranscriptNotice;
@@ -612,8 +612,13 @@ impl SessionManager {
                 .get(TransientMessageSlot::WorkflowNotice)
                 .map(|message| format!("{}\n\n{notice}", message.body.text()))
                 .unwrap_or(notice);
+            let anchor = if matches!(session.status, Status::InProgress | Status::Queued) {
+                TransientMessageAnchor::AfterActiveTurn
+            } else {
+                TransientMessageAnchor::AfterCompletedTurn
+            };
             session.transient_messages.upsert(TransientMessage {
-                anchor: TransientMessageAnchor::AfterCompletedTurn,
+                anchor,
                 body: TransientMessageBody::Markdown(notice),
                 lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
                 slot: TransientMessageSlot::WorkflowNotice,

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -31,7 +31,7 @@ use crate::domain::session::{
 use crate::domain::session_message::SessionTranscript;
 use crate::domain::setting::SettingName;
 use crate::domain::transient_message::{
-    TransientMessageBody, TransientMessageSlot, TransientMessageStore,
+    TransientMessageAnchor, TransientMessageBody, TransientMessageSlot, TransientMessageStore,
 };
 use crate::infra::clock::RealClock;
 use crate::infra::db::AppRepositories;
@@ -795,6 +795,32 @@ fn test_append_stacked_rebase_failure_notices_updates_affected_child() {
             .map(|message| message.body.text()),
         Some("[Sync Error] Stacked child auto-sync failed: Session handles not found")
     );
+}
+
+#[test]
+fn test_append_workflow_notice_anchors_active_status_notices_after_active_turn() {
+    for status in [Status::InProgress, Status::Queued] {
+        // Arrange
+        let mut session_manager = test_session_manager("session-id", None);
+        session_manager.sessions_mut()[0].status = status;
+
+        // Act
+        session_manager.append_workflow_notice(
+            "session-id",
+            "[Sync] Queued until the current turn finishes.".to_string(),
+        );
+
+        // Assert
+        let workflow_notice = session_manager.sessions()[0]
+            .transient_messages
+            .get(TransientMessageSlot::WorkflowNotice)
+            .expect("workflow notice should be present");
+        assert_eq!(
+            workflow_notice.anchor,
+            TransientMessageAnchor::AfterActiveTurn,
+            "unexpected anchor for {status}"
+        );
+    }
 }
 
 #[test]

--- a/crates/agentty/src/domain/transient_message.rs
+++ b/crates/agentty/src/domain/transient_message.rs
@@ -24,6 +24,8 @@ pub(crate) enum TransientMessageSlot {
 pub(crate) enum TransientMessageAnchor {
     /// Immediately after durable content from the latest completed turn.
     AfterCompletedTurn,
+    /// Immediately after content from the active user turn.
+    AfterActiveTurn,
     /// At the end of the output, beside other active status rows.
     Tail,
 }

--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -251,13 +251,14 @@ enum SessionOutputSeparator {
     AfterPreviousContent,
 }
 
-const SESSION_OUTPUT_BLOCK_ORDER: [SessionOutputBlock; 8] = [
+const SESSION_OUTPUT_BLOCK_ORDER: [SessionOutputBlock; 9] = [
     SessionOutputBlock::CompletedTranscript,
     SessionOutputBlock::TrailingTranscriptNotice(
         TrailingTranscriptNoticePlacement::BeforeActiveTurn,
     ),
     SessionOutputBlock::Transient(TransientMessageAnchor::AfterCompletedTurn),
     SessionOutputBlock::ActiveTurn,
+    SessionOutputBlock::Transient(TransientMessageAnchor::AfterActiveTurn),
     SessionOutputBlock::QueuedMessage,
     SessionOutputBlock::TrailingTranscriptNotice(TrailingTranscriptNoticePlacement::AfterReview),
     SessionOutputBlock::Transient(TransientMessageAnchor::Tail),
@@ -3273,6 +3274,57 @@ mod tests {
         assert!(commit_index < prompt_index);
         assert!(prompt_index < queued_index);
         assert!(text.contains("        with context"));
+    }
+
+    #[test]
+    fn test_output_lines_in_progress_session_places_notice_after_active_turn() {
+        // Arrange
+        let mut session = session_fixture();
+        set_conversation_transcript(
+            &mut session,
+            vec![
+                (SessionMessageKind::UserPrompt, "previous turn"),
+                (SessionMessageKind::AssistantAnswer, "previous answer"),
+                (SessionMessageKind::UserPrompt, "current turn"),
+                (SessionMessageKind::AssistantAnswer, "working"),
+            ],
+        );
+        session.status = Status::InProgress;
+        session.queued_messages = vec!["queued follow-up".to_string()];
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::AfterActiveTurn,
+            body: TransientMessageBody::Markdown(
+                "[Sync] Queued until the current turn finishes.".to_string(),
+            ),
+            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::WorkflowNotice,
+            turn_position: session.latest_user_prompt_position(),
+        });
+
+        // Act
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 8), line_context(), None);
+        let text = lines
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let previous_answer_index = text
+            .find("previous answer")
+            .expect("previous answer should be rendered");
+        let current_turn_index = text
+            .find("current turn")
+            .expect("current turn should be rendered");
+        let notice_index = text
+            .find("[Sync] Queued until the current turn finishes.")
+            .expect("queued sync notice should be rendered");
+        let queued_message_index = text
+            .find("queued › queued follow-up")
+            .expect("queued follow-up should be rendered");
+
+        // Assert
+        assert!(previous_answer_index < current_turn_index);
+        assert!(current_turn_index < notice_index);
+        assert!(notice_index < queued_message_index);
     }
 
     /// Verifies an active prompt at the start of the transcript hides stale

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -2178,6 +2178,19 @@ fn session_running_turn_shows_sync_shortcut() -> E2eResult {
                     &queued_full,
                 );
                 assertion::assert_text_in_region(&queued_frame, "Ctrl+c: stop", &queued_full);
+                let active_turn_row = queued_frame
+                    .find_text("Keep the active turn running")
+                    .first()
+                    .expect("missing active turn prompt")
+                    .rect
+                    .row;
+                let queued_sync_row = queued_frame
+                    .find_text("will rebase after the current turn finishes")
+                    .first()
+                    .expect("missing queued sync notice")
+                    .rect
+                    .row;
+                assert!(active_turn_row < queued_sync_row);
 
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, QUEUED_SYNC_TURN_ANSWER, &full);

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -187,7 +187,7 @@ the queued sync command starts. The existing worker must accept the request; Age
 never creates a second worker from an **InProgress** status just to start sync. If sync
 arrives while Agentty is draining queued chat, the active chat turn finishes before sync
 runs, and sync runs before the remaining queued messages. Agentty shows a `[Sync]`
-notice in the session output while the rebase is queued, and repeated `r` presses keep
+notice below the active turn while the rebase is queued, and repeated `r` presses keep
 the single queued rebase instead of adding duplicates. Session sync reserves
 branch-publish ownership before it queues or starts, and retains that ownership through
 its post-rebase push. A completed turn or subsequent sync therefore cannot start a


### PR DESCRIPTION
- Anchor workflow notices after the active turn for `InProgress` and `Queued` sessions.
- Render `AfterActiveTurn` messages before queued follow-up messages.
- Add unit and E2E coverage and document the notice placement.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)