### PR TITLE
Keep empty prompts open on Backspace

### DIFF
--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -348,13 +348,16 @@ async fn apply_prompt_input_command(app: &mut App, command: InputCommand) {
 }
 
 /// Returns the prompt-aware range for shared deletion commands.
+///
+/// Boundary deletions return `None` without evaluating an out-of-range cursor
+/// position.
 fn prompt_command_delete_range(
     input: &InputState,
     command: &InputCommand,
 ) -> Option<(usize, usize)> {
     match command {
         InputCommand::DeleteBackward => {
-            (input.cursor > 0).then_some((input.cursor - 1, input.cursor))
+            (input.cursor > 0).then(|| (input.cursor - 1, input.cursor))
         }
         InputCommand::DeleteCurrentLine => prompt_current_line_delete_range(input),
         InputCommand::DeleteForward => (input.cursor < input.text().chars().count())
@@ -2467,6 +2470,21 @@ mod tests {
             assert_eq!(input.text(), "secon");
             assert_eq!(history_state.selected_index, None);
             assert_eq!(history_state.draft_text, None);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_prompt_backspace_on_empty_input_is_noop() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("", None).await;
+
+        // Act
+        apply_prompt_input_command(&mut app, InputCommand::DeleteBackward).await;
+
+        // Assert
+        if let AppMode::Prompt { input, .. } = &app.mode {
+            assert!(input.is_empty());
+            assert_eq!(input.cursor, 0);
         }
     }
 

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -4898,6 +4898,38 @@ fn prompt_typing_shows_text() -> E2eResult {
     Ok(())
 }
 
+/// Verify that pressing `Backspace` after deleting all prompt text leaves the
+/// empty prompt open.
+#[test]
+fn prompt_backspace_on_empty_input() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("prompt_empty_backspace").with_git().run(
+        |scenario| {
+            scenario
+                .compose(&common::wait_for_agentty_startup())
+                .compose(&common::switch_to_tab("Sessions"))
+                .press_key("a")
+                .press_key("Enter")
+                .wait_for_stable_frame(300, 5000)
+                .write_text("bug")
+                .wait_for_text("bug", 3000)
+                .press_key("Backspace")
+                .press_key("Backspace")
+                .press_key("Backspace")
+                .press_key("Backspace")
+                .wait_for_text("Type your message", 3000)
+                .capture_labeled("empty_prompt", "Empty prompt after one extra Backspace")
+        },
+        |frame, _report| {
+            let full = Region::full(frame.cols(), frame.rows());
+            assertion::assert_text_in_region(frame, "Type your message", &full);
+            assertion::assert_text_in_region(frame, "Enter: send", &full);
+        },
+    )?;
+
+    Ok(())
+}
+
 /// Verify that Alt+Enter inserts a newline in the prompt input,
 /// producing multiline content.
 ///


### PR DESCRIPTION
- Return no deletion range at the input boundary.
- Cover empty-input Backspace handling with unit and E2E tests.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)