### PR TITLE
Render queued messages after workflow notices

### DIFF
--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -259,8 +259,8 @@ const SESSION_OUTPUT_BLOCK_ORDER: [SessionOutputBlock; 9] = [
     SessionOutputBlock::Transient(TransientMessageAnchor::AfterCompletedTurn),
     SessionOutputBlock::ActiveTurn,
     SessionOutputBlock::Transient(TransientMessageAnchor::AfterActiveTurn),
-    SessionOutputBlock::QueuedMessage,
     SessionOutputBlock::TrailingTranscriptNotice(TrailingTranscriptNoticePlacement::AfterReview),
+    SessionOutputBlock::QueuedMessage,
     SessionOutputBlock::Transient(TransientMessageAnchor::Tail),
     SessionOutputBlock::SessionTail,
 ];
@@ -902,14 +902,15 @@ impl<'a> SessionOutput<'a> {
     /// block. When a new prompt is active, the previous-turn summary is hidden
     /// so the output stream no longer shows stale change metadata for work
     /// that is already being superseded.
-    /// Queued follow-up messages render beneath the running turn so users can
-    /// see staged local input without mixing it into completed transcript
-    /// content. Trailing transcript notices that belong to a completed turn
-    /// stay above any active prompt so in-progress sessions remain
-    /// chronological. Focused-review output is appended before trailing
-    /// transcript notices for non-terminal review states, keeping workflow
-    /// failures below the completed turn's summary/review content while
-    /// terminal views keep their final transcript and summary display stable.
+    /// Queued follow-up messages render beneath the running turn and any
+    /// existing workflow notices so users see staged local input after the
+    /// transcript content that preceded it. Trailing transcript notices that
+    /// belong to a completed turn stay above any active prompt so in-progress
+    /// sessions remain chronological. Focused-review output is appended before
+    /// trailing transcript notices for non-terminal review states, keeping
+    /// workflow failures below the completed turn's summary/review content
+    /// while terminal views keep their final transcript and summary display
+    /// stable.
     fn output_lines_with_metadata<'assembly>(
         session: &'assembly Session,
         output_area: Rect,
@@ -3325,6 +3326,50 @@ mod tests {
         assert!(previous_answer_index < current_turn_index);
         assert!(current_turn_index < notice_index);
         assert!(notice_index < queued_message_index);
+    }
+
+    /// Verifies a queued follow-up remains below workflow notices that were
+    /// already visible when a session sync accepted the message.
+    #[test]
+    fn test_output_lines_rebasing_session_places_queued_message_after_workflow_notices() {
+        // Arrange
+        let mut session = session_fixture();
+        set_conversation_transcript(
+            &mut session,
+            vec![
+                (
+                    SessionMessageKind::WorkflowNotice,
+                    "\n[Commit] No changes to commit.\n",
+                ),
+                (
+                    SessionMessageKind::WorkflowNotice,
+                    "\n[Sync Assist] Attempt 1/3. Resolving conflicts.\n",
+                ),
+            ],
+        );
+        session.status = Status::Rebasing;
+        session.queued_messages = vec!["address review comments".to_string()];
+
+        // Act
+        let lines = output_lines(&session, Rect::new(0, 0, 80, 12), line_context(), None);
+        let text = lines
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let commit_index = text
+            .find("[Commit] No changes to commit.")
+            .expect("commit notice should be rendered");
+        let sync_assist_index = text
+            .find("[Sync Assist] Attempt 1/3.")
+            .expect("sync-assist notice should be rendered");
+        let queued_message_index = text
+            .find("queued › address review comments")
+            .expect("queued follow-up should be rendered");
+
+        // Assert
+        assert!(commit_index < sync_assist_index);
+        assert!(sync_assist_index < queued_message_index);
     }
 
     /// Verifies an active prompt at the start of the transcript hides stale

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -955,6 +955,27 @@ fn seed_rebasing_queue_session(env: &BuilderEnv) -> Result<(), Box<dyn std::erro
     let worktree_name = &REBASING_QUEUE_SESSION_ID[..8];
     std::fs::create_dir_all(env.agentty_root.join("wt").join(worktree_name))?;
 
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        database
+            .sessions()
+            .append_session_message(
+                REBASING_QUEUE_SESSION_ID,
+                SessionMessageKind::WorkflowNotice,
+                "\n[Commit] No changes to commit.\n",
+            )
+            .await?;
+        database
+            .sessions()
+            .append_session_message(
+                REBASING_QUEUE_SESSION_ID,
+                SessionMessageKind::WorkflowNotice,
+                "\n[Sync Assist] Resolving existing conflicts.\n",
+            )
+            .await
+    })?;
+
     Ok(())
 }
 
@@ -2188,8 +2209,8 @@ fn session_queue_chat_messages_during_in_progress_turn() -> E2eResult {
 }
 
 /// Verify `Enter` opens the composer while a session is `Rebasing` and the
-/// submitted follow-up renders inline as queued work without replacing the
-/// active rebase status.
+/// submitted follow-up renders below existing workflow notices as queued work
+/// without replacing the active rebase status.
 #[test]
 fn session_queue_chat_message_during_rebase() -> E2eResult {
     // Arrange, Act, Assert
@@ -2219,8 +2240,35 @@ fn session_queue_chat_message_during_rebase() -> E2eResult {
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "Rebasing...", &full);
+                assertion::assert_text_in_region(frame, "[Commit] No changes to commit.", &full);
+                assertion::assert_text_in_region(
+                    frame,
+                    "[Sync Assist] Resolving existing conflicts.",
+                    &full,
+                );
                 assertion::assert_text_in_region(frame, "queued ›", &full);
                 assertion::assert_text_in_region(frame, "follow up after sync", &full);
+                let commit_row = frame
+                    .find_text("[Commit] No changes to commit.")
+                    .first()
+                    .expect("missing commit notice")
+                    .rect
+                    .row;
+                let sync_assist_row = frame
+                    .find_text("[Sync Assist] Resolving existing conflicts.")
+                    .first()
+                    .expect("missing sync-assist notice")
+                    .rect
+                    .row;
+                let queued_message_row = frame
+                    .find_text("queued › follow up after sync")
+                    .first()
+                    .expect("missing queued follow-up")
+                    .rect
+                    .row;
+
+                assert!(commit_row < sync_assist_row);
+                assert!(sync_assist_row < queued_message_row);
             },
         )?;
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -169,12 +169,13 @@ thought and tool-status text; the transcript itself updates only after the final
 result is parsed and persisted.
 
 Pressing `Enter` during a running turn or session sync opens the composer and queues the
-message inline with a `queued ›` prefix. Queued messages dispatch one-by-one as new
-turns after the active turn or sync finishes. During **InProgress**, each `Ctrl+c` press
-retracts the most recently queued message (LIFO) without interrupting the running turn;
-once the queue is empty, the next `Ctrl+c` stops the current turn and returns the
-session to **Review**. **Rebasing** keeps cancellation unavailable while still accepting
-queued messages. The queue is in-memory only and is discarded if `agentty` restarts.
+message inline with a `queued ›` prefix below the transcript messages and workflow
+notices that preceded it. Queued messages dispatch one-by-one as new turns after the
+active turn or sync finishes. During **InProgress**, each `Ctrl+c` press retracts the
+most recently queued message (LIFO) without interrupting the running turn; once the
+queue is empty, the next `Ctrl+c` stops the current turn and returns the session to
+**Review**. **Rebasing** keeps cancellation unavailable while still accepting queued
+messages. The queue is in-memory only and is discarded if `agentty` restarts.
 
 While the composer is open, `Tab` moves focus to the chat transcript above it so the
 conversation can be scrolled with `j` / `k`, `g` / `G`, and `Ctrl+D` / `Ctrl+U` without


### PR DESCRIPTION
- Queued follow-ups render below existing workflow notices during rebasing.
- Unit and end-to-end coverage verifies the ordering.
- Workflow documentation describes the updated queue placement.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)