### PR TITLE
Keep prompt composer state in runtime

### DIFF
--- a/crates/agentty/src/app/prompt_intent.rs
+++ b/crates/agentty/src/app/prompt_intent.rs
@@ -6,18 +6,13 @@ use ag_forge::{ReviewComment, ReviewCommentSnapshot, ReviewCommentThread};
 use tracing::warn;
 
 use crate::app::{App, ReviewCacheEntry, diff_content_hash};
-use crate::domain::agent::{AgentKind, ReasoningLevel};
+use crate::domain::agent::{AgentSelection, ReasoningLevel};
 use crate::domain::composer::PromptAttachment;
 use crate::domain::review;
 use crate::domain::session::{SessionId, Status};
 use crate::domain::transcript_notice::TranscriptNotice;
 use crate::domain::turn_prompt::{TurnPrompt, TurnPromptAttachment, TurnPromptTextSource};
 use crate::infra::clipboard_image;
-use crate::presentation::app_mode::AppMode;
-use crate::presentation::prompt::{
-    PromptSlashStage, PromptSuggestionSelection, drain_prompt_submission,
-    insert_prompt_local_image, resolve_prompt_slash_selection,
-};
 
 /// Checked-in prompt template submitted by the `/apply` slash command.
 const APPLY_REVIEW_PROMPT_TEMPLATE: &str = include_str!("template/apply_review_prompt.md");
@@ -34,64 +29,38 @@ pub(crate) enum ReviewCommentSelection {
     Selected(usize),
 }
 
-/// App-layer prompt intent context derived from prompt-mode runtime state.
-///
-/// Runtime key handling constructs this snapshot when a key maps to an
-/// application workflow. The app layer then owns the execution decision:
-/// prompt submission routing, slash-command selection, cancellation cleanup,
-/// and view restoration.
+/// Presentation navigation requested after a review-comment resolution attempt.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct PromptIntentContext {
-    /// Active prompt input shape used for app-layer submit/cancel routing.
-    pub(crate) input_mode: PromptIntentInputMode,
-    /// Session transcript scroll offset to restore when returning to view.
-    pub(crate) scroll_offset: Option<u16>,
+pub(crate) enum ReviewCommentResolutionOutcome {
+    /// Keep the review-comment page open because no reply was enqueued.
+    KeepReviewComments,
+    /// Show the session that accepted the review-comment reply.
+    ShowSession { session_id: SessionId },
+}
+
+/// Typed prompt submission emitted by the presentation boundary.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PromptSubmission {
+    /// Structured user input drained from the prompt composer.
+    pub(crate) prompt: TurnPrompt,
     /// Stable identifier for the active prompt session.
     pub(crate) session_id: SessionId,
-    /// Current list index for the active prompt session.
-    pub(crate) session_index: usize,
-    /// Session lifecycle shape used for app-layer submit/cancel routing.
-    pub(crate) session_mode: PromptIntentSessionMode,
+    /// Session lifecycle shape used for app-layer submission routing.
+    pub(crate) session_mode: PromptSessionMode,
 }
 
-impl PromptIntentContext {
-    /// Returns whether `Esc` should delete the blank backing session instead
-    /// of restoring session view.
-    fn can_delete_on_cancel(&self) -> bool {
-        self.session_mode == PromptIntentSessionMode::NewDeletable
-    }
-
-    /// Returns whether this prompt belongs to a draft session still staging
-    /// messages.
-    fn is_draft_session(&self) -> bool {
-        self.session_mode == PromptIntentSessionMode::NewDraft
-    }
-
-    /// Returns whether this prompt belongs to a session that has not started
-    /// yet.
-    fn is_new_session(&self) -> bool {
-        self.session_mode != PromptIntentSessionMode::Existing
-    }
-
-    /// Returns whether the active prompt input currently represents a slash
-    /// command.
-    fn is_slash_command(&self) -> bool {
-        self.input_mode == PromptIntentInputMode::SlashCommand
-    }
+/// Typed cancellation request emitted by the presentation boundary.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PromptCancellation {
+    /// Stable identifier for the active prompt session.
+    pub(crate) session_id: SessionId,
+    /// Session lifecycle shape used for app-layer cancellation routing.
+    pub(crate) session_mode: PromptSessionMode,
 }
 
-/// Active prompt input shape used by app-layer prompt intent routing.
+/// Session lifecycle shape used by prompt submission and cancellation routing.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum PromptIntentInputMode {
-    /// Prompt text starts with a slash-command prefix.
-    SlashCommand,
-    /// Prompt text is normal user input.
-    Text,
-}
-
-/// Session lifecycle shape used by app-layer prompt intent routing.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum PromptIntentSessionMode {
+pub(crate) enum PromptSessionMode {
     /// Existing session receiving a follow-up reply.
     Existing,
     /// New non-draft session that can be deleted when prompt composition is
@@ -104,17 +73,48 @@ pub(crate) enum PromptIntentSessionMode {
     NewRegular,
 }
 
+/// Presentation navigation requested after one app-layer prompt workflow.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum PromptWorkflowOutcome {
+    /// Keep the prompt composer open because no submit action was performed.
+    KeepPrompt,
+    /// Return to the active session chat view.
+    ShowSession { session_id: SessionId },
+    /// Return to the top-level session list after deleting a blank draft.
+    ShowSessionList,
+}
+
+/// Presentation action requested after executing `/apply`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum PromptApplyOutcome {
+    /// Clear the accepted slash command and keep the composer open.
+    ClearComposer,
+    /// Preserve the slash command for correction or retry.
+    KeepComposer,
+    /// Clear the composer and show the session chat view.
+    ShowSession { session_id: SessionId },
+}
+
+/// Clipboard-image capture request emitted from a prompt composer.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PromptImagePaste {
+    /// One-based image placeholder number allocated by presentation state.
+    pub(crate) attachment_number: usize,
+    /// Session that owns the prompt composer.
+    pub(crate) session_id: SessionId,
+}
+
 impl App {
     /// Submits one agent turn for the selected forge review comments.
     ///
-    /// Returns `true` only when at least one actionable comment was rendered
-    /// and the session worker accepted the reply.
+    /// Returns a navigation effect that shows the session only when at least
+    /// one actionable comment was rendered and its worker accepted the reply.
     pub(crate) async fn resolve_session_review_comments(
         &mut self,
         session_id: &SessionId,
         snapshot: &ReviewCommentSnapshot,
         selection: ReviewCommentSelection,
-    ) -> bool {
+    ) -> ReviewCommentResolutionOutcome {
         let can_reply = self
             .sessions
             .sessions()
@@ -124,12 +124,12 @@ impl App {
                 session.status.allows_review_actions() || session.status == Status::Question
             });
         if !can_reply {
-            return false;
+            return ReviewCommentResolutionOutcome::KeepReviewComments;
         }
 
         let Some((prompt, thread_ids)) = build_resolve_review_comment_prompt(snapshot, selection)
         else {
-            return false;
+            return ReviewCommentResolutionOutcome::KeepReviewComments;
         };
 
         self.clear_review_output(session_id.as_str());
@@ -143,182 +143,64 @@ impl App {
             .sessions
             .reply_to_review_comments(&self.services, session_id, prompt, thread_ids)
             .await;
-        if enqueued {
-            self.mode = AppMode::View {
-                scroll_offset: None,
-                session_id: session_id.clone(),
-            };
+        if !enqueued {
+            return ReviewCommentResolutionOutcome::KeepReviewComments;
         }
 
-        enqueued
+        ReviewCommentResolutionOutcome::ShowSession {
+            session_id: session_id.clone(),
+        }
     }
 
-    /// Handles the submit intent emitted by prompt-mode key routing.
-    ///
-    /// Slash-command submissions are resolved inside the app layer. Text
-    /// submissions drain the prompt composer, choose the correct session
-    /// workflow, and return to session view after a non-empty prompt.
-    pub(crate) async fn handle_prompt_submit_intent(&mut self, context: &PromptIntentContext) {
-        if context.is_slash_command() {
-            self.handle_prompt_slash_submit_intent(context).await;
-
-            return;
-        }
-
-        let archived_prompt = self.archived_prompt_attachments();
-        let prompt = self.take_submitted_turn_prompt();
-        if let Some(archived_prompt) = archived_prompt {
-            self.cleanup_prompt_attachment_files(&archived_prompt).await;
-        }
-        if prompt.is_empty() {
-            return;
-        }
-
-        self.submit_turn_prompt_for_context(context, prompt).await;
-        self.restore_prompt_session_view(context);
-    }
-
-    /// Executes the active slash-command selection for prompt mode.
-    pub(crate) async fn handle_prompt_slash_submit_intent(
+    /// Routes one presentation-owned prompt submission through the matching
+    /// session workflow and returns the requested navigation effect.
+    pub(crate) async fn submit_prompt(
         &mut self,
-        context: &PromptIntentContext,
-    ) {
-        let session_agent_kind = self
-            .session_at(context.session_index)
-            .map_or(AgentKind::Codex, |session| session.agent.kind());
-        let selection = match &self.mode {
-            AppMode::Prompt {
-                input, slash_state, ..
-            } => resolve_prompt_slash_selection(
-                input.text(),
-                slash_state,
-                session_agent_kind,
-                self.prompt_apply_command_is_available_for_session(&context.session_id),
-            ),
-            _ => None,
-        };
-
-        match selection {
-            Some(PromptSuggestionSelection::Command("/apply")) => {
-                if self.handle_apply_prompt_command(context).await {
-                    self.reset_prompt_slash_input().await;
-                } else {
-                    self.reset_prompt_slash_state();
-                }
-            }
-            Some(PromptSuggestionSelection::Command("/reasoning")) => {
-                let selected_reasoning_level = self
-                    .session_at(context.session_index)
-                    .map_or(self.settings.reasoning_level, |session| {
-                        session.effective_reasoning_level()
-                    });
-                let selected_index = ReasoningLevel::ALL
-                    .iter()
-                    .position(|level| *level == selected_reasoning_level)
-                    .unwrap_or(0);
-
-                if let AppMode::Prompt { slash_state, .. } = &mut self.mode {
-                    slash_state.stage = PromptSlashStage::Reasoning;
-                    slash_state.selected_agent = None;
-                    slash_state.selected_index = selected_index;
-                }
-            }
-            Some(PromptSuggestionSelection::Command(_)) => {
-                if let AppMode::Prompt { slash_state, .. } = &mut self.mode {
-                    slash_state.stage = PromptSlashStage::Agent;
-                    slash_state.selected_agent = None;
-                    slash_state.selected_index = 0;
-                }
-            }
-            Some(PromptSuggestionSelection::Agent(selected_agent)) => {
-                if let AppMode::Prompt { slash_state, .. } = &mut self.mode {
-                    slash_state.selected_agent = Some(selected_agent);
-                    slash_state.stage = PromptSlashStage::Model;
-                    slash_state.selected_index = 0;
-                }
-            }
-            Some(PromptSuggestionSelection::Model(selected_agent)) => {
-                self.reset_prompt_slash_input().await;
-                self.update_prompt_session_model(context, selected_agent)
-                    .await;
-            }
-            Some(PromptSuggestionSelection::Reasoning(reasoning_level)) => {
-                self.reset_prompt_slash_input().await;
-                self.update_prompt_session_reasoning_level(context, reasoning_level)
-                    .await;
-            }
-            None => {}
+        submission: PromptSubmission,
+    ) -> PromptWorkflowOutcome {
+        let PromptSubmission {
+            prompt,
+            session_id,
+            session_mode,
+        } = submission;
+        if prompt.is_empty() {
+            return PromptWorkflowOutcome::KeepPrompt;
         }
+
+        self.submit_turn_prompt(session_id.clone(), session_mode, prompt)
+            .await;
+
+        PromptWorkflowOutcome::ShowSession { session_id }
     }
 
-    /// Handles the image-paste intent emitted by prompt-mode key routing.
-    ///
-    /// The app layer owns attachment numbering, clipboard-image service
-    /// dispatch, prompt mutation, and user-visible paste errors so runtime
-    /// only routes the key intent.
-    pub(crate) async fn handle_prompt_image_paste_intent(&mut self, context: &PromptIntentContext) {
-        let attachment_number = match &self.mode {
-            AppMode::Prompt {
-                attachment_state, ..
-            } => attachment_state.next_attachment_number,
-            _ => return,
-        };
-
+    /// Persists one clipboard image and returns its local path for the
+    /// presentation-owned composer to insert as a placeholder.
+    pub(crate) async fn persist_prompt_image(&self, request: PromptImagePaste) -> Option<PathBuf> {
         match self
             .services
             .clipboard_image_client()
-            .persist_clipboard_image(context.session_id.as_str().to_string(), attachment_number)
+            .persist_clipboard_image(
+                request.session_id.as_str().to_string(),
+                request.attachment_number,
+            )
             .await
         {
-            Ok(persisted_image) => {
-                let unreachable_attachments =
-                    self.insert_pasted_image_placeholder(persisted_image.local_image_path);
-                self.cleanup_prompt_attachments(unreachable_attachments)
-                    .await;
-            }
+            Ok(persisted_image) => Some(persisted_image.local_image_path),
             Err(error) => {
                 self.append_prompt_status_line(
-                    context.session_id.as_str(),
+                    request.session_id.as_str(),
                     TranscriptNotice::PasteImageError,
                     &clipboard_image::normalize_clipboard_image_error(&error),
                 )
                 .await;
+
+                None
             }
         }
     }
 
-    /// Inserts one persisted image placeholder into the prompt input and
-    /// records the attachment metadata in prompt state.
-    pub(crate) fn insert_pasted_image_placeholder(
-        &mut self,
-        local_image_path: PathBuf,
-    ) -> Vec<PromptAttachment> {
-        if let AppMode::Prompt {
-            at_mention_state,
-            attachment_state,
-            history_state,
-            input,
-            slash_state,
-            ..
-        } = &mut self.mode
-        {
-            insert_prompt_local_image(
-                attachment_state,
-                history_state,
-                input,
-                slash_state,
-                local_image_path,
-            );
-            *at_mention_state = None;
-
-            return attachment_state.prune_unreachable(input);
-        }
-
-        Vec::new()
-    }
-
     /// Removes image files whose attachment identities are no longer
-    /// reachable through the prompt input's bounded undo/redo history.
+    /// reachable through the presentation-owned prompt composer.
     pub(crate) async fn cleanup_prompt_attachments(&self, attachments: Vec<PromptAttachment>) {
         if attachments.is_empty() {
             return;
@@ -340,194 +222,43 @@ impl App {
         self.cleanup_prompt_attachment_files(&prompt).await;
     }
 
-    /// Handles the cancel intent emitted by prompt-mode key routing.
-    ///
-    /// Slash-command cancellation only clears the slash input. Prompt
-    /// cancellation cleans up composer-owned attachments, optionally deletes
-    /// a blank backing session, and otherwise restores session view.
-    pub(crate) async fn handle_prompt_cancel_intent(&mut self, context: &PromptIntentContext) {
-        if context.is_slash_command() {
-            self.reset_prompt_slash_input().await;
-
-            return;
-        }
-
-        self.cleanup_prompt_attachment_state().await;
-
-        if context.can_delete_on_cancel() {
+    /// Cancels one presentation-owned prompt and returns the requested
+    /// navigation effect.
+    pub(crate) async fn cancel_prompt(
+        &mut self,
+        cancellation: PromptCancellation,
+    ) -> PromptWorkflowOutcome {
+        if cancellation.session_mode == PromptSessionMode::NewDeletable {
             self.delete_selected_session_deferred_cleanup().await;
-            self.mode = AppMode::List;
 
-            return;
+            return PromptWorkflowOutcome::ShowSessionList;
         }
 
-        self.mode = AppMode::View {
-            scroll_offset: context.scroll_offset,
-            session_id: context.session_id.clone(),
-        };
+        PromptWorkflowOutcome::ShowSession {
+            session_id: cancellation.session_id,
+        }
     }
 
-    /// Returns whether the active prompt session has cached focused-review
-    /// suggestions that make `/apply` selectable.
-    pub(crate) fn prompt_apply_command_is_available(&self) -> bool {
-        let Some(session_id) = self.prompt_session_id() else {
+    /// Returns whether cached focused-review text contains actionable
+    /// suggestions for one session.
+    pub(crate) fn prompt_apply_command_is_available_for_session(&self, session_id: &str) -> bool {
+        let Some(ReviewCacheEntry::Ready { text, .. }) = self.review_cache.get(session_id) else {
             return false;
         };
 
-        self.prompt_apply_command_is_available_for_session(&session_id)
-    }
-
-    /// Drains the prompt composer into the structured turn payload sent to
-    /// the session workflow.
-    ///
-    /// Attachments are filtered against the submitted text so manually
-    /// deleted `[Image #n]` placeholders do not leave orphaned image inputs in
-    /// the final turn payload.
-    pub(crate) fn take_submitted_turn_prompt(&mut self) -> TurnPrompt {
-        match &mut self.mode {
-            AppMode::Prompt {
-                attachment_state,
-                input,
-                ..
-            } => {
-                let submission = drain_prompt_submission(attachment_state, input);
-                let attachments = submission
-                    .attachments
-                    .into_iter()
-                    .map(|attachment| TurnPromptAttachment {
-                        local_image_path: attachment.local_image_path,
-                        placeholder: attachment.placeholder,
-                    })
-                    .collect();
-
-                TurnPrompt {
-                    attachments,
-                    text: submission.text,
-                    text_source: TurnPromptTextSource::UserPrompt,
-                }
-            }
-            _ => TurnPrompt::from_text(String::new()),
-        }
-    }
-
-    /// Builds a cleanup-only prompt for image attachments currently absent
-    /// from the editable text but retained for undo.
-    fn archived_prompt_attachments(&self) -> Option<TurnPrompt> {
-        let AppMode::Prompt {
-            attachment_state, ..
-        } = &self.mode
-        else {
-            return None;
-        };
-        if attachment_state.archived_attachments.is_empty() {
-            return None;
-        }
-
-        let attachments = attachment_state
-            .archived_attachments
-            .iter()
-            .map(|attachment| TurnPromptAttachment {
-                local_image_path: attachment.local_image_path.clone(),
-                placeholder: attachment.placeholder.clone(),
-            })
-            .collect();
-
-        Some(TurnPrompt {
-            attachments,
-            text: String::new(),
-            text_source: TurnPromptTextSource::UserPrompt,
-        })
-    }
-
-    /// Routes one prepared turn prompt through the lifecycle path for the
-    /// active prompt context.
-    async fn submit_turn_prompt_for_context(
-        &mut self,
-        context: &PromptIntentContext,
-        prompt: TurnPrompt,
-    ) {
-        if context.is_draft_session() {
-            if let Err(error) = self.stage_draft_message(&context.session_id, prompt).await {
-                self.append_output_for_session(
-                    &context.session_id,
-                    &TranscriptNotice::Error.format(error),
-                )
-                .await;
-            }
-        } else if context.is_new_session() {
-            if let Err(error) = self.start_session(&context.session_id, prompt).await {
-                self.append_output_for_session(
-                    &context.session_id,
-                    &TranscriptNotice::Error.format(error),
-                )
-                .await;
-            }
-        } else if self.session_queues_messages(&context.session_id) {
-            if let Err(error) = self.enqueue_message(&context.session_id, prompt) {
-                self.append_output_for_session(
-                    &context.session_id,
-                    &TranscriptNotice::QueueError.format(error),
-                )
-                .await;
-            }
-        } else {
-            self.reply(&context.session_id, prompt).await;
-        }
-    }
-
-    /// Restores view mode for the session that owned prompt input.
-    fn restore_prompt_session_view(&mut self, context: &PromptIntentContext) {
-        self.mode = AppMode::View {
-            scroll_offset: None,
-            session_id: context.session_id.clone(),
-        };
-    }
-
-    /// Returns whether the targeted session is running a turn or rebase, used
-    /// to route non-slash submissions into the in-memory message queue
-    /// instead of the live reply path.
-    fn session_queues_messages(&self, session_id: &str) -> bool {
-        self.sessions
-            .sessions()
-            .iter()
-            .find(|session| session.id == session_id)
-            .is_some_and(|session| matches!(session.status, Status::InProgress | Status::Rebasing))
-    }
-
-    /// Clears the slash-command buffer and cleans up attachments removed with
-    /// it after one prompt slash action is accepted or canceled.
-    async fn reset_prompt_slash_input(&mut self) {
-        self.cleanup_prompt_attachment_state().await;
-
-        if let AppMode::Prompt {
-            input, slash_state, ..
-        } = &mut self.mode
-        {
-            input.take_text();
-            slash_state.reset();
-        }
-    }
-
-    /// Resets the slash-command menu without clearing the user's input text.
-    fn reset_prompt_slash_state(&mut self) {
-        if let AppMode::Prompt { slash_state, .. } = &mut self.mode {
-            slash_state.reset();
-        }
+        review::has_actionable_review_suggestions(Some(text))
     }
 
     /// Persists one slash-selected model change and logs any failure with
     /// session context.
-    async fn update_prompt_session_model(
+    pub(crate) async fn update_prompt_session_model(
         &mut self,
-        context: &PromptIntentContext,
-        selected_agent: crate::domain::agent::AgentSelection,
+        session_id: &SessionId,
+        selected_agent: AgentSelection,
     ) {
-        if let Err(error) = self
-            .set_session_model(&context.session_id, selected_agent)
-            .await
-        {
+        if let Err(error) = self.set_session_model(session_id, selected_agent).await {
             warn!(
-                session_id = %context.session_id,
+                session_id = %session_id,
                 agent = %selected_agent.kind(),
                 model = %selected_agent.model().as_str(),
                 error = %error,
@@ -536,19 +267,19 @@ impl App {
         }
     }
 
-    /// Persists one slash-selected reasoning level and logs any failure
-    /// with session context.
-    async fn update_prompt_session_reasoning_level(
+    /// Persists one slash-selected reasoning level and logs any failure with
+    /// session context.
+    pub(crate) async fn update_prompt_session_reasoning_level(
         &mut self,
-        context: &PromptIntentContext,
+        session_id: &SessionId,
         reasoning_level: ReasoningLevel,
     ) {
         if let Err(error) = self
-            .set_session_reasoning_level(&context.session_id, reasoning_level)
+            .set_session_reasoning_level(session_id, reasoning_level)
             .await
         {
             warn!(
-                session_id = %context.session_id,
+                session_id = %session_id,
                 reasoning_level = ?reasoning_level,
                 error = %error,
                 "failed to update session reasoning level from prompt slash command"
@@ -556,76 +287,15 @@ impl App {
         }
     }
 
-    /// Returns the active prompt session id without mutating prompt state.
-    fn prompt_session_id(&self) -> Option<SessionId> {
-        match &self.mode {
-            AppMode::Prompt { session_id, .. } => Some(session_id.clone()),
-            _ => None,
-        }
-    }
-
-    /// Returns whether cached focused-review text contains actionable
-    /// suggestions for one session.
-    fn prompt_apply_command_is_available_for_session(&self, session_id: &str) -> bool {
-        let Some(ReviewCacheEntry::Ready { text, .. }) = self.review_cache.get(session_id) else {
-            return false;
-        };
-
-        review::has_actionable_review_suggestions(Some(text))
-    }
-
-    /// Appends one prompt-mode status line to the session transcript shown
-    /// above the composer.
-    async fn append_prompt_status_line(
-        &self,
-        session_id: &str,
-        notice: TranscriptNotice,
-        message: &str,
-    ) {
-        self.append_output_for_session(session_id, &notice.format(message))
-            .await;
-    }
-
-    /// Removes any prompt attachment files still owned by the active composer
-    /// and resets attachment state before leaving prompt mode.
-    async fn cleanup_prompt_attachment_state(&mut self) {
-        let prompt = match &mut self.mode {
-            AppMode::Prompt {
-                attachment_state, ..
-            } => {
-                let attachments = attachment_state
-                    .attachments
-                    .iter()
-                    .chain(&attachment_state.archived_attachments)
-                    .map(|attachment| TurnPromptAttachment {
-                        local_image_path: attachment.local_image_path.clone(),
-                        placeholder: attachment.placeholder.clone(),
-                    })
-                    .collect::<Vec<_>>();
-                attachment_state.reset();
-
-                TurnPrompt {
-                    attachments,
-                    text: String::new(),
-                    text_source: TurnPromptTextSource::UserPrompt,
-                }
-            }
-            _ => return,
-        };
-
-        self.cleanup_prompt_attachment_files(&prompt).await;
-    }
-
     /// Handles `/apply` by extracting suggestions from the focused review and
     /// submitting them as a verification-gated prompt to the agent.
-    ///
-    /// Returns `true` when the command consumed the slash-command input. A
-    /// validation failure that leaves actionable cached suggestions available
-    /// returns `false`, preserving the visible `/apply` text for correction or
-    /// retry.
-    async fn handle_apply_prompt_command(&mut self, context: &PromptIntentContext) -> bool {
+    pub(crate) async fn apply_focused_review(
+        &mut self,
+        session_id: &SessionId,
+        session_index: usize,
+    ) -> PromptApplyOutcome {
         let Some((session_status, session_folder, base_branch)) =
-            self.session_at(context.session_index).map(|session| {
+            self.session_at(session_index).map(|session| {
                 (
                     session.status,
                     session.folder.clone(),
@@ -633,34 +303,34 @@ impl App {
                 )
             })
         else {
-            return false;
+            return PromptApplyOutcome::KeepComposer;
         };
 
         if session_status != Status::Review {
             self.append_prompt_status_line(
-                &context.session_id,
+                session_id,
                 TranscriptNotice::Apply,
                 "Apply is only available after a focused review completes (session status must be \
                  Review).",
             )
             .await;
 
-            return true;
+            return PromptApplyOutcome::ClearComposer;
         }
 
         let (cached_hash, cached_text) = if let Some(ReviewCacheEntry::Ready { diff_hash, text }) =
-            self.review_cache.get(context.session_id.as_str())
+            self.review_cache.get(session_id.as_str())
         {
             (*diff_hash, text.clone())
         } else {
             self.append_prompt_status_line(
-                &context.session_id,
+                session_id,
                 TranscriptNotice::Apply,
                 "No actionable suggestions available. Run a focused review first (f key).",
             )
             .await;
 
-            return true;
+            return PromptApplyOutcome::ClearComposer;
         };
 
         let current_diff = match self
@@ -670,57 +340,105 @@ impl App {
             .await
         {
             Ok(diff) => diff,
-            Err(err) => {
+            Err(error) => {
                 self.append_prompt_status_line(
-                    &context.session_id,
+                    session_id,
                     TranscriptNotice::Apply,
                     &format!(
-                        "Failed to read worktree diff: {err}. Review cache preserved; try /apply \
-                         again."
+                        "Failed to read worktree diff: {error}. Review cache preserved; try \
+                         /apply again."
                     ),
                 )
                 .await;
 
-                return true;
+                return PromptApplyOutcome::ClearComposer;
             }
         };
         let current_hash = diff_content_hash(&current_diff);
 
         if current_hash != cached_hash {
-            self.clear_review_output(context.session_id.as_str());
+            self.clear_review_output(session_id.as_str());
             self.append_prompt_status_line(
-                &context.session_id,
+                session_id,
                 TranscriptNotice::Apply,
                 "Review is stale; the worktree changed since it was generated. Run focused review \
                  again (f key).",
             )
             .await;
 
-            return true;
+            return PromptApplyOutcome::ClearComposer;
         }
 
         let Some(suggestions) = review::review_suggestions(&cached_text) else {
             self.append_prompt_status_line(
-                &context.session_id,
+                session_id,
                 TranscriptNotice::Apply,
                 "No actionable suggestions found in the current review.",
             )
             .await;
 
-            return false;
+            return PromptApplyOutcome::KeepComposer;
         };
 
-        let prompt = build_apply_review_prompt(&suggestions);
+        self.reply(session_id, build_apply_review_prompt(&suggestions))
+            .await;
 
-        self.cleanup_prompt_attachment_state().await;
-        self.reply(&context.session_id, prompt).await;
+        PromptApplyOutcome::ShowSession {
+            session_id: session_id.clone(),
+        }
+    }
 
-        self.mode = AppMode::View {
-            scroll_offset: None,
-            session_id: context.session_id.clone(),
-        };
+    /// Routes one prepared turn prompt through the lifecycle path for the
+    /// active prompt session.
+    async fn submit_turn_prompt(
+        &mut self,
+        session_id: SessionId,
+        session_mode: PromptSessionMode,
+        prompt: TurnPrompt,
+    ) {
+        if session_mode == PromptSessionMode::NewDraft {
+            if let Err(error) = self.stage_draft_message(&session_id, prompt).await {
+                self.append_output_for_session(&session_id, &TranscriptNotice::Error.format(error))
+                    .await;
+            }
+        } else if session_mode != PromptSessionMode::Existing {
+            if let Err(error) = self.start_session(&session_id, prompt).await {
+                self.append_output_for_session(&session_id, &TranscriptNotice::Error.format(error))
+                    .await;
+            }
+        } else if self.session_queues_messages(&session_id) {
+            if let Err(error) = self.enqueue_message(&session_id, prompt) {
+                self.append_output_for_session(
+                    &session_id,
+                    &TranscriptNotice::QueueError.format(error),
+                )
+                .await;
+            }
+        } else {
+            self.reply(&session_id, prompt).await;
+        }
+    }
 
-        true
+    /// Returns whether the targeted session is running a turn or rebase, used
+    /// to route submissions into the in-memory message queue.
+    fn session_queues_messages(&self, session_id: &str) -> bool {
+        self.sessions
+            .sessions()
+            .iter()
+            .find(|session| session.id == session_id)
+            .is_some_and(|session| matches!(session.status, Status::InProgress | Status::Rebasing))
+    }
+
+    /// Appends one prompt-workflow status line to the target session
+    /// transcript.
+    async fn append_prompt_status_line(
+        &self,
+        session_id: &str,
+        notice: TranscriptNotice,
+        message: &str,
+    ) {
+        self.append_output_for_session(session_id, &notice.format(message))
+            .await;
     }
 }
 
@@ -844,11 +562,6 @@ mod tests {
     use ag_forge::ReviewCommentAnchorSide;
 
     use super::*;
-    use crate::domain::composer::{
-        PromptAttachment, PromptAttachmentState, PromptHistoryState, PromptSlashState,
-    };
-    use crate::domain::input::InputState;
-    use crate::presentation::app_mode::ChatFocus;
 
     /// Verifies `/apply` submits the checked-in markdown prompt with the
     /// review suggestions fenced as data.
@@ -890,7 +603,6 @@ mod tests {
         assert!(prompt.text.contains("````text\n"));
         assert!(prompt.text.contains("```markdown\nexample\n```"));
     }
-
     /// Ensures the all-comments prompt includes general discussion and only
     /// unresolved, current thread IDs.
     #[test]
@@ -986,6 +698,142 @@ mod tests {
         assert!(prompt.text.contains("```rust\nlet value = 1;\n```"));
     }
 
+    #[tokio::test]
+    async fn test_submit_prompt_reports_missing_draft_and_regular_sessions() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_git_test_app().await;
+        let draft_session_id = SessionId::from("missing-draft-session");
+        let regular_session_id = SessionId::from("missing-regular-session");
+
+        // Act
+        let draft_outcome = app
+            .submit_prompt(PromptSubmission {
+                prompt: TurnPrompt::from_text("Draft prompt".to_string()),
+                session_id: draft_session_id.clone(),
+                session_mode: PromptSessionMode::NewDraft,
+            })
+            .await;
+        let regular_outcome = app
+            .submit_prompt(PromptSubmission {
+                prompt: TurnPrompt::from_text("Regular prompt".to_string()),
+                session_id: regular_session_id.clone(),
+                session_mode: PromptSessionMode::NewRegular,
+            })
+            .await;
+
+        // Assert
+        assert_eq!(
+            draft_outcome,
+            PromptWorkflowOutcome::ShowSession {
+                session_id: draft_session_id,
+            }
+        );
+        assert_eq!(
+            regular_outcome,
+            PromptWorkflowOutcome::ShowSession {
+                session_id: regular_session_id,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_submit_prompt_reports_queue_failure_without_session_handles() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_git_test_app().await;
+        let session_id: SessionId = app
+            .create_session()
+            .await
+            .expect("session should be created")
+            .into();
+        app.sessions.sessions_mut()[0].status = Status::InProgress;
+        app.sessions
+            .session_handles_mut()
+            .remove(session_id.as_str());
+
+        // Act
+        let outcome = app
+            .submit_prompt(PromptSubmission {
+                prompt: TurnPrompt::from_text("Queued prompt".to_string()),
+                session_id: session_id.clone(),
+                session_mode: PromptSessionMode::Existing,
+            })
+            .await;
+
+        // Assert
+        assert_eq!(
+            outcome,
+            PromptWorkflowOutcome::ShowSession {
+                session_id: session_id.clone(),
+            }
+        );
+        assert!(app.sessions.sessions()[0].queued_messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_apply_focused_review_returns_validation_outcomes() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_git_test_app().await;
+        let session_id: SessionId = app
+            .create_session()
+            .await
+            .expect("session should be created")
+            .into();
+
+        // Act
+        let missing_session = app.apply_focused_review(&session_id, usize::MAX).await;
+        app.sessions.sessions_mut()[0].status = Status::Review;
+        let missing_review = app.apply_focused_review(&session_id, 0).await;
+        let session = &app.sessions.sessions()[0];
+        let current_diff = app
+            .services
+            .git_client()
+            .diff(session.folder.clone(), session.base_branch.clone())
+            .await
+            .expect("test repository diff should load");
+        app.review_cache.insert(
+            session_id.clone(),
+            ReviewCacheEntry::Ready {
+                diff_hash: diff_content_hash(&current_diff),
+                text: "## Review\n### Suggestions\n- None".to_string(),
+            },
+        );
+        let empty_review = app.apply_focused_review(&session_id, 0).await;
+
+        // Assert
+        assert_eq!(missing_session, PromptApplyOutcome::KeepComposer);
+        assert_eq!(missing_review, PromptApplyOutcome::ClearComposer);
+        assert_eq!(empty_review, PromptApplyOutcome::KeepComposer);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_session_review_comments_keeps_page_when_enqueue_fails() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_git_test_app().await;
+        let session_id: SessionId = app
+            .create_session()
+            .await
+            .expect("session should be created")
+            .into();
+        app.sessions.sessions_mut()[0].prompt = "Existing prompt".to_string();
+        app.sessions.sessions_mut()[0].status = Status::Review;
+        app.sessions
+            .session_handles_mut()
+            .remove(session_id.as_str());
+        let snapshot = review_comment_snapshot();
+
+        // Act
+        let outcome = app
+            .resolve_session_review_comments(
+                &session_id,
+                &snapshot,
+                ReviewCommentSelection::AllUnresolved,
+            )
+            .await;
+
+        // Assert
+        assert_eq!(outcome, ReviewCommentResolutionOutcome::KeepReviewComments);
+    }
+
     /// Ensures comment resolution does not enqueue a turn for a blocked
     /// session or a selection without actionable review data.
     #[tokio::test]
@@ -1017,63 +865,11 @@ mod tests {
             .await;
 
         // Assert
-        assert!(!blocked);
-        assert!(!empty_selection);
-    }
-
-    /// Ensures image files retained for input undo are included in the
-    /// cleanup payload produced when the prompt is submitted.
-    #[tokio::test]
-    async fn test_archived_prompt_attachments_builds_cleanup_prompt() {
-        // Arrange
-        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
-        let attachment = PromptAttachment::new(1, PathBuf::from("/tmp/image-1.png"));
-        let expected_placeholder = attachment.placeholder.clone();
-        app.mode = AppMode::Prompt {
-            at_mention_state: None,
-            attachment_state: PromptAttachmentState {
-                archived_attachments: vec![attachment],
-                ..PromptAttachmentState::default()
-            },
-            focus: ChatFocus::Input,
-            history_state: PromptHistoryState::new(Vec::new()),
-            input: InputState::default(),
-            scroll_offset: None,
-            session_id: "session-id".into(),
-            slash_state: PromptSlashState::default(),
-        };
-
-        // Act
-        let prompt = app
-            .archived_prompt_attachments()
-            .expect("archived attachment should produce a cleanup prompt");
-
-        // Assert
-        assert_eq!(prompt.attachments.len(), 1);
+        assert_eq!(blocked, ReviewCommentResolutionOutcome::KeepReviewComments);
         assert_eq!(
-            prompt.attachments[0].local_image_path,
-            PathBuf::from("/tmp/image-1.png")
+            empty_selection,
+            ReviewCommentResolutionOutcome::KeepReviewComments
         );
-        assert_eq!(prompt.attachments[0].placeholder, expected_placeholder);
-        assert!(prompt.text.is_empty());
-        assert_eq!(prompt.text_source, TurnPromptTextSource::UserPrompt);
-    }
-
-    #[tokio::test]
-    async fn test_non_prompt_mode_has_no_composer_attachments() {
-        // Arrange
-        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
-        app.mode = AppMode::List;
-
-        // Act
-        let pruned = app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-1.png"));
-        let archived_prompt = app.archived_prompt_attachments();
-        let submission = app.take_submitted_turn_prompt();
-
-        // Assert
-        assert!(pruned.is_empty());
-        assert!(archived_prompt.is_none());
-        assert!(submission.is_empty());
     }
 
     /// Builds review data with one comment followed by current, resolved, and

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -22,7 +22,7 @@ use tempfile::tempdir;
 use tokio::sync::{Barrier, Notify};
 
 use super::*;
-use crate::app::prompt_intent::ReviewCommentSelection;
+use crate::app::prompt_intent::{ReviewCommentResolutionOutcome, ReviewCommentSelection};
 use crate::app::review::{review_failure_message, review_loading_message};
 use crate::app::{App, AppEvent, ReviewCacheEntry, SyncSessionStartError, Tab};
 use crate::domain::agent::{
@@ -2564,7 +2564,7 @@ async fn test_resolve_session_review_comments_enqueues_turn_and_clears_focused_r
         .insert(session_id.clone(), Arc::new(mock_channel));
 
     // Act
-    let enqueued = app
+    let outcome = app
         .resolve_session_review_comments(
             &session_id,
             &snapshot,
@@ -2582,16 +2582,14 @@ async fn test_resolve_session_review_comments_enqueues_turn_and_clears_focused_r
         .expect("failed to load focused reviews");
 
     // Assert
-    assert!(enqueued);
+    assert_eq!(
+        outcome,
+        ReviewCommentResolutionOutcome::ShowSession {
+            session_id: session_id.clone(),
+        }
+    );
     assert!(!app.review_cache.contains_key(&session_id));
     assert!(focused_reviews.is_empty());
-    assert!(matches!(
-        &app.mode,
-        AppMode::View {
-            session_id: viewed_session_id,
-            ..
-        } if viewed_session_id == &session_id
-    ));
 }
 
 /// Builds one actionable inline review thread for session-resolution tests.

--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::path::PathBuf;
 
 use crossterm::event::{self, KeyCode, KeyEvent};
 use ratatui::Terminal;
@@ -7,16 +8,21 @@ use ratatui::layout::Rect;
 
 use crate::app::App;
 use crate::app::prompt_intent::{
-    PromptIntentContext, PromptIntentInputMode, PromptIntentSessionMode,
+    PromptApplyOutcome, PromptCancellation, PromptImagePaste, PromptSessionMode, PromptSubmission,
+    PromptWorkflowOutcome,
 };
-use crate::domain::agent::AgentKind;
+use crate::domain::agent::{AgentKind, ReasoningLevel};
+use crate::domain::composer::PromptAttachment;
 use crate::domain::input::{InputCommand, InputEffect, InputState};
 use crate::domain::session::SessionId;
+use crate::domain::turn_prompt::{TurnPrompt, TurnPromptAttachment, TurnPromptTextSource};
 use crate::presentation::app_mode::{AppMode, ChatFocus, DiffRestoreTarget, PromptModeSnapshot};
 use crate::presentation::prompt::{
-    PromptAtMentionState, apply_prompt_delete_range as apply_prompt_delete_range_components,
-    current_line_delete_range as prompt_current_line_delete_range, insert_prompt_text,
-    prompt_slash_option_count,
+    PromptAtMentionState, PromptSlashStage, PromptSuggestionSelection,
+    apply_prompt_delete_range as apply_prompt_delete_range_components,
+    current_line_delete_range as prompt_current_line_delete_range, drain_prompt_submission,
+    insert_prompt_local_image, insert_prompt_text, prompt_slash_option_count,
+    resolve_prompt_slash_selection,
 };
 use crate::runtime::EventResult;
 use crate::runtime::mode::chat_scroll::{self, ChatScrollMetrics};
@@ -38,26 +44,6 @@ struct PromptContext {
 }
 
 impl PromptContext {
-    /// Converts runtime prompt routing state into an app-layer execution
-    /// intent context.
-    fn to_intent_context(&self) -> PromptIntentContext {
-        PromptIntentContext {
-            input_mode: match self.input_mode {
-                PromptInputMode::SlashCommand => PromptIntentInputMode::SlashCommand,
-                PromptInputMode::AtMention | PromptInputMode::Text => PromptIntentInputMode::Text,
-            },
-            scroll_offset: self.scroll_offset,
-            session_id: self.session_id.clone(),
-            session_index: self.session_index,
-            session_mode: match self.session_mode {
-                PromptSessionMode::Existing => PromptIntentSessionMode::Existing,
-                PromptSessionMode::NewDeletable => PromptIntentSessionMode::NewDeletable,
-                PromptSessionMode::NewDraft => PromptIntentSessionMode::NewDraft,
-                PromptSessionMode::NewRegular => PromptIntentSessionMode::NewRegular,
-            },
-        }
-    }
-
     /// Returns whether the prompt is currently editing an active `@` mention.
     fn is_at_mention(&self) -> bool {
         self.input_mode == PromptInputMode::AtMention
@@ -78,22 +64,6 @@ enum PromptInputMode {
     SlashCommand,
     /// Prompt text is normal user input.
     Text,
-}
-
-/// Session lifecycle shape that determines prompt submission and cancellation
-/// behavior.
-#[derive(Clone, Copy, Eq, PartialEq)]
-enum PromptSessionMode {
-    /// Existing session receiving a follow-up reply.
-    Existing,
-    /// New non-draft session that can be deleted when prompt composition is
-    /// canceled.
-    NewDeletable,
-    /// Draft-mode session that stages prompt text instead of starting a turn.
-    NewDraft,
-    /// New non-draft session that should be preserved on cancel because it has
-    /// staged drafts.
-    NewRegular,
 }
 
 /// Handles key input while the app is in `AppMode::Prompt`.
@@ -692,17 +662,20 @@ fn navigate_prompt_history_down(app: &mut App) {
 }
 
 fn advance_prompt_slash_selection(app: &mut App) {
-    let allow_apply_command = app.prompt_apply_command_is_available();
     let (
         available_agent_kinds,
         input_text,
         selected_agent,
         selected_index,
         session_agent_kind,
+        session_id,
         stage,
     ) = match &app.mode {
         AppMode::Prompt {
-            input, slash_state, ..
+            input,
+            session_id,
+            slash_state,
+            ..
         } => (
             slash_state.available_agent_kinds.clone(),
             input.text().to_string(),
@@ -710,10 +683,13 @@ fn advance_prompt_slash_selection(app: &mut App) {
             slash_state.selected_index,
             app.selected_session()
                 .map_or(AgentKind::Codex, |session| session.agent.kind()),
+            Some(session_id.clone()),
             slash_state.stage,
         ),
         _ => return,
     };
+    let allow_apply_command = session_id
+        .is_some_and(|session_id| app.prompt_apply_command_is_available_for_session(&session_id));
 
     let option_count = prompt_slash_option_count(
         &input_text,
@@ -741,14 +717,28 @@ fn advance_prompt_slash_selection(app: &mut App) {
 /// text in [`prompt_context`], so any leading `/` falls through to the queue
 /// path instead of executing a slash command against the active operation.
 async fn handle_prompt_submit_key(app: &mut App, prompt_context: &PromptContext) {
-    app.handle_prompt_submit_intent(&prompt_context.to_intent_context())
+    if prompt_context.is_slash_command() {
+        handle_prompt_slash_submit(app, prompt_context).await;
+
+        return;
+    }
+
+    let (prompt, archived_attachments) = take_submitted_turn_prompt(app);
+    app.cleanup_prompt_attachments(archived_attachments).await;
+    let outcome = app
+        .submit_prompt(PromptSubmission {
+            prompt,
+            session_id: prompt_context.session_id.clone(),
+            session_mode: prompt_context.session_mode,
+        })
         .await;
+
+    apply_prompt_workflow_outcome(app, outcome, None);
 }
 
 /// Dispatches one clipboard-image paste intent for the active prompt.
 async fn handle_prompt_image_paste(app: &mut App, prompt_context: &PromptContext) {
-    app.handle_prompt_image_paste_intent(&prompt_context.to_intent_context())
-        .await;
+    paste_image_into_active_prompt(app, &prompt_context.session_id).await;
 }
 
 /// Cancels the active prompt and drops any composer-owned attachment files.
@@ -756,8 +746,260 @@ async fn handle_prompt_image_paste(app: &mut App, prompt_context: &PromptContext
 /// Existing focused-review output is restored into session view because no new
 /// prompt was submitted.
 async fn handle_prompt_cancel_key(app: &mut App, prompt_context: &PromptContext) {
-    app.handle_prompt_cancel_intent(&prompt_context.to_intent_context())
+    if prompt_context.is_slash_command() {
+        clear_prompt_slash_input(app).await;
+
+        return;
+    }
+
+    let attachments = take_prompt_attachment_cleanup(app);
+    app.cleanup_prompt_attachments(attachments).await;
+    let outcome = app
+        .cancel_prompt(PromptCancellation {
+            session_id: prompt_context.session_id.clone(),
+            session_mode: prompt_context.session_mode,
+        })
         .await;
+
+    apply_prompt_workflow_outcome(app, outcome, prompt_context.scroll_offset);
+}
+
+/// Executes the selected slash-command action from presentation-owned state.
+async fn handle_prompt_slash_submit(app: &mut App, prompt_context: &PromptContext) {
+    let session_agent_kind = app
+        .session_at(prompt_context.session_index)
+        .map_or(AgentKind::Codex, |session| session.agent.kind());
+    let selection = match &app.mode {
+        AppMode::Prompt {
+            input, slash_state, ..
+        } => resolve_prompt_slash_selection(
+            input.text(),
+            slash_state,
+            session_agent_kind,
+            app.prompt_apply_command_is_available_for_session(&prompt_context.session_id),
+        ),
+        _ => None,
+    };
+
+    match selection {
+        Some(PromptSuggestionSelection::Command("/apply")) => {
+            let outcome = app
+                .apply_focused_review(&prompt_context.session_id, prompt_context.session_index)
+                .await;
+            apply_prompt_apply_outcome(app, outcome).await;
+        }
+        Some(PromptSuggestionSelection::Command("/reasoning")) => {
+            let selected_reasoning_level = app
+                .session_at(prompt_context.session_index)
+                .map_or(app.settings.reasoning_level, |session| {
+                    session.effective_reasoning_level()
+                });
+            let selected_index = ReasoningLevel::ALL
+                .iter()
+                .position(|level| *level == selected_reasoning_level)
+                .unwrap_or(0);
+
+            if let AppMode::Prompt { slash_state, .. } = &mut app.mode {
+                slash_state.stage = PromptSlashStage::Reasoning;
+                slash_state.selected_agent = None;
+                slash_state.selected_index = selected_index;
+            }
+        }
+        Some(PromptSuggestionSelection::Command(_)) => {
+            if let AppMode::Prompt { slash_state, .. } = &mut app.mode {
+                slash_state.stage = PromptSlashStage::Agent;
+                slash_state.selected_agent = None;
+                slash_state.selected_index = 0;
+            }
+        }
+        Some(PromptSuggestionSelection::Agent(selected_agent)) => {
+            if let AppMode::Prompt { slash_state, .. } = &mut app.mode {
+                slash_state.selected_agent = Some(selected_agent);
+                slash_state.stage = PromptSlashStage::Model;
+                slash_state.selected_index = 0;
+            }
+        }
+        Some(PromptSuggestionSelection::Model(selected_agent)) => {
+            clear_prompt_slash_input(app).await;
+            app.update_prompt_session_model(&prompt_context.session_id, selected_agent)
+                .await;
+        }
+        Some(PromptSuggestionSelection::Reasoning(reasoning_level)) => {
+            clear_prompt_slash_input(app).await;
+            app.update_prompt_session_reasoning_level(&prompt_context.session_id, reasoning_level)
+                .await;
+        }
+        None => {}
+    }
+}
+
+/// Applies the navigation requested by one app-layer prompt workflow.
+fn apply_prompt_workflow_outcome(
+    app: &mut App,
+    outcome: PromptWorkflowOutcome,
+    scroll_offset: Option<u16>,
+) {
+    match outcome {
+        PromptWorkflowOutcome::KeepPrompt => {}
+        PromptWorkflowOutcome::ShowSession { session_id } => {
+            app.mode = AppMode::View {
+                scroll_offset,
+                session_id,
+            };
+        }
+        PromptWorkflowOutcome::ShowSessionList => app.mode = AppMode::List,
+    }
+}
+
+/// Applies the composer and navigation changes requested by `/apply`.
+async fn apply_prompt_apply_outcome(app: &mut App, outcome: PromptApplyOutcome) {
+    match outcome {
+        PromptApplyOutcome::ClearComposer => clear_prompt_slash_input(app).await,
+        PromptApplyOutcome::KeepComposer => reset_prompt_slash_state(app),
+        PromptApplyOutcome::ShowSession { session_id } => {
+            let attachments = take_prompt_attachment_cleanup(app);
+            app.cleanup_prompt_attachments(attachments).await;
+            app.mode = AppMode::View {
+                scroll_offset: None,
+                session_id,
+            };
+        }
+    }
+}
+
+/// Persists a clipboard image and inserts it into the active presentation
+/// composer when the capture succeeds.
+pub(crate) async fn paste_image_into_active_prompt(app: &mut App, session_id: &SessionId) {
+    let attachment_number = match &app.mode {
+        AppMode::Prompt {
+            attachment_state, ..
+        } => attachment_state.next_attachment_number,
+        _ => return,
+    };
+    let request = PromptImagePaste {
+        attachment_number,
+        session_id: session_id.clone(),
+    };
+    let Some(local_image_path) = app.persist_prompt_image(request).await else {
+        return;
+    };
+
+    let unreachable_attachments = insert_pasted_image_placeholder(app, local_image_path);
+    app.cleanup_prompt_attachments(unreachable_attachments)
+        .await;
+}
+
+/// Inserts one persisted image placeholder into presentation-owned prompt
+/// state.
+fn insert_pasted_image_placeholder(
+    app: &mut App,
+    local_image_path: PathBuf,
+) -> Vec<PromptAttachment> {
+    if let AppMode::Prompt {
+        at_mention_state,
+        attachment_state,
+        history_state,
+        input,
+        slash_state,
+        ..
+    } = &mut app.mode
+    {
+        insert_prompt_local_image(
+            attachment_state,
+            history_state,
+            input,
+            slash_state,
+            local_image_path,
+        );
+        *at_mention_state = None;
+
+        return attachment_state.prune_unreachable(input);
+    }
+
+    Vec::new()
+}
+
+/// Drains presentation-owned prompt input into an app-layer submission and
+/// returns archived attachment files that require cleanup.
+fn take_submitted_turn_prompt(app: &mut App) -> (TurnPrompt, Vec<PromptAttachment>) {
+    let AppMode::Prompt {
+        attachment_state,
+        input,
+        ..
+    } = &mut app.mode
+    else {
+        return (TurnPrompt::from_text(String::new()), Vec::new());
+    };
+    let archived_attachments = attachment_state.archived_attachments.clone();
+    let submission = drain_prompt_submission(attachment_state, input);
+    let attachments = submission
+        .attachments
+        .into_iter()
+        .map(|attachment| TurnPromptAttachment {
+            local_image_path: attachment.local_image_path,
+            placeholder: attachment.placeholder,
+        })
+        .collect();
+    let prompt = TurnPrompt {
+        attachments,
+        text: submission.text,
+        text_source: TurnPromptTextSource::UserPrompt,
+    };
+
+    (prompt, archived_attachments)
+}
+
+/// Removes all attachments owned by the active composer and resets that
+/// presentation state before it leaves prompt mode.
+fn take_prompt_attachment_cleanup(app: &mut App) -> Vec<PromptAttachment> {
+    let attachments = prompt_attachment_cleanup(app);
+
+    reset_prompt_attachment_state(app);
+
+    attachments
+}
+
+/// Clones every image attachment owned by the active presentation composer.
+fn prompt_attachment_cleanup(app: &App) -> Vec<PromptAttachment> {
+    let AppMode::Prompt {
+        attachment_state, ..
+    } = &app.mode
+    else {
+        return Vec::new();
+    };
+
+    attachment_state
+        .attachments
+        .iter()
+        .chain(&attachment_state.archived_attachments)
+        .cloned()
+        .collect()
+}
+
+/// Clears attachment state after its files have been cleaned up elsewhere.
+fn reset_prompt_attachment_state(app: &mut App) {
+    let AppMode::Prompt {
+        attachment_state, ..
+    } = &mut app.mode
+    else {
+        return;
+    };
+
+    attachment_state.reset();
+}
+
+/// Clears the slash buffer and cleans up composer attachments it owned.
+async fn clear_prompt_slash_input(app: &mut App) {
+    let attachments = take_prompt_attachment_cleanup(app);
+    app.cleanup_prompt_attachments(attachments).await;
+
+    if let AppMode::Prompt {
+        input, slash_state, ..
+    } = &mut app.mode
+    {
+        input.take_text();
+        slash_state.reset();
+    }
 }
 
 fn prompt_input_width<B: Backend>(terminal: &Terminal<B>) -> io::Result<u16>
@@ -891,22 +1133,40 @@ async fn handle_at_mention_select(app: &mut App) {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::process::Command;
 
     use tempfile::tempdir;
 
     use super::*;
     use crate::app::prompt_intent::build_apply_review_prompt;
-    use crate::domain::agent::ReasoningLevel;
+    use crate::domain::agent::{AgentCliInfo, AgentModel, AgentSelection, ReasoningLevel};
     use crate::domain::file_entry::FileEntry;
     use crate::domain::input::INPUT_HISTORY_LIMIT;
     use crate::domain::session_message::SessionTranscript;
     use crate::infra::db::Database;
+    use crate::infra::fs;
     use crate::presentation::prompt::{
         PromptAtMentionState, PromptAttachmentState, PromptHistoryState, PromptSlashStage,
         PromptSlashState,
     };
+
+    trait PromptTestAppExt {
+        fn insert_pasted_image_placeholder(&mut self, local_image_path: PathBuf);
+        fn take_submitted_turn_prompt(&mut self) -> TurnPrompt;
+    }
+
+    impl PromptTestAppExt for App {
+        fn insert_pasted_image_placeholder(&mut self, local_image_path: PathBuf) {
+            let _ = insert_pasted_image_placeholder(self, local_image_path);
+        }
+
+        fn take_submitted_turn_prompt(&mut self) -> TurnPrompt {
+            let (prompt, _) = take_submitted_turn_prompt(self);
+
+            prompt
+        }
+    }
 
     fn session_replay_text(session: &crate::domain::session::Session) -> String {
         session
@@ -926,8 +1186,7 @@ mod tests {
         let db = app.services.db().clone();
         let event_sender = app.services.event_sender();
         let available_agent_kinds = app.services.available_agent_kinds();
-        let available_agent_clis =
-            crate::domain::agent::AgentCliInfo::from_kinds(&available_agent_kinds);
+        let available_agent_clis = AgentCliInfo::from_kinds(&available_agent_kinds);
         let app_server_client_override = app.services.app_server_client_override();
         let clipboard_image_client_override = Some(app.services.clipboard_image_client());
         let fs_client = app.services.fs_client();
@@ -964,8 +1223,7 @@ mod tests {
         let db = app.services.db().clone();
         let event_sender = app.services.event_sender();
         let available_agent_kinds = app.services.available_agent_kinds();
-        let available_agent_clis =
-            crate::domain::agent::AgentCliInfo::from_kinds(&available_agent_kinds);
+        let available_agent_clis = AgentCliInfo::from_kinds(&available_agent_kinds);
         let app_server_client_override = app.services.app_server_client_override();
         let fs_client = app.services.fs_client();
         let git_client = app.services.git_client();
@@ -979,6 +1237,38 @@ mod tests {
                 app_server_client_override,
                 available_agent_kinds,
                 clipboard_image_client_override: Some(clipboard_image_client),
+                fs_client,
+                git_client,
+                one_shot_client_override: None,
+                repositories: db,
+                review_request_client,
+            },
+            available_agent_clis,
+        );
+    }
+
+    /// Replaces the app-level filesystem dependency with a caller-provided
+    /// mock.
+    fn install_mock_fs_client(app: &mut App, mock_fs_client: fs::MockFsClient) {
+        let fs_client: std::sync::Arc<dyn fs::FsClient> = std::sync::Arc::new(mock_fs_client);
+        let base_path = app.services.base_path().to_path_buf();
+        let db = app.services.db().clone();
+        let event_sender = app.services.event_sender();
+        let available_agent_kinds = app.services.available_agent_kinds();
+        let available_agent_clis = AgentCliInfo::from_kinds(&available_agent_kinds);
+        let app_server_client_override = app.services.app_server_client_override();
+        let clipboard_image_client_override = Some(app.services.clipboard_image_client());
+        let git_client = app.services.git_client();
+        let review_request_client = app.services.review_request_client();
+
+        app.services = crate::app::AppServices::new_with_agent_clis(
+            base_path,
+            app.services.clock(),
+            event_sender,
+            crate::app::AppServiceDeps {
+                app_server_client_override,
+                available_agent_kinds,
+                clipboard_image_client_override,
                 fs_client,
                 git_client,
                 one_shot_client_override: None,
@@ -1296,7 +1586,7 @@ mod tests {
             .expect("failed to write diff fixture");
 
         let mut attachment_state = PromptAttachmentState::default();
-        attachment_state.register_local_image(std::path::PathBuf::from("/tmp/pic.png"), 0);
+        attachment_state.register_local_image(PathBuf::from("/tmp/pic.png"), 0);
         let expected_attachment_state = attachment_state.clone();
 
         let mut history_state =
@@ -1597,7 +1887,7 @@ mod tests {
         }
 
         // Act
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-1.png"));
 
         // Assert
         if let AppMode::Prompt {
@@ -1613,7 +1903,7 @@ mod tests {
             assert_eq!(attachment_state.attachments.len(), 1);
             assert_eq!(
                 attachment_state.attachments[0].local_image_path,
-                std::path::PathBuf::from("/tmp/image-1.png")
+                PathBuf::from("/tmp/image-1.png")
             );
             assert_eq!(history_state.selected_index, None);
             assert_eq!(history_state.draft_text, None);
@@ -1639,7 +1929,7 @@ mod tests {
             .returning(|_, _| {
                 Box::pin(async {
                     Ok(crate::infra::clipboard_image::PersistedClipboardImage {
-                        local_image_path: std::path::PathBuf::from("/tmp/pasted.png"),
+                        local_image_path: PathBuf::from("/tmp/pasted.png"),
                     })
                 })
             });
@@ -1659,7 +1949,7 @@ mod tests {
             assert_eq!(attachment_state.attachments.len(), 1);
             assert_eq!(
                 attachment_state.attachments[0].local_image_path,
-                std::path::PathBuf::from("/tmp/pasted.png")
+                PathBuf::from("/tmp/pasted.png")
             );
         }
     }
@@ -1697,6 +1987,28 @@ mod tests {
             assert_eq!(input.text(), "Review ");
             assert!(attachment_state.attachments.is_empty());
         }
+    }
+
+    #[tokio::test]
+    async fn test_prompt_attachment_helpers_ignore_non_prompt_mode() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("Review ", None).await;
+        app.mode = AppMode::List;
+        let session_id = SessionId::from("session-id");
+
+        // Act
+        paste_image_into_active_prompt(&mut app, &session_id).await;
+        let inserted_attachments =
+            insert_pasted_image_placeholder(&mut app, PathBuf::from("/tmp/image-1.png"));
+        let (prompt, archived_attachments) = take_submitted_turn_prompt(&mut app);
+        let cleanup_attachments = take_prompt_attachment_cleanup(&mut app);
+
+        // Assert
+        assert!(matches!(app.mode, AppMode::List));
+        assert!(inserted_attachments.is_empty());
+        assert!(prompt.is_empty());
+        assert!(archived_attachments.is_empty());
+        assert!(cleanup_attachments.is_empty());
     }
 
     /// Verifies unavailable clipboard backends surface as inline paste errors
@@ -1744,7 +2056,7 @@ mod tests {
     async fn test_take_submitted_turn_prompt_drains_text_and_attachment_state() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("Review ", None).await;
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-1.png"));
 
         // Act
         let prompt = app.take_submitted_turn_prompt();
@@ -1755,7 +2067,7 @@ mod tests {
         assert_eq!(prompt.attachments[0].placeholder, "[Image #1]");
         assert_eq!(
             prompt.attachments[0].local_image_path,
-            std::path::PathBuf::from("/tmp/image-1.png")
+            PathBuf::from("/tmp/image-1.png")
         );
         if let AppMode::Prompt {
             attachment_state,
@@ -1773,8 +2085,8 @@ mod tests {
     async fn test_take_submitted_turn_prompt_filters_deleted_attachment_placeholders() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("Review ", None).await;
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-2.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-1.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-2.png"));
         if let AppMode::Prompt { input, .. } = &mut app.mode {
             input.cursor = "Review ".chars().count();
         }
@@ -1789,7 +2101,7 @@ mod tests {
         assert_eq!(prompt.attachments[0].placeholder, "[Image #2]");
         assert_eq!(
             prompt.attachments[0].local_image_path,
-            std::path::PathBuf::from("/tmp/image-2.png")
+            PathBuf::from("/tmp/image-2.png")
         );
         if let AppMode::Prompt {
             attachment_state,
@@ -1804,14 +2116,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_take_submitted_turn_prompt_returns_archived_attachments_for_cleanup() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("Review ", None).await;
+        let image_path = PathBuf::from("/tmp/image-1.png");
+        app.insert_pasted_image_placeholder(image_path.clone());
+        apply_prompt_input_command(&mut app, InputCommand::DeleteBackward).await;
+
+        // Act
+        let (prompt, archived_attachments) = take_submitted_turn_prompt(&mut app);
+
+        // Assert
+        assert_eq!(prompt.text, "Review ");
+        assert!(prompt.attachments.is_empty());
+        assert_eq!(archived_attachments.len(), 1);
+        assert_eq!(archived_attachments[0].local_image_path, image_path);
+        assert_eq!(archived_attachments[0].placeholder, "[Image #1]");
+    }
+
+    #[tokio::test]
     async fn test_take_submitted_turn_prompt_sorts_attachments_by_text_position() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("", None).await;
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-1.png"));
         if let AppMode::Prompt { input, .. } = &mut app.mode {
             input.cursor = 0;
         }
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-2.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-2.png"));
         handle_paste(&mut app, " then ").await;
 
         // Act
@@ -2068,7 +2399,7 @@ mod tests {
     async fn test_prompt_history_round_trip_restores_image_draft_attachment() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("Review ", None).await;
-        let image_path = std::path::PathBuf::from("/tmp/image-1.png");
+        let image_path = PathBuf::from("/tmp/image-1.png");
         app.insert_pasted_image_placeholder(image_path.clone());
         if let AppMode::Prompt { history_state, .. } = &mut app.mode {
             history_state.entries = vec!["Earlier prompt".to_string()];
@@ -2133,8 +2464,7 @@ mod tests {
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
 
         // Assert
         if let AppMode::Prompt {
@@ -2149,14 +2479,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_handle_prompt_slash_submit_ignores_non_prompt_mode() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("/model", None).await;
+        let prompt_context = prompt_context(&mut app).expect("expected prompt context");
+        app.mode = AppMode::List;
+
+        // Act
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
+
+        // Assert
+        assert!(matches!(app.mode, AppMode::List));
+    }
+
+    #[tokio::test]
     async fn test_handle_prompt_slash_submit_maps_filtered_first_command_to_model() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("/", None).await;
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
 
         // Assert
         if let AppMode::Prompt { slash_state, .. } = &app.mode {
@@ -2181,8 +2524,7 @@ mod tests {
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
 
         // Assert
         if let AppMode::Prompt { slash_state, .. } = &app.mode {
@@ -2205,8 +2547,7 @@ mod tests {
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
         app.process_pending_app_events().await;
 
         // Assert
@@ -2224,9 +2565,7 @@ mod tests {
     async fn test_model_slash_submit_discards_pasted_image_before_normal_submission() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("/model", None).await;
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from(
-            "/tmp/nonexistent-test-attachment.png",
-        ));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/nonexistent-test-attachment.png"));
         if let AppMode::Prompt { slash_state, .. } = &mut app.mode {
             slash_state.stage = PromptSlashStage::Model;
             slash_state.selected_agent = Some(AgentKind::Claude);
@@ -2235,8 +2574,7 @@ mod tests {
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
         if let AppMode::Prompt { input, .. } = &mut app.mode {
             input.reset_text("normal prompt".to_string());
         }
@@ -2258,8 +2596,7 @@ mod tests {
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
         app.process_pending_app_events().await;
 
         // Assert
@@ -2278,9 +2615,7 @@ mod tests {
     async fn test_canceling_slash_input_discards_pasted_attachment() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("/model", None).await;
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from(
-            "/tmp/nonexistent-test-attachment.png",
-        ));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/nonexistent-test-attachment.png"));
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
@@ -2306,8 +2641,7 @@ mod tests {
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
 
         // Assert
         if let AppMode::Prompt { slash_state, .. } = &app.mode {
@@ -2325,8 +2659,7 @@ mod tests {
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
 
         // Assert
         if let AppMode::Prompt { slash_state, .. } = &app.mode {
@@ -2346,8 +2679,7 @@ mod tests {
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
 
         // Assert
         if let AppMode::Prompt { slash_state, .. } = &app.mode {
@@ -2366,8 +2698,7 @@ mod tests {
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
 
         // Assert
         if let AppMode::Prompt {
@@ -2492,7 +2823,7 @@ mod tests {
     async fn test_handle_prompt_backspace_removes_whole_image_token_and_attachment() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("Review ", None).await;
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-1.png"));
         if let AppMode::Prompt {
             history_state,
             input,
@@ -2527,7 +2858,7 @@ mod tests {
     async fn test_handle_prompt_delete_removes_whole_image_token_and_attachment() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("Review ", None).await;
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-1.png"));
         if let AppMode::Prompt {
             history_state,
             input,
@@ -2562,7 +2893,7 @@ mod tests {
     async fn test_prompt_undo_restores_deleted_image_attachment() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("Review ", None).await;
-        let image_path = std::path::PathBuf::from("/tmp/image-1.png");
+        let image_path = PathBuf::from("/tmp/image-1.png");
         app.insert_pasted_image_placeholder(image_path.clone());
 
         // Act
@@ -2587,7 +2918,7 @@ mod tests {
     async fn test_manually_entered_image_placeholder_does_not_restore_attachment() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("Review ", None).await;
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-1.png"));
         apply_prompt_input_command(&mut app, InputCommand::DeleteBackward).await;
 
         // Act
@@ -2610,7 +2941,7 @@ mod tests {
     async fn test_deleting_original_duplicate_placeholder_does_not_submit_image() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("", None).await;
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-1.png"));
         handle_paste(&mut app, "[Image #1]").await;
         if let AppMode::Prompt { input, .. } = &mut app.mode {
             input.cursor = 0;
@@ -2629,7 +2960,7 @@ mod tests {
     async fn test_deleting_duplicate_lookalike_keeps_original_image() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("", None).await;
-        let image_path = std::path::PathBuf::from("/tmp/image-1.png");
+        let image_path = PathBuf::from("/tmp/image-1.png");
         app.insert_pasted_image_placeholder(image_path.clone());
         handle_paste(&mut app, "[Image #1]").await;
 
@@ -2647,7 +2978,7 @@ mod tests {
     async fn test_prompt_edit_prunes_attachment_after_undo_revision_eviction() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("", None).await;
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-1.png"));
         apply_prompt_input_command(&mut app, InputCommand::DeleteBackward).await;
 
         // Act
@@ -2669,16 +3000,16 @@ mod tests {
     async fn test_handle_prompt_delete_keeps_new_image_number_unique_for_undo() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("", None).await;
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-2.png"));
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-3.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-1.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-2.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-3.png"));
         if let AppMode::Prompt { input, .. } = &mut app.mode {
             input.cursor = "[Image #1][Image #2]".chars().count();
         }
 
         // Act
         apply_prompt_input_command(&mut app, InputCommand::DeleteForward).await;
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-4.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-4.png"));
 
         // Assert
         if let AppMode::Prompt {
@@ -2693,7 +3024,7 @@ mod tests {
             assert_eq!(attachment_state.attachments[2].placeholder, "[Image #4]");
             assert_eq!(
                 attachment_state.attachments[2].local_image_path,
-                std::path::PathBuf::from("/tmp/image-4.png")
+                PathBuf::from("/tmp/image-4.png")
             );
         }
     }
@@ -2955,7 +3286,7 @@ mod tests {
             path: selected_path.to_string(),
         }]);
         let (mut app, _base_dir) = new_test_prompt_app("@v", None).await;
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-1.png"));
         if let AppMode::Prompt {
             at_mention_state: state,
             input,
@@ -3135,7 +3466,7 @@ mod tests {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("", None).await;
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
-        assert!(prompt_context.session_mode != PromptSessionMode::Existing);
+        assert_ne!(prompt_context.session_mode, PromptSessionMode::Existing);
         assert_eq!(app.sessions.sessions().len(), 1);
 
         // Act
@@ -3151,8 +3482,8 @@ mod tests {
         // Arrange
         let (mut app, _base_dir) = new_test_draft_prompt_app("", None).await;
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
-        assert!(prompt_context.session_mode != PromptSessionMode::Existing);
-        assert!(prompt_context.session_mode != PromptSessionMode::NewDeletable);
+        assert_ne!(prompt_context.session_mode, PromptSessionMode::Existing);
+        assert_ne!(prompt_context.session_mode, PromptSessionMode::NewDeletable);
         assert_eq!(app.sessions.sessions().len(), 1);
 
         // Act
@@ -3184,12 +3515,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_handle_prompt_submit_key_routes_slash_command() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("/model", None).await;
+        let prompt_context = prompt_context(&mut app).expect("expected prompt context");
+
+        // Act
+        handle_prompt_submit_key(&mut app, &prompt_context).await;
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Prompt {
+                input, slash_state, ..
+            } if input.text() == "/model" && slash_state.stage == PromptSlashStage::Agent
+        ));
+    }
+
+    #[tokio::test]
     async fn test_handle_prompt_submit_key_cleans_archived_attachment() {
         // Arrange
         let (mut app, _base_dir) = new_test_draft_prompt_app("Review ", None).await;
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from(
-            "/tmp/nonexistent-test-attachment.png",
-        ));
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/nonexistent-test-attachment.png"));
         apply_prompt_input_command(&mut app, InputCommand::DeleteBackward).await;
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
@@ -3206,11 +3553,9 @@ mod tests {
     async fn test_handle_prompt_submit_key_drains_supported_image_turn() {
         // Arrange
         let (mut app, _base_dir) = new_test_draft_prompt_app("Review ", None).await;
-        app.sessions.sessions_mut()[0].agent = crate::domain::agent::AgentSelection::new(
-            crate::domain::agent::AgentKind::Claude,
-            crate::domain::agent::AgentModel::ClaudeSonnet5,
-        );
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
+        app.sessions.sessions_mut()[0].agent =
+            AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeSonnet5);
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-1.png"));
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
@@ -3234,11 +3579,9 @@ mod tests {
     async fn test_handle_prompt_submit_key_starts_regular_session_with_image_turn() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("Review ", None).await;
-        app.sessions.sessions_mut()[0].agent = crate::domain::agent::AgentSelection::new(
-            crate::domain::agent::AgentKind::Claude,
-            crate::domain::agent::AgentModel::ClaudeSonnet5,
-        );
-        app.insert_pasted_image_placeholder(std::path::PathBuf::from("/tmp/image-1.png"));
+        app.sessions.sessions_mut()[0].agent =
+            AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeSonnet5);
+        app.insert_pasted_image_placeholder(PathBuf::from("/tmp/image-1.png"));
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
@@ -3287,7 +3630,7 @@ mod tests {
         handle_prompt_submit_key(&mut app, &prompt_context).await;
 
         // Assert
-        assert!(prompt_context.session_mode != PromptSessionMode::NewDraft);
+        assert_ne!(prompt_context.session_mode, PromptSessionMode::NewDraft);
         assert!(matches!(app.mode, AppMode::View { .. }));
         assert!(
             !session_replay_text(&app.sessions.sessions()[0])
@@ -3370,6 +3713,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_apply_prompt_apply_outcome_keeps_composer_for_retry() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("/apply", None).await;
+        if let AppMode::Prompt { slash_state, .. } = &mut app.mode {
+            slash_state.stage = PromptSlashStage::Model;
+            slash_state.selected_agent = Some(AgentKind::Codex);
+            slash_state.selected_index = 2;
+        }
+
+        // Act
+        apply_prompt_apply_outcome(&mut app, PromptApplyOutcome::KeepComposer).await;
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Prompt {
+                input, slash_state, ..
+            } if input.text() == "/apply" && *slash_state == PromptSlashState::default()
+        ));
+    }
+
+    #[tokio::test]
     async fn test_handle_apply_command_rejects_when_session_not_in_review_status() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("/apply", None).await;
@@ -3384,8 +3749,7 @@ mod tests {
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
 
         // Assert
         assert!(matches!(app.mode, AppMode::Prompt { .. }));
@@ -3400,8 +3764,7 @@ mod tests {
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
 
         // Assert
         assert!(matches!(app.mode, AppMode::Prompt { .. }));
@@ -3423,8 +3786,7 @@ mod tests {
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
 
         // Assert
         assert!(!app.review_cache.contains_key(session_id.as_str()));
@@ -3453,11 +3815,40 @@ mod tests {
                 text: "## Review\n### Suggestions\n- Fix the typo in `README.md`.".to_string(),
             },
         );
+        let image_path = crate::infra::home::agentty_home()
+            .join("tmp")
+            .join(session_id.as_str())
+            .join("images")
+            .join("image-1.png");
+        if let AppMode::Prompt {
+            attachment_state, ..
+        } = &mut app.mode
+        {
+            attachment_state
+                .attachments
+                .push(PromptAttachment::new(1, image_path.clone()));
+        }
+        let expected_image_path = image_path.clone();
+        let expected_image_directory = image_path
+            .parent()
+            .expect("managed image path should have a parent")
+            .to_path_buf();
+        let mut mock_fs_client = fs::MockFsClient::new();
+        mock_fs_client
+            .expect_remove_file()
+            .once()
+            .withf(move |path| path == &expected_image_path)
+            .returning(|_| Box::pin(async { Ok(()) }));
+        mock_fs_client
+            .expect_remove_dir()
+            .once()
+            .withf(move |path| path == &expected_image_directory)
+            .returning(|_| Box::pin(async { Ok(()) }));
+        install_mock_fs_client(&mut app, mock_fs_client);
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
 
         // Assert
         assert!(!app.review_cache.contains_key(session_id.as_str()));
@@ -3491,8 +3882,7 @@ mod tests {
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
 
         // Assert
         assert!(matches!(app.mode, AppMode::Prompt { .. }));
@@ -3649,18 +4039,15 @@ mod tests {
             attachment_state, ..
         } = &mut app.mode
         {
-            attachment_state
-                .attachments
-                .push(crate::domain::composer::PromptAttachment::new(
-                    1,
-                    std::path::PathBuf::from("/tmp/nonexistent-test-attachment.png"),
-                ));
+            attachment_state.attachments.push(PromptAttachment::new(
+                1,
+                PathBuf::from("/tmp/nonexistent-test-attachment.png"),
+            ));
         }
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
 
         // Assert
         let AppMode::Prompt {
@@ -3692,8 +4079,7 @@ mod tests {
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        app.handle_prompt_slash_submit_intent(&prompt_context.to_intent_context())
-            .await;
+        handle_prompt_slash_submit(&mut app, &prompt_context).await;
 
         // Assert
         let AppMode::Prompt {

--- a/crates/agentty/src/runtime/mode/review_comment.rs
+++ b/crates/agentty/src/runtime/mode/review_comment.rs
@@ -2,7 +2,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::Rect;
 
 use crate::app::App;
-use crate::app::prompt_intent::ReviewCommentSelection;
+use crate::app::prompt_intent::{ReviewCommentResolutionOutcome, ReviewCommentSelection};
 use crate::presentation::app_mode::AppMode;
 use crate::runtime::EventResult;
 use crate::ui::{RenderCacheStore, page};
@@ -65,8 +65,10 @@ pub(crate) async fn handle_with_cache(
             session_id: session_id.clone(),
             scroll_offset,
         };
-        app.resolve_session_review_comments(&session_id, &snapshot, selection)
+        let outcome = app
+            .resolve_session_review_comments(&session_id, &snapshot, selection)
             .await;
+        apply_review_comment_resolution_outcome(app, outcome);
 
         return EventResult::Continue;
     }
@@ -120,6 +122,19 @@ pub(crate) async fn handle_with_cache(
     EventResult::Continue
 }
 
+/// Applies presentation navigation returned by the review-comment workflow.
+fn apply_review_comment_resolution_outcome(app: &mut App, outcome: ReviewCommentResolutionOutcome) {
+    match outcome {
+        ReviewCommentResolutionOutcome::KeepReviewComments => {}
+        ReviewCommentResolutionOutcome::ShowSession { session_id } => {
+            app.mode = AppMode::View {
+                session_id,
+                scroll_offset: None,
+            };
+        }
+    }
+}
+
 /// Returns the next wrapped selection index.
 fn next_selected_index(selected_index: usize, item_count: usize) -> usize {
     if item_count == 0 {
@@ -149,6 +164,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::domain::session::SessionId;
 
     fn comment_snapshot() -> ReviewCommentSnapshot {
         ReviewCommentSnapshot {
@@ -402,6 +418,30 @@ mod tests {
                 scroll_offset: 3,
                 ..
             }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_apply_review_comment_resolution_outcome_shows_session() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let session_id = SessionId::from("session-id");
+
+        // Act
+        apply_review_comment_resolution_outcome(
+            &mut app,
+            ReviewCommentResolutionOutcome::ShowSession {
+                session_id: session_id.clone(),
+            },
+        );
+
+        // Assert
+        assert!(matches!(
+            app.mode,
+            AppMode::View {
+                session_id: viewed_session_id,
+                scroll_offset: None,
+            } if viewed_session_id == session_id
         ));
     }
 

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -6,9 +6,6 @@ use ratatui::backend::Backend;
 use ratatui::layout::Rect;
 use tracing::warn;
 
-use crate::app::prompt_intent::{
-    PromptIntentContext, PromptIntentInputMode, PromptIntentSessionMode,
-};
 use crate::app::session::{SessionTaskService, remote_branch_name_from_upstream_ref};
 use crate::app::{self, App, AppEvent, ReviewCacheEntry, diff_content_hash};
 use crate::domain::input::InputState;
@@ -924,14 +921,7 @@ async fn open_draft_prompt_with_pasted_image(
         scroll_offset,
     );
 
-    app.handle_prompt_image_paste_intent(&PromptIntentContext {
-        input_mode: PromptIntentInputMode::Text,
-        scroll_offset,
-        session_id: view_context.session_id.clone(),
-        session_index: view_context.session_index,
-        session_mode: PromptIntentSessionMode::NewDraft,
-    })
-    .await;
+    prompt::paste_image_into_active_prompt(app, &view_context.session_id).await;
 }
 
 /// Opens the help overlay while preserving the currently viewed session state.

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -52,10 +52,11 @@ For file-level detail, read the module docstrings directly.
   runtime launch, and public module exports.
 - `app/`: Orchestration layer. Owns the `App` state, the `AppEvent` reducer, project and
   settings persistence manager, the merge queue, the sync orchestrator, branch publish,
-  focused review, and the session module (`app/session/`) with its per-session worker
-  queues and workflow steps (`lifecycle`, `turn`, `post_turn`, `merge`, `task`,
-  `worker`). No direct process, filesystem, or clock calls — everything external goes
-  through `infra/` traits.
+  review, typed prompt workflow requests and outcomes, and the session module
+  (`app/session/`) with its per-session worker queues and workflow steps (`lifecycle`,
+  `turn`, `post_turn`, `merge`, `task`, `worker`). Prompt composers, slash-menu state,
+  and mode navigation remain presentation-owned. No direct process, filesystem, or clock
+  calls — everything external goes through `infra/` traits.
 - `domain/`: Pure business entities and logic — sessions and statuses, projects,
   settings keys, themes, structured questions, typed transcript messages, explicit
   transient-message slots and lifecycles, prompt-composer logic, the shared `InputState`
@@ -105,6 +106,8 @@ For file-level detail, read the module docstrings directly.
   synchronizes selection at the frame projection boundary.
 - `app/` must not import runtime mode handlers. Shared interaction calculations belong
   in `domain/` or `presentation.rs`, while application task registries belong in `app/`.
+- Runtime converts presentation-owned prompt state into typed app requests, then applies
+  returned navigation and composer effects. `app/` must not inspect or mutate `AppMode`.
 - Business entities and enums live in `domain/`.
 - External side effects live in `infra/` behind mockable traits; see
   [Testability Boundaries](@/docs/architecture/testability-boundaries.md).

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -168,9 +168,10 @@ derived data instead of recomputing the render twice per frame.
 
 <a id="architecture-runtime-flow-turn"></a> From prompt submit to persisted result:
 
-1. Prompt mode converts a submit key into an app-layer prompt intent;
-   `App::handle_prompt_submit_intent()` drains normal submissions or dispatches
-   slash-command selections.
+1. Prompt mode drains presentation-owned composer state into a typed submission, or
+   resolves a presentation-owned slash-menu selection. `app/prompt_intent.rs` executes
+   the requested session workflow and returns typed composer/navigation effects; prompt
+   mode applies those effects to `AppMode`.
 1. `start_session()` (first prompt) or `reply()` (follow-up) persists the command in
    `session_operation` and enqueues it on the per-session worker.
 1. The worker marks the operation `running`, checks cancel flags, verifies worktree


### PR DESCRIPTION
- Moves prompt submission, slash selection, image paste insertion, attachment cleanup, and mode navigation into runtime.
- Narrows app prompt workflows to typed submissions, cancellations, `/apply`, model and reasoning updates, and returned composer/navigation outcomes.
- Documents prompt state ownership across runtime, presentation, and app architecture.