### PR TITLE
Require 100% pull request patch coverage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -168,7 +168,7 @@ repos:
         description: Verify source-test coverage meets workspace ratchet thresholds and write the CI LCOV report for SonarQube and Codecov.
         entry: >-
           cargo llvm-cov nextest --workspace --lib --bins --locked --profile ci
-          --fail-under-lines 91 --fail-under-functions 91
+          --fail-under-lines 93 --fail-under-functions 91
           --lcov --ignore-filename-regex '^crates/agentty/tests/'
           --output-path coverage.lcov
         language: system

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    patch:
+      default:
+        informational: false
+        only_pulls: true
+        target: 100%
+        threshold: 0%


### PR DESCRIPTION
- Raises the workspace line coverage threshold to 93%.
- Enforces 100% patch coverage for pull requests through Codecov.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)