### PR TITLE
Unifies chat focus key handling

### DIFF
--- a/crates/agentty/src/runtime/mode/chat_scroll.rs
+++ b/crates/agentty/src/runtime/mode/chat_scroll.rs
@@ -9,6 +9,7 @@ use ratatui::layout::Rect;
 
 use crate::app::App;
 use crate::domain::session::SessionId;
+use crate::presentation::app_mode::ChatFocus;
 use crate::runtime::mode::session_output_metric;
 use crate::ui::page::session_chat::{self, SessionChatLayoutInput};
 use crate::ui::{RenderCacheStore, input_layout, layout, session_format};
@@ -23,6 +24,23 @@ pub(crate) struct ChatScrollMetrics {
     pub(crate) total_lines: u16,
     /// Visible transcript height in terminal lines.
     pub(crate) view_height: u16,
+}
+
+/// A semantic action for a key while a chat page owns the active focus.
+///
+/// Prompt and question modes share transcript navigation and focus switching.
+/// Question mode additionally permits diff preview, while prompt mode consumes
+/// that action with the rest of its unsupported chat-focused keys.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ChatFocusAction {
+    /// Opens the session diff preview when the active mode allows it.
+    OpenDiff,
+    /// Moves the transcript viewport.
+    Scroll,
+    /// Switches focus between the transcript and the bottom input panel.
+    ToggleFocus,
+    /// Consumes a key that has no chat-focused behavior.
+    Swallow,
 }
 
 impl ChatScrollMetrics {
@@ -94,6 +112,43 @@ impl ChatScrollMetrics {
     }
 }
 
+/// Classifies `key` into a shared chat-page action for the current focus.
+///
+/// `Tab` switches focus from either panel. When the transcript is focused,
+/// `d` requests a diff preview, recognized scroll keys move the transcript,
+/// and all remaining keys are swallowed to preserve the bottom-panel draft.
+/// Keys from the bottom input panel return `None` so its mode can handle them.
+pub(crate) fn classify_chat_focus_action(
+    focus: ChatFocus,
+    key: KeyEvent,
+) -> Option<ChatFocusAction> {
+    if key.code == KeyCode::Tab {
+        return Some(ChatFocusAction::ToggleFocus);
+    }
+
+    if focus == ChatFocus::Input {
+        return None;
+    }
+
+    if is_diff_preview_key(key) {
+        return Some(ChatFocusAction::OpenDiff);
+    }
+
+    if is_scroll_key(key) {
+        return Some(ChatFocusAction::Scroll);
+    }
+
+    Some(ChatFocusAction::Swallow)
+}
+
+/// Switches focus between the chat transcript and its bottom input panel.
+pub(crate) fn toggle_chat_focus(focus: &mut ChatFocus) {
+    *focus = match *focus {
+        ChatFocus::Input => ChatFocus::Chat,
+        ChatFocus::Chat => ChatFocus::Input,
+    };
+}
+
 /// Returns whether `key` scrolls the session transcript.
 ///
 /// Handlers that swallow every other key check this before building
@@ -101,6 +156,11 @@ impl ChatScrollMetrics {
 /// whole transcript and would otherwise run on each ignored keystroke.
 pub(crate) fn is_scroll_key(key: KeyEvent) -> bool {
     ScrollStep::from_key(key).is_some()
+}
+
+/// Returns whether `key` requests the session diff preview from chat focus.
+fn is_diff_preview_key(key: KeyEvent) -> bool {
+    matches!(key.code, KeyCode::Char('d')) && !key.modifiers.contains(KeyModifiers::CONTROL)
 }
 
 /// Applies one transcript scroll key to `scroll_offset`.
@@ -237,6 +297,61 @@ mod tests {
         // Act, Assert
         assert!(scroll_keys.into_iter().all(is_scroll_key));
         assert!(!other_keys.into_iter().any(is_scroll_key));
+    }
+
+    #[test]
+    fn test_classify_chat_focus_action_distinguishes_input_and_chat_keys() {
+        // Arrange
+        let input_key = plain_key(KeyCode::Char('q'));
+        let chat_keys = [
+            (plain_key(KeyCode::Tab), ChatFocusAction::ToggleFocus),
+            (plain_key(KeyCode::Char('d')), ChatFocusAction::OpenDiff),
+            (plain_key(KeyCode::Char('j')), ChatFocusAction::Scroll),
+            (plain_key(KeyCode::Esc), ChatFocusAction::Swallow),
+        ];
+
+        // Act, Assert
+        assert_eq!(
+            classify_chat_focus_action(ChatFocus::Input, input_key),
+            None
+        );
+        assert_eq!(
+            classify_chat_focus_action(ChatFocus::Input, plain_key(KeyCode::Tab)),
+            Some(ChatFocusAction::ToggleFocus)
+        );
+        for (key, action) in chat_keys {
+            assert_eq!(
+                classify_chat_focus_action(ChatFocus::Chat, key),
+                Some(action)
+            );
+        }
+    }
+
+    #[test]
+    fn test_classify_chat_focus_action_keeps_ctrl_d_as_scroll() {
+        // Arrange
+        let key = KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL);
+
+        // Act
+        let action = classify_chat_focus_action(ChatFocus::Chat, key);
+
+        // Assert
+        assert_eq!(action, Some(ChatFocusAction::Scroll));
+    }
+
+    #[test]
+    fn test_toggle_chat_focus_switches_between_panels() {
+        // Arrange
+        let mut focus = ChatFocus::Input;
+
+        // Act
+        toggle_chat_focus(&mut focus);
+        let chat_focus = focus;
+        toggle_chat_focus(&mut focus);
+
+        // Assert
+        assert_eq!(chat_focus, ChatFocus::Chat);
+        assert_eq!(focus, ChatFocus::Input);
     }
 
     #[test]

--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -123,10 +123,6 @@ where
         return Ok(EventResult::Continue);
     }
 
-    if handle_focus_toggle(app, key) {
-        return Ok(EventResult::Continue);
-    }
-
     if handle_chat_focus_key(app, render_cache_store, terminal, &prompt_context, key)? {
         return Ok(EventResult::Continue);
     }
@@ -136,33 +132,14 @@ where
     Ok(EventResult::Continue)
 }
 
-/// Toggles focus between the composer and the chat transcript on `Tab`.
-///
-/// Returns `true` when the key was consumed as a focus toggle.
-fn handle_focus_toggle(app: &mut App, key: KeyEvent) -> bool {
-    if key.code != KeyCode::Tab {
-        return false;
-    }
-
-    let AppMode::Prompt { focus, .. } = &mut app.mode else {
-        return false;
-    };
-
-    *focus = match *focus {
-        ChatFocus::Input => ChatFocus::Chat,
-        ChatFocus::Chat => ChatFocus::Input,
-    };
-
-    true
-}
-
 /// Handles keys while the chat transcript above the composer holds focus.
 ///
-/// Scroll keys navigate the transcript and `Tab` returns focus to the composer.
-/// Every other key — including `Ctrl+C` and `Esc` — is swallowed so the typed
-/// draft and the prompt itself cannot change while the user reads back the
-/// conversation. Swallowed keys skip scroll-metric construction, which lays
-/// out the transcript.
+/// The shared chat-focus classifier handles `Tab`, transcript navigation, and
+/// unsupported keys. Prompt mode does not permit diff preview, so it consumes
+/// that action like every other unsupported chat-focused key. This keeps the
+/// typed draft and prompt unchanged while the user reads the conversation.
+/// Swallowed keys skip scroll-metric construction, which lays out the
+/// transcript.
 ///
 /// Returns `true` when the key was consumed by the focused transcript.
 fn handle_chat_focus_key<B: Backend>(
@@ -175,38 +152,39 @@ fn handle_chat_focus_key<B: Backend>(
 where
     B::Error: std::error::Error + Send + Sync + 'static,
 {
-    if !matches!(
-        &app.mode,
-        AppMode::Prompt {
-            focus: ChatFocus::Chat,
-            ..
-        }
-    ) {
-        return Ok(false);
-    }
-
-    // Swallow non-scroll keys before building scroll metrics, which lay out and
-    // fingerprint the whole transcript.
-    if !chat_scroll::is_scroll_key(key) {
-        return Ok(true);
-    }
-
-    let terminal_size = terminal.size().map_err(crate::runtime::backend_err)?;
-    let metrics = ChatScrollMetrics::new(
-        app,
-        render_cache_store,
-        &prompt_context.session_id,
-        prompt_context.session_index,
-        Rect::new(0, 0, terminal_size.width, terminal_size.height),
-    );
-
-    let AppMode::Prompt { scroll_offset, .. } = &mut app.mode else {
+    let AppMode::Prompt { focus, .. } = &app.mode else {
         return Ok(false);
     };
 
-    chat_scroll::apply_scroll_key(scroll_offset, metrics, key);
+    match chat_scroll::classify_chat_focus_action(*focus, key) {
+        None => Ok(false),
+        Some(chat_scroll::ChatFocusAction::ToggleFocus) => {
+            if let AppMode::Prompt { focus, .. } = &mut app.mode {
+                chat_scroll::toggle_chat_focus(focus);
+            }
 
-    Ok(true)
+            Ok(true)
+        }
+        Some(chat_scroll::ChatFocusAction::Scroll) => {
+            let terminal_size = terminal.size().map_err(crate::runtime::backend_err)?;
+            let metrics = ChatScrollMetrics::new(
+                app,
+                render_cache_store,
+                &prompt_context.session_id,
+                prompt_context.session_index,
+                Rect::new(0, 0, terminal_size.width, terminal_size.height),
+            );
+
+            if let AppMode::Prompt { scroll_offset, .. } = &mut app.mode {
+                chat_scroll::apply_scroll_key(scroll_offset, metrics, key);
+            }
+
+            Ok(true)
+        }
+        Some(chat_scroll::ChatFocusAction::OpenDiff | chat_scroll::ChatFocusAction::Swallow) => {
+            Ok(true)
+        }
+    }
 }
 
 /// Handles keys when the at-mention dropdown is active.
@@ -1129,6 +1107,51 @@ mod tests {
 
         // Assert
         assert_eq!(chat_focus, ChatFocus::Chat);
+        assert_eq!(prompt_focus(&app), ChatFocus::Input);
+    }
+
+    #[tokio::test]
+    async fn test_chat_focus_key_ignores_non_prompt_mode() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("draft text", None).await;
+        let prompt_context = prompt_context(&mut app).expect("prompt context should be available");
+        app.mode = AppMode::List;
+        let terminal = test_terminal();
+
+        // Act
+        let is_consumed = handle_chat_focus_key(
+            &mut app,
+            &RenderCacheStore::default(),
+            &terminal,
+            &prompt_context,
+            KeyEvent::new(KeyCode::Tab, event::KeyModifiers::NONE),
+        )
+        .expect("chat focus handling should not fail");
+
+        // Assert
+        assert!(!is_consumed);
+        assert!(matches!(app.mode, AppMode::List));
+    }
+
+    #[tokio::test]
+    async fn test_chat_focus_key_leaves_input_panel_keys_unclaimed() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("draft text", None).await;
+        let prompt_context = prompt_context(&mut app).expect("prompt context should be available");
+        let terminal = test_terminal();
+
+        // Act
+        let is_consumed = handle_chat_focus_key(
+            &mut app,
+            &RenderCacheStore::default(),
+            &terminal,
+            &prompt_context,
+            KeyEvent::new(KeyCode::Char('q'), event::KeyModifiers::NONE),
+        )
+        .expect("chat focus handling should not fail");
+
+        // Assert
+        assert!(!is_consumed);
         assert_eq!(prompt_focus(&app), ChatFocus::Input);
     }
 

--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{self, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::Rect;
 
 use crate::app::session::SessionTaskService;
@@ -36,7 +36,13 @@ pub(crate) async fn handle_with_cache(
     terminal_size: Rect,
     key: KeyEvent,
 ) -> EventResult {
-    if handle_focus_toggle(app, key) {
+    if is_plain_q(key) && should_exit_to_list_on_q(app) {
+        exit_to_list_saving_progress(app);
+
+        return EventResult::Continue;
+    }
+
+    if handle_chat_focus_key(app, render_cache_store, terminal_size, key).await {
         return EventResult::Continue;
     }
 
@@ -45,16 +51,6 @@ pub(crate) async fn handle_with_cache(
             end_turn_no_answer(app).await;
         }
 
-        return EventResult::Continue;
-    }
-
-    if is_plain_q(key) && should_exit_to_list_on_q(app) {
-        exit_to_list_saving_progress(app);
-
-        return EventResult::Continue;
-    }
-
-    if handle_chat_scroll(app, render_cache_store, terminal_size, key).await {
         return EventResult::Continue;
     }
 
@@ -160,70 +156,52 @@ fn exit_to_list_saving_progress(app: &mut App) {
     }
 }
 
-/// Toggles focus between the question panel and chat output on `Tab`.
+/// Applies shared semantic actions while the chat output area is focused.
 ///
-/// Returns `true` when the key was consumed as a focus toggle.
-fn handle_focus_toggle(app: &mut App, key: KeyEvent) -> bool {
-    if key.code != KeyCode::Tab {
-        return false;
-    }
-
-    let AppMode::Question { focus, .. } = &mut app.mode else {
-        return false;
-    };
-
-    *focus = match *focus {
-        ChatFocus::Input => ChatFocus::Chat,
-        ChatFocus::Chat => ChatFocus::Input,
-    };
-
-    true
-}
-
-/// Applies scroll keys when the chat output area is focused.
-///
-/// Returns `true` when the key was consumed as a chat-focus action. `d` opens
-/// the diff preview for the session; `Tab` is the sole focus toggle.
-async fn handle_chat_scroll(
+/// Returns `true` when the key was consumed as a chat-focus action. Question
+/// mode permits the shared diff-preview action; unsupported actions are
+/// swallowed to keep the answer draft unchanged.
+async fn handle_chat_focus_key(
     app: &mut App,
     render_cache_store: &RenderCacheStore,
     terminal_size: Rect,
     key: KeyEvent,
 ) -> bool {
-    if !matches!(
-        &app.mode,
-        AppMode::Question {
-            focus: ChatFocus::Chat,
-            ..
-        }
-    ) {
+    let AppMode::Question {
+        focus, session_id, ..
+    } = &app.mode
+    else {
         return false;
-    }
+    };
+    let focus = *focus;
 
-    if key.code == KeyCode::Char('d') && !key.modifiers.contains(event::KeyModifiers::CONTROL) {
-        if let Some(session_id) = extract_question_session_id(app) {
+    match chat_scroll::classify_chat_focus_action(focus, key) {
+        None => false,
+        Some(chat_scroll::ChatFocusAction::ToggleFocus) => {
+            if let AppMode::Question { focus, .. } = &mut app.mode {
+                chat_scroll::toggle_chat_focus(focus);
+            }
+
+            true
+        }
+        Some(chat_scroll::ChatFocusAction::OpenDiff) => {
+            let session_id = session_id.clone();
+
             show_question_diff(app, &session_id).await;
+
+            true
         }
+        Some(chat_scroll::ChatFocusAction::Scroll) => {
+            if let Some(metrics) = question_scroll_metrics(app, render_cache_store, terminal_size)
+                && let AppMode::Question { scroll_offset, .. } = &mut app.mode
+            {
+                chat_scroll::apply_scroll_key(scroll_offset, metrics, key);
+            }
 
-        return true;
+            true
+        }
+        Some(chat_scroll::ChatFocusAction::Swallow) => true,
     }
-
-    // Chat focus is read-only: only transcript navigation keys may continue
-    // past this point. This prevents `Enter` and `Esc` from reaching the
-    // answer-input submission and end-turn handlers.
-    if !chat_scroll::is_scroll_key(key) {
-        return true;
-    }
-
-    let Some(metrics) = question_scroll_metrics(app, render_cache_store, terminal_size) else {
-        return false;
-    };
-
-    let AppMode::Question { scroll_offset, .. } = &mut app.mode else {
-        return false;
-    };
-
-    chat_scroll::apply_scroll_key(scroll_offset, metrics, key)
 }
 
 /// Returns transcript scroll metrics while question mode focuses the chat.
@@ -263,15 +241,6 @@ fn question_scroll_metrics(
             )
         },
     ))
-}
-
-/// Extracts the `session_id` from the current question mode, if active.
-fn extract_question_session_id(app: &App) -> Option<SessionId> {
-    if let AppMode::Question { session_id, .. } = &app.mode {
-        Some(session_id.clone())
-    } else {
-        None
-    }
 }
 
 /// Opens the diff preview from question mode.
@@ -2293,6 +2262,26 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[tokio::test]
+    async fn test_chat_focus_key_ignores_non_question_mode() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.mode = AppMode::List;
+
+        // Act
+        let is_consumed = handle_chat_focus_key(
+            &mut app,
+            &RenderCacheStore::default(),
+            TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE),
+        )
+        .await;
+
+        // Assert
+        assert!(!is_consumed);
+        assert!(matches!(app.mode, AppMode::List));
     }
 
     #[tokio::test]


### PR DESCRIPTION
- Centralizes chat-focus action classification for focus toggling, diff preview, transcript scrolling, and swallowed keys.
- Routes prompt and question mode handlers through the shared classifier while preserving prompt draft protection, question diff preview, and question-mode `q` exit handling.
- Covers classifier behavior, focus toggling, and mode-specific chat-focus handling with tests.