### PR TITLE
Bump version to 0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,45 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.13.3] - 2026-07-17
+
 ### Added
 
+- agentty: add a review-comments view for linked GitHub pull requests and GitLab merge
+  requests, with selectable general comments, inline threads, current diff context, and
+  read-only navigation.
+- agentty: let session agents resolve selected or all actionable review comments, then
+  reply to and resolve fixed GitHub and GitLab threads after a successful branch push.
 - release: generate keyless Sigstore build provenance for final GitHub release artifacts
   and attach a Scorecard-discoverable bundle.
 
 ### Changed
 
+- agentty: open the session diff with `d` from prompt chat focus and restore the
+  composer draft, attachments, history, suggestions, and scroll state on return.
+- agentty: persist focused review output across session and project switches.
+- agentty: block local merge queueing when a forge review request is linked.
+- ag-agent: route utility prompts through a typed, injectable one-shot client and
+  encapsulate turn continuation state.
+- ag-protocol: reorganize protocol definitions by responsibility.
+- ag-clipboard: unify platform backend initialization and report invalid UTF-8 text as
+  backend errors on Wayland and X11.
+- ag-forge: simplify review-request adapter ownership and command workflows.
+- ci: enforce 100% patch coverage for pull requests and raise the workspace line
+  coverage threshold to 93%.
 - release: upload the complete artifact set through a retry-safe draft before
   publication so GitHub release immutability protects every shipped file.
 - docs: document GitHub release, asset, and provenance verification.
+- release: bump workspace crate metadata and lockfile package versions to `0.13.3`.
+
+### Fixed
+
+- agentty: keep an empty prompt open when `Backspace` is pressed.
+
+### Contributors
+
+- @andagaev
+- @minev-dev
 
 ## [v0.13.2] - 2026-07-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "image",
  "mockall",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "mockall",
  "serde",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "mockall",
  "rustix",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "askama",
  "schemars 1.2.1",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "clap",
  "tempfile",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.13.2"
+version = "0.13.3"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -16,13 +16,13 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.13.2" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.13.2" }
-ag-forge = { path = "crates/ag-forge", version = "0.13.2" }
-ag-git = { path = "crates/ag-git", version = "0.13.2" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.13.2" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.13.2" }
-testty = { path = "crates/testty", version = "0.13.2" }
+ag-agent = { path = "crates/ag-agent", version = "0.13.3" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.13.3" }
+ag-forge = { path = "crates/ag-forge", version = "0.13.3" }
+ag-git = { path = "crates/ag-git", version = "0.13.3" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.13.3" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.13.3" }
+testty = { path = "crates/testty", version = "0.13.3" }
 async-trait = "0.1"
 agent-client-protocol = "1.2.0"
 assert_cmd = "2"


### PR DESCRIPTION
- Record the v0.13.3 release changelog.
- Update workspace crate metadata and lockfile package versions to `0.13.3`.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)