### PR TITLE
Unifies text editing across input modes

### DIFF
--- a/crates/agentty/src/app/prompt_intent.rs
+++ b/crates/agentty/src/app/prompt_intent.rs
@@ -5,6 +5,7 @@ use tracing::warn;
 
 use crate::app::{App, ReviewCacheEntry, diff_content_hash};
 use crate::domain::agent::{AgentKind, ReasoningLevel};
+use crate::domain::composer::PromptAttachment;
 use crate::domain::review;
 use crate::domain::session::{SessionId, Status};
 use crate::domain::transcript_notice::TranscriptNotice;
@@ -102,7 +103,11 @@ impl App {
             return;
         }
 
+        let archived_prompt = self.archived_prompt_attachments();
         let prompt = self.take_submitted_turn_prompt();
+        if let Some(archived_prompt) = archived_prompt {
+            self.cleanup_prompt_attachment_files(&archived_prompt).await;
+        }
         if prompt.is_empty() {
             return;
         }
@@ -134,7 +139,7 @@ impl App {
         match selection {
             Some(PromptSuggestionSelection::Command("/apply")) => {
                 if self.handle_apply_prompt_command(context).await {
-                    self.reset_prompt_slash_input();
+                    self.reset_prompt_slash_input().await;
                 } else {
                     self.reset_prompt_slash_state();
                 }
@@ -171,12 +176,12 @@ impl App {
                 }
             }
             Some(PromptSuggestionSelection::Model(selected_agent)) => {
-                self.reset_prompt_slash_input();
+                self.reset_prompt_slash_input().await;
                 self.update_prompt_session_model(context, selected_agent)
                     .await;
             }
             Some(PromptSuggestionSelection::Reasoning(reasoning_level)) => {
-                self.reset_prompt_slash_input();
+                self.reset_prompt_slash_input().await;
                 self.update_prompt_session_reasoning_level(context, reasoning_level)
                     .await;
             }
@@ -204,7 +209,10 @@ impl App {
             .await
         {
             Ok(persisted_image) => {
-                self.insert_pasted_image_placeholder(persisted_image.local_image_path);
+                let unreachable_attachments =
+                    self.insert_pasted_image_placeholder(persisted_image.local_image_path);
+                self.cleanup_prompt_attachments(unreachable_attachments)
+                    .await;
             }
             Err(error) => {
                 self.append_prompt_status_line(
@@ -219,7 +227,10 @@ impl App {
 
     /// Inserts one persisted image placeholder into the prompt input and
     /// records the attachment metadata in prompt state.
-    pub(crate) fn insert_pasted_image_placeholder(&mut self, local_image_path: PathBuf) {
+    pub(crate) fn insert_pasted_image_placeholder(
+        &mut self,
+        local_image_path: PathBuf,
+    ) -> Vec<PromptAttachment> {
         if let AppMode::Prompt {
             at_mention_state,
             attachment_state,
@@ -237,7 +248,34 @@ impl App {
                 local_image_path,
             );
             *at_mention_state = None;
+
+            return attachment_state.prune_unreachable(input);
         }
+
+        Vec::new()
+    }
+
+    /// Removes image files whose attachment identities are no longer
+    /// reachable through the prompt input's bounded undo/redo history.
+    pub(crate) async fn cleanup_prompt_attachments(&self, attachments: Vec<PromptAttachment>) {
+        if attachments.is_empty() {
+            return;
+        }
+
+        let attachments = attachments
+            .into_iter()
+            .map(|attachment| TurnPromptAttachment {
+                local_image_path: attachment.local_image_path,
+                placeholder: attachment.placeholder,
+            })
+            .collect();
+        let prompt = TurnPrompt {
+            attachments,
+            text: String::new(),
+            text_source: TurnPromptTextSource::UserPrompt,
+        };
+
+        self.cleanup_prompt_attachment_files(&prompt).await;
     }
 
     /// Handles the cancel intent emitted by prompt-mode key routing.
@@ -247,7 +285,7 @@ impl App {
     /// a blank backing session, and otherwise restores session view.
     pub(crate) async fn handle_prompt_cancel_intent(&mut self, context: &PromptIntentContext) {
         if context.is_slash_command() {
-            self.reset_prompt_slash_input();
+            self.reset_prompt_slash_input().await;
 
             return;
         }
@@ -310,6 +348,35 @@ impl App {
         }
     }
 
+    /// Builds a cleanup-only prompt for image attachments currently absent
+    /// from the editable text but retained for undo.
+    fn archived_prompt_attachments(&self) -> Option<TurnPrompt> {
+        let AppMode::Prompt {
+            attachment_state, ..
+        } = &self.mode
+        else {
+            return None;
+        };
+        if attachment_state.archived_attachments.is_empty() {
+            return None;
+        }
+
+        let attachments = attachment_state
+            .archived_attachments
+            .iter()
+            .map(|attachment| TurnPromptAttachment {
+                local_image_path: attachment.local_image_path.clone(),
+                placeholder: attachment.placeholder.clone(),
+            })
+            .collect();
+
+        Some(TurnPrompt {
+            attachments,
+            text: String::new(),
+            text_source: TurnPromptTextSource::UserPrompt,
+        })
+    }
+
     /// Routes one prepared turn prompt through the lifecycle path for the
     /// active prompt context.
     async fn submit_turn_prompt_for_context(
@@ -365,9 +432,11 @@ impl App {
             .is_some_and(|session| matches!(session.status, Status::InProgress | Status::Rebasing))
     }
 
-    /// Clears the slash-command buffer after one prompt slash action is
-    /// accepted.
-    fn reset_prompt_slash_input(&mut self) {
+    /// Clears the slash-command buffer and cleans up attachments removed with
+    /// it after one prompt slash action is accepted or canceled.
+    async fn reset_prompt_slash_input(&mut self) {
+        self.cleanup_prompt_attachment_state().await;
+
         if let AppMode::Prompt {
             input, slash_state, ..
         } = &mut self.mode
@@ -465,6 +534,7 @@ impl App {
                 let attachments = attachment_state
                     .attachments
                     .iter()
+                    .chain(&attachment_state.archived_attachments)
                     .map(|attachment| TurnPromptAttachment {
                         local_image_path: attachment.local_image_path.clone(),
                         placeholder: attachment.placeholder.clone(),
@@ -611,6 +681,11 @@ pub(crate) fn build_apply_review_prompt(suggestions: &str) -> TurnPrompt {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::composer::{
+        PromptAttachment, PromptAttachmentState, PromptHistoryState, PromptSlashState,
+    };
+    use crate::domain::input::InputState;
+    use crate::presentation::app_mode::ChatFocus;
 
     /// Verifies `/apply` submits the checked-in markdown prompt with the
     /// review suggestions fenced as data.
@@ -651,5 +726,60 @@ mod tests {
         // Assert
         assert!(prompt.text.contains("````text\n"));
         assert!(prompt.text.contains("```markdown\nexample\n```"));
+    }
+
+    /// Ensures image files retained for input undo are included in the
+    /// cleanup payload produced when the prompt is submitted.
+    #[tokio::test]
+    async fn test_archived_prompt_attachments_builds_cleanup_prompt() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let attachment = PromptAttachment::new(1, PathBuf::from("/tmp/image-1.png"));
+        let expected_placeholder = attachment.placeholder.clone();
+        app.mode = AppMode::Prompt {
+            at_mention_state: None,
+            attachment_state: PromptAttachmentState {
+                archived_attachments: vec![attachment],
+                ..PromptAttachmentState::default()
+            },
+            focus: ChatFocus::Input,
+            history_state: PromptHistoryState::new(Vec::new()),
+            input: InputState::default(),
+            scroll_offset: None,
+            session_id: "session-id".into(),
+            slash_state: PromptSlashState::default(),
+        };
+
+        // Act
+        let prompt = app
+            .archived_prompt_attachments()
+            .expect("archived attachment should produce a cleanup prompt");
+
+        // Assert
+        assert_eq!(prompt.attachments.len(), 1);
+        assert_eq!(
+            prompt.attachments[0].local_image_path,
+            PathBuf::from("/tmp/image-1.png")
+        );
+        assert_eq!(prompt.attachments[0].placeholder, expected_placeholder);
+        assert!(prompt.text.is_empty());
+        assert_eq!(prompt.text_source, TurnPromptTextSource::UserPrompt);
+    }
+
+    #[tokio::test]
+    async fn test_non_prompt_mode_has_no_composer_attachments() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.mode = AppMode::List;
+
+        // Act
+        let pruned = app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-1.png"));
+        let archived_prompt = app.archived_prompt_attachments();
+        let submission = app.take_submitted_turn_prompt();
+
+        // Assert
+        assert!(pruned.is_empty());
+        assert!(archived_prompt.is_none());
+        assert!(submission.is_empty());
     }
 }

--- a/crates/agentty/src/app/setting.rs
+++ b/crates/agentty/src/app/setting.rs
@@ -4,7 +4,7 @@ use crate::app::AppServices;
 use crate::domain::agent::{
     self, AgentKind, AgentModel, AgentSelection, AgentSelectionMetadata, ReasoningLevel,
 };
-use crate::domain::input::InputState;
+use crate::domain::input::{InputCommand, InputState};
 use crate::domain::selection::SelectionState;
 use crate::domain::setting::SettingName;
 use crate::domain::theme::ColorTheme;
@@ -602,59 +602,16 @@ impl SettingsManager {
         editor.mode = LaunchConfigurationListEditorMode::Browse;
     }
 
-    /// Appends one character to the active launch-configuration input field.
-    pub fn append_launch_configuration_input_character(&mut self, character: char) {
-        let Some(editor) = &mut self.launch_configuration_list_editor else {
-            return;
-        };
-
-        if editor.is_input_mode() {
-            editor.input.insert_char(character);
-        }
-    }
-
-    /// Removes the character before the cursor in the active
-    /// launch-configuration input field.
-    pub fn remove_launch_configuration_input_character(&mut self) {
-        let Some(editor) = &mut self.launch_configuration_list_editor else {
-            return;
-        };
-
-        if editor.is_input_mode() {
-            editor.input.delete_backward();
-        }
-    }
-
-    /// Removes the character at the cursor in the active launch-configuration
+    /// Applies one shared editing command to the active launch-configuration
     /// input field.
-    pub fn delete_launch_configuration_input_character(&mut self) {
+    pub fn apply_launch_configuration_input_command(&mut self, command: InputCommand) {
         let Some(editor) = &mut self.launch_configuration_list_editor else {
             return;
         };
 
         if editor.is_input_mode() {
-            editor.input.delete_forward();
+            editor.input.apply(command);
         }
-    }
-
-    /// Moves the launch-configuration input cursor one character to the left.
-    pub fn move_launch_configuration_input_cursor_left(&mut self) {
-        self.move_launch_configuration_input_cursor(LaunchConfigurationInputCursorDirection::Left);
-    }
-
-    /// Moves the launch-configuration input cursor one character to the right.
-    pub fn move_launch_configuration_input_cursor_right(&mut self) {
-        self.move_launch_configuration_input_cursor(LaunchConfigurationInputCursorDirection::Right);
-    }
-
-    /// Moves the launch-configuration input cursor to the start of the field.
-    pub fn move_launch_configuration_input_cursor_home(&mut self) {
-        self.move_launch_configuration_input_cursor(LaunchConfigurationInputCursorDirection::Home);
-    }
-
-    /// Moves the launch-configuration input cursor to the end of the field.
-    pub fn move_launch_configuration_input_cursor_end(&mut self) {
-        self.move_launch_configuration_input_cursor(LaunchConfigurationInputCursorDirection::End);
     }
 
     /// Confirms the active add/edit input and persists the normalized command
@@ -962,27 +919,6 @@ impl SettingsManager {
         };
     }
 
-    /// Moves the launch-configuration input cursor in the requested direction.
-    fn move_launch_configuration_input_cursor(
-        &mut self,
-        direction: LaunchConfigurationInputCursorDirection,
-    ) {
-        let Some(editor) = &mut self.launch_configuration_list_editor else {
-            return;
-        };
-
-        if !editor.is_input_mode() {
-            return;
-        }
-
-        match direction {
-            LaunchConfigurationInputCursorDirection::End => editor.input.move_end(),
-            LaunchConfigurationInputCursorDirection::Home => editor.input.move_home(),
-            LaunchConfigurationInputCursorDirection::Left => editor.input.move_left(),
-            LaunchConfigurationInputCursorDirection::Right => editor.input.move_right(),
-        }
-    }
-
     /// Applies the active add/edit input to the command list.
     fn apply_launch_configuration_input(&mut self) -> bool {
         let Some(editor) = &mut self.launch_configuration_list_editor else {
@@ -1277,15 +1213,6 @@ impl SettingsManager {
 enum LaunchConfigurationListDirection {
     Next,
     Previous,
-}
-
-/// Launch-configuration editor input cursor movement direction.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum LaunchConfigurationInputCursorDirection {
-    End,
-    Home,
-    Left,
-    Right,
 }
 
 /// Launch-configuration editor reorder direction.
@@ -2483,7 +2410,7 @@ mod tests {
         select_row(&mut manager, 6);
         manager.handle_enter();
         manager.start_adding_launch_configuration();
-        manager.append_launch_configuration_input_character('n');
+        manager.apply_launch_configuration_input_command(InputCommand::Insert('n'));
 
         // Act
         manager.cancel_launch_configuration_input();
@@ -2507,12 +2434,9 @@ mod tests {
         manager.start_adding_launch_configuration();
 
         // Act
-        manager.append_launch_configuration_input_character(' ');
-        manager.append_launch_configuration_input_character('n');
-        manager.append_launch_configuration_input_character('v');
-        manager.append_launch_configuration_input_character('i');
-        manager.append_launch_configuration_input_character('m');
-        manager.append_launch_configuration_input_character(' ');
+        manager.apply_launch_configuration_input_command(InputCommand::InsertText(
+            " nvim ".to_string(),
+        ));
         manager.confirm_launch_configuration_input(&services).await;
 
         // Assert
@@ -2540,10 +2464,10 @@ mod tests {
         manager.start_editing_selected_launch_configuration();
 
         for _ in 0.."npm run dev".chars().count() {
-            manager.remove_launch_configuration_input_character();
+            manager.apply_launch_configuration_input_command(InputCommand::DeleteBackward);
         }
         for character in "lazygit".chars() {
-            manager.append_launch_configuration_input_character(character);
+            manager.apply_launch_configuration_input_command(InputCommand::Insert(character));
         }
 
         // Act
@@ -2573,7 +2497,7 @@ mod tests {
         manager.start_editing_selected_launch_configuration();
 
         for _ in 0.."cargo test".chars().count() {
-            manager.remove_launch_configuration_input_character();
+            manager.apply_launch_configuration_input_command(InputCommand::DeleteBackward);
         }
 
         // Act
@@ -2723,13 +2647,13 @@ mod tests {
         // Act
         manager.start_adding_launch_configuration();
         manager.start_editing_selected_launch_configuration();
-        manager.append_launch_configuration_input_character('n');
-        manager.remove_launch_configuration_input_character();
-        manager.delete_launch_configuration_input_character();
-        manager.move_launch_configuration_input_cursor_left();
-        manager.move_launch_configuration_input_cursor_right();
-        manager.move_launch_configuration_input_cursor_home();
-        manager.move_launch_configuration_input_cursor_end();
+        manager.apply_launch_configuration_input_command(InputCommand::Insert('n'));
+        manager.apply_launch_configuration_input_command(InputCommand::DeleteBackward);
+        manager.apply_launch_configuration_input_command(InputCommand::DeleteForward);
+        manager.apply_launch_configuration_input_command(InputCommand::MoveLeft);
+        manager.apply_launch_configuration_input_command(InputCommand::MoveRight);
+        manager.apply_launch_configuration_input_command(InputCommand::MoveHome);
+        manager.apply_launch_configuration_input_command(InputCommand::MoveEnd);
         manager.confirm_launch_configuration_input(&services).await;
         manager
             .delete_selected_launch_configuration(&services)

--- a/crates/agentty/src/domain/composer.rs
+++ b/crates/agentty/src/domain/composer.rs
@@ -47,6 +47,13 @@ pub enum PromptSuggestionSelection {
     Reasoning(ReasoningLevel),
 }
 
+/// Concrete character location owned by an attachment in one input revision.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct AttachmentRevision {
+    revision: u64,
+    start: usize,
+}
+
 /// Inline attachment metadata for one pasted local image placeholder.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PromptAttachment {
@@ -56,6 +63,8 @@ pub struct PromptAttachment {
     pub local_image_path: PathBuf,
     /// Placeholder token inserted into the prompt composer text.
     pub placeholder: String,
+    current_start: Option<usize>,
+    valid_locations: Vec<AttachmentRevision>,
 }
 
 impl PromptAttachment {
@@ -64,8 +73,10 @@ impl PromptAttachment {
     pub fn new(attachment_number: usize, local_image_path: PathBuf) -> Self {
         Self {
             attachment_number,
+            current_start: None,
             local_image_path,
             placeholder: Self::placeholder_for(attachment_number),
+            valid_locations: Vec::new(),
         }
     }
 
@@ -73,6 +84,51 @@ impl PromptAttachment {
     #[must_use]
     pub fn placeholder_for(attachment_number: usize) -> String {
         format!("[Image #{attachment_number}]")
+    }
+
+    /// Records the concrete placeholder occurrence owned by this attachment
+    /// in one input revision.
+    fn remember_revision(&mut self, revision: u64) {
+        let Some(start) = self.current_start else {
+            return;
+        };
+        if !self
+            .valid_locations
+            .iter()
+            .any(|location| location.revision == revision)
+        {
+            self.valid_locations
+                .push(AttachmentRevision { revision, start });
+        }
+    }
+
+    /// Restores the concrete placeholder occurrence owned in `revision`.
+    fn restore_revision(&mut self, revision: u64) {
+        self.current_start = self
+            .valid_locations
+            .iter()
+            .find(|location| location.revision == revision)
+            .map(|location| location.start);
+    }
+
+    /// Updates the owned placeholder occurrence across one text edit.
+    fn apply_edit(&mut self, old_start: usize, old_end: usize, new_end: usize) {
+        let Some(current_start) = self.current_start else {
+            return;
+        };
+        let current_end = current_start + self.placeholder.chars().count();
+
+        if old_end <= current_start {
+            let removed_length = old_end - old_start;
+            let inserted_length = new_end - old_start;
+            self.current_start = Some(if inserted_length >= removed_length {
+                current_start + inserted_length - removed_length
+            } else {
+                current_start - (removed_length - inserted_length)
+            });
+        } else if old_start < current_end {
+            self.current_start = None;
+        }
     }
 }
 
@@ -96,6 +152,9 @@ impl PromptComposerSubmission {
 /// UI state for pasted local-image attachments in prompt mode.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PromptAttachmentState {
+    /// Deleted attachments retained while input undo history can restore their
+    /// placeholders.
+    pub archived_attachments: Vec<PromptAttachment>,
     /// Attachments in the same order their placeholders were inserted.
     pub attachments: Vec<PromptAttachment>,
     /// Next placeholder number that should be assigned to a pasted image.
@@ -105,8 +164,13 @@ pub struct PromptAttachmentState {
 impl PromptAttachmentState {
     /// Registers a pasted local image and returns the placeholder inserted
     /// into the prompt input text.
-    pub fn register_local_image(&mut self, local_image_path: PathBuf) -> String {
-        let attachment = PromptAttachment::new(self.next_attachment_number, local_image_path);
+    pub fn register_local_image(
+        &mut self,
+        local_image_path: PathBuf,
+        placeholder_start: usize,
+    ) -> String {
+        let mut attachment = PromptAttachment::new(self.next_attachment_number, local_image_path);
+        attachment.current_start = Some(placeholder_start);
         let placeholder = attachment.placeholder.clone();
 
         self.attachments.push(attachment);
@@ -123,25 +187,121 @@ impl PromptAttachmentState {
             .find(|attachment| attachment.placeholder == placeholder)
     }
 
-    /// Recomputes the next placeholder number by reusing the smallest missing
-    /// positive attachment number.
+    /// Recomputes the next placeholder number after all active and archived
+    /// attachment numbers.
     pub fn refresh_next_attachment_number(&mut self) {
-        let mut next_attachment_number = 1;
-
-        while self
+        self.next_attachment_number = self
             .attachments
             .iter()
-            .any(|attachment| attachment.attachment_number == next_attachment_number)
-        {
-            next_attachment_number += 1;
+            .chain(&self.archived_attachments)
+            .map(|attachment| attachment.attachment_number)
+            .max()
+            .unwrap_or_default()
+            .saturating_add(1);
+    }
+
+    /// Associates currently active attachments with the current input
+    /// revision before a text mutation changes it.
+    pub fn remember_current_revision(&mut self, input: &InputState) {
+        for attachment in &mut self.attachments {
+            attachment.remember_revision(input.revision());
+        }
+    }
+
+    /// Reconciles concrete attachment occurrences after one normal text edit
+    /// without activating archived images from lookalike placeholder text.
+    pub fn sync_after_edit(
+        &mut self,
+        input: &InputState,
+        old_start: usize,
+        old_end: usize,
+        new_end: usize,
+    ) {
+        for attachment in &mut self.attachments {
+            attachment.apply_edit(old_start, old_end, new_end);
         }
 
-        self.next_attachment_number = next_attachment_number;
+        let (mut active, removed): (Vec<_>, Vec<_>) = std::mem::take(&mut self.attachments)
+            .into_iter()
+            .partition(|attachment| attachment.current_start.is_some());
+        for attachment in &mut active {
+            attachment.remember_revision(input.revision());
+        }
+
+        self.attachments = active;
+        self.archived_attachments.extend(removed);
+        self.archived_attachments
+            .sort_by_key(|attachment| attachment.attachment_number);
+    }
+
+    /// Restores attachment membership for the exact input revision reached
+    /// through undo or redo.
+    pub fn sync_after_history_restore(&mut self, input: &InputState) {
+        let mut tracked_attachments = std::mem::take(&mut self.attachments);
+        tracked_attachments.append(&mut self.archived_attachments);
+        tracked_attachments.sort_by_key(|attachment| attachment.attachment_number);
+
+        for attachment in &mut tracked_attachments {
+            attachment.restore_revision(input.revision());
+        }
+
+        (self.attachments, self.archived_attachments) = tracked_attachments
+            .into_iter()
+            .partition(|attachment| attachment.current_start.is_some());
+    }
+
+    /// Archives every current attachment while prompt-history navigation is
+    /// showing a previously submitted text entry.
+    pub fn archive_current(&mut self) {
+        for attachment in &mut self.attachments {
+            attachment.current_start = None;
+        }
+        self.archived_attachments.append(&mut self.attachments);
+        self.archived_attachments
+            .sort_by_key(|attachment| attachment.attachment_number);
+    }
+
+    /// Restores draft attachment occurrences from `draft_revision` into the
+    /// input's new current revision after prompt-history navigation.
+    pub fn restore_draft_revision(&mut self, draft_revision: u64, input: &InputState) {
+        let mut tracked_attachments = std::mem::take(&mut self.attachments);
+        tracked_attachments.append(&mut self.archived_attachments);
+        tracked_attachments.sort_by_key(|attachment| attachment.attachment_number);
+        for attachment in &mut tracked_attachments {
+            attachment.restore_revision(draft_revision);
+            attachment.remember_revision(input.revision());
+        }
+
+        (self.attachments, self.archived_attachments) = tracked_attachments
+            .into_iter()
+            .partition(|attachment| attachment.current_start.is_some());
+    }
+
+    /// Drops archived attachments whose valid revisions have all fallen out
+    /// of bounded input undo/redo history and returns them for file cleanup.
+    pub fn prune_unreachable(&mut self, input: &InputState) -> Vec<PromptAttachment> {
+        for attachment in self
+            .attachments
+            .iter_mut()
+            .chain(&mut self.archived_attachments)
+        {
+            attachment
+                .valid_locations
+                .retain(|location| input.retains_revision(location.revision));
+        }
+
+        let (retained, unreachable) = std::mem::take(&mut self.archived_attachments)
+            .into_iter()
+            .partition(|attachment| !attachment.valid_locations.is_empty());
+        self.archived_attachments = retained;
+
+        unreachable
     }
 
     /// Clears all tracked attachments and resets numbering back to the first
     /// placeholder.
     pub fn reset(&mut self) {
+        self.archived_attachments.clear();
         self.attachments.clear();
         self.next_attachment_number = 1;
     }
@@ -152,6 +312,7 @@ impl Default for PromptAttachmentState {
     /// starting at 1.
     fn default() -> Self {
         Self {
+            archived_attachments: Vec::new(),
             attachments: Vec::new(),
             next_attachment_number: 1,
         }
@@ -161,6 +322,8 @@ impl Default for PromptAttachmentState {
 /// UI state for navigating previously sent prompts with `Up` and `Down`.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct PromptHistoryState {
+    /// Input revision containing the attachment membership of `draft_text`.
+    pub draft_input_revision: Option<u64>,
     /// Draft input captured before entering history navigation.
     pub draft_text: Option<String>,
     /// Previously sent user prompts in chronological order.
@@ -174,6 +337,7 @@ impl PromptHistoryState {
     #[must_use]
     pub fn new(entries: Vec<String>) -> Self {
         Self {
+            draft_input_revision: None,
             draft_text: None,
             entries,
             selected_index: None,
@@ -182,6 +346,7 @@ impl PromptHistoryState {
 
     /// Clears active history navigation and stored draft text.
     pub fn reset_navigation(&mut self) {
+        self.draft_input_revision = None;
         self.draft_text = None;
         self.selected_index = None;
     }
@@ -335,22 +500,38 @@ impl PromptComposerState {
     /// Inserts pasted prompt text by delegating to the canonical field-level
     /// helper and clears any transient slash/history navigation state.
     pub fn insert_text(&mut self, text: &str) {
+        self.attachment_state.remember_current_revision(&self.input);
+        let insert_start = self.input.cursor;
         insert_prompt_text(
             &mut self.input,
             &mut self.history_state,
             &mut self.slash_state,
             text,
         );
+        self.attachment_state.sync_after_edit(
+            &self.input,
+            insert_start,
+            insert_start,
+            self.input.cursor,
+        );
     }
 
     /// Inserts one typed character by delegating to the canonical field-level
     /// helper and clears transient slash/history state.
     pub fn insert_char(&mut self, character: char) {
+        self.attachment_state.remember_current_revision(&self.input);
+        let insert_start = self.input.cursor;
         insert_prompt_character(
             &mut self.input,
             &mut self.history_state,
             &mut self.slash_state,
             character,
+        );
+        self.attachment_state.sync_after_edit(
+            &self.input,
+            insert_start,
+            insert_start,
+            self.input.cursor,
         );
     }
 
@@ -539,8 +720,13 @@ pub fn insert_prompt_local_image(
     slash_state: &mut PromptSlashState,
     local_image_path: PathBuf,
 ) {
-    let placeholder = attachment_state.register_local_image(local_image_path);
+    attachment_state.remember_current_revision(input);
+    let placeholder_start = input.cursor;
+    let placeholder = PromptAttachment::placeholder_for(attachment_state.next_attachment_number);
     input.insert_text(&placeholder);
+    attachment_state.sync_after_edit(input, placeholder_start, placeholder_start, input.cursor);
+    attachment_state.register_local_image(local_image_path, placeholder_start);
+    attachment_state.remember_current_revision(input);
     history_state.reset_navigation();
     slash_state.reset();
 }
@@ -564,11 +750,9 @@ pub fn apply_prompt_delete_range(
         return;
     }
 
+    attachment_state.remember_current_revision(input);
     input.replace_range(delete_start, delete_end, "");
-    attachment_state
-        .attachments
-        .retain(|attachment| input.text().contains(&attachment.placeholder));
-    attachment_state.refresh_next_attachment_number();
+    attachment_state.sync_after_edit(input, delete_start, delete_end, delete_start);
     history_state.reset_navigation();
     slash_state.reset();
 }
@@ -587,10 +771,10 @@ pub fn drain_prompt_submission(
     let mut attachments = attachment_state
         .attachments
         .iter()
-        .filter(|attachment| text.contains(&attachment.placeholder))
+        .filter(|attachment| attachment.current_start.is_some())
         .cloned()
         .collect::<Vec<_>>();
-    attachments.sort_by_key(|attachment| text.find(&attachment.placeholder).unwrap_or(usize::MAX));
+    attachments.sort_by_key(|attachment| attachment.current_start.unwrap_or(usize::MAX));
     attachment_state.reset();
 
     PromptComposerSubmission { attachments, text }
@@ -921,6 +1105,30 @@ fn image_token_end_index(characters: &[char], start_index: usize) -> Option<usiz
 mod tests {
     use super::*;
     use crate::domain::agent::AgentModel;
+    use crate::domain::input::INPUT_HISTORY_LIMIT;
+
+    fn insert_test_attachment(
+        attachment_state: &mut PromptAttachmentState,
+        input: &mut InputState,
+        local_image_path: PathBuf,
+    ) -> String {
+        let mut history_state = PromptHistoryState::default();
+        let mut slash_state = PromptSlashState::default();
+        insert_prompt_local_image(
+            attachment_state,
+            &mut history_state,
+            input,
+            &mut slash_state,
+            local_image_path,
+        );
+
+        attachment_state
+            .attachments
+            .last()
+            .expect("attachment should be registered")
+            .placeholder
+            .clone()
+    }
 
     #[test]
     fn test_prompt_attachment_state_registers_images_in_placeholder_order() {
@@ -929,34 +1137,35 @@ mod tests {
 
         // Act
         let first_placeholder =
-            attachment_state.register_local_image(PathBuf::from("/tmp/first-image.png"));
+            attachment_state.register_local_image(PathBuf::from("/tmp/first-image.png"), 0);
         let second_placeholder =
-            attachment_state.register_local_image(PathBuf::from("/tmp/second-image.png"));
+            attachment_state.register_local_image(PathBuf::from("/tmp/second-image.png"), 10);
 
         // Assert
         assert_eq!(first_placeholder, "[Image #1]");
         assert_eq!(second_placeholder, "[Image #2]");
         assert_eq!(attachment_state.attachments.len(), 2);
+        let attachment = attachment_state
+            .attachment_for_placeholder("[Image #2]")
+            .expect("second attachment should exist");
+        assert_eq!(attachment.attachment_number, 2);
         assert_eq!(
-            attachment_state.attachment_for_placeholder("[Image #2]"),
-            Some(&PromptAttachment {
-                attachment_number: 2,
-                local_image_path: PathBuf::from("/tmp/second-image.png"),
-                placeholder: "[Image #2]".to_string(),
-            })
+            attachment.local_image_path,
+            PathBuf::from("/tmp/second-image.png")
         );
+        assert_eq!(attachment.placeholder, "[Image #2]");
     }
 
     #[test]
     fn test_prompt_attachment_state_reset_clears_attachments_and_restarts_numbering() {
         // Arrange
         let mut attachment_state = PromptAttachmentState::default();
-        let _ = attachment_state.register_local_image(PathBuf::from("/tmp/first-image.png"));
+        let _ = attachment_state.register_local_image(PathBuf::from("/tmp/first-image.png"), 0);
 
         // Act
         attachment_state.reset();
         let placeholder =
-            attachment_state.register_local_image(PathBuf::from("/tmp/second-image.png"));
+            attachment_state.register_local_image(PathBuf::from("/tmp/second-image.png"), 0);
 
         // Assert
         assert_eq!(attachment_state.attachments.len(), 1);
@@ -965,9 +1174,10 @@ mod tests {
     }
 
     #[test]
-    fn test_prompt_attachment_state_refresh_next_attachment_number_reuses_gaps() {
+    fn test_prompt_attachment_state_refresh_next_attachment_number_stays_monotonic() {
         // Arrange
         let mut attachment_state = PromptAttachmentState {
+            archived_attachments: Vec::new(),
             attachments: vec![
                 PromptAttachment::new(1, PathBuf::from("/tmp/first-image.png")),
                 PromptAttachment::new(3, PathBuf::from("/tmp/third-image.png")),
@@ -979,7 +1189,118 @@ mod tests {
         attachment_state.refresh_next_attachment_number();
 
         // Assert
+        assert_eq!(attachment_state.next_attachment_number, 4);
+    }
+
+    #[test]
+    fn test_prompt_attachment_state_ignores_revision_before_attachment_is_placed() {
+        // Arrange
+        let input = InputState::default();
+        let mut attachment_state = PromptAttachmentState::default();
+        attachment_state.attachments.push(PromptAttachment::new(
+            1,
+            PathBuf::from("/tmp/first-image.png"),
+        ));
+
+        // Act
+        attachment_state.remember_current_revision(&input);
+
+        // Assert
+        assert!(attachment_state.attachments[0].valid_locations.is_empty());
+    }
+
+    #[test]
+    fn test_prompt_attachment_ignores_edits_while_not_in_input() {
+        // Arrange
+        let mut attachment = PromptAttachment::new(1, PathBuf::from("/tmp/first-image.png"));
+
+        // Act
+        attachment.apply_edit(0, 0, 1);
+
+        // Assert
+        assert_eq!(attachment.current_start, None);
+    }
+
+    #[test]
+    fn test_prompt_attachment_state_sync_restores_undone_attachment() {
+        // Arrange
+        let mut input = InputState::default();
+        let mut attachment_state = PromptAttachmentState::default();
+        let placeholder = insert_test_attachment(
+            &mut attachment_state,
+            &mut input,
+            PathBuf::from("/tmp/first-image.png"),
+        );
+        attachment_state.remember_current_revision(&input);
+        input.replace_range(0, placeholder.chars().count(), "");
+        attachment_state.sync_after_edit(&input, 0, placeholder.chars().count(), 0);
+
+        // Act
+        input.undo();
+        attachment_state.sync_after_history_restore(&input);
+
+        // Assert
+        assert_eq!(attachment_state.attachments.len(), 1);
+        assert!(attachment_state.archived_attachments.is_empty());
         assert_eq!(attachment_state.next_attachment_number, 2);
+    }
+
+    #[test]
+    fn test_prompt_attachment_state_does_not_activate_manually_entered_placeholder() {
+        // Arrange
+        let mut input = InputState::default();
+        let mut attachment_state = PromptAttachmentState::default();
+        let placeholder = insert_test_attachment(
+            &mut attachment_state,
+            &mut input,
+            PathBuf::from("/tmp/first-image.png"),
+        );
+        attachment_state.remember_current_revision(&input);
+        input.replace_range(0, placeholder.chars().count(), "");
+        attachment_state.sync_after_edit(&input, 0, placeholder.chars().count(), 0);
+
+        // Act
+        let insert_start = input.cursor;
+        input.insert_text(&placeholder);
+        attachment_state.sync_after_edit(&input, insert_start, insert_start, input.cursor);
+
+        // Assert
+        assert!(attachment_state.attachments.is_empty());
+        assert_eq!(attachment_state.archived_attachments.len(), 1);
+        let submission = drain_prompt_submission(&mut attachment_state, &mut input);
+        assert!(submission.attachments.is_empty());
+        assert_eq!(submission.text, placeholder);
+    }
+
+    #[test]
+    fn test_prompt_attachment_state_prunes_attachment_after_revision_eviction() {
+        // Arrange
+        let mut input = InputState::default();
+        let mut attachment_state = PromptAttachmentState::default();
+        let placeholder = insert_test_attachment(
+            &mut attachment_state,
+            &mut input,
+            PathBuf::from("/tmp/first-image.png"),
+        );
+        attachment_state.remember_current_revision(&input);
+        input.replace_range(0, placeholder.chars().count(), "");
+        attachment_state.sync_after_edit(&input, 0, placeholder.chars().count(), 0);
+        for _ in 0..INPUT_HISTORY_LIMIT {
+            let insert_start = input.cursor;
+            input.insert_char('x');
+            attachment_state.sync_after_edit(&input, insert_start, insert_start, input.cursor);
+        }
+
+        // Act
+        let unreachable = attachment_state.prune_unreachable(&input);
+
+        // Assert
+        assert!(attachment_state.archived_attachments.is_empty());
+        assert_eq!(unreachable.len(), 1);
+        assert_eq!(
+            unreachable[0].local_image_path,
+            PathBuf::from("/tmp/first-image.png")
+        );
     }
 
     #[test]
@@ -1219,10 +1540,9 @@ mod tests {
     fn test_prompt_composer_delete_range_removes_whole_image_token() {
         // Arrange
         let mut composer = PromptComposerState::new(AgentKind::ALL.to_vec());
-        composer.insert_text("Review [Image #1] now");
-        composer.attachment_state.attachments =
-            vec![PromptAttachment::new(1, PathBuf::from("/tmp/image.png"))];
-        composer.attachment_state.next_attachment_number = 2;
+        composer.insert_text("Review ");
+        composer.insert_local_image(PathBuf::from("/tmp/image.png"));
+        composer.insert_text(" now");
 
         // Act
         composer.delete_range(10, 11);
@@ -1230,18 +1550,35 @@ mod tests {
         // Assert
         assert_eq!(composer.input.text(), "Review  now");
         assert!(composer.attachment_state.attachments.is_empty());
-        assert_eq!(composer.attachment_state.next_attachment_number, 1);
+        assert_eq!(composer.attachment_state.archived_attachments.len(), 1);
+        assert_eq!(composer.attachment_state.next_attachment_number, 2);
+    }
+
+    #[test]
+    fn test_prompt_composer_insert_char_keeps_attachment_position_synchronized() {
+        // Arrange
+        let mut composer = PromptComposerState::new(AgentKind::ALL.to_vec());
+        composer.insert_local_image(PathBuf::from("/tmp/image.png"));
+        composer.input.cursor = 0;
+
+        // Act
+        composer.insert_char('x');
+        let submission = composer.take_submission();
+
+        // Assert
+        assert_eq!(submission.text, "x[Image #1]");
+        assert_eq!(submission.attachments.len(), 1);
+        assert_eq!(submission.attachments[0].current_start, Some(1));
     }
 
     #[test]
     fn test_take_submission_filters_deleted_attachment_placeholders() {
         // Arrange
         let mut composer = PromptComposerState::new(AgentKind::ALL.to_vec());
-        composer.insert_text("One [Image #1] two [Image #2]");
-        composer.attachment_state.attachments = vec![
-            PromptAttachment::new(1, PathBuf::from("/tmp/one.png")),
-            PromptAttachment::new(2, PathBuf::from("/tmp/two.png")),
-        ];
+        composer.insert_text("One ");
+        composer.insert_local_image(PathBuf::from("/tmp/one.png"));
+        composer.insert_text(" two ");
+        composer.insert_local_image(PathBuf::from("/tmp/two.png"));
         composer.delete_range(4, 15);
 
         // Act

--- a/crates/agentty/src/domain/input.rs
+++ b/crates/agentty/src/domain/input.rs
@@ -1,4 +1,67 @@
-/// Editable text input with a character-based cursor index.
+use std::collections::VecDeque;
+
+/// Maximum number of text snapshots retained by each input's undo or redo
+/// stack.
+pub(crate) const INPUT_HISTORY_LIMIT: usize = 100;
+
+/// Semantic editing command shared by every text input.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InputCommand {
+    DeleteBackward,
+    DeleteCurrentLine,
+    DeleteForward,
+    DeleteToLineEnd,
+    DeleteWordBackward,
+    Insert(char),
+    InsertNewline,
+    InsertText(String),
+    MoveDown,
+    MoveEnd,
+    MoveHome,
+    MoveLeft,
+    MoveLineEnd,
+    MoveLineStart,
+    MoveRight,
+    MoveUp,
+    MoveWordLeft,
+    MoveWordRight,
+    Redo,
+    ReplaceRange {
+        start: usize,
+        end: usize,
+        text: String,
+    },
+    Undo,
+}
+
+/// Observable result of applying one [`InputCommand`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InputEffect {
+    CursorMoved,
+    TextChanged,
+    Unchanged,
+}
+
+/// Text and cursor snapshot stored by bounded undo/redo history.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct InputSnapshot {
+    cursor: usize,
+    revision: u64,
+    text: String,
+}
+
+/// Heap-backed history keeps `InputState` compact when it is embedded in
+/// larger application-mode snapshots.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct InputHistory {
+    next_revision: u64,
+    redo_stack: VecDeque<InputSnapshot>,
+    revision: u64,
+    undo_stack: VecDeque<InputSnapshot>,
+}
+
+/// Editable text input with a character-based cursor index and bounded edit
+/// history.
 ///
 /// The derived `Default` produces an empty input with the cursor at position
 /// `0` and an empty text buffer.
@@ -6,6 +69,7 @@
 pub struct InputState {
     /// Cursor position measured in Unicode scalar values from the start.
     pub cursor: usize,
+    history: Box<InputHistory>,
     text: String,
 }
 
@@ -14,7 +78,11 @@ impl InputState {
     pub fn with_text(text: String) -> Self {
         let cursor = text.chars().count();
 
-        Self { cursor, text }
+        Self {
+            cursor,
+            history: Box::default(),
+            text,
+        }
     }
 
     /// Returns the current text buffer.
@@ -22,9 +90,41 @@ impl InputState {
         &self.text
     }
 
+    /// Returns the stable identity of the current text snapshot.
+    pub fn revision(&self) -> u64 {
+        self.history.revision
+    }
+
+    /// Returns whether `revision` is the current snapshot or remains
+    /// reachable through bounded undo/redo history.
+    pub fn retains_revision(&self, revision: u64) -> bool {
+        self.history.revision == revision
+            || self
+                .history
+                .undo_stack
+                .iter()
+                .chain(&self.history.redo_stack)
+                .any(|snapshot| snapshot.revision == revision)
+    }
+
+    /// Replaces the entire buffer with a fresh revision and clears edit
+    /// history, preserving revision uniqueness for external state tracking.
+    pub fn reset_text(&mut self, text: String) {
+        self.cursor = text.chars().count();
+        self.history.redo_stack.clear();
+        self.history.undo_stack.clear();
+        self.history.next_revision = self.history.next_revision.saturating_add(1);
+        self.history.revision = self.history.next_revision;
+        self.text = text;
+    }
+
     /// Drains and returns the text buffer, then resets the cursor to `0`.
     pub fn take_text(&mut self) -> String {
         self.cursor = 0;
+        self.history.redo_stack.clear();
+        self.history.undo_stack.clear();
+        self.history.next_revision = self.history.next_revision.saturating_add(1);
+        self.history.revision = self.history.next_revision;
 
         std::mem::take(&mut self.text)
     }
@@ -36,9 +136,11 @@ impl InputState {
 
     /// Inserts one character at the cursor and advances the cursor by one.
     pub fn insert_char(&mut self, ch: char) {
+        let snapshot = self.snapshot();
         let byte_offset = self.byte_offset();
         self.text.insert(byte_offset, ch);
         self.cursor += 1;
+        self.record_text_change(snapshot);
     }
 
     /// Inserts `text` at the cursor and moves the cursor to the end of the
@@ -48,9 +150,11 @@ impl InputState {
             return;
         }
 
+        let snapshot = self.snapshot();
         let byte_offset = self.byte_offset();
         self.text.insert_str(byte_offset, text);
         self.cursor += text.chars().count();
+        self.record_text_change(snapshot);
     }
 
     /// Inserts a newline at the cursor position.
@@ -64,10 +168,12 @@ impl InputState {
             return;
         }
 
+        let snapshot = self.snapshot();
         let start = self.byte_offset_at(self.cursor - 1);
         let end = self.byte_offset();
         self.text.replace_range(start..end, "");
         self.cursor -= 1;
+        self.record_text_change(snapshot);
     }
 
     /// Deletes the entire current line including one adjacent newline
@@ -110,9 +216,20 @@ impl InputState {
             return;
         }
 
+        let snapshot = self.snapshot();
         let start = self.byte_offset();
         let end = self.byte_offset_at(self.cursor + 1);
         self.text.replace_range(start..end, "");
+        self.record_text_change(snapshot);
+    }
+
+    /// Deletes the previous word and adjacent separator whitespace.
+    pub fn delete_word_backward(&mut self) {
+        let Some((start, end)) = self.word_delete_range() else {
+            return;
+        };
+
+        self.replace_range(start, end, "");
     }
 
     /// Moves the cursor one character to the left.
@@ -204,6 +321,42 @@ impl InputState {
         self.cursor = self.text.chars().count();
     }
 
+    /// Moves the cursor to the start of the previous word.
+    pub fn move_word_left(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+
+        let characters: Vec<char> = self.text.chars().collect();
+        let mut cursor = self.cursor;
+
+        while cursor > 0 && characters[cursor - 1].is_whitespace() {
+            cursor -= 1;
+        }
+
+        while cursor > 0 && !characters[cursor - 1].is_whitespace() {
+            cursor -= 1;
+        }
+
+        self.cursor = cursor;
+    }
+
+    /// Moves the cursor to the start of the next word.
+    pub fn move_word_right(&mut self) {
+        let characters: Vec<char> = self.text.chars().collect();
+        let mut cursor = self.cursor;
+
+        while cursor < characters.len() && !characters[cursor].is_whitespace() {
+            cursor += 1;
+        }
+
+        while cursor < characters.len() && characters[cursor].is_whitespace() {
+            cursor += 1;
+        }
+
+        self.cursor = cursor;
+    }
+
     /// Moves the cursor to the start of the current line.
     ///
     /// Scans backward from the cursor to the nearest preceding newline (or
@@ -247,10 +400,51 @@ impl InputState {
         }
 
         if line_end > self.cursor {
+            let snapshot = self.snapshot();
             let start_byte = self.byte_offset();
             let end_byte = self.byte_offset_at(line_end);
             self.text.replace_range(start_byte..end_byte, "");
+            self.record_text_change(snapshot);
         }
+    }
+
+    /// Returns the character range removed by [`Self::delete_to_line_end`].
+    #[must_use]
+    pub fn line_end_delete_range(&self) -> Option<(usize, usize)> {
+        let characters: Vec<char> = self.text.chars().collect();
+        let mut line_end = self.cursor;
+
+        while line_end < characters.len() && characters[line_end] != '\n' {
+            line_end += 1;
+        }
+
+        (line_end > self.cursor).then_some((self.cursor, line_end))
+    }
+
+    /// Returns the character range for deleting the previous word and its
+    /// adjacent separator whitespace.
+    #[must_use]
+    pub fn word_delete_range(&self) -> Option<(usize, usize)> {
+        if self.cursor == 0 {
+            return None;
+        }
+
+        let characters: Vec<char> = self.text.chars().collect();
+        let mut start = self.cursor;
+
+        while start > 0 && characters[start - 1].is_whitespace() {
+            start -= 1;
+        }
+
+        while start > 0 && !characters[start - 1].is_whitespace() {
+            start -= 1;
+        }
+
+        while start > 0 && characters[start - 1].is_whitespace() {
+            start -= 1;
+        }
+
+        Some((start, self.cursor))
     }
 
     /// Extracts the `@query` text at the current cursor position.
@@ -264,10 +458,76 @@ impl InputState {
     /// Replaces characters in `[start_char..end_char)` with `replacement`
     /// and moves the cursor to the end of the inserted text.
     pub fn replace_range(&mut self, start_char: usize, end_char: usize, replacement: &str) {
+        let snapshot = self.snapshot();
         let start_byte = self.byte_offset_at(start_char);
         let end_byte = self.byte_offset_at(end_char);
         self.text.replace_range(start_byte..end_byte, replacement);
         self.cursor = start_char + replacement.chars().count();
+        self.record_text_change(snapshot);
+    }
+
+    /// Applies one shared semantic editing command.
+    pub fn apply(&mut self, command: InputCommand) -> InputEffect {
+        let cursor_before = self.cursor;
+        let revision_before = self.history.revision;
+
+        match command {
+            InputCommand::DeleteBackward => self.delete_backward(),
+            InputCommand::DeleteCurrentLine => self.delete_current_line(),
+            InputCommand::DeleteForward => self.delete_forward(),
+            InputCommand::DeleteToLineEnd => self.delete_to_line_end(),
+            InputCommand::DeleteWordBackward => self.delete_word_backward(),
+            InputCommand::Insert(character) => self.insert_char(character),
+            InputCommand::InsertNewline => self.insert_newline(),
+            InputCommand::InsertText(text) => self.insert_text(&text),
+            InputCommand::MoveDown => self.move_down(),
+            InputCommand::MoveEnd => self.move_end(),
+            InputCommand::MoveHome => self.move_home(),
+            InputCommand::MoveLeft => self.move_left(),
+            InputCommand::MoveLineEnd => self.move_line_end(),
+            InputCommand::MoveLineStart => self.move_line_start(),
+            InputCommand::MoveRight => self.move_right(),
+            InputCommand::MoveUp => self.move_up(),
+            InputCommand::MoveWordLeft => self.move_word_left(),
+            InputCommand::MoveWordRight => self.move_word_right(),
+            InputCommand::Redo => self.redo(),
+            InputCommand::ReplaceRange { start, end, text } => {
+                self.replace_range(start, end, &text);
+            }
+            InputCommand::Undo => self.undo(),
+        }
+
+        if self.history.revision != revision_before {
+            return InputEffect::TextChanged;
+        }
+
+        if self.cursor != cursor_before {
+            return InputEffect::CursorMoved;
+        }
+
+        InputEffect::Unchanged
+    }
+
+    /// Restores the most recent text mutation and cursor position.
+    pub fn undo(&mut self) {
+        let Some(snapshot) = self.history.undo_stack.pop_back() else {
+            return;
+        };
+
+        let current = self.snapshot();
+        Self::push_bounded(&mut self.history.redo_stack, current);
+        self.restore(snapshot);
+    }
+
+    /// Reapplies the most recently undone text mutation.
+    pub fn redo(&mut self) {
+        let Some(snapshot) = self.history.redo_stack.pop_back() else {
+            return;
+        };
+
+        let current = self.snapshot();
+        Self::push_bounded(&mut self.history.undo_stack, current);
+        self.restore(snapshot);
     }
 
     fn byte_offset(&self) -> usize {
@@ -298,6 +558,39 @@ impl InputState {
         }
 
         (line, column)
+    }
+
+    fn snapshot(&self) -> InputSnapshot {
+        InputSnapshot {
+            cursor: self.cursor,
+            revision: self.history.revision,
+            text: self.text.clone(),
+        }
+    }
+
+    fn record_text_change(&mut self, snapshot: InputSnapshot) {
+        if self.text == snapshot.text {
+            return;
+        }
+
+        Self::push_bounded(&mut self.history.undo_stack, snapshot);
+        self.history.redo_stack.clear();
+        self.history.next_revision = self.history.next_revision.saturating_add(1);
+        self.history.revision = self.history.next_revision;
+    }
+
+    fn push_bounded(stack: &mut VecDeque<InputSnapshot>, snapshot: InputSnapshot) {
+        if stack.len() == INPUT_HISTORY_LIMIT {
+            let _ = stack.pop_front();
+        }
+
+        stack.push_back(snapshot);
+    }
+
+    fn restore(&mut self, snapshot: InputSnapshot) {
+        self.cursor = snapshot.cursor;
+        self.history.revision = snapshot.revision;
+        self.text = snapshot.text;
     }
 }
 
@@ -557,5 +850,168 @@ mod tests {
         // Assert
         assert_eq!(state.text(), "hello");
         assert_eq!(state.cursor, "hello".chars().count());
+    }
+
+    #[test]
+    fn test_word_movement_and_deletion_share_input_state_behavior() {
+        // Arrange
+        let mut state = InputState::with_text("hello brave world".to_string());
+
+        // Act
+        state.move_word_left();
+        let word_start = state.cursor;
+        state.move_end();
+        state.delete_word_backward();
+
+        // Assert
+        assert_eq!(word_start, "hello brave ".chars().count());
+        assert_eq!(state.text(), "hello brave");
+        assert_eq!(state.cursor, "hello brave".chars().count());
+    }
+
+    #[test]
+    fn test_word_operations_handle_buffer_start_and_trailing_whitespace() {
+        // Arrange
+        let mut state = InputState::with_text("hello  ".to_string());
+
+        // Act
+        state.move_word_left();
+        let word_start = state.cursor;
+        state.move_home();
+        state.move_word_left();
+        state.delete_word_backward();
+
+        // Assert
+        assert_eq!(word_start, 0);
+        assert_eq!(state.cursor, 0);
+        assert_eq!(state.text(), "hello  ");
+    }
+
+    #[test]
+    fn test_delete_ranges_report_line_end_and_whitespace_prefixed_word() {
+        // Arrange
+        let mut state = InputState::with_text("first line\nsecond word  ".to_string());
+        state.cursor = "first ".chars().count();
+
+        // Act
+        let line_end_range = state.line_end_delete_range();
+        state.move_end();
+        let word_range = state.word_delete_range();
+        state.move_home();
+        let empty_word_range = state.word_delete_range();
+
+        // Assert
+        assert_eq!(line_end_range, Some((6, 10)));
+        assert_eq!(word_range, Some((17, 24)));
+        assert_eq!(empty_word_range, None);
+    }
+
+    #[test]
+    fn test_apply_reports_effect_from_revision_and_cursor_changes() {
+        // Arrange
+        let mut state = InputState::with_text("hello".to_string());
+
+        // Act
+        let cursor_effect = state.apply(InputCommand::MoveLeft);
+        let text_effect = state.apply(InputCommand::Insert('!'));
+        let home_effect = state.apply(InputCommand::MoveHome);
+        let end_effect = state.apply(InputCommand::MoveEnd);
+        let unchanged_effect = state.apply(InputCommand::MoveRight);
+
+        // Assert
+        assert_eq!(cursor_effect, InputEffect::CursorMoved);
+        assert_eq!(text_effect, InputEffect::TextChanged);
+        assert_eq!(home_effect, InputEffect::CursorMoved);
+        assert_eq!(end_effect, InputEffect::CursorMoved);
+        assert_eq!(unchanged_effect, InputEffect::Unchanged);
+    }
+
+    #[test]
+    fn test_noop_edit_and_empty_undo_leave_input_unchanged() {
+        // Arrange
+        let mut state = InputState::with_text("hello".to_string());
+        let revision = state.revision();
+
+        // Act
+        state.replace_range(0, 0, "");
+        state.undo();
+
+        // Assert
+        assert_eq!(state.text(), "hello");
+        assert_eq!(state.revision(), revision);
+    }
+
+    #[test]
+    fn test_undo_and_redo_restore_text_and_cursor() {
+        // Arrange
+        let mut state = InputState::with_text("helo".to_string());
+        state.cursor = 3;
+        state.insert_char('l');
+
+        // Act
+        state.undo();
+
+        // Assert
+        assert_eq!(state.text(), "helo");
+        assert_eq!(state.cursor, 3);
+
+        // Act
+        state.redo();
+
+        // Assert
+        assert_eq!(state.text(), "hello");
+        assert_eq!(state.cursor, 4);
+    }
+
+    #[test]
+    fn test_undo_and_redo_restore_stable_revision_identity() {
+        // Arrange
+        let mut state = InputState::with_text("first".to_string());
+        let first_revision = state.revision();
+        state.insert_text(" second");
+        let second_revision = state.revision();
+
+        // Act
+        state.undo();
+
+        // Assert
+        assert_eq!(state.revision(), first_revision);
+        assert!(state.retains_revision(second_revision));
+
+        // Act
+        state.redo();
+
+        // Assert
+        assert_eq!(state.revision(), second_revision);
+        assert!(state.retains_revision(first_revision));
+    }
+
+    #[test]
+    fn test_new_edit_after_undo_clears_redo_history() {
+        // Arrange
+        let mut state = InputState::default();
+        state.insert_text("first");
+        state.undo();
+        state.insert_text("second");
+
+        // Act
+        state.redo();
+
+        // Assert
+        assert_eq!(state.text(), "second");
+    }
+
+    #[test]
+    fn test_pasted_text_is_one_undo_step() {
+        // Arrange
+        let mut state = InputState::with_text("prefix ".to_string());
+        state.insert_text("pasted text");
+
+        // Act
+        state.undo();
+
+        // Assert
+        assert_eq!(state.text(), "prefix ");
+        assert_eq!(state.cursor, "prefix ".chars().count());
     }
 }

--- a/crates/agentty/src/runtime/event.rs
+++ b/crates/agentty/src/runtime/event.rs
@@ -13,6 +13,7 @@ use tokio::sync::mpsc;
 use tracing::debug;
 
 use crate::app::{App, AppEvent};
+use crate::domain::input::InputCommand;
 use crate::presentation::app_mode::AppMode;
 use crate::runtime::{EventResult, FRAME_INTERVAL, PresentationState, key_handler, mode};
 
@@ -246,7 +247,7 @@ where
                 return handle_key_event(app, terminal, key).await;
             }
             Event::Paste(pasted_text) => {
-                process_paste_event(app, &pasted_text);
+                process_paste_event(app, &pasted_text).await;
                 app.mark_dirty();
             }
             _ => {}
@@ -265,14 +266,34 @@ fn is_press_key_event(key: KeyEvent) -> bool {
     key.kind == KeyEventKind::Press
 }
 
-/// Applies one pasted-text event to the active prompt or question input.
-fn process_paste_event(app: &mut App, pasted_text: &str) {
+/// Applies one pasted-text event to the active editable input.
+async fn process_paste_event(app: &mut App, pasted_text: &str) {
     if matches!(&app.mode, AppMode::Prompt { .. }) {
-        mode::prompt::handle_paste(app, pasted_text);
+        mode::prompt::handle_paste(app, pasted_text).await;
     }
 
     if matches!(&app.mode, AppMode::Question { .. }) {
         mode::question::handle_paste(app, pasted_text);
+    }
+
+    if let AppMode::PublishBranchInput {
+        input,
+        locked_upstream_ref: None,
+        ..
+    } = &mut app.mode
+    {
+        let text = mode::input_key::normalize_single_line_pasted_text(pasted_text);
+        input.apply(InputCommand::InsertText(text));
+    }
+
+    if matches!(&app.mode, AppMode::List)
+        && app
+            .settings
+            .is_launch_configuration_list_editor_input_active()
+    {
+        let text = mode::input_key::normalize_single_line_pasted_text(pasted_text);
+        app.settings
+            .apply_launch_configuration_input_command(InputCommand::InsertText(text));
     }
 }
 
@@ -531,6 +552,57 @@ mod tests {
                 selected_option_index: None,
                 ..
             } if input.text() == "custom\nanswer"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_process_paste_event_updates_publish_branch_input() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.mode = AppMode::PublishBranchInput {
+            default_branch_name: "wt/session".to_string(),
+            input: InputState::default(),
+            locked_upstream_ref: None,
+            publish_branch_action: crate::domain::session::PublishBranchAction::Push,
+            restore_view: crate::presentation::app_mode::ConfirmationViewMode {
+                scroll_offset: None,
+                session_id: "session-1".into(),
+            },
+        };
+
+        // Act
+        process_paste_event(&mut app, "review/shared-input\r\nignored").await;
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::PublishBranchInput { input, .. }
+                if input.text() == "review/shared-input"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_process_paste_event_updates_launch_configuration_input() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.tabs.set(crate::app::Tab::Settings);
+        for _ in 0..6 {
+            app.settings.next();
+        }
+        app.settings.handle_enter();
+        app.settings.start_adding_launch_configuration();
+
+        // Act
+        process_paste_event(&mut app, "cargo nextest run\r\nignored").await;
+
+        // Assert
+        let editor = app
+            .settings
+            .launch_configuration_list_editor()
+            .expect("launch-configuration editor should be open");
+        assert!(matches!(
+            editor.input,
+            Some(ref input) if input.text() == "cargo nextest run"
         ));
     }
 

--- a/crates/agentty/src/runtime/key_handler.rs
+++ b/crates/agentty/src/runtime/key_handler.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::Terminal;
 use ratatui::backend::Backend;
 use ratatui::layout::{Constraint, Layout, Rect};
@@ -402,40 +402,17 @@ fn handle_publish_branch_input_key(app: &mut App, key: KeyEvent) -> EventResult 
                 remote_branch_name,
             );
         }
-        KeyCode::Left if !input_locked => {
-            app.mode =
-                publish_branch_input.apply_input_edit(crate::domain::input::InputState::move_left);
-        }
-        KeyCode::Right if !input_locked => {
-            app.mode =
-                publish_branch_input.apply_input_edit(crate::domain::input::InputState::move_right);
-        }
-        KeyCode::Up if !input_locked => {
-            app.mode =
-                publish_branch_input.apply_input_edit(crate::domain::input::InputState::move_up);
-        }
-        KeyCode::Down if !input_locked => {
-            app.mode =
-                publish_branch_input.apply_input_edit(crate::domain::input::InputState::move_down);
-        }
-        KeyCode::Home if !input_locked => {
-            app.mode =
-                publish_branch_input.apply_input_edit(crate::domain::input::InputState::move_home);
-        }
-        KeyCode::End if !input_locked => {
-            app.mode =
-                publish_branch_input.apply_input_edit(crate::domain::input::InputState::move_end);
-        }
-        KeyCode::Backspace if !input_locked => {
-            app.mode = publish_branch_input
-                .apply_input_edit(crate::domain::input::InputState::delete_backward);
-        }
-        KeyCode::Delete if !input_locked => {
-            app.mode = publish_branch_input
-                .apply_input_edit(crate::domain::input::InputState::delete_forward);
-        }
-        KeyCode::Char(character) if !input_locked && is_publish_branch_input_text_key(key) => {
-            app.mode = publish_branch_input.apply_input_edit(|input| input.insert_char(character));
+        _ if !input_locked => {
+            app.mode = if let Some(command) = mode::input_key::command_for_key(
+                key,
+                mode::input_key::InputCapabilities::SINGLE_LINE,
+            ) {
+                publish_branch_input.apply_input_edit(|input| {
+                    input.apply(command);
+                })
+            } else {
+                publish_branch_input.into_mode()
+            };
         }
         _ => {
             app.mode = publish_branch_input.into_mode();
@@ -443,15 +420,6 @@ fn handle_publish_branch_input_key(app: &mut App, key: KeyEvent) -> EventResult 
     }
 
     EventResult::Continue
-}
-
-/// Returns whether one key event should insert text into the publish-branch
-/// input field.
-///
-/// Matches the prompt/question input policy: only plain and shifted
-/// characters are treated as text input.
-fn is_publish_branch_input_text_key(key: KeyEvent) -> bool {
-    key.modifiers == KeyModifiers::NONE || key.modifiers == KeyModifiers::SHIFT
 }
 
 /// Captures `AppMode::PublishBranchInput` fields so key handlers can rebuild
@@ -1728,6 +1696,75 @@ mod tests {
         };
         assert_eq!(input.text(), "review/custom");
         assert_eq!(input.cursor, "review/custom".chars().count() - 1);
+    }
+
+    #[tokio::test]
+    async fn test_handle_publish_branch_input_key_supports_word_delete_undo_and_redo() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app_with_mock_tmux_client().await;
+        app.mode = AppMode::PublishBranchInput {
+            default_branch_name: "wt/session".to_string(),
+            input: crate::domain::input::InputState::with_text("review custom".to_string()),
+            locked_upstream_ref: None,
+            publish_branch_action: crate::domain::session::PublishBranchAction::Push,
+            restore_view: ConfirmationViewMode {
+                scroll_offset: None,
+                session_id: "session-id".into(),
+            },
+        };
+
+        // Act
+        handle_publish_branch_input_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL),
+        );
+        handle_publish_branch_input_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('z'), KeyModifiers::CONTROL),
+        );
+        assert!(matches!(
+            &app.mode,
+            AppMode::PublishBranchInput { input, .. } if input.text() == "review custom"
+        ));
+        handle_publish_branch_input_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('y'), KeyModifiers::CONTROL),
+        );
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::PublishBranchInput { input, .. } if input.text() == "review"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_publish_branch_input_key_preserves_mode_for_unmapped_key() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app_with_mock_tmux_client().await;
+        app.mode = AppMode::PublishBranchInput {
+            default_branch_name: "wt/session".to_string(),
+            input: crate::domain::input::InputState::with_text("review/custom".to_string()),
+            locked_upstream_ref: None,
+            publish_branch_action: crate::domain::session::PublishBranchAction::Push,
+            restore_view: ConfirmationViewMode {
+                scroll_offset: None,
+                session_id: "session-id".into(),
+            },
+        };
+
+        // Act
+        let result = handle_publish_branch_input_key(
+            &mut app,
+            KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE),
+        );
+
+        // Assert
+        assert!(matches!(result, EventResult::Continue));
+        assert!(matches!(
+            &app.mode,
+            AppMode::PublishBranchInput { input, .. } if input.text() == "review/custom"
+        ));
     }
 
     #[tokio::test]

--- a/crates/agentty/src/runtime/mode/input_key.rs
+++ b/crates/agentty/src/runtime/mode/input_key.rs
@@ -1,12 +1,22 @@
 //! Shared input key handling utilities used by both prompt and question modes.
 //!
-//! Contains modifier predicates, cursor position queries, word-based cursor
-//! movement, word deletion, and text normalization that are common across
-//! text-input modes.
+//! Contains the canonical `KeyEvent` to semantic input-command mapping plus
+//! paste normalization shared across text-input modes.
 
 use crossterm::event::{self, KeyCode, KeyEvent};
 
-use crate::domain::input::InputState;
+use crate::domain::input::{InputCommand, InputState};
+
+/// Capabilities that differ between single-line and multiline inputs.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct InputCapabilities {
+    multiline: bool,
+}
+
+impl InputCapabilities {
+    pub(crate) const MULTILINE: Self = Self { multiline: true };
+    pub(crate) const SINGLE_LINE: Self = Self { multiline: false };
+}
 
 // ---------------------------------------------------------------------------
 // Modifier predicates
@@ -34,7 +44,7 @@ pub(crate) fn is_alt_key(key: KeyEvent) -> bool {
 /// single character.
 ///
 /// `Option`+`Backspace` is reported as `Alt` on macOS terminals. `Shift` is
-/// also accepted for backward compatibility with existing behavior.
+/// also accepted for compatibility with the existing word-delete shortcut.
 /// `Cmd`+`Backspace` is handled separately as a whole-line deletion shortcut.
 pub(crate) fn is_word_delete_backspace(key: KeyEvent) -> bool {
     key.modifiers
@@ -89,6 +99,82 @@ pub(crate) fn is_control_newline_key(key: KeyEvent, character: char) -> bool {
     key.modifiers == event::KeyModifiers::CONTROL && matches!(character, 'j' | 'm' | '\n' | '\r')
 }
 
+/// Maps one terminal key event to the shared semantic input command.
+///
+/// Mode-specific handlers intercept submission, cancellation, completion,
+/// history navigation, and other contextual actions before using this map as
+/// their editing fallback.
+pub(crate) fn command_for_key(
+    key: KeyEvent,
+    capabilities: InputCapabilities,
+) -> Option<InputCommand> {
+    let command = match key.code {
+        KeyCode::Enter | KeyCode::Char('\r' | '\n')
+            if capabilities.multiline && should_insert_newline(key) =>
+        {
+            InputCommand::InsertNewline
+        }
+        KeyCode::Backspace if is_line_delete_backspace(key) => InputCommand::DeleteCurrentLine,
+        KeyCode::Backspace if is_word_delete_backspace(key) => InputCommand::DeleteWordBackward,
+        KeyCode::Backspace => InputCommand::DeleteBackward,
+        KeyCode::Delete => InputCommand::DeleteForward,
+        KeyCode::Left if key.modifiers.contains(event::KeyModifiers::SUPER) => {
+            InputCommand::MoveLineStart
+        }
+        KeyCode::Left
+            if key
+                .modifiers
+                .intersects(event::KeyModifiers::ALT | event::KeyModifiers::SHIFT) =>
+        {
+            InputCommand::MoveWordLeft
+        }
+        KeyCode::Left => InputCommand::MoveLeft,
+        KeyCode::Right if key.modifiers.contains(event::KeyModifiers::SUPER) => {
+            InputCommand::MoveLineEnd
+        }
+        KeyCode::Right
+            if key
+                .modifiers
+                .intersects(event::KeyModifiers::ALT | event::KeyModifiers::SHIFT) =>
+        {
+            InputCommand::MoveWordRight
+        }
+        KeyCode::Right => InputCommand::MoveRight,
+        KeyCode::Up => InputCommand::MoveUp,
+        KeyCode::Down => InputCommand::MoveDown,
+        KeyCode::Home => InputCommand::MoveHome,
+        KeyCode::End => InputCommand::MoveEnd,
+        KeyCode::Char('z' | 'Z')
+            if key.modifiers == event::KeyModifiers::CONTROL | event::KeyModifiers::SHIFT =>
+        {
+            InputCommand::Redo
+        }
+        KeyCode::Char('z') if is_control_key(key) => InputCommand::Undo,
+        KeyCode::Char('y') if is_control_key(key) => InputCommand::Redo,
+        KeyCode::Char('a') if is_control_key(key) => InputCommand::MoveLineStart,
+        KeyCode::Char('e') if is_control_key(key) => InputCommand::MoveLineEnd,
+        KeyCode::Char('f') if is_control_key(key) => InputCommand::MoveRight,
+        KeyCode::Char('b') if is_control_key(key) => InputCommand::MoveLeft,
+        KeyCode::Char('p') if is_control_key(key) => InputCommand::MoveUp,
+        KeyCode::Char('n') if is_control_key(key) => InputCommand::MoveDown,
+        KeyCode::Char('d') if is_control_key(key) => InputCommand::DeleteForward,
+        KeyCode::Char('k') if is_control_key(key) => InputCommand::DeleteToLineEnd,
+        KeyCode::Char('u') if is_control_key(key) => InputCommand::DeleteCurrentLine,
+        KeyCode::Char('w') if is_control_key(key) => InputCommand::DeleteWordBackward,
+        KeyCode::Char('b') if is_alt_key(key) => InputCommand::MoveWordLeft,
+        KeyCode::Char('f') if is_alt_key(key) => InputCommand::MoveWordRight,
+        KeyCode::Char(character)
+            if capabilities.multiline && is_control_newline_key(key, character) =>
+        {
+            InputCommand::InsertNewline
+        }
+        KeyCode::Char(character) if is_insertable_char_key(key) => InputCommand::Insert(character),
+        _ => return None,
+    };
+
+    Some(command)
+}
+
 // ---------------------------------------------------------------------------
 // Cursor position queries
 // ---------------------------------------------------------------------------
@@ -107,91 +193,6 @@ pub(crate) fn is_cursor_on_first_line(input: &InputState) -> bool {
 /// including when the input is empty.
 pub(crate) fn is_cursor_on_last_line(input: &InputState) -> bool {
     input.text().chars().skip(input.cursor).all(|ch| ch != '\n')
-}
-
-// ---------------------------------------------------------------------------
-// Word-based cursor movement
-// ---------------------------------------------------------------------------
-
-/// Moves the cursor to the start of the previous word, skipping adjacent
-/// whitespace separators.
-pub(crate) fn move_cursor_word_left(input: &mut InputState) {
-    if input.cursor == 0 {
-        return;
-    }
-
-    let characters: Vec<char> = input.text().chars().collect();
-    let mut cursor = input.cursor;
-
-    while cursor > 0 && characters[cursor - 1].is_whitespace() {
-        cursor -= 1;
-    }
-
-    while cursor > 0 && !characters[cursor - 1].is_whitespace() {
-        cursor -= 1;
-    }
-
-    input.cursor = cursor;
-}
-
-/// Moves the cursor to the start of the next word, skipping adjacent
-/// whitespace separators.
-pub(crate) fn move_cursor_word_right(input: &mut InputState) {
-    let characters: Vec<char> = input.text().chars().collect();
-    let mut cursor = input.cursor;
-
-    while cursor < characters.len() && !characters[cursor].is_whitespace() {
-        cursor += 1;
-    }
-
-    while cursor < characters.len() && characters[cursor].is_whitespace() {
-        cursor += 1;
-    }
-
-    input.cursor = cursor;
-}
-
-// ---------------------------------------------------------------------------
-// Word-based deletion
-// ---------------------------------------------------------------------------
-
-/// Returns the character range for deleting the previous word plus adjacent
-/// separator whitespace.
-///
-/// The three-step backward scan skips trailing whitespace, then the word body,
-/// then leading whitespace before the word. Returns `None` when the cursor is
-/// already at position zero.
-pub(crate) fn word_delete_range(text: &str, cursor: usize) -> Option<(usize, usize)> {
-    if cursor == 0 {
-        return None;
-    }
-
-    let characters: Vec<char> = text.chars().collect();
-    let mut start = cursor;
-
-    while start > 0 && characters[start - 1].is_whitespace() {
-        start -= 1;
-    }
-
-    while start > 0 && !characters[start - 1].is_whitespace() {
-        start -= 1;
-    }
-
-    while start > 0 && characters[start - 1].is_whitespace() {
-        start -= 1;
-    }
-
-    Some((start, cursor))
-}
-
-/// Deletes the previous word and any preceding whitespace from the input.
-///
-/// Matches the `Ctrl+w` / `Alt+Backspace` behavior: skip trailing whitespace,
-/// skip the word body, then skip leading whitespace before the word.
-pub(crate) fn delete_word_backward(input: &mut InputState) {
-    if let Some((start, end)) = word_delete_range(input.text(), input.cursor) {
-        input.replace_range(start, end, "");
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -221,6 +222,16 @@ pub(crate) fn normalize_pasted_text(pasted_text: &str) -> String {
     }
 
     normalized_text
+}
+
+/// Normalizes pasted text and keeps only its first line for a single-line
+/// input field.
+pub(crate) fn normalize_single_line_pasted_text(pasted_text: &str) -> String {
+    normalize_pasted_text(pasted_text)
+        .split('\n')
+        .next()
+        .unwrap_or_default()
+        .to_string()
 }
 
 #[cfg(test)]
@@ -451,18 +462,6 @@ mod tests {
     }
 
     #[test]
-    fn test_is_word_delete_backspace_accepts_shift_modifier() {
-        // Arrange
-        let key = KeyEvent::new(KeyCode::Backspace, event::KeyModifiers::SHIFT);
-
-        // Act
-        let result = is_word_delete_backspace(key);
-
-        // Assert
-        assert!(result);
-    }
-
-    #[test]
     fn test_is_word_delete_backspace_rejects_plain_backspace() {
         // Arrange
         let key = KeyEvent::new(KeyCode::Backspace, event::KeyModifiers::NONE);
@@ -595,109 +594,88 @@ mod tests {
         assert!(!is_cursor_on_last_line(&input));
     }
 
-    // -----------------------------------------------------------------------
-    // move_cursor_word_left / move_cursor_word_right
-    // -----------------------------------------------------------------------
+    #[test]
+    fn test_command_for_key_maps_shared_editing_shortcuts() {
+        // Arrange
+        let cases = [
+            (
+                KeyEvent::new(KeyCode::Backspace, event::KeyModifiers::ALT),
+                InputCommand::DeleteWordBackward,
+            ),
+            (
+                KeyEvent::new(KeyCode::Backspace, event::KeyModifiers::SHIFT),
+                InputCommand::DeleteWordBackward,
+            ),
+            (
+                KeyEvent::new(KeyCode::Left, event::KeyModifiers::SHIFT),
+                InputCommand::MoveWordLeft,
+            ),
+            (
+                KeyEvent::new(KeyCode::Right, event::KeyModifiers::SHIFT),
+                InputCommand::MoveWordRight,
+            ),
+            (
+                KeyEvent::new(KeyCode::Char('w'), event::KeyModifiers::CONTROL),
+                InputCommand::DeleteWordBackward,
+            ),
+            (
+                KeyEvent::new(KeyCode::Char('z'), event::KeyModifiers::CONTROL),
+                InputCommand::Undo,
+            ),
+            (
+                KeyEvent::new(KeyCode::Char('y'), event::KeyModifiers::CONTROL),
+                InputCommand::Redo,
+            ),
+            (
+                KeyEvent::new(KeyCode::Delete, event::KeyModifiers::NONE),
+                InputCommand::DeleteForward,
+            ),
+            (
+                KeyEvent::new(KeyCode::Right, event::KeyModifiers::NONE),
+                InputCommand::MoveRight,
+            ),
+            (
+                KeyEvent::new(KeyCode::Home, event::KeyModifiers::NONE),
+                InputCommand::MoveHome,
+            ),
+            (
+                KeyEvent::new(KeyCode::End, event::KeyModifiers::NONE),
+                InputCommand::MoveEnd,
+            ),
+            (
+                KeyEvent::new(
+                    KeyCode::Char('Z'),
+                    event::KeyModifiers::CONTROL | event::KeyModifiers::SHIFT,
+                ),
+                InputCommand::Redo,
+            ),
+            (
+                KeyEvent::new(KeyCode::Char('u'), event::KeyModifiers::CONTROL),
+                InputCommand::DeleteCurrentLine,
+            ),
+        ];
+
+        // Act & Assert
+        for (key, expected) in cases {
+            assert_eq!(
+                command_for_key(key, InputCapabilities::SINGLE_LINE),
+                Some(expected)
+            );
+        }
+    }
 
     #[test]
-    fn test_move_cursor_word_left_skips_whitespace_and_word() {
+    fn test_command_for_key_respects_multiline_capability() {
         // Arrange
-        let mut input = InputState::with_text("hello world".to_string());
-        input.cursor = "hello world".chars().count();
+        let key = KeyEvent::new(KeyCode::Enter, event::KeyModifiers::SHIFT);
 
         // Act
-        move_cursor_word_left(&mut input);
+        let multiline_command = command_for_key(key, InputCapabilities::MULTILINE);
+        let single_line_command = command_for_key(key, InputCapabilities::SINGLE_LINE);
 
         // Assert
-        assert_eq!(input.cursor, "hello ".chars().count());
-    }
-
-    #[test]
-    fn test_move_cursor_word_left_at_zero_is_noop() {
-        // Arrange
-        let mut input = InputState::with_text("hello".to_string());
-        input.cursor = 0;
-
-        // Act
-        move_cursor_word_left(&mut input);
-
-        // Assert
-        assert_eq!(input.cursor, 0);
-    }
-
-    #[test]
-    fn test_move_cursor_word_right_skips_word_and_whitespace() {
-        // Arrange
-        let mut input = InputState::with_text("hello world".to_string());
-        input.cursor = 0;
-
-        // Act
-        move_cursor_word_right(&mut input);
-
-        // Assert
-        assert_eq!(input.cursor, "hello ".chars().count());
-    }
-
-    #[test]
-    fn test_move_cursor_word_right_at_end_is_noop() {
-        // Arrange
-        let mut input = InputState::with_text("hello".to_string());
-        input.cursor = "hello".chars().count();
-
-        // Act
-        move_cursor_word_right(&mut input);
-
-        // Assert
-        assert_eq!(input.cursor, "hello".chars().count());
-    }
-
-    // -----------------------------------------------------------------------
-    // word_delete_range / delete_word_backward
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_word_delete_range_returns_none_at_zero() {
-        // Arrange & Act
-        let result = word_delete_range("hello world", 0);
-
-        // Assert
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_word_delete_range_deletes_last_word_and_separator() {
-        // Arrange & Act
-        let result = word_delete_range("hello brave world", "hello brave world".chars().count());
-
-        // Assert — range covers " world" (the trailing word and its preceding
-        // whitespace).
-        assert_eq!(result, Some((11, "hello brave world".chars().count())));
-    }
-
-    #[test]
-    fn test_delete_word_backward_removes_last_word_and_separator() {
-        // Arrange
-        let mut input = InputState::with_text("hello brave world".to_string());
-        input.cursor = "hello brave world".chars().count();
-
-        // Act
-        delete_word_backward(&mut input);
-
-        // Assert
-        assert_eq!(input.text(), "hello brave");
-    }
-
-    #[test]
-    fn test_delete_word_backward_noop_at_zero() {
-        // Arrange
-        let mut input = InputState::with_text("hello".to_string());
-        input.cursor = 0;
-
-        // Act
-        delete_word_backward(&mut input);
-
-        // Assert
-        assert_eq!(input.text(), "hello");
+        assert_eq!(multiline_command, Some(InputCommand::InsertNewline));
+        assert_eq!(single_line_command, None);
     }
 
     // -----------------------------------------------------------------------
@@ -726,5 +704,17 @@ mod tests {
 
         // Assert
         assert_eq!(normalized, pasted_text);
+    }
+
+    #[test]
+    fn test_normalize_single_line_pasted_text_keeps_first_line() {
+        // Arrange
+        let pasted_text = "feature/shared-input\r\nignored";
+
+        // Act
+        let normalized = normalize_single_line_pasted_text(pasted_text);
+
+        // Assert
+        assert_eq!(normalized, "feature/shared-input");
     }
 }

--- a/crates/agentty/src/runtime/mode/list.rs
+++ b/crates/agentty/src/runtime/mode/list.rs
@@ -13,6 +13,7 @@ use crate::presentation::help_action::{
 use crate::presentation::prompt::{PromptAttachmentState, PromptHistoryState};
 use crate::runtime::EventResult;
 use crate::runtime::mode::confirmation::DEFAULT_OPTION_INDEX;
+use crate::runtime::mode::input_key;
 
 /// Handles key input while the app is in list mode.
 ///
@@ -274,37 +275,17 @@ async fn handle_settings_launch_configuration_input(
         KeyCode::Esc => {
             app.settings.cancel_launch_configuration_input();
         }
-        KeyCode::Left => {
-            app.settings.move_launch_configuration_input_cursor_left();
+        _ => {
+            if let Some(command) =
+                input_key::command_for_key(key, input_key::InputCapabilities::SINGLE_LINE)
+            {
+                app.settings
+                    .apply_launch_configuration_input_command(command);
+            }
         }
-        KeyCode::Right => {
-            app.settings.move_launch_configuration_input_cursor_right();
-        }
-        KeyCode::Home => {
-            app.settings.move_launch_configuration_input_cursor_home();
-        }
-        KeyCode::End => {
-            app.settings.move_launch_configuration_input_cursor_end();
-        }
-        KeyCode::Backspace => {
-            app.settings.remove_launch_configuration_input_character();
-        }
-        KeyCode::Delete => {
-            app.settings.delete_launch_configuration_input_character();
-        }
-        KeyCode::Char(character) if is_settings_text_key(key) => {
-            app.settings
-                .append_launch_configuration_input_character(character);
-        }
-        _ => {}
     }
 
     Ok(EventResult::Continue)
-}
-
-/// Returns whether a key event should insert text into a settings string value.
-fn is_settings_text_key(key: KeyEvent) -> bool {
-    key.modifiers == KeyModifiers::NONE || key.modifiers == KeyModifiers::SHIFT
 }
 
 /// Starts the sync action that applies to the visible list tab.

--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -10,13 +10,13 @@ use crate::app::prompt_intent::{
     PromptIntentContext, PromptIntentInputMode, PromptIntentSessionMode,
 };
 use crate::domain::agent::AgentKind;
-use crate::domain::input::InputState;
+use crate::domain::input::{InputCommand, InputEffect, InputState};
 use crate::domain::session::SessionId;
 use crate::presentation::app_mode::{AppMode, ChatFocus};
 use crate::presentation::prompt::{
     PromptAtMentionState, apply_prompt_delete_range as apply_prompt_delete_range_components,
-    current_line_delete_range as prompt_current_line_delete_range, insert_prompt_character,
-    insert_prompt_text, prompt_slash_option_count,
+    current_line_delete_range as prompt_current_line_delete_range, insert_prompt_text,
+    prompt_slash_option_count,
 };
 use crate::runtime::EventResult;
 use crate::runtime::mode::chat_scroll::{self, ChatScrollMetrics};
@@ -119,7 +119,7 @@ where
         reset_prompt_slash_state(app);
     }
 
-    if prompt_context.is_at_mention() && handle_at_mention_key(app, key) {
+    if prompt_context.is_at_mention() && handle_at_mention_key(app, key).await {
         return Ok(EventResult::Continue);
     }
 
@@ -212,11 +212,13 @@ where
 /// Handles keys when the at-mention dropdown is active.
 ///
 /// Returns `true` if the key was consumed by at-mention logic.
-fn handle_at_mention_key(app: &mut App, key: KeyEvent) -> bool {
+async fn handle_at_mention_key(app: &mut App, key: KeyEvent) -> bool {
     match key.code {
         KeyCode::Esc => dismiss_at_mention(app),
-        KeyCode::Enter if !input_key::should_insert_newline(key) => handle_at_mention_select(app),
-        KeyCode::Tab => handle_at_mention_select(app),
+        KeyCode::Enter if !input_key::should_insert_newline(key) => {
+            handle_at_mention_select(app).await;
+        }
+        KeyCode::Tab => handle_at_mention_select(app).await,
         KeyCode::Up => handle_at_mention_up(app),
         KeyCode::Down => handle_at_mention_down(app),
         _ => return false,
@@ -236,18 +238,12 @@ where
     B::Error: std::error::Error + Send + Sync + 'static,
 {
     match key.code {
-        KeyCode::Enter | KeyCode::Char('\r' | '\n') if input_key::should_insert_newline(key) => {
-            reset_prompt_history_navigation(app);
-            if let AppMode::Prompt { input, .. } = &mut app.mode {
-                input.insert_newline();
-            }
+        KeyCode::Enter | KeyCode::Char('\r' | '\n') if !input_key::should_insert_newline(key) => {
+            handle_prompt_submit_key(app, prompt_context).await;
         }
-        KeyCode::Enter => handle_prompt_submit_key(app, prompt_context).await,
         KeyCode::Esc | KeyCode::Char('c') if is_prompt_cancel_key(key) => {
             handle_prompt_cancel_key(app, prompt_context).await;
         }
-        KeyCode::Left => handle_prompt_left(app, key),
-        KeyCode::Right => handle_prompt_right(app, key),
         KeyCode::Up => handle_prompt_up_key(app, terminal, prompt_context)?,
         KeyCode::Down => handle_prompt_down_key(app, terminal, prompt_context)?,
         KeyCode::Char('k') if prompt_context.is_slash_command() && is_plain_char_key(key, 'k') => {
@@ -256,31 +252,8 @@ where
         KeyCode::Char('j') if prompt_context.is_slash_command() && is_plain_char_key(key, 'j') => {
             handle_prompt_down_key(app, terminal, prompt_context)?;
         }
-        KeyCode::Home => handle_prompt_input(app, InputState::move_home),
-        KeyCode::End => handle_prompt_input(app, InputState::move_end),
-        KeyCode::Backspace => handle_prompt_backspace(app, key),
-        KeyCode::Delete => handle_prompt_delete(app),
-        KeyCode::Char(character) if input_key::is_control_newline_key(key, character) => {
-            reset_prompt_history_navigation(app);
-            if let AppMode::Prompt { input, .. } = &mut app.mode {
-                input.insert_newline();
-            }
-        }
-        KeyCode::Char('u') if input_key::is_control_key(key) => handle_prompt_line_delete(app),
         KeyCode::Char('v' | 'V') if is_prompt_image_paste_key(key) => {
             handle_prompt_image_paste(app, prompt_context).await;
-        }
-        KeyCode::Char('a') if input_key::is_control_key(key) => {
-            handle_prompt_input(app, InputState::move_line_start);
-        }
-        KeyCode::Char('e') if input_key::is_control_key(key) => {
-            handle_prompt_input(app, InputState::move_line_end);
-        }
-        KeyCode::Char('f') if input_key::is_control_key(key) => {
-            handle_prompt_input(app, InputState::move_right);
-        }
-        KeyCode::Char('b') if input_key::is_control_key(key) => {
-            handle_prompt_input(app, InputState::move_left);
         }
         KeyCode::Char('p') if input_key::is_control_key(key) => {
             handle_prompt_up_key(app, terminal, prompt_context)?;
@@ -288,38 +261,101 @@ where
         KeyCode::Char('n') if input_key::is_control_key(key) => {
             handle_prompt_down_key(app, terminal, prompt_context)?;
         }
-        KeyCode::Char('d') if input_key::is_control_key(key) => handle_prompt_delete(app),
-        KeyCode::Char('k') if input_key::is_control_key(key) => handle_prompt_kill_to_line_end(app),
-        KeyCode::Char('w') if input_key::is_control_key(key) => handle_prompt_word_delete(app),
-        KeyCode::Char('b') if input_key::is_alt_key(key) => {
-            if let AppMode::Prompt { input, .. } = &mut app.mode {
-                input_key::move_cursor_word_left(input);
+        _ => {
+            if let Some(command) =
+                input_key::command_for_key(key, input_key::InputCapabilities::MULTILINE)
+            {
+                apply_prompt_input_command(app, command).await;
             }
-
-            sync_prompt_at_mention_state(app);
         }
-        KeyCode::Char('f') if input_key::is_alt_key(key) => {
-            if let AppMode::Prompt { input, .. } = &mut app.mode {
-                input_key::move_cursor_word_right(input);
-            }
-
-            sync_prompt_at_mention_state(app);
-        }
-        KeyCode::Char(character) => handle_prompt_char(app, character),
-        _ => {}
     }
 
     Ok(())
 }
 
-/// Applies one `InputState` method to the prompt input and keeps `@` mention
-/// state aligned with the updated cursor location.
-fn handle_prompt_input(app: &mut App, action: fn(&mut InputState)) {
-    if let AppMode::Prompt { input, .. } = &mut app.mode {
-        action(input);
+/// Applies one shared input command while preserving prompt-specific
+/// attachment, history, slash-command, and `@`-mention behavior.
+async fn apply_prompt_input_command(app: &mut App, command: InputCommand) {
+    let delete_range = if let AppMode::Prompt { input, .. } = &app.mode {
+        prompt_command_delete_range(input, &command)
+    } else {
+        None
+    };
+
+    if let Some((start, end)) = delete_range {
+        apply_prompt_delete_range(app, start, end).await;
+
+        return;
     }
 
+    let is_history_restore = matches!(command, InputCommand::Undo | InputCommand::Redo);
+    let mut unreachable_attachments = Vec::new();
+    if let AppMode::Prompt {
+        attachment_state,
+        history_state,
+        input,
+        slash_state,
+        ..
+    } = &mut app.mode
+    {
+        attachment_state.remember_current_revision(input);
+        let edit_span = prompt_command_edit_span(input, &command);
+        let effect = input.apply(command);
+        if effect == InputEffect::TextChanged {
+            if is_history_restore {
+                attachment_state.sync_after_history_restore(input);
+            } else if let Some((old_start, old_end, new_end)) = edit_span {
+                attachment_state.sync_after_edit(input, old_start, old_end, new_end);
+            }
+            unreachable_attachments = attachment_state.prune_unreachable(input);
+            history_state.reset_navigation();
+            slash_state.reset();
+        }
+    }
+
+    app.cleanup_prompt_attachments(unreachable_attachments)
+        .await;
     sync_prompt_at_mention_state(app);
+}
+
+/// Returns the prompt-aware range for shared deletion commands.
+fn prompt_command_delete_range(
+    input: &InputState,
+    command: &InputCommand,
+) -> Option<(usize, usize)> {
+    match command {
+        InputCommand::DeleteBackward => {
+            (input.cursor > 0).then_some((input.cursor - 1, input.cursor))
+        }
+        InputCommand::DeleteCurrentLine => prompt_current_line_delete_range(input),
+        InputCommand::DeleteForward => (input.cursor < input.text().chars().count())
+            .then_some((input.cursor, input.cursor + 1)),
+        InputCommand::DeleteToLineEnd => input.line_end_delete_range(),
+        InputCommand::DeleteWordBackward => input.word_delete_range(),
+        _ => None,
+    }
+}
+
+/// Returns the exact character span replaced by one non-deletion text
+/// command before that command mutates the input.
+fn prompt_command_edit_span(
+    input: &InputState,
+    command: &InputCommand,
+) -> Option<(usize, usize, usize)> {
+    match command {
+        InputCommand::Insert(_) | InputCommand::InsertNewline => {
+            Some((input.cursor, input.cursor, input.cursor + 1))
+        }
+        InputCommand::InsertText(text) => Some((
+            input.cursor,
+            input.cursor,
+            input.cursor + text.chars().count(),
+        )),
+        InputCommand::ReplaceRange { start, end, text } => {
+            Some((*start, *end, *start + text.chars().count()))
+        }
+        _ => None,
+    }
 }
 
 /// Inserts pasted content into the prompt input while normalizing mixed
@@ -327,7 +363,7 @@ fn handle_prompt_input(app: &mut App, action: fn(&mut InputState)) {
 ///
 /// Pastes are dropped while the chat transcript holds focus so scrolling the
 /// conversation never rewrites the typed draft.
-pub(crate) fn handle_paste(app: &mut App, pasted_text: &str) {
+pub(crate) async fn handle_paste(app: &mut App, pasted_text: &str) {
     let normalized_text = input_key::normalize_pasted_text(pasted_text);
     if normalized_text.is_empty() {
         return;
@@ -341,16 +377,24 @@ pub(crate) fn handle_paste(app: &mut App, pasted_text: &str) {
         return;
     }
 
+    let mut unreachable_attachments = Vec::new();
     if let AppMode::Prompt {
+        attachment_state,
         history_state,
         input,
         slash_state,
         ..
     } = &mut app.mode
     {
+        attachment_state.remember_current_revision(input);
+        let insert_start = input.cursor;
         insert_prompt_text(input, history_state, slash_state, &normalized_text);
+        attachment_state.sync_after_edit(input, insert_start, insert_start, input.cursor);
+        unreachable_attachments = attachment_state.prune_unreachable(input);
     }
 
+    app.cleanup_prompt_attachments(unreachable_attachments)
+        .await;
     sync_prompt_at_mention_state(app);
 }
 
@@ -469,12 +513,6 @@ fn reset_prompt_slash_state(app: &mut App) {
     }
 }
 
-fn reset_prompt_history_navigation(app: &mut App) {
-    if let AppMode::Prompt { history_state, .. } = &mut app.mode {
-        history_state.reset_navigation();
-    }
-}
-
 fn is_prompt_cancel_key(key: KeyEvent) -> bool {
     key.code == KeyCode::Esc || key.modifiers.contains(event::KeyModifiers::CONTROL)
 }
@@ -562,6 +600,7 @@ where
 
 fn navigate_prompt_history_up(app: &mut App) {
     if let AppMode::Prompt {
+        attachment_state,
         history_state,
         input,
         ..
@@ -575,17 +614,21 @@ fn navigate_prompt_history_up(app: &mut App) {
             selected_index.saturating_sub(1)
         } else {
             history_state.draft_text = Some(input.text().to_string());
+            attachment_state.remember_current_revision(input);
+            history_state.draft_input_revision = Some(input.revision());
 
             history_state.entries.len().saturating_sub(1)
         };
 
         history_state.selected_index = Some(next_index);
-        *input = InputState::with_text(history_state.entries[next_index].clone());
+        attachment_state.archive_current();
+        input.reset_text(history_state.entries[next_index].clone());
     }
 }
 
 fn navigate_prompt_history_down(app: &mut App) {
     if let AppMode::Prompt {
+        attachment_state,
         history_state,
         input,
         ..
@@ -599,13 +642,20 @@ fn navigate_prompt_history_down(app: &mut App) {
             let next_index = selected_index + 1;
 
             history_state.selected_index = Some(next_index);
-            *input = InputState::with_text(history_state.entries[next_index].clone());
+            attachment_state.archive_current();
+            input.reset_text(history_state.entries[next_index].clone());
 
             return;
         }
 
         history_state.selected_index = None;
-        *input = InputState::with_text(history_state.draft_text.take().unwrap_or_default());
+        let draft_input_revision = history_state.draft_input_revision.take();
+        input.reset_text(history_state.draft_text.take().unwrap_or_default());
+        if let Some(draft_input_revision) = draft_input_revision {
+            attachment_state.restore_draft_revision(draft_input_revision, input);
+        } else {
+            attachment_state.archive_current();
+        }
     }
 }
 
@@ -687,139 +737,10 @@ where
     Ok(terminal_width.saturating_sub(2))
 }
 
-/// Moves the prompt cursor left with modifier-aware behavior.
-///
-/// `Cmd`+`Left` (`SUPER`) moves to the start of the current line,
-/// `Option`+`Left` (`ALT`) and `Shift`+`Left` move to the previous word
-/// start, and a plain `Left` moves one character. When the move lands inside
-/// an existing `@path` token, the file dropdown is reopened.
-fn handle_prompt_left(app: &mut App, key: KeyEvent) {
-    if let AppMode::Prompt { input, .. } = &mut app.mode {
-        if key.modifiers.contains(event::KeyModifiers::SUPER) {
-            input.move_line_start();
-        } else if key
-            .modifiers
-            .intersects(event::KeyModifiers::ALT | event::KeyModifiers::SHIFT)
-        {
-            input_key::move_cursor_word_left(input);
-        } else {
-            input.move_left();
-        }
-    }
-
-    sync_prompt_at_mention_state(app);
-}
-
-/// Moves the prompt cursor right with modifier-aware behavior.
-///
-/// `Cmd`+`Right` (`SUPER`) moves to the end of the current line,
-/// `Option`+`Right` (`ALT`) and `Shift`+`Right` move to the next word
-/// start, and a plain `Right` moves one character. When the move lands inside
-/// an existing `@path` token, the file dropdown is reopened.
-fn handle_prompt_right(app: &mut App, key: KeyEvent) {
-    if let AppMode::Prompt { input, .. } = &mut app.mode {
-        if key.modifiers.contains(event::KeyModifiers::SUPER) {
-            input.move_line_end();
-        } else if key
-            .modifiers
-            .intersects(event::KeyModifiers::ALT | event::KeyModifiers::SHIFT)
-        {
-            input_key::move_cursor_word_right(input);
-        } else {
-            input.move_right();
-        }
-    }
-
-    sync_prompt_at_mention_state(app);
-}
-
-/// Handles `Ctrl+u` line deletion by clearing the current line content.
-///
-/// This is the standard Unix "kill line" binding and also the sequence macOS
-/// terminals send for `Cmd`+`Backspace`.
-fn handle_prompt_line_delete(app: &mut App) {
-    if let AppMode::Prompt { input, .. } = &app.mode
-        && let Some((start, end)) = prompt_current_line_delete_range(input)
-    {
-        apply_prompt_delete_range(app, start, end);
-    }
-}
-
-/// Handles `Ctrl+k` kill-to-end-of-line by deleting text from the cursor to
-/// the end of the current line (stopping before the newline).
-fn handle_prompt_kill_to_line_end(app: &mut App) {
-    if let AppMode::Prompt { input, .. } = &mut app.mode {
-        input.delete_to_line_end();
-    }
-}
-
-/// Handles `Ctrl+w` word deletion by deleting the previous word.
-fn handle_prompt_word_delete(app: &mut App) {
-    if let AppMode::Prompt { input, .. } = &app.mode
-        && let Some((start, end)) = input_key::word_delete_range(input.text(), input.cursor)
-    {
-        apply_prompt_delete_range(app, start, end);
-    }
-}
-
-/// Handles prompt backspace by deleting one character or one whole word when
-/// `Option`/`Alt` (or `Shift` for compatibility) is pressed.
-///
-/// `Cmd`+`Backspace` takes precedence and clears the current line content.
-fn handle_prompt_backspace(app: &mut App, key: KeyEvent) {
-    let Some(delete_range) = prompt_backspace_range(app, key) else {
-        return;
-    };
-
-    apply_prompt_delete_range(app, delete_range.0, delete_range.1);
-}
-
-/// Returns the character range deleted by one prompt backspace key press.
-fn prompt_backspace_range(app: &App, key: KeyEvent) -> Option<(usize, usize)> {
-    let AppMode::Prompt { input, .. } = &app.mode else {
-        return None;
-    };
-
-    if input_key::is_line_delete_backspace(key) {
-        return prompt_current_line_delete_range(input);
-    }
-
-    if input_key::is_word_delete_backspace(key) {
-        return input_key::word_delete_range(input.text(), input.cursor);
-    }
-
-    if input.cursor == 0 {
-        return None;
-    }
-
-    Some((input.cursor - 1, input.cursor))
-}
-
-fn handle_prompt_delete(app: &mut App) {
-    let Some(delete_range) = prompt_delete_range(app) else {
-        return;
-    };
-
-    apply_prompt_delete_range(app, delete_range.0, delete_range.1);
-}
-
-/// Returns the character range deleted by one prompt forward-delete key press.
-fn prompt_delete_range(app: &App) -> Option<(usize, usize)> {
-    let AppMode::Prompt { input, .. } = &app.mode else {
-        return None;
-    };
-
-    let char_count = input.text().chars().count();
-    if input.cursor >= char_count {
-        return None;
-    }
-
-    Some((input.cursor, input.cursor + 1))
-}
-
 /// Applies one prompt deletion range, expanding it to cover full image
 /// placeholder tokens and removing orphaned attachments from prompt state.
-fn apply_prompt_delete_range(app: &mut App, start: usize, end: usize) {
+async fn apply_prompt_delete_range(app: &mut App, start: usize, end: usize) {
+    let mut unreachable_attachments = Vec::new();
     if let AppMode::Prompt {
         attachment_state,
         history_state,
@@ -836,24 +757,11 @@ fn apply_prompt_delete_range(app: &mut App, start: usize, end: usize) {
             start,
             end,
         );
+        unreachable_attachments = attachment_state.prune_unreachable(input);
     }
 
-    sync_prompt_at_mention_state(app);
-}
-
-/// Inserts one typed character into prompt input and keeps at-mention state
-/// in sync.
-fn handle_prompt_char(app: &mut App, character: char) {
-    if let AppMode::Prompt {
-        input,
-        history_state,
-        slash_state,
-        ..
-    } = &mut app.mode
-    {
-        insert_prompt_character(input, history_state, slash_state, character);
-    }
-
+    app.cleanup_prompt_attachments(unreachable_attachments)
+        .await;
     sync_prompt_at_mention_state(app);
 }
 
@@ -920,7 +828,7 @@ fn handle_at_mention_down(app: &mut App) {
 }
 
 /// Selects the currently highlighted file and inserts it into the input.
-fn handle_at_mention_select(app: &mut App) {
+async fn handle_at_mention_select(app: &mut App) {
     let replacement = match &app.mode {
         AppMode::Prompt {
             at_mention_state: Some(state),
@@ -930,17 +838,21 @@ fn handle_at_mention_select(app: &mut App) {
         _ => return,
     };
 
-    if replacement.is_none() {
+    let Some(selection) = replacement else {
         dismiss_at_mention(app);
 
         return;
-    }
+    };
 
-    if let Some(selection) = replacement
-        && let AppMode::Prompt { input, .. } = &mut app.mode
-    {
-        input.replace_range(selection.at_start, selection.cursor, &selection.text);
-    }
+    apply_prompt_input_command(
+        app,
+        InputCommand::ReplaceRange {
+            start: selection.at_start,
+            end: selection.cursor,
+            text: selection.text,
+        },
+    )
+    .await;
 
     dismiss_at_mention(app);
 }
@@ -956,6 +868,7 @@ mod tests {
     use crate::app::prompt_intent::build_apply_review_prompt;
     use crate::domain::agent::ReasoningLevel;
     use crate::domain::file_entry::FileEntry;
+    use crate::domain::input::INPUT_HISTORY_LIMIT;
     use crate::domain::session_message::SessionTranscript;
     use crate::infra::db::Database;
     use crate::presentation::prompt::{
@@ -1191,6 +1104,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_prompt_mode_handler_edits_and_submits_input() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("draft", None).await;
+
+        // Act
+        press_prompt_key(&mut app, KeyCode::Char('!')).await;
+        press_prompt_key(&mut app, KeyCode::Enter).await;
+
+        // Assert
+        assert!(matches!(app.mode, AppMode::View { .. }));
+        assert_eq!(app.sessions.sessions()[0].prompt, "draft!");
+    }
+
+    #[tokio::test]
     async fn test_tab_toggles_focus_between_composer_and_chat() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("draft text", None).await;
@@ -1278,7 +1205,7 @@ mod tests {
         press_prompt_key(&mut app, KeyCode::Tab).await;
 
         // Act
-        handle_paste(&mut app, "pasted");
+        handle_paste(&mut app, "pasted").await;
 
         // Assert
         let AppMode::Prompt { input, .. } = &app.mode else {
@@ -1380,7 +1307,7 @@ mod tests {
         let (mut app, _base_dir) = new_test_prompt_app("prefix ", None).await;
 
         // Act
-        handle_paste(&mut app, "line 1\r\nline 2\rline 3");
+        handle_paste(&mut app, "line 1\r\nline 2\rline 3").await;
 
         // Assert
         if let AppMode::Prompt { input, .. } = &app.mode {
@@ -1390,6 +1317,38 @@ mod tests {
                 "prefix line 1\nline 2\nline 3".chars().count()
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_prompt_shared_commands_insert_text_and_delete_to_line_end() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("first\nsecond", None).await;
+        if let AppMode::Prompt { input, .. } = &mut app.mode {
+            input.cursor = "first\nse".chars().count();
+        }
+
+        // Act
+        apply_prompt_input_command(&mut app, InputCommand::InsertText("X".to_string())).await;
+        apply_prompt_input_command(&mut app, InputCommand::DeleteToLineEnd).await;
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Prompt { input, .. } if input.text() == "first\nseX"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_prompt_input_command_ignores_non_prompt_mode() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("draft", None).await;
+        app.mode = AppMode::List;
+
+        // Act
+        apply_prompt_input_command(&mut app, InputCommand::Insert('x')).await;
+
+        // Assert
+        assert!(matches!(app.mode, AppMode::List));
     }
 
     #[tokio::test]
@@ -1592,8 +1551,9 @@ mod tests {
         app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
         app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-2.png"));
         if let AppMode::Prompt { input, .. } = &mut app.mode {
-            *input = InputState::with_text("Review [Image #2]".to_string());
+            input.cursor = "Review ".chars().count();
         }
+        apply_prompt_input_command(&mut app, InputCommand::DeleteForward).await;
 
         // Act
         let prompt = app.take_submitted_turn_prompt();
@@ -1623,10 +1583,11 @@ mod tests {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("", None).await;
         app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-2.png"));
         if let AppMode::Prompt { input, .. } = &mut app.mode {
-            *input = InputState::with_text("[Image #2] then [Image #1]".to_string());
+            input.cursor = 0;
         }
+        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-2.png"));
+        handle_paste(&mut app, " then ").await;
 
         // Act
         let prompt = app.take_submitted_turn_prompt();
@@ -1800,6 +1761,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_navigate_prompt_history_down_selects_next_entry() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("first", None).await;
+        if let AppMode::Prompt { history_state, .. } = &mut app.mode {
+            history_state.entries = vec![
+                "first".to_string(),
+                "second".to_string(),
+                "third".to_string(),
+            ];
+            history_state.selected_index = Some(0);
+        }
+
+        // Act
+        navigate_prompt_history_down(&mut app);
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Prompt {
+                history_state,
+                input,
+                ..
+            } if input.text() == "second" && history_state.selected_index == Some(1)
+        ));
+    }
+
+    #[tokio::test]
     async fn test_navigate_prompt_history_down_restores_draft_after_latest_entry() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("draft", None).await;
@@ -1822,6 +1810,54 @@ mod tests {
             assert_eq!(history_state.selected_index, None);
             assert_eq!(history_state.draft_text, None);
         }
+    }
+
+    #[tokio::test]
+    async fn test_navigate_prompt_history_down_restores_draft_without_attachment_revision() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("earlier", None).await;
+        if let AppMode::Prompt { history_state, .. } = &mut app.mode {
+            history_state.draft_text = Some("draft".to_string());
+            history_state.entries = vec!["earlier".to_string()];
+            history_state.selected_index = Some(0);
+        }
+
+        // Act
+        navigate_prompt_history_down(&mut app);
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Prompt {
+                attachment_state,
+                history_state,
+                input,
+                ..
+            } if input.text() == "draft"
+                && history_state.selected_index.is_none()
+                && attachment_state.attachments.is_empty()
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_prompt_history_round_trip_restores_image_draft_attachment() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("Review ", None).await;
+        let image_path = std::path::PathBuf::from("/tmp/image-1.png");
+        app.insert_pasted_image_placeholder(image_path.clone());
+        if let AppMode::Prompt { history_state, .. } = &mut app.mode {
+            history_state.entries = vec!["Earlier prompt".to_string()];
+        }
+
+        // Act
+        navigate_prompt_history_up(&mut app);
+        navigate_prompt_history_down(&mut app);
+        let prompt = app.take_submitted_turn_prompt();
+
+        // Assert
+        assert_eq!(prompt.text, "Review [Image #1]");
+        assert_eq!(prompt.attachments.len(), 1);
+        assert_eq!(prompt.attachments[0].local_image_path, image_path);
     }
 
     #[tokio::test]
@@ -1960,6 +1996,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_model_slash_submit_discards_pasted_image_before_normal_submission() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("/model", None).await;
+        app.insert_pasted_image_placeholder(std::path::PathBuf::from(
+            "/tmp/nonexistent-test-attachment.png",
+        ));
+        if let AppMode::Prompt { slash_state, .. } = &mut app.mode {
+            slash_state.stage = PromptSlashStage::Model;
+            slash_state.selected_agent = Some(AgentKind::Claude);
+            slash_state.selected_index = 0;
+        }
+        let prompt_context = prompt_context(&mut app).expect("expected prompt context");
+
+        // Act
+        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
+            .await;
+        if let AppMode::Prompt { input, .. } = &mut app.mode {
+            input.reset_text("normal prompt".to_string());
+        }
+        let prompt = app.take_submitted_turn_prompt();
+
+        // Assert
+        assert_eq!(prompt.text, "normal prompt");
+        assert!(prompt.attachments.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_reasoning_slash_submit_sets_level_and_resets_input() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("/reasoning", None).await;
+        if let AppMode::Prompt { slash_state, .. } = &mut app.mode {
+            slash_state.stage = PromptSlashStage::Reasoning;
+            slash_state.selected_index = 2;
+        }
+        let prompt_context = prompt_context(&mut app).expect("expected prompt context");
+
+        // Act
+        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
+            .await;
+        app.process_pending_app_events().await;
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Prompt { input, slash_state, .. }
+                if input.is_empty() && *slash_state == PromptSlashState::default()
+        ));
+        assert_eq!(
+            app.sessions.sessions()[0].reasoning_level_override,
+            Some(ReasoningLevel::High)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_canceling_slash_input_discards_pasted_attachment() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("/model", None).await;
+        app.insert_pasted_image_placeholder(std::path::PathBuf::from(
+            "/tmp/nonexistent-test-attachment.png",
+        ));
+        let prompt_context = prompt_context(&mut app).expect("expected prompt context");
+
+        // Act
+        handle_prompt_cancel_key(&mut app, &prompt_context).await;
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Prompt {
+                attachment_state,
+                input,
+                ..
+            } if input.is_empty() && attachment_state.attachments.is_empty()
+        ));
+    }
+
+    #[tokio::test]
     async fn test_handle_prompt_slash_submit_prefills_reasoning_selection_from_session_value() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("/reasoning", None).await;
@@ -2042,60 +2155,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_prompt_left_with_shift_moves_cursor_to_previous_word_start() {
-        // Arrange
-        let (mut app, _base_dir) = new_test_prompt_app("hello brave world", None).await;
-        if let AppMode::Prompt { input, .. } = &mut app.mode {
-            input.cursor = "hello brave world".chars().count();
-        }
-
-        // Act
-        let key = KeyEvent::new(KeyCode::Left, event::KeyModifiers::SHIFT);
-        handle_prompt_left(&mut app, key);
-
-        // Assert
-        if let AppMode::Prompt { input, .. } = &app.mode {
-            assert_eq!(input.cursor, "hello brave ".chars().count());
-        }
-    }
-
-    #[tokio::test]
-    async fn test_handle_prompt_left_with_shift_skips_whitespace_separators() {
-        // Arrange
-        let (mut app, _base_dir) = new_test_prompt_app("hello\t \nworld", None).await;
-        if let AppMode::Prompt { input, .. } = &mut app.mode {
-            input.cursor = "hello\t \nworld".chars().count();
-        }
-
-        // Act
-        let key = KeyEvent::new(KeyCode::Left, event::KeyModifiers::SHIFT);
-        handle_prompt_left(&mut app, key);
-
-        // Assert
-        if let AppMode::Prompt { input, .. } = &app.mode {
-            assert_eq!(input.cursor, "hello\t \n".chars().count());
-        }
-    }
-
-    #[tokio::test]
-    async fn test_handle_prompt_right_with_shift_moves_cursor_to_next_word_start() {
-        // Arrange
-        let (mut app, _base_dir) = new_test_prompt_app("hello brave world", None).await;
-        if let AppMode::Prompt { input, .. } = &mut app.mode {
-            input.cursor = 0;
-        }
-
-        // Act
-        let key = KeyEvent::new(KeyCode::Right, event::KeyModifiers::SHIFT);
-        handle_prompt_right(&mut app, key);
-
-        // Assert
-        if let AppMode::Prompt { input, .. } = &app.mode {
-            assert_eq!(input.cursor, "hello ".chars().count());
-        }
-    }
-
-    #[tokio::test]
     async fn test_handle_prompt_left_with_alt_moves_cursor_to_previous_word_start() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("hello brave world", None).await;
@@ -2104,8 +2163,7 @@ mod tests {
         }
 
         // Act
-        let key = KeyEvent::new(KeyCode::Left, event::KeyModifiers::ALT);
-        handle_prompt_left(&mut app, key);
+        apply_prompt_input_command(&mut app, InputCommand::MoveWordLeft).await;
 
         // Assert
         if let AppMode::Prompt { input, .. } = &app.mode {
@@ -2122,8 +2180,7 @@ mod tests {
         }
 
         // Act
-        let key = KeyEvent::new(KeyCode::Right, event::KeyModifiers::ALT);
-        handle_prompt_right(&mut app, key);
+        apply_prompt_input_command(&mut app, InputCommand::MoveWordRight).await;
 
         // Assert
         if let AppMode::Prompt { input, .. } = &app.mode {
@@ -2140,8 +2197,7 @@ mod tests {
         }
 
         // Act
-        let key = KeyEvent::new(KeyCode::Left, event::KeyModifiers::SUPER);
-        handle_prompt_left(&mut app, key);
+        apply_prompt_input_command(&mut app, InputCommand::MoveLineStart).await;
 
         // Assert
         if let AppMode::Prompt { input, .. } = &app.mode {
@@ -2158,8 +2214,7 @@ mod tests {
         }
 
         // Act
-        let key = KeyEvent::new(KeyCode::Right, event::KeyModifiers::SUPER);
-        handle_prompt_right(&mut app, key);
+        apply_prompt_input_command(&mut app, InputCommand::MoveLineEnd).await;
 
         // Assert
         if let AppMode::Prompt { input, .. } = &app.mode {
@@ -2178,8 +2233,7 @@ mod tests {
         }
 
         // Act
-        let key = KeyEvent::new(KeyCode::Backspace, event::KeyModifiers::NONE);
-        handle_prompt_backspace(&mut app, key);
+        apply_prompt_input_command(&mut app, InputCommand::DeleteBackward).await;
 
         // Assert
         if let AppMode::Prompt {
@@ -2211,8 +2265,7 @@ mod tests {
         }
 
         // Act
-        let key = KeyEvent::new(KeyCode::Backspace, event::KeyModifiers::NONE);
-        handle_prompt_backspace(&mut app, key);
+        apply_prompt_input_command(&mut app, InputCommand::DeleteBackward).await;
 
         // Assert
         if let AppMode::Prompt {
@@ -2224,34 +2277,7 @@ mod tests {
         {
             assert_eq!(input.text(), "Review ");
             assert!(attachment_state.attachments.is_empty());
-            assert_eq!(attachment_state.next_attachment_number, 1);
-            assert_eq!(history_state.selected_index, None);
-            assert_eq!(history_state.draft_text, None);
-        }
-    }
-
-    #[tokio::test]
-    async fn test_handle_prompt_backspace_with_shift_removes_whole_word() {
-        // Arrange
-        let (mut app, _base_dir) = new_test_prompt_app("hello brave world", None).await;
-        if let AppMode::Prompt { history_state, .. } = &mut app.mode {
-            history_state.draft_text = Some("draft".to_string());
-            history_state.entries = vec!["first".to_string(), "second".to_string()];
-            history_state.selected_index = Some(1);
-        }
-
-        // Act
-        let key = KeyEvent::new(KeyCode::Backspace, event::KeyModifiers::SHIFT);
-        handle_prompt_backspace(&mut app, key);
-
-        // Assert
-        if let AppMode::Prompt {
-            history_state,
-            input,
-            ..
-        } = &app.mode
-        {
-            assert_eq!(input.text(), "hello brave");
+            assert_eq!(attachment_state.next_attachment_number, 2);
             assert_eq!(history_state.selected_index, None);
             assert_eq!(history_state.draft_text, None);
         }
@@ -2274,7 +2300,7 @@ mod tests {
         }
 
         // Act
-        handle_prompt_delete(&mut app);
+        apply_prompt_input_command(&mut app, InputCommand::DeleteForward).await;
 
         // Assert
         if let AppMode::Prompt {
@@ -2286,14 +2312,121 @@ mod tests {
         {
             assert_eq!(input.text(), "Review ");
             assert!(attachment_state.attachments.is_empty());
-            assert_eq!(attachment_state.next_attachment_number, 1);
+            assert_eq!(attachment_state.next_attachment_number, 2);
             assert_eq!(history_state.selected_index, None);
             assert_eq!(history_state.draft_text, None);
         }
     }
 
     #[tokio::test]
-    async fn test_handle_prompt_delete_reuses_deleted_image_number_on_next_paste() {
+    async fn test_prompt_undo_restores_deleted_image_attachment() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("Review ", None).await;
+        let image_path = std::path::PathBuf::from("/tmp/image-1.png");
+        app.insert_pasted_image_placeholder(image_path.clone());
+
+        // Act
+        apply_prompt_input_command(&mut app, InputCommand::DeleteBackward).await;
+        apply_prompt_input_command(&mut app, InputCommand::Undo).await;
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Prompt {
+                attachment_state,
+                input,
+                ..
+            } if input.text() == "Review [Image #1]"
+                && attachment_state.attachments.len() == 1
+                && attachment_state.attachments[0].local_image_path == image_path
+                && attachment_state.archived_attachments.is_empty()
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_manually_entered_image_placeholder_does_not_restore_attachment() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("Review ", None).await;
+        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
+        apply_prompt_input_command(&mut app, InputCommand::DeleteBackward).await;
+
+        // Act
+        handle_paste(&mut app, "[Image #1]").await;
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Prompt {
+                attachment_state,
+                input,
+                ..
+            } if input.text() == "Review [Image #1]"
+                && attachment_state.attachments.is_empty()
+                && attachment_state.archived_attachments.len() == 1
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_deleting_original_duplicate_placeholder_does_not_submit_image() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("", None).await;
+        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
+        handle_paste(&mut app, "[Image #1]").await;
+        if let AppMode::Prompt { input, .. } = &mut app.mode {
+            input.cursor = 0;
+        }
+
+        // Act
+        apply_prompt_input_command(&mut app, InputCommand::DeleteForward).await;
+        let prompt = app.take_submitted_turn_prompt();
+
+        // Assert
+        assert_eq!(prompt.text, "[Image #1]");
+        assert!(prompt.attachments.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_deleting_duplicate_lookalike_keeps_original_image() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("", None).await;
+        let image_path = std::path::PathBuf::from("/tmp/image-1.png");
+        app.insert_pasted_image_placeholder(image_path.clone());
+        handle_paste(&mut app, "[Image #1]").await;
+
+        // Act
+        apply_prompt_input_command(&mut app, InputCommand::DeleteBackward).await;
+        let prompt = app.take_submitted_turn_prompt();
+
+        // Assert
+        assert_eq!(prompt.text, "[Image #1]");
+        assert_eq!(prompt.attachments.len(), 1);
+        assert_eq!(prompt.attachments[0].local_image_path, image_path);
+    }
+
+    #[tokio::test]
+    async fn test_prompt_edit_prunes_attachment_after_undo_revision_eviction() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("", None).await;
+        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
+        apply_prompt_input_command(&mut app, InputCommand::DeleteBackward).await;
+
+        // Act
+        for _ in 0..INPUT_HISTORY_LIMIT {
+            apply_prompt_input_command(&mut app, InputCommand::Insert('x')).await;
+        }
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Prompt {
+                attachment_state, ..
+            } if attachment_state.attachments.is_empty()
+                && attachment_state.archived_attachments.is_empty()
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_prompt_delete_keeps_new_image_number_unique_for_undo() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("", None).await;
         app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
@@ -2304,7 +2437,7 @@ mod tests {
         }
 
         // Act
-        handle_prompt_delete(&mut app);
+        apply_prompt_input_command(&mut app, InputCommand::DeleteForward).await;
         app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-4.png"));
 
         // Assert
@@ -2314,10 +2447,10 @@ mod tests {
             ..
         } = &app.mode
         {
-            assert_eq!(input.text(), "[Image #1][Image #2][Image #3]");
+            assert_eq!(input.text(), "[Image #1][Image #2][Image #4]");
             assert_eq!(attachment_state.attachments.len(), 3);
-            assert_eq!(attachment_state.next_attachment_number, 4);
-            assert_eq!(attachment_state.attachments[2].placeholder, "[Image #3]");
+            assert_eq!(attachment_state.next_attachment_number, 5);
+            assert_eq!(attachment_state.attachments[2].placeholder, "[Image #4]");
             assert_eq!(
                 attachment_state.attachments[2].local_image_path,
                 std::path::PathBuf::from("/tmp/image-4.png")
@@ -2336,8 +2469,7 @@ mod tests {
         }
 
         // Act
-        let key = KeyEvent::new(KeyCode::Backspace, event::KeyModifiers::ALT);
-        handle_prompt_backspace(&mut app, key);
+        apply_prompt_input_command(&mut app, InputCommand::DeleteWordBackward).await;
 
         // Assert
         if let AppMode::Prompt {
@@ -2366,8 +2498,7 @@ mod tests {
         }
 
         // Act
-        let key = KeyEvent::new(KeyCode::Backspace, event::KeyModifiers::SUPER);
-        handle_prompt_backspace(&mut app, key);
+        apply_prompt_input_command(&mut app, InputCommand::DeleteCurrentLine).await;
 
         // Assert
         if let AppMode::Prompt {
@@ -2396,7 +2527,7 @@ mod tests {
         }
 
         // Act
-        handle_prompt_line_delete(&mut app);
+        apply_prompt_input_command(&mut app, InputCommand::DeleteCurrentLine).await;
 
         // Assert
         if let AppMode::Prompt {
@@ -2406,33 +2537,6 @@ mod tests {
         } = &app.mode
         {
             assert_eq!(input.text(), "first line");
-            assert_eq!(history_state.selected_index, None);
-            assert_eq!(history_state.draft_text, None);
-        }
-    }
-
-    #[tokio::test]
-    async fn test_handle_prompt_backspace_with_shift_removes_whitespace_separators() {
-        // Arrange
-        let (mut app, _base_dir) = new_test_prompt_app("hello\t \nworld", None).await;
-        if let AppMode::Prompt { history_state, .. } = &mut app.mode {
-            history_state.draft_text = Some("draft".to_string());
-            history_state.entries = vec!["first".to_string(), "second".to_string()];
-            history_state.selected_index = Some(1);
-        }
-
-        // Act
-        let key = KeyEvent::new(KeyCode::Backspace, event::KeyModifiers::SHIFT);
-        handle_prompt_backspace(&mut app, key);
-
-        // Assert
-        if let AppMode::Prompt {
-            history_state,
-            input,
-            ..
-        } = &app.mode
-        {
-            assert_eq!(input.text(), "hello");
             assert_eq!(history_state.selected_index, None);
             assert_eq!(history_state.draft_text, None);
         }
@@ -2523,7 +2627,7 @@ mod tests {
         let (mut app, _base_dir) = new_test_prompt_app("email@test", Some(state)).await;
 
         // Act
-        handle_at_mention_select(&mut app);
+        handle_at_mention_select(&mut app).await;
 
         // Assert
         assert!(matches!(app.mode, AppMode::Prompt { .. }));
@@ -2539,6 +2643,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_handle_at_mention_key_supports_enter_tab_and_unhandled_keys() {
+        // Arrange
+        let entry = FileEntry {
+            is_dir: false,
+            path: "src/main.rs".to_string(),
+        };
+        let (mut enter_app, _enter_base_dir) =
+            new_test_prompt_app("@src", Some(PromptAtMentionState::new(vec![entry.clone()]))).await;
+        let (mut tab_app, _tab_base_dir) =
+            new_test_prompt_app("@src", Some(PromptAtMentionState::new(vec![entry]))).await;
+        let (mut ignored_app, _ignored_base_dir) =
+            new_test_prompt_app("@src", Some(PromptAtMentionState::new(Vec::new()))).await;
+
+        // Act
+        let enter_handled = handle_at_mention_key(
+            &mut enter_app,
+            KeyEvent::new(KeyCode::Enter, event::KeyModifiers::NONE),
+        )
+        .await;
+        let tab_handled = handle_at_mention_key(
+            &mut tab_app,
+            KeyEvent::new(KeyCode::Tab, event::KeyModifiers::NONE),
+        )
+        .await;
+        let character_handled = handle_at_mention_key(
+            &mut ignored_app,
+            KeyEvent::new(KeyCode::Char('x'), event::KeyModifiers::NONE),
+        )
+        .await;
+
+        // Assert
+        assert!(enter_handled);
+        assert!(tab_handled);
+        assert!(!character_handled);
+        assert!(matches!(
+            &enter_app.mode,
+            AppMode::Prompt { input, .. } if input.text() == "@src/main.rs "
+        ));
+        assert!(matches!(
+            &tab_app.mode,
+            AppMode::Prompt { input, .. } if input.text() == "@src/main.rs "
+        ));
+    }
+
+    #[tokio::test]
     async fn test_handle_at_mention_select_inserts_directory_with_trailing_slash() {
         // Arrange
         let state = PromptAtMentionState::new(vec![FileEntry {
@@ -2548,13 +2697,47 @@ mod tests {
         let (mut app, _base_dir) = new_test_prompt_app("@src", Some(state)).await;
 
         // Act
-        handle_at_mention_select(&mut app);
+        handle_at_mention_select(&mut app).await;
 
         // Assert
         assert!(matches!(app.mode, AppMode::Prompt { .. }));
         if let AppMode::Prompt { input, .. } = &app.mode {
             assert_eq!(input.text(), "@src/ ");
         }
+    }
+
+    #[tokio::test]
+    async fn test_at_mention_completion_keeps_following_image_occurrence_synchronized() {
+        // Arrange
+        let selected_path = "very/long/path/to/main.rs";
+        let at_mention_state = PromptAtMentionState::new(vec![FileEntry {
+            is_dir: false,
+            path: selected_path.to_string(),
+        }]);
+        let (mut app, _base_dir) = new_test_prompt_app("@v", None).await;
+        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
+        if let AppMode::Prompt {
+            at_mention_state: state,
+            input,
+            ..
+        } = &mut app.mode
+        {
+            *state = Some(at_mention_state);
+            input.cursor = "@v".chars().count();
+        }
+
+        // Act
+        handle_at_mention_select(&mut app).await;
+        let completed_mention = format!("@{selected_path} ");
+        if let AppMode::Prompt { input, .. } = &mut app.mode {
+            input.cursor = completed_mention.chars().count();
+        }
+        apply_prompt_input_command(&mut app, InputCommand::DeleteForward).await;
+        let prompt = app.take_submitted_turn_prompt();
+
+        // Assert
+        assert_eq!(prompt.text, completed_mention);
+        assert!(prompt.attachments.is_empty());
     }
 
     /// Verifies stale at-mention selections are clamped to the filtered entry
@@ -2576,7 +2759,7 @@ mod tests {
         let (mut app, _base_dir) = new_test_prompt_app("@src/ma", Some(state)).await;
 
         // Act
-        handle_at_mention_select(&mut app);
+        handle_at_mention_select(&mut app).await;
 
         // Assert
         if let AppMode::Prompt {
@@ -2591,12 +2774,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_prompt_char_activates_and_clears_at_mention_state() {
+    async fn test_prompt_input_edit_and_undo_resync_at_mention_state() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("", None).await;
 
         // Act
-        handle_prompt_char(&mut app, '@');
+        apply_prompt_input_command(&mut app, InputCommand::Insert('@')).await;
 
         // Assert
         assert!(matches!(app.mode, AppMode::Prompt { .. }));
@@ -2608,7 +2791,7 @@ mod tests {
         }
 
         // Act
-        handle_prompt_char(&mut app, ' ');
+        apply_prompt_input_command(&mut app, InputCommand::Insert(' ')).await;
 
         // Assert
         assert!(matches!(app.mode, AppMode::Prompt { .. }));
@@ -2618,6 +2801,39 @@ mod tests {
         {
             assert!(at_mention_state.is_none());
         }
+
+        // Act
+        apply_prompt_input_command(&mut app, InputCommand::Undo).await;
+
+        // Assert
+        if let AppMode::Prompt {
+            at_mention_state,
+            input,
+            ..
+        } = &app.mode
+        {
+            assert_eq!(input.text(), "@");
+            assert!(at_mention_state.is_some());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_prompt_undo_restores_slash_command_context() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("", None).await;
+        apply_prompt_input_command(&mut app, InputCommand::Insert('/')).await;
+        apply_prompt_input_command(&mut app, InputCommand::Insert('x')).await;
+
+        // Act
+        apply_prompt_input_command(&mut app, InputCommand::Undo).await;
+
+        // Assert
+        let context = prompt_context(&mut app).expect("prompt context should remain available");
+        assert!(context.is_slash_command());
+        assert!(matches!(
+            &app.mode,
+            AppMode::Prompt { input, .. } if input.text() == "/"
+        ));
     }
 
     #[tokio::test]
@@ -2631,7 +2847,7 @@ mod tests {
         assert!(!app.sessions.sessions()[0].folder.exists());
 
         // Act
-        handle_prompt_char(&mut app, '@');
+        apply_prompt_input_command(&mut app, InputCommand::Insert('@')).await;
         let next_event = wait_for_at_mention_entries_event(&mut app).await;
 
         // Assert
@@ -2659,10 +2875,7 @@ mod tests {
 
         // Act
         for _ in 0..moves_back_into_mention {
-            handle_prompt_left(
-                &mut app,
-                KeyEvent::new(KeyCode::Left, event::KeyModifiers::NONE),
-            );
+            apply_prompt_input_command(&mut app, InputCommand::MoveLeft).await;
         }
 
         // Assert
@@ -2728,6 +2941,25 @@ mod tests {
         assert!(matches!(app.mode, AppMode::Prompt { .. }));
         assert_eq!(app.sessions.sessions().len(), 1);
         assert_eq!(app.sessions.sessions()[0].prompt, "");
+    }
+
+    #[tokio::test]
+    async fn test_handle_prompt_submit_key_cleans_archived_attachment() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_draft_prompt_app("Review ", None).await;
+        app.insert_pasted_image_placeholder(std::path::PathBuf::from(
+            "/tmp/nonexistent-test-attachment.png",
+        ));
+        apply_prompt_input_command(&mut app, InputCommand::DeleteBackward).await;
+        let prompt_context = prompt_context(&mut app).expect("expected prompt context");
+
+        // Act
+        handle_prompt_submit_key(&mut app, &prompt_context).await;
+
+        // Assert
+        assert!(matches!(app.mode, AppMode::View { .. }));
+        assert_eq!(app.sessions.sessions()[0].prompt, "Review ");
+        assert!(app.sessions.sessions()[0].draft_attachments.is_empty());
     }
 
     #[tokio::test]

--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -519,93 +519,9 @@ fn navigate_option_down(selected_option_index: &mut Option<usize>, option_count:
 
 /// Resolves a key event in free-text input mode (no option selected).
 fn resolve_free_text_key(input: &mut InputState, key: KeyEvent) -> QuestionAction {
-    match key.code {
-        KeyCode::Backspace if input_key::is_line_delete_backspace(key) => {
-            input.delete_current_line();
-        }
-        KeyCode::Backspace if input_key::is_word_delete_backspace(key) => {
-            input_key::delete_word_backward(input);
-        }
-        KeyCode::Backspace => input.delete_backward(),
-        KeyCode::Delete => input.delete_forward(),
-        KeyCode::Left if key.modifiers.contains(event::KeyModifiers::SUPER) => {
-            input.move_line_start();
-        }
-        KeyCode::Left
-            if key
-                .modifiers
-                .intersects(event::KeyModifiers::ALT | event::KeyModifiers::SHIFT) =>
-        {
-            input_key::move_cursor_word_left(input);
-        }
-        KeyCode::Left => input.move_left(),
-        KeyCode::Right if key.modifiers.contains(event::KeyModifiers::SUPER) => {
-            input.move_line_end();
-        }
-        KeyCode::Right
-            if key
-                .modifiers
-                .intersects(event::KeyModifiers::ALT | event::KeyModifiers::SHIFT) =>
-        {
-            input_key::move_cursor_word_right(input);
-        }
-        KeyCode::Right => input.move_right(),
-        KeyCode::Up => input.move_up(),
-        KeyCode::Down => input.move_down(),
-        KeyCode::Home => input.move_home(),
-        KeyCode::End => input.move_end(),
-        // Ctrl+a / Ctrl+e: macOS terminals send these for Cmd+Left / Cmd+Right.
-        KeyCode::Char('a') if input_key::is_control_key(key) => {
-            input.move_line_start();
-        }
-        KeyCode::Char('e') if input_key::is_control_key(key) => {
-            input.move_line_end();
-        }
-        // Ctrl+f / Ctrl+b: emacs-style forward/backward character movement.
-        KeyCode::Char('f') if input_key::is_control_key(key) => {
-            input.move_right();
-        }
-        KeyCode::Char('b') if input_key::is_control_key(key) => {
-            input.move_left();
-        }
-        // Ctrl+p / Ctrl+n: emacs-style up/down line movement.
-        KeyCode::Char('p') if input_key::is_control_key(key) => {
-            input.move_up();
-        }
-        KeyCode::Char('n') if input_key::is_control_key(key) => {
-            input.move_down();
-        }
-        // Ctrl+d: emacs-style forward delete.
-        KeyCode::Char('d') if input_key::is_control_key(key) => {
-            input.delete_forward();
-        }
-        // Ctrl+k: kill to end of current line.
-        KeyCode::Char('k') if input_key::is_control_key(key) => {
-            input.delete_to_line_end();
-        }
-        // Ctrl+w: delete previous word.
-        KeyCode::Char('w') if input_key::is_control_key(key) => {
-            input_key::delete_word_backward(input);
-        }
-        // Alt+b / Alt+f: macOS terminals send these for Option+Left / Option+Right.
-        KeyCode::Char('b') if input_key::is_alt_key(key) => {
-            input_key::move_cursor_word_left(input);
-        }
-        KeyCode::Char('f') if input_key::is_alt_key(key) => {
-            input_key::move_cursor_word_right(input);
-        }
-        // KeyCode::Tab is handled by the focus toggle at the top level.
-        KeyCode::Char('u') if input_key::is_control_key(key) => {
-            input.delete_current_line();
-        }
-        // Ctrl+j / Ctrl+m: alternative newline insertion (macOS terminal compat).
-        KeyCode::Char(character) if input_key::is_control_newline_key(key, character) => {
-            input.insert_newline();
-        }
-        KeyCode::Char(character) if input_key::is_insertable_char_key(key) => {
-            input.insert_char(character);
-        }
-        _ => {}
+    if let Some(command) = input_key::command_for_key(key, input_key::InputCapabilities::MULTILINE)
+    {
+        input.apply(command);
     }
 
     QuestionAction::Continue
@@ -2966,6 +2882,33 @@ mod tests {
         // Assert — deletes "world" and the preceding whitespace.
         if let AppMode::Question { input, .. } = &app.mode {
             assert_eq!(input.text(), "hello brave");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_free_text_ctrl_z_undoes_previous_edit() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.mode = free_text_question_mode("hello brave", "hello brave".chars().count());
+        let _ = handle(
+            &mut app,
+            TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Char('!'), KeyModifiers::NONE),
+        )
+        .await;
+
+        // Act
+        let _ = handle(
+            &mut app,
+            TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Char('z'), KeyModifiers::CONTROL),
+        )
+        .await;
+
+        // Assert
+        if let AppMode::Question { input, .. } = &app.mode {
+            assert_eq!(input.text(), "hello brave");
+            assert_eq!(input.cursor, "hello brave".chars().count());
         }
     }
 

--- a/crates/agentty/tests/e2e/setting.rs
+++ b/crates/agentty/tests/e2e/setting.rs
@@ -383,6 +383,66 @@ fn settings_launch_configurations_list_editor() {
         .expect("feature test failed");
 }
 
+/// Verify shared input word deletion, undo, and redo in a single-line editor.
+#[test]
+fn test_input_undo_redo() {
+    // Arrange, Act, Assert
+    FeatureTest::new("input_undo_redo")
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .compose(&common::switch_to_tab("Inbox"))
+                    .compose(&common::switch_to_tab("Issues"))
+                    .compose(&common::switch_to_tab("Settings"))
+                    .press_key("j")
+                    .press_key("j")
+                    .press_key("j")
+                    .press_key("j")
+                    .press_key("j")
+                    .press_key("j")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(200, 3000)
+                    .press_key("a")
+                    .write_text("hello brave world")
+                    .wait_for_stable_frame(200, 3000)
+                    .capture_labeled("typed", "Text before shared editing shortcuts")
+                    .press_key("ctrl+w")
+                    .wait_for_stable_frame(200, 3000)
+                    .capture_labeled("word_deleted", "Previous word deleted with Ctrl+w")
+                    .press_key("ctrl+z")
+                    .wait_for_stable_frame(200, 3000)
+                    .capture_labeled("undone", "Deleted word restored with Ctrl+z")
+                    .press_key("ctrl+y")
+                    .wait_for_stable_frame(200, 3000)
+                    .capture_labeled("redone", "Word deletion restored with Ctrl+y")
+            },
+            |frame, report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "hello brave|", &full);
+                assert_eq!(
+                    report.captures.len(),
+                    4,
+                    "Expected four input edit captures"
+                );
+
+                let typed_frame = common::frame_from_capture(&report.captures[0]);
+                let typed_full = Region::full(typed_frame.cols(), typed_frame.rows());
+                assertion::assert_text_in_region(&typed_frame, "hello brave world|", &typed_full);
+
+                let deleted_frame = common::frame_from_capture(&report.captures[1]);
+                let deleted_full = Region::full(deleted_frame.cols(), deleted_frame.rows());
+                assertion::assert_text_in_region(&deleted_frame, "hello brave|", &deleted_full);
+
+                let undone_frame = common::frame_from_capture(&report.captures[2]);
+                let undone_full = Region::full(undone_frame.cols(), undone_frame.rows());
+                assertion::assert_text_in_region(&undone_frame, "hello brave world|", &undone_full);
+            },
+        )
+        .expect("feature test failed");
+}
+
 /// Verify that the `Theme` settings row dropdown selects `Agentty Default`,
 /// `Agentty Green`, and `Dark Horizon` and wraps back to `Agentty Default`.
 #[test]

--- a/docs/site/content/docs/architecture/change-recipes.md
+++ b/docs/site/content/docs/architecture/change-recipes.md
@@ -39,8 +39,13 @@ through the correct modules without crossing layer boundaries.
 
 ## Add a Keybinding or Mode Interaction
 
-1. Update the handler in `crates/agentty/src/runtime/mode/`, or in
-   `crates/agentty/src/runtime/key_handler.rs` when the interaction is a cross-mode
+1. For basic text editing, add or update the semantic command in
+   `crates/agentty/src/domain/input.rs`, then map terminal keys once in
+   `crates/agentty/src/runtime/mode/input_key.rs`.
+1. Let prompt, question, branch-publish, and settings input modes intercept only their
+   context-specific actions before falling back to the shared input command mapping.
+1. For other interactions, update the handler in `crates/agentty/src/runtime/mode/`, or
+   in `crates/agentty/src/runtime/key_handler.rs` when the interaction is a cross-mode
    overlay dispatch.
 1. If a new mode/state is needed, extend `crates/agentty/src/presentation/app_mode.rs`.
 1. If help content changes, update `crates/agentty/src/presentation/help_action.rs` as

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -55,9 +55,11 @@ For file-level detail, read the module docstrings directly.
   traits.
 - `domain/`: Pure business entities and logic — sessions and statuses, projects,
   settings keys, themes, structured questions, typed transcript messages, explicit
-  transient-message slots and lifecycles, prompt-composer logic, and thin re-export
-  modules for `ag-agent` provider models plus shared protocol question and turn prompt
-  payloads. No I/O.
+  transient-message slots and lifecycles, prompt-composer logic, the shared `InputState`
+  command and undo/redo model, stable input-revision and character-offset identities
+  used to bind prompt attachments to exact placeholder occurrences and history states,
+  and thin re-export modules for `ag-agent` provider models plus shared protocol
+  question and turn prompt payloads. No I/O.
 - `infra/`: External integrations behind traits — Agentty data-root resolution, SQLite
   persistence (`infra/db/` repositories), git (`GitClient`, backed by `ag-git`),
   filesystem (`FsClient`), tmux, clipboard images, version checks, project discovery,
@@ -68,8 +70,9 @@ For file-level detail, read the module docstrings directly.
 - `runtime/`: Terminal lifecycle and the event loop — terminal setup, the event-reader
   thread, key dispatch, mode-focused handlers under `runtime/mode/`, and shared handlers
   for common interactions such as issue/review detail navigation, session-output
-  metrics, and transcript scrolling. Runtime owns `PresentationState`, including the
-  shared `RenderCacheStore` used by input metrics and frame rendering.
+  metrics, transcript scrolling, and `KeyEvent` mapping to domain input commands.
+  Runtime owns `PresentationState`, including the shared `RenderCacheStore` used by
+  input metrics and frame rendering.
 - `presentation.rs` and `presentation/`: Frontend-neutral interaction state shared by
   runtime input and UI output. They expose mode, help-action, prompt, editor, scroll,
   viewport, and semantic list-selection contracts without importing Ratatui or `ui/`

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -11,6 +11,32 @@ For session states and transition behavior, see [Workflow](@/docs/usage/workflow
 
 <!-- more -->
 
+## Shared Text Editing
+
+Prompt, question, publish-branch, and launch-configuration inputs share the same basic
+editing shortcuts. Context-specific actions such as prompt submission, slash commands,
+`@` completion, and question-option navigation run before these common fallbacks.
+
+| Key                                      | Action                              |
+| ---------------------------------------- | ----------------------------------- |
+| `Left` / `Right`                         | Move one character                  |
+| `Option+Left` / `Shift+Left` / `Alt+B`   | Move to previous word               |
+| `Option+Right` / `Shift+Right` / `Alt+F` | Move to next word                   |
+| `Home` / `End`                           | Move to start / end of input        |
+| `Ctrl+A` / `Ctrl+E`                      | Move to start / end of current line |
+| `Backspace` / `Delete`                   | Delete backward / forward           |
+| `Option+Backspace` / `Shift+Backspace`   | Delete previous word                |
+| `Ctrl+W`                                 | Delete previous word                |
+| `Cmd+Backspace` / `Ctrl+U`               | Delete current line                 |
+| `Ctrl+K`                                 | Delete to end of current line       |
+| `Ctrl+Z`                                 | Undo                                |
+| `Ctrl+Y` / `Ctrl+Shift+Z`                | Redo                                |
+| paste                                    | Insert text at the cursor           |
+
+Multiline prompt and question inputs also share vertical cursor movement and newline
+insertion. Single-line publish and launch-configuration inputs keep only the first line
+of pasted text.
+
 ## Session List
 
 | Key                 | Action                                               |
@@ -69,8 +95,7 @@ highlighted in the table with a `* ` prefix and accented row text.
 <tr><td><code>e</code></td><td>Edit the selected entry in the <code>Launch Configurations</code> browser</td></tr>
 <tr><td><code>d</code></td><td>Delete the selected entry in the <code>Launch Configurations</code> browser</td></tr>
 <tr><td><code>J</code> / <code>K</code></td><td>Move the selected <code>Launch Configurations</code> entry down or up</td></tr>
-<tr><td><code>Left</code> / <code>Right</code> / <code>Home</code> / <code>End</code></td><td>Move cursor while adding or editing one <code>Launch Configurations</code> entry</td></tr>
-<tr><td><code>Backspace</code> / <code>Delete</code></td><td>Delete characters while adding or editing one <code>Launch Configurations</code> entry</td></tr>
+<tr><td>shared text-editing keys</td><td>Edit, move by character or word, paste, undo, or redo while adding or editing one <code>Launch Configurations</code> entry</td></tr>
 <tr><td><code>Tab</code> / <code>Shift+Tab</code></td><td>Switch to next / previous tab</td></tr>
 <tr><td><code>?</code></td><td>Help</td></tr>
 </tbody>
@@ -167,14 +192,12 @@ Publish (`p`), sync (`r`), and stacked behavior are described in
 
 ## Publish Popup
 
-| Key                               | Action                             |
-| --------------------------------- | ---------------------------------- |
-| `Enter`                           | Start publishing in the background |
-| `Esc` / `q`                       | Cancel and return to session view  |
-| `Left` / `Right` / `Home` / `End` | Move cursor                        |
-| `Up` / `Down`                     | Move cursor across wrapped lines   |
-| `Backspace` / `Delete`            | Delete character                   |
-| text keys                         | Edit remote branch name            |
+| Key                      | Action                                             |
+| ------------------------ | -------------------------------------------------- |
+| `Enter`                  | Publish typed or default target in the background  |
+| `Esc`                    | Cancel and return to session view                  |
+| shared text-editing keys | Edit, paste, move, delete, undo, or redo           |
+| text keys                | Edit remote branch name, including the character q |
 
 ## Launch Configuration Selector
 
@@ -211,6 +234,8 @@ diff.
 | `Option+Left` / `Option+Right`      | Move to previous / next word        |
 | `Option+Backspace`                  | Delete previous word                |
 | `Cmd+Backspace`                     | Delete current line                 |
+| `Ctrl+Z`                            | Undo                                |
+| `Ctrl+Y` / `Ctrl+Shift+Z`           | Redo                                |
 | `Esc`                               | Cancel                              |
 | `Tab`                               | Focus chat output for scrolling     |
 | `@`                                 | Open file picker                    |
@@ -267,6 +292,8 @@ exist:
 | `Cmd+Backspace`                  | Delete current line                  |
 | `Ctrl+K`                         | Delete to end of current line        |
 | `Ctrl+D`                         | Delete character forward             |
+| `Ctrl+Z`                         | Undo                                 |
+| `Ctrl+Y` / `Ctrl+Shift+Z`        | Redo                                 |
 | `Tab`                            | Focus chat output for scrolling      |
 
 In free-text mode every other printable character — including `q` — is inserted into the

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -413,6 +413,18 @@ unsupported clipboard backends report an inline paste error. Draft image files a
 removed when the composer is canceled, after a submitted turn finishes, and when a
 session is deleted or canceled.
 
+All editable inputs use the same character movement, word movement and deletion,
+line-editing, paste, `Ctrl+Z` undo, and `Ctrl+Y` / `Ctrl+Shift+Z` redo behavior. Prompt
+and clarification inputs extend that shared editor with multiline movement and their own
+completion or option actions. Undoing prompt text also recomputes slash-command and `@`
+lookup state; deleted image metadata remains available while undo history can restore
+its `[Image #n]` placeholder. Typing the same placeholder text manually does not attach
+the deleted image, and Agentty removes archived image files after their restoring edit
+falls out of bounded undo history. Attachment identity follows the exact placeholder
+occurrence, so duplicate lookalike text cannot substitute for the pasted token. Moving
+through prompt history with `Up` and `Down` preserves the attachment membership of the
+captured draft.
+
 `@` file lookups keep the raw `@path/to/file` text visible in the composer and
 transcript; the agent-facing prompt rewrites them to quoted `path/to/file` tokens.
 
@@ -471,7 +483,8 @@ save the highlighted value.
 The `Launch Configurations` row opens a command-list editor instead of a multiline text
 field. Use `a` to add an entry, `e` or `Enter` to edit the selected entry, `d` to delete
 it, and `J` / `K` to reorder entries. Add/edit mode uses a single-line input; `Enter`
-saves the command, and `Esc` cancels the input. Agentty trims commands and drops empty
+saves the command, `Esc` cancels the input, and the shared word-editing, paste,
+undo/redo, and cursor shortcuts remain available. Agentty trims commands and drops empty
 entries when saving. When multiple `Launch Configurations` entries are configured,
 pressing `o` in a session opens a selector popup.
 


### PR DESCRIPTION
- Maps terminal editing keys to shared semantic commands with bounded undo and redo history.
- Preserves exact prompt attachment identities across edits and history navigation, avoids reactivating lookalike placeholders, and cleans up discarded files.
- Extends paste handling to single-line inputs, cleans up attachments discarded by slash actions, and documents shared shortcuts with unit and E2E coverage.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)