### PR TITLE
Add protocol response fuzzing

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,41 @@
+FROM gcr.io/oss-fuzz-base/base-builder-rust:v1@sha256:d1b7545a6a5680d66886e9ee729f6575e0e885143a1bb74289f14e7e91de3463
+
+RUN groupadd --gid 10001 fuzz-builder \
+    && useradd --create-home --uid 10001 --gid 10001 fuzz-builder \
+    && install -d --owner 10001 --group 10001 "$WORK/cargo" /rustc
+
+# The OSS-Fuzz wrapper prepares these paths before invoking build.sh.
+ENV CARGO_HOME="$WORK/cargo" \
+    LIB_FUZZING_ENGINE_DEPRECATED="$WORK/libFuzzingEngine.a"
+
+COPY --chown=fuzz-builder:fuzz-builder Cargo.toml Cargo.lock "$SRC/agentty/"
+COPY --chown=fuzz-builder:fuzz-builder \
+    crates/ag-protocol/Cargo.toml \
+    crates/ag-protocol/askama.toml \
+    "$SRC/agentty/crates/ag-protocol/"
+COPY --chown=fuzz-builder:fuzz-builder \
+    crates/ag-protocol/src/envelope.rs \
+    crates/ag-protocol/src/lib.rs \
+    crates/ag-protocol/src/model.rs \
+    crates/ag-protocol/src/parse.rs \
+    crates/ag-protocol/src/prompt.rs \
+    crates/ag-protocol/src/question.rs \
+    crates/ag-protocol/src/schema.rs \
+    "$SRC/agentty/crates/ag-protocol/src/"
+COPY --chown=fuzz-builder:fuzz-builder \
+    crates/ag-protocol/src/template/protocol_instruction_policy_prompt.md \
+    crates/ag-protocol/src/template/protocol_instruction_prompt.md \
+    crates/ag-protocol/src/template/protocol_instruction_session_turn_usage.md \
+    crates/ag-protocol/src/template/protocol_instruction_utility_prompt_usage.md \
+    crates/ag-protocol/src/template/protocol_refresh_prompt.md \
+    crates/ag-protocol/src/template/protocol_refresh_session_turn_instruction.md \
+    crates/ag-protocol/src/template/protocol_refresh_utility_prompt_instruction.md \
+    crates/ag-protocol/src/template/protocol_repair_prompt.md \
+    crates/ag-protocol/src/template/questions_field_description.md \
+    "$SRC/agentty/crates/ag-protocol/src/template/"
+COPY --chown=fuzz-builder:fuzz-builder fuzz/Cargo.toml "$SRC/agentty/fuzz/"
+COPY --chown=fuzz-builder:fuzz-builder fuzz/fuzz_targets/protocol_response.rs "$SRC/agentty/fuzz/fuzz_targets/"
+COPY --chown=fuzz-builder:fuzz-builder .clusterfuzzlite/build.sh "$SRC/"
+
+WORKDIR "$SRC/agentty"
+USER fuzz-builder

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eu
+
+cd "$SRC/agentty"
+
+# Full LTO breaks cargo-fuzz sanitizer coverage instrumentation.
+CARGO_PROFILE_RELEASE_LTO=false cargo fuzz build -O protocol_response
+cp target/x86_64-unknown-linux-gnu/release/protocol_response "$OUT/"

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: rust

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,47 @@
+name: ClusterFuzzLite PR fuzzing
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  fuzz:
+    name: AddressSanitizer
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Prepare fuzz output
+        run: sudo install -d -o 10001 -g "$(id -g)" -m 0775 build-out
+
+      - name: Build fuzzers
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: rust
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sanitizer: address
+
+      - name: Run fuzzers
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: rust
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 600
+          mode: code-change
+          sanitizer: address
+          output-sarif: true
+
+      - name: Upload SARIF
+        if: ${{ always() && hashFiles('cifuzz-sarif/results.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          sarif_file: cifuzz-sarif/results.sarif

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
       - id: clippy-fix
         name: clippy fix
         description: Auto-fix clippy lints across Rust targets when a mechanical fix is available.
-        entry: cargo clippy --fix --allow-dirty --allow-staged -q --all-targets --all-features -- -D warnings
+        entry: cargo clippy --fix --allow-dirty --allow-staged -q --workspace --exclude ag-fuzz --all-targets --all-features -- -D warnings
         language: system
         files: (^|/)(Cargo\.toml|Cargo\.lock|.*\.rs)$
         pass_filenames: false
@@ -58,14 +58,14 @@ repos:
       - id: cargo-check
         name: cargo check
         description: Type-check all Rust workspace targets and features without running tests.
-        entry: cargo check -q --locked --all-targets --all-features
+        entry: cargo check -q --locked --workspace --exclude ag-fuzz --all-targets --all-features
         language: system
         files: (^|/)(Cargo\.toml|Cargo\.lock|.*\.rs)$
         pass_filenames: false
       - id: clippy
         name: clippy
         description: Run strict clippy across all Rust targets and features, failing on warnings.
-        entry: cargo clippy -q --locked --all-targets --all-features -- -D warnings
+        entry: cargo clippy -q --locked --workspace --exclude ag-fuzz --all-targets --all-features -- -D warnings
         language: system
         files: (^|/)(Cargo\.toml|Cargo\.lock|.*\.rs)$
         pass_filenames: false
@@ -183,7 +183,7 @@ repos:
         name: coverage
         description: Verify source-test coverage meets workspace ratchet thresholds and write the CI LCOV report for SonarQube and Codecov.
         entry: >-
-          cargo llvm-cov nextest --workspace --lib --bins --locked --profile ci
+          cargo llvm-cov nextest --workspace --exclude ag-fuzz --lib --bins --locked --profile ci
           --fail-under-lines 93 --fail-under-functions 91
           --lcov --ignore-filename-regex '^crates/agentty/tests/'
           --output-path coverage.lcov

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ag-fuzz"
+version = "0.13.7"
+dependencies = [
+ "ag-protocol",
+ "libfuzzer-sys",
+]
+
+[[package]]
 name = "ag-git"
 version = "0.13.7"
 dependencies = [
@@ -314,6 +322,12 @@ checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arrayvec"
@@ -2312,6 +2326,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4152,7 +4176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.52.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/*"]
+members = ["crates/*", "fuzz"]
 
 [workspace.package]
 version = "0.13.7"
@@ -34,6 +34,7 @@ crossterm = { version = "0.29.0", default-features = false, features = ["bracket
 ignore = "0.4"
 image = { version = "0.25", default-features = false, features = ["png", "gif"] }
 jsonschema = { version = "0.40.0", default-features = false }
+libfuzzer-sys = "0.4"
 mockall = "0.15"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", default-features = false }

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+artifacts/
+corpus/
+coverage/
+target/

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ag-fuzz"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+description.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+ag-protocol.workspace = true
+libfuzzer-sys.workspace = true
+
+[[bin]]
+name = "protocol_response"
+path = "fuzz_targets/protocol_response.rs"
+test = false
+doc = false
+bench = false
+
+[lints]
+workspace = true

--- a/fuzz/fuzz_targets/protocol_response.rs
+++ b/fuzz/fuzz_targets/protocol_response.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use ag_protocol::parse_agent_response_strict;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let raw_response = String::from_utf8_lossy(data);
+
+    let _ = parse_agent_response_strict(&raw_response);
+});


### PR DESCRIPTION
- Add a cargo-fuzz target for strict protocol response parsing.
- Build the fuzzer from a pinned ClusterFuzzLite image as a non-root user with sanitizer-compatible settings.
- Run AddressSanitizer fuzzing on pull requests with read-only repository access and SARIF reporting.
- Exclude the fuzz crate from workspace coverage checks.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)