### PR TITLE
Simplify forge review request adapter workflows

### DIFF
--- a/crates/ag-forge/src/adapter_common.rs
+++ b/crates/ag-forge/src/adapter_common.rs
@@ -35,13 +35,13 @@ impl ReviewRequestOperations {
             .command_runner
             .run(command)
             .await
-            .map_err(|error| map_spawn_error(remote, error))?;
+            .map_err(|error| Self::map_spawn_error(remote, error))?;
         if output.success() {
             return Ok(());
         }
 
         let detail = command_output_detail(&output);
-        if looks_like_host_resolution_failure(&detail) {
+        if Self::looks_like_host_resolution_failure(&detail) {
             return Err(ReviewRequestError::HostResolutionFailed {
                 forge_kind: remote.forge_kind,
                 host: remote.host.clone(),
@@ -82,20 +82,20 @@ impl ReviewRequestOperations {
             .command_runner
             .run(command)
             .await
-            .map_err(|error| map_spawn_error(remote, error))?;
+            .map_err(|error| Self::map_spawn_error(remote, error))?;
         if output.success() {
             return Ok(output);
         }
 
         let detail = command_output_detail(&output);
-        if looks_like_host_resolution_failure(&detail) {
+        if Self::looks_like_host_resolution_failure(&detail) {
             return Err(ReviewRequestError::HostResolutionFailed {
                 forge_kind: remote.forge_kind,
                 host: remote.host.clone(),
             });
         }
 
-        if looks_like_authentication_failure(&detail, remote.forge_kind) {
+        if Self::looks_like_authentication_failure(&detail, remote.forge_kind) {
             return Err(ReviewRequestError::AuthenticationRequired {
                 detail: Some(detail),
                 forge_kind: remote.forge_kind,
@@ -109,35 +109,8 @@ impl ReviewRequestOperations {
         ))
     }
 
-    /// Finds one review request by source branch, then refreshes its full
-    /// summary.
-    pub(crate) async fn find_by_source_branch(
-        &self,
-        remote: ForgeRemote,
-        lookup_command: ForgeCommand,
-        operation: &str,
-        parse_lookup_display_id: impl FnOnce(&str) -> Result<Option<String>, String>,
-        refresh_review_request: impl FnOnce(
-            ForgeRemote,
-            String,
-        ) -> ForgeFuture<
-            Result<ReviewRequestSummary, ReviewRequestError>,
-        >,
-    ) -> Result<Option<ReviewRequestSummary>, ReviewRequestError> {
-        let output = self
-            .run_review_command(&remote, lookup_command, operation)
-            .await?;
-        let display_id =
-            map_parse_error(remote.forge_kind, parse_lookup_display_id(&output.stdout))?;
-
-        let Some(display_id) = display_id else {
-            return Ok(None);
-        };
-
-        refresh_review_request(remote, display_id).await.map(Some)
-    }
-
-    /// Builds a source-branch lookup future for adapter trait implementations.
+    /// Finds one review request by source branch, then builds an owned future
+    /// that refreshes its full summary for adapter trait implementations.
     pub(crate) fn find_by_source_branch_future(
         &self,
         remote: ForgeRemote,
@@ -157,43 +130,22 @@ impl ReviewRequestOperations {
 
         Box::pin(async move {
             let lookup_command = lookup_command(&remote, &source_branch);
+            let output = operations
+                .run_review_command(&remote, lookup_command, operation)
+                .await?;
+            let display_id =
+                map_parse_error(remote.forge_kind, parse_lookup_display_id(&output.stdout))?;
 
-            operations
-                .find_by_source_branch(
-                    remote,
-                    lookup_command,
-                    operation,
-                    parse_lookup_display_id,
-                    refresh_review_request,
-                )
-                .await
+            let Some(display_id) = display_id else {
+                return Ok(None);
+            };
+
+            refresh_review_request(remote, display_id).await.map(Some)
         })
     }
 
-    /// Refreshes one review request by provider display id.
-    pub(crate) async fn refresh_review_request(
-        &self,
-        remote: ForgeRemote,
-        display_id: String,
-        parse_display_id: impl FnOnce(&str) -> Result<String, ReviewRequestError>,
-        view_command: impl FnOnce(&ForgeRemote, &str) -> ForgeCommand,
-        operation: &str,
-        parse_view_response: impl FnOnce(&str) -> Result<ReviewRequestSummary, String>,
-    ) -> Result<ReviewRequestSummary, ReviewRequestError> {
-        let command_display_id = parse_display_id(&display_id)?;
-        let output = self
-            .run_review_command(
-                &remote,
-                view_command(&remote, &command_display_id),
-                operation,
-            )
-            .await?;
-
-        map_parse_error(remote.forge_kind, parse_view_response(&output.stdout))
-    }
-
-    /// Builds a review-request refresh future for adapter trait
-    /// implementations.
+    /// Refreshes one review request by provider display id in an owned future
+    /// for adapter trait implementations.
     pub(crate) fn refresh_review_request_future(
         &self,
         remote: ForgeRemote,
@@ -206,66 +158,28 @@ impl ReviewRequestOperations {
         let operations = self.clone();
 
         Box::pin(async move {
-            operations
-                .refresh_review_request(
-                    remote,
-                    display_id,
-                    parse_display_id,
-                    view_command,
+            let command_display_id = parse_display_id(&display_id)?;
+            let output = operations
+                .run_review_command(
+                    &remote,
+                    view_command(&remote, &command_display_id),
                     operation,
-                    parse_view_response,
                 )
-                .await
+                .await?;
+
+            map_parse_error(remote.forge_kind, parse_view_response(&output.stdout))
         })
     }
 
     /// Synchronizes review-request metadata when the remote values differ
-    /// from `input`, then refreshes the full summary.
-    pub(crate) async fn sync_review_request_metadata<Metadata>(
-        &self,
-        remote: ForgeRemote,
-        display_id: String,
-        input: UpdateReviewRequestInput,
-        config: SyncReviewRequestMetadataConfig<Metadata>,
-        refresh_review_request: impl FnOnce(
-            ForgeRemote,
-            String,
-        ) -> ForgeFuture<
-            Result<ReviewRequestSummary, ReviewRequestError>,
-        >,
-    ) -> Result<ReviewRequestSummary, ReviewRequestError> {
-        let command_display_id = (config.parse_display_id)(&display_id)?;
-        let output = self
-            .run_review_command(
-                &remote,
-                (config.view_metadata_command)(&remote, &command_display_id),
-                config.view_operation,
-            )
-            .await?;
-        let metadata = map_parse_error(
-            remote.forge_kind,
-            (config.parse_metadata_response)(&output.stdout),
-        )?;
-
-        if (config.requires_update)(&metadata, &input) {
-            self.run_review_command(
-                &remote,
-                (config.edit_metadata_command)(&remote, &command_display_id, &input),
-                config.edit_operation,
-            )
-            .await?;
-        }
-
-        refresh_review_request(remote, display_id).await
-    }
-
-    /// Builds a metadata sync future for adapter trait implementations.
+    /// from `input`, then refreshes the full summary in an owned future for
+    /// adapter trait implementations.
     pub(crate) fn sync_review_request_metadata_future<Metadata: Send + 'static>(
         &self,
         remote: ForgeRemote,
         display_id: String,
         input: UpdateReviewRequestInput,
-        config: SyncReviewRequestMetadataConfig<Metadata>,
+        config: &SyncReviewRequestMetadataConfig<Metadata>,
         refresh_review_request: impl FnOnce(
             ForgeRemote,
             String,
@@ -274,45 +188,43 @@ impl ReviewRequestOperations {
         > + Send
         + 'static,
     ) -> ForgeFuture<Result<ReviewRequestSummary, ReviewRequestError>> {
+        let edit_metadata_command = config.edit_metadata_command;
+        let edit_operation = config.edit_operation;
+        let parse_display_id = config.parse_display_id;
+        let parse_metadata_response = config.parse_metadata_response;
+        let requires_update = config.requires_update;
+        let view_metadata_command = config.view_metadata_command;
+        let view_operation = config.view_operation;
         let operations = self.clone();
 
         Box::pin(async move {
-            operations
-                .sync_review_request_metadata(
-                    remote,
-                    display_id,
-                    input,
-                    config,
-                    refresh_review_request,
+            let command_display_id = parse_display_id(&display_id)?;
+            let output = operations
+                .run_review_command(
+                    &remote,
+                    view_metadata_command(&remote, &command_display_id),
+                    view_operation,
                 )
-                .await
+                .await?;
+            let metadata =
+                map_parse_error(remote.forge_kind, parse_metadata_response(&output.stdout))?;
+
+            if requires_update(&metadata, &input) {
+                operations
+                    .run_review_command(
+                        &remote,
+                        edit_metadata_command(&remote, &command_display_id, &input),
+                        edit_operation,
+                    )
+                    .await?;
+            }
+
+            refresh_review_request(remote, display_id).await
         })
     }
 
-    /// Fetches and parses one review-comment snapshot.
-    pub(crate) async fn fetch_review_comment_snapshot(
-        &self,
-        remote: ForgeRemote,
-        display_id: String,
-        parse_display_id: impl FnOnce(&str) -> Result<String, ReviewRequestError>,
-        snapshot_command: impl FnOnce(&ForgeRemote, &str) -> ForgeCommand,
-        operation: &str,
-        parse_snapshot_response: impl FnOnce(&str) -> Result<ReviewCommentSnapshot, String>,
-    ) -> Result<ReviewCommentSnapshot, ReviewRequestError> {
-        let command_display_id = parse_display_id(&display_id)?;
-        let output = self
-            .run_review_command(
-                &remote,
-                snapshot_command(&remote, &command_display_id),
-                operation,
-            )
-            .await?;
-
-        map_parse_error(remote.forge_kind, parse_snapshot_response(&output.stdout))
-    }
-
-    /// Builds a review-comment snapshot future for adapter trait
-    /// implementations.
+    /// Fetches and parses one review-comment snapshot in an owned future for
+    /// adapter trait implementations.
     pub(crate) fn fetch_review_comment_snapshot_future(
         &self,
         remote: ForgeRemote,
@@ -325,37 +237,21 @@ impl ReviewRequestOperations {
         let operations = self.clone();
 
         Box::pin(async move {
-            operations
-                .fetch_review_comment_snapshot(
-                    remote,
-                    display_id,
-                    parse_display_id,
-                    snapshot_command,
+            let command_display_id = parse_display_id(&display_id)?;
+            let output = operations
+                .run_review_command(
+                    &remote,
+                    snapshot_command(&remote, &command_display_id),
                     operation,
-                    parse_snapshot_response,
                 )
-                .await
+                .await?;
+
+            map_parse_error(remote.forge_kind, parse_snapshot_response(&output.stdout))
         })
     }
 
-    /// Runs one requested-review list command and parses normalized rows.
-    pub(crate) async fn list_requested_reviews(
-        &self,
-        remote: ForgeRemote,
-        command: ForgeCommand,
-        operation: &str,
-        parse_requested_reviews: impl FnOnce(&str, &ForgeRemote) -> Result<Vec<RequestedReview>, String>,
-    ) -> Result<Vec<RequestedReview>, ReviewRequestError> {
-        let output = self.run_review_command(&remote, command, operation).await?;
-
-        map_parse_error(
-            remote.forge_kind,
-            parse_requested_reviews(&output.stdout, &remote),
-        )
-    }
-
-    /// Builds a requested-review list future for adapter trait
-    /// implementations.
+    /// Runs one requested-review list command and parses normalized rows in an
+    /// owned future for adapter trait implementations.
     pub(crate) fn list_requested_reviews_future(
         &self,
         remote: ForgeRemote,
@@ -367,11 +263,78 @@ impl ReviewRequestOperations {
 
         Box::pin(async move {
             let command = command(&remote);
+            let output = operations
+                .run_review_command(&remote, command, operation)
+                .await?;
 
-            operations
-                .list_requested_reviews(remote, command, operation, parse_requested_reviews)
-                .await
+            map_parse_error(
+                remote.forge_kind,
+                parse_requested_reviews(&output.stdout, &remote),
+            )
         })
+    }
+
+    /// Maps one spawn-time failure into a normalized review-request error for
+    /// the forge owning `remote`.
+    fn map_spawn_error(remote: &ForgeRemote, error: ForgeCommandError) -> ReviewRequestError {
+        let forge_kind = remote.forge_kind;
+
+        match error {
+            ForgeCommandError::ExecutableNotFound { .. } => {
+                ReviewRequestError::CliNotInstalled { forge_kind }
+            }
+            ForgeCommandError::SpawnFailed { message, .. } => {
+                if Self::looks_like_host_resolution_failure(&message) {
+                    return ReviewRequestError::HostResolutionFailed {
+                        forge_kind,
+                        host: remote.host.clone(),
+                    };
+                }
+
+                ReviewRequestError::OperationFailed {
+                    forge_kind,
+                    message: format!("failed to execute `{}`: {message}", forge_kind.cli_name()),
+                }
+            }
+            ForgeCommandError::TimedOut {
+                executable,
+                timeout,
+            } => ReviewRequestError::OperationFailed {
+                forge_kind,
+                message: format!(
+                    "`{executable}` timed out after {} seconds while contacting {}",
+                    timeout.as_secs(),
+                    remote.host
+                ),
+            },
+        }
+    }
+
+    /// Returns whether `detail` looks like a DNS or host-resolution failure.
+    fn looks_like_host_resolution_failure(detail: &str) -> bool {
+        let normalized_detail = detail.to_ascii_lowercase();
+
+        normalized_detail.contains("no such host")
+            || normalized_detail.contains("name or service not known")
+            || normalized_detail.contains("temporary failure in name resolution")
+            || normalized_detail.contains("could not resolve host")
+            || normalized_detail.contains("lookup ")
+    }
+
+    /// Returns whether `detail` looks like a forge CLI authentication failure.
+    ///
+    /// Parameterized on `forge_kind` so the CLI-specific `{cli} auth login`
+    /// marker stays accurate across forges while the remaining substrings are
+    /// shared.
+    fn looks_like_authentication_failure(detail: &str, forge_kind: ForgeKind) -> bool {
+        let normalized_detail = detail.to_ascii_lowercase();
+        let auth_login_marker = format!("{} auth login", forge_kind.cli_name());
+
+        normalized_detail.contains(&auth_login_marker)
+            || normalized_detail.contains("not logged in")
+            || normalized_detail.contains("authentication failed")
+            || normalized_detail.contains("authentication required")
+            || normalized_detail.contains("http 401")
     }
 }
 
@@ -394,31 +357,23 @@ pub(crate) struct SyncReviewRequestMetadataConfig<Metadata> {
     pub(crate) view_operation: &'static str,
 }
 
-/// Returns whether `detail` looks like a forge CLI authentication failure.
-///
-/// Parameterized on `forge_kind` so the CLI-specific `{cli} auth login`
-/// marker stays accurate across forges while the remaining substrings are
-/// shared.
-pub(crate) fn looks_like_authentication_failure(detail: &str, forge_kind: ForgeKind) -> bool {
-    let normalized_detail = detail.to_ascii_lowercase();
-    let auth_login_marker = format!("{} auth login", forge_kind.cli_name());
-
-    normalized_detail.contains(&auth_login_marker)
-        || normalized_detail.contains("not logged in")
-        || normalized_detail.contains("authentication failed")
-        || normalized_detail.contains("authentication required")
-        || normalized_detail.contains("http 401")
+/// Wraps a provider operation failure with its forge kind.
+pub(crate) fn operation_failed(
+    forge_kind: ForgeKind,
+    message: impl Into<String>,
+) -> ReviewRequestError {
+    ReviewRequestError::OperationFailed {
+        forge_kind,
+        message: message.into(),
+    }
 }
 
-/// Returns whether `detail` looks like a DNS or host-resolution failure.
-pub(crate) fn looks_like_host_resolution_failure(detail: &str) -> bool {
-    let normalized_detail = detail.to_ascii_lowercase();
-
-    normalized_detail.contains("no such host")
-        || normalized_detail.contains("name or service not known")
-        || normalized_detail.contains("temporary failure in name resolution")
-        || normalized_detail.contains("could not resolve host")
-        || normalized_detail.contains("lookup ")
+/// Maps provider parser failures into a normalized operation error.
+pub(crate) fn map_parse_error<T>(
+    forge_kind: ForgeKind,
+    result: Result<T, String>,
+) -> Result<T, ReviewRequestError> {
+    result.map_err(|message| operation_failed(forge_kind, message))
 }
 
 /// Joins one ordered list of status-summary parts into a comma-separated
@@ -445,64 +400,6 @@ pub(crate) fn normalize_provider_label(label: &str) -> String {
     normalized
 }
 
-/// Wraps a provider operation failure with its forge kind.
-pub(crate) fn operation_failed(
-    forge_kind: ForgeKind,
-    message: impl Into<String>,
-) -> ReviewRequestError {
-    ReviewRequestError::OperationFailed {
-        forge_kind,
-        message: message.into(),
-    }
-}
-
-/// Maps provider parser failures into a normalized operation error.
-pub(crate) fn map_parse_error<T>(
-    forge_kind: ForgeKind,
-    result: Result<T, String>,
-) -> Result<T, ReviewRequestError> {
-    result.map_err(|message| operation_failed(forge_kind, message))
-}
-
-/// Maps one spawn-time failure into a normalized review-request error for the
-/// forge owning `remote`.
-pub(crate) fn map_spawn_error(
-    remote: &ForgeRemote,
-    error: ForgeCommandError,
-) -> ReviewRequestError {
-    let forge_kind = remote.forge_kind;
-
-    match error {
-        ForgeCommandError::ExecutableNotFound { .. } => {
-            ReviewRequestError::CliNotInstalled { forge_kind }
-        }
-        ForgeCommandError::SpawnFailed { message, .. } => {
-            if looks_like_host_resolution_failure(&message) {
-                return ReviewRequestError::HostResolutionFailed {
-                    forge_kind,
-                    host: remote.host.clone(),
-                };
-            }
-
-            ReviewRequestError::OperationFailed {
-                forge_kind,
-                message: format!("failed to execute `{}`: {message}", forge_kind.cli_name()),
-            }
-        }
-        ForgeCommandError::TimedOut {
-            executable,
-            timeout,
-        } => ReviewRequestError::OperationFailed {
-            forge_kind,
-            message: format!(
-                "`{executable}` timed out after {} seconds while contacting {}",
-                timeout.as_secs(),
-                remote.host
-            ),
-        },
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -513,7 +410,8 @@ mod tests {
         let detail = "You are not logged into any GitHub hosts. Run `gh auth login`.";
 
         // Act
-        let matched = looks_like_authentication_failure(detail, ForgeKind::GitHub);
+        let matched =
+            ReviewRequestOperations::looks_like_authentication_failure(detail, ForgeKind::GitHub);
 
         // Assert
         assert!(matched);
@@ -525,7 +423,8 @@ mod tests {
         let detail = "You are not logged in. Run `glab auth login`.";
 
         // Act
-        let matched = looks_like_authentication_failure(detail, ForgeKind::GitLab);
+        let matched =
+            ReviewRequestOperations::looks_like_authentication_failure(detail, ForgeKind::GitLab);
 
         // Assert
         assert!(matched);
@@ -537,8 +436,10 @@ mod tests {
         let detail = "HTTP 401 Unauthorized";
 
         // Act
-        let matched_github = looks_like_authentication_failure(detail, ForgeKind::GitHub);
-        let matched_gitlab = looks_like_authentication_failure(detail, ForgeKind::GitLab);
+        let matched_github =
+            ReviewRequestOperations::looks_like_authentication_failure(detail, ForgeKind::GitHub);
+        let matched_gitlab =
+            ReviewRequestOperations::looks_like_authentication_failure(detail, ForgeKind::GitLab);
 
         // Assert
         assert!(matched_github);
@@ -551,7 +452,8 @@ mod tests {
         let detail = "Request failed: rate limit exceeded";
 
         // Act
-        let matched = looks_like_authentication_failure(detail, ForgeKind::GitHub);
+        let matched =
+            ReviewRequestOperations::looks_like_authentication_failure(detail, ForgeKind::GitHub);
 
         // Assert
         assert!(!matched);
@@ -570,7 +472,7 @@ mod tests {
         // Act & Assert
         for detail in details {
             assert!(
-                looks_like_host_resolution_failure(detail),
+                ReviewRequestOperations::looks_like_host_resolution_failure(detail),
                 "expected `{detail}` to match",
             );
         }
@@ -582,10 +484,29 @@ mod tests {
         let detail = "HTTP 500 Internal Server Error";
 
         // Act
-        let matched = looks_like_host_resolution_failure(detail);
+        let matched = ReviewRequestOperations::looks_like_host_resolution_failure(detail);
 
         // Assert
         assert!(!matched);
+    }
+
+    #[test]
+    fn operation_failed_preserves_forge_kind_and_message() {
+        // Arrange
+        let forge_kind = ForgeKind::GitLab;
+        let message = "merge request lookup failed";
+
+        // Act
+        let error = operation_failed(forge_kind, message);
+
+        // Assert
+        assert_eq!(
+            error,
+            ReviewRequestError::OperationFailed {
+                forge_kind,
+                message: message.to_string(),
+            }
+        );
     }
 
     #[test]
@@ -649,7 +570,7 @@ mod tests {
         };
 
         // Act
-        let review_request_error = map_spawn_error(&remote, error);
+        let review_request_error = ReviewRequestOperations::map_spawn_error(&remote, error);
 
         // Assert
         assert_eq!(
@@ -670,7 +591,7 @@ mod tests {
         };
 
         // Act
-        let review_request_error = map_spawn_error(&remote, error);
+        let review_request_error = ReviewRequestOperations::map_spawn_error(&remote, error);
 
         // Assert
         assert_eq!(
@@ -692,7 +613,7 @@ mod tests {
         };
 
         // Act
-        let review_request_error = map_spawn_error(&remote, error);
+        let review_request_error = ReviewRequestOperations::map_spawn_error(&remote, error);
 
         // Assert
         assert_eq!(
@@ -714,7 +635,7 @@ mod tests {
         };
 
         // Act
-        let review_request_error = map_spawn_error(&remote, error);
+        let review_request_error = ReviewRequestOperations::map_spawn_error(&remote, error);
 
         // Assert
         assert_eq!(

--- a/crates/ag-forge/src/client.rs
+++ b/crates/ag-forge/src/client.rs
@@ -132,6 +132,41 @@ impl RealReviewRequestClient {
     pub(crate) fn new(command_runner: Arc<dyn ForgeCommandRunner>) -> Self {
         Self { command_runner }
     }
+
+    /// Runs `call` on an authenticated adapter selected for `remote`.
+    fn call_with_authenticated_adapter<T>(
+        &self,
+        remote: ForgeRemote,
+        call: impl FnOnce(
+            Arc<dyn ReviewRequestAdapter>,
+            ForgeRemote,
+        ) -> ForgeFuture<Result<T, ReviewRequestError>>
+        + Send
+        + 'static,
+    ) -> ForgeFuture<Result<T, ReviewRequestError>>
+    where
+        T: Send + 'static,
+    {
+        let adapter = self.adapter_for(remote.forge_kind);
+
+        Box::pin(async move {
+            adapter.ensure_authenticated(&remote).await?;
+
+            call(adapter, remote).await
+        })
+    }
+
+    /// Returns one adapter implementation for `forge_kind`.
+    fn adapter_for(&self, forge_kind: ForgeKind) -> Arc<dyn ReviewRequestAdapter> {
+        match forge_kind {
+            ForgeKind::GitHub => Arc::new(GitHubReviewRequestAdapter::new(Arc::clone(
+                &self.command_runner,
+            ))),
+            ForgeKind::GitLab => Arc::new(GitLabReviewRequestAdapter::new(Arc::clone(
+                &self.command_runner,
+            ))),
+        }
+    }
 }
 
 impl Default for RealReviewRequestClient {
@@ -251,43 +286,6 @@ impl ReviewRequestClient for RealReviewRequestClient {
     ) -> ForgeFuture<Result<Vec<RequestedReview>, ReviewRequestError>> {
         self.call_with_authenticated_adapter(remote, move |adapter, remote| {
             adapter.list_authenticated_requested_reviews(remote)
-        })
-    }
-}
-
-impl RealReviewRequestClient {
-    /// Returns one adapter implementation for `forge_kind`.
-    fn adapter_for(&self, forge_kind: ForgeKind) -> Arc<dyn ReviewRequestAdapter> {
-        match forge_kind {
-            ForgeKind::GitHub => Arc::new(GitHubReviewRequestAdapter::new(Arc::clone(
-                &self.command_runner,
-            ))),
-            ForgeKind::GitLab => Arc::new(GitLabReviewRequestAdapter::new(Arc::clone(
-                &self.command_runner,
-            ))),
-        }
-    }
-
-    /// Runs `call` on an authenticated adapter selected for `remote`.
-    fn call_with_authenticated_adapter<T>(
-        &self,
-        remote: ForgeRemote,
-        call: impl FnOnce(
-            Arc<dyn ReviewRequestAdapter>,
-            ForgeRemote,
-        ) -> ForgeFuture<Result<T, ReviewRequestError>>
-        + Send
-        + 'static,
-    ) -> ForgeFuture<Result<T, ReviewRequestError>>
-    where
-        T: Send + 'static,
-    {
-        let adapter = self.adapter_for(remote.forge_kind);
-
-        Box::pin(async move {
-            adapter.ensure_authenticated(&remote).await?;
-
-            call(adapter, remote).await
         })
     }
 }

--- a/crates/ag-forge/src/command.rs
+++ b/crates/ag-forge/src/command.rs
@@ -123,6 +123,21 @@ impl ForgeCommandRunner for RealForgeCommandRunner {
     }
 }
 
+/// Extracts the best human-readable error detail from command output.
+pub(crate) fn command_output_detail(output: &ForgeCommandOutput) -> String {
+    let stderr_text = output.stderr.trim();
+    if !stderr_text.is_empty() {
+        return stderr_text.to_string();
+    }
+
+    let stdout_text = output.stdout.trim();
+    if !stdout_text.is_empty() {
+        return stdout_text.to_string();
+    }
+
+    "Unknown forge CLI error".to_string()
+}
+
 /// Runs one forge CLI command and captures stdout, stderr, and exit status.
 async fn run_command(command: ForgeCommand) -> Result<ForgeCommandOutput, ForgeCommandError> {
     run_command_with_timeout(command, FORGE_COMMAND_TIMEOUT).await
@@ -169,21 +184,6 @@ async fn run_command_with_timeout(
         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
         stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
     })
-}
-
-/// Extracts the best human-readable error detail from command output.
-pub(crate) fn command_output_detail(output: &ForgeCommandOutput) -> String {
-    let stderr_text = output.stderr.trim();
-    if !stderr_text.is_empty() {
-        return stderr_text.to_string();
-    }
-
-    let stdout_text = output.stdout.trim();
-    if !stdout_text.is_empty() {
-        return stdout_text.to_string();
-    }
-
-    "Unknown forge CLI error".to_string()
 }
 
 #[cfg(test)]

--- a/crates/ag-forge/src/github.rs
+++ b/crates/ag-forge/src/github.rs
@@ -18,6 +18,15 @@ use super::{
 const REQUESTED_REVIEW_LIMIT: usize = 100;
 /// Maximum assigned-issue rows loaded from `gh` for one refresh.
 const ASSIGNED_ISSUE_LIMIT: usize = 100;
+/// GraphQL query text used to fetch review threads and review-request-wide
+/// conversation comments for one pull request.
+///
+/// Capped at 100 threads per request and 100 comments per thread/PR.
+const REVIEW_THREADS_QUERY: &str =
+    "query($owner: String!, $repo: String!, $number: Int!) { repository(owner: $owner, name: \
+     $repo) { pullRequest(number: $number) { comments(first: 100) { nodes { author { login } body \
+     } } reviewThreads(first: 100) { nodes { diffSide isOutdated isResolved line path startLine \
+     subjectType comments(first: 100) { nodes { author { login } body } } } } } } }";
 
 /// GitHub pull-request adapter that normalizes `gh` command output.
 #[derive(Clone)]
@@ -191,7 +200,7 @@ impl ReviewRequestAdapter for GitHubReviewRequestAdapter {
             remote,
             display_id,
             input,
-            config,
+            &config,
             move |remote, display_id| {
                 adapter.refresh_authenticated_review_request(remote, display_id)
             },
@@ -256,19 +265,6 @@ impl ReviewRequestAdapter for GitHubReviewRequestAdapter {
     }
 }
 
-/// Builds the `gh auth status` command for one GitHub host.
-fn auth_status_command(remote: &ForgeRemote) -> ForgeCommand {
-    github_command(
-        remote,
-        vec![
-            "auth".to_string(),
-            "status".to_string(),
-            "--hostname".to_string(),
-            remote.host.clone(),
-        ],
-    )
-}
-
 /// Builds the project-scoped `gh search issues` command for assigned open
 /// issues.
 fn assigned_issues_command(remote: &ForgeRemote) -> ForgeCommand {
@@ -291,6 +287,23 @@ fn assigned_issues_command(remote: &ForgeRemote) -> ForgeCommand {
     )
 }
 
+/// Parses GitHub issue search rows into normalized assigned-issue rows.
+fn parse_assigned_issues_response(stdout: &str) -> Result<Vec<AssignedIssue>, String> {
+    let issues: Vec<GitHubAssignedIssueResponse> = serde_json::from_str(stdout)
+        .map_err(|error| format!("invalid GitHub assigned-issue response: {error}"))?;
+
+    Ok(issues
+        .into_iter()
+        .map(|issue| AssignedIssue {
+            display_id: format!("#{}", issue.number),
+            repository: issue.repository.name_with_owner,
+            title: issue.title,
+            updated_at: issue.updated_at,
+            web_url: issue.url,
+        })
+        .collect())
+}
+
 /// Builds the project-scoped `gh issue view` command for base issue details.
 fn issue_detail_command(remote: &ForgeRemote, display_id: &str) -> ForgeCommand {
     github_command(
@@ -303,6 +316,41 @@ fn issue_detail_command(remote: &ForgeRemote, display_id: &str) -> ForgeCommand 
             remote.project_path(),
             "--json".to_string(),
             "assignees,author,body,createdAt,labels,number,state,title,updatedAt,url".to_string(),
+        ],
+    )
+}
+
+/// Parses one GitHub issue detail response without comment data.
+fn parse_issue_detail_response(remote: &ForgeRemote, stdout: &str) -> Result<IssueDetail, String> {
+    let issue: GitHubIssueDetailResponse = serde_json::from_str(stdout)
+        .map_err(|error| format!("invalid GitHub issue-detail response: {error}"))?;
+
+    Ok(IssueDetail {
+        assignees: issue.assignees.into_iter().map(|user| user.login).collect(),
+        author: issue
+            .author
+            .map_or_else(|| "ghost".to_string(), |author| author.login),
+        body: issue.body,
+        created_at: issue.created_at,
+        display_id: format!("#{}", issue.number),
+        labels: issue.labels.into_iter().map(|label| label.name).collect(),
+        repository: remote.project_path(),
+        state: issue.state,
+        title: issue.title,
+        updated_at: issue.updated_at,
+        web_url: issue.url,
+    })
+}
+
+/// Builds the `gh auth status` command for one GitHub host.
+fn auth_status_command(remote: &ForgeRemote) -> ForgeCommand {
+    github_command(
+        remote,
+        vec![
+            "auth".to_string(),
+            "status".to_string(),
+            "--hostname".to_string(),
+            remote.host.clone(),
         ],
     )
 }
@@ -333,6 +381,16 @@ fn lookup_command(remote: &ForgeRemote, source_branch: &str) -> ForgeCommand {
     )
 }
 
+/// Parses one optional display id from a GitHub pull-request lookup response.
+fn parse_lookup_display_id(stdout: &str) -> Result<Option<String>, String> {
+    let pull_requests: Vec<GitHubLookupResponse> = serde_json::from_str(stdout)
+        .map_err(|error| format!("invalid GitHub pull-request lookup response: {error}"))?;
+
+    Ok(pull_requests
+        .first()
+        .map(|pull_request| format!("#{}", pull_request.number)))
+}
+
 /// Builds the `gh pr create` command for `input`.
 ///
 /// GitHub pull requests default to draft so session-published review requests
@@ -352,6 +410,102 @@ fn create_command(remote: &ForgeRemote, input: &CreateReviewRequestInput) -> For
             input.source_branch.clone(),
             "--base".to_string(),
             input.target_branch.clone(),
+            "--title".to_string(),
+            input.title.clone(),
+            "--body".to_string(),
+            input.body.clone().unwrap_or_default(),
+        ],
+    )
+}
+
+/// Parses one GitHub pull-request display id into the numeric argument for
+/// `gh`.
+fn parse_display_id(display_id: &str) -> Result<String, ReviewRequestError> {
+    let trimmed = display_id.trim().trim_start_matches('#');
+    if trimmed.is_empty() || !trimmed.chars().all(|character| character.is_ascii_digit()) {
+        return Err(ReviewRequestError::OperationFailed {
+            forge_kind: ForgeKind::GitHub,
+            message: format!("invalid GitHub pull-request display id: `{display_id}`"),
+        });
+    }
+
+    Ok(trimmed.to_string())
+}
+
+/// Builds the `gh pr view` command for one pull-request number.
+fn view_command(remote: &ForgeRemote, pull_request_number: &str) -> ForgeCommand {
+    github_command(
+        remote,
+        vec![
+            "pr".to_string(),
+            "view".to_string(),
+            pull_request_number.to_string(),
+            "--repo".to_string(),
+            remote.project_path(),
+            "--json".to_string(),
+            "number,title,state,url,baseRefName,headRefName,isDraft,mergeStateStatus,\
+             reviewDecision,mergedAt"
+                .to_string(),
+        ],
+    )
+}
+
+/// Parses one pull-request summary from a `gh pr view` JSON response.
+fn parse_view_response(stdout: &str) -> Result<ReviewRequestSummary, String> {
+    let pull_request: GitHubViewResponse = serde_json::from_str(stdout)
+        .map_err(|error| format!("invalid GitHub pull-request view response: {error}"))?;
+    let state = pull_request.review_request_state();
+    let status_summary = pull_request.status_summary();
+
+    Ok(ReviewRequestSummary {
+        display_id: format!("#{}", pull_request.number),
+        forge_kind: ForgeKind::GitHub,
+        source_branch: pull_request.head_ref_name,
+        state,
+        status_summary,
+        target_branch: pull_request.base_ref_name,
+        title: pull_request.title,
+        web_url: pull_request.url,
+    })
+}
+
+/// Builds the `gh pr view` command that reads title/body metadata used for
+/// change detection before editing a pull request.
+fn view_metadata_command(remote: &ForgeRemote, pull_request_number: &str) -> ForgeCommand {
+    github_command(
+        remote,
+        vec![
+            "pr".to_string(),
+            "view".to_string(),
+            pull_request_number.to_string(),
+            "--repo".to_string(),
+            remote.project_path(),
+            "--json".to_string(),
+            "title,body".to_string(),
+        ],
+    )
+}
+
+/// Parses current pull-request title/body metadata from `gh pr view` JSON.
+fn parse_metadata_response(stdout: &str) -> Result<GitHubMetadataResponse, String> {
+    serde_json::from_str(stdout)
+        .map_err(|error| format!("invalid GitHub pull-request metadata response: {error}"))
+}
+
+/// Builds the `gh pr edit` command for updating one pull-request title/body.
+fn edit_metadata_command(
+    remote: &ForgeRemote,
+    pull_request_number: &str,
+    input: &UpdateReviewRequestInput,
+) -> ForgeCommand {
+    github_command(
+        remote,
+        vec![
+            "pr".to_string(),
+            "edit".to_string(),
+            pull_request_number.to_string(),
+            "--repo".to_string(),
+            remote.project_path(),
             "--title".to_string(),
             input.title.clone(),
             "--body".to_string(),
@@ -381,314 +535,6 @@ fn review_threads_command(remote: &ForgeRemote, pull_request_number: &str) -> Fo
         ],
     )
 }
-
-/// Builds the `gh search prs` command for PRs requesting the current user's
-/// review in the selected repository.
-fn requested_reviews_command(remote: &ForgeRemote) -> ForgeCommand {
-    github_command(
-        remote,
-        vec![
-            "search".to_string(),
-            "prs".to_string(),
-            "--review-requested".to_string(),
-            "@me".to_string(),
-            "--state".to_string(),
-            "open".to_string(),
-            "--repo".to_string(),
-            remote.project_path(),
-            "--limit".to_string(),
-            REQUESTED_REVIEW_LIMIT.to_string(),
-            "--json".to_string(),
-            "number,title,body,url,isDraft,updatedAt,author".to_string(),
-        ],
-    )
-}
-
-/// Builds the `gh search prs` command for pull requests requesting review
-/// from the current GitHub user directly, excluding team-only requests.
-fn personal_requested_reviews_command(remote: &ForgeRemote) -> ForgeCommand {
-    github_command(
-        remote,
-        vec![
-            "search".to_string(),
-            "prs".to_string(),
-            "user-review-requested:@me".to_string(),
-            "--state".to_string(),
-            "open".to_string(),
-            "--repo".to_string(),
-            remote.project_path(),
-            "--limit".to_string(),
-            REQUESTED_REVIEW_LIMIT.to_string(),
-            "--json".to_string(),
-            "number,title,body,url,isDraft,updatedAt,author".to_string(),
-        ],
-    )
-}
-
-/// Builds the `gh pr view` command for one pull-request number.
-fn view_command(remote: &ForgeRemote, pull_request_number: &str) -> ForgeCommand {
-    github_command(
-        remote,
-        vec![
-            "pr".to_string(),
-            "view".to_string(),
-            pull_request_number.to_string(),
-            "--repo".to_string(),
-            remote.project_path(),
-            "--json".to_string(),
-            "number,title,state,url,baseRefName,headRefName,isDraft,mergeStateStatus,\
-             reviewDecision,mergedAt"
-                .to_string(),
-        ],
-    )
-}
-
-/// Builds the `gh pr view` command that reads title/body metadata used for
-/// change detection before editing a pull request.
-fn view_metadata_command(remote: &ForgeRemote, pull_request_number: &str) -> ForgeCommand {
-    github_command(
-        remote,
-        vec![
-            "pr".to_string(),
-            "view".to_string(),
-            pull_request_number.to_string(),
-            "--repo".to_string(),
-            remote.project_path(),
-            "--json".to_string(),
-            "title,body".to_string(),
-        ],
-    )
-}
-
-/// Builds the `gh pr edit` command for updating one pull-request title/body.
-fn edit_metadata_command(
-    remote: &ForgeRemote,
-    pull_request_number: &str,
-    input: &UpdateReviewRequestInput,
-) -> ForgeCommand {
-    github_command(
-        remote,
-        vec![
-            "pr".to_string(),
-            "edit".to_string(),
-            pull_request_number.to_string(),
-            "--repo".to_string(),
-            remote.project_path(),
-            "--title".to_string(),
-            input.title.clone(),
-            "--body".to_string(),
-            input.body.clone().unwrap_or_default(),
-        ],
-    )
-}
-
-/// Builds one base `gh` command with deterministic color settings and the
-/// optional session worktree for repository-aware git fallback commands.
-fn github_command(remote: &ForgeRemote, arguments: Vec<String>) -> ForgeCommand {
-    ForgeCommand::new("gh", arguments)
-        .with_environment("CLICOLOR", "0")
-        .with_environment("NO_COLOR", "1")
-        .with_optional_working_directory(remote.command_working_directory.clone())
-}
-
-/// Parses one optional display id from a GitHub pull-request lookup response.
-fn parse_lookup_display_id(stdout: &str) -> Result<Option<String>, String> {
-    let pull_requests: Vec<GitHubLookupResponse> = serde_json::from_str(stdout)
-        .map_err(|error| format!("invalid GitHub pull-request lookup response: {error}"))?;
-
-    Ok(pull_requests
-        .first()
-        .map(|pull_request| format!("#{}", pull_request.number)))
-}
-
-/// Parses one pull-request summary from a `gh pr view` JSON response.
-fn parse_view_response(stdout: &str) -> Result<ReviewRequestSummary, String> {
-    let pull_request: GitHubViewResponse = serde_json::from_str(stdout)
-        .map_err(|error| format!("invalid GitHub pull-request view response: {error}"))?;
-    let state = pull_request.review_request_state();
-    let status_summary = pull_request.status_summary();
-
-    Ok(ReviewRequestSummary {
-        display_id: format!("#{}", pull_request.number),
-        forge_kind: ForgeKind::GitHub,
-        source_branch: pull_request.head_ref_name,
-        state,
-        status_summary,
-        target_branch: pull_request.base_ref_name,
-        title: pull_request.title,
-        web_url: pull_request.url,
-    })
-}
-
-/// Parses current pull-request title/body metadata from `gh pr view` JSON.
-fn parse_metadata_response(stdout: &str) -> Result<GitHubMetadataResponse, String> {
-    serde_json::from_str(stdout)
-        .map_err(|error| format!("invalid GitHub pull-request metadata response: {error}"))
-}
-
-/// Parses GitHub search rows into normalized requested-review rows.
-fn parse_requested_reviews_response(
-    stdout: &str,
-    remote: &ForgeRemote,
-) -> Result<Vec<RequestedReview>, String> {
-    let pull_requests: Vec<GitHubRequestedReviewResponse> = serde_json::from_str(stdout)
-        .map_err(|error| format!("invalid GitHub requested-review response: {error}"))?;
-
-    Ok(pull_requests
-        .into_iter()
-        .map(|pull_request| {
-            let status_summary = if pull_request.is_draft {
-                Some("Draft".to_string())
-            } else {
-                None
-            };
-
-            RequestedReview {
-                audience: RequestedReviewAudience::Personal,
-                author: pull_request
-                    .author
-                    .map_or_else(|| "ghost".to_string(), |author| author.login),
-                body: pull_request.body,
-                comment_snapshot: None,
-                display_id: format!("#{}", pull_request.number),
-                forge_kind: ForgeKind::GitHub,
-                repository: remote.project_path(),
-                status_summary,
-                title: pull_request.title,
-                updated_at: pull_request.updated_at,
-                web_url: pull_request.url,
-            }
-        })
-        .collect())
-}
-
-/// Parses GitHub issue search rows into normalized assigned-issue rows.
-fn parse_assigned_issues_response(stdout: &str) -> Result<Vec<AssignedIssue>, String> {
-    let issues: Vec<GitHubAssignedIssueResponse> = serde_json::from_str(stdout)
-        .map_err(|error| format!("invalid GitHub assigned-issue response: {error}"))?;
-
-    Ok(issues
-        .into_iter()
-        .map(|issue| AssignedIssue {
-            display_id: format!("#{}", issue.number),
-            repository: issue.repository.name_with_owner,
-            title: issue.title,
-            updated_at: issue.updated_at,
-            web_url: issue.url,
-        })
-        .collect())
-}
-
-/// Parses one GitHub issue detail response without comment data.
-fn parse_issue_detail_response(remote: &ForgeRemote, stdout: &str) -> Result<IssueDetail, String> {
-    let issue: GitHubIssueDetailResponse = serde_json::from_str(stdout)
-        .map_err(|error| format!("invalid GitHub issue-detail response: {error}"))?;
-
-    Ok(IssueDetail {
-        assignees: issue.assignees.into_iter().map(|user| user.login).collect(),
-        author: issue
-            .author
-            .map_or_else(|| "ghost".to_string(), |author| author.login),
-        body: issue.body,
-        created_at: issue.created_at,
-        display_id: format!("#{}", issue.number),
-        labels: issue.labels.into_iter().map(|label| label.name).collect(),
-        repository: remote.project_path(),
-        state: issue.state,
-        title: issue.title,
-        updated_at: issue.updated_at,
-        web_url: issue.url,
-    })
-}
-
-/// Merges requested-review rows from both GitHub searches, marking rows as
-/// personal when they appear in the `user-review-requested:@me` result and as
-/// group requests otherwise.
-///
-/// Rows from the broader search keep their original order, while personal-only
-/// rows are appended so brief API timing or pagination differences do not drop
-/// directly requested pull requests from the UI.
-fn categorize_requested_reviews(
-    all_reviews: Vec<RequestedReview>,
-    personal_reviews: &[RequestedReview],
-) -> Vec<RequestedReview> {
-    let personal_urls = personal_reviews
-        .iter()
-        .map(|review| review.web_url.as_str())
-        .collect::<HashSet<_>>();
-    let mut seen_urls = HashSet::new();
-    let mut categorized_reviews = Vec::with_capacity(all_reviews.len().max(personal_reviews.len()));
-
-    for mut review in all_reviews {
-        review.audience = if personal_urls.contains(review.web_url.as_str()) {
-            RequestedReviewAudience::Personal
-        } else {
-            RequestedReviewAudience::Group
-        };
-
-        if seen_urls.insert(review.web_url.clone()) {
-            categorized_reviews.push(review);
-        }
-    }
-
-    for review in personal_reviews {
-        if seen_urls.insert(review.web_url.clone()) {
-            let mut review = review.clone();
-            review.audience = RequestedReviewAudience::Personal;
-            categorized_reviews.push(review);
-        }
-    }
-
-    categorized_reviews
-}
-
-/// Parses one GitHub pull-request display id into the numeric argument for
-/// `gh`.
-fn parse_display_id(display_id: &str) -> Result<String, ReviewRequestError> {
-    let trimmed = display_id.trim().trim_start_matches('#');
-    if trimmed.is_empty() || !trimmed.chars().all(|character| character.is_ascii_digit()) {
-        return Err(ReviewRequestError::OperationFailed {
-            forge_kind: ForgeKind::GitHub,
-            message: format!("invalid GitHub pull-request display id: `{display_id}`"),
-        });
-    }
-
-    Ok(trimmed.to_string())
-}
-
-/// Formats one GitHub merge-state label for the UI.
-fn merge_state_summary(merge_state_status: Option<&str>) -> Option<String> {
-    match merge_state_status {
-        Some("BLOCKED") => Some("Blocked".to_string()),
-        Some("CLEAN") => Some("Mergeable".to_string()),
-        Some("DIRTY") => Some("Conflicts".to_string()),
-        Some("HAS_HOOKS") => Some("Hooks pending".to_string()),
-        Some("UNSTABLE") => Some("Checks pending".to_string()),
-        Some("UNKNOWN") | None => None,
-        Some(other) => Some(normalize_provider_label(other)),
-    }
-}
-
-/// Formats one GitHub review-decision label for the UI.
-fn review_decision_summary(review_decision: Option<&str>) -> Option<String> {
-    match review_decision {
-        Some("APPROVED") => Some("Approved".to_string()),
-        Some("CHANGES_REQUESTED") => Some("Changes requested".to_string()),
-        Some("REVIEW_REQUIRED") => Some("Review required".to_string()),
-        Some(other) => Some(normalize_provider_label(other)),
-        None => None,
-    }
-}
-
-/// GraphQL query text used to fetch review threads and review-request-wide
-/// conversation comments for one pull request.
-///
-/// Capped at 100 threads per request and 100 comments per thread/PR.
-const REVIEW_THREADS_QUERY: &str =
-    "query($owner: String!, $repo: String!, $number: Int!) { repository(owner: $owner, name: \
-     $repo) { pullRequest(number: $number) { comments(first: 100) { nodes { author { login } body \
-     } } reviewThreads(first: 100) { nodes { diffSide isOutdated isResolved line path startLine \
-     subjectType comments(first: 100) { nodes { author { login } body } } } } } } }";
 
 /// Parses the full review-comment snapshot from a GraphQL response.
 ///
@@ -755,16 +601,6 @@ fn review_comment_thread_from_node(node: GitHubReviewThreadNode) -> ReviewCommen
     }
 }
 
-/// Converts one GraphQL comment node into the forge-neutral representation.
-fn review_comment_from_node(node: GitHubReviewCommentNode) -> ReviewComment {
-    ReviewComment {
-        author: node
-            .author
-            .map_or_else(|| "ghost".to_string(), |author| author.login),
-        body: node.body,
-    }
-}
-
 /// Converts GitHub's diff-side labels into Agentty's normalized anchor side.
 fn github_anchor_side(node: &GitHubReviewThreadNode) -> ReviewCommentAnchorSide {
     if node.subject_type == "FILE" || node.line.is_none() {
@@ -775,6 +611,145 @@ fn github_anchor_side(node: &GitHubReviewThreadNode) -> ReviewCommentAnchorSide 
         "LEFT" => ReviewCommentAnchorSide::Old,
         _ => ReviewCommentAnchorSide::New,
     }
+}
+
+/// Converts one GraphQL comment node into the forge-neutral representation.
+fn review_comment_from_node(node: GitHubReviewCommentNode) -> ReviewComment {
+    ReviewComment {
+        author: node
+            .author
+            .map_or_else(|| "ghost".to_string(), |author| author.login),
+        body: node.body,
+    }
+}
+
+/// Builds the `gh search prs` command for PRs requesting the current user's
+/// review in the selected repository.
+fn requested_reviews_command(remote: &ForgeRemote) -> ForgeCommand {
+    github_command(
+        remote,
+        vec![
+            "search".to_string(),
+            "prs".to_string(),
+            "--review-requested".to_string(),
+            "@me".to_string(),
+            "--state".to_string(),
+            "open".to_string(),
+            "--repo".to_string(),
+            remote.project_path(),
+            "--limit".to_string(),
+            REQUESTED_REVIEW_LIMIT.to_string(),
+            "--json".to_string(),
+            "number,title,body,url,isDraft,updatedAt,author".to_string(),
+        ],
+    )
+}
+
+/// Builds the `gh search prs` command for pull requests requesting review
+/// from the current GitHub user directly, excluding team-only requests.
+fn personal_requested_reviews_command(remote: &ForgeRemote) -> ForgeCommand {
+    github_command(
+        remote,
+        vec![
+            "search".to_string(),
+            "prs".to_string(),
+            "user-review-requested:@me".to_string(),
+            "--state".to_string(),
+            "open".to_string(),
+            "--repo".to_string(),
+            remote.project_path(),
+            "--limit".to_string(),
+            REQUESTED_REVIEW_LIMIT.to_string(),
+            "--json".to_string(),
+            "number,title,body,url,isDraft,updatedAt,author".to_string(),
+        ],
+    )
+}
+
+/// Parses GitHub search rows into normalized requested-review rows.
+fn parse_requested_reviews_response(
+    stdout: &str,
+    remote: &ForgeRemote,
+) -> Result<Vec<RequestedReview>, String> {
+    let pull_requests: Vec<GitHubRequestedReviewResponse> = serde_json::from_str(stdout)
+        .map_err(|error| format!("invalid GitHub requested-review response: {error}"))?;
+
+    Ok(pull_requests
+        .into_iter()
+        .map(|pull_request| {
+            let status_summary = if pull_request.is_draft {
+                Some("Draft".to_string())
+            } else {
+                None
+            };
+
+            RequestedReview {
+                audience: RequestedReviewAudience::Personal,
+                author: pull_request
+                    .author
+                    .map_or_else(|| "ghost".to_string(), |author| author.login),
+                body: pull_request.body,
+                comment_snapshot: None,
+                display_id: format!("#{}", pull_request.number),
+                forge_kind: ForgeKind::GitHub,
+                repository: remote.project_path(),
+                status_summary,
+                title: pull_request.title,
+                updated_at: pull_request.updated_at,
+                web_url: pull_request.url,
+            }
+        })
+        .collect())
+}
+
+/// Merges requested-review rows from both GitHub searches, marking rows as
+/// personal when they appear in the `user-review-requested:@me` result and as
+/// group requests otherwise.
+///
+/// Rows from the broader search keep their original order, while personal-only
+/// rows are appended so brief API timing or pagination differences do not drop
+/// directly requested pull requests from the UI.
+fn categorize_requested_reviews(
+    all_reviews: Vec<RequestedReview>,
+    personal_reviews: &[RequestedReview],
+) -> Vec<RequestedReview> {
+    let personal_urls = personal_reviews
+        .iter()
+        .map(|review| review.web_url.as_str())
+        .collect::<HashSet<_>>();
+    let mut seen_urls = HashSet::new();
+    let mut categorized_reviews = Vec::with_capacity(all_reviews.len().max(personal_reviews.len()));
+
+    for mut review in all_reviews {
+        review.audience = if personal_urls.contains(review.web_url.as_str()) {
+            RequestedReviewAudience::Personal
+        } else {
+            RequestedReviewAudience::Group
+        };
+
+        if seen_urls.insert(review.web_url.clone()) {
+            categorized_reviews.push(review);
+        }
+    }
+
+    for review in personal_reviews {
+        if seen_urls.insert(review.web_url.clone()) {
+            let mut review = review.clone();
+            review.audience = RequestedReviewAudience::Personal;
+            categorized_reviews.push(review);
+        }
+    }
+
+    categorized_reviews
+}
+
+/// Builds one base `gh` command with deterministic color settings and the
+/// optional session worktree for repository-aware git fallback commands.
+fn github_command(remote: &ForgeRemote, arguments: Vec<String>) -> ForgeCommand {
+    ForgeCommand::new("gh", arguments)
+        .with_environment("CLICOLOR", "0")
+        .with_environment("NO_COLOR", "1")
+        .with_optional_working_directory(remote.command_working_directory.clone())
 }
 
 /// Minimal GitHub API lookup payload used to find an existing pull request.
@@ -965,15 +940,40 @@ impl GitHubViewResponse {
             parts.push("Draft".to_string());
         }
 
-        if let Some(review_summary) = review_decision_summary(self.review_decision.as_deref()) {
+        if let Some(review_summary) = Self::review_decision_summary(self.review_decision.as_deref())
+        {
             parts.push(review_summary);
         }
 
-        if let Some(merge_summary) = merge_state_summary(self.merge_state_status.as_deref()) {
+        if let Some(merge_summary) = Self::merge_state_summary(self.merge_state_status.as_deref()) {
             parts.push(merge_summary);
         }
 
         status_summary_parts(&parts)
+    }
+
+    /// Formats one GitHub review-decision label for the UI.
+    fn review_decision_summary(review_decision: Option<&str>) -> Option<String> {
+        match review_decision {
+            Some("APPROVED") => Some("Approved".to_string()),
+            Some("CHANGES_REQUESTED") => Some("Changes requested".to_string()),
+            Some("REVIEW_REQUIRED") => Some("Review required".to_string()),
+            Some(other) => Some(normalize_provider_label(other)),
+            None => None,
+        }
+    }
+
+    /// Formats one GitHub merge-state label for the UI.
+    fn merge_state_summary(merge_state_status: Option<&str>) -> Option<String> {
+        match merge_state_status {
+            Some("BLOCKED") => Some("Blocked".to_string()),
+            Some("CLEAN") => Some("Mergeable".to_string()),
+            Some("DIRTY") => Some("Conflicts".to_string()),
+            Some("HAS_HOOKS") => Some("Hooks pending".to_string()),
+            Some("UNSTABLE") => Some("Checks pending".to_string()),
+            Some("UNKNOWN") | None => None,
+            Some(other) => Some(normalize_provider_label(other)),
+        }
     }
 }
 
@@ -1231,6 +1231,24 @@ mod tests {
         assert_eq!(
             review_request.status_summary.as_deref(),
             Some("Approved, Mergeable")
+        );
+    }
+
+    #[test]
+    fn parse_display_id_rejects_invalid_pull_request_reference() {
+        // Arrange
+        let display_id = "#not-a-number";
+
+        // Act
+        let error = parse_display_id(display_id).expect_err("invalid display id should fail");
+
+        // Assert
+        assert_eq!(
+            error,
+            ReviewRequestError::OperationFailed {
+                forge_kind: ForgeKind::GitHub,
+                message: "invalid GitHub pull-request display id: `#not-a-number`".to_string(),
+            }
         );
     }
 
@@ -1495,7 +1513,7 @@ mod tests {
             .expect("GitHub review-comment snapshot fetch should succeed");
 
         // Assert
-        assert_eq!(snapshot.threads.len(), 2);
+        assert_eq!(snapshot.threads.len(), 3);
         let unresolved = &snapshot.threads[0];
         assert_eq!(unresolved.path, "src/foo.rs");
         assert_eq!(unresolved.line, Some(42));
@@ -1512,6 +1530,11 @@ mod tests {
         assert!(resolved.is_resolved);
         assert_eq!(resolved.comments.len(), 1);
         assert_eq!(resolved.comments[0].author, "ghost");
+
+        let file_level = &snapshot.threads[2];
+        assert_eq!(file_level.path, "Cargo.toml");
+        assert_eq!(file_level.line, None);
+        assert_eq!(file_level.anchor_side, ReviewCommentAnchorSide::File);
 
         assert_eq!(snapshot.pr_level_comments.len(), 2);
         assert_eq!(snapshot.pr_level_comments[0].author, "carol");
@@ -1609,6 +1632,42 @@ mod tests {
         );
     }
 
+    #[test]
+    fn github_status_helpers_map_provider_labels() {
+        // Arrange
+        let review_decision_cases = [
+            (Some("APPROVED"), Some("Approved")),
+            (Some("CHANGES_REQUESTED"), Some("Changes requested")),
+            (Some("REVIEW_REQUIRED"), Some("Review required")),
+            (Some("COMMENTED"), Some("Commented")),
+            (None, None),
+        ];
+        let merge_state_cases = [
+            (Some("BLOCKED"), Some("Blocked")),
+            (Some("CLEAN"), Some("Mergeable")),
+            (Some("DIRTY"), Some("Conflicts")),
+            (Some("HAS_HOOKS"), Some("Hooks pending")),
+            (Some("UNSTABLE"), Some("Checks pending")),
+            (Some("UNKNOWN"), None),
+            (Some("BEHIND"), Some("Behind")),
+            (None, None),
+        ];
+
+        // Act & Assert
+        for (status, expected) in review_decision_cases {
+            assert_eq!(
+                GitHubViewResponse::review_decision_summary(status).as_deref(),
+                expected
+            );
+        }
+        for (status, expected) in merge_state_cases {
+            assert_eq!(
+                GitHubViewResponse::merge_state_summary(status).as_deref(),
+                expected
+            );
+        }
+    }
+
     fn github_remote() -> ForgeRemote {
         ForgeRemote {
             command_working_directory: None,
@@ -1693,6 +1752,19 @@ mod tests {
                                                 "url": "https://github.com/agentty-xyz/agentty/pull/42#discussion_r3"
                                             }
                                         ]
+                                    }
+                                },
+                                {
+                                    "id": "thread-3",
+                                    "isResolved": false,
+                                    "isOutdated": false,
+                                    "path": "Cargo.toml",
+                                    "line": null,
+                                    "startLine": null,
+                                    "diffSide": "RIGHT",
+                                    "subjectType": "FILE",
+                                    "comments": {
+                                        "nodes": []
                                     }
                                 }
                             ]

--- a/crates/ag-forge/src/gitlab.rs
+++ b/crates/ag-forge/src/gitlab.rs
@@ -133,7 +133,7 @@ impl ReviewRequestAdapter for GitLabReviewRequestAdapter {
             remote,
             display_id,
             input,
-            config,
+            &config,
             move |remote, display_id| {
                 adapter.refresh_authenticated_review_request(remote, display_id)
             },
@@ -212,6 +212,16 @@ fn lookup_command(remote: &ForgeRemote, source_branch: &str) -> ForgeCommand {
     )
 }
 
+/// Parses one optional display id from a GitLab merge-request lookup response.
+fn parse_lookup_display_id(stdout: &str) -> Result<Option<String>, String> {
+    let merge_requests: Vec<GitLabLookupResponse> = serde_json::from_str(stdout)
+        .map_err(|error| format!("invalid GitLab merge-request lookup response: {error}"))?;
+
+    Ok(merge_requests
+        .first()
+        .map(|merge_request| format!("!{}", merge_request.iid)))
+}
+
 /// Builds the `glab mr create` command for `input`.
 ///
 /// GitLab merge requests default to draft so session-published review requests
@@ -239,115 +249,6 @@ fn create_command(remote: &ForgeRemote, input: &CreateReviewRequestInput) -> For
     )
 }
 
-/// Builds the `glab mr view` command for one merge-request IID.
-fn view_command(remote: &ForgeRemote, merge_request_iid: &str) -> ForgeCommand {
-    gitlab_command(
-        remote,
-        "glab",
-        vec![
-            "mr".to_string(),
-            "view".to_string(),
-            merge_request_iid.to_string(),
-            "--repo".to_string(),
-            remote.web_url.clone(),
-            "--output".to_string(),
-            "json".to_string(),
-        ],
-    )
-}
-
-/// Builds the `glab mr update` command for updating one merge-request
-/// title/description.
-fn update_metadata_command(
-    remote: &ForgeRemote,
-    merge_request_iid: &str,
-    input: &UpdateReviewRequestInput,
-) -> ForgeCommand {
-    gitlab_command(
-        remote,
-        "glab",
-        vec![
-            "mr".to_string(),
-            "update".to_string(),
-            merge_request_iid.to_string(),
-            "--repo".to_string(),
-            remote.web_url.clone(),
-            "--title".to_string(),
-            input.title.clone(),
-            "--description".to_string(),
-            input.body.clone().unwrap_or_default(),
-            "--yes".to_string(),
-        ],
-    )
-}
-
-/// Builds the `glab mr list` command for MRs requesting the current user's
-/// review in the selected repository.
-fn requested_reviews_command(remote: &ForgeRemote) -> ForgeCommand {
-    gitlab_command(
-        remote,
-        "glab",
-        vec![
-            "mr".to_string(),
-            "list".to_string(),
-            "--repo".to_string(),
-            remote.web_url.clone(),
-            "--reviewer".to_string(),
-            "@me".to_string(),
-            "--per-page".to_string(),
-            REQUESTED_REVIEW_LIMIT.to_string(),
-            "--output".to_string(),
-            "json".to_string(),
-        ],
-    )
-}
-
-/// Builds the `glab api` command for merge-request discussions.
-fn discussions_command(remote: &ForgeRemote, merge_request_iid: &str) -> ForgeCommand {
-    let encoded_project_path: String =
-        form_urlencoded::byte_serialize(remote.project_path().as_bytes()).collect();
-    let endpoint = format!(
-        "/projects/{encoded_project_path}/merge_requests/{merge_request_iid}/discussions?\
-         per_page=100"
-    );
-
-    gitlab_command(
-        remote,
-        "glab",
-        vec![
-            "api".to_string(),
-            "--hostname".to_string(),
-            remote.host.clone(),
-            "--paginate".to_string(),
-            endpoint,
-        ],
-    )
-}
-
-/// Builds one base `glab` command with deterministic color settings and the
-/// optional session worktree for repository-aware host detection.
-fn gitlab_command(
-    remote: &ForgeRemote,
-    executable: &'static str,
-    arguments: Vec<String>,
-) -> ForgeCommand {
-    ForgeCommand::new(executable, arguments)
-        .with_environment("CLICOLOR", "0")
-        .with_environment("NO_COLOR", "1")
-        .with_environment("GITLAB_HOST", remote.host.clone())
-        .with_optional_working_directory(remote.command_working_directory.clone())
-}
-
-/// Parses one optional display id from a GitLab merge-request lookup response.
-fn parse_lookup_display_id(stdout: &str) -> Result<Option<String>, String> {
-    let merge_requests: Vec<GitLabLookupResponse> = serde_json::from_str(stdout)
-        .map_err(|error| format!("invalid GitLab merge-request lookup response: {error}"))?;
-
-    Ok(merge_requests
-        .first()
-        .map(|merge_request| format!("!{}", merge_request.iid)))
-}
-
 /// Parses one merge-request display id from `glab mr create` stdout.
 fn parse_create_display_id(stdout: &str) -> Result<String, String> {
     let created_url = stdout
@@ -369,12 +270,47 @@ fn parse_create_display_id(stdout: &str) -> Result<String, String> {
         .get(merge_request_index + 1)
         .ok_or_else(|| "missing merge request iid in create response URL".to_string())?;
     let display_id = format!("!{merge_request_iid}");
-    parse_display_id(&display_id).map_err(|error| match error {
-        ReviewRequestError::OperationFailed { message, .. } => message,
-        _ => "invalid GitLab merge-request display id".to_string(),
-    })?;
+    parse_display_id_value(&display_id)?;
 
     Ok(display_id)
+}
+
+/// Parses one GitLab merge-request display id into the numeric argument for
+/// `glab`.
+fn parse_display_id(display_id: &str) -> Result<String, ReviewRequestError> {
+    parse_display_id_value(display_id).map_err(|message| ReviewRequestError::OperationFailed {
+        forge_kind: ForgeKind::GitLab,
+        message,
+    })
+}
+
+/// Validates one GitLab merge-request display id and returns its numeric value.
+fn parse_display_id_value(display_id: &str) -> Result<String, String> {
+    let trimmed = display_id.trim().trim_start_matches('!');
+    if trimmed.is_empty() || !trimmed.chars().all(|character| character.is_ascii_digit()) {
+        return Err(format!(
+            "invalid GitLab merge-request display id: `{display_id}`"
+        ));
+    }
+
+    Ok(trimmed.to_string())
+}
+
+/// Builds the `glab mr view` command for one merge-request IID.
+fn view_command(remote: &ForgeRemote, merge_request_iid: &str) -> ForgeCommand {
+    gitlab_command(
+        remote,
+        "glab",
+        vec![
+            "mr".to_string(),
+            "view".to_string(),
+            merge_request_iid.to_string(),
+            "--repo".to_string(),
+            remote.web_url.clone(),
+            "--output".to_string(),
+            "json".to_string(),
+        ],
+    )
 }
 
 /// Parses one merge-request summary from a `glab mr view --output json`
@@ -404,50 +340,51 @@ fn parse_metadata_response(stdout: &str) -> Result<GitLabMetadataResponse, Strin
         .map_err(|error| format!("invalid GitLab merge-request metadata response: {error}"))
 }
 
-/// Parses GitLab list rows into normalized requested-review rows.
-///
-/// The current `glab mr list --reviewer @me` surface filters by user reviewer
-/// and does not expose a separate reviewer-group audience for listed rows, so
-/// GitLab requested reviews are normalized as personal requests.
-fn parse_requested_reviews_response(
-    stdout: &str,
+/// Builds the `glab mr update` command for updating one merge-request
+/// title/description.
+fn update_metadata_command(
     remote: &ForgeRemote,
-) -> Result<Vec<RequestedReview>, String> {
-    let merge_requests: Vec<GitLabRequestedReviewResponse> = serde_json::from_str(stdout)
-        .map_err(|error| format!("invalid GitLab requested-review response: {error}"))?;
+    merge_request_iid: &str,
+    input: &UpdateReviewRequestInput,
+) -> ForgeCommand {
+    gitlab_command(
+        remote,
+        "glab",
+        vec![
+            "mr".to_string(),
+            "update".to_string(),
+            merge_request_iid.to_string(),
+            "--repo".to_string(),
+            remote.web_url.clone(),
+            "--title".to_string(),
+            input.title.clone(),
+            "--description".to_string(),
+            input.body.clone().unwrap_or_default(),
+            "--yes".to_string(),
+        ],
+    )
+}
 
-    Ok(merge_requests
-        .into_iter()
-        .map(|merge_request| {
-            let status_summary = if merge_request.draft {
-                Some("Draft".to_string())
-            } else {
-                None
-            };
+/// Builds the `glab api` command for merge-request discussions.
+fn discussions_command(remote: &ForgeRemote, merge_request_iid: &str) -> ForgeCommand {
+    let encoded_project_path: String =
+        form_urlencoded::byte_serialize(remote.project_path().as_bytes()).collect();
+    let endpoint = format!(
+        "/projects/{encoded_project_path}/merge_requests/{merge_request_iid}/discussions?\
+         per_page=100"
+    );
 
-            RequestedReview {
-                audience: RequestedReviewAudience::Personal,
-                author: merge_request.author.map_or_else(
-                    || "unknown".to_string(),
-                    |author| {
-                        author
-                            .username
-                            .or(author.name)
-                            .unwrap_or_else(|| "unknown".to_string())
-                    },
-                ),
-                body: merge_request.description,
-                comment_snapshot: None,
-                display_id: format!("!{}", merge_request.iid),
-                forge_kind: ForgeKind::GitLab,
-                repository: remote.project_path(),
-                status_summary,
-                title: merge_request.title,
-                updated_at: merge_request.updated_at,
-                web_url: merge_request.web_url,
-            }
-        })
-        .collect())
+    gitlab_command(
+        remote,
+        "glab",
+        vec![
+            "api".to_string(),
+            "--hostname".to_string(),
+            remote.host.clone(),
+            "--paginate".to_string(),
+            endpoint,
+        ],
+    )
 }
 
 /// Parses merge-request discussions into inline threads and MR-level comments.
@@ -557,37 +494,85 @@ fn review_comment_from_note(note: GitLabDiscussionNote) -> ReviewComment {
     }
 }
 
-/// Parses one GitLab merge-request display id into the numeric argument for
-/// `glab`.
-fn parse_display_id(display_id: &str) -> Result<String, ReviewRequestError> {
-    let trimmed = display_id.trim().trim_start_matches('!');
-    if trimmed.is_empty() || !trimmed.chars().all(|character| character.is_ascii_digit()) {
-        return Err(ReviewRequestError::OperationFailed {
-            forge_kind: ForgeKind::GitLab,
-            message: format!("invalid GitLab merge-request display id: `{display_id}`"),
-        });
-    }
-
-    Ok(trimmed.to_string())
+/// Builds the `glab mr list` command for MRs requesting the current user's
+/// review in the selected repository.
+fn requested_reviews_command(remote: &ForgeRemote) -> ForgeCommand {
+    gitlab_command(
+        remote,
+        "glab",
+        vec![
+            "mr".to_string(),
+            "list".to_string(),
+            "--repo".to_string(),
+            remote.web_url.clone(),
+            "--reviewer".to_string(),
+            "@me".to_string(),
+            "--per-page".to_string(),
+            REQUESTED_REVIEW_LIMIT.to_string(),
+            "--output".to_string(),
+            "json".to_string(),
+        ],
+    )
 }
 
-/// Formats one GitLab merge-status label for the UI.
-fn merge_status_summary(
-    merge_status: Option<&str>,
-    detailed_merge_status: Option<&str>,
-) -> Option<String> {
-    let status = detailed_merge_status.or(merge_status)?;
+/// Parses GitLab list rows into normalized requested-review rows.
+///
+/// The current `glab mr list --reviewer @me` surface filters by user reviewer
+/// and does not expose a separate reviewer-group audience for listed rows, so
+/// GitLab requested reviews are normalized as personal requests.
+fn parse_requested_reviews_response(
+    stdout: &str,
+    remote: &ForgeRemote,
+) -> Result<Vec<RequestedReview>, String> {
+    let merge_requests: Vec<GitLabRequestedReviewResponse> = serde_json::from_str(stdout)
+        .map_err(|error| format!("invalid GitLab requested-review response: {error}"))?;
 
-    match status {
-        "can_be_merged" | "mergeable" => Some("Mergeable".to_string()),
-        "cannot_be_merged" => Some("Conflicts".to_string()),
-        "cannot_be_merged_recheck" | "checking" | "unchecked" => Some("Checking".to_string()),
-        "ci_still_running" | "commits_status" => Some("Checks pending".to_string()),
-        "ci_must_pass" => Some("Checks required".to_string()),
-        "discussions_not_resolved" => Some("Discussions unresolved".to_string()),
-        "draft_status" | "not_open" => None,
-        other => Some(normalize_provider_label(other)),
-    }
+    Ok(merge_requests
+        .into_iter()
+        .map(|merge_request| {
+            let status_summary = if merge_request.draft {
+                Some("Draft".to_string())
+            } else {
+                None
+            };
+
+            RequestedReview {
+                audience: RequestedReviewAudience::Personal,
+                author: merge_request.author.map_or_else(
+                    || "unknown".to_string(),
+                    |author| {
+                        author
+                            .username
+                            .or(author.name)
+                            .unwrap_or_else(|| "unknown".to_string())
+                    },
+                ),
+                body: merge_request.description,
+                comment_snapshot: None,
+                display_id: format!("!{}", merge_request.iid),
+                forge_kind: ForgeKind::GitLab,
+                repository: remote.project_path(),
+                status_summary,
+                title: merge_request.title,
+                updated_at: merge_request.updated_at,
+                web_url: merge_request.web_url,
+            }
+        })
+        .collect())
+}
+
+/// Builds one base `glab` command with deterministic color settings and the
+/// optional session worktree for repository-aware host detection.
+fn gitlab_command(
+    remote: &ForgeRemote,
+    executable: &'static str,
+    arguments: Vec<String>,
+) -> ForgeCommand {
+    ForgeCommand::new(executable, arguments)
+        .with_environment("CLICOLOR", "0")
+        .with_environment("NO_COLOR", "1")
+        .with_environment("GITLAB_HOST", remote.host.clone())
+        .with_optional_working_directory(remote.command_working_directory.clone())
 }
 
 /// Minimal GitLab list payload used to find an existing merge request.
@@ -639,6 +624,57 @@ struct GitLabViewResponse {
     title: String,
     #[serde(rename = "web_url")]
     web_url: String,
+}
+
+impl GitLabViewResponse {
+    /// Maps GitLab state fields into the normalized review-request state.
+    fn review_request_state(&self) -> ReviewRequestState {
+        if self.merged_at.is_some() || self.state.eq_ignore_ascii_case("merged") {
+            return ReviewRequestState::Merged;
+        }
+
+        if matches!(self.state.as_str(), "closed" | "locked") {
+            return ReviewRequestState::Closed;
+        }
+
+        ReviewRequestState::Open
+    }
+
+    /// Formats the provider-specific status summary for the UI.
+    fn status_summary(&self) -> Option<String> {
+        let mut parts = Vec::new();
+        if self.draft {
+            parts.push("Draft".to_string());
+        }
+
+        if let Some(merge_summary) = Self::merge_status_summary(
+            self.merge_status.as_deref(),
+            self.detailed_merge_status.as_deref(),
+        ) {
+            parts.push(merge_summary);
+        }
+
+        status_summary_parts(&parts)
+    }
+
+    /// Formats one GitLab merge-status label for the UI.
+    fn merge_status_summary(
+        merge_status: Option<&str>,
+        detailed_merge_status: Option<&str>,
+    ) -> Option<String> {
+        let status = detailed_merge_status.or(merge_status)?;
+
+        match status {
+            "can_be_merged" | "mergeable" => Some("Mergeable".to_string()),
+            "cannot_be_merged" => Some("Conflicts".to_string()),
+            "cannot_be_merged_recheck" | "checking" | "unchecked" => Some("Checking".to_string()),
+            "ci_still_running" | "commits_status" => Some("Checks pending".to_string()),
+            "ci_must_pass" => Some("Checks required".to_string()),
+            "discussions_not_resolved" => Some("Discussions unresolved".to_string()),
+            "draft_status" | "not_open" => None,
+            other => Some(normalize_provider_label(other)),
+        }
+    }
 }
 
 /// GitLab merge-request title/description payload returned by
@@ -695,38 +731,6 @@ struct GitLabDiscussionPosition {
     old_line: Option<u32>,
     #[serde(rename = "old_path")]
     old_path: Option<String>,
-}
-
-impl GitLabViewResponse {
-    /// Maps GitLab state fields into the normalized review-request state.
-    fn review_request_state(&self) -> ReviewRequestState {
-        if self.merged_at.is_some() || self.state.eq_ignore_ascii_case("merged") {
-            return ReviewRequestState::Merged;
-        }
-
-        if matches!(self.state.as_str(), "closed" | "locked") {
-            return ReviewRequestState::Closed;
-        }
-
-        ReviewRequestState::Open
-    }
-
-    /// Formats the provider-specific status summary for the UI.
-    fn status_summary(&self) -> Option<String> {
-        let mut parts = Vec::new();
-        if self.draft {
-            parts.push("Draft".to_string());
-        }
-
-        if let Some(merge_summary) = merge_status_summary(
-            self.merge_status.as_deref(),
-            self.detailed_merge_status.as_deref(),
-        ) {
-            parts.push(merge_summary);
-        }
-
-        status_summary_parts(&parts)
-    }
 }
 
 #[cfg(test)]
@@ -1026,6 +1030,102 @@ mod tests {
         );
     }
 
+    #[test]
+    fn parse_requested_reviews_response_defaults_optional_fields() {
+        // Arrange
+        let remote = gitlab_remote();
+        let stdout = r#"[{
+            "iid": 43,
+            "title": "Review parser defaults",
+            "web_url": "https://gitlab.com/agentty-xyz/agentty/-/merge_requests/43"
+        }]"#;
+
+        // Act
+        let requested_reviews = parse_requested_reviews_response(stdout, &remote)
+            .expect("requested-review defaults should parse");
+
+        // Assert
+        assert_eq!(requested_reviews.len(), 1);
+        let requested_review = &requested_reviews[0];
+        assert_eq!(requested_review.author, "unknown");
+        assert_eq!(requested_review.body, None);
+        assert_eq!(requested_review.status_summary, None);
+        assert_eq!(requested_review.updated_at, None);
+    }
+
+    #[test]
+    fn gitlab_view_response_maps_terminal_states() {
+        // Arrange
+        let cases = [
+            (
+                Some("2026-07-16T12:00:00Z"),
+                "opened",
+                ReviewRequestState::Merged,
+            ),
+            (None, "merged", ReviewRequestState::Merged),
+            (None, "closed", ReviewRequestState::Closed),
+            (None, "locked", ReviewRequestState::Closed),
+            (None, "opened", ReviewRequestState::Open),
+        ];
+
+        // Act & Assert
+        for (merged_at, state, expected) in cases {
+            let response = GitLabViewResponse {
+                draft: false,
+                detailed_merge_status: None,
+                iid: 42,
+                merge_status: None,
+                merged_at: merged_at.map(str::to_string),
+                source_branch: "feature/forge".to_string(),
+                state: state.to_string(),
+                target_branch: "main".to_string(),
+                title: "Add forge review support".to_string(),
+                web_url: "https://gitlab.com/agentty-xyz/agentty/-/merge_requests/42".to_string(),
+            };
+
+            assert_eq!(response.review_request_state(), expected);
+        }
+    }
+
+    #[test]
+    fn gitlab_merge_status_summary_maps_provider_labels() {
+        // Arrange
+        let cases = [
+            (Some("can_be_merged"), None, Some("Mergeable")),
+            (Some("mergeable"), None, Some("Mergeable")),
+            (Some("cannot_be_merged"), None, Some("Conflicts")),
+            (Some("cannot_be_merged_recheck"), None, Some("Checking")),
+            (Some("checking"), None, Some("Checking")),
+            (Some("unchecked"), None, Some("Checking")),
+            (Some("ci_still_running"), None, Some("Checks pending")),
+            (Some("commits_status"), None, Some("Checks pending")),
+            (Some("ci_must_pass"), None, Some("Checks required")),
+            (
+                Some("discussions_not_resolved"),
+                None,
+                Some("Discussions unresolved"),
+            ),
+            (Some("draft_status"), None, None),
+            (Some("not_open"), None, None),
+            (Some("needs_rebase"), None, Some("Needs rebase")),
+            (
+                Some("can_be_merged"),
+                Some("cannot_be_merged"),
+                Some("Conflicts"),
+            ),
+            (None, None, None),
+        ];
+
+        // Act & Assert
+        for (merge_status, detailed_merge_status, expected) in cases {
+            assert_eq!(
+                GitLabViewResponse::merge_status_summary(merge_status, detailed_merge_status)
+                    .as_deref(),
+                expected
+            );
+        }
+    }
+
     #[tokio::test]
     async fn fetch_authenticated_review_comment_snapshot_parses_discussions_response() {
         // Arrange
@@ -1109,6 +1209,21 @@ mod tests {
 
         // Assert
         assert_eq!(display_id, "!42");
+    }
+
+    #[test]
+    fn parse_create_display_id_rejects_non_numeric_iid() {
+        // Arrange
+        let stdout = "https://gitlab.com/agentty-xyz/agentty/-/merge_requests/not-a-number\n";
+
+        // Act
+        let error = parse_create_display_id(stdout).expect_err("non-numeric iid should fail");
+
+        // Assert
+        assert_eq!(
+            error,
+            "invalid GitLab merge-request display id: `!not-a-number`"
+        );
     }
 
     #[test]

--- a/crates/ag-forge/src/model.rs
+++ b/crates/ag-forge/src/model.rs
@@ -73,14 +73,6 @@ impl ForgeKind {
     }
 }
 
-/// Returns whether `host` looks like one GitLab instance hostname.
-pub fn is_gitlab_host(host: &str) -> bool {
-    host == "gitlab.com"
-        || host.ends_with(".gitlab.com")
-        || host.starts_with("gitlab.")
-        || host.contains(".gitlab.")
-}
-
 impl fmt::Display for ForgeKind {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(self.as_str())
@@ -97,6 +89,14 @@ impl FromStr for ForgeKind {
             _ => Err(format!("Unknown review-request forge: {value}")),
         }
     }
+}
+
+/// Returns whether `host` looks like one GitLab instance hostname.
+pub fn is_gitlab_host(host: &str) -> bool {
+    host == "gitlab.com"
+        || host.ends_with(".gitlab.com")
+        || host.starts_with("gitlab.")
+        || host.contains(".gitlab.")
 }
 
 /// Normalized remote lifecycle state for one linked review request.
@@ -458,43 +458,6 @@ impl ReviewRequestError {
     }
 }
 
-/// Returns actionable copy for one CLI authentication failure and preserves
-/// the original CLI output when it is available.
-fn authentication_required_message(
-    forge_kind: ForgeKind,
-    host: &str,
-    detail: Option<&str>,
-) -> String {
-    let mut message = format!(
-        "{} review requests require local CLI authentication for `{host}`.\nRun `{}` and retry.",
-        forge_kind.display_name(),
-        forge_kind.auth_login_command(),
-    );
-
-    if let Some(detail) = non_empty_detail(detail) {
-        // Infallible: writing to a String cannot fail.
-        let _ = write!(
-            message,
-            "\n\nOriginal `{}` error:\n```text\n{detail}",
-            forge_kind.cli_name(),
-        );
-        if !detail.ends_with('\n') {
-            message.push('\n');
-        }
-        message.push_str("```");
-    }
-
-    message
-}
-
-/// Returns one trimmed CLI error detail when the captured output is not empty.
-fn non_empty_detail(detail: Option<&str>) -> Option<&str> {
-    detail.and_then(|detail| {
-        let trimmed_detail = detail.trim();
-        (!trimmed_detail.is_empty()).then_some(trimmed_detail)
-    })
-}
-
 /// Builds one GitHub compare URL that opens the new pull-request flow.
 fn github_review_request_creation_url(
     remote: &ForgeRemote,
@@ -563,9 +526,63 @@ fn invalid_web_url_error(remote: &ForgeRemote) -> ReviewRequestError {
     }
 }
 
+/// Returns actionable copy for one CLI authentication failure and preserves
+/// the original CLI output when it is available.
+fn authentication_required_message(
+    forge_kind: ForgeKind,
+    host: &str,
+    detail: Option<&str>,
+) -> String {
+    let mut message = format!(
+        "{} review requests require local CLI authentication for `{host}`.\nRun `{}` and retry.",
+        forge_kind.display_name(),
+        forge_kind.auth_login_command(),
+    );
+
+    if let Some(detail) = non_empty_detail(detail) {
+        // Infallible: writing to a String cannot fail.
+        let _ = write!(
+            message,
+            "\n\nOriginal `{}` error:\n```text\n{detail}",
+            forge_kind.cli_name(),
+        );
+        if !detail.ends_with('\n') {
+            message.push('\n');
+        }
+        message.push_str("```");
+    }
+
+    message
+}
+
+/// Returns one trimmed CLI error detail when the captured output is not empty.
+fn non_empty_detail(detail: Option<&str>) -> Option<&str> {
+    detail.and_then(|detail| {
+        let trimmed_detail = detail.trim();
+        (!trimmed_detail.is_empty()).then_some(trimmed_detail)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn forge_kind_from_str_gitlab() {
+        // Arrange
+        let raw_forge_kind = "GitLab";
+
+        // Act
+        let forge_kind = raw_forge_kind
+            .parse::<ForgeKind>()
+            .expect("gitlab forge kind should parse");
+
+        // Assert
+        assert_eq!(forge_kind, ForgeKind::GitLab);
+        assert_eq!(forge_kind.cli_name(), "glab");
+        assert_eq!(forge_kind.review_request_name(), "merge request");
+        assert_eq!(forge_kind.review_request_short_name(), "MR");
+    }
 
     #[test]
     fn authentication_required_message_includes_original_cli_error_detail() {
@@ -655,23 +672,6 @@ mod tests {
                 message: "repository remote is missing a valid web URL: `not a url`".to_string(),
             }
         );
-    }
-
-    #[test]
-    fn forge_kind_from_str_gitlab() {
-        // Arrange
-        let raw_forge_kind = "GitLab";
-
-        // Act
-        let forge_kind = raw_forge_kind
-            .parse::<ForgeKind>()
-            .expect("gitlab forge kind should parse");
-
-        // Assert
-        assert_eq!(forge_kind, ForgeKind::GitLab);
-        assert_eq!(forge_kind.cli_name(), "glab");
-        assert_eq!(forge_kind.review_request_name(), "merge request");
-        assert_eq!(forge_kind.review_request_short_name(), "MR");
     }
 
     #[test]

--- a/crates/ag-forge/src/remote.rs
+++ b/crates/ag-forge/src/remote.rs
@@ -87,13 +87,6 @@ pub(crate) fn strip_port(host: &str) -> &str {
     host.split(':').next().unwrap_or(host)
 }
 
-/// Removes any `username[:password]@` prefix from one URL authority segment.
-fn strip_userinfo(authority: &str) -> &str {
-    authority
-        .rsplit_once('@')
-        .map_or(authority, |(_, host)| host)
-}
-
 /// Builds one parsed remote from extracted host and path components.
 ///
 /// When `strip_transport_port` is `true`, the parsed host is normalized for
@@ -127,6 +120,13 @@ fn parsed_remote_from_parts(
         repo_url: repo_url.to_string(),
         web_url: format!("https://{host}/{path}"),
     })
+}
+
+/// Removes any `username[:password]@` prefix from one URL authority segment.
+fn strip_userinfo(authority: &str) -> &str {
+    authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Inline review-request operations into owned futures.
- Keep forge-specific error and status helpers scoped to their owning implementations.
- Reorganize parsing and command helpers by module ownership and extend focused coverage.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)