### PR TITLE
Prepare the 0.13.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.13.1] - 2026-07-15
+
 ### Added
 
 - testty: add `feature::Redaction` and `FeatureDemo::redact` so callers can declare
@@ -34,6 +36,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   feature GIF frame hashes reproduce across macOS and Linux CI.
 - agentty: stub every supported agent CLI in E2E test environments — not just `claude` —
   so the default agent a new session resolves is identical on developer machines and CI.
+- agentty: run feature tests and VHS recordings with color disabled so GIF hashes remain
+  stable across local shells and CI.
+- agentty: preserve prompt and question drafts while chat output is focused for
+  scrolling, and clarify the related footer shortcuts and send labels.
+- agentty: accept and queue follow-up prompts while sessions are rebasing.
+- agentty: preserve review-request publishing progress across session refreshes.
+- agentty: place queued synchronization notices after the active turn and before
+  follow-up messages.
+- ci: run coverage checks in presubmit and postsubmit workflows.
+- release: bump workspace crate metadata and lockfile package versions to `0.13.1`.
+
+### Contributors
+
+- @andagaev
+- @minev-dev
 
 ## [v0.13.0] - 2026-07-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "image",
  "mockall",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "mockall",
  "serde",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "mockall",
  "rustix",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "askama",
  "schemars 1.2.1",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "clap",
  "tempfile",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.13.1"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -16,13 +16,13 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.13.0" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.13.0" }
-ag-forge = { path = "crates/ag-forge", version = "0.13.0" }
-ag-git = { path = "crates/ag-git", version = "0.13.0" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.13.0" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.13.0" }
-testty = { path = "crates/testty", version = "0.13.0" }
+ag-agent = { path = "crates/ag-agent", version = "0.13.1" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.13.1" }
+ag-forge = { path = "crates/ag-forge", version = "0.13.1" }
+ag-git = { path = "crates/ag-git", version = "0.13.1" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.13.1" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.13.1" }
+testty = { path = "crates/testty", version = "0.13.1" }
 async-trait = "0.1"
 agent-client-protocol = "1.0.0"
 assert_cmd = "2"


### PR DESCRIPTION
- Document session queuing, review publishing progress, and synchronization notice ordering.
- Run coverage checks in presubmit and postsubmit workflows.
- Bump workspace crate metadata and lockfile package versions to 0.13.1.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)