### PR TITLE
Block local merges for linked review requests

### DIFF
--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -2010,7 +2010,8 @@ impl App {
     /// Sessions are eligible while actively under review or already marked as
     /// `Queued` (for example, after app restart). A parent with idle
     /// materialized children can enter merge queueing because merge completion
-    /// retargets those children; active stack work still blocks the request.
+    /// retargets those children; linked forge review requests and active stack
+    /// work still block the request.
     ///
     /// # Errors
     /// Returns an error when the session does not exist or has an ineligible
@@ -2024,7 +2025,9 @@ impl App {
         }
         if !self.sessions.can_merge_session_branch_in_stack(session_id) {
             return Err(AppError::Workflow(
-                "Merge can only run when no other stack session is active".to_string(),
+                "Merge cannot run for linked review requests or while another stack session is \
+                 active"
+                    .to_string(),
             ));
         }
 

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -155,6 +155,40 @@ async fn test_new_with_clients_fails_when_no_backend_cli_is_available() {
 }
 
 #[tokio::test]
+async fn merge_session_rejects_linked_review_request_before_queueing() {
+    // Arrange
+    let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+    let review_request = ReviewRequest {
+        last_refreshed_at: 0,
+        summary: ReviewRequestSummary {
+            display_id: "#42".to_string(),
+            forge_kind: ForgeKind::GitHub,
+            source_branch: "wt/session-id".to_string(),
+            state: ReviewRequestState::Open,
+            status_summary: None,
+            target_branch: "main".to_string(),
+            title: "Linked review request".to_string(),
+            web_url: "https://github.com/agentty-xyz/agentty/pull/42".to_string(),
+        },
+    };
+    app.sessions.push_session(
+        crate::test_support::SessionFixtureBuilder::new()
+            .review_request(Some(review_request))
+            .build(),
+    );
+
+    // Act
+    let result = app.merge_session("session-id").await;
+
+    // Assert
+    let error = result.expect_err("linked review request should block merge queueing");
+    assert_eq!(
+        error.to_string(),
+        "Merge cannot run for linked review requests or while another stack session is active"
+    );
+}
+
+#[tokio::test]
 async fn review_comments_page_has_no_tick_driven_ui() {
     // Arrange
     let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;

--- a/crates/agentty/src/app/session/workflow/merge.rs
+++ b/crates/agentty/src/app/session/workflow/merge.rs
@@ -637,7 +637,9 @@ impl SessionMergeService {
         }
         if !manager.can_merge_session_branch_in_stack(session_id) {
             return Err(SessionError::Workflow(
-                "Merge can only run when no other stack session is active".to_string(),
+                "Merge cannot run for linked review requests or while another stack session is \
+                 active"
+                    .to_string(),
             ));
         }
 
@@ -3053,6 +3055,30 @@ mod tests {
         });
 
         Arc::new(one_shot_client)
+    }
+
+    #[tokio::test]
+    async fn test_merge_session_rejects_linked_review_request_before_workflow_start() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.sessions.push_session(
+            crate::test_support::SessionFixtureBuilder::new()
+                .review_request(Some(linked_github_review_request()))
+                .build(),
+        );
+
+        // Act
+        let result = app
+            .sessions
+            .merge_session("session-id", &app.projects, &app.services)
+            .await;
+
+        // Assert
+        let error = result.expect_err("linked review request should block merge workflow");
+        assert_eq!(
+            error.to_string(),
+            "Merge cannot run for linked review requests or while another stack session is active"
+        );
     }
 
     #[test]

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -869,16 +869,18 @@ pub(crate) fn can_mutate_session_branch_in_stack(sessions: &[Session], session_i
 /// Returns whether a session can enter the merge queue while preserving stack
 /// consistency.
 ///
-/// Merging a parent with idle materialized children is allowed because the
-/// successful parent merge retargets and syncs the children afterward. Active
-/// stack members still block the request so the stack does not run competing
-/// branch work.
+/// A linked forge review request disables local merge queueing so the remote
+/// review remains the only merge path. Otherwise, merging a parent with idle
+/// materialized children is allowed because the successful parent merge
+/// retargets and syncs the children afterward. Active stack members still
+/// block the request so the stack does not run competing branch work.
 pub(crate) fn can_merge_session_branch_in_stack(sessions: &[Session], session_id: &str) -> bool {
     let Some(stack) = SessionStack::for_session(sessions, session_id) else {
         return false;
     };
 
-    !stack.has_branch_mutating_member_except(session_id)
+    stack.requested_session.review_request.is_none()
+        && !stack.has_branch_mutating_member_except(session_id)
 }
 
 /// Returns whether a session can start session sync while preserving stack
@@ -1346,6 +1348,36 @@ pub(crate) mod tests {
 
         // Assert
         assert!(!can_merge_review_child);
+    }
+
+    #[test]
+    fn test_can_merge_session_branch_in_stack_blocks_linked_review_request() {
+        // Arrange
+        let review_request = ReviewRequest {
+            last_refreshed_at: 0,
+            summary: ReviewRequestSummary {
+                display_id: "#42".to_string(),
+                forge_kind: ForgeKind::GitHub,
+                source_branch: "wt/session-id".to_string(),
+                state: ReviewRequestState::Open,
+                status_summary: None,
+                target_branch: "main".to_string(),
+                title: "Review request".to_string(),
+                web_url: "https://github.com/agentty-xyz/agentty/pull/42".to_string(),
+            },
+        };
+        let session = SessionFixtureBuilder::new()
+            .id("linked-session")
+            .review_request(Some(review_request))
+            .status(Status::Review)
+            .build();
+        let sessions = vec![session];
+
+        // Act
+        let can_merge_session = can_merge_session_branch_in_stack(&sessions, "linked-session");
+
+        // Assert
+        assert!(!can_merge_session);
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -3960,8 +3960,8 @@ fn review_request_publish_runs_in_background() -> E2eResult {
     Ok(())
 }
 
-/// Verify that review-ready sessions no longer expose a manual review-request
-/// sync shortcut because linked review requests refresh in the background.
+/// Verify that linked review requests refresh in the background without a
+/// manual review-request sync shortcut and disable local merge queueing.
 #[test]
 fn review_request_sync_runs_in_background() -> E2eResult {
     // Arrange, Act, Assert
@@ -3997,6 +3997,7 @@ fn review_request_sync_runs_in_background() -> E2eResult {
                     !view_text.contains("s: Sync"),
                     "manual sync help action should be absent"
                 );
+                assertion::assert_not_visible(frame, "m: add to merge queue");
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -240,7 +240,8 @@ restart-safe:
 - `Review/Question -> InProgress` (reply)
 - Root `Review/AgentReview -> Review` (forked session snapshot opens as a new
   review-ready session)
-- `Review -> Queued -> Merging -> Done` (merge queue path)
+- `Review -> Queued -> Merging -> Done` (local merge queue path for sessions without a
+  linked review request)
 - `Review/AgentReview -> Rebasing -> Review/Question` (session sync path; starting from
   `AgentReview` cancels pending focused-review output)
 - `InProgress -> Rebasing -> Review/Question` (session sync requested during a running
@@ -474,9 +475,11 @@ orchestration paths:
 
 - `sync main`: selected project branch pull/rebase/push with optional assisted conflict
   resolution, serialized through the shared sync orchestrator.
-- Session merge: queue-aware workflow — assisted rebase first, squash commit into the
-  base branch reusing the session-branch `HEAD` commit message, then worktree cleanup
-  and status `Done`.
+- Session merge: queue-aware workflow for sessions without a linked forge review request
+  — assisted rebase first, squash commit into the base branch reusing the session-branch
+  `HEAD` commit message, then worktree cleanup and status `Done`. Once a review request
+  is linked, the shared merge-eligibility policy hides the local action and rejects
+  direct queue attempts.
 - Session sync: assisted rebase onto the local base branch (unpublished) or the
   published upstream's remote base ref (published). Rebase-conflict prompts run through
   the existing session channel so the provider keeps conversation context while Agentty

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -182,8 +182,9 @@ State-specific differences:
 - **Question** sessions hide `r` until they return to review-ready state.
 - Review-ready stacked parents with a materialized child keep `Enter`, `m`, and `r`
   while the stack is idle, but hide `/` until the child is terminal or no longer linked.
-- Sessions with a linked pull request or merge request use `c` to open its comments
-  page. Linked terminal sessions keep continuation available on `C`.
+- Sessions with a linked pull request or merge request use `c` to open its comments page
+  and hide `m`; merge the linked request through its forge instead of Agentty's local
+  merge queue. Linked terminal sessions keep continuation available on `C`.
 - **Done** sessions without a linked review request offer `c` to start a continuation
   draft (confirmation popup).
 - **Canceled**, **Queued**, and **Merging** sessions are otherwise read-only (`q`,

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -296,9 +296,12 @@ commit succeeds without the configured hook, the session output records a
 unchanged warning in the same session. Installed hooks remain enabled and their failures
 still stop the commit.
 
-When a session merges, Agentty reuses the session branch `HEAD` commit message for the
-final squash commit on the base branch. Merging requires a clean main checkout and
-returns the session to **Review** if the preparatory rebase or squash-merge fails.
+When a session without a linked review request merges, Agentty reuses the session branch
+`HEAD` commit message for the final squash commit on the base branch. Merging requires a
+clean main checkout and returns the session to **Review** if the preparatory rebase or
+squash-merge fails. After a pull request or merge request is linked, Agentty hides `m`
+and rejects local merge queueing; merge through the forge, and background review-request
+sync moves the session to **Done** when that remote merge completes.
 
 When a session syncs (`r`), Agentty rebases the session branch: published sessions fetch
 first and rebase onto the remote base ref, unpublished sessions rebase onto the stored


### PR DESCRIPTION
- Reject merge queueing when a forge review request is linked.
- Cover the restriction in app, domain, and E2E tests.
- Update workflow, keybinding, and runtime-flow documentation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)