### PR TITLE
Use Ctrl+Z for input undo

### DIFF
--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -33,6 +33,9 @@ editing shortcuts. Context-specific actions such as prompt submission, slash com
 | `Ctrl+Y` / `Ctrl+Shift+Z`                | Redo                                |
 | paste                                    | Insert text at the cursor           |
 
+On macOS, undo still uses `Ctrl+Z`, not `Cmd+Z`. Terminal applications such as Ghostty
+may consume `Cmd+Z` before Agentty or a surrounding `tmux` session receives it.
+
 Multiline prompt and question inputs also share vertical cursor movement and newline
 insertion. Single-line publish and launch-configuration inputs keep only the first line
 of pasted text.

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -447,6 +447,9 @@ occurrence, so duplicate lookalike text cannot substitute for the pasted token. 
 through prompt history with `Up` and `Down` preserves the attachment membership of the
 captured draft.
 
+On macOS, use `Ctrl+Z` rather than `Cmd+Z` for input undo. Terminal applications such as
+Ghostty may consume `Cmd+Z` before Agentty or a surrounding `tmux` session receives it.
+
 `@` file lookups keep the raw `@path/to/file` text visible in the composer and
 transcript; the agent-facing prompt rewrites them to quoted `path/to/file` tokens.
 


### PR DESCRIPTION
- Limits the shared undo shortcut to `Ctrl+Z`.
- Updates unit and E2E input tests to cover the supported undo path.
- Documents that macOS terminals may consume `Cmd+Z` before Agentty or `tmux` receives it.