### PR TITLE
Prepare 0.13.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,50 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.13.2] - 2026-07-16
+
+### Added
+
+- agentty: add shared semantic text editing across prompt, clarification,
+  publish-branch, and launch-configuration inputs, including word and line movement,
+  consistent paste behavior, and bounded undo and redo history.
+- security: add a security policy covering supported versions, private vulnerability
+  reporting, response and disclosure timelines, and safe harbor.
+- docs: add the SonarCloud coverage badge to `README.md`.
+
 ### Changed
 
+- agentty: bind pasted image attachments to exact placeholder occurrences and input
+  revisions so editing, undo, redo, and prompt-history navigation preserve the intended
+  images and clean up discarded files safely.
+- agentty: align the activity heatmap with its dashboard panel by deriving panel height
+  from content and removing the redundant legend and summary footer.
+- agentty: render queued follow-up messages after the transcript messages and workflow
+  notices that preceded them.
+- agentty: normalize transcript, queued-message, and workflow-notice spacing to one
+  empty line between visible messages.
 - agentty: keep focused review suggestions aligned with decisions, accepted tradeoffs,
   and explanations already resolved in the session chat.
+- agentty: centralize chat-focus key handling while preserving transcript scrolling,
+  diff preview, prompt draft protection, and question-mode exit behavior.
+- agentty: extract transcript-to-display-line assembly from `SessionOutput`, leaving the
+  component responsible for layout caching, scrolling, loader effects, and painting.
+- deps: update `agent-client-protocol` to `1.2.0` and `serde_with` to `3.21.0`.
+- ci: run SonarQube from coverage jobs with LCOV input and remove the standalone
+  security-scan workflow.
+- ci: update `taiki-e/install-action` from `2.82.10` to `2.82.11`.
+- release: bump workspace crate metadata and lockfile package versions to `0.13.2`.
+
+### Fixed
+
+- agentty: render assigned issue rows with the active theme's text color.
+- ci: grant the Pages workflow the read permissions required by its build steps.
+
+### Contributors
+
+- @andagaev
+- @dependabot
+- @minev-dev
 
 ## [v0.13.1] - 2026-07-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "image",
  "mockall",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "mockall",
  "serde",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "mockall",
  "rustix",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "askama",
  "schemars 1.2.1",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "clap",
  "tempfile",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.13.1"
+version = "0.13.2"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -16,15 +16,15 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.13.1" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.13.1" }
-ag-forge = { path = "crates/ag-forge", version = "0.13.1" }
-ag-git = { path = "crates/ag-git", version = "0.13.1" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.13.1" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.13.1" }
-testty = { path = "crates/testty", version = "0.13.1" }
+ag-agent = { path = "crates/ag-agent", version = "0.13.2" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.13.2" }
+ag-forge = { path = "crates/ag-forge", version = "0.13.2" }
+ag-git = { path = "crates/ag-git", version = "0.13.2" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.13.2" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.13.2" }
+testty = { path = "crates/testty", version = "0.13.2" }
 async-trait = "0.1"
-agent-client-protocol = "1.0.0"
+agent-client-protocol = "1.2.0"
 assert_cmd = "2"
 askama = "0.16.0"
 base64 = "0.22"


### PR DESCRIPTION
- Workspace crate metadata and lockfile package versions move to `0.13.2`.
- Agentty adds semantic text editing, attachment preservation, and chat rendering improvements.
- Dependencies and CI workflows update, including SonarCloud coverage integration.
- The agent CLI availability test uses a 2-second timeout.
- The security policy and SonarCloud coverage badge are added.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)