### PR TITLE
Attest release artifacts and publish immutable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,7 +296,9 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-22.04"
     permissions:
+      "attestations": "write"
       "contents": "write"
+      "id-token": "write"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -343,7 +345,19 @@ jobs:
         run: |
           # Remove the granular manifests
           rm -f artifacts/*-dist-manifest.json
-      - name: Create GitHub Release
+      - id: attest
+        name: Attest release artifacts
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f
+        with:
+          subject-path: artifacts/*
+      - name: Stage Sigstore bundle
+        env:
+          ATTESTATION_BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+          RELEASE_TAG: ${{ needs.plan.outputs.tag }}
+        run: |
+          bundle_name="${RELEASE_TAG//\//-}.sigstore.json"
+          cp "$ATTESTATION_BUNDLE_PATH" "artifacts/$bundle_name"
+      - name: Create or reuse GitHub Release
         env:
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
           ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
@@ -359,7 +373,17 @@ jobs:
             release_args+=("$PRERELEASE_FLAG")
           fi
 
-          gh release create "$RELEASE_TAG" --target "$RELEASE_COMMIT" "${release_args[@]}" --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          if release_is_draft="$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft' 2>/dev/null)"; then
+            if [ "$release_is_draft" != "true" ]; then
+              echo "release $RELEASE_TAG already exists and is not a draft" >&2
+              exit 1
+            fi
+          else
+            gh release create "$RELEASE_TAG" --draft --target "$RELEASE_COMMIT" "${release_args[@]}" --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt"
+          fi
+
+          gh release upload "$RELEASE_TAG" artifacts/* --clobber
+          gh release edit "$RELEASE_TAG" --draft=false
 
   custom-publish-npm-oidc:
     needs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- release: generate keyless Sigstore build provenance for final GitHub release artifacts
+  and attach a Scorecard-discoverable bundle.
+
+### Changed
+
+- release: upload the complete artifact set through a retry-safe draft before
+  publication so GitHub release immutability protects every shipped file.
+- docs: document GitHub release, asset, and provenance verification.
+
 ## [v0.13.2] - 2026-07-16
 
 ### Added

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,9 +10,10 @@ ci = "github"
 # Keep release CI marked as intentionally customized because the checked-in
 # workflow avoids blanket secret forwarding on custom jobs that do not need it,
 # and the generated `host` job is patched to require release checks before
-# creating the GitHub release announcement. The generated workflow still runs
-# the release plan on pull requests and merge queue checks, while release-only
-# validation is tag-gated in `.github/workflows/release-checks.yml`.
+# creating the GitHub release announcement and to reuse an existing draft when a
+# release upload is retried. The generated workflow still runs the release plan
+# on pull requests and merge queue checks, while release-only validation is
+# tag-gated in `.github/workflows/release-checks.yml`.
 allow-dirty = ["ci"]
 # The installers to generate for each app
 installers = ["shell", "npm"]
@@ -27,6 +28,10 @@ publish-jobs = ["./publish-npm-oidc", "./publish-crates-io"]
 github-custom-job-permissions = { "publish-npm-oidc" = { contents = "read", id-token = "write" }, "publish-crates-io" = { contents = "read", id-token = "write" } }
 # Repository checks that must pass before generated release build and publish jobs.
 plan-jobs = ["./release-checks"]
+# Attest the final, aggregated release files with GitHub's keyless Sigstore identity.
+github-attestations = true
+github-attestations-phase = "host"
+# Omitting filters makes the generated host-phase action attest `artifacts/*`.
 # Whether to install an updater program
 install-updater = true
 
@@ -34,6 +39,7 @@ install-updater = true
 # `dist init` regenerates the workflow.
 [dist.github-action-commits]
 "actions/checkout" = "de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
+"actions/attest-build-provenance" = "96278af6caaf10aea03fd8d33a09a777ca52d62f" # v3.2.0
 "actions/download-artifact" = "37930b1c2abaa49bbe596cd826c3c89aef350131" # v7.0.0
 "actions/setup-node" = "48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e" # v6.4.0
 "actions/upload-artifact" = "b7c566a772e6b6bfb58ed0dc250532a479d7789f" # v6.0.0

--- a/docs/site/content/docs/getting-started/installation.md
+++ b/docs/site/content/docs/getting-started/installation.md
@@ -49,6 +49,24 @@ curl --proto '=https' --tlsv1.2 -LsSf https://github.com/agentty-xyz/agentty/rel
 cargo install agentty
 ```
 
+## Verify a GitHub Release
+
+Install the [GitHub CLI](https://cli.github.com/), then download a GitHub release
+artifact. Each artifact has keyless Sigstore build provenance that identifies Agentty's
+release workflow:
+
+```bash
+gh attestation verify PATH_TO_ARTIFACT --repo agentty-xyz/agentty
+```
+
+Release immutability also protects the published tag and complete asset set. Verify a
+specific release and a downloaded asset with:
+
+```bash
+gh release verify vX.Y.Z --repo agentty-xyz/agentty
+gh release verify-asset vX.Y.Z PATH_TO_ARTIFACT --repo agentty-xyz/agentty
+```
+
 ## Prepare an Agent Backend
 
 Agentty also requires at least one supported agent CLI on your `PATH`. Install and


### PR DESCRIPTION
- The release workflow generates keyless Sigstore provenance for aggregated GitHub release artifacts and attaches a Scorecard-discoverable bundle.
- The release workflow uploads the complete asset set through a retry-safe draft before publishing it.
- The installation guide documents GitHub release, asset, and provenance verification.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)