### PR TITLE
Unify clipboard backend initialization and error handling

### DIFF
--- a/crates/ag-clipboard/Cargo.toml
+++ b/crates/ag-clipboard/Cargo.toml
@@ -18,6 +18,8 @@ thiserror.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true
+rustix.workspace = true
+x11rb.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rustix.workspace = true

--- a/crates/ag-clipboard/src/backend.rs
+++ b/crates/ag-clipboard/src/backend.rs
@@ -7,7 +7,7 @@ mod macos;
 mod unsupported;
 #[cfg(any(target_os = "linux", test))]
 mod wayland;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 mod x11;
 
 pub(crate) use contract::ClipboardBackend;

--- a/crates/ag-clipboard/src/backend/wayland.rs
+++ b/crates/ag-clipboard/src/backend/wayland.rs
@@ -10,12 +10,6 @@ use super::ClipboardBackend;
 use crate::{ClipboardError, RgbaImageData, format, uri};
 
 const IMAGE_PNG_MIME: &str = "image/png";
-const TEXT_URI_LIST_MIME: &str = "text/uri-list";
-#[cfg(target_os = "linux")]
-const WL_PASTE_COMMAND: &str = "wl-paste";
-const WL_PASTE_LIST_TYPES_ARGS: &[&str] = &["--list-types"];
-#[cfg(target_os = "linux")]
-const WL_PASTE_VERSION_ARGS: &[&str] = &["--version"];
 const TEXT_MIME_CANDIDATES: &[&str] = &[
     "text/plain;charset=utf-8",
     "text/plain;charset=UTF-8",
@@ -24,6 +18,12 @@ const TEXT_MIME_CANDIDATES: &[&str] = &[
     "TEXT",
     "STRING",
 ];
+const TEXT_URI_LIST_MIME: &str = "text/uri-list";
+#[cfg(target_os = "linux")]
+const WL_PASTE_COMMAND: &str = "wl-paste";
+const WL_PASTE_LIST_TYPES_ARGS: &[&str] = &["--list-types"];
+#[cfg(target_os = "linux")]
+const WL_PASTE_VERSION_ARGS: &[&str] = &["--version"];
 
 pub(crate) struct WaylandClipboard {
     runner: Box<dyn WaylandCommandRunner>,
@@ -55,23 +55,23 @@ impl WaylandClipboard {
         Ok(())
     }
 
-    fn read_clipboard_bytes_for_mime(&self, mime_type: &str) -> Result<Vec<u8>, ClipboardError> {
-        let args = ["--no-newline", "--type", mime_type];
-
-        self.run_successful(&args, "failed to read Wayland clipboard payload")
-    }
-
     fn available_mime_types(&self) -> Result<Vec<String>, ClipboardError> {
         let stdout = self.run_successful(
             WL_PASTE_LIST_TYPES_ARGS,
             "failed to list Wayland clipboard types",
         )?;
-        let mime_types = parse_mime_types(&stdout);
+        let mime_types = Self::parse_mime_types(&stdout);
         if mime_types.is_empty() {
             return Err(ClipboardError::ContentUnavailable);
         }
 
         Ok(mime_types)
+    }
+
+    fn read_clipboard_bytes_for_mime(&self, mime_type: &str) -> Result<Vec<u8>, ClipboardError> {
+        let args = ["--no-newline", "--type", mime_type];
+
+        self.run_successful(&args, "failed to read Wayland clipboard payload")
     }
 
     fn run_successful(
@@ -82,7 +82,7 @@ impl WaylandClipboard {
         let output = self.run_wl_paste(args)?;
         if !output.status_success {
             return Err(ClipboardError::Backend {
-                reason: wl_paste_failure_reason(context, &output.stderr),
+                reason: Self::wl_paste_failure_reason(context, &output.stderr),
             });
         }
 
@@ -97,20 +97,42 @@ impl WaylandClipboard {
 
         self.runner.run(&owned_args)
     }
+
+    fn parse_mime_types(stdout: &[u8]) -> Vec<String> {
+        String::from_utf8_lossy(stdout)
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn wl_paste_failure_reason(context: &str, stderr: &[u8]) -> String {
+        let stderr = String::from_utf8_lossy(stderr).trim().to_string();
+        if stderr.is_empty() {
+            return format!("{context}: `wl-paste` exited unsuccessfully");
+        }
+
+        format!("{context}: {stderr}")
+    }
+
+    fn select_text_mime_type(mime_types: &[String]) -> Option<&str> {
+        TEXT_MIME_CANDIDATES
+            .iter()
+            .find(|candidate| mime_types.iter().any(|mime_type| mime_type == **candidate))
+            .copied()
+    }
 }
 
 impl ClipboardBackend for WaylandClipboard {
     fn read_text(&mut self) -> Result<String, ClipboardError> {
         let mime_types = self.available_mime_types()?;
         let mime_type =
-            select_text_mime_type(&mime_types).ok_or(ClipboardError::ContentUnavailable)?;
+            Self::select_text_mime_type(&mime_types).ok_or(ClipboardError::ContentUnavailable)?;
         let bytes = self.read_clipboard_bytes_for_mime(mime_type)?;
 
         String::from_utf8(bytes).map_err(|error| {
-            ClipboardError::image_conversion(
-                "failed to decode Wayland clipboard text as UTF-8",
-                error,
-            )
+            ClipboardError::backend("failed to decode Wayland clipboard text as UTF-8", error)
         })
     }
 
@@ -188,31 +210,6 @@ fn map_wl_paste_spawn_error(error: io::Error) -> ClipboardError {
     ClipboardError::backend("failed to run `wl-paste`", error)
 }
 
-fn parse_mime_types(stdout: &[u8]) -> Vec<String> {
-    String::from_utf8_lossy(stdout)
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .map(str::to_string)
-        .collect()
-}
-
-fn select_text_mime_type(mime_types: &[String]) -> Option<&str> {
-    TEXT_MIME_CANDIDATES
-        .iter()
-        .find(|candidate| mime_types.iter().any(|mime_type| mime_type == **candidate))
-        .copied()
-}
-
-fn wl_paste_failure_reason(context: &str, stderr: &[u8]) -> String {
-    let stderr = String::from_utf8_lossy(stderr).trim().to_string();
-    if stderr.is_empty() {
-        return format!("{context}: `wl-paste` exited unsuccessfully");
-    }
-
-    format!("{context}: {stderr}")
-}
-
 #[cfg(test)]
 mod tests {
     use image::codecs::png::PngEncoder;
@@ -222,7 +219,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_read_image_rgba_reads_wayland_png_payload() {
+    fn test_run_successful_reports_backend_failure_for_unsuccessful_command() {
         // Arrange
         let mut runner = MockWaylandCommandRunner::new();
         runner
@@ -233,76 +230,25 @@ mod tests {
             }))
             .returning(|_| {
                 Ok(WaylandCommandOutput {
-                    status_success: true,
-                    stderr: Vec::new(),
-                    stdout: b"image/png\ntext/plain;charset=utf-8\n".to_vec(),
+                    status_success: false,
+                    stderr: b"compositor rejected request\n".to_vec(),
+                    stdout: Vec::new(),
                 })
             });
-        runner
-            .expect_run()
-            .once()
-            .with(predicate::function(|args: &[String]| {
-                args_match(args, &["--no-newline", "--type", "image/png"])
-            }))
-            .returning(|_| {
-                Ok(WaylandCommandOutput {
-                    status_success: true,
-                    stderr: Vec::new(),
-                    stdout: test_png_bytes(),
-                })
-            });
-        let mut clipboard = WaylandClipboard::with_runner(Box::new(runner));
+        let clipboard = WaylandClipboard::with_runner(Box::new(runner));
 
         // Act
-        let image_data = clipboard
-            .read_image_rgba()
-            .expect("mocked PNG payload should decode");
+        let result = clipboard.run_successful(
+            WL_PASTE_LIST_TYPES_ARGS,
+            "failed to list Wayland clipboard types",
+        );
 
         // Assert
-        assert_eq!(image_data.width, 1);
-        assert_eq!(image_data.height, 1);
-        assert_eq!(image_data.rgba_bytes, vec![255, 0, 0, 255]);
-    }
-
-    #[test]
-    fn test_read_file_list_reads_wayland_uri_list_payload() {
-        // Arrange
-        let mut runner = MockWaylandCommandRunner::new();
-        runner
-            .expect_run()
-            .once()
-            .with(predicate::function(|args: &[String]| {
-                args_match(args, &["--list-types"])
-            }))
-            .returning(|_| {
-                Ok(WaylandCommandOutput {
-                    status_success: true,
-                    stderr: Vec::new(),
-                    stdout: b"text/uri-list\ntext/plain;charset=utf-8\n".to_vec(),
-                })
-            });
-        runner
-            .expect_run()
-            .once()
-            .with(predicate::function(|args: &[String]| {
-                args_match(args, &["--no-newline", "--type", "text/uri-list"])
-            }))
-            .returning(|_| {
-                Ok(WaylandCommandOutput {
-                    status_success: true,
-                    stderr: Vec::new(),
-                    stdout: b"file:///tmp/image%201.png\r\n".to_vec(),
-                })
-            });
-        let mut clipboard = WaylandClipboard::with_runner(Box::new(runner));
-
-        // Act
-        let paths = clipboard
-            .read_file_list()
-            .expect("mocked URI list should parse");
-
-        // Assert
-        assert_eq!(paths, vec![PathBuf::from("/tmp/image 1.png")]);
+        assert!(matches!(
+            result,
+            Err(ClipboardError::Backend { reason })
+                if reason == "failed to list Wayland clipboard types: compositor rejected request"
+        ));
     }
 
     #[test]
@@ -350,6 +296,136 @@ mod tests {
     }
 
     #[test]
+    fn test_read_text_reports_backend_failure_for_invalid_utf8() {
+        // Arrange
+        let mut runner = MockWaylandCommandRunner::new();
+        runner
+            .expect_run()
+            .once()
+            .with(predicate::function(|args: &[String]| {
+                args_match(args, &["--list-types"])
+            }))
+            .returning(|_| {
+                Ok(WaylandCommandOutput {
+                    status_success: true,
+                    stderr: Vec::new(),
+                    stdout: b"text/plain;charset=utf-8\n".to_vec(),
+                })
+            });
+        runner
+            .expect_run()
+            .once()
+            .with(predicate::function(|args: &[String]| {
+                args_match(
+                    args,
+                    &["--no-newline", "--type", "text/plain;charset=utf-8"],
+                )
+            }))
+            .returning(|_| {
+                Ok(WaylandCommandOutput {
+                    status_success: true,
+                    stderr: Vec::new(),
+                    stdout: vec![0xFF],
+                })
+            });
+        let mut clipboard = WaylandClipboard::with_runner(Box::new(runner));
+
+        // Act
+        let result = clipboard.read_text();
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(ClipboardError::Backend { reason })
+                if reason.starts_with("failed to decode Wayland clipboard text as UTF-8")
+        ));
+    }
+
+    #[test]
+    fn test_read_file_list_reads_wayland_uri_list_payload() {
+        // Arrange
+        let mut runner = MockWaylandCommandRunner::new();
+        runner
+            .expect_run()
+            .once()
+            .with(predicate::function(|args: &[String]| {
+                args_match(args, &["--list-types"])
+            }))
+            .returning(|_| {
+                Ok(WaylandCommandOutput {
+                    status_success: true,
+                    stderr: Vec::new(),
+                    stdout: b"text/uri-list\ntext/plain;charset=utf-8\n".to_vec(),
+                })
+            });
+        runner
+            .expect_run()
+            .once()
+            .with(predicate::function(|args: &[String]| {
+                args_match(args, &["--no-newline", "--type", "text/uri-list"])
+            }))
+            .returning(|_| {
+                Ok(WaylandCommandOutput {
+                    status_success: true,
+                    stderr: Vec::new(),
+                    stdout: b"file:///tmp/image%201.png\r\n".to_vec(),
+                })
+            });
+        let mut clipboard = WaylandClipboard::with_runner(Box::new(runner));
+
+        // Act
+        let paths = clipboard
+            .read_file_list()
+            .expect("mocked URI list should parse");
+
+        // Assert
+        assert_eq!(paths, vec![PathBuf::from("/tmp/image 1.png")]);
+    }
+
+    #[test]
+    fn test_read_image_rgba_reads_wayland_png_payload() {
+        // Arrange
+        let mut runner = MockWaylandCommandRunner::new();
+        runner
+            .expect_run()
+            .once()
+            .with(predicate::function(|args: &[String]| {
+                args_match(args, &["--list-types"])
+            }))
+            .returning(|_| {
+                Ok(WaylandCommandOutput {
+                    status_success: true,
+                    stderr: Vec::new(),
+                    stdout: b"image/png\ntext/plain;charset=utf-8\n".to_vec(),
+                })
+            });
+        runner
+            .expect_run()
+            .once()
+            .with(predicate::function(|args: &[String]| {
+                args_match(args, &["--no-newline", "--type", "image/png"])
+            }))
+            .returning(|_| {
+                Ok(WaylandCommandOutput {
+                    status_success: true,
+                    stderr: Vec::new(),
+                    stdout: test_png_bytes(),
+                })
+            });
+        let mut clipboard = WaylandClipboard::with_runner(Box::new(runner));
+
+        // Act
+        let image_data = clipboard
+            .read_image_rgba()
+            .expect("mocked PNG payload should decode");
+
+        // Assert
+        assert_eq!(image_data.width, 1);
+        assert_eq!(image_data.height, 1);
+        assert_eq!(image_data.rgba_bytes, vec![255, 0, 0, 255]);
+    }
+
+    #[test]
     fn test_read_image_rgba_reports_content_unavailable_without_png_mime() {
         // Arrange
         let mut runner = MockWaylandCommandRunner::new();
@@ -381,7 +457,7 @@ mod tests {
         let stdout = b"\n image/png \n\ntext/plain;charset=utf-8\n";
 
         // Act
-        let mime_types = parse_mime_types(stdout);
+        let mime_types = WaylandClipboard::parse_mime_types(stdout);
 
         // Assert
         assert_eq!(
@@ -399,12 +475,33 @@ mod tests {
         let stderr = b"compositor does not support data-control\n";
 
         // Act
-        let reason = wl_paste_failure_reason("failed to list Wayland clipboard types", stderr);
+        let reason = WaylandClipboard::wl_paste_failure_reason(
+            "failed to list Wayland clipboard types",
+            stderr,
+        );
 
         // Assert
         assert_eq!(
             reason,
             "failed to list Wayland clipboard types: compositor does not support data-control"
+        );
+    }
+
+    #[test]
+    fn test_wl_paste_failure_reason_describes_empty_stderr() {
+        // Arrange
+        let stderr = b"";
+
+        // Act
+        let reason = WaylandClipboard::wl_paste_failure_reason(
+            "failed to list Wayland clipboard types",
+            stderr,
+        );
+
+        // Assert
+        assert_eq!(
+            reason,
+            "failed to list Wayland clipboard types: `wl-paste` exited unsuccessfully"
         );
     }
 

--- a/crates/ag-clipboard/src/backend/x11.rs
+++ b/crates/ag-clipboard/src/backend/x11.rs
@@ -3,14 +3,18 @@ use std::time::{Duration, Instant};
 
 use image::ImageFormat;
 use rustix::event::{self, PollFd, PollFlags, Timespec};
+use x11rb::NONE;
 use x11rb::connection::Connection;
 use x11rb::protocol::Event;
 use x11rb::protocol::xproto::{
-    Atom, ConnectionExt, CreateWindowAux, EventMask, GetPropertyReply, Property,
-    PropertyNotifyEvent, SelectionNotifyEvent, Time, WindowClass,
+    Atom, ConnectionExt, GetPropertyReply, Property, PropertyNotifyEvent, SelectionNotifyEvent,
+    Time,
 };
+#[cfg(target_os = "linux")]
+use x11rb::protocol::xproto::{CreateWindowAux, EventMask, WindowClass};
 use x11rb::rust_connection::RustConnection;
-use x11rb::{COPY_DEPTH_FROM_PARENT, COPY_FROM_PARENT, NONE};
+#[cfg(target_os = "linux")]
+use x11rb::{COPY_DEPTH_FROM_PARENT, COPY_FROM_PARENT};
 
 use super::ClipboardBackend;
 use crate::{ClipboardError, RgbaImageData, format, uri};
@@ -47,6 +51,7 @@ pub(crate) struct X11Clipboard {
 }
 
 impl X11Clipboard {
+    #[cfg(target_os = "linux")]
     pub(crate) fn new() -> Result<Self, ClipboardError> {
         let (connection, screen_number) =
             RustConnection::connect(None).map_err(|error| ClipboardError::Unavailable {
@@ -122,6 +127,14 @@ impl X11Clipboard {
     }
 
     fn read_target(&self, target_format: Atom) -> Result<Vec<u8>, ClipboardError> {
+        self.read_target_with_event_waiter(target_format, Self::wait_for_x11_event)
+    }
+
+    fn read_target_with_event_waiter(
+        &self,
+        target_format: Atom,
+        mut wait_for_event: impl FnMut(&RustConnection, Instant) -> Result<bool, ClipboardError>,
+    ) -> Result<Vec<u8>, ClipboardError> {
         self.connection
             .delete_property(self.window_id, self.atoms.AGENTTY_CLIPBOARD)
             .map_err(|error| {
@@ -152,7 +165,7 @@ impl X11Clipboard {
                 ClipboardError::backend("failed to poll X11 clipboard events", error)
             })?
             else {
-                if !wait_for_x11_event(&self.connection, timeout_end)? {
+                if !wait_for_event(&self.connection, timeout_end)? {
                     break;
                 }
                 continue;
@@ -169,7 +182,7 @@ impl X11Clipboard {
                     SelectionRead::IncrStarted => {
                         let now = Instant::now();
                         incr_transfer_timeout_end = Some(now + INCR_TRANSFER_TIMEOUT);
-                        timeout_end = next_incr_timeout(now, incr_transfer_timeout_end);
+                        timeout_end = Self::next_incr_timeout(now, incr_transfer_timeout_end);
                     }
                     SelectionRead::Ignored => {}
                 },
@@ -226,7 +239,7 @@ impl X11Clipboard {
             .map_err(|error| {
                 ClipboardError::backend("failed to receive X11 clipboard property", error)
             })?;
-        ensure_property_payload_within_limit(&property)?;
+        Self::ensure_property_payload_within_limit(&property)?;
 
         if property.type_ == target_format {
             return Ok(SelectionRead::Complete(property.value));
@@ -250,7 +263,7 @@ impl X11Clipboard {
             .map_err(|error| ClipboardError::backend("failed to read X11 INCR header", error))?
             .reply()
             .map_err(|error| ClipboardError::backend("failed to receive X11 INCR header", error))?;
-        if let Some(minimum_byte_count) = minimum_incr_byte_count(&property) {
+        if let Some(minimum_byte_count) = Self::minimum_incr_byte_count(&property) {
             incr_transfer.reserve_at_least(minimum_byte_count)?;
         }
         *is_incr_transfer = true;
@@ -289,15 +302,86 @@ impl X11Clipboard {
             .map_err(|error| {
                 ClipboardError::backend("failed to receive X11 INCR segment", error)
             })?;
-        ensure_property_payload_within_limit(&property)?;
+        Self::ensure_property_payload_within_limit(&property)?;
         if property.value_len == 0 {
             return Ok(true);
         }
 
         incr_transfer.push_chunk(property.value)?;
-        *timeout_end = next_incr_timeout(Instant::now(), incr_transfer_timeout_end);
+        *timeout_end = Self::next_incr_timeout(Instant::now(), incr_transfer_timeout_end);
 
         Ok(false)
+    }
+
+    fn wait_for_x11_event(
+        connection: &RustConnection,
+        timeout_end: Instant,
+    ) -> Result<bool, ClipboardError> {
+        let mut poll_fds = [PollFd::new(connection.stream(), PollFlags::IN)];
+
+        Self::wait_for_x11_event_with_poller(timeout_end, |timeout| {
+            event::poll(&mut poll_fds, Some(timeout))
+        })
+    }
+
+    fn wait_for_x11_event_with_poller(
+        timeout_end: Instant,
+        poll_events: impl FnOnce(&Timespec) -> rustix::io::Result<usize>,
+    ) -> Result<bool, ClipboardError> {
+        let Some(timeout) = Self::poll_timeout_until(Instant::now(), timeout_end) else {
+            return Ok(false);
+        };
+        let ready_count = poll_events(&timeout).map_err(|error| {
+            ClipboardError::backend("failed to wait for X11 clipboard events", error)
+        })?;
+
+        Ok(ready_count > 0)
+    }
+
+    fn poll_timeout_until(now: Instant, timeout_end: Instant) -> Option<Timespec> {
+        if now >= timeout_end {
+            return None;
+        }
+        let duration = timeout_end.checked_duration_since(now)?;
+
+        Some(Self::duration_to_timespec(duration))
+    }
+
+    fn duration_to_timespec(duration: Duration) -> Timespec {
+        Timespec::try_from(duration).unwrap_or(Timespec {
+            tv_sec: i64::MAX,
+            tv_nsec: 999_999_999,
+        })
+    }
+
+    fn next_incr_timeout(now: Instant, transfer_timeout_end: Option<Instant>) -> Instant {
+        let segment_timeout_end = now + INCR_SEGMENT_TIMEOUT;
+
+        transfer_timeout_end.map_or(segment_timeout_end, |deadline| {
+            segment_timeout_end.min(deadline)
+        })
+    }
+
+    fn ensure_property_payload_within_limit(
+        property: &GetPropertyReply,
+    ) -> Result<(), ClipboardError> {
+        checked_clipboard_byte_count(property.value.len(), property.bytes_after as usize)?;
+
+        Ok(())
+    }
+
+    fn minimum_incr_byte_count(property: &GetPropertyReply) -> Option<u32> {
+        property.value32().and_then(|mut values| values.next())
+    }
+
+    fn latin1_bytes_to_string(bytes: Vec<u8>) -> String {
+        bytes.into_iter().map(char::from).collect()
+    }
+
+    fn utf8_bytes_to_string(bytes: Vec<u8>) -> Result<String, ClipboardError> {
+        String::from_utf8(bytes).map_err(|error| {
+            ClipboardError::backend("failed to decode X11 clipboard text as UTF-8", error)
+        })
     }
 }
 
@@ -313,12 +397,10 @@ impl ClipboardBackend for X11Clipboard {
         ];
         let clipboard_data = self.read_clipboard_data(&target_formats)?;
         if clipboard_data.format == self.atoms.STRING {
-            return Ok(latin1_bytes_to_string(clipboard_data.bytes));
+            return Ok(Self::latin1_bytes_to_string(clipboard_data.bytes));
         }
 
-        String::from_utf8(clipboard_data.bytes).map_err(|error| {
-            ClipboardError::image_conversion("failed to decode X11 clipboard text as UTF-8", error)
-        })
+        Self::utf8_bytes_to_string(clipboard_data.bytes)
     }
 
     fn read_file_list(&mut self) -> Result<Vec<PathBuf>, ClipboardError> {
@@ -388,16 +470,6 @@ impl IncrTransfer {
     }
 }
 
-fn minimum_incr_byte_count(property: &GetPropertyReply) -> Option<u32> {
-    property.value32().and_then(|mut values| values.next())
-}
-
-fn ensure_property_payload_within_limit(property: &GetPropertyReply) -> Result<(), ClipboardError> {
-    checked_clipboard_byte_count(property.value.len(), property.bytes_after as usize)?;
-
-    Ok(())
-}
-
 fn checked_clipboard_byte_count(
     current_byte_count: usize,
     additional_byte_count: usize,
@@ -421,54 +493,440 @@ fn clipboard_payload_too_large(byte_count: usize) -> ClipboardError {
     }
 }
 
-fn wait_for_x11_event(
-    connection: &RustConnection,
-    timeout_end: Instant,
-) -> Result<bool, ClipboardError> {
-    let Some(timeout) = poll_timeout_until(Instant::now(), timeout_end) else {
-        return Ok(false);
-    };
-    let mut poll_fds = [PollFd::new(connection.stream(), PollFlags::IN)];
-    let ready_count = event::poll(&mut poll_fds, Some(&timeout)).map_err(|error| {
-        ClipboardError::backend("failed to wait for X11 clipboard events", error)
-    })?;
-
-    Ok(ready_count > 0)
-}
-
-fn poll_timeout_until(now: Instant, timeout_end: Instant) -> Option<Timespec> {
-    if now >= timeout_end {
-        return None;
-    }
-    let duration = timeout_end.checked_duration_since(now)?;
-
-    Some(duration_to_timespec(duration))
-}
-
-fn duration_to_timespec(duration: Duration) -> Timespec {
-    Timespec::try_from(duration).unwrap_or(Timespec {
-        tv_sec: i64::MAX,
-        tv_nsec: 999_999_999,
-    })
-}
-
-fn next_incr_timeout(now: Instant, transfer_timeout_end: Option<Instant>) -> Instant {
-    let segment_timeout_end = now + INCR_SEGMENT_TIMEOUT;
-
-    transfer_timeout_end.map_or(segment_timeout_end, |deadline| {
-        segment_timeout_end.min(deadline)
-    })
-}
-
-fn latin1_bytes_to_string(bytes: Vec<u8>) -> String {
-    bytes.into_iter().map(char::from).collect()
-}
-
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Write};
+    use std::os::unix::net::UnixStream;
+    use std::thread;
+
+    use x11rb::protocol::xproto::{
+        CONVERT_SELECTION_REQUEST, DELETE_PROPERTY_REQUEST, GET_PROPERTY_REQUEST,
+        PROPERTY_NOTIFY_EVENT, PropertyNotifyEvent, SELECTION_NOTIFY_EVENT, Screen,
+        SelectionNotifyEvent, Setup,
+    };
+    use x11rb::rust_connection::DefaultStream;
+    use x11rb::x11_utils::Serialize;
+
     use super::*;
 
     const MAX_CLIPBOARD_BYTE_COUNT_U32: u32 = 64 * 1024 * 1024;
+    const TEST_WINDOW_ID: u32 = 42;
+
+    struct X11TestServer {
+        server_thread: thread::JoinHandle<()>,
+        writer: UnixStream,
+    }
+
+    impl X11TestServer {
+        fn start(steps: Vec<X11ServerStep>) -> (Self, RustConnection) {
+            let (client_stream, server_stream) =
+                UnixStream::pair().expect("test X11 socket pair should open");
+            let writer = server_stream
+                .try_clone()
+                .expect("test X11 server socket should clone");
+            let server_thread = thread::spawn(move || Self::run(server_stream, steps));
+            let (client_stream, _) = DefaultStream::from_unix_stream(client_stream)
+                .expect("test X11 client stream should initialize");
+            let connection = RustConnection::connect_to_stream(client_stream, 0)
+                .expect("test X11 connection should complete setup");
+
+            (
+                Self {
+                    server_thread,
+                    writer,
+                },
+                connection,
+            )
+        }
+
+        fn run(mut server_stream: UnixStream, steps: Vec<X11ServerStep>) {
+            let mut setup_request = [0; 12];
+            server_stream
+                .read_exact(&mut setup_request)
+                .expect("test X11 server should receive setup request");
+            server_stream
+                .write_all(&Self::setup_bytes())
+                .expect("test X11 server should send setup response");
+
+            for (step_index, step) in steps.into_iter().enumerate() {
+                let opcode = Self::read_request_opcode(&mut server_stream);
+                assert_eq!(opcode, step.expected_opcode);
+                let sequence = u16::try_from(step_index + 1)
+                    .expect("test X11 request sequence should fit in u16");
+                for response in step.responses {
+                    response.write_to(&mut server_stream, sequence);
+                }
+            }
+        }
+
+        fn setup_bytes() -> Vec<u8> {
+            let mut setup = Setup {
+                maximum_request_length: u16::MAX,
+                protocol_major_version: 11,
+                resource_id_base: 0x0100_0000,
+                resource_id_mask: 0x00FF_FFFF,
+                roots: vec![Screen {
+                    root: 1,
+                    ..Screen::default()
+                }],
+                status: 1,
+                ..Setup::default()
+            };
+            setup.length = u16::try_from((setup.serialize().len() - 8) / 4)
+                .expect("test X11 setup length should fit in u16");
+
+            setup.serialize()
+        }
+
+        fn read_request_opcode(server_stream: &mut UnixStream) -> u8 {
+            let mut header = [0; 4];
+            server_stream
+                .read_exact(&mut header)
+                .expect("test X11 server should receive request header");
+            let request_byte_count = usize::from(u16::from_ne_bytes([header[2], header[3]])) * 4;
+            let body_byte_count = request_byte_count
+                .checked_sub(header.len())
+                .expect("test X11 request should include its header");
+            let mut body = vec![0; body_byte_count];
+            server_stream
+                .read_exact(&mut body)
+                .expect("test X11 server should receive request body");
+
+            header[0]
+        }
+
+        fn send_response(&mut self, response: X11ServerResponse) {
+            response.write_to(&mut self.writer, 0);
+        }
+
+        fn finish(self) {
+            drop(self.writer);
+            self.server_thread
+                .join()
+                .expect("test X11 server thread should finish");
+        }
+    }
+
+    struct X11ServerStep {
+        expected_opcode: u8,
+        responses: Vec<X11ServerResponse>,
+    }
+
+    enum X11ServerResponse {
+        GetProperty(GetPropertyReply),
+        PropertyNotify(PropertyNotifyEvent),
+        SelectionNotify(SelectionNotifyEvent),
+    }
+
+    impl X11ServerResponse {
+        fn write_to(self, server_stream: &mut UnixStream, sequence: u16) {
+            let bytes = match self {
+                Self::GetProperty(mut reply) => {
+                    reply.sequence = sequence;
+                    let reply_byte_count = 32 + reply.length as usize * 4;
+                    let mut bytes = reply.serialize();
+                    bytes.resize(reply_byte_count, 0);
+
+                    bytes
+                }
+                Self::PropertyNotify(mut event) => {
+                    event.sequence = sequence;
+                    let mut bytes = event.serialize().to_vec();
+                    bytes.resize(32, 0);
+
+                    bytes
+                }
+                Self::SelectionNotify(mut event) => {
+                    event.sequence = sequence;
+                    let mut bytes = event.serialize().to_vec();
+                    bytes.resize(32, 0);
+
+                    bytes
+                }
+            };
+            server_stream
+                .write_all(&bytes)
+                .expect("test X11 server should send scripted response");
+        }
+    }
+
+    #[test]
+    fn test_read_target_waits_for_delayed_selection_event() {
+        // Arrange
+        let atoms = test_atoms();
+        let target_format = atoms.UTF8_STRING;
+        let steps = vec![
+            server_step(DELETE_PROPERTY_REQUEST, Vec::new()),
+            server_step(CONVERT_SELECTION_REQUEST, Vec::new()),
+            server_step(
+                GET_PROPERTY_REQUEST,
+                vec![property_response(8, target_format, b"delayed".to_vec())],
+            ),
+        ];
+        let (mut server, connection) = X11TestServer::start(steps);
+        let clipboard = X11Clipboard {
+            atoms,
+            connection,
+            window_id: TEST_WINDOW_ID,
+        };
+        let mut wait_call_count = 0;
+
+        // Act
+        let bytes = clipboard
+            .read_target_with_event_waiter(target_format, |_, _| {
+                wait_call_count += 1;
+                server.send_response(selection_response(
+                    atoms,
+                    target_format,
+                    atoms.AGENTTY_CLIPBOARD,
+                ));
+
+                Ok(true)
+            })
+            .expect("delayed X11 selection should be read");
+        drop(clipboard);
+        server.finish();
+
+        // Assert
+        assert_eq!(bytes, b"delayed");
+        assert_eq!(wait_call_count, 1);
+    }
+
+    #[test]
+    fn test_read_target_reassembles_incremental_transfer() {
+        // Arrange
+        let atoms = test_atoms();
+        let target_format = atoms.UTF8_STRING;
+        let steps = vec![
+            server_step(DELETE_PROPERTY_REQUEST, Vec::new()),
+            server_step(
+                CONVERT_SELECTION_REQUEST,
+                vec![selection_response(
+                    atoms,
+                    target_format,
+                    atoms.AGENTTY_CLIPBOARD,
+                )],
+            ),
+            server_step(
+                GET_PROPERTY_REQUEST,
+                vec![property_response(8, atoms.INCR, Vec::new())],
+            ),
+            server_step(
+                GET_PROPERTY_REQUEST,
+                vec![
+                    property_response(32, atoms.INCR, 8_u32.to_ne_bytes().to_vec()),
+                    property_notify_response(atoms),
+                ],
+            ),
+            server_step(
+                GET_PROPERTY_REQUEST,
+                vec![
+                    property_response(8, target_format, b"incremental".to_vec()),
+                    property_notify_response(atoms),
+                ],
+            ),
+            server_step(
+                GET_PROPERTY_REQUEST,
+                vec![property_response(8, target_format, Vec::new())],
+            ),
+        ];
+        let (server, connection) = X11TestServer::start(steps);
+        let clipboard = X11Clipboard {
+            atoms,
+            connection,
+            window_id: TEST_WINDOW_ID,
+        };
+
+        // Act
+        let bytes = clipboard
+            .read_target(target_format)
+            .expect("scripted X11 INCR transfer should complete");
+        drop(clipboard);
+        server.finish();
+
+        // Assert
+        assert_eq!(bytes, b"incremental");
+    }
+
+    #[test]
+    fn test_wait_for_x11_event_reports_ready_connection() {
+        // Arrange
+        let atoms = test_atoms();
+        let (mut server, connection) = X11TestServer::start(Vec::new());
+        server.send_response(selection_response(
+            atoms,
+            atoms.UTF8_STRING,
+            atoms.AGENTTY_CLIPBOARD,
+        ));
+        let timeout_end = Instant::now() + Duration::from_secs(1);
+
+        // Act
+        let is_ready = X11Clipboard::wait_for_x11_event(&connection, timeout_end)
+            .expect("readable test connection should poll successfully");
+        drop(connection);
+        server.finish();
+
+        // Assert
+        assert!(is_ready);
+    }
+
+    #[test]
+    fn test_wait_for_x11_event_returns_false_without_ready_events() {
+        // Arrange
+        let timeout_end = Instant::now() + Duration::from_secs(1);
+
+        // Act
+        let is_ready = X11Clipboard::wait_for_x11_event_with_poller(timeout_end, empty_poller)
+            .expect("empty poll result should not fail");
+
+        // Assert
+        assert!(!is_ready);
+    }
+
+    #[test]
+    fn test_wait_for_x11_event_returns_false_after_deadline() {
+        // Arrange
+        let timeout_end = Instant::now();
+
+        // Act
+        let is_ready = X11Clipboard::wait_for_x11_event_with_poller(timeout_end, empty_poller)
+            .expect("expired deadline should not fail");
+
+        // Assert
+        assert!(!is_ready);
+    }
+
+    #[test]
+    fn test_wait_for_x11_event_reports_poll_failure() {
+        // Arrange
+        let timeout_end = Instant::now() + Duration::from_secs(1);
+
+        // Act
+        let result = X11Clipboard::wait_for_x11_event_with_poller(timeout_end, |_| {
+            Err(rustix::io::Errno::INVAL)
+        });
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(ClipboardError::Backend { reason })
+                if reason.starts_with("failed to wait for X11 clipboard events")
+        ));
+    }
+
+    #[test]
+    fn test_poll_timeout_until_returns_remaining_duration() {
+        // Arrange
+        let now = Instant::now();
+        let timeout_end = now + Duration::from_millis(1500);
+
+        // Act
+        let timeout = X11Clipboard::poll_timeout_until(now, timeout_end)
+            .expect("deadline should be in future");
+
+        // Assert
+        assert_eq!(timeout.tv_sec, 1);
+        assert_eq!(timeout.tv_nsec, 500_000_000);
+    }
+
+    #[test]
+    fn test_poll_timeout_until_returns_none_after_deadline() {
+        // Arrange
+        let now = Instant::now();
+        let timeout_end = now;
+
+        // Act
+        let timeout = X11Clipboard::poll_timeout_until(now, timeout_end);
+
+        // Assert
+        assert_eq!(timeout, None);
+    }
+
+    #[test]
+    fn test_next_incr_timeout_uses_segment_timeout_without_transfer_cap() {
+        // Arrange
+        let now = Instant::now();
+
+        // Act
+        let timeout_end = X11Clipboard::next_incr_timeout(now, None);
+
+        // Assert
+        assert_eq!(timeout_end, now + INCR_SEGMENT_TIMEOUT);
+    }
+
+    #[test]
+    fn test_next_incr_timeout_caps_segment_timeout_to_transfer_deadline() {
+        // Arrange
+        let now = Instant::now();
+        let transfer_timeout_end = now + Duration::from_millis(50);
+
+        // Act
+        let timeout_end = X11Clipboard::next_incr_timeout(now, Some(transfer_timeout_end));
+
+        // Assert
+        assert_eq!(timeout_end, transfer_timeout_end);
+    }
+
+    #[test]
+    fn test_property_payload_limit_accepts_payload_within_limit() {
+        // Arrange
+        let property = GetPropertyReply {
+            bytes_after: 4,
+            format: 8,
+            length: 1,
+            sequence: 0,
+            type_: 0,
+            value: vec![0],
+            value_len: 1,
+        };
+
+        // Act
+        let result = X11Clipboard::ensure_property_payload_within_limit(&property);
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_property_payload_limit_rejects_payload_above_limit() {
+        // Arrange
+        let property = GetPropertyReply {
+            bytes_after: MAX_CLIPBOARD_BYTE_COUNT_U32,
+            format: 8,
+            length: 0,
+            sequence: 0,
+            type_: 0,
+            value: vec![0],
+            value_len: 1,
+        };
+
+        // Act
+        let result = X11Clipboard::ensure_property_payload_within_limit(&property);
+
+        // Assert
+        assert!(matches!(result, Err(ClipboardError::Backend { .. })));
+    }
+
+    #[test]
+    fn test_minimum_incr_byte_count_reads_first_header_value() {
+        // Arrange
+        let minimum_byte_count = 4096_u32;
+        let property = GetPropertyReply {
+            bytes_after: 0,
+            format: 32,
+            length: 1,
+            sequence: 0,
+            type_: 0,
+            value: minimum_byte_count.to_ne_bytes().to_vec(),
+            value_len: 1,
+        };
+
+        // Act
+        let result = X11Clipboard::minimum_incr_byte_count(&property);
+
+        // Assert
+        assert_eq!(result, Some(minimum_byte_count));
+    }
 
     #[test]
     fn test_latin1_bytes_to_string_maps_bytes_directly_to_unicode_scalars() {
@@ -476,10 +934,103 @@ mod tests {
         let bytes = vec![b'a', 0xE9, b'z'];
 
         // Act
-        let text = latin1_bytes_to_string(bytes);
+        let text = X11Clipboard::latin1_bytes_to_string(bytes);
 
         // Assert
         assert_eq!(text, "a\u{e9}z");
+    }
+
+    #[test]
+    fn test_utf8_bytes_to_string_decodes_valid_utf8() {
+        // Arrange
+        let bytes = "clipboard text".as_bytes().to_vec();
+
+        // Act
+        let text = X11Clipboard::utf8_bytes_to_string(bytes)
+            .expect("valid UTF-8 clipboard text should decode");
+
+        // Assert
+        assert_eq!(text, "clipboard text");
+    }
+
+    #[test]
+    fn test_utf8_bytes_to_string_reports_backend_failure_for_invalid_utf8() {
+        // Arrange
+        let bytes = vec![0xFF];
+
+        // Act
+        let result = X11Clipboard::utf8_bytes_to_string(bytes);
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(ClipboardError::Backend { reason })
+                if reason.starts_with("failed to decode X11 clipboard text as UTF-8")
+        ));
+    }
+
+    #[test]
+    fn test_read_text_decodes_utf8_target() {
+        // Arrange
+        let atoms = test_atoms();
+        let steps = available_target_steps(
+            atoms,
+            atoms.UTF8_STRING,
+            atoms.UTF8_STRING,
+            "clipboard text".as_bytes().to_vec(),
+        );
+        let (server, connection) = X11TestServer::start(steps);
+        let mut clipboard = X11Clipboard {
+            atoms,
+            connection,
+            window_id: TEST_WINDOW_ID,
+        };
+
+        // Act
+        let text = clipboard
+            .read_text()
+            .expect("scripted UTF-8 X11 text should decode");
+        drop(clipboard);
+        server.finish();
+
+        // Assert
+        assert_eq!(text, "clipboard text");
+    }
+
+    #[test]
+    fn test_read_text_decodes_string_target_as_latin1() {
+        // Arrange
+        let atoms = test_atoms();
+        let mut steps = Vec::new();
+        for target_format in [
+            atoms.UTF8_STRING,
+            atoms.UTF8_MIME_LOWER,
+            atoms.UTF8_MIME_UPPER,
+        ] {
+            steps.extend(unavailable_target_steps(atoms, target_format));
+        }
+        steps.extend(available_target_steps(
+            atoms,
+            atoms.STRING,
+            atoms.STRING,
+            vec![0xE9],
+        ));
+        let (server, connection) = X11TestServer::start(steps);
+        let mut clipboard = X11Clipboard {
+            atoms,
+            connection,
+            window_id: TEST_WINDOW_ID,
+        };
+
+        // Act
+        let text = clipboard
+            .read_text()
+            .expect("scripted Latin-1 X11 text should decode");
+        drop(clipboard);
+        server.finish();
+
+        // Assert
+        assert_eq!(text, "\u{e9}");
     }
 
     #[test]
@@ -542,75 +1093,113 @@ mod tests {
         assert!(matches!(result, Err(ClipboardError::Backend { .. })));
     }
 
-    #[test]
-    fn test_property_payload_limit_rejects_payload_above_limit() {
-        // Arrange
-        let property = GetPropertyReply {
-            bytes_after: MAX_CLIPBOARD_BYTE_COUNT_U32,
-            format: 8,
-            length: 0,
+    fn test_atoms() -> AtomCollection {
+        AtomCollection {
+            AGENTTY_CLIPBOARD: 12,
+            CLIPBOARD: 1,
+            INCR: 3,
+            PNG_MIME: 11,
+            STRING: 7,
+            TARGETS: 2,
+            TEXT: 8,
+            TEXT_MIME: 9,
+            URI_LIST: 10,
+            UTF8_MIME_LOWER: 5,
+            UTF8_MIME_UPPER: 6,
+            UTF8_STRING: 4,
+        }
+    }
+
+    fn server_step(expected_opcode: u8, responses: Vec<X11ServerResponse>) -> X11ServerStep {
+        X11ServerStep {
+            expected_opcode,
+            responses,
+        }
+    }
+
+    fn property_response(format: u8, type_: Atom, value: Vec<u8>) -> X11ServerResponse {
+        let bytes_per_value = usize::from(format) / 8;
+        assert_eq!(value.len() % bytes_per_value, 0);
+        let value_len = u32::try_from(value.len() / bytes_per_value)
+            .expect("test X11 property value length should fit in u32");
+        let length = u32::try_from(value.len().div_ceil(4))
+            .expect("test X11 property reply length should fit in u32");
+
+        X11ServerResponse::GetProperty(GetPropertyReply {
+            bytes_after: 0,
+            format,
+            length,
             sequence: 0,
-            type_: 0,
-            value: vec![0],
-            value_len: 1,
+            type_,
+            value,
+            value_len,
+        })
+    }
+
+    fn selection_response(
+        atoms: AtomCollection,
+        target: Atom,
+        property: Atom,
+    ) -> X11ServerResponse {
+        X11ServerResponse::SelectionNotify(SelectionNotifyEvent {
+            property,
+            requestor: TEST_WINDOW_ID,
+            response_type: SELECTION_NOTIFY_EVENT,
+            selection: atoms.CLIPBOARD,
+            target,
+            ..SelectionNotifyEvent::default()
+        })
+    }
+
+    fn property_notify_response(atoms: AtomCollection) -> X11ServerResponse {
+        X11ServerResponse::PropertyNotify(PropertyNotifyEvent {
+            atom: atoms.AGENTTY_CLIPBOARD,
+            response_type: PROPERTY_NOTIFY_EVENT,
+            state: Property::NEW_VALUE,
+            window: TEST_WINDOW_ID,
+            ..PropertyNotifyEvent::default()
+        })
+    }
+
+    fn available_target_steps(
+        atoms: AtomCollection,
+        target_format: Atom,
+        property_type: Atom,
+        value: Vec<u8>,
+    ) -> Vec<X11ServerStep> {
+        vec![
+            server_step(DELETE_PROPERTY_REQUEST, Vec::new()),
+            server_step(
+                CONVERT_SELECTION_REQUEST,
+                vec![selection_response(
+                    atoms,
+                    target_format,
+                    atoms.AGENTTY_CLIPBOARD,
+                )],
+            ),
+            server_step(
+                GET_PROPERTY_REQUEST,
+                vec![property_response(8, property_type, value)],
+            ),
+        ]
+    }
+
+    fn unavailable_target_steps(atoms: AtomCollection, target_format: Atom) -> Vec<X11ServerStep> {
+        vec![
+            server_step(DELETE_PROPERTY_REQUEST, Vec::new()),
+            server_step(
+                CONVERT_SELECTION_REQUEST,
+                vec![selection_response(atoms, target_format, NONE)],
+            ),
+        ]
+    }
+
+    fn empty_poller(_: &Timespec) -> rustix::io::Result<usize> {
+        let immediate_timeout = Timespec {
+            tv_nsec: 0,
+            tv_sec: 0,
         };
 
-        // Act
-        let result = ensure_property_payload_within_limit(&property);
-
-        // Assert
-        assert!(matches!(result, Err(ClipboardError::Backend { .. })));
-    }
-
-    #[test]
-    fn test_next_incr_timeout_uses_segment_timeout_without_transfer_cap() {
-        // Arrange
-        let now = Instant::now();
-
-        // Act
-        let timeout_end = next_incr_timeout(now, None);
-
-        // Assert
-        assert_eq!(timeout_end, now + INCR_SEGMENT_TIMEOUT);
-    }
-
-    #[test]
-    fn test_next_incr_timeout_caps_segment_timeout_to_transfer_deadline() {
-        // Arrange
-        let now = Instant::now();
-        let transfer_timeout_end = now + Duration::from_millis(50);
-
-        // Act
-        let timeout_end = next_incr_timeout(now, Some(transfer_timeout_end));
-
-        // Assert
-        assert_eq!(timeout_end, transfer_timeout_end);
-    }
-
-    #[test]
-    fn test_poll_timeout_until_returns_remaining_duration() {
-        // Arrange
-        let now = Instant::now();
-        let timeout_end = now + Duration::from_millis(1500);
-
-        // Act
-        let timeout = poll_timeout_until(now, timeout_end).expect("deadline should be in future");
-
-        // Assert
-        assert_eq!(timeout.tv_sec, 1);
-        assert_eq!(timeout.tv_nsec, 500_000_000);
-    }
-
-    #[test]
-    fn test_poll_timeout_until_returns_none_after_deadline() {
-        // Arrange
-        let now = Instant::now();
-        let timeout_end = now;
-
-        // Act
-        let timeout = poll_timeout_until(now, timeout_end);
-
-        // Assert
-        assert_eq!(timeout, None);
+        event::poll(&mut [], Some(&immediate_timeout))
     }
 }

--- a/crates/ag-clipboard/src/error.rs
+++ b/crates/ag-clipboard/src/error.rs
@@ -38,7 +38,7 @@ pub enum ClipboardError {
 }
 
 impl ClipboardError {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", test))]
     pub(crate) fn backend(context: &str, error: impl fmt::Display) -> Self {
         Self::Backend {
             reason: format!("{context}: {error}"),

--- a/crates/ag-clipboard/src/lib.rs
+++ b/crates/ag-clipboard/src/lib.rs
@@ -25,32 +25,8 @@ impl Clipboard {
     /// Returns [`ClipboardError::Unavailable`] when no supported clipboard
     /// backend is available for the current display server or operating
     /// system.
-    #[cfg(target_os = "macos")]
     pub fn new() -> Result<Self, ClipboardError> {
-        if let Some(error) = Self::disabled_by_env() {
-            return Err(error);
-        }
-
-        Ok(Self {
-            backend: backend::new_backend(),
-        })
-    }
-
-    /// Opens the best clipboard backend available on the current platform.
-    ///
-    /// # Errors
-    /// Returns [`ClipboardError::Unavailable`] when no supported clipboard
-    /// backend is available for the current display server or operating
-    /// system.
-    #[cfg(not(target_os = "macos"))]
-    pub fn new() -> Result<Self, ClipboardError> {
-        if let Some(error) = Self::disabled_by_env() {
-            return Err(error);
-        }
-
-        Ok(Self {
-            backend: backend::new_backend()?,
-        })
+        Self::new_with_backend(Self::disabled_by_env(), backend::new_backend)
     }
 
     /// Reads clipboard text.
@@ -80,9 +56,179 @@ impl Clipboard {
         self.backend.read_image_rgba()
     }
 
+    fn new_with_backend<B>(
+        disabled_error: Option<ClipboardError>,
+        backend_factory: impl FnOnce() -> B,
+    ) -> Result<Self, ClipboardError>
+    where
+        B: IntoBackendResult,
+    {
+        if let Some(error) = disabled_error {
+            return Err(error);
+        }
+
+        let backend = backend_factory().into_backend_result()?;
+
+        Ok(Self { backend })
+    }
+
     fn disabled_by_env() -> Option<ClipboardError> {
         std::env::var_os(DISABLE_CLIPBOARD_ENV).map(|_| ClipboardError::Unavailable {
             reason: format!("clipboard access is disabled by `{DISABLE_CLIPBOARD_ENV}`"),
+        })
+    }
+}
+
+trait IntoBackendResult {
+    fn into_backend_result(self) -> Result<Box<dyn backend::ClipboardBackend>, ClipboardError>;
+}
+
+impl IntoBackendResult for Box<dyn backend::ClipboardBackend> {
+    fn into_backend_result(self) -> Result<Box<dyn backend::ClipboardBackend>, ClipboardError> {
+        Ok(self)
+    }
+}
+
+impl IntoBackendResult for Result<Box<dyn backend::ClipboardBackend>, ClipboardError> {
+    fn into_backend_result(self) -> Result<Box<dyn backend::ClipboardBackend>, ClipboardError> {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use super::*;
+
+    const DISABLED_CONSTRUCTOR_CHILD_ENV: &str = "AGENTTY_TEST_DISABLED_CONSTRUCTOR_CHILD";
+
+    struct TestClipboardBackend;
+
+    impl backend::ClipboardBackend for TestClipboardBackend {
+        fn read_text(&mut self) -> Result<String, ClipboardError> {
+            Ok("test clipboard text".to_string())
+        }
+
+        fn read_file_list(&mut self) -> Result<Vec<PathBuf>, ClipboardError> {
+            Ok(vec![PathBuf::from("/tmp/test.txt")])
+        }
+
+        fn read_image_rgba(&mut self) -> Result<RgbaImageData, ClipboardError> {
+            Ok(RgbaImageData {
+                height: 1,
+                rgba_bytes: vec![0, 0, 0, 255],
+                width: 1,
+            })
+        }
+    }
+
+    #[test]
+    fn test_new_respects_disable_environment_variable_in_child_process() {
+        if std::env::var_os(DISABLED_CONSTRUCTOR_CHILD_ENV).is_some() {
+            // Arrange
+            let expected_environment_variable = DISABLE_CLIPBOARD_ENV;
+
+            // Act
+            let result = Clipboard::new();
+
+            // Assert
+            assert!(matches!(
+                result,
+                Err(ClipboardError::Unavailable { reason })
+                    if reason.contains(expected_environment_variable)
+            ));
+
+            return;
+        }
+
+        // Arrange
+        let current_test_binary =
+            std::env::current_exe().expect("current test binary path should be available");
+
+        // Act
+        let output = Command::new(current_test_binary)
+            .arg("--exact")
+            .arg("tests::test_new_respects_disable_environment_variable_in_child_process")
+            .arg("--nocapture")
+            .env(DISABLED_CONSTRUCTOR_CHILD_ENV, "1")
+            .env(DISABLE_CLIPBOARD_ENV, "1")
+            .output()
+            .expect("disabled constructor child test should run");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        // Assert
+        assert!(
+            output.status.success(),
+            "disabled constructor child test failed: {stderr}"
+        );
+    }
+
+    #[test]
+    fn test_new_with_backend_respects_disabled_error() {
+        // Arrange
+        let disabled_error = ClipboardError::Unavailable {
+            reason: "test clipboard is disabled".to_string(),
+        };
+        let backend_factory = unavailable_backend_factory;
+
+        // Act
+        let result = Clipboard::new_with_backend(Some(disabled_error), backend_factory);
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(ClipboardError::Unavailable { reason })
+                if reason == "test clipboard is disabled"
+        ));
+    }
+
+    #[test]
+    fn test_new_with_backend_accepts_infallible_backend() {
+        // Arrange
+        let backend_factory =
+            || Box::new(TestClipboardBackend) as Box<dyn backend::ClipboardBackend>;
+
+        // Act
+        let mut clipboard = Clipboard::new_with_backend(None, backend_factory)
+            .expect("infallible test backend should initialize");
+        let text = clipboard
+            .read_text()
+            .expect("test backend should return text");
+        let paths = clipboard
+            .read_file_list()
+            .expect("test backend should return a file list");
+        let image = clipboard
+            .read_image_rgba()
+            .expect("test backend should return image data");
+
+        // Assert
+        assert_eq!(text, "test clipboard text");
+        assert_eq!(paths, vec![PathBuf::from("/tmp/test.txt")]);
+        assert_eq!(image.width, 1);
+        assert_eq!(image.height, 1);
+        assert_eq!(image.rgba_bytes, vec![0, 0, 0, 255]);
+    }
+
+    #[test]
+    fn test_new_with_backend_propagates_backend_error() {
+        // Arrange
+        let backend_factory = unavailable_backend_factory;
+
+        // Act
+        let result = Clipboard::new_with_backend(None, backend_factory);
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(ClipboardError::Unavailable { reason })
+                if reason == "test backend is unavailable"
+        ));
+    }
+
+    fn unavailable_backend_factory() -> Result<Box<dyn backend::ClipboardBackend>, ClipboardError> {
+        Err(ClipboardError::Unavailable {
+            reason: "test backend is unavailable".to_string(),
         })
     }
 }


### PR DESCRIPTION
- Share `Clipboard::new()` setup while preserving platform-specific backend results.
- Report invalid UTF-8 text as backend errors for Wayland and X11.
- Keep backend helpers within their implementations and expand platform backend test coverage.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)