### PR TITLE
Restore focused reviews across session and project switches

### DIFF
--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -193,9 +193,8 @@ impl App {
         })
     }
 
-    /// Loads persisted focused reviews for the startup project into the render
-    /// cache.
-    async fn load_focused_review_cache(
+    /// Loads persisted focused reviews for one project into the render cache.
+    pub(super) async fn load_focused_review_cache(
         repositories: &AppRepositories,
         active_project_id: i64,
     ) -> std::collections::HashMap<crate::domain::session::SessionId, review::ReviewCacheEntry>

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -672,6 +672,13 @@ impl App {
         .await;
         self.sessions
             .set_default_session_model(default_session_model);
+        for (session_id, persisted_review) in
+            Self::load_focused_review_cache(self.services.db(), project.id).await
+        {
+            self.review_cache
+                .entry(session_id)
+                .or_insert(persisted_review);
+        }
         self.reload_projects().await;
         self.refresh_sessions_now().await;
 
@@ -1130,6 +1137,17 @@ impl App {
             self.review_cache.get(session_id),
             Some(ReviewCacheEntry::Loading { .. })
         )
+    }
+
+    /// Restores one session's cache-backed focused review into its visible
+    /// output slot when the session is reopened.
+    pub(crate) fn restore_review_output(&mut self, session_id: &str) {
+        app::review::hydrate_review_transient(
+            &self.review_cache,
+            self.sessions.state_mut(),
+            session_id,
+            self.settings.default_review_selection.model(),
+        );
     }
 
     /// Clears cached focused-review state and retracts its display slot.
@@ -1631,6 +1649,7 @@ impl App {
             .refresh_sessions_if_needed(&mut self.mode, &self.projects, &self.services)
             .await;
         if refreshed {
+            app::review::prune_review_cache(&mut self.review_cache, self.sessions.state());
             app::review::hydrate_review_transients(
                 &self.review_cache,
                 self.sessions.state_mut(),
@@ -1646,6 +1665,7 @@ impl App {
         self.sessions
             .refresh_sessions_now(&mut self.mode, &self.projects, &self.services)
             .await;
+        app::review::prune_review_cache(&mut self.review_cache, self.sessions.state());
         app::review::hydrate_review_transients(
             &self.review_cache,
             self.sessions.state_mut(),
@@ -1838,6 +1858,7 @@ impl App {
     /// clarification sessions.
     fn open_session_by_index(&mut self, target_session_id: &str, session_index: usize) {
         self.sessions.select_session_index(Some(session_index));
+        self.restore_review_output(target_session_id);
 
         let Some(session) = self.sessions.session_at(session_index) else {
             return;

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -77,6 +77,50 @@ async fn test_app_viewing_reconcile_session(
     app.mode = test_view_app_mode("session-1");
 
     app
+}
+
+/// Seeds one review-ready session and its persisted focused review.
+async fn seed_persisted_review_session(
+    database: &AppRepositories,
+    base_path: &Path,
+    project_id: i64,
+    session_id: &str,
+    diff_hash: &str,
+    review_text: &str,
+) {
+    database
+        .sessions()
+        .insert_session(
+            session_id,
+            AgentModel::Gpt55.as_str(),
+            "main",
+            &Status::Review.to_string(),
+            project_id,
+        )
+        .await
+        .expect("failed to insert review session");
+    fs::create_dir_all(session::session_folder(base_path, session_id).join(SESSION_DATA_DIR))
+        .expect("failed to create review session data dir");
+    database
+        .sessions()
+        .update_session_focused_review(
+            session_id,
+            Some(diff_hash.to_string()),
+            Some(review_text.to_string()),
+        )
+        .await
+        .expect("failed to persist focused review");
+}
+
+/// Inserts one completed focused review into an app cache for eviction tests.
+fn insert_test_ready_review(app: &mut App, session_id: &str) {
+    app.review_cache.insert(
+        session_id.into(),
+        ReviewCacheEntry::Ready {
+            diff_hash: 1,
+            text: "inactive review".to_string(),
+        },
+    );
 }
 
 /// Builds a successful branch-publish batch payload for one session.
@@ -300,6 +344,105 @@ async fn test_switch_project_reloads_project_scoped_settings() {
         AgentModel::Gpt55
     );
     assert_eq!(app.settings.launch_configuration, "cargo test");
+}
+
+#[tokio::test]
+async fn test_switch_project_restores_project_scoped_focused_reviews() {
+    // Arrange
+    let base_dir = tempdir().expect("failed to create temp dir");
+    let second_project_dir = tempdir().expect("failed to create second temp dir");
+    let base_path = base_dir.path().to_path_buf();
+    let database = AppRepositories::in_memory().await;
+    let first_project_id = database
+        .projects()
+        .upsert_project(&base_path.to_string_lossy(), None)
+        .await
+        .expect("failed to insert first project");
+    let second_project_id = database
+        .projects()
+        .upsert_project(&second_project_dir.path().to_string_lossy(), None)
+        .await
+        .expect("failed to insert second project");
+    let second_session_id = "second-review";
+    let loading_session_id = "loading-review";
+    let review_text = "## Review\nSecond project finding.";
+    seed_persisted_review_session(
+        &database,
+        &base_path,
+        second_project_id,
+        second_session_id,
+        "42",
+        review_text,
+    )
+    .await;
+    seed_persisted_review_session(
+        &database,
+        &base_path,
+        second_project_id,
+        loading_session_id,
+        "7",
+        "outdated persisted review",
+    )
+    .await;
+    database
+        .settings()
+        .set_active_project_id(first_project_id)
+        .await
+        .expect("failed to persist initial active project");
+    let mut app = App::new_with_clients(
+        base_path.clone(),
+        base_path,
+        None,
+        database,
+        crate::test_support::test_app_clients(),
+    )
+    .await
+    .expect("failed to build app");
+    let mut mock_git_client = ag_git::MockGitClient::new();
+    mock_git_client
+        .expect_detect_git_info()
+        .times(3)
+        .returning(|_| Box::pin(async { None }));
+    install_mock_git_client(&mut app, mock_git_client);
+    app.review_cache.insert(
+        loading_session_id.into(),
+        ReviewCacheEntry::Loading { diff_hash: 21 },
+    );
+    insert_test_ready_review(&mut app, "inactive-review");
+
+    // Act
+    app.switch_project(second_project_id)
+        .await
+        .expect("failed to switch project");
+
+    // Assert
+    assert!(matches!(
+        app.review_cache.get(second_session_id),
+        Some(ReviewCacheEntry::Ready { diff_hash: 42, text }) if text == review_text
+    ));
+    assert!(matches!(
+        app.review_cache.get(loading_session_id),
+        Some(ReviewCacheEntry::Loading { diff_hash: 21 })
+    ));
+    assert!(!app.review_cache.contains_key("inactive-review"));
+    assert_eq!(
+        app.sessions
+            .session_or_err(second_session_id)
+            .expect("second-project session should be loaded")
+            .transient_messages
+            .get(TransientMessageSlot::Review)
+            .map(|message| message.body.text()),
+        Some(review_text)
+    );
+    assert!(matches!(
+        app.sessions
+            .session_or_err(loading_session_id)
+            .expect("loading review session should be loaded")
+            .transient_messages
+            .get(TransientMessageSlot::Review)
+            .map(|message| &message.body),
+        Some(TransientMessageBody::Loading(_))
+    ));
 }
 
 #[tokio::test]
@@ -4795,6 +4938,11 @@ async fn apply_review_update_stores_failure_in_cache() {
     .await;
     let session_id = "session-review-fail";
     let error_message = "Review assist failed with exit code 1";
+    let mut session =
+        crate::test_support::session_fixture_with_folder(PathBuf::from("/tmp/session-review-fail"));
+    session.id = session_id.to_string().into();
+    session.status = Status::AgentReview;
+    app.sessions.push_session(session);
     app.review_cache.insert(
         session_id.to_string().into(),
         ReviewCacheEntry::Loading { diff_hash: 456 },

--- a/crates/agentty/src/app/review.rs
+++ b/crates/agentty/src/app/review.rs
@@ -11,7 +11,7 @@ use super::core::AppEvent;
 use super::task;
 use crate::app::session_state::SessionState;
 use crate::domain::agent::{AgentModel, AgentSelection};
-use crate::domain::session::{SessionId, Status};
+use crate::domain::session::{Session, SessionId, Status};
 use crate::domain::session_message::SessionTranscript;
 use crate::domain::transient_message::{
     TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
@@ -143,43 +143,100 @@ pub(crate) fn hydrate_review_transients(
     review_model: AgentModel,
 ) {
     for session in session_state.sessions_mut() {
-        if !matches!(
-            session.status,
-            Status::Review | Status::Question | Status::AgentReview
-        ) {
+        hydrate_session_review_transient(review_cache, session, review_model);
+    }
+}
+
+/// Rehydrates one session's focused-review cache entry into its stable display
+/// slot, retracting stale display state when the cache no longer owns output.
+pub(crate) fn hydrate_review_transient(
+    review_cache: &HashMap<SessionId, ReviewCacheEntry>,
+    session_state: &mut SessionState,
+    session_id: &str,
+    review_model: AgentModel,
+) {
+    let Some(session) = session_state.session_mut_for_id(session_id) else {
+        return;
+    };
+
+    hydrate_session_review_transient(review_cache, session, review_model);
+}
+
+/// Evicts inactive completed review entries while retaining in-flight work.
+///
+/// A `Loading` entry must survive project switches so its eventual result can
+/// still be validated and persisted. Once that result arrives,
+/// [`apply_review_updates()`] replaces the entry and this pruning step removes
+/// it unless the session belongs to the currently loaded project.
+pub(crate) fn prune_review_cache(
+    review_cache: &mut HashMap<SessionId, ReviewCacheEntry>,
+    session_state: &SessionState,
+) {
+    let active_session_ids = session_state
+        .sessions()
+        .iter()
+        .map(|session| session.id.as_str())
+        .collect::<HashSet<_>>();
+
+    review_cache.retain(|session_id, cache_entry| {
+        active_session_ids.contains(session_id.as_str())
+            || matches!(cache_entry, ReviewCacheEntry::Loading { .. })
+    });
+}
+
+/// Synchronizes one session's focused-review display slot from the canonical
+/// cache state.
+fn hydrate_session_review_transient(
+    review_cache: &HashMap<SessionId, ReviewCacheEntry>,
+    session: &mut Session,
+    review_model: AgentModel,
+) {
+    if !matches!(
+        session.status,
+        Status::Review | Status::Question | Status::AgentReview
+    ) {
+        session
+            .transient_messages
+            .retract(TransientMessageSlot::Review);
+
+        return;
+    }
+    let Some(cache_entry) = review_cache.get(&session.id) else {
+        session
+            .transient_messages
+            .retract(TransientMessageSlot::Review);
+
+        return;
+    };
+    let (anchor, body) = match cache_entry {
+        ReviewCacheEntry::Loading { .. } => (
+            TransientMessageAnchor::Tail,
+            TransientMessageBody::Loading(review_loading_message(review_model)),
+        ),
+        ReviewCacheEntry::Ready { text, .. } => (
+            TransientMessageAnchor::AfterCompletedTurn,
+            TransientMessageBody::Markdown(text.clone()),
+        ),
+        ReviewCacheEntry::Failed { error, .. } => (
+            TransientMessageAnchor::AfterCompletedTurn,
+            TransientMessageBody::Plain(review_failure_message(error)),
+        ),
+        ReviewCacheEntry::Suppressed => {
             session
                 .transient_messages
                 .retract(TransientMessageSlot::Review);
 
-            continue;
+            return;
         }
-        let Some(cache_entry) = review_cache.get(&session.id) else {
-            continue;
-        };
-        let (anchor, body) = match cache_entry {
-            ReviewCacheEntry::Loading { .. } => (
-                TransientMessageAnchor::Tail,
-                TransientMessageBody::Loading(review_loading_message(review_model)),
-            ),
-            ReviewCacheEntry::Ready { text, .. } => (
-                TransientMessageAnchor::AfterCompletedTurn,
-                TransientMessageBody::Markdown(text.clone()),
-            ),
-            ReviewCacheEntry::Failed { error, .. } => (
-                TransientMessageAnchor::AfterCompletedTurn,
-                TransientMessageBody::Plain(review_failure_message(error)),
-            ),
-            ReviewCacheEntry::Suppressed => continue,
-        };
+    };
 
-        session.transient_messages.upsert(TransientMessage {
-            anchor,
-            body,
-            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
-            slot: TransientMessageSlot::Review,
-            turn_position: session.latest_user_prompt_position(),
-        });
-    }
+    session.transient_messages.upsert(TransientMessage {
+        anchor,
+        body,
+        lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+        slot: TransientMessageSlot::Review,
+        turn_position: session.latest_user_prompt_position(),
+    });
 }
 
 /// Builds the startup focused-review cache from persisted rows.
@@ -249,6 +306,8 @@ pub(crate) fn apply_review_updates(
             persistence_updates.push(persistence_update);
         }
     }
+
+    prune_review_cache(review_cache, session_state);
 
     persistence_updates
 }
@@ -500,6 +559,30 @@ mod tests {
         )])
     }
 
+    /// Builds one review-ready session with stale focused-review display text.
+    fn session_state_with_stale_review(session_id: &SessionId) -> SessionState {
+        let mut session = SessionFixtureBuilder::new()
+            .id(session_id.as_str())
+            .status(Status::Review)
+            .build();
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::AfterCompletedTurn,
+            body: TransientMessageBody::Markdown("stale review".to_string()),
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::Review,
+            turn_position: None,
+        });
+
+        SessionState::new(
+            HashMap::new(),
+            vec![session],
+            SelectionState::default(),
+            Arc::new(RealClock),
+            0,
+            0,
+        )
+    }
+
     #[test]
     fn review_loading_message_uses_requested_model_name() {
         // Arrange
@@ -605,7 +688,151 @@ mod tests {
     }
 
     #[test]
-    fn apply_review_updates_returns_success_for_persistence() {
+    fn hydrate_review_transient_retracts_review_without_cache_entry() {
+        // Arrange
+        let session_id = SessionId::from("session-id");
+        let mut session_state = session_state_with_stale_review(&session_id);
+
+        // Act
+        hydrate_review_transient(
+            &HashMap::new(),
+            &mut session_state,
+            &session_id,
+            AgentModel::Gpt55,
+        );
+
+        // Assert
+        assert!(
+            session_state.sessions()[0]
+                .transient_messages
+                .get(TransientMessageSlot::Review)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn hydrate_review_transient_retracts_suppressed_review() {
+        // Arrange
+        let session_id = SessionId::from("session-id");
+        let review_cache = HashMap::from([(session_id.clone(), ReviewCacheEntry::Suppressed)]);
+        let mut session_state = session_state_with_stale_review(&session_id);
+
+        // Act
+        hydrate_review_transient(
+            &review_cache,
+            &mut session_state,
+            &session_id,
+            AgentModel::Gpt55,
+        );
+
+        // Assert
+        assert!(
+            session_state.sessions()[0]
+                .transient_messages
+                .get(TransientMessageSlot::Review)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn hydrate_review_transient_restores_failed_review() {
+        // Arrange
+        let session_id = SessionId::from("session-id");
+        let review_cache = HashMap::from([(
+            session_id.clone(),
+            ReviewCacheEntry::Failed {
+                diff_hash: 42,
+                error: "provider unavailable".to_string(),
+            },
+        )]);
+        let mut session_state = session_state_with_stale_review(&session_id);
+
+        // Act
+        hydrate_review_transient(
+            &review_cache,
+            &mut session_state,
+            &session_id,
+            AgentModel::Gpt55,
+        );
+
+        // Assert
+        assert_eq!(
+            session_state.sessions()[0]
+                .transient_messages
+                .get(TransientMessageSlot::Review)
+                .map(|message| &message.body),
+            Some(&TransientMessageBody::Plain(
+                "Review assist unavailable: provider unavailable".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn hydrate_review_transient_ignores_missing_session() {
+        // Arrange
+        let mut session_state = empty_session_state();
+
+        // Act
+        hydrate_review_transient(
+            &HashMap::new(),
+            &mut session_state,
+            "missing-session",
+            AgentModel::Gpt55,
+        );
+
+        // Assert
+        assert!(session_state.sessions().is_empty());
+    }
+
+    #[test]
+    fn prune_review_cache_retains_active_and_loading_entries() {
+        // Arrange
+        let active_session_id = SessionId::from("active-session");
+        let loading_session_id = SessionId::from("loading-session");
+        let mut review_cache = HashMap::from([
+            (
+                active_session_id.clone(),
+                ReviewCacheEntry::Ready {
+                    diff_hash: 1,
+                    text: "active review".to_string(),
+                },
+            ),
+            (
+                "inactive-ready".into(),
+                ReviewCacheEntry::Ready {
+                    diff_hash: 2,
+                    text: "inactive review".to_string(),
+                },
+            ),
+            (
+                "inactive-failed".into(),
+                ReviewCacheEntry::Failed {
+                    diff_hash: 3,
+                    error: "failed review".to_string(),
+                },
+            ),
+            ("inactive-suppressed".into(), ReviewCacheEntry::Suppressed),
+            (
+                loading_session_id.clone(),
+                ReviewCacheEntry::Loading { diff_hash: 4 },
+            ),
+        ]);
+        let session_state = session_state_with_stale_review(&active_session_id);
+
+        // Act
+        prune_review_cache(&mut review_cache, &session_state);
+
+        // Assert
+        assert_eq!(review_cache.len(), 2);
+        assert!(review_cache.contains_key(&active_session_id));
+        assert!(matches!(
+            review_cache.get(&loading_session_id),
+            Some(ReviewCacheEntry::Loading { diff_hash: 4 })
+        ));
+    }
+
+    #[test]
+    fn apply_review_updates_persists_and_evicts_inactive_success() {
         // Arrange
         let session_id = SessionId::from("session-persist-review");
         let diff_hash = 19;
@@ -623,10 +850,11 @@ mod tests {
             persistence_updates,
             vec![FocusedReviewPersistence {
                 diff_hash: Some(diff_hash),
-                session_id,
+                session_id: session_id.clone(),
                 text: Some(review_text.to_string()),
             }]
         );
+        assert!(!review_cache.contains_key(&session_id));
     }
 
     #[test]
@@ -666,7 +894,7 @@ mod tests {
         let diff_hash = 11;
         let review_text = "## Review\nCache-backed finding.";
         let mut review_cache = loading_review_cache(&session_id, diff_hash);
-        let mut session_state = empty_session_state();
+        let mut session_state = session_state_with_stale_review(&session_id);
         let review_updates = successful_review_update(&session_id, diff_hash, review_text);
 
         // Act
@@ -685,7 +913,7 @@ mod tests {
         let session_id = SessionId::from("session-suppressed-review");
         let diff_hash = 23;
         let mut review_cache = HashMap::from([(session_id.clone(), ReviewCacheEntry::Suppressed)]);
-        let mut session_state = empty_session_state();
+        let mut session_state = session_state_with_stale_review(&session_id);
         let review_updates =
             successful_review_update(&session_id, diff_hash, "## Review\nShould not be rendered.");
 

--- a/crates/agentty/src/runtime/mode/list.rs
+++ b/crates/agentty/src/runtime/mode/list.rs
@@ -151,6 +151,7 @@ async fn handle_enter_key(app: &mut App) -> io::Result<EventResult> {
                 app.sessions
                     .load_session_detail_into_state(app.services.db(), session_id.as_str())
                     .await;
+                app.restore_review_output(&session_id);
 
                 if let Some(session) = app.sessions.session_at(session_index)
                     && session.status == Status::Question
@@ -645,6 +646,11 @@ mod tests {
                 text: "Focused review".to_string(),
             },
         );
+        crate::test_support::set_session_status_for_test(
+            &mut app,
+            &expected_session_id,
+            Status::Review,
+        );
         app.tabs.set(Tab::Sessions);
         app.sessions.select_session_index(Some(0));
         app.mode = AppMode::List;
@@ -664,6 +670,13 @@ mod tests {
                 ..
             } if session_id == &expected_session_id
         ));
+        assert_eq!(
+            app.sessions.sessions()[0]
+                .transient_messages
+                .get(crate::domain::transient_message::TransientMessageSlot::Review)
+                .map(|message| message.body.text()),
+            Some("Focused review")
+        );
     }
 
     #[tokio::test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1005,6 +1005,40 @@ fn seed_review_ready_session_with_persisted_focused_review(
     Ok(())
 }
 
+/// Seeds two review-ready sessions with distinct persisted focused reviews so
+/// switching away and back can verify cache-backed output restoration.
+fn seed_sessions_with_persisted_focused_reviews(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    seed_review_ready_session_with_persisted_focused_review(env)?;
+    common::seed_session(
+        env,
+        SessionSeed::regular("second-review-0001", "gpt-5.5", "main", "Review")
+            .with_title("Second persisted review"),
+    )?;
+
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        database
+            .sessions()
+            .update_session_focused_review(
+                "second-review-0001",
+                Some("84".to_string()),
+                Some(
+                    "## Review\n\n### Project Impact\n\n- Second persisted review finding.\n\n### \
+                     Suggestions\n\n- None."
+                        .to_string(),
+                ),
+            )
+            .await
+    })?;
+
+    std::fs::create_dir_all(env.agentty_root.join("wt").join("second-r"))?;
+
+    Ok(())
+}
+
 /// Seeds one running session so `Ctrl+c` can exercise the turn-stop path
 /// without needing a live agent backend.
 fn seed_running_stop_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
@@ -4267,6 +4301,70 @@ fn persisted_focused_review_survives_reload() -> E2eResult {
                 assert_eq!(impact_finding.rect.row, impact_header.rect.row + 1);
                 assert_eq!(empty_suggestion.rect.row, suggestions_header.rect.row + 1);
                 assertion::assert_not_visible(frame, "type \"/apply\" to verify and apply");
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify each session restores its own persisted focused review after users
+/// switch between session views.
+#[test]
+fn focused_reviews_survive_session_switching() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("focused_reviews_survive_session_switching")
+        .with_git()
+        .setup(seed_sessions_with_persisted_focused_reviews)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("Enter")
+                    .wait_for_text("Persisted focused review finding.", 5000)
+                    .capture_labeled("first_review", "First session focused review")
+                    .press_key("q")
+                    .press_key("j")
+                    .press_key("Enter")
+                    .wait_for_text("Second persisted review finding.", 5000)
+                    .capture_labeled("second_review", "Second session focused review")
+                    .press_key("q")
+                    .press_key("k")
+                    .press_key("Enter")
+                    .wait_for_text("Persisted focused review finding.", 5000)
+                    .capture_labeled("restored_first_review", "Restored first focused review")
+            },
+            |frame, report| {
+                assert_eq!(report.captures.len(), 3);
+                let first_frame = common::frame_from_capture(&report.captures[0]);
+                let second_frame = common::frame_from_capture(&report.captures[1]);
+                let restored_first_frame = common::frame_from_capture(&report.captures[2]);
+                let first_full = Region::full(first_frame.cols(), first_frame.rows());
+                let second_full = Region::full(second_frame.cols(), second_frame.rows());
+                let restored_first_full =
+                    Region::full(restored_first_frame.cols(), restored_first_frame.rows());
+                let final_full = Region::full(frame.cols(), frame.rows());
+
+                assertion::assert_text_in_region(
+                    &first_frame,
+                    "Persisted focused review finding.",
+                    &first_full,
+                );
+                assertion::assert_text_in_region(
+                    &second_frame,
+                    "Second persisted review finding.",
+                    &second_full,
+                );
+                assertion::assert_text_in_region(
+                    &restored_first_frame,
+                    "Persisted focused review finding.",
+                    &restored_first_full,
+                );
+                assertion::assert_text_in_region(
+                    frame,
+                    "Persisted focused review finding.",
+                    &final_full,
+                );
             },
         )?;
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -207,19 +207,19 @@ competing published-branch auto-push.
 When a session enters **Review**, Agentty starts generating a focused review in the
 background and temporarily shows **AgentReview**. Press `f` to append the cached review
 into the session output, or to see a loading message while generation is still running.
-The appended review stays visible across diff mode, question mode, and background
-session metadata refreshes, and is cleared when you submit the next prompt. Focused
-review includes the saved user and agent chat history for context. It uses
-inspection-only context: it may read files, search, inspect git history, and browse when
-needed, but it recommends verification commands instead of running checks itself. The
-review treats explicit decisions, accepted tradeoffs, and explanations in the chat as
-constraints, and only reopens a resolved suggestion when the current diff contradicts
-the resolution or inspection finds a new significant risk. `Project Impact` renders
-concise bullets directly beneath its heading. `Suggestions` uses the same compact
-spacing and formats its bullets as `[Severity]: Issue details`, using `[High]` or
-`[Medium]` when follow-up work is needed. Empty `Suggestions` output does not offer the
-`/apply` action. A turn stopped with `Ctrl+c` does not start a focused review
-automatically; press `f` for a manual one.
+The appended review stays visible across diff mode, question mode, session switching,
+project switching, and background session metadata refreshes, and is cleared when you
+submit the next prompt. Focused review includes the saved user and agent chat history
+for context. It uses inspection-only context: it may read files, search, inspect git
+history, and browse when needed, but it recommends verification commands instead of
+running checks itself. The review treats explicit decisions, accepted tradeoffs, and
+explanations in the chat as constraints, and only reopens a resolved suggestion when the
+current diff contradicts the resolution or inspection finds a new significant risk.
+`Project Impact` renders concise bullets directly beneath its heading. `Suggestions`
+uses the same compact spacing and formats its bullets as `[Severity]: Issue details`,
+using `[High]` or `[Medium]` when follow-up work is needed. Empty `Suggestions` output
+does not offer the `/apply` action. A turn stopped with `Ctrl+c` does not start a
+focused review automatically; press `f` for a manual one.
 
 ### Session Output Markdown
 


### PR DESCRIPTION
- Load persisted review entries when switching projects without overwriting active cache state.
- Rehydrate each reopened session’s review output and retract stale display state.
- Prune inactive completed entries while retaining in-flight reviews for later persistence.
- Add unit and E2E coverage and document persistence across switches.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)