### PR TITLE
Add session review comments view

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ user in the active project. Press `Enter` to load base issue details and the
 description; comments are not loaded in this iteration. Install `gh` and run
 `gh auth login` to enable it.
 
+For sessions linked to a GitHub pull request or GitLab merge request, press `c` in
+session view to browse review comments read-only. General comments and inline threads
+are listed on the left, with the selected conversation and attached current-diff context
+on the right.
+
 ## Documentation
 
 Documentation for installation and workflows is available at

--- a/crates/ag-git/Cargo.toml
+++ b/crates/ag-git/Cargo.toml
@@ -14,12 +14,12 @@ test-utils = ["dep:mockall"]
 [dependencies]
 mockall = { workspace = true, optional = true }
 rustix.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true
-tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/ag-git/src/repo.rs
+++ b/crates/ag-git/src/repo.rs
@@ -297,7 +297,7 @@ pub(super) fn run_git_command_output_sync(
     repo_path: &Path,
     args: &[&str],
 ) -> Result<Output, GitError> {
-    run_git_command_output_with_env_sync(repo_path, args, &[])
+    run_git_command_output_with_env_sync(repo_path, args, &[] as &[(&str, &str)])
 }
 
 /// Runs a git command in `repo_path` with environment overrides and returns
@@ -319,11 +319,15 @@ pub(super) fn run_git_command_output_sync(
 ///
 /// # Errors
 /// Returns [`GitError::CommandFailed`] if spawning the command fails.
-pub(super) fn run_git_command_output_with_env_sync(
+pub(super) fn run_git_command_output_with_env_sync<Key, Value>(
     repo_path: &Path,
     args: &[&str],
-    environment: &[(&str, &str)],
-) -> Result<Output, GitError> {
+    environment: &[(Key, Value)],
+) -> Result<Output, GitError>
+where
+    Key: AsRef<std::ffi::OsStr>,
+    Value: AsRef<std::ffi::OsStr>,
+{
     let mut command = Command::new("git");
     command
         .args(args)

--- a/crates/ag-git/src/sync.rs
+++ b/crates/ag-git/src/sync.rs
@@ -10,7 +10,7 @@ use super::error::GitError;
 use super::rebase::{is_rebase_conflict, run_git_command_with_index_lock_retry};
 use super::repo::{
     command_output_detail, run_git_command, run_git_command_cancellable,
-    run_git_command_output_sync, run_git_command_sync,
+    run_git_command_output_sync, run_git_command_output_with_env_sync, run_git_command_sync,
 };
 
 /// Map of local branch names to their ahead/behind counts relative to their
@@ -257,12 +257,13 @@ pub(crate) async fn delete_branch(repo_path: PathBuf, branch_name: String) -> Re
 /// Returns the output of `git diff` for the given repository path, showing
 /// all changes (committed and uncommitted) relative to the base branch.
 ///
-/// Uses `git add --intent-to-add` to mark untracked files in the index, then
+/// Copies the repository index into a temporary index and uses
+/// `git add --intent-to-add` there to make untracked files visible, then
 /// finds the merge-base between `HEAD` and `base_branch` to diff against the
 /// fork point. To avoid re-showing squash-merged/cherry-picked session commits
 /// on non-rebased branches, this also checks `git cherry` and, when applicable,
 /// diffs from the last leading commit already applied to `base_branch`.
-/// Finally resets the index to restore the original state.
+/// The real repository index is never modified.
 ///
 /// # Arguments
 /// * `repo_path` - Path to the git repository or worktree
@@ -272,13 +273,27 @@ pub(crate) async fn delete_branch(repo_path: PathBuf, branch_name: String) -> Re
 /// The diff output as a string.
 ///
 /// # Errors
-/// Returns a [`GitError`] if preparing the index, generating the diff, or
-/// restoring index state fails.
+/// Returns a [`GitError`] if preparing the temporary index or generating the
+/// diff fails.
 pub(crate) async fn diff(repo_path: PathBuf, base_branch: String) -> Result<String, GitError> {
     spawn_blocking(move || -> Result<String, GitError> {
-        run_git_command_sync(
+        let index_path = run_git_command_sync(
+            &repo_path,
+            &["rev-parse", "--git-path", "index"],
+            "Git index path resolution failed",
+        )?;
+        let index_path = PathBuf::from(index_path.trim());
+        let index_path = if index_path.is_absolute() {
+            index_path
+        } else {
+            repo_path.join(index_path)
+        };
+        let temporary_index = copy_git_index_to_temp(&index_path)?;
+
+        run_git_command_with_index_sync(
             &repo_path,
             &["add", "-A", "--intent-to-add"],
+            &temporary_index,
             "Git add --intent-to-add failed",
         )?;
 
@@ -295,30 +310,62 @@ pub(crate) async fn diff(repo_path: PathBuf, base_branch: String) -> Result<Stri
             base_branch
         };
 
-        let diff_output = run_git_command_sync(
+        run_git_command_with_index_sync(
             &repo_path,
             &["diff", diff_target.as_str()],
+            &temporary_index,
             "Git diff failed",
-        );
-        let reset_result = run_git_command_sync(&repo_path, &["reset"], "Git reset failed");
-
-        if let Err(diff_error) = diff_output {
-            return match reset_result {
-                Ok(_) => Err(diff_error),
-                Err(reset_error) => Err(GitError::CommandFailed {
-                    command: "git diff".to_string(),
-                    stderr: format!(
-                        "{diff_error} Additionally failed to restore index state: {reset_error}"
-                    ),
-                }),
-            };
-        }
-
-        reset_result?;
-
-        diff_output
+        )
     })
     .await?
+}
+
+/// Copies one repository index beside its source and returns the temporary
+/// path used by isolated read-only diff commands.
+fn copy_git_index_to_temp(index_path: &Path) -> Result<tempfile::TempPath, GitError> {
+    let index_parent = index_path.parent().ok_or_else(|| {
+        GitError::OutputParse(format!(
+            "Git index path has no parent: {}",
+            index_path.display()
+        ))
+    })?;
+    let temporary_index =
+        tempfile::NamedTempFile::new_in(index_parent).map_err(|error| GitError::CommandFailed {
+            command: "create temporary git index".to_string(),
+            stderr: error.to_string(),
+        })?;
+    std::fs::copy(index_path, temporary_index.path()).map_err(|error| GitError::CommandFailed {
+        command: "copy git index".to_string(),
+        stderr: error.to_string(),
+    })?;
+
+    Ok(temporary_index.into_temp_path())
+}
+
+/// Runs one git command against a temporary index without touching the real
+/// index.
+fn run_git_command_with_index_sync(
+    repo_path: &Path,
+    args: &[&str],
+    index_path: &Path,
+    error_context: &str,
+) -> Result<String, GitError> {
+    let output = run_git_command_output_with_env_sync(
+        repo_path,
+        args,
+        &[("GIT_INDEX_FILE", index_path.as_os_str())],
+    )?;
+    if !output.status.success() {
+        return Err(GitError::CommandFailed {
+            command: format!("git {}", args.join(" ")),
+            stderr: format!(
+                "{error_context}: {}",
+                command_output_detail(&output.stdout, &output.stderr)
+            ),
+        });
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 /// Returns whether a repository or worktree has no uncommitted changes.
@@ -1330,6 +1377,109 @@ mod tests {
         fs::write(repo_path.join("README.md"), "base\n").expect("failed to write base file");
         run_git_command(repo_path, &["add", "README.md"]);
         run_git_command(repo_path, &["commit", "-m", "Initial commit"]);
+    }
+
+    #[tokio::test]
+    async fn diff_preserves_staged_changes_and_includes_untracked_files() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        setup_test_git_repo(temp_dir.path());
+        fs::write(temp_dir.path().join("README.md"), "staged change\n")
+            .expect("failed to write staged change");
+        run_git_command(temp_dir.path(), &["add", "README.md"]);
+        fs::write(
+            temp_dir.path().join("README.md"),
+            "staged change\nunstaged change\n",
+        )
+        .expect("failed to write unstaged change");
+        fs::write(temp_dir.path().join("new.txt"), "untracked change\n")
+            .expect("failed to write untracked file");
+        let cached_diff_before = git_command_output(temp_dir.path(), &["diff", "--cached"]).stdout;
+        let status_before = git_command_output(
+            temp_dir.path(),
+            &["status", "--porcelain=v1", "--untracked-files=all"],
+        )
+        .stdout;
+
+        // Act
+        let result = diff(temp_dir.path().to_path_buf(), "main".to_string()).await;
+
+        // Assert
+        let diff_output = result.expect("diff should succeed");
+        let cached_diff_after = git_command_output(temp_dir.path(), &["diff", "--cached"]).stdout;
+        let status_after = git_command_output(
+            temp_dir.path(),
+            &["status", "--porcelain=v1", "--untracked-files=all"],
+        )
+        .stdout;
+        assert!(diff_output.contains("staged change"));
+        assert!(diff_output.contains("unstaged change"));
+        assert!(diff_output.contains("untracked change"));
+        assert_eq!(cached_diff_after, cached_diff_before);
+        assert_eq!(status_after, status_before);
+    }
+
+    #[test]
+    fn copy_git_index_to_temp_maps_path_create_and_copy_failures() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let path_without_parent = Path::new("/");
+        let missing_parent_index = temp_dir.path().join("missing-parent").join("index");
+        let missing_index = temp_dir.path().join("missing-index");
+
+        // Act
+        let parent_error = copy_git_index_to_temp(path_without_parent);
+        let create_error = copy_git_index_to_temp(&missing_parent_index);
+        let copy_error = copy_git_index_to_temp(&missing_index);
+
+        // Assert
+        assert!(matches!(parent_error, Err(GitError::OutputParse(_))));
+        assert!(matches!(
+            create_error,
+            Err(GitError::CommandFailed { ref command, .. })
+                if command == "create temporary git index"
+        ));
+        assert!(matches!(
+            copy_error,
+            Err(GitError::CommandFailed { ref command, .. }) if command == "copy git index"
+        ));
+    }
+
+    #[test]
+    fn run_git_command_with_index_sync_maps_process_and_command_failures() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let index_path = temp_dir.path().join("index");
+        let missing_repo_path = temp_dir.path().join("missing-repository");
+        fs::write(&index_path, []).expect("failed to create temporary index");
+
+        // Act
+        let process_error = run_git_command_with_index_sync(
+            &missing_repo_path,
+            &["status"],
+            &index_path,
+            "Expected process failure",
+        );
+        let command_error = run_git_command_with_index_sync(
+            temp_dir.path(),
+            &["definitely-not-a-git-command"],
+            &index_path,
+            "Expected git failure",
+        );
+
+        // Assert
+        assert!(matches!(
+            process_error,
+            Err(GitError::CommandFailed { ref command, .. }) if command == "git status"
+        ));
+        assert!(matches!(
+            command_error,
+            Err(GitError::CommandFailed {
+                ref command,
+                ref stderr,
+            }) if command == "git definitely-not-a-git-command"
+                && stderr.starts_with("Expected git failure:")
+        ));
     }
 
     #[cfg(unix)]

--- a/crates/agentty/src/app/core/draw.rs
+++ b/crates/agentty/src/app/core/draw.rs
@@ -88,7 +88,7 @@ impl App {
                 restore_view,
                 ..
             } => *is_loading || self.session_has_tick_driven_ui(&restore_view.session_id),
-            AppMode::Diff { .. } => false,
+            AppMode::Diff { .. } | AppMode::ReviewComments { .. } => false,
             AppMode::Help { context, .. } => self.help_overlay_has_tick_driven_ui(context),
         }
     }

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -127,6 +127,13 @@ pub(crate) enum AppEvent {
         /// Browser-openable review-request URL used to disambiguate rows.
         web_url: String,
     },
+    /// Indicates completion of a linked session review-request comment load.
+    SessionReviewCommentSnapshotLoaded {
+        /// Comment snapshot result from the background forge task.
+        result: Result<ag_forge::ReviewCommentSnapshot, String>,
+        /// Session whose comments were requested.
+        session_id: SessionId,
+    },
     /// Indicates compact live thinking text for an in-progress session.
     SessionProgressUpdated {
         progress_message: Option<String>,
@@ -233,6 +240,8 @@ pub(super) struct AppEventBatch {
     pub(super) session_reasoning_level_updates:
         HashMap<SessionId, crate::domain::agent::ReasoningLevel>,
     pub(super) session_progress_updates: HashMap<SessionId, Option<String>>,
+    pub(super) session_review_comment_snapshots:
+        HashMap<SessionId, Result<ag_forge::ReviewCommentSnapshot, String>>,
     pub(super) session_size_updates: HashMap<SessionId, (u64, u64, SessionSize)>,
     pub(super) stacked_parent_merge_child_rebases: HashSet<SessionId>,
     pub(super) stacked_parent_syncs_completed: HashSet<SessionId>,
@@ -390,6 +399,10 @@ impl AppEventBatch {
                 progress_message,
                 session_id,
             } => self.collect_session_progress_updated(session_id, progress_message),
+            AppEvent::SessionReviewCommentSnapshotLoaded { result, session_id } => {
+                self.session_review_comment_snapshots
+                    .insert(session_id, result);
+            }
             AppEvent::SyncMainCompleted { result } => self.collect_sync_main_completed(result),
             AppEvent::SyncMainConflictResolutionStarted { conflicted_files } => {
                 self.collect_sync_main_conflict_resolution_started(conflicted_files);
@@ -856,6 +869,9 @@ impl App {
         self.apply_session_progress_updates(std::mem::take(
             &mut event_batch.session_progress_updates,
         ));
+        self.apply_session_review_comment_snapshot_updates(std::mem::take(
+            &mut event_batch.session_review_comment_snapshots,
+        ));
 
         for (session_id, turn_applied_state) in event_batch.applied_turns {
             self.apply_agent_response_received(&session_id, &turn_applied_state);
@@ -915,6 +931,41 @@ impl App {
 
         if should_mark_dirty {
             self.mark_dirty();
+        }
+    }
+
+    /// Applies completed linked-session comment loads only while the matching
+    /// comments page remains visible.
+    fn apply_session_review_comment_snapshot_updates(
+        &mut self,
+        updates: HashMap<SessionId, Result<ag_forge::ReviewCommentSnapshot, String>>,
+    ) {
+        for (loaded_session_id, result) in updates {
+            let AppMode::ReviewComments {
+                comment_error,
+                comment_snapshot,
+                is_loading_comments,
+                session_id,
+                ..
+            } = &mut self.mode
+            else {
+                continue;
+            };
+            if *session_id != loaded_session_id {
+                continue;
+            }
+
+            *is_loading_comments = false;
+            match result {
+                Ok(snapshot) => {
+                    *comment_error = None;
+                    *comment_snapshot = Some(snapshot);
+                }
+                Err(error) => {
+                    *comment_error = Some(format!("Failed to load review comments: {error}"));
+                    *comment_snapshot = None;
+                }
+            }
         }
     }
 
@@ -1246,6 +1297,7 @@ impl App {
             || !event_batch.review_updates.is_empty()
             || !event_batch.session_model_updates.is_empty()
             || !event_batch.session_progress_updates.is_empty()
+            || !event_batch.session_review_comment_snapshots.is_empty()
             || !event_batch.session_reasoning_level_updates.is_empty()
             || !event_batch.session_size_updates.is_empty()
             || !event_batch.session_title_generation_finished.is_empty()
@@ -1411,6 +1463,10 @@ impl App {
                 ..
             }
             | AppMode::Diff {
+                session_id: view_id,
+                ..
+            }
+            | AppMode::ReviewComments {
                 session_id: view_id,
                 ..
             }
@@ -2045,6 +2101,84 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn test_session_review_comment_result_updates_matching_open_page() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.mode = AppMode::ReviewComments {
+            comment_error: None,
+            comment_snapshot: None,
+            diff: String::new(),
+            is_loading_comments: true,
+            selected_comment_index: 0,
+            session_id: "session-id".into(),
+            scroll_offset: 0,
+        };
+
+        // Act
+        app.apply_app_events(AppEvent::SessionReviewCommentSnapshotLoaded {
+            result: Ok(ag_forge::ReviewCommentSnapshot::default()),
+            session_id: "session-id".into(),
+        })
+        .await;
+
+        // Assert
+        assert!(matches!(
+            app.mode,
+            AppMode::ReviewComments {
+                comment_error: None,
+                comment_snapshot: Some(_),
+                is_loading_comments: false,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_session_review_comment_result_ignores_stale_pages_and_surfaces_errors() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+
+        // Act
+        app.apply_app_events(AppEvent::SessionReviewCommentSnapshotLoaded {
+            result: Ok(ag_forge::ReviewCommentSnapshot::default()),
+            session_id: "closed-session".into(),
+        })
+        .await;
+        app.mode = AppMode::ReviewComments {
+            comment_error: None,
+            comment_snapshot: None,
+            diff: String::new(),
+            is_loading_comments: true,
+            selected_comment_index: 0,
+            session_id: "open-session".into(),
+            scroll_offset: 0,
+        };
+        app.apply_app_events(AppEvent::SessionReviewCommentSnapshotLoaded {
+            result: Ok(ag_forge::ReviewCommentSnapshot::default()),
+            session_id: "stale-session".into(),
+        })
+        .await;
+        app.apply_app_events(AppEvent::SessionReviewCommentSnapshotLoaded {
+            result: Err("authentication failed".to_string()),
+            session_id: "open-session".into(),
+        })
+        .await;
+
+        // Assert
+        assert!(app.is_viewing_session("open-session"));
+        assert!(!app.is_viewing_session("stale-session"));
+        assert!(matches!(
+            app.mode,
+            AppMode::ReviewComments {
+                comment_error: Some(ref error),
+                comment_snapshot: None,
+                is_loading_comments: false,
+                ..
+            } if error == "Failed to load review comments: authentication failed"
+        ));
+    }
 
     #[test]
     fn test_refresh_sessions_batch_sets_only_session_reload_scope() {

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -494,6 +494,52 @@ impl App {
         };
     }
 
+    /// Opens the read-only comment page for a session's linked review request
+    /// and starts a background forge comment load.
+    pub(crate) fn open_session_review_comments(
+        &mut self,
+        session_id: &SessionId,
+        diff: String,
+    ) -> bool {
+        let Some(session) = self
+            .sessions
+            .sessions()
+            .iter()
+            .find(|session| session.id == *session_id)
+        else {
+            return false;
+        };
+        let Some(review_request) = session.review_request.as_ref() else {
+            return false;
+        };
+        let display_id = review_request.summary.display_id.clone();
+        let fallback_repo_url = SessionManager::review_request_repo_url(review_request);
+        let working_dir = session.folder.clone();
+
+        self.mode = AppMode::ReviewComments {
+            comment_error: None,
+            comment_snapshot: None,
+            diff,
+            is_loading_comments: true,
+            selected_comment_index: 0,
+            session_id: session_id.clone(),
+            scroll_offset: 0,
+        };
+        task::TaskService::spawn_session_review_comment_snapshot_task(
+            task::SessionReviewCommentSnapshotTask {
+                display_id,
+                fallback_repo_url,
+                session_id: session_id.clone(),
+                working_dir,
+            },
+            self.services.event_sender(),
+            self.services.git_client(),
+            self.services.review_request_client(),
+        );
+
+        true
+    }
+
     /// Caches a lazily loaded requested-review comment snapshot back onto the
     /// loaded Inbox tab row so reopening the same detail page avoids another
     /// comment API call.

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -111,6 +111,27 @@ async fn test_new_with_clients_fails_when_no_backend_cli_is_available() {
 }
 
 #[tokio::test]
+async fn review_comments_page_has_no_tick_driven_ui() {
+    // Arrange
+    let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+    app.mode = AppMode::ReviewComments {
+        comment_error: None,
+        comment_snapshot: None,
+        diff: String::new(),
+        is_loading_comments: true,
+        selected_comment_index: 0,
+        session_id: "session-id".into(),
+        scroll_offset: 0,
+    };
+
+    // Act
+    let has_tick_driven_ui = app.has_visible_tick_driven_ui();
+
+    // Assert
+    assert!(!has_tick_driven_ui);
+}
+
+#[tokio::test]
 async fn session_git_status_targets_include_active_unpublished_sessions() {
     // Arrange
     let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
@@ -495,6 +516,93 @@ async fn open_selected_requested_review_applies_background_comment_snapshot() {
         Some(&expected_comment_snapshot)
     );
     assert!(app.requested_review_comment_fetches.is_empty());
+}
+
+#[tokio::test]
+async fn open_session_review_comments_requires_link_and_applies_background_snapshot() {
+    // Arrange
+    let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    let session_id = SessionId::from("session-review-comments");
+    let session = crate::test_support::SessionFixtureBuilder::new()
+        .id(session_id.clone())
+        .folder(PathBuf::from("/tmp/session-review-comments"))
+        .build();
+    app.sessions.push_session(session);
+
+    let missing_session_opened =
+        app.open_session_review_comments(&SessionId::from("missing-session"), String::new());
+    let unlinked_session_opened = app.open_session_review_comments(&session_id, String::new());
+
+    let session = app
+        .sessions
+        .sessions_mut()
+        .iter_mut()
+        .find(|session| session.id == session_id)
+        .expect("session should exist");
+    session.review_request = Some(ReviewRequest {
+        last_refreshed_at: 0,
+        summary: ReviewRequestSummary {
+            display_id: "#42".to_string(),
+            forge_kind: ForgeKind::GitHub,
+            source_branch: "wt/session-review-comments".to_string(),
+            state: ReviewRequestState::Open,
+            status_summary: None,
+            target_branch: "main".to_string(),
+            title: "Review comments".to_string(),
+            web_url: "https://github.com/agentty-xyz/agentty/pull/42".to_string(),
+        },
+    });
+    let mut mock_git_client = ag_git::MockGitClient::new();
+    mock_git_client.expect_repo_url().once().returning(|_| {
+        Box::pin(async { Ok("https://github.com/agentty-xyz/agentty.git".to_string()) })
+    });
+    install_mock_git_client(&mut app, mock_git_client);
+    let mut mock_review_request_client = forge::MockReviewRequestClient::new();
+    mock_review_request_client
+        .expect_detect_remote()
+        .once()
+        .returning(|_| Ok(forge_remote()));
+    mock_review_request_client
+        .expect_fetch_review_comment_snapshot()
+        .once()
+        .returning(|_, _| Box::pin(async { Ok(review_comment_snapshot()) }));
+    install_mock_review_request_client(&mut app, mock_review_request_client);
+
+    // Act
+    let linked_session_opened =
+        app.open_session_review_comments(&session_id, "review diff".to_string());
+    wait_for_app_condition(&mut app, |app| {
+        matches!(
+            app.mode,
+            AppMode::ReviewComments {
+                is_loading_comments: false,
+                ..
+            }
+        )
+    })
+    .await;
+
+    // Assert
+    assert!(!missing_session_opened);
+    assert!(!unlinked_session_opened);
+    assert!(linked_session_opened);
+    assert!(matches!(
+        app.mode,
+        AppMode::ReviewComments {
+            comment_error: None,
+            comment_snapshot: Some(ref snapshot),
+            ref diff,
+            is_loading_comments: false,
+            selected_comment_index: 0,
+            ref session_id,
+            scroll_offset: 0,
+        } if snapshot == &review_comment_snapshot()
+            && diff == "review diff"
+            && session_id == "session-review-comments"
+    ));
 }
 
 /// Verifies reopening a loading requested-review detail reuses the

--- a/crates/agentty/src/app/service.rs
+++ b/crates/agentty/src/app/service.rs
@@ -295,6 +295,7 @@ fn app_event_label(event: &AppEvent) -> &'static str {
         AppEvent::RequestedReviewCommentSnapshotLoaded { .. } => {
             "RequestedReviewCommentSnapshotLoaded"
         }
+        AppEvent::SessionReviewCommentSnapshotLoaded { .. } => "SessionReviewCommentSnapshotLoaded",
         AppEvent::SessionProgressUpdated { .. } => "SessionProgressUpdated",
         AppEvent::SyncMainCompleted { .. } => "SyncMainCompleted",
         AppEvent::SyncMainConflictResolutionStarted { .. } => "SyncMainConflictResolutionStarted",
@@ -319,6 +320,21 @@ mod tests {
     use std::future;
 
     use super::*;
+
+    #[test]
+    fn app_event_label_names_session_review_comment_snapshot_loads() {
+        // Arrange
+        let event = AppEvent::SessionReviewCommentSnapshotLoaded {
+            result: Err("forge unavailable".to_string()),
+            session_id: "session-id".into(),
+        };
+
+        // Act
+        let label = app_event_label(&event);
+
+        // Assert
+        assert_eq!(label, "SessionReviewCommentSnapshotLoaded");
+    }
 
     #[tokio::test]
     async fn cleanup_task_wait_cancels_work_after_shared_deadline() {

--- a/crates/agentty/src/app/session/workflow/refresh.rs
+++ b/crates/agentty/src/app/session/workflow/refresh.rs
@@ -191,7 +191,7 @@ impl SessionManager {
     }
 
     /// Derives a repository URL from one persisted review-request web URL.
-    fn review_request_repo_url(review_request: &ReviewRequest) -> Option<String> {
+    pub(crate) fn review_request_repo_url(review_request: &ReviewRequest) -> Option<String> {
         let web_url = review_request.summary.web_url.trim_end_matches('/');
 
         match review_request.summary.forge_kind {
@@ -243,6 +243,7 @@ impl SessionManager {
             | AppMode::Question { session_id, .. }
             | AppMode::View { session_id, .. }
             | AppMode::Diff { session_id, .. }
+            | AppMode::ReviewComments { session_id, .. }
             | AppMode::LaunchConfigurationSelector {
                 restore_view: ConfirmationViewMode { session_id, .. },
                 ..
@@ -722,6 +723,29 @@ mod tests {
 
         // Assert
         assert!(refresh_due);
+    }
+
+    #[test]
+    fn test_ensure_mode_session_exists_closes_missing_review_comments_page() {
+        // Arrange
+        let now = Instant::now();
+        let clock: Arc<dyn Clock> = Arc::new(FakeClock::new(now, SystemTime::UNIX_EPOCH));
+        let session_manager = session_manager_fixture(clock);
+        let mut mode = AppMode::ReviewComments {
+            comment_error: None,
+            comment_snapshot: None,
+            diff: String::new(),
+            is_loading_comments: true,
+            selected_comment_index: 0,
+            session_id: "missing-session".into(),
+            scroll_offset: 0,
+        };
+
+        // Act
+        session_manager.ensure_mode_session_exists(&mut mode);
+
+        // Assert
+        assert!(matches!(mode, AppMode::List));
     }
 
     /// Builds a session manager with deterministic time and empty state.

--- a/crates/agentty/src/app/task.rs
+++ b/crates/agentty/src/app/task.rs
@@ -41,6 +41,18 @@ pub(super) struct RequestedReviewCommentSnapshotTask {
     pub(super) working_dir: PathBuf,
 }
 
+/// Payload needed to load comments for a linked session review request.
+pub(super) struct SessionReviewCommentSnapshotTask {
+    /// Provider display id such as GitHub `#123` or GitLab `!123`.
+    pub(super) display_id: String,
+    /// Repository URL reconstructed from the persisted review-request link.
+    pub(super) fallback_repo_url: Option<String>,
+    /// Session whose comments should receive the completed snapshot.
+    pub(super) session_id: SessionId,
+    /// Session worktree used for remote detection and forge CLI context.
+    pub(super) working_dir: PathBuf,
+}
+
 /// Inputs needed to generate review assist text in the background.
 pub(super) struct ReviewAssistTaskInput {
     pub(super) app_event_tx: mpsc::UnboundedSender<AppEvent>,
@@ -208,6 +220,57 @@ impl TaskService {
         });
     }
 
+    /// Spawns one linked session review-comment load without blocking terminal
+    /// input or redraws.
+    pub(super) fn spawn_session_review_comment_snapshot_task(
+        task: SessionReviewCommentSnapshotTask,
+        app_event_tx: mpsc::UnboundedSender<AppEvent>,
+        git_client: Arc<dyn GitClient>,
+        review_request_client: Arc<dyn ReviewRequestClient>,
+    ) {
+        tokio::spawn(async move {
+            let result = Self::load_session_review_comment_snapshot(
+                task.working_dir,
+                task.fallback_repo_url,
+                task.display_id,
+                git_client.as_ref(),
+                review_request_client.as_ref(),
+            )
+            .await;
+            let _ = app_event_tx.send(AppEvent::SessionReviewCommentSnapshotLoaded {
+                result,
+                session_id: task.session_id,
+            });
+        });
+    }
+
+    /// Loads comments for one linked session review request, falling back to
+    /// its persisted forge URL when terminal-session cleanup removed the
+    /// worktree.
+    async fn load_session_review_comment_snapshot(
+        working_dir: PathBuf,
+        fallback_repo_url: Option<String>,
+        display_id: String,
+        git_client: &dyn GitClient,
+        review_request_client: &dyn ReviewRequestClient,
+    ) -> Result<ReviewCommentSnapshot, String> {
+        let remote =
+            match review_request_remote(working_dir, git_client, review_request_client).await {
+                Ok(remote) => remote,
+                Err(working_dir_error) => {
+                    let Some(repo_url) = fallback_repo_url else {
+                        return Err(working_dir_error);
+                    };
+
+                    review_request_client
+                        .detect_remote(repo_url)
+                        .map_err(|error| error.detail_message())?
+                }
+            };
+
+        load_review_comment_snapshot(remote, display_id, review_request_client).await
+    }
+
     /// Loads and normalizes the comment snapshot for one requested review.
     ///
     /// This is triggered lazily when users open a specific review detail page
@@ -221,11 +284,7 @@ impl TaskService {
     ) -> Result<ReviewCommentSnapshot, String> {
         let remote = review_request_remote(working_dir, git_client, review_request_client).await?;
 
-        review_request_client
-            .fetch_review_comment_snapshot(remote, display_id)
-            .await
-            .map(sorted_review_comment_snapshot)
-            .map_err(|error| error.detail_message())
+        load_review_comment_snapshot(remote, display_id, review_request_client).await
     }
 
     /// Spawns a one-shot background check for newer `agentty` versions on
@@ -532,6 +591,20 @@ async fn review_request_remote(
         .map_err(|error| error.detail_message())
 }
 
+/// Fetches and normalizes one review-comment snapshot from an already
+/// resolved forge remote.
+async fn load_review_comment_snapshot(
+    remote: ForgeRemote,
+    display_id: String,
+    review_request_client: &dyn ReviewRequestClient,
+) -> Result<ReviewCommentSnapshot, String> {
+    review_request_client
+        .fetch_review_comment_snapshot(remote, display_id)
+        .await
+        .map(sorted_review_comment_snapshot)
+        .map_err(|error| error.detail_message())
+}
+
 /// Sorts inline review-comment threads once before storing them for rendering.
 fn sorted_review_comment_snapshot(
     mut review_comment_snapshot: ReviewCommentSnapshot,
@@ -702,6 +775,74 @@ mod tests {
 
         // Assert
         assert_eq!(comment_snapshot, Ok(review_comment_snapshot()));
+    }
+
+    #[tokio::test]
+    async fn load_session_review_comment_snapshot_uses_persisted_url_without_worktree() {
+        // Arrange
+        let mut mock_git_client = MockGitClient::new();
+        mock_git_client.expect_repo_url().times(1).returning(|_| {
+            Box::pin(async {
+                Err(ag_git::GitError::Io(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "session worktree was removed",
+                )))
+            })
+        });
+        let mut mock_review_request_client = MockReviewRequestClient::new();
+        mock_review_request_client
+            .expect_detect_remote()
+            .times(1)
+            .withf(|repo_url| repo_url == "https://github.com/agentty-xyz/agentty")
+            .returning(|_| Ok(forge_remote()));
+        mock_review_request_client
+            .expect_fetch_review_comment_snapshot()
+            .times(1)
+            .withf(|remote, display_id| {
+                remote.command_working_directory.is_none() && display_id == "#42"
+            })
+            .returning(|_, _| Box::pin(async { Ok(review_comment_snapshot()) }));
+
+        // Act
+        let comment_snapshot = TaskService::load_session_review_comment_snapshot(
+            PathBuf::from("/tmp/missing-session"),
+            Some("https://github.com/agentty-xyz/agentty".to_string()),
+            "#42".to_string(),
+            &mock_git_client,
+            &mock_review_request_client,
+        )
+        .await;
+
+        // Assert
+        assert_eq!(comment_snapshot, Ok(review_comment_snapshot()));
+    }
+
+    #[tokio::test]
+    async fn load_session_review_comment_snapshot_returns_worktree_error_without_fallback() {
+        // Arrange
+        let mut mock_git_client = MockGitClient::new();
+        mock_git_client.expect_repo_url().once().returning(|_| {
+            Box::pin(async {
+                Err(ag_git::GitError::Io(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "session worktree was removed",
+                )))
+            })
+        });
+        let mock_review_request_client = MockReviewRequestClient::new();
+
+        // Act
+        let result = TaskService::load_session_review_comment_snapshot(
+            PathBuf::from("/tmp/missing-session"),
+            None,
+            "#42".to_string(),
+            &mock_git_client,
+            &mock_review_request_client,
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(result, Err(error) if error.contains("session worktree was removed")));
     }
 
     #[tokio::test]
@@ -1165,6 +1306,18 @@ mod tests {
             path: path.to_string(),
             start_line: None,
         }
+    }
+
+    #[test]
+    fn review_comment_anchor_side_order_places_file_before_old_and_new_lines() {
+        // Arrange, Act
+        let file_order = review_comment_anchor_side_order(ReviewCommentAnchorSide::File);
+        let old_order = review_comment_anchor_side_order(ReviewCommentAnchorSide::Old);
+        let new_order = review_comment_anchor_side_order(ReviewCommentAnchorSide::New);
+
+        // Assert
+        assert!(file_order < old_order);
+        assert!(old_order < new_order);
     }
 
     #[test]

--- a/crates/agentty/src/app/view.rs
+++ b/crates/agentty/src/app/view.rs
@@ -111,6 +111,7 @@ fn visible_review_session_id(mode: &AppMode) -> Option<&str> {
         | AppMode::Prompt { session_id, .. }
         | AppMode::Question { session_id, .. }
         | AppMode::Diff { session_id, .. }
+        | AppMode::ReviewComments { session_id, .. }
         | AppMode::Help {
             context: HelpContext::View { session_id, .. } | HelpContext::Diff { session_id, .. },
             ..
@@ -131,5 +132,30 @@ fn visible_review_session_id(mode: &AppMode) -> Option<&str> {
         | AppMode::Confirmation { .. }
         | AppMode::SyncBlockedPopup { .. }
         | AppMode::Help { .. } => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn visible_review_session_id_includes_review_comments() {
+        // Arrange
+        let mode = AppMode::ReviewComments {
+            comment_error: None,
+            comment_snapshot: None,
+            diff: String::new(),
+            is_loading_comments: true,
+            selected_comment_index: 0,
+            session_id: "session-id".into(),
+            scroll_offset: 0,
+        };
+
+        // Act
+        let session_id = visible_review_session_id(&mode);
+
+        // Assert
+        assert_eq!(session_id, Some("session-id"));
     }
 }

--- a/crates/agentty/src/presentation/app_mode.rs
+++ b/crates/agentty/src/presentation/app_mode.rs
@@ -1,4 +1,4 @@
-use ag_forge::{AssignedIssue, IssueDetail, RequestedReview};
+use ag_forge::{AssignedIssue, IssueDetail, RequestedReview, ReviewCommentSnapshot};
 
 use super::help_action::{
     self, HelpAction, ViewActionAvailability, ViewHelpState, ViewSessionState,
@@ -269,6 +269,24 @@ pub enum AppMode {
         /// Session whose diff is currently visible.
         session_id: SessionId,
     },
+    /// Displays read-only forge review comments for one linked session review
+    /// request, with comment selection and current diff context.
+    ReviewComments {
+        /// User-facing failure returned while loading review comments.
+        comment_error: Option<String>,
+        /// Loaded review-request comment snapshot.
+        comment_snapshot: Option<ReviewCommentSnapshot>,
+        /// Raw session diff used to derive code context for inline threads.
+        diff: String,
+        /// Whether the linked review request's comments are loading.
+        is_loading_comments: bool,
+        /// Selected general comment or inline review thread.
+        selected_comment_index: usize,
+        /// Session whose linked review-request comments are visible.
+        session_id: SessionId,
+        /// Vertical offset inside the selected comment detail panel.
+        scroll_offset: u16,
+    },
 
     /// Interactive clarification flow that asks agent questions one-by-one.
     Question {
@@ -312,6 +330,7 @@ pub enum HelpContext {
         can_rebase_session_branch: bool,
         can_reply_to_session: bool,
         can_start_staged_session: bool,
+        can_view_review_comments: bool,
         publish_pull_request_action: Option<PublishBranchAction>,
         session_id: SessionId,
         session_state: ViewSessionState,
@@ -340,28 +359,32 @@ impl HelpContext {
                 can_rebase_session_branch,
                 can_reply_to_session,
                 can_start_staged_session,
+                can_view_review_comments,
                 publish_pull_request_action,
                 session_state,
                 ..
-            } => help_action::view_actions(ViewHelpState {
-                can_fork_session: ViewActionAvailability::from_bool(*can_fork_session),
-                can_merge_session_branch: ViewActionAvailability::from_bool(
-                    *can_merge_session_branch,
-                ),
-                can_mutate_session_branch: ViewActionAvailability::from_bool(
-                    *can_mutate_session_branch,
-                ),
-                can_open_worktree: ViewActionAvailability::from_bool(*can_open_worktree),
-                can_rebase_session_branch: ViewActionAvailability::from_bool(
-                    *can_rebase_session_branch,
-                ),
-                reply_to_session: ViewActionAvailability::from_bool(*can_reply_to_session),
-                can_start_staged_session: ViewActionAvailability::from_bool(
-                    *can_start_staged_session,
-                ),
-                publish_pull_request_action: *publish_pull_request_action,
-                session_state: *session_state,
-            }),
+            } => help_action::view_actions_with_review_comments(
+                ViewHelpState {
+                    can_fork_session: ViewActionAvailability::from_bool(*can_fork_session),
+                    can_merge_session_branch: ViewActionAvailability::from_bool(
+                        *can_merge_session_branch,
+                    ),
+                    can_mutate_session_branch: ViewActionAvailability::from_bool(
+                        *can_mutate_session_branch,
+                    ),
+                    can_open_worktree: ViewActionAvailability::from_bool(*can_open_worktree),
+                    can_rebase_session_branch: ViewActionAvailability::from_bool(
+                        *can_rebase_session_branch,
+                    ),
+                    reply_to_session: ViewActionAvailability::from_bool(*can_reply_to_session),
+                    can_start_staged_session: ViewActionAvailability::from_bool(
+                        *can_start_staged_session,
+                    ),
+                    publish_pull_request_action: *publish_pull_request_action,
+                    session_state: *session_state,
+                },
+                *can_view_review_comments,
+            ),
             HelpContext::List { keybindings } => keybindings.clone(),
             HelpContext::Diff { .. } => help_action::diff_actions(),
         }
@@ -440,6 +463,7 @@ mod tests {
             can_rebase_session_branch: true,
             can_reply_to_session: true,
             can_start_staged_session: false,
+            can_view_review_comments: false,
             publish_pull_request_action: None,
             session_id: "session-id".into(),
             session_state: ViewSessionState::InProgress,
@@ -472,6 +496,7 @@ mod tests {
             can_rebase_session_branch: true,
             can_reply_to_session: true,
             can_start_staged_session: false,
+            can_view_review_comments: false,
             publish_pull_request_action: Some(PublishBranchAction::PublishPullRequest),
             session_id: "session-id".into(),
             session_state: ViewSessionState::InProgress,
@@ -503,6 +528,7 @@ mod tests {
             can_rebase_session_branch: true,
             can_reply_to_session: true,
             can_start_staged_session: false,
+            can_view_review_comments: false,
             publish_pull_request_action: Some(PublishBranchAction::PublishPullRequest),
             session_id: "session-id".into(),
             session_state: ViewSessionState::Interactive,

--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -418,6 +418,18 @@ pub(crate) fn view_actions(state: ViewHelpState) -> Vec<HelpAction> {
     actions
 }
 
+/// Returns full session-view help actions with linked review comments on `c`
+/// and terminal continuation on `C` when both actions are available.
+pub(crate) fn view_actions_with_review_comments(
+    state: ViewHelpState,
+    can_view_review_comments: bool,
+) -> Vec<HelpAction> {
+    let mut actions = view_actions(state);
+    append_review_comment_action(&mut actions, can_view_review_comments);
+
+    actions
+}
+
 /// Returns compact session-view footer actions for the page-level hint line.
 ///
 /// Review-oriented and running sessions keep sync controls discoverable in
@@ -442,6 +454,38 @@ pub(crate) fn view_footer_actions(state: ViewHelpState) -> Vec<HelpAction> {
     actions.extend(VIEW_FOOTER_TRAILING_ACTIONS);
 
     actions
+}
+
+/// Returns compact session-view footer actions with linked review comments on
+/// `c` and terminal continuation on `C` when both actions are available.
+pub(crate) fn view_footer_actions_with_review_comments(
+    state: ViewHelpState,
+    can_view_review_comments: bool,
+) -> Vec<HelpAction> {
+    let mut actions = view_footer_actions(state);
+    append_review_comment_action(&mut actions, can_view_review_comments);
+
+    actions
+}
+
+/// Adds the comments shortcut before trailing navigation actions and remaps
+/// terminal continuation to `C` when both actions are available.
+fn append_review_comment_action(actions: &mut Vec<HelpAction>, is_available: bool) {
+    if !is_available {
+        return;
+    }
+
+    if let Some(continue_action) = actions
+        .iter_mut()
+        .find(|action| action.key == "c" && action.footer_label == "continue")
+    {
+        continue_action.key = "C";
+    }
+    let insertion_index = 1.min(actions.len());
+    actions.insert(
+        insertion_index,
+        HelpAction::new("comments", "c", "Show review comments"),
+    );
 }
 
 /// Appends the stop action shared by full help and compact footer rows.
@@ -698,6 +742,15 @@ pub(crate) fn diff_footer_actions() -> Vec<HelpAction> {
     ]
 }
 
+/// Returns compact read-only review-comment page actions.
+pub(crate) fn review_comment_footer_actions() -> Vec<HelpAction> {
+    vec![
+        HelpAction::new("back", "q/Esc", "Back to session"),
+        HelpAction::new("select comment", "j/k", "Select comment"),
+        HelpAction::new("scroll pane", "Up/Down", "Scroll comment details"),
+    ]
+}
+
 /// Returns list-mode actions shared by all tabs.
 fn list_base_actions() -> Vec<HelpAction> {
     Vec::from(LIST_BASE_ACTIONS)
@@ -717,6 +770,7 @@ fn publish_pull_request_help_action(action: PublishBranchAction) -> HelpAction {
 mod tests {
     use super::*;
     use crate::domain::session::PublishBranchAction;
+    use crate::test_support::SessionFixtureBuilder;
 
     #[test]
     fn test_project_list_actions_exclude_new_session_shortcut() {
@@ -1526,6 +1580,35 @@ mod tests {
     }
 
     #[test]
+    fn test_view_footer_actions_linked_review_uses_c_for_comments_before_other_actions() {
+        // Arrange
+        let state = ViewHelpState {
+            can_fork_session: ViewActionAvailability::Enabled,
+            can_merge_session_branch: ViewActionAvailability::Enabled,
+            can_mutate_session_branch: ViewActionAvailability::Enabled,
+            can_rebase_session_branch: ViewActionAvailability::Enabled,
+            can_open_worktree: ViewActionAvailability::Enabled,
+            reply_to_session: ViewActionAvailability::Enabled,
+            can_start_staged_session: ViewActionAvailability::Disabled,
+            publish_pull_request_action: None,
+            session_state: ViewSessionState::Done,
+        };
+
+        // Act
+        let actions = view_footer_actions_with_review_comments(state, true);
+
+        // Assert
+        assert_eq!(actions[1].key, "c");
+        assert_eq!(actions[1].popup_label, "Show review comments");
+        assert_eq!(actions.iter().filter(|action| action.key == "c").count(), 1);
+        assert!(actions.iter().any(|action| {
+            action.key == "C"
+                && action.footer_label == "continue"
+                && action.popup_label == "Continue in new session"
+        }));
+    }
+
+    #[test]
     fn test_view_footer_actions_canceled_hides_continue() {
         // Arrange
         let state = ViewHelpState {
@@ -1615,5 +1698,41 @@ mod tests {
 
         // Assert
         assert!(!actions.iter().any(|action| action.key == "Ctrl+c"));
+    }
+
+    #[test]
+    fn test_session_view_state_maps_agent_review_status() {
+        // Arrange
+        let session = SessionFixtureBuilder::new()
+            .status(Status::AgentReview)
+            .build();
+
+        // Act
+        let state = session_view_state(&session);
+
+        // Assert
+        assert_eq!(state, ViewSessionState::AgentReview);
+    }
+
+    #[test]
+    fn test_read_only_detail_and_diff_action_groups_expose_expected_keys() {
+        // Arrange, Act
+        let issue_keys = issue_detail_actions()
+            .iter()
+            .map(|action| action.key)
+            .collect::<Vec<_>>();
+        let diff_keys = diff_actions()
+            .iter()
+            .map(|action| action.key)
+            .collect::<Vec<_>>();
+        let comment_keys = review_comment_footer_actions()
+            .iter()
+            .map(|action| action.key)
+            .collect::<Vec<_>>();
+
+        // Assert
+        assert_eq!(issue_keys, ["q/Esc", "j/k", "Ctrl+d/u", "g/G"]);
+        assert_eq!(diff_keys, ["q/Esc", "j/k", "Up/Down", "?"]);
+        assert_eq!(comment_keys, ["q/Esc", "j/k", "Up/Down"]);
     }
 }

--- a/crates/agentty/src/runtime/key_handler.rs
+++ b/crates/agentty/src/runtime/key_handler.rs
@@ -92,17 +92,9 @@ where
                 )
                 .await
             }
-            AppMode::Question { .. } => {
-                let size = terminal.size().map_err(backend_err)?;
-                let terminal_rect = Rect::new(0, 0, size.width, size.height);
-
-                Ok(mode::question::handle_with_cache(
-                    app,
-                    presentation.render_cache_store(),
-                    terminal_rect,
-                    key,
-                )
-                .await)
+            AppMode::Question { .. } => handle_question_key(app, presentation, terminal, key).await,
+            AppMode::ReviewComments { .. } => {
+                handle_review_comment_key(app, presentation, terminal, key)
             }
             AppMode::Diff { .. } => {
                 let size = terminal.size().map_err(backend_err)?;
@@ -133,6 +125,51 @@ where
     }
 
     result
+}
+
+/// Resolves the full terminal area and routes one clarification-question key
+/// event through the shared render cache.
+async fn handle_question_key<B: Backend>(
+    app: &mut App,
+    presentation: &PresentationState,
+    terminal: &mut Terminal<B>,
+    key: KeyEvent,
+) -> io::Result<EventResult>
+where
+    B::Error: std::error::Error + Send + Sync + 'static,
+{
+    let size = terminal.size().map_err(backend_err)?;
+    let terminal_rect = Rect::new(0, 0, size.width, size.height);
+
+    Ok(mode::question::handle_with_cache(
+        app,
+        presentation.render_cache_store(),
+        terminal_rect,
+        key,
+    )
+    .await)
+}
+
+/// Resolves the page content area and routes one review-comment key event.
+fn handle_review_comment_key<B: Backend>(
+    app: &mut App,
+    presentation: &PresentationState,
+    terminal: &mut Terminal<B>,
+    key: KeyEvent,
+) -> io::Result<EventResult>
+where
+    B::Error: std::error::Error + Send + Sync + 'static,
+{
+    let size = terminal.size().map_err(backend_err)?;
+    let terminal_rect = Rect::new(0, 0, size.width, size.height);
+    let content_area = content_area_for_terminal(terminal_rect);
+
+    Ok(mode::review_comment::handle_with_cache(
+        app,
+        presentation.render_cache_store(),
+        content_area,
+        key,
+    ))
 }
 
 /// Returns the central content area after removing the global status and
@@ -1320,6 +1357,77 @@ mod tests {
             } if confirmation_title == "Confirm Continue"
                 && matches!(restore_view, Some(restore_view) if restore_view.session_id == source_session_id)
                 && matches!(session_id, Some(session_id) if session_id.as_str() == source_session_id)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_key_event_routes_question_input_through_terminal_bounds() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.mode = AppMode::Question {
+            at_mention_state: None,
+            current_index: 0,
+            focus: crate::presentation::app_mode::ChatFocus::Input,
+            input: crate::domain::input::InputState::default(),
+            questions: vec![crate::domain::question::QuestionItem::new("Which branch?")],
+            responses: Vec::new(),
+            scroll_offset: None,
+            selected_option_index: None,
+            session_id: "session-id".into(),
+        };
+        let backend = ratatui::backend::TestBackend::new(120, 30);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+
+        // Act
+        let event_result = handle_key_event(
+            &mut app,
+            &PresentationState::default(),
+            &mut terminal,
+            KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(event_result, Ok(EventResult::Continue)));
+        assert!(matches!(
+            app.mode,
+            AppMode::Question { ref input, .. } if input.text() == "x"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_key_event_routes_review_comment_back_shortcut() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.mode = AppMode::ReviewComments {
+            comment_error: None,
+            comment_snapshot: None,
+            diff: String::new(),
+            is_loading_comments: true,
+            selected_comment_index: 0,
+            session_id: "session-id".into(),
+            scroll_offset: 0,
+        };
+        let backend = ratatui::backend::TestBackend::new(120, 30);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+
+        // Act
+        let event_result = handle_key_event(
+            &mut app,
+            &PresentationState::default(),
+            &mut terminal,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(event_result, Ok(EventResult::Continue)));
+        assert!(matches!(
+            app.mode,
+            AppMode::View {
+                ref session_id,
+                scroll_offset: None,
+            } if session_id == "session-id"
         ));
     }
 

--- a/crates/agentty/src/runtime/mode.rs
+++ b/crates/agentty/src/runtime/mode.rs
@@ -10,6 +10,7 @@ pub(crate) mod input_key;
 pub(crate) mod list;
 pub(crate) mod prompt;
 pub(crate) mod question;
+pub(crate) mod review_comment;
 pub(crate) mod session_output_metric;
 pub(crate) mod session_view;
 pub(crate) mod sync_blocked;

--- a/crates/agentty/src/runtime/mode/help.rs
+++ b/crates/agentty/src/runtime/mode/help.rs
@@ -74,6 +74,7 @@ mod tests {
                 can_rebase_session_branch: true,
                 can_reply_to_session: true,
                 can_start_staged_session: false,
+                can_view_review_comments: false,
                 publish_pull_request_action: None,
                 session_id: "s1".into(),
                 session_state: ViewSessionState::Interactive,

--- a/crates/agentty/src/runtime/mode/review_comment.rs
+++ b/crates/agentty/src/runtime/mode/review_comment.rs
@@ -1,0 +1,351 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::layout::Rect;
+
+use crate::app::App;
+use crate::presentation::app_mode::AppMode;
+use crate::runtime::EventResult;
+use crate::ui::{RenderCacheStore, page};
+
+/// Handles selection, detail scrolling, and exit keys for the read-only
+/// session review-comment page.
+pub(crate) fn handle_with_cache(
+    app: &mut App,
+    render_cache_store: &RenderCacheStore,
+    content_area: Rect,
+    key: KeyEvent,
+) -> EventResult {
+    if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+        let mode = std::mem::replace(&mut app.mode, AppMode::List);
+        if let AppMode::ReviewComments { session_id, .. } = mode {
+            app.mode = AppMode::View {
+                session_id,
+                scroll_offset: None,
+            };
+        } else {
+            app.mode = mode;
+        }
+
+        return EventResult::Continue;
+    }
+
+    let mode = std::mem::replace(&mut app.mode, AppMode::List);
+    let AppMode::ReviewComments {
+        comment_error,
+        comment_snapshot,
+        diff,
+        is_loading_comments,
+        mut selected_comment_index,
+        session_id,
+        mut scroll_offset,
+    } = mode
+    else {
+        app.mode = mode;
+
+        return EventResult::Continue;
+    };
+    let item_count = page::review_comment::review_comment_item_count(comment_snapshot.as_ref());
+
+    match key.code {
+        KeyCode::Char('j') if key.modifiers == KeyModifiers::NONE => {
+            let next_index = next_selected_index(selected_comment_index, item_count);
+            if next_index != selected_comment_index {
+                selected_comment_index = next_index;
+                scroll_offset = 0;
+            }
+        }
+        KeyCode::Char('k') if key.modifiers == KeyModifiers::NONE => {
+            let previous_index = previous_selected_index(selected_comment_index, item_count);
+            if previous_index != selected_comment_index {
+                selected_comment_index = previous_index;
+                scroll_offset = 0;
+            }
+        }
+        KeyCode::Down => {
+            let max_scroll_offset = page::review_comment::review_comment_view_max_scroll_offset(
+                comment_snapshot.as_ref(),
+                comment_error.as_deref(),
+                is_loading_comments,
+                &diff,
+                selected_comment_index,
+                content_area,
+                render_cache_store.markdown_render_cache(),
+            );
+            scroll_offset = scroll_offset
+                .min(max_scroll_offset)
+                .saturating_add(1)
+                .min(max_scroll_offset);
+        }
+        KeyCode::Up => {
+            scroll_offset = scroll_offset.saturating_sub(1);
+        }
+        _ => {}
+    }
+
+    app.mode = AppMode::ReviewComments {
+        comment_error,
+        comment_snapshot,
+        diff,
+        is_loading_comments,
+        selected_comment_index,
+        session_id,
+        scroll_offset,
+    };
+
+    EventResult::Continue
+}
+
+/// Returns the next wrapped selection index.
+fn next_selected_index(selected_index: usize, item_count: usize) -> usize {
+    if item_count == 0 {
+        return selected_index;
+    }
+
+    (selected_index.min(item_count - 1) + 1) % item_count
+}
+
+/// Returns the previous wrapped selection index.
+fn previous_selected_index(selected_index: usize, item_count: usize) -> usize {
+    if item_count == 0 {
+        return selected_index;
+    }
+    let selected_index = selected_index.min(item_count - 1);
+    if selected_index == 0 {
+        return item_count - 1;
+    }
+
+    selected_index - 1
+}
+
+#[cfg(test)]
+mod tests {
+    use ag_forge::{
+        ReviewComment, ReviewCommentAnchorSide, ReviewCommentSnapshot, ReviewCommentThread,
+    };
+
+    use super::*;
+
+    fn comment_snapshot() -> ReviewCommentSnapshot {
+        ReviewCommentSnapshot {
+            pr_level_comments: vec![ReviewComment {
+                author: "alice".to_string(),
+                body: "General comment".to_string(),
+            }],
+            threads: vec![ReviewCommentThread {
+                anchor_side: ReviewCommentAnchorSide::New,
+                comments: vec![ReviewComment {
+                    author: "bob".to_string(),
+                    body: "Inline comment".to_string(),
+                }],
+                is_outdated: Some(false),
+                is_resolved: false,
+                line: Some(2),
+                path: "src/main.rs".to_string(),
+                start_line: None,
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_selects_next_comment_and_resets_detail_scroll() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.mode = AppMode::ReviewComments {
+            comment_error: None,
+            comment_snapshot: Some(comment_snapshot()),
+            diff: String::new(),
+            is_loading_comments: false,
+            selected_comment_index: 0,
+            session_id: "session-id".into(),
+            scroll_offset: 4,
+        };
+
+        // Act
+        handle_with_cache(
+            &mut app,
+            &RenderCacheStore::default(),
+            Rect::new(0, 0, 80, 24),
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+        );
+
+        // Assert
+        assert!(matches!(
+            app.mode,
+            AppMode::ReviewComments {
+                selected_comment_index: 1,
+                scroll_offset: 0,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_q_restores_session_view() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.mode = AppMode::ReviewComments {
+            comment_error: None,
+            comment_snapshot: None,
+            diff: String::new(),
+            is_loading_comments: true,
+            selected_comment_index: 0,
+            session_id: "session-id".into(),
+            scroll_offset: 0,
+        };
+
+        // Act
+        handle_with_cache(
+            &mut app,
+            &RenderCacheStore::default(),
+            Rect::new(0, 0, 80, 24),
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
+        );
+
+        // Assert
+        assert!(matches!(
+            app.mode,
+            AppMode::View {
+                ref session_id,
+                scroll_offset: None,
+            } if session_id == "session-id"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_selects_previous_comment_and_resets_detail_scroll() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.mode = AppMode::ReviewComments {
+            comment_error: None,
+            comment_snapshot: Some(comment_snapshot()),
+            diff: String::new(),
+            is_loading_comments: false,
+            selected_comment_index: 1,
+            session_id: "session-id".into(),
+            scroll_offset: 4,
+        };
+
+        // Act
+        handle_with_cache(
+            &mut app,
+            &RenderCacheStore::default(),
+            Rect::new(0, 0, 80, 24),
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+        );
+
+        // Assert
+        assert!(matches!(
+            app.mode,
+            AppMode::ReviewComments {
+                selected_comment_index: 0,
+                scroll_offset: 0,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_down_scrolls_within_rendered_detail() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.mode = AppMode::ReviewComments {
+            comment_error: None,
+            comment_snapshot: Some(comment_snapshot()),
+            diff: String::new(),
+            is_loading_comments: false,
+            selected_comment_index: 0,
+            session_id: "session-id".into(),
+            scroll_offset: 0,
+        };
+
+        // Act
+        handle_with_cache(
+            &mut app,
+            &RenderCacheStore::default(),
+            Rect::new(0, 0, 80, 8),
+            KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+        );
+
+        // Assert
+        assert!(matches!(
+            app.mode,
+            AppMode::ReviewComments {
+                scroll_offset: 1,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_up_decrements_scroll_and_other_keys_preserve_mode() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.mode = AppMode::ReviewComments {
+            comment_error: None,
+            comment_snapshot: Some(comment_snapshot()),
+            diff: String::new(),
+            is_loading_comments: false,
+            selected_comment_index: 0,
+            session_id: "session-id".into(),
+            scroll_offset: 2,
+        };
+
+        // Act
+        handle_with_cache(
+            &mut app,
+            &RenderCacheStore::default(),
+            Rect::new(0, 0, 80, 24),
+            KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        );
+        handle_with_cache(
+            &mut app,
+            &RenderCacheStore::default(),
+            Rect::new(0, 0, 80, 24),
+            KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+        );
+
+        // Assert
+        assert!(matches!(
+            app.mode,
+            AppMode::ReviewComments {
+                scroll_offset: 1,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_preserves_non_review_comment_modes() {
+        // Arrange
+        let mut exit_app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let mut other_app = crate::test_support::new_test_app_without_retained_base_dir().await;
+
+        // Act
+        handle_with_cache(
+            &mut exit_app,
+            &RenderCacheStore::default(),
+            Rect::new(0, 0, 80, 24),
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+        );
+        handle_with_cache(
+            &mut other_app,
+            &RenderCacheStore::default(),
+            Rect::new(0, 0, 80, 24),
+            KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+        );
+
+        // Assert
+        assert!(matches!(exit_app.mode, AppMode::List));
+        assert!(matches!(other_app.mode, AppMode::List));
+    }
+
+    #[test]
+    fn test_selection_helpers_wrap_clamp_and_preserve_empty_selection() {
+        // Arrange, Act, Assert
+        assert_eq!(next_selected_index(0, 0), 0);
+        assert_eq!(next_selected_index(1, 2), 0);
+        assert_eq!(next_selected_index(usize::MAX, 2), 0);
+        assert_eq!(previous_selected_index(0, 0), 0);
+        assert_eq!(previous_selected_index(0, 2), 1);
+        assert_eq!(previous_selected_index(usize::MAX, 2), 0);
+    }
+}

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -89,6 +89,7 @@ struct ViewSessionSnapshot {
     publish_pull_request_action: Option<PublishBranchAction>,
     rebase_session_branch: ViewActionState,
     reply_to_session: ViewActionState,
+    review_comments: ViewActionState,
     session_state: ViewSessionState,
     session_status: Status,
     start_staged_session: ViewActionState,
@@ -145,6 +146,12 @@ impl ViewSessionSnapshot {
     /// Returns whether this session can accept a reply under stack rules.
     fn can_reply_to_session(&self) -> bool {
         self.reply_to_session.is_enabled()
+    }
+
+    /// Returns whether the session has a linked forge review request whose
+    /// comments can be opened read-only.
+    fn can_open_review_comments(&self) -> bool {
+        self.review_comments.is_enabled()
     }
 
     /// Returns whether this staged draft can start its first live turn.
@@ -333,8 +340,14 @@ async fn handle_primary_view_key(
         }
         KeyCode::Char('c')
             if key.modifiers == event::KeyModifiers::NONE
-                && view_session_snapshot.can_continue_terminal_session() =>
+                && view_session_snapshot.can_open_review_comments() =>
         {
+            let diff = load_view_session_diff(app, view_context).await;
+            app.open_session_review_comments(&view_context.session_id, diff);
+
+            return Some(false);
+        }
+        KeyCode::Char('c' | 'C') if is_continue_terminal_shortcut(key, view_session_snapshot) => {
             open_continue_confirmation(app, view_context);
 
             return Some(false);
@@ -374,6 +387,22 @@ async fn handle_primary_view_key(
     }
 
     Some(true)
+}
+
+fn is_continue_terminal_shortcut(
+    key: KeyEvent,
+    view_session_snapshot: &ViewSessionSnapshot,
+) -> bool {
+    let has_supported_modifiers = matches!(
+        key.modifiers,
+        event::KeyModifiers::NONE | event::KeyModifiers::SHIFT
+    );
+    let has_unambiguous_key =
+        key.code == KeyCode::Char('C') || !view_session_snapshot.can_open_review_comments();
+
+    has_supported_modifiers
+        && view_session_snapshot.can_continue_terminal_session()
+        && has_unambiguous_key
 }
 
 /// Handles workflow actions in session view such as diff, publish, review,
@@ -593,6 +622,7 @@ fn view_session_snapshot(app: &App, view_context: &ViewContext) -> Option<ViewSe
             app.sessions
                 .can_reply_to_session_in_stack(view_context.session_id.as_str()),
         ),
+        review_comments: ViewActionState::from_bool(session.review_request.is_some()),
         session_state: help_action::session_view_state(session),
         session_status,
         start_staged_session: ViewActionState::from_bool(
@@ -917,6 +947,7 @@ fn open_view_help_overlay(
             can_rebase_session_branch: view_session_snapshot.can_rebase_session_branch(),
             can_reply_to_session: view_session_snapshot.can_reply_to_session(),
             can_start_staged_session: view_session_snapshot.can_start_staged_session(),
+            can_view_review_comments: view_session_snapshot.can_open_review_comments(),
             publish_pull_request_action: view_session_snapshot.publish_pull_request_action,
             session_id: view_context.session_id.clone(),
             session_state: view_session_snapshot.session_state,
@@ -1171,6 +1202,9 @@ mod tests {
     use super::*;
     use crate::app::review_loading_message;
     use crate::domain::agent::AgentModel;
+    use crate::domain::session::{
+        ForgeKind, ReviewRequest, ReviewRequestState, ReviewRequestSummary,
+    };
     use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
     use crate::infra::tmux::{MockTmuxClient, TmuxClient};
     use crate::runtime::mode::session_output_metric;
@@ -2287,6 +2321,7 @@ mod tests {
             rebase_session_branch: ViewActionState::Enabled,
             open_worktree: ViewActionState::Enabled,
             reply_to_session: ViewActionState::Enabled,
+            review_comments: ViewActionState::Disabled,
             start_staged_session: ViewActionState::Disabled,
             follow_up_task_action: None,
             publish_pull_request_action: Some(PublishBranchAction::PublishPullRequest),
@@ -2658,6 +2693,7 @@ mod tests {
             rebase_session_branch: ViewActionState::Enabled,
             open_worktree: ViewActionState::Disabled,
             reply_to_session: ViewActionState::Enabled,
+            review_comments: ViewActionState::Disabled,
             start_staged_session: ViewActionState::Disabled,
             follow_up_task_action: None,
             publish_pull_request_action: None,
@@ -2714,6 +2750,7 @@ mod tests {
             rebase_session_branch: ViewActionState::Enabled,
             open_worktree: ViewActionState::Enabled,
             reply_to_session: ViewActionState::Enabled,
+            review_comments: ViewActionState::Disabled,
             start_staged_session: ViewActionState::Disabled,
             follow_up_task_action: None,
             publish_pull_request_action: None,
@@ -2850,6 +2887,100 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_linked_terminal_session_routes_c_to_comments_and_shift_c_to_continue() {
+        // Arrange
+        let (mut app, _base_dir, session_id) = new_test_app_with_session().await;
+        let session = app
+            .sessions
+            .sessions_mut()
+            .iter_mut()
+            .find(|session| session.id == session_id)
+            .expect("session should exist");
+        session.review_request = Some(ReviewRequest {
+            last_refreshed_at: 0,
+            summary: ReviewRequestSummary {
+                display_id: "#42".to_string(),
+                forge_kind: ForgeKind::GitHub,
+                source_branch: "wt/linked-terminal".to_string(),
+                state: ReviewRequestState::Open,
+                status_summary: None,
+                target_branch: "main".to_string(),
+                title: "Linked terminal session".to_string(),
+                web_url: "https://github.com/agentty-xyz/agentty/pull/42".to_string(),
+            },
+        });
+        app.mode = AppMode::View {
+            session_id: session_id.into(),
+            scroll_offset: Some(0),
+        };
+        let view_context = view_context(&mut app).expect("expected view context");
+        let pending_update = ViewPendingUpdate::from_context(&view_context);
+        let view_session_snapshot = ViewSessionSnapshot {
+            continue_terminal_session: ViewActionState::Enabled,
+            fork_session: ViewActionState::Disabled,
+            follow_up_task_action: None,
+            merge_session_branch: ViewActionState::Disabled,
+            mutate_session_branch: ViewActionState::Disabled,
+            open_worktree: ViewActionState::Disabled,
+            publish_pull_request_action: None,
+            rebase_session_branch: ViewActionState::Disabled,
+            reply_to_session: ViewActionState::Disabled,
+            review_comments: ViewActionState::Enabled,
+            session_state: ViewSessionState::Done,
+            session_status: Status::Done,
+            start_staged_session: ViewActionState::Disabled,
+        };
+
+        // Act
+        let lowercase_continues = is_continue_terminal_shortcut(
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE),
+            &view_session_snapshot,
+        );
+        let uppercase_continues = is_continue_terminal_shortcut(
+            KeyEvent::new(KeyCode::Char('C'), KeyModifiers::SHIFT),
+            &view_session_snapshot,
+        );
+
+        // Assert
+        assert!(!lowercase_continues);
+        assert!(uppercase_continues);
+
+        // Act
+        let comments_result = handle_primary_view_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE),
+            &view_context,
+            &view_session_snapshot,
+            &pending_update,
+        )
+        .await;
+
+        // Assert
+        assert_eq!(comments_result, Some(false));
+        assert!(matches!(app.mode, AppMode::ReviewComments { .. }));
+
+        // Act
+        let continue_result = handle_primary_view_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('C'), KeyModifiers::SHIFT),
+            &view_context,
+            &view_session_snapshot,
+            &pending_update,
+        )
+        .await;
+
+        // Assert
+        assert_eq!(continue_result, Some(false));
+        assert!(matches!(
+            app.mode,
+            AppMode::Confirmation {
+                confirmation_intent: ConfirmationIntent::ContinueSession,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
     async fn test_handle_continue_key_does_not_open_confirmation_for_canceled_session() {
         // Arrange
         let (mut app, _base_dir, source_session_id) = new_test_app_with_session().await;
@@ -2904,6 +3035,7 @@ mod tests {
             rebase_session_branch: ViewActionState::Enabled,
             open_worktree: ViewActionState::Enabled,
             reply_to_session: ViewActionState::Enabled,
+            review_comments: ViewActionState::Disabled,
             start_staged_session: ViewActionState::Disabled,
             follow_up_task_action: None,
             publish_pull_request_action: None,
@@ -2961,6 +3093,7 @@ mod tests {
             rebase_session_branch: ViewActionState::Enabled,
             open_worktree: ViewActionState::Enabled,
             reply_to_session: ViewActionState::Enabled,
+            review_comments: ViewActionState::Disabled,
             start_staged_session: ViewActionState::Disabled,
             follow_up_task_action: None,
             publish_pull_request_action: Some(PublishBranchAction::PublishPullRequest),
@@ -3015,6 +3148,7 @@ mod tests {
             rebase_session_branch: ViewActionState::Enabled,
             open_worktree: ViewActionState::Enabled,
             reply_to_session: ViewActionState::Enabled,
+            review_comments: ViewActionState::Disabled,
             start_staged_session: ViewActionState::Disabled,
             follow_up_task_action: None,
             publish_pull_request_action: Some(PublishBranchAction::PublishPullRequest),
@@ -3087,6 +3221,7 @@ mod tests {
                 rebase_session_branch: ViewActionState::Enabled,
                 open_worktree: ViewActionState::Disabled,
                 reply_to_session: ViewActionState::Enabled,
+                review_comments: ViewActionState::Disabled,
                 start_staged_session: ViewActionState::Disabled,
                 follow_up_task_action: None,
                 publish_pull_request_action: None,

--- a/crates/agentty/src/ui/diff_util.rs
+++ b/crates/agentty/src/ui/diff_util.rs
@@ -1,5 +1,8 @@
 use ag_protocol::AgentResponseSummary;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::Style;
+
+use crate::ui::style;
 
 const BORDER_HORIZONTAL_WIDTH: u16 = 2;
 const DIFF_GIT_FILE_HEADER_PREFIX: &str = "diff --git";
@@ -163,6 +166,16 @@ pub fn max_diff_line_number(lines: &[DiffLine<'_>]) -> u32 {
         .unwrap_or(0)
 }
 
+/// Returns the shared display width for each old/new line-number column.
+pub fn diff_line_gutter_width(lines: &[DiffLine<'_>]) -> usize {
+    let max_line_number = max_diff_line_number(lines);
+    if max_line_number == 0 {
+        return MIN_GUTTER_WIDTH;
+    }
+
+    max_line_number.ilog10() as usize + MIN_GUTTER_WIDTH
+}
+
 /// Counts total added and removed lines across parsed diff content.
 pub fn diff_line_change_totals(lines: &[DiffLine<'_>]) -> (usize, usize) {
     lines.iter().fold(
@@ -173,6 +186,46 @@ pub fn diff_line_change_totals(lines: &[DiffLine<'_>]) -> (usize, usize) {
             _ => (added_count, removed_count),
         },
     )
+}
+
+/// Returns the sign and semantic content style shared by diff body rows.
+pub fn body_diff_line_style(kind: DiffLineKind) -> (&'static str, Style) {
+    match kind {
+        DiffLineKind::Addition => (
+            "+",
+            Style::default()
+                .fg(style::palette::success())
+                .bg(style::palette::surface_success()),
+        ),
+        DiffLineKind::Deletion => (
+            "-",
+            Style::default()
+                .fg(style::palette::danger())
+                .bg(style::palette::surface_danger()),
+        ),
+        DiffLineKind::Context | DiffLineKind::FileHeader | DiffLineKind::HunkHeader => {
+            (" ", Style::default().fg(style::palette::text_muted()))
+        }
+    }
+}
+
+/// Returns the subtle style shared by old/new line-number gutters.
+pub fn body_diff_line_gutter_style() -> Style {
+    Style::default().fg(style::palette::text_subtle())
+}
+
+/// Builds the old/new line-number gutter shared by diff body rows.
+pub fn body_diff_line_gutter(diff_line: &DiffLine<'_>, gutter_width: usize) -> String {
+    let old_line = diff_line.old_line.map_or_else(
+        || " ".repeat(gutter_width),
+        |line_number| format!("{line_number:>gutter_width$}"),
+    );
+    let new_line = diff_line.new_line.map_or_else(
+        || " ".repeat(gutter_width),
+        |line_number| format!("{line_number:>gutter_width$}"),
+    );
+
+    format!("{old_line}│{new_line} ")
 }
 
 /// Split a diff content string into chunks that fit within `max_width`
@@ -232,12 +285,7 @@ pub fn diff_render_layout(
     diff_area: Rect,
     reserve_scrollbar_width: bool,
 ) -> DiffRenderLayout {
-    let max_num = max_diff_line_number(parsed_lines);
-    let gutter_width = if max_num == 0 {
-        MIN_GUTTER_WIDTH
-    } else {
-        max_num.ilog10() as usize + MIN_GUTTER_WIDTH
-    };
+    let gutter_width = diff_line_gutter_width(parsed_lines);
     let prefix_width =
         gutter_width * LINE_NUMBER_COLUMN_COUNT + GUTTER_EXTRA_WIDTH + SIGN_COLUMN_WIDTH;
     let scrollbar_width = usize::from(reserve_scrollbar_width) * SCROLLBAR_WIDTH;
@@ -1055,6 +1103,18 @@ index abc..def 100644
 
         // Assert
         assert_eq!(max_num, 0);
+    }
+
+    #[test]
+    fn test_diff_line_gutter_width_matches_largest_line_number() {
+        // Arrange
+        let lines = parse_diff_lines("@@ -95,1 +100,1 @@\n context");
+
+        // Act
+        let gutter_width = diff_line_gutter_width(&lines);
+
+        // Assert
+        assert_eq!(gutter_width, 3);
     }
 
     #[test]

--- a/crates/agentty/src/ui/layout.rs
+++ b/crates/agentty/src/ui/layout.rs
@@ -377,19 +377,22 @@ mod tests {
     }
 
     fn view_footer_text(session: &Session, can_open_worktree: bool) -> String {
-        session_view_footer_line(ViewHelpState {
-            can_fork_session: ViewActionAvailability::from_bool(session.allows_fork_action()),
-            can_merge_session_branch: ViewActionAvailability::Enabled,
-            can_mutate_session_branch: ViewActionAvailability::Enabled,
-            can_open_worktree: ViewActionAvailability::from_bool(can_open_worktree),
-            can_rebase_session_branch: ViewActionAvailability::Enabled,
-            reply_to_session: ViewActionAvailability::Enabled,
-            can_start_staged_session: ViewActionAvailability::from_bool(
-                session.can_start_staged_session(),
-            ),
-            publish_pull_request_action: session.publish_pull_request_action(),
-            session_state: help_action::session_view_state(session),
-        })
+        session_view_footer_line_with_review_comments(
+            ViewHelpState {
+                can_fork_session: ViewActionAvailability::from_bool(session.allows_fork_action()),
+                can_merge_session_branch: ViewActionAvailability::Enabled,
+                can_mutate_session_branch: ViewActionAvailability::Enabled,
+                can_open_worktree: ViewActionAvailability::from_bool(can_open_worktree),
+                can_rebase_session_branch: ViewActionAvailability::Enabled,
+                reply_to_session: ViewActionAvailability::Enabled,
+                can_start_staged_session: ViewActionAvailability::from_bool(
+                    session.can_start_staged_session(),
+                ),
+                publish_pull_request_action: session.publish_pull_request_action(),
+                session_state: help_action::session_view_state(session),
+            },
+            false,
+        )
         .to_string()
     }
 

--- a/crates/agentty/src/ui/overlay.rs
+++ b/crates/agentty/src/ui/overlay.rs
@@ -752,6 +752,7 @@ mod tests {
             can_rebase_session_branch: true,
             can_reply_to_session: true,
             can_start_staged_session: false,
+            can_view_review_comments: false,
             publish_pull_request_action: None,
             session_id: "missing-session".into(),
             session_state: crate::presentation::help_action::ViewSessionState::Done,

--- a/crates/agentty/src/ui/page.rs
+++ b/crates/agentty/src/ui/page.rs
@@ -6,6 +6,7 @@ pub mod inbox;
 pub mod issue_detail;
 pub mod issue_list;
 pub mod project_list;
+pub mod review_comment;
 pub mod review_detail;
 pub mod session_chat;
 pub mod session_list;

--- a/crates/agentty/src/ui/page/diff.rs
+++ b/crates/agentty/src/ui/page/diff.rs
@@ -631,27 +631,13 @@ impl<'a> DiffPage<'a> {
             .collect()
     }
 
-    /// Returns the style used for added diff lines.
-    fn addition_line_style() -> Style {
-        Style::default()
-            .fg(style::palette::success())
-            .bg(style::palette::surface_success())
-    }
-
-    /// Returns the style used for removed diff lines.
-    fn deletion_line_style() -> Style {
-        Style::default()
-            .fg(style::palette::danger())
-            .bg(style::palette::surface_danger())
-    }
-
     /// Builds wrapped diff lines for the diff panel, optionally reserving one
     /// column for the scrollbar thumb.
     fn build_diff_lines(
         parsed: &[DiffLine<'_>],
         layout: diff_util::DiffRenderLayout,
     ) -> Vec<Line<'static>> {
-        let gutter_style = Style::default().fg(style::palette::text_subtle());
+        let gutter_style = diff_util::body_diff_line_gutter_style();
         let mut lines: Vec<Line<'static>> = Vec::with_capacity(parsed.len());
 
         for diff_line in parsed {
@@ -707,8 +693,8 @@ impl<'a> DiffPage<'a> {
         layout: diff_util::DiffRenderLayout,
         gutter_style: Style,
     ) {
-        let (sign, content_style) = Self::body_diff_line_style(diff_line.kind);
-        let gutter_text = Self::body_diff_line_gutter(diff_line, layout.gutter_width);
+        let (sign, content_style) = diff_util::body_diff_line_style(diff_line.kind);
+        let gutter_text = diff_util::body_diff_line_gutter(diff_line, layout.gutter_width);
         let content_available = layout.content_width.saturating_sub(layout.prefix_width);
         let chunks = diff_util::wrap_diff_content(diff_line.content, content_available);
 
@@ -726,32 +712,6 @@ impl<'a> DiffPage<'a> {
                 ]));
             }
         }
-    }
-
-    /// Returns the sign and style for one body diff line.
-    fn body_diff_line_style(kind: DiffLineKind) -> (&'static str, Style) {
-        match kind {
-            DiffLineKind::Addition => ("+", Self::addition_line_style()),
-            DiffLineKind::Deletion => ("-", Self::deletion_line_style()),
-            DiffLineKind::Context => (" ", Style::default().fg(style::palette::text_muted())),
-            DiffLineKind::FileHeader | DiffLineKind::HunkHeader => {
-                (" ", Style::default().fg(style::palette::text_muted()))
-            }
-        }
-    }
-
-    /// Builds the old/new line-number gutter for one body diff line.
-    fn body_diff_line_gutter(diff_line: &DiffLine<'_>, gutter_width: usize) -> String {
-        let old_str = match diff_line.old_line {
-            Some(num) => format!("{num:>gutter_width$}"),
-            None => " ".repeat(gutter_width),
-        };
-        let new_str = match diff_line.new_line {
-            Some(num) => format!("{num:>gutter_width$}"),
-            None => " ".repeat(gutter_width),
-        };
-
-        format!("{old_str}│{new_str} ")
     }
 }
 

--- a/crates/agentty/src/ui/page/review_comment.rs
+++ b/crates/agentty/src/ui/page/review_comment.rs
@@ -1,0 +1,994 @@
+use std::slice;
+
+use ag_forge::{
+    ReviewComment, ReviewCommentAnchorSide, ReviewCommentSnapshot, ReviewCommentThread,
+};
+use ag_tui_text::text_util;
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+
+use crate::domain::session::Session;
+use crate::presentation::help_action;
+use crate::ui::component::vertical_scrollbar::VerticalScrollbar;
+use crate::ui::diff_util::{DiffLine, DiffLineKind};
+use crate::ui::{Component, Page, diff_util, help_format, markdown, review_comment_format, style};
+
+const CODE_CONTEXT_RADIUS: usize = 3;
+
+/// Read-only split page for a session's linked review-request comments.
+pub struct ReviewCommentPage<'a> {
+    comment_error: Option<&'a str>,
+    comment_snapshot: Option<&'a ReviewCommentSnapshot>,
+    diff: &'a str,
+    is_loading_comments: bool,
+    markdown_render_cache: &'a markdown::MarkdownRenderCache,
+    scroll_offset: u16,
+    selected_comment_index: usize,
+    session: &'a Session,
+}
+
+/// Borrowed inputs needed to construct one review-comment page renderer.
+#[derive(Clone, Copy)]
+pub struct ReviewCommentPageInput<'a> {
+    /// User-facing failure returned by the forge comment load.
+    pub comment_error: Option<&'a str>,
+    /// Loaded general comments and inline review threads.
+    pub comment_snapshot: Option<&'a ReviewCommentSnapshot>,
+    /// Raw current session diff used to derive inline code context.
+    pub diff: &'a str,
+    /// Whether the forge comment request is still running.
+    pub is_loading_comments: bool,
+    /// Shared cache used for styled Markdown comment bodies.
+    pub markdown_render_cache: &'a markdown::MarkdownRenderCache,
+    /// Vertical offset inside the selected comment detail panel.
+    pub scroll_offset: u16,
+    /// Selected general comment or inline thread index.
+    pub selected_comment_index: usize,
+    /// Session whose linked review request owns the comments.
+    pub session: &'a Session,
+}
+
+impl<'a> ReviewCommentPage<'a> {
+    /// Creates a review-comment page for one session frame.
+    pub fn new(input: ReviewCommentPageInput<'a>) -> Self {
+        let ReviewCommentPageInput {
+            comment_error,
+            comment_snapshot,
+            diff,
+            is_loading_comments,
+            markdown_render_cache,
+            scroll_offset,
+            selected_comment_index,
+            session,
+        } = input;
+
+        Self {
+            comment_error,
+            comment_snapshot,
+            diff,
+            is_loading_comments,
+            markdown_render_cache,
+            scroll_offset,
+            selected_comment_index,
+            session,
+        }
+    }
+
+    /// Renders the left comment selector for loaded, loading, empty, and error
+    /// states.
+    fn render_comment_list(&self, frame: &mut Frame, area: Rect) {
+        let entries = self
+            .comment_snapshot
+            .map(comment_entries)
+            .unwrap_or_default();
+        let title = format!(" Comments ({}) ", entries.len());
+        let items = if entries.is_empty() {
+            vec![ListItem::new(comment_list_fallback(
+                self.comment_error,
+                self.is_loading_comments,
+            ))]
+        } else {
+            entries
+                .iter()
+                .map(|entry| ListItem::new(entry.label()))
+                .collect()
+        };
+        let list = List::new(items)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(title)
+                    .border_style(style::border_style()),
+            )
+            .highlight_style(
+                Style::default()
+                    .fg(style::palette::text())
+                    .bg(style::palette::surface_selection())
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol("▶ ");
+        let mut state = ListState::default();
+        if !entries.is_empty() {
+            state.select(Some(normalized_selection(
+                self.selected_comment_index,
+                entries.len(),
+            )));
+        }
+
+        frame.render_stateful_widget(list, area, &mut state);
+    }
+
+    /// Renders metadata, conversation text, and attached code context for the
+    /// selected comment entry.
+    fn render_comment_detail(&self, frame: &mut Frame, area: Rect) {
+        let content_width = usize::from(area.width.saturating_sub(2).max(1));
+        let lines = comment_detail_lines(
+            self.comment_snapshot,
+            self.comment_error,
+            self.is_loading_comments,
+            self.diff,
+            self.selected_comment_index,
+            self.markdown_render_cache,
+            content_width,
+        );
+        let viewport_height = area.height.saturating_sub(2);
+        let line_count = lines.len();
+        let max_scroll_offset = max_scroll_offset(line_count, viewport_height);
+        let scroll_offset = self.scroll_offset.min(max_scroll_offset);
+        let paragraph = Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(format!(" Comment — {} ", self.session.display_title()))
+                    .border_style(style::border_style()),
+            )
+            .scroll((scroll_offset, 0));
+
+        frame.render_widget(paragraph, area);
+
+        if max_scroll_offset > 0 {
+            let scrollbar_area = diff_util::diff_scrollbar_area(area, viewport_height);
+            VerticalScrollbar::new(scroll_offset, line_count).render(frame, scrollbar_area);
+        }
+    }
+}
+
+impl Page for ReviewCommentPage<'_> {
+    fn render(&mut self, frame: &mut Frame, area: Rect) {
+        let areas = diff_util::diff_page_areas(area);
+
+        self.render_comment_list(frame, areas.file_list_area);
+        self.render_comment_detail(frame, areas.diff_area);
+
+        let footer = Paragraph::new(help_format::footer_line(
+            &help_action::review_comment_footer_actions(),
+        ));
+        frame.render_widget(footer, areas.footer_area);
+    }
+}
+
+/// Returns the largest valid vertical offset for the selected comment detail.
+pub(crate) fn review_comment_view_max_scroll_offset(
+    comment_snapshot: Option<&ReviewCommentSnapshot>,
+    comment_error: Option<&str>,
+    is_loading_comments: bool,
+    diff: &str,
+    selected_comment_index: usize,
+    area: Rect,
+    markdown_render_cache: &markdown::MarkdownRenderCache,
+) -> u16 {
+    let detail_area = diff_util::diff_page_areas(area).diff_area;
+    let viewport_height = detail_area.height.saturating_sub(2);
+    let content_width = usize::from(detail_area.width.saturating_sub(2).max(1));
+    let line_count = comment_detail_lines(
+        comment_snapshot,
+        comment_error,
+        is_loading_comments,
+        diff,
+        selected_comment_index,
+        markdown_render_cache,
+        content_width,
+    )
+    .len();
+
+    max_scroll_offset(line_count, viewport_height)
+}
+
+/// Returns the number of selectable general comments and inline threads.
+pub(crate) fn review_comment_item_count(snapshot: Option<&ReviewCommentSnapshot>) -> usize {
+    snapshot.map_or(0, |snapshot| {
+        snapshot
+            .pr_level_comments
+            .len()
+            .saturating_add(snapshot.threads.len())
+    })
+}
+
+/// One selectable left-panel row and its right-panel detail source.
+enum CommentEntry<'a> {
+    General(&'a ReviewComment),
+    Thread(&'a ReviewCommentThread),
+}
+
+impl CommentEntry<'_> {
+    /// Builds the compact label shown in the left selector.
+    fn label(&self) -> Line<'static> {
+        match self {
+            Self::General(comment) => Line::from(vec![
+                Span::styled("General", Style::default().fg(style::palette::accent())),
+                Span::styled(
+                    format!(" · {}", comment.author),
+                    Style::default().fg(style::palette::text_muted()),
+                ),
+            ]),
+            Self::Thread(thread) => {
+                let anchor = review_comment_format::thread_anchor(thread);
+                let author = thread
+                    .comments
+                    .first()
+                    .map_or("unknown", |comment| comment.author.as_str());
+
+                Line::from(vec![
+                    Span::styled(anchor, Style::default().fg(style::palette::accent())),
+                    Span::styled(
+                        format!(" · {author}"),
+                        Style::default().fg(style::palette::text_muted()),
+                    ),
+                ])
+            }
+        }
+    }
+}
+
+/// Flattens general comments and inline threads into selector order.
+fn comment_entries(snapshot: &ReviewCommentSnapshot) -> Vec<CommentEntry<'_>> {
+    snapshot
+        .pr_level_comments
+        .iter()
+        .map(CommentEntry::General)
+        .chain(snapshot.threads.iter().map(CommentEntry::Thread))
+        .collect()
+}
+
+/// Builds all visible rows for one selected comment detail.
+fn comment_detail_lines(
+    snapshot: Option<&ReviewCommentSnapshot>,
+    comment_error: Option<&str>,
+    is_loading_comments: bool,
+    diff: &str,
+    selected_comment_index: usize,
+    markdown_render_cache: &markdown::MarkdownRenderCache,
+    width: usize,
+) -> Vec<Line<'static>> {
+    let Some(snapshot) = snapshot else {
+        return vec![Line::from(comment_detail_fallback(
+            comment_error,
+            is_loading_comments,
+        ))];
+    };
+    let entries = comment_entries(snapshot);
+    let Some(entry) = entries.get(normalized_selection(selected_comment_index, entries.len()))
+    else {
+        return vec![Line::from("No review comments.")];
+    };
+
+    match entry {
+        CommentEntry::General(comment) => {
+            general_comment_detail_lines(comment, markdown_render_cache, width)
+        }
+        CommentEntry::Thread(thread) => {
+            thread_comment_detail_lines(thread, diff, markdown_render_cache, width)
+        }
+    }
+}
+
+/// Builds metadata and body rows for one review-request-wide comment.
+fn general_comment_detail_lines(
+    comment: &ReviewComment,
+    markdown_render_cache: &markdown::MarkdownRenderCache,
+    width: usize,
+) -> Vec<Line<'static>> {
+    let mut lines = vec![
+        field_line("Scope", "General discussion"),
+        field_line("Author", &comment.author),
+        Line::default(),
+        section_line("Comment"),
+    ];
+    review_comment_format::append_comment_bodies(
+        &mut lines,
+        slice::from_ref(comment),
+        markdown_render_cache,
+        width,
+    );
+    lines.extend([
+        Line::default(),
+        section_line("Code context"),
+        muted_line("This comment is not attached to a code line."),
+    ]);
+
+    lines
+}
+
+/// Builds metadata, current diff context, and thread conversation rows for an
+/// inline review thread.
+fn thread_comment_detail_lines(
+    thread: &ReviewCommentThread,
+    diff: &str,
+    markdown_render_cache: &markdown::MarkdownRenderCache,
+    width: usize,
+) -> Vec<Line<'static>> {
+    let mut lines = vec![
+        review_comment_format::thread_header_line(
+            thread,
+            Style::default()
+                .fg(style::palette::accent())
+                .add_modifier(Modifier::BOLD),
+        ),
+        Line::default(),
+        section_line("Code context"),
+    ];
+    lines.extend(code_context_lines(thread, diff, width));
+    lines.extend([Line::default(), section_line("Conversation")]);
+    review_comment_format::append_comment_bodies(
+        &mut lines,
+        &thread.comments,
+        markdown_render_cache,
+        width,
+    );
+
+    lines
+}
+
+/// Extracts nearby current-diff rows for the thread's file and anchor range.
+fn code_context_lines(
+    thread: &ReviewCommentThread,
+    diff: &str,
+    width: usize,
+) -> Vec<Line<'static>> {
+    if thread.anchor_side == ReviewCommentAnchorSide::File {
+        return vec![muted_line(
+            "This file-level comment is not attached to a code line.",
+        )];
+    }
+
+    let parsed_lines = diff_util::parse_diff_lines(diff);
+    let file_lines = diff_file_lines(&parsed_lines, &thread.path);
+    if file_lines.is_empty() {
+        return vec![muted_line(
+            "No current diff context is available for this file.",
+        )];
+    }
+
+    let Some(anchor_line_range) = review_comment_format::thread_anchor_line_range(thread) else {
+        return vec![muted_line("This comment has no attached line anchor.")];
+    };
+    let target_indexes = file_lines
+        .iter()
+        .position(|line| diff_line_matches_anchor(line, thread.anchor_side, anchor_line_range))
+        .zip(file_lines.iter().rposition(|line| {
+            diff_line_matches_anchor(line, thread.anchor_side, anchor_line_range)
+        }));
+    let Some((target_start_index, target_end_index)) = target_indexes else {
+        return vec![muted_line(
+            "The attached line or range is outside the current diff context.",
+        )];
+    };
+    let start_index = target_start_index.saturating_sub(CODE_CONTEXT_RADIUS);
+    let end_index = target_end_index
+        .saturating_add(CODE_CONTEXT_RADIUS + 1)
+        .min(file_lines.len());
+    let gutter_width = diff_util::diff_line_gutter_width(&file_lines);
+
+    file_lines[start_index..end_index]
+        .iter()
+        .map(|line| {
+            let is_anchor = diff_line_matches_anchor(line, thread.anchor_side, anchor_line_range);
+
+            code_context_line(line, is_anchor, gutter_width, width)
+        })
+        .collect()
+}
+
+/// Returns diff body lines belonging to `path`, excluding diff metadata.
+fn diff_file_lines<'a>(parsed_lines: &'a [DiffLine<'a>], path: &str) -> Vec<DiffLine<'a>> {
+    let mut is_selected_file = false;
+    let mut lines = Vec::new();
+
+    for line in parsed_lines {
+        if line.kind == DiffLineKind::FileHeader && line.content.starts_with("diff --git") {
+            is_selected_file = diff_util::diff_header_paths(line.content)
+                .is_some_and(|(old_path, new_path)| old_path == path || new_path == path);
+
+            continue;
+        }
+        if is_selected_file
+            && matches!(
+                line.kind,
+                DiffLineKind::Addition | DiffLineKind::Deletion | DiffLineKind::Context
+            )
+        {
+            lines.push(*line);
+        }
+    }
+
+    lines
+}
+
+/// Returns whether one diff row belongs to an inclusive thread anchor range.
+fn diff_line_matches_anchor(
+    line: &DiffLine<'_>,
+    anchor_side: ReviewCommentAnchorSide,
+    anchor_line_range: (u32, u32),
+) -> bool {
+    let line_number = match anchor_side {
+        ReviewCommentAnchorSide::File => return false,
+        ReviewCommentAnchorSide::New => line.new_line,
+        ReviewCommentAnchorSide::Old => line.old_line,
+    };
+    let (start_line, end_line) = anchor_line_range;
+
+    line_number.is_some_and(|line_number| (start_line..=end_line).contains(&line_number))
+}
+
+/// Formats one code-context row with old/new gutters and anchor emphasis.
+fn code_context_line(
+    line: &DiffLine<'_>,
+    is_anchor: bool,
+    gutter_width: usize,
+    width: usize,
+) -> Line<'static> {
+    let (sign, content_style) = diff_util::body_diff_line_style(line.kind);
+    let gutter_style = diff_util::body_diff_line_gutter_style();
+    let (gutter_style, content_style) = if is_anchor {
+        (
+            gutter_style
+                .bg(style::palette::surface_selection())
+                .add_modifier(Modifier::BOLD),
+            content_style
+                .bg(style::palette::surface_selection())
+                .add_modifier(Modifier::BOLD),
+        )
+    } else {
+        (gutter_style, content_style)
+    };
+    let gutter = diff_util::body_diff_line_gutter(line, gutter_width);
+    let spans = vec![
+        Span::styled(gutter, gutter_style),
+        Span::styled(sign, content_style),
+        Span::styled(line.content.to_string(), content_style),
+    ];
+
+    Line::from(text_util::truncate_spans_with_ellipsis(spans, width))
+}
+
+/// Returns the left-panel status label when no selectable entries exist.
+fn comment_list_fallback(comment_error: Option<&str>, is_loading_comments: bool) -> &'static str {
+    if comment_error.is_some() {
+        return "Load failed";
+    }
+    if is_loading_comments {
+        return "Loading...";
+    }
+
+    "No comments"
+}
+
+/// Returns the right-panel status text before comments are available.
+fn comment_detail_fallback(comment_error: Option<&str>, is_loading_comments: bool) -> String {
+    if let Some(comment_error) = comment_error {
+        return comment_error.to_string();
+    }
+    if is_loading_comments {
+        return "Loading review comments...".to_string();
+    }
+
+    "No review comments.".to_string()
+}
+
+/// Clamps a possibly stale selection to the loaded entry range.
+fn normalized_selection(selected_index: usize, item_count: usize) -> usize {
+    selected_index.min(item_count.saturating_sub(1))
+}
+
+/// Returns the largest scroll offset for a rendered detail line count.
+fn max_scroll_offset(line_count: usize, viewport_height: u16) -> u16 {
+    u16::try_from(line_count.saturating_sub(usize::from(viewport_height))).unwrap_or(u16::MAX)
+}
+
+/// Builds one bold metadata field.
+fn field_line(label: &'static str, value: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{label}: "),
+            Style::default()
+                .fg(style::palette::text_muted())
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            value.to_string(),
+            Style::default().fg(style::palette::text()),
+        ),
+    ])
+}
+
+/// Builds one emphasized detail section label.
+fn section_line(label: &'static str) -> Line<'static> {
+    Line::from(Span::styled(
+        label,
+        Style::default()
+            .fg(style::palette::warning())
+            .add_modifier(Modifier::BOLD),
+    ))
+}
+
+/// Builds one muted informational row.
+fn muted_line(text: &'static str) -> Line<'static> {
+    Line::from(Span::styled(
+        text,
+        Style::default().fg(style::palette::text_muted()),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+    use crate::domain::theme::ColorTheme;
+    use crate::test_support::SessionFixtureBuilder;
+    use crate::ui::component::vertical_scrollbar::SCROLLBAR_THUMB_SYMBOL;
+
+    const SAMPLE_DIFF: &str = concat!(
+        "diff --git a/src/main.rs b/src/main.rs\n",
+        "index 1111111..2222222 100644\n",
+        "--- a/src/main.rs\n",
+        "+++ b/src/main.rs\n",
+        "@@ -1,2 +1,3 @@\n",
+        " fn main() {\n",
+        "+    println!(\"review\");\n",
+        " }\n",
+    );
+
+    fn inline_thread(line: u32) -> ReviewCommentThread {
+        ReviewCommentThread {
+            anchor_side: ReviewCommentAnchorSide::New,
+            comments: vec![ReviewComment {
+                author: "alice".to_string(),
+                body: "Please explain this output.".to_string(),
+            }],
+            is_outdated: Some(false),
+            is_resolved: false,
+            line: Some(line),
+            path: "src/main.rs".to_string(),
+            start_line: None,
+        }
+    }
+
+    fn file_thread() -> ReviewCommentThread {
+        ReviewCommentThread {
+            anchor_side: ReviewCommentAnchorSide::File,
+            comments: vec![ReviewComment {
+                author: "bob".to_string(),
+                body: "Please review the whole file.".to_string(),
+            }],
+            is_outdated: Some(false),
+            is_resolved: false,
+            line: None,
+            path: "src/main.rs".to_string(),
+            start_line: None,
+        }
+    }
+
+    fn comment_snapshot() -> ReviewCommentSnapshot {
+        let mut thread = inline_thread(2);
+        thread.comments[0].body = (0..12)
+            .map(|line_number| format!("Inline comment line {line_number}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        ReviewCommentSnapshot {
+            pr_level_comments: vec![ReviewComment {
+                author: "alice".to_string(),
+                body: "General comment".to_string(),
+            }],
+            threads: vec![thread],
+        }
+    }
+
+    fn render_review_comment_page(
+        snapshot: Option<&ReviewCommentSnapshot>,
+        comment_error: Option<&str>,
+        is_loading_comments: bool,
+        selected_comment_index: usize,
+        scroll_offset: u16,
+        terminal_size: (u16, u16),
+    ) -> ratatui::buffer::Buffer {
+        let session = SessionFixtureBuilder::new()
+            .title(Some("Review comments session".to_string()))
+            .build();
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+        let backend = TestBackend::new(terminal_size.0, terminal_size.1);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+
+        terminal
+            .draw(|frame| {
+                let mut page = ReviewCommentPage::new(ReviewCommentPageInput {
+                    comment_error,
+                    comment_snapshot: snapshot,
+                    diff: SAMPLE_DIFF,
+                    is_loading_comments,
+                    markdown_render_cache: &markdown_render_cache,
+                    scroll_offset,
+                    selected_comment_index,
+                    session: &session,
+                });
+                Page::render(&mut page, frame, frame.area());
+            })
+            .expect("failed to draw review-comment page");
+
+        terminal.backend().buffer().clone()
+    }
+
+    fn buffer_text(buffer: &ratatui::buffer::Buffer) -> String {
+        buffer
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect()
+    }
+
+    #[test]
+    fn test_render_shows_comment_selector_general_detail_and_footer() {
+        // Arrange
+        let _theme_scope = style::scoped_active_theme(ColorTheme::Current);
+        let snapshot = comment_snapshot();
+
+        // Act
+        let buffer = render_review_comment_page(Some(&snapshot), None, false, 0, 0, (100, 24));
+        let text = buffer_text(&buffer);
+
+        // Assert
+        assert!(text.contains("Comments (2)"));
+        assert!(text.contains("General · alice"));
+        assert!(text.contains("src/main.rs:2"));
+        assert!(text.contains("Comment — Review comments session"));
+        assert!(text.contains("Scope: General discussion"));
+        assert!(text.contains("General comment"));
+        assert!(text.contains("This comment is not attached to a code line."));
+        assert!(text.contains("q/Esc: back"));
+        assert!(
+            buffer
+                .content()
+                .iter()
+                .any(|cell| cell.bg == style::palette::surface_selection())
+        );
+    }
+
+    #[test]
+    fn test_render_shows_selected_inline_context_and_scrollbar() {
+        // Arrange
+        let snapshot = comment_snapshot();
+
+        // Act
+        let buffer = render_review_comment_page(Some(&snapshot), None, false, 1, 0, (100, 14));
+        let text = buffer_text(&buffer);
+
+        // Assert
+        assert!(text.contains("src/main.rs:2"));
+        assert!(text.contains("Code context"));
+        assert!(text.contains("println!(\"review\")"));
+        assert!(text.contains(SCROLLBAR_THUMB_SYMBOL));
+    }
+
+    #[test]
+    fn test_render_shows_loading_error_and_empty_fallbacks() {
+        // Arrange
+        let empty_snapshot = ReviewCommentSnapshot {
+            pr_level_comments: Vec::new(),
+            threads: Vec::new(),
+        };
+
+        // Act
+        let loading = buffer_text(&render_review_comment_page(
+            None,
+            None,
+            true,
+            0,
+            0,
+            (80, 12),
+        ));
+        let error = buffer_text(&render_review_comment_page(
+            None,
+            Some("Forge unavailable"),
+            false,
+            0,
+            0,
+            (80, 12),
+        ));
+        let empty = buffer_text(&render_review_comment_page(
+            Some(&empty_snapshot),
+            None,
+            false,
+            0,
+            0,
+            (80, 12),
+        ));
+        let missing = buffer_text(&render_review_comment_page(
+            None,
+            None,
+            false,
+            0,
+            0,
+            (80, 12),
+        ));
+
+        // Assert
+        assert!(loading.contains("Loading..."));
+        assert!(loading.contains("Loading review comments..."));
+        assert!(error.contains("Load failed"));
+        assert!(error.contains("Forge unavailable"));
+        assert!(empty.contains("No comments"));
+        assert!(empty.contains("No review comments."));
+        assert!(missing.contains("No review comments."));
+    }
+
+    #[test]
+    fn test_review_comment_view_max_scroll_offset_reflects_detail_overflow() {
+        // Arrange
+        let snapshot = comment_snapshot();
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+
+        // Act
+        let scroll_offset = review_comment_view_max_scroll_offset(
+            Some(&snapshot),
+            None,
+            false,
+            SAMPLE_DIFF,
+            1,
+            Rect::new(0, 0, 80, 10),
+            &markdown_render_cache,
+        );
+
+        // Assert
+        assert!(scroll_offset > 0);
+    }
+
+    #[test]
+    fn test_code_context_lines_include_and_highlight_attached_new_line() {
+        // Arrange
+        let thread = inline_thread(2);
+
+        // Act
+        let lines = code_context_lines(&thread, SAMPLE_DIFF, 80);
+
+        // Assert
+        let attached_line = lines
+            .iter()
+            .find(|line| line.to_string().contains("println!"))
+            .expect("attached line should be visible");
+        assert!(attached_line.to_string().contains("+    println!"));
+        assert!(
+            attached_line
+                .spans
+                .iter()
+                .all(|span| span.style.bg == Some(style::palette::surface_selection()))
+        );
+    }
+
+    #[test]
+    fn test_code_context_lines_highlight_every_line_in_multiline_anchor_range() {
+        // Arrange
+        let mut thread = inline_thread(2);
+        thread.start_line = Some(1);
+
+        // Act
+        let lines = code_context_lines(&thread, SAMPLE_DIFF, 80);
+
+        // Assert
+        let start_line = lines
+            .iter()
+            .find(|line| line.to_string().contains("fn main"))
+            .expect("attached range start should be visible");
+        let end_line = lines
+            .iter()
+            .find(|line| line.to_string().contains("println!"))
+            .expect("attached range end should be visible");
+        let trailing_line = lines
+            .iter()
+            .find(|line| line.to_string().contains('}'))
+            .expect("surrounding context should be visible");
+        assert!(
+            start_line
+                .spans
+                .iter()
+                .all(|span| span.style.bg == Some(style::palette::surface_selection()))
+        );
+        assert!(
+            end_line
+                .spans
+                .iter()
+                .all(|span| span.style.bg == Some(style::palette::surface_selection()))
+        );
+        assert!(
+            trailing_line
+                .spans
+                .iter()
+                .all(|span| span.style.bg.is_none())
+        );
+    }
+
+    #[test]
+    fn test_code_context_line_uses_diff_page_gutter_and_change_styles() {
+        // Arrange
+        let addition = DiffLine {
+            content: "added",
+            kind: DiffLineKind::Addition,
+            new_line: Some(2),
+            old_line: None,
+        };
+        let deletion = DiffLine {
+            content: "removed",
+            kind: DiffLineKind::Deletion,
+            new_line: None,
+            old_line: Some(2),
+        };
+
+        // Act
+        let addition_line = code_context_line(&addition, false, 1, 80);
+        let deletion_line = code_context_line(&deletion, false, 1, 80);
+
+        // Assert
+        assert_eq!(
+            addition_line.spans[0].style.fg,
+            Some(style::palette::text_subtle())
+        );
+        assert_eq!(
+            addition_line.spans[1].style.bg,
+            Some(style::palette::surface_success())
+        );
+        assert_eq!(
+            deletion_line.spans[0].style.fg,
+            Some(style::palette::text_subtle())
+        );
+        assert_eq!(
+            deletion_line.spans[1].style.bg,
+            Some(style::palette::surface_danger())
+        );
+    }
+
+    #[test]
+    fn test_code_context_lines_explain_file_level_anchor_without_synthetic_code() {
+        // Arrange
+        let thread = file_thread();
+
+        // Act
+        let lines = code_context_lines(&thread, SAMPLE_DIFF, 80);
+
+        // Assert
+        assert_eq!(
+            lines.iter().map(Line::to_string).collect::<Vec<_>>(),
+            vec!["This file-level comment is not attached to a code line."]
+        );
+        assert!(
+            lines
+                .iter()
+                .flat_map(|line| &line.spans)
+                .all(|span| span.style.bg.is_none())
+        );
+    }
+
+    #[test]
+    fn test_code_context_lines_cover_old_side_and_missing_anchor_fallbacks() {
+        // Arrange
+        let mut old_thread = inline_thread(1);
+        old_thread.anchor_side = ReviewCommentAnchorSide::Old;
+        let mut missing_file_thread = inline_thread(2);
+        missing_file_thread.path = "src/missing.rs".to_string();
+        let outside_thread = inline_thread(99);
+        let mut missing_anchor_thread = inline_thread(2);
+        missing_anchor_thread.line = None;
+
+        // Act
+        let old_lines = code_context_lines(&old_thread, SAMPLE_DIFF, 80);
+        let missing_file_lines = code_context_lines(&missing_file_thread, SAMPLE_DIFF, 80);
+        let outside_lines = code_context_lines(&outside_thread, SAMPLE_DIFF, 80);
+        let missing_anchor_lines = code_context_lines(&missing_anchor_thread, SAMPLE_DIFF, 80);
+        let file_side_matches = diff_line_matches_anchor(
+            &DiffLine {
+                content: "file",
+                kind: DiffLineKind::Context,
+                new_line: Some(1),
+                old_line: Some(1),
+            },
+            ReviewCommentAnchorSide::File,
+            (1, 1),
+        );
+
+        // Assert
+        let old_anchor = old_lines
+            .iter()
+            .find(|line| line.to_string().contains("fn main"))
+            .expect("old-side anchor should be visible");
+        assert!(
+            old_anchor
+                .spans
+                .iter()
+                .all(|span| span.style.bg == Some(style::palette::surface_selection()))
+        );
+        assert_eq!(
+            missing_file_lines[0].to_string(),
+            "No current diff context is available for this file."
+        );
+        assert_eq!(
+            outside_lines[0].to_string(),
+            "The attached line or range is outside the current diff context."
+        );
+        assert_eq!(
+            missing_anchor_lines[0].to_string(),
+            "This comment has no attached line anchor."
+        );
+        assert!(!file_side_matches);
+    }
+
+    #[test]
+    fn test_comment_detail_lines_include_thread_metadata_body_and_code() {
+        // Arrange
+        let snapshot = ReviewCommentSnapshot {
+            pr_level_comments: Vec::new(),
+            threads: vec![inline_thread(2)],
+        };
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+
+        // Act
+        let lines = comment_detail_lines(
+            Some(&snapshot),
+            None,
+            false,
+            SAMPLE_DIFF,
+            0,
+            &markdown_render_cache,
+            80,
+        );
+        let text = lines
+            .iter()
+            .map(Line::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let code_context_index = lines
+            .iter()
+            .position(|line| line.to_string() == "Code context")
+            .expect("code context section should be visible");
+        let conversation_index = lines
+            .iter()
+            .position(|line| line.to_string() == "Conversation")
+            .expect("conversation section should be visible");
+
+        // Assert
+        assert!(text.contains("src/main.rs:2"));
+        assert!(text.contains("Please explain this output."));
+        assert!(text.contains("Code context"));
+        assert!(text.contains("println!(\"review\")"));
+        assert!(code_context_index < conversation_index);
+    }
+
+    #[test]
+    fn test_review_comment_item_count_includes_general_comments_and_threads() {
+        // Arrange
+        let snapshot = ReviewCommentSnapshot {
+            pr_level_comments: vec![ReviewComment {
+                author: "bob".to_string(),
+                body: "General note".to_string(),
+            }],
+            threads: vec![inline_thread(2), inline_thread(3)],
+        };
+
+        // Act
+        let count = review_comment_item_count(Some(&snapshot));
+
+        // Assert
+        assert_eq!(count, 3);
+    }
+}

--- a/crates/agentty/src/ui/page/session_chat.rs
+++ b/crates/agentty/src/ui/page/session_chat.rs
@@ -303,8 +303,12 @@ impl<'a> SessionChatPage<'a> {
             publish_pull_request_action: session.publish_pull_request_action(),
             session_state: help_action::session_view_state(session),
         };
-        let help_message =
-            Paragraph::new(session_format::session_view_footer_line(view_help_state));
+        let help_message = Paragraph::new(
+            session_format::session_view_footer_line_with_review_comments(
+                view_help_state,
+                session.review_request.is_some(),
+            ),
+        );
         f.render_widget(help_message, bottom_area);
     }
 }

--- a/crates/agentty/src/ui/render.rs
+++ b/crates/agentty/src/ui/render.rs
@@ -222,6 +222,7 @@ fn render_footer_bar(f: &mut Frame, footer_bar_area: Rect, context: FooterBarRen
         | AppMode::Prompt { session_id, .. }
         | AppMode::Question { session_id, .. }
         | AppMode::Diff { session_id, .. }
+        | AppMode::ReviewComments { session_id, .. }
         | AppMode::ViewInfoPopup {
             restore_view: ConfirmationViewMode { session_id, .. },
             ..
@@ -333,48 +334,67 @@ mod tests {
     }
 
     #[test]
-    fn render_footer_bar_prefers_session_folder_and_branch_for_view_mode() {
+    fn render_footer_bar_prefers_session_folder_and_branch_for_session_modes() {
         // Arrange
         let backend = ratatui::backend::TestBackend::new(120, 3);
         let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
         let session_id = "session-view-mode";
         let session = session_fixture(session_id, "/tmp/session-view-folder");
-        let mode = AppMode::View {
-            session_id: session_id.into(),
-            scroll_offset: None,
-        };
+        let modes = [
+            AppMode::View {
+                session_id: session_id.into(),
+                scroll_offset: None,
+            },
+            AppMode::ReviewComments {
+                comment_error: None,
+                comment_snapshot: None,
+                diff: String::new(),
+                is_loading_comments: true,
+                selected_comment_index: 0,
+                session_id: session_id.into(),
+                scroll_offset: 0,
+            },
+        ];
         let sessions = vec![session];
         let session_index_by_id = session_index_by_id(&sessions);
         let session_branch_names = HashMap::new();
 
         // Act
-        terminal
-            .draw(|frame| {
-                render_footer_bar(
-                    frame,
-                    frame.area(),
-                    FooterBarRenderContext {
-                        current_tab: Tab::Sessions,
-                        mode: &mode,
-                        project: ProjectFooterContext {
-                            git_branch: Some("main"),
-                            git_status: Some((2, 1)),
-                            git_upstream_ref: Some("origin/main"),
-                            working_dir: Path::new("/tmp/workspace-root"),
-                        },
-                        session_branch_names: &session_branch_names,
-                        session_git_statuses: &HashMap::new(),
-                        session_index_by_id: &session_index_by_id,
-                        sessions: &sessions,
-                    },
-                );
+        let rendered_texts = modes
+            .iter()
+            .map(|mode| {
+                terminal
+                    .draw(|frame| {
+                        render_footer_bar(
+                            frame,
+                            frame.area(),
+                            FooterBarRenderContext {
+                                current_tab: Tab::Sessions,
+                                mode,
+                                project: ProjectFooterContext {
+                                    git_branch: Some("main"),
+                                    git_status: Some((2, 1)),
+                                    git_upstream_ref: Some("origin/main"),
+                                    working_dir: Path::new("/tmp/workspace-root"),
+                                },
+                                session_branch_names: &session_branch_names,
+                                session_git_statuses: &HashMap::new(),
+                                session_index_by_id: &session_index_by_id,
+                                sessions: &sessions,
+                            },
+                        );
+                    })
+                    .expect("failed to draw");
+
+                buffer_text(terminal.backend().buffer())
             })
-            .expect("failed to draw");
+            .collect::<Vec<_>>();
 
         // Assert
-        let text = buffer_text(terminal.backend().buffer());
-        assert!(text.contains("/tmp/session-view-folder"));
-        assert!(text.contains(&session_branch(session_id)));
+        for text in rendered_texts {
+            assert!(text.contains("/tmp/session-view-folder"));
+            assert!(text.contains(&session_branch(session_id)));
+        }
     }
 
     #[test]

--- a/crates/agentty/src/ui/review_comment_format.rs
+++ b/crates/agentty/src/ui/review_comment_format.rs
@@ -20,8 +20,8 @@ pub(crate) fn append_comment_bodies(
     }
 }
 
-/// Renders the `path:line · side · N comments · resolved/unresolved` header
-/// shared by review-detail and diff comment panels.
+/// Renders the `path:start-end · side · N comments · resolved/unresolved`
+/// header shared by review-detail and diff comment panels.
 pub(crate) fn thread_header_line(
     thread: &ReviewCommentThread,
     anchor_style: Style,
@@ -51,6 +51,28 @@ pub(crate) fn thread_header_line(
     ])
 }
 
+/// Returns the file-and-line or file-and-range anchor for one review thread.
+pub(crate) fn thread_anchor(thread: &ReviewCommentThread) -> String {
+    match thread_anchor_line_range(thread) {
+        Some((start_line, end_line)) if start_line != end_line => {
+            format!("{}:{start_line}-{end_line}", thread.path)
+        }
+        Some((_, end_line)) => format!("{}:{end_line}", thread.path),
+        None => thread.path.clone(),
+    }
+}
+
+/// Returns the normalized inclusive line range attached to one inline thread.
+pub(crate) fn thread_anchor_line_range(thread: &ReviewCommentThread) -> Option<(u32, u32)> {
+    if thread.anchor_side == ReviewCommentAnchorSide::File {
+        return None;
+    }
+    let end_line = thread.line?;
+    let start_line = thread.start_line.unwrap_or(end_line);
+
+    Some((start_line.min(end_line), start_line.max(end_line)))
+}
+
 /// Appends one comment's author header followed by the markdown-rendered body.
 fn append_comment_body(
     lines: &mut Vec<Line<'static>>,
@@ -72,14 +94,6 @@ fn append_comment_body(
         spans.push(Span::raw("  "));
         spans.extend(rendered_line.spans.iter().cloned());
         lines.push(Line::from(spans));
-    }
-}
-
-/// Returns the file-and-line anchor for one review thread.
-fn thread_anchor(thread: &ReviewCommentThread) -> String {
-    match thread.line {
-        Some(line) => format!("{}:{line}", thread.path),
-        None => thread.path.clone(),
     }
 }
 
@@ -123,6 +137,32 @@ mod tests {
     }
 
     #[test]
+    fn test_thread_header_line_includes_multiline_anchor_range() {
+        // Arrange
+        let thread = ReviewCommentThread {
+            anchor_side: ReviewCommentAnchorSide::New,
+            comments: vec![ReviewComment {
+                author: "alice".to_string(),
+                body: "Please check these lines.".to_string(),
+            }],
+            is_outdated: Some(false),
+            is_resolved: false,
+            line: Some(12),
+            path: "src/lib.rs".to_string(),
+            start_line: Some(10),
+        };
+
+        // Act
+        let line = thread_header_line(&thread, Style::default());
+
+        // Assert
+        assert_eq!(
+            line.to_string(),
+            "src/lib.rs:10-12  ·  new  ·  1 comments  ·  unresolved"
+        );
+    }
+
+    #[test]
     fn test_append_comment_bodies_indents_markdown_under_author() {
         // Arrange
         let mut lines = Vec::new();
@@ -143,5 +183,54 @@ mod tests {
             .join("\n");
         assert!(text.contains("alice"));
         assert!(text.contains("  Looks good."));
+    }
+
+    #[test]
+    fn test_append_comment_bodies_separates_multiple_comments() {
+        // Arrange
+        let mut lines = Vec::new();
+        let comments = vec![
+            ReviewComment {
+                author: "alice".to_string(),
+                body: "First".to_string(),
+            },
+            ReviewComment {
+                author: "bob".to_string(),
+                body: "Second".to_string(),
+            },
+        ];
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+
+        // Act
+        append_comment_bodies(&mut lines, &comments, &markdown_render_cache, 40);
+
+        // Assert
+        assert!(lines.iter().any(|line| line.spans.is_empty()));
+        assert!(lines.iter().any(|line| line.to_string() == "alice"));
+        assert!(lines.iter().any(|line| line.to_string() == "bob"));
+    }
+
+    #[test]
+    fn test_thread_header_line_shows_file_level_anchor() {
+        // Arrange
+        let thread = ReviewCommentThread {
+            anchor_side: ReviewCommentAnchorSide::File,
+            comments: Vec::new(),
+            is_outdated: None,
+            is_resolved: false,
+            line: None,
+            path: "src/lib.rs".to_string(),
+            start_line: None,
+        };
+
+        // Act
+        let line = thread_header_line(&thread, Style::default());
+
+        // Assert
+        assert_eq!(
+            line.to_string(),
+            "src/lib.rs  ·  file  ·  0 comments  ·  unresolved"
+        );
+        assert_eq!(thread_anchor_line_range(&thread), None);
     }
 }

--- a/crates/agentty/src/ui/router.rs
+++ b/crates/agentty/src/ui/router.rs
@@ -389,7 +389,8 @@ fn render_list_or_overlay_mode(
         | AppMode::Question { .. }
         | AppMode::PublishBranchInput { .. }
         | AppMode::LaunchConfigurationSelector { .. }
-        | AppMode::Diff { .. } => {
+        | AppMode::Diff { .. }
+        | AppMode::ReviewComments { .. } => {
             return false;
         }
     }
@@ -718,6 +719,31 @@ fn render_session_or_diff_mode(
                     scroll_offset: *scroll_offset,
                     session,
                 })
+                .render(f, area);
+            }
+        }
+        AppMode::ReviewComments {
+            comment_error,
+            comment_snapshot,
+            diff,
+            is_loading_comments,
+            selected_comment_index,
+            session_id,
+            scroll_offset,
+        } => {
+            if let Some(session) = sessions.iter().find(|session| &session.id == session_id) {
+                page::review_comment::ReviewCommentPage::new(
+                    page::review_comment::ReviewCommentPageInput {
+                        comment_error: comment_error.as_deref(),
+                        comment_snapshot: comment_snapshot.as_ref(),
+                        diff,
+                        is_loading_comments: *is_loading_comments,
+                        markdown_render_cache: aux.markdown_render_cache,
+                        scroll_offset: *scroll_offset,
+                        selected_comment_index: *selected_comment_index,
+                        session,
+                    },
+                )
                 .render(f, area);
             }
         }
@@ -1105,6 +1131,58 @@ mod tests {
         let text = buffer_text(terminal.backend().buffer());
         assert!(text.contains("Diff Session"));
         assert!(text.contains("No changes found."));
+    }
+
+    #[test]
+    fn render_session_or_diff_mode_renders_review_comments_for_matching_session() {
+        // Arrange
+        let backend = ratatui::backend::TestBackend::new(120, 30);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+        let session_id = "session-comments";
+        let sessions = vec![session_fixture(session_id)];
+        let mode = AppMode::ReviewComments {
+            comment_error: None,
+            comment_snapshot: None,
+            diff: String::new(),
+            is_loading_comments: true,
+            selected_comment_index: 0,
+            session_id: session_id.into(),
+            scroll_offset: 0,
+        };
+        let progress_messages = HashMap::new();
+        let cache = markdown::MarkdownRenderCache::default();
+        let diff_layout_cache = page::diff::DiffLayoutCache::default();
+        let output_layout_cache = component::session_output::SessionOutputLayoutCache::default();
+        let session_update_versions = HashMap::new();
+
+        // Act
+        terminal
+            .draw(|frame| {
+                render_session_or_diff_mode(
+                    frame,
+                    frame.area(),
+                    &mode,
+                    &sessions,
+                    RouteAuxContext {
+                        active_prompt_outputs: &HashMap::new(),
+                        default_reasoning_level: ReasoningLevel::default(),
+                        diff_layout_cache: &diff_layout_cache,
+                        markdown_render_cache: &cache,
+                        output_layout_cache: &output_layout_cache,
+                        review_snapshot: None,
+                        session_progress_messages: &progress_messages,
+                        session_update_versions: &session_update_versions,
+                        session_worktree_availability: &HashMap::new(),
+                        wall_clock_unix_seconds: 0,
+                    },
+                );
+            })
+            .expect("failed to draw");
+
+        // Assert
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(text.contains("Comment — Router Session"));
+        assert!(text.contains("Loading review comments..."));
     }
 
     #[test]

--- a/crates/agentty/src/ui/session_format.rs
+++ b/crates/agentty/src/ui/session_format.rs
@@ -159,9 +159,16 @@ fn session_metadata_base_text(
     )
 }
 
-/// Builds the footer help line shown in session view mode.
-pub(crate) fn session_view_footer_line(view_help_state: ViewHelpState) -> Line<'static> {
-    crate::ui::help_format::footer_line(&help_action::view_footer_actions(view_help_state))
+/// Builds the session-view footer and exposes linked forge comments on `c`
+/// when the current session has a review request.
+pub(crate) fn session_view_footer_line_with_review_comments(
+    view_help_state: ViewHelpState,
+    can_view_review_comments: bool,
+) -> Line<'static> {
+    crate::ui::help_format::footer_line(&help_action::view_footer_actions_with_review_comments(
+        view_help_state,
+        can_view_review_comments,
+    ))
 }
 
 /// Renders persisted summary payloads into display markdown.

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1420,6 +1420,9 @@ case "$*" in
   *"auth status"*)
     exit 0
     ;;
+  *"api --hostname github.com graphql"*)
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"comments":{"nodes":[]},"reviewThreads":{"nodes":[{"diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":2,"path":"src/main.rs","startLine":1,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"alice"},"body":"Please explain why this review output is needed."}]}},{"diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":null,"path":"src/main.rs","startLine":null,"subjectType":"FILE","comments":{"nodes":[{"author":{"login":"bob"},"body":"Please review the whole file."}]}}]}}}}}'
+    ;;
   *"pr view"*)
     printf '%s\n' '{"number":42,"title":"Review-ready session shortcuts","state":"OPEN","url":"https://github.com/agentty-xyz/agentty/pull/42","baseRefName":"main","headRefName":"wt/review-s","isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"REVIEW_REQUIRED","mergedAt":null}'
     ;;
@@ -4032,6 +4035,83 @@ fn diff_preview_opens_from_session() -> E2eResult {
                 assertion::assert_text_in_region(frame, "src/ +1 -0", &full);
                 assertion::assert_text_in_region(frame, "println!(\"review\")", &full);
                 assertion::assert_text_in_region(frame, "j/k: select file", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that a linked review request opens a read-only split comment page
+/// with the selected thread's current diff context.
+#[test]
+fn test_session_review_comments() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_review_comments")
+        .with_git()
+        .setup(seed_review_ready_session_with_review_request)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .compose(&common::open_selected_session_view())
+                    .wait_for_text("c: comments", 5000)
+                    .press_key("c")
+                    .wait_for_text("Please explain why this review output is needed.", 5000)
+                    .wait_for_stable_frame(300, 5000)
+                    .viewing_pause_ms(1500)
+                    .capture_labeled(
+                        "inline_review_comment",
+                        "Multiline review comment with its attached code context",
+                    )
+                    .press_key("j")
+                    .wait_for_text(
+                        "This file-level comment is not attached to a code line.",
+                        5000,
+                    )
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled(
+                        "file_review_comment",
+                        "File-level review comment without a synthetic code anchor",
+                    )
+            },
+            |frame, report| {
+                let inline_frame = common::frame_from_capture(&report.captures[0]);
+                let inline_full = Region::full(inline_frame.cols(), inline_frame.rows());
+                let page_text = inline_frame.text_in_region(&inline_full);
+                let code_context_index = page_text
+                    .find("Code context")
+                    .expect("code context section should be visible");
+                let conversation_index = page_text
+                    .find("Conversation")
+                    .expect("conversation section should be visible");
+
+                assertion::assert_text_in_region(&inline_frame, "Comments (2)", &inline_full);
+                assertion::assert_text_in_region(&inline_frame, "src/main.rs:1-2", &inline_full);
+                assertion::assert_text_in_region(&inline_frame, "Conversation", &inline_full);
+                assertion::assert_text_in_region(
+                    &inline_frame,
+                    "Please explain why this review output is needed.",
+                    &inline_full,
+                );
+                assertion::assert_text_in_region(&inline_frame, "Code context", &inline_full);
+                assertion::assert_text_in_region(
+                    &inline_frame,
+                    "println!(\"review\")",
+                    &inline_full,
+                );
+                assert!(code_context_index < conversation_index);
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "file  ·  1 comments", &full);
+                assertion::assert_text_in_region(
+                    frame,
+                    "This file-level comment is not attached to a code line.",
+                    &full,
+                );
+                assertion::assert_text_in_region(frame, "Please review the whole file.", &full);
+                assertion::assert_not_visible(frame, "println!(\"review\")");
+                assertion::assert_text_in_region(frame, "j/k: select comment", &full);
             },
         )?;
 

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -70,9 +70,9 @@ For file-level detail, read the module docstrings directly.
 - `runtime/`: Terminal lifecycle and the event loop — terminal setup, the event-reader
   thread, key dispatch, mode-focused handlers under `runtime/mode/`, and shared handlers
   for common interactions such as issue/review detail navigation, session-output
-  metrics, transcript scrolling, and `KeyEvent` mapping to domain input commands.
-  Runtime owns `PresentationState`, including the shared `RenderCacheStore` used by
-  input metrics and frame rendering.
+  metrics, transcript scrolling, `KeyEvent` mapping to domain input commands, and
+  read-only session review-comment selection. Runtime owns `PresentationState`,
+  including the shared `RenderCacheStore` used by input metrics and frame rendering.
 - `presentation.rs` and `presentation/`: Frontend-neutral interaction state shared by
   runtime input and UI output. They expose mode, help-action, prompt, editor, scroll,
   viewport, and semantic list-selection contracts without importing Ratatui or `ui/`
@@ -80,9 +80,10 @@ For file-level detail, read the module docstrings directly.
 - `ui/`: Rendering — frame composition, mode-to-page routing, pages under `ui/page/`,
   reusable widgets under `ui/component/`, application-to-frame projection in
   `ui/app_render.rs`, Agentty theme adapters for `ag-tui-text`, plus diff, layout,
-  review-comment formatting, and theme helpers. `ui/session_output_assembly.rs` owns the
-  pure transcript-to-display-line projection; the `SessionOutput` component retains
-  layout caching, scrollbar metrics, loader effects, and Ratatui painting.
+  review-comment formatting, the split session review-comment page, and theme helpers.
+  `ui/session_output_assembly.rs` owns the pure transcript-to-display-line projection;
+  the `SessionOutput` component retains layout caching, scrollbar metrics, loader
+  effects, and Ratatui painting.
 
 ## Layer Rules
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -467,7 +467,13 @@ orchestration paths:
   schedule cleanup again. Cleanup-critical git subprocesses are cancellable and bounded
   to 30 seconds; confirmed shutdown shares a five-second grace period across all tracked
   cleanup tasks before canceling unfinished work. The Inbox tab loads comment snapshots
-  on demand with generation-scoped deduplication.
+  on demand with generation-scoped deduplication. Session view also loads comments on
+  demand for its linked review request: `AppMode::ReviewComments` renders immediately
+  with a loading state, `TaskService` resolves the session worktree remote through the
+  injected git/forge boundaries, falls back to the persisted review-request URL after
+  terminal-session worktree cleanup, and uses the matching `AppEvent` to update only the
+  still-open comments page. Inline code context is derived from the already loaded
+  current diff.
 - Assigned-issue refresh: the Issues tab resolves the active project remote and runs a
   repository-scoped, generation-scoped `gh search issues` task through
   `ReviewRequestClient`; stale completions are discarded before the list cache is

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -151,6 +151,7 @@ The full set in **Review** state, subject to session and forge availability:
 | `/`                 | Open composer with `/` prefilled                    |
 | `o`                 | Run a launch configuration in the worktree          |
 | `p`                 | Publish branch and create or refresh review request |
+| `c`                 | Show linked review-request comments                 |
 | `d`                 | Show diff                                           |
 | `f`                 | Append or regenerate focused review output          |
 | `F`                 | Fork session with copied transcript history         |
@@ -181,14 +182,34 @@ State-specific differences:
 - **Question** sessions hide `r` until they return to review-ready state.
 - Review-ready stacked parents with a materialized child keep `Enter`, `m`, and `r`
   while the stack is idle, but hide `/` until the child is terminal or no longer linked.
-- **Done** sessions offer `c` to start a continuation draft (confirmation popup).
-- **Canceled**, **Queued**, and **Merging** sessions are read-only (`q`, scroll, help).
+- Sessions with a linked pull request or merge request use `c` to open its read-only
+  comments page. Linked terminal sessions keep continuation available on `C`.
+- **Done** sessions without a linked review request offer `c` to start a continuation
+  draft (confirmation popup).
+- **Canceled**, **Queued**, and **Merging** sessions are otherwise read-only (`q`,
+  scroll, help). Linked review requests remain available from any session state with
+  `c`.
 
 `o` runs the configured `Launch Configurations` entry, or opens a selector popup when
 several are configured. Run Agentty inside `tmux` when you rely on
 `Launch Configurations`, because those commands are dispatched into tmux windows.
 Publish (`p`), sync (`r`), and stacked behavior are described in
 [Workflow](@/docs/usage/workflow.md).
+
+## Review Comments
+
+The review-comments page uses the same split layout as diff view. The left panel lists
+general comments and inline threads; the right panel shows the selected comment's author
+and thread state, current diff context for its attached line or range, and then the
+conversation. File-level comments explicitly show that they have no attached code line
+instead of highlighting an arbitrary diff row. Inline snippets use the same gutters and
+added/removed line colors as diff view.
+
+| Key           | Action                       |
+| ------------- | ---------------------------- |
+| `q` / `Esc`   | Return to session view       |
+| `j` / `k`     | Select previous/next comment |
+| `Up` / `Down` | Scroll selected comment info |
 
 ## Publish Popup
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -48,9 +48,14 @@ In session chat view, the status-colored session title renders in a header row a
 output panel, with a metadata row showing the size bucket, `+added` / `-deleted` line
 totals, the cumulative active-work timer, the current model, the effective reasoning
 level, and token usage. A linked pull-request or merge-request URL appears in the header
-when present. The timer ticks only while the session is actively working. Each session
-stores the project reasoning default when it is created, so later default changes affect
-new sessions without relabeling existing ones.
+when present. Press `c` on a linked review request to open its read-only comments in a
+split page: comments and inline threads appear on the left, while the selected thread's
+metadata, attached current-diff context, and conversation appear on the right. The timer
+ticks only while the session is actively working. A linked terminal session keeps `C`
+available for starting a continuation draft. File-level comments show an explicit
+no-line-context message instead of a synthetic code anchor. Each session stores the
+project reasoning default when it is created, so later default changes affect new
+sessions without relabeling existing ones.
 
 The top status bar shows the current version and update status, and rotates short
 page-scoped `FYI:` messages once per minute in the **Sessions** list and session chat


### PR DESCRIPTION
- Opens linked pull request or merge request comments with `c` and preserves terminal continuation on `C`.
- Renders selectable general comments and inline threads with current diff context and read-only navigation.
- Loads comments through forge tasks, falls back to persisted review-request URLs, and normalizes multiline anchors.
- Preserves repository staging with a temporary diff index and shares diff gutter styling with comment context.
- Covers loading, selection, navigation, rendering, diff preservation, documentation, and unit and E2E tests.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)