### PR TITLE
Centralize CLI subprocess execution

### DIFF
--- a/crates/ag-agent/src/agent/cli.rs
+++ b/crates/ag-agent/src/agent/cli.rs
@@ -5,4 +5,5 @@
 //! utility prompts without duplicating subprocess details.
 
 pub(crate) mod error;
+pub(crate) mod execution;
 pub(crate) mod stdin;

--- a/crates/ag-agent/src/agent/cli/execution.rs
+++ b/crates/ag-agent/src/agent/cli/execution.rs
@@ -1,0 +1,630 @@
+//! Shared raw subprocess execution for CLI-backed agent transports.
+
+use std::io;
+use std::os::unix::process::ExitStatusExt as _;
+use std::process::ExitStatus;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufRead, AsyncBufReadExt as _, AsyncRead, AsyncReadExt as _};
+
+use super::stdin;
+use crate::agent::{self as agent, AgentBackend, AgentBackendError, BuildCommandRequest};
+use crate::model::agent::AgentKind;
+
+/// Observer for execution details that are meaningful to a transport adapter.
+pub(crate) trait CliExecutionObserver: Send + Sync {
+    /// Reports the active child PID and clears it after process termination.
+    fn pid_updated(&self, child_pid: Option<u32>);
+
+    /// Reports one complete stdout line while retaining the same line in the
+    /// final raw output.
+    fn stdout_line(&self, line: &str);
+}
+
+/// Observer used by callers that only need the collected raw output.
+pub(crate) struct CollectingCliObserver;
+
+impl CliExecutionObserver for CollectingCliObserver {
+    fn pid_updated(&self, _child_pid: Option<u32>) {}
+
+    fn stdout_line(&self, _line: &str) {}
+}
+
+/// Classified process termination state independent of caller policy.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CliExitStatus {
+    /// Process exited unsuccessfully without a Unix signal.
+    NonZero(Option<i32>),
+    /// Process terminated after receiving a Unix signal.
+    Signaled(i32),
+    /// Process exited successfully.
+    Success,
+}
+
+/// Raw subprocess output returned before provider-specific parsing.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct CliExecutionOutput {
+    /// Classified process termination state.
+    pub exit_status: CliExitStatus,
+    /// Complete stderr captured from the child process.
+    pub stderr: String,
+    /// Complete stdout captured from the child process.
+    pub stdout: String,
+}
+
+/// Infrastructure failure while preparing or running a CLI subprocess.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CliExecutionError {
+    /// Provider backend could not construct the command.
+    #[error("command build failed: {0}")]
+    CommandBuild(AgentBackendError),
+    /// A configured child pipe was unexpectedly unavailable.
+    #[error("{0} pipe unavailable after spawn")]
+    PipeUnavailable(&'static str),
+    /// Child process could not be spawned.
+    #[error("process spawn failed: {0}")]
+    Spawn(io::Error),
+    /// Stderr capture failed.
+    #[error("stderr capture failed: {0}")]
+    StderrRead(io::Error),
+    /// Provider prompt could not be rendered for stdin delivery.
+    #[error("stdin payload build failed: {0}")]
+    StdinBuild(AgentBackendError),
+    /// Stdin delivery failed after the child was spawned.
+    #[error("stdin delivery failed: {0}")]
+    StdinWrite(String),
+    /// Stdout capture failed.
+    #[error("stdout capture failed: {0}")]
+    StdoutRead(io::Error),
+    /// Child execution exceeded the caller-provided deadline.
+    #[error("process timed out after {}s", .0.as_secs())]
+    Timeout(Duration),
+    /// Waiting for child termination failed.
+    #[error("process wait failed: {0}")]
+    Wait(io::Error),
+}
+
+/// Builds and executes one CLI backend command, returning unparsed output.
+///
+/// Command construction, prompt stdin rendering, pipe setup, concurrent stream
+/// capture, PID lifetime, timeout enforcement, and exit classification all
+/// live here. Callers remain responsible for interpreting output and applying
+/// response-repair policy.
+///
+/// # Errors
+/// Returns [`CliExecutionError`] when command preparation or subprocess I/O
+/// fails, or when `timeout` expires.
+pub(crate) async fn execute_cli_command(
+    backend: &dyn AgentBackend,
+    kind: AgentKind,
+    build_request: BuildCommandRequest<'_>,
+    observer: &dyn CliExecutionObserver,
+    timeout: Option<Duration>,
+) -> Result<CliExecutionOutput, CliExecutionError> {
+    let command = backend
+        .build_command(build_request)
+        .map_err(CliExecutionError::CommandBuild)?;
+    let stdin_payload = agent::build_command_stdin_payload(kind, build_request)
+        .map_err(CliExecutionError::StdinBuild)?;
+    let mut tokio_command = tokio::process::Command::from(command);
+    tokio_command
+        .stdin(if stdin_payload.is_some() {
+            std::process::Stdio::piped()
+        } else {
+            std::process::Stdio::null()
+        })
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = tokio_command.spawn().map_err(CliExecutionError::Spawn)?;
+    let _pid_guard = ChildPidObserverGuard::new(observer, child.id());
+    let stdout = require_pipe(child.stdout.take(), "stdout")?;
+    let stderr = require_pipe(child.stderr.take(), "stderr")?;
+    let mut stdin_write_task = stdin::spawn_optional_stdin_write(
+        child.stdin.take(),
+        stdin_payload,
+        "stdin pipe unavailable after spawn",
+        CliExecutionError::StdinWrite,
+    );
+
+    let execution = async {
+        let wait = async { child.wait().await.map_err(CliExecutionError::Wait) };
+        let stdout_capture = capture_stdout(tokio::io::BufReader::new(stdout), observer);
+        let stderr_capture = capture_stderr(stderr);
+        let (exit_status, stdout, stderr) = tokio::try_join!(wait, stdout_capture, stderr_capture)?;
+
+        Ok((exit_status, stdout, stderr))
+    };
+    let execution_result = match timeout {
+        Some(timeout) => {
+            let Ok(execution_result) = tokio::time::timeout(timeout, execution).await else {
+                abort_stdin_write_task(&mut stdin_write_task).await;
+
+                return Err(CliExecutionError::Timeout(timeout));
+            };
+
+            execution_result
+        }
+        None => execution.await,
+    };
+    let (exit_status, stdout, stderr) =
+        finish_cli_execution(stdin_write_task, execution_result).await?;
+
+    Ok(CliExecutionOutput {
+        exit_status: classify_exit_status(exit_status),
+        stderr,
+        stdout,
+    })
+}
+
+/// Finalizes stdin delivery without leaving its task detached after failure.
+async fn finish_cli_execution(
+    mut stdin_write_task: Option<tokio::task::JoinHandle<Result<(), CliExecutionError>>>,
+    execution_result: Result<(ExitStatus, String, String), CliExecutionError>,
+) -> Result<(ExitStatus, String, String), CliExecutionError> {
+    if execution_result.is_err() {
+        abort_stdin_write_task(&mut stdin_write_task).await;
+    }
+
+    stdin::await_optional_stdin_write(
+        stdin_write_task,
+        "stdin write task failed",
+        CliExecutionError::StdinWrite,
+    )
+    .await?;
+
+    execution_result
+}
+
+/// Cancels and joins one active stdin writer before an execution error exits.
+async fn abort_stdin_write_task(
+    stdin_write_task: &mut Option<tokio::task::JoinHandle<Result<(), CliExecutionError>>>,
+) {
+    let Some(stdin_write_task) = stdin_write_task.take() else {
+        return;
+    };
+
+    stdin_write_task.abort();
+    let _ = stdin_write_task.await;
+}
+
+/// Reports a spawned PID and guarantees a matching clear notification.
+struct ChildPidObserverGuard<'a> {
+    observer: &'a dyn CliExecutionObserver,
+}
+
+impl<'a> ChildPidObserverGuard<'a> {
+    /// Creates a PID guard and reports the current child identifier.
+    fn new(observer: &'a dyn CliExecutionObserver, child_pid: Option<u32>) -> Self {
+        observer.pid_updated(child_pid);
+
+        Self { observer }
+    }
+}
+
+impl Drop for ChildPidObserverGuard<'_> {
+    fn drop(&mut self) {
+        self.observer.pid_updated(None);
+    }
+}
+
+/// Returns one required child pipe or a typed infrastructure error.
+fn require_pipe<Pipe>(
+    pipe: Option<Pipe>,
+    pipe_name: &'static str,
+) -> Result<Pipe, CliExecutionError> {
+    pipe.ok_or(CliExecutionError::PipeUnavailable(pipe_name))
+}
+
+/// Captures stdout exactly while reporting completed lines to the observer.
+async fn capture_stdout<Reader>(
+    mut reader: Reader,
+    observer: &dyn CliExecutionObserver,
+) -> Result<String, CliExecutionError>
+where
+    Reader: AsyncBufRead + Unpin,
+{
+    let mut output = Vec::new();
+    let mut line = Vec::new();
+
+    loop {
+        line.clear();
+        let bytes_read = reader
+            .read_until(b'\n', &mut line)
+            .await
+            .map_err(CliExecutionError::StdoutRead)?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        output.extend_from_slice(&line);
+        let line_text = String::from_utf8_lossy(&line);
+        observer.stdout_line(line_text.trim_end_matches(['\r', '\n']));
+    }
+
+    Ok(String::from_utf8_lossy(&output).into_owned())
+}
+
+/// Captures the complete stderr byte stream.
+async fn capture_stderr<Reader>(mut reader: Reader) -> Result<String, CliExecutionError>
+where
+    Reader: AsyncRead + Unpin,
+{
+    let mut output = Vec::new();
+    reader
+        .read_to_end(&mut output)
+        .await
+        .map_err(CliExecutionError::StderrRead)?;
+
+    Ok(String::from_utf8_lossy(&output).into_owned())
+}
+
+/// Converts an OS exit status into the transport-neutral classification.
+fn classify_exit_status(exit_status: ExitStatus) -> CliExitStatus {
+    if let Some(signal) = exit_status.signal() {
+        return CliExitStatus::Signaled(signal);
+    }
+    if exit_status.success() {
+        return CliExitStatus::Success;
+    }
+
+    CliExitStatus::NonZero(exit_status.code())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt as _;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::sync::Mutex;
+    use std::task::{Context, Poll};
+
+    use ag_protocol::TurnPromptAttachment;
+    use tempfile::tempdir;
+    use tokio::io::{AsyncRead, ReadBuf};
+
+    use super::*;
+    use crate::MockAgentBackend;
+    use crate::channel::AgentRequestKind;
+    use crate::model::agent::ReasoningLevel;
+
+    /// Observer that records all streaming callbacks for assertions.
+    struct RecordingObserver {
+        lines: Mutex<Vec<String>>,
+        pid_updates: Mutex<Vec<Option<u32>>>,
+    }
+
+    impl RecordingObserver {
+        /// Creates an empty callback recorder.
+        fn new() -> Self {
+            Self {
+                lines: Mutex::new(Vec::new()),
+                pid_updates: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl CliExecutionObserver for RecordingObserver {
+        fn pid_updated(&self, child_pid: Option<u32>) {
+            self.pid_updates
+                .lock()
+                .expect("PID update lock should be available")
+                .push(child_pid);
+        }
+
+        fn stdout_line(&self, line: &str) {
+            self.lines
+                .lock()
+                .expect("line lock should be available")
+                .push(line.to_string());
+        }
+    }
+
+    /// Async reader that deterministically fails every read.
+    struct FailingReader;
+
+    impl AsyncRead for FailingReader {
+        fn poll_read(
+            self: std::pin::Pin<&mut Self>,
+            _context: &mut Context<'_>,
+            _buffer: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Ready(Err(io::Error::other("read failed")))
+        }
+    }
+
+    /// Builds one borrowed command request for executor tests.
+    fn build_request<'a>(
+        attachments: &'a [TurnPromptAttachment],
+        folder: &'a Path,
+        prompt: &'a str,
+        request_kind: &'a AgentRequestKind,
+    ) -> BuildCommandRequest<'a> {
+        BuildCommandRequest {
+            attachments,
+            folder,
+            main_checkout_root: None,
+            model: "test-model",
+            prompt,
+            reasoning_level: ReasoningLevel::default(),
+            request_kind,
+            replay_transcript: None,
+        }
+    }
+
+    /// Builds a shell command for deterministic subprocess output.
+    fn shell_command(script: &str) -> Command {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg(script);
+
+        command
+    }
+
+    #[tokio::test]
+    async fn test_execute_cli_command_returns_command_build_failure() {
+        // Arrange
+        let folder = tempdir().expect("temporary folder should be created");
+        let request_kind = AgentRequestKind::UtilityPrompt;
+        let mut backend = MockAgentBackend::new();
+        backend.expect_build_command().returning(|_| {
+            Err(AgentBackendError::CommandBuild(
+                "command unavailable".to_string(),
+            ))
+        });
+
+        // Act
+        let error = execute_cli_command(
+            &backend,
+            AgentKind::Codex,
+            build_request(&[], folder.path(), "prompt", &request_kind),
+            &CollectingCliObserver,
+            None,
+        )
+        .await
+        .expect_err("command construction should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            CliExecutionError::CommandBuild(AgentBackendError::CommandBuild(message))
+                if message == "command unavailable"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_execute_cli_command_returns_stdin_build_failure() {
+        // Arrange
+        let folder = tempdir().expect("temporary folder should be created");
+        let request_kind = AgentRequestKind::UtilityPrompt;
+        let attachments = vec![TurnPromptAttachment {
+            local_image_path: PathBuf::from(OsString::from_vec(b"/tmp/image-\xff.png".to_vec())),
+            placeholder: "[Image #1]".to_string(),
+        }];
+        let mut backend = MockAgentBackend::new();
+        backend
+            .expect_build_command()
+            .returning(|_| Ok(shell_command("exit 0")));
+
+        // Act
+        let error = execute_cli_command(
+            &backend,
+            AgentKind::Claude,
+            build_request(
+                &attachments,
+                folder.path(),
+                "Review [Image #1]",
+                &request_kind,
+            ),
+            &CollectingCliObserver,
+            None,
+        )
+        .await
+        .expect_err("stdin rendering should fail");
+
+        // Assert
+        assert!(matches!(error, CliExecutionError::StdinBuild(_)));
+    }
+
+    #[tokio::test]
+    async fn test_execute_cli_command_returns_spawn_failure() {
+        // Arrange
+        let folder = tempdir().expect("temporary folder should be created");
+        let request_kind = AgentRequestKind::UtilityPrompt;
+        let mut backend = MockAgentBackend::new();
+        backend
+            .expect_build_command()
+            .returning(|_| Ok(Command::new("/no-such-binary-agentty-cli-execution-test")));
+
+        // Act
+        let error = execute_cli_command(
+            &backend,
+            AgentKind::Codex,
+            build_request(&[], folder.path(), "prompt", &request_kind),
+            &CollectingCliObserver,
+            None,
+        )
+        .await
+        .expect_err("process spawning should fail");
+
+        // Assert
+        assert!(matches!(error, CliExecutionError::Spawn(_)));
+    }
+
+    #[tokio::test]
+    async fn test_execute_cli_command_collects_output_and_streams_lines() {
+        // Arrange
+        let folder = tempdir().expect("temporary folder should be created");
+        let request_kind = AgentRequestKind::UtilityPrompt;
+        let mut backend = MockAgentBackend::new();
+        backend.expect_build_command().returning(|_| {
+            Ok(shell_command(
+                "printf 'first\\nsecond'; printf 'warning' >&2",
+            ))
+        });
+        let observer = RecordingObserver::new();
+
+        // Act
+        let output = execute_cli_command(
+            &backend,
+            AgentKind::Codex,
+            build_request(&[], folder.path(), "prompt", &request_kind),
+            &observer,
+            None,
+        )
+        .await
+        .expect("process should complete");
+
+        // Assert
+        assert_eq!(output.exit_status, CliExitStatus::Success);
+        assert_eq!(output.stdout, "first\nsecond");
+        assert_eq!(output.stderr, "warning");
+        assert_eq!(
+            *observer
+                .lines
+                .lock()
+                .expect("line lock should be available"),
+            vec!["first".to_string(), "second".to_string()]
+        );
+        let pid_updates = observer
+            .pid_updates
+            .lock()
+            .expect("PID update lock should be available");
+        assert!(pid_updates.first().is_some_and(Option::is_some));
+        assert_eq!(pid_updates.last(), Some(&None));
+    }
+
+    #[tokio::test]
+    async fn test_execute_cli_command_classifies_non_zero_exit() {
+        // Arrange
+        let folder = tempdir().expect("temporary folder should be created");
+        let request_kind = AgentRequestKind::UtilityPrompt;
+        let mut backend = MockAgentBackend::new();
+        backend
+            .expect_build_command()
+            .returning(|_| Ok(shell_command("exit 7")));
+
+        // Act
+        let output = execute_cli_command(
+            &backend,
+            AgentKind::Codex,
+            build_request(&[], folder.path(), "prompt", &request_kind),
+            &CollectingCliObserver,
+            None,
+        )
+        .await
+        .expect("non-zero termination should still return raw output");
+
+        // Assert
+        assert_eq!(output.exit_status, CliExitStatus::NonZero(Some(7)));
+    }
+
+    #[tokio::test]
+    async fn test_execute_cli_command_classifies_signal_termination() {
+        // Arrange
+        let folder = tempdir().expect("temporary folder should be created");
+        let request_kind = AgentRequestKind::UtilityPrompt;
+        let mut backend = MockAgentBackend::new();
+        backend
+            .expect_build_command()
+            .returning(|_| Ok(shell_command("kill -9 $$")));
+
+        // Act
+        let output = execute_cli_command(
+            &backend,
+            AgentKind::Codex,
+            build_request(&[], folder.path(), "prompt", &request_kind),
+            &CollectingCliObserver,
+            None,
+        )
+        .await
+        .expect("signal termination should still return raw output");
+
+        // Assert
+        assert_eq!(output.exit_status, CliExitStatus::Signaled(9));
+    }
+
+    #[tokio::test]
+    async fn test_execute_cli_command_enforces_timeout() {
+        // Arrange
+        let folder = tempdir().expect("temporary folder should be created");
+        let request_kind = AgentRequestKind::UtilityPrompt;
+        let mut backend = MockAgentBackend::new();
+        backend
+            .expect_build_command()
+            .returning(|_| Ok(shell_command("while :; do :; done")));
+
+        // Act
+        let error = execute_cli_command(
+            &backend,
+            AgentKind::Codex,
+            build_request(&[], folder.path(), "prompt", &request_kind),
+            &CollectingCliObserver,
+            Some(Duration::from_millis(20)),
+        )
+        .await
+        .expect_err("process should time out");
+
+        // Assert
+        assert!(matches!(error, CliExecutionError::Timeout(_)));
+    }
+
+    #[tokio::test]
+    async fn test_finish_cli_execution_aborts_stdin_writer_after_execution_error() {
+        // Arrange
+        let stdin_write_task = tokio::spawn(std::future::pending());
+        let execution_result = Err(CliExecutionError::StdoutRead(io::Error::other(
+            "read failed",
+        )));
+
+        // Act
+        let error = tokio::time::timeout(
+            Duration::from_secs(1),
+            finish_cli_execution(Some(stdin_write_task), execution_result),
+        )
+        .await
+        .expect("stdin writer cleanup should not hang")
+        .expect_err("execution failure should be preserved");
+
+        // Assert
+        assert!(matches!(error, CliExecutionError::StdoutRead(_)));
+    }
+
+    #[test]
+    fn test_require_pipe_returns_unavailable_error() {
+        // Arrange / Act
+        let error = require_pipe::<u8>(None, "stdout").expect_err("pipe should be required");
+
+        // Assert
+        assert!(matches!(
+            error,
+            CliExecutionError::PipeUnavailable("stdout")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_capture_stdout_returns_read_error() {
+        // Arrange
+        let observer = CollectingCliObserver;
+
+        // Act
+        let error = capture_stdout(tokio::io::BufReader::new(FailingReader), &observer)
+            .await
+            .expect_err("stdout read should fail");
+
+        // Assert
+        assert!(matches!(error, CliExecutionError::StdoutRead(_)));
+    }
+
+    #[tokio::test]
+    async fn test_capture_stderr_returns_read_error() {
+        // Arrange / Act
+        let error = capture_stderr(FailingReader)
+            .await
+            .expect_err("stderr read should fail");
+
+        // Assert
+        assert!(matches!(error, CliExecutionError::StderrRead(_)));
+    }
+}

--- a/crates/ag-agent/src/agent/submission.rs
+++ b/crates/ag-agent/src/agent/submission.rs
@@ -5,7 +5,6 @@
 //! transport so one-shot callers enforce the same schema contract as normal
 //! session turns.
 
-use std::os::unix::process::ExitStatusExt as _;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -16,7 +15,8 @@ use ag_protocol::{
 use async_trait::async_trait;
 
 use super::backend::{AgentBackend, BuildCommandRequest};
-use super::cli::{error, stdin};
+use super::cli::error;
+use super::cli::execution::{self, CliExecutionError, CliExecutionObserver, CliExitStatus};
 use super::{
     ParsedResponse, create_app_server_client, create_backend, parse_response, transport_mode,
 };
@@ -368,59 +368,45 @@ async fn execute_one_shot_command(
         reasoning_level: request.reasoning_level,
         request_kind: &request.request_kind,
     };
-    let command = backend
-        .build_command(build_request)
-        .map_err(|error| format!("Failed to build one-shot agent command: {error}"))?;
-    let stdin_payload = super::build_command_stdin_payload(request.agent_kind, build_request)
-        .map_err(|error| format!("Failed to build one-shot agent stdin payload: {error}"))?;
-    let mut tokio_command = tokio::process::Command::from(command);
-    tokio_command
-        .stdin(if stdin_payload.is_some() {
-            std::process::Stdio::piped()
-        } else {
-            std::process::Stdio::null()
-        })
-        .kill_on_drop(true);
-    let mut pid_guard = ChildPidGuard::new(request.child_pid);
-    let mut child = tokio_command
-        .spawn()
-        .map_err(|error| format!("Failed to execute one-shot agent command: {error}"))?;
-    pid_guard.update_from_child(&child);
-    let stdin_write_task = stdin::spawn_optional_stdin_write(
-        child.stdin.take(),
-        stdin_payload,
-        "one-shot stdin pipe unavailable after spawn",
-        std::convert::identity,
-    );
-    let output = child
-        .wait_with_output()
-        .await
-        .map_err(|error| format!("Failed to execute one-shot agent command: {error}"))?;
-    stdin::await_optional_stdin_write(
-        stdin_write_task,
-        "One-shot stdin write task failed",
-        std::convert::identity,
-    )
-    .await?;
+    let observer = OneShotCliObserver {
+        child_pid: request.child_pid,
+    };
+    let output =
+        execution::execute_cli_command(backend, request.agent_kind, build_request, &observer, None)
+            .await
+            .map_err(format_one_shot_execution_error)?;
 
-    if output.status.signal().is_some() {
-        return Err("One-shot agent command was interrupted".to_string());
+    match output.exit_status {
+        CliExitStatus::Signaled(_) => {
+            return Err("One-shot agent command was interrupted".to_string());
+        }
+        CliExitStatus::NonZero(exit_code) => {
+            return Err(format_one_shot_exit_error(
+                request.agent_kind,
+                exit_code,
+                &output.stdout,
+                &output.stderr,
+            ));
+        }
+        CliExitStatus::Success => {}
     }
 
-    let stdout_text = String::from_utf8_lossy(&output.stdout).into_owned();
-    let stderr_text = String::from_utf8_lossy(&output.stderr).into_owned();
-    if !output.status.success() {
-        return Err(format_one_shot_exit_error(
-            request.agent_kind,
-            output.status.code(),
-            &stdout_text,
-            &stderr_text,
-        ));
-    }
-
-    let parsed_response = parse_response(request.agent_kind, &stdout_text, &stderr_text);
+    let parsed_response = parse_response(request.agent_kind, &output.stdout, &output.stderr);
 
     Ok(parsed_response)
+}
+
+/// Preserves the established one-shot context around shared execution errors.
+fn format_one_shot_execution_error(error: CliExecutionError) -> String {
+    match error {
+        CliExecutionError::CommandBuild(error) => {
+            format!("Failed to build one-shot agent command: {error}")
+        }
+        CliExecutionError::StdinBuild(error) => {
+            format!("Failed to build one-shot agent stdin payload: {error}")
+        }
+        error => format!("Failed to execute one-shot agent command: {error}"),
+    }
 }
 
 /// Formats one non-zero one-shot command exit into a user-facing error.
@@ -450,43 +436,23 @@ fn clear_child_pid_slot(child_pid: Option<&Mutex<Option<u32>>>) {
     }
 }
 
-/// Tracks the active one-shot subprocess identifier for cancel/stop flows.
-struct ChildPidGuard {
+/// Bridges shared CLI PID observations into the one-shot cancellation slot.
+struct OneShotCliObserver {
     child_pid: Option<Arc<Mutex<Option<u32>>>>,
 }
 
-impl ChildPidGuard {
-    /// Creates one PID guard for the optional shared child slot.
-    fn new(child_pid: Option<Arc<Mutex<Option<u32>>>>) -> Self {
-        Self { child_pid }
-    }
-
-    /// Copies the spawned child PID into the shared slot when available.
-    fn update_from_child(&mut self, child: &tokio::process::Child) {
-        let Some(pid) = child.id() else {
+impl CliExecutionObserver for OneShotCliObserver {
+    fn pid_updated(&self, active_child_pid: Option<u32>) {
+        let Some(child_pid_slot) = self.child_pid.as_deref() else {
             return;
         };
 
-        let Some(child_pid) = self.child_pid.as_deref() else {
-            return;
-        };
-
-        if let Ok(mut guard) = child_pid.lock() {
-            *guard = Some(pid);
+        if let Ok(mut guard) = child_pid_slot.lock() {
+            *guard = active_child_pid;
         }
     }
-}
 
-impl Drop for ChildPidGuard {
-    fn drop(&mut self) {
-        let Some(child_pid) = self.child_pid.as_deref() else {
-            return;
-        };
-
-        if let Ok(mut guard) = child_pid.lock() {
-            *guard = None;
-        }
-    }
+    fn stdout_line(&self, _line: &str) {}
 }
 
 #[cfg(test)]
@@ -529,6 +495,89 @@ mod tests {
         command.stderr(std::process::Stdio::piped());
 
         command
+    }
+
+    #[test]
+    fn test_format_one_shot_execution_error_preserves_build_context() {
+        // Arrange
+        let command_error = CliExecutionError::CommandBuild(
+            crate::agent::AgentBackendError::CommandBuild("command".to_string()),
+        );
+        let stdin_error = CliExecutionError::StdinBuild(
+            crate::agent::AgentBackendError::CommandBuild("stdin".to_string()),
+        );
+        let execution_error = CliExecutionError::StdinWrite("write".to_string());
+
+        // Act
+        let command_message = format_one_shot_execution_error(command_error);
+        let stdin_message = format_one_shot_execution_error(stdin_error);
+        let execution_message = format_one_shot_execution_error(execution_error);
+
+        // Assert
+        assert_eq!(
+            command_message,
+            "Failed to build one-shot agent command: command"
+        );
+        assert_eq!(
+            stdin_message,
+            "Failed to build one-shot agent stdin payload: stdin"
+        );
+        assert_eq!(
+            execution_message,
+            "Failed to execute one-shot agent command: stdin delivery failed: write"
+        );
+    }
+
+    #[test]
+    fn test_one_shot_cli_observer_updates_child_pid_slot() {
+        // Arrange
+        let child_pid = Arc::new(Mutex::new(None));
+        let observer = OneShotCliObserver {
+            child_pid: Some(Arc::clone(&child_pid)),
+        };
+
+        // Act
+        observer.pid_updated(Some(42));
+        let active_pid = *child_pid.lock().expect("PID lock should be available");
+        observer.stdout_line("collected output");
+        observer.pid_updated(None);
+        let cleared_pid = *child_pid.lock().expect("PID lock should be available");
+
+        // Assert
+        assert_eq!(active_pid, Some(42));
+        assert_eq!(cleared_pid, None);
+    }
+
+    #[tokio::test]
+    async fn test_submit_one_shot_with_backend_reports_signal_interruption() {
+        // Arrange
+        let temp_directory = tempdir().expect("failed to create temp dir");
+        let mut backend = MockAgentBackend::new();
+        backend.expect_build_command().returning(|_| {
+            let mut command = Command::new("sh");
+            command.arg("-c").arg("kill -9 $$");
+
+            Ok(command)
+        });
+
+        // Act
+        let error = submit_one_shot_with_backend(
+            &backend,
+            OneShotRequest {
+                agent_kind: AgentKind::Codex,
+                child_pid: None,
+                folder: temp_directory.path().to_path_buf(),
+                model: AgentModel::Gpt55,
+                prompt: "Generate title".to_string(),
+                request_kind: AgentRequestKind::UtilityPrompt,
+                reasoning_level: ReasoningLevel::default(),
+            },
+        )
+        .await
+        .expect_err("signal termination should interrupt the one-shot command");
+
+        // Assert
+        assert_eq!(error, "One-shot agent command was interrupted");
     }
 
     #[tokio::test]
@@ -960,33 +1009,6 @@ mod tests {
         );
         assert!(error.contains("`claude auth login`"));
         assert!(error.contains("`claude auth status`"));
-    }
-
-    #[tokio::test]
-    /// Verifies the child PID guard tracks a running process, ignores a
-    /// completed process without an id, and clears the slot when dropped.
-    async fn test_child_pid_guard_tracks_and_clears_child_process() {
-        // Arrange
-        let child_pid = Arc::new(Mutex::new(None));
-        let mut child = tokio::process::Command::new("sh")
-            .arg("-c")
-            .arg("exit 0")
-            .spawn()
-            .expect("test child should spawn");
-        let expected_pid = child.id().expect("running child should expose its pid");
-        let mut guard = ChildPidGuard::new(Some(Arc::clone(&child_pid)));
-
-        // Act
-        guard.update_from_child(&child);
-        let tracked_pid = *child_pid.lock().expect("child pid lock should succeed");
-        child.wait().await.expect("test child should exit");
-        guard.update_from_child(&child);
-        drop(guard);
-        let cleared_pid = *child_pid.lock().expect("child pid lock should succeed");
-
-        // Assert
-        assert_eq!(tracked_pid, Some(expected_pid));
-        assert_eq!(cleared_pid, None);
     }
 
     #[tokio::test]

--- a/crates/ag-agent/src/channel/cli.rs
+++ b/crates/ag-agent/src/channel/cli.rs
@@ -3,17 +3,18 @@
 //! Spawns a provider CLI process per turn, streams stdout line-by-line as
 //! [`TurnEvent`]s, and parses the final process output when the process exits.
 
-use std::os::unix::process::ExitStatusExt as _;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use ag_protocol::{
     AgentResponse, AgentResponseSummary, ProtocolRequestProfile, TurnPrompt,
     build_protocol_repair_prompt,
 };
-use tokio::io::AsyncBufReadExt as _;
 use tokio::sync::mpsc;
 
-use crate::agent::cli::{error, stdin};
+use crate::agent::cli::error;
+use crate::agent::cli::execution::{
+    self, CliExecutionError, CliExecutionObserver, CliExitStatus, CollectingCliObserver,
+};
 use crate::agent::{self as agent, AgentBackend, BuildCommandRequest};
 use crate::channel::{
     AgentChannel, AgentError, AgentFuture, SessionRef, StartSessionRequest, TurnEvent, TurnRequest,
@@ -44,6 +45,39 @@ impl CliAgentChannel {
     /// process spawning without relying on a real provider binary.
     pub(crate) fn with_backend(backend: Arc<dyn agent::AgentBackend>, kind: AgentKind) -> Self {
         Self { backend, kind }
+    }
+}
+
+/// Bridges raw CLI execution observations into session turn events.
+struct CliTurnObserver {
+    /// Session event sink receiving PID and thought updates.
+    events: mpsc::UnboundedSender<TurnEvent>,
+    /// Provider family used to classify streamed stdout lines.
+    kind: AgentKind,
+}
+
+impl CliExecutionObserver for CliTurnObserver {
+    fn pid_updated(&self, child_pid: Option<u32>) {
+        let _ = self.events.send(TurnEvent::PidUpdate(child_pid));
+    }
+
+    fn stdout_line(&self, line: &str) {
+        let Some((text, is_response_content)) = agent::parse_stream_output_line(self.kind, line)
+        else {
+            return;
+        };
+        if is_response_content {
+            return;
+        }
+
+        let trimmed_text = text.trim();
+        if trimmed_text.is_empty() {
+            return;
+        }
+
+        let _ = self
+            .events
+            .send(TurnEvent::ThoughtDelta(trimmed_text.to_string()));
     }
 }
 
@@ -98,109 +132,38 @@ impl AgentChannel for CliAgentChannel {
         Box::pin(async move {
             let prompt_text = req.prompt.agent_text();
             let build_request = build_command_request(&req, &prompt_text);
-            let build_result = backend.build_command(build_request);
-            let stdin_payload_result = agent::build_command_stdin_payload(kind, build_request);
-            let command = build_result.map_err(|error| {
-                AgentError::Backend(format!("Failed to build command: {error}"))
-            })?;
-            let stdin_payload = stdin_payload_result.map_err(|error| {
-                AgentError::Backend(format!("Failed to build command stdin payload: {error}"))
-            })?;
-
-            let mut tokio_cmd = tokio::process::Command::from(command);
-            tokio_cmd.stdin(if stdin_payload.is_some() {
-                std::process::Stdio::piped()
-            } else {
-                std::process::Stdio::null()
-            });
-            tokio_cmd.stdout(std::process::Stdio::piped());
-            tokio_cmd.stderr(std::process::Stdio::piped());
-            tokio_cmd.kill_on_drop(true);
-
-            let mut child = tokio_cmd
-                .spawn()
-                .map_err(|error| AgentError::Io(format!("Failed to spawn process: {error}")))?;
-
-            // Notify the consumer of the child PID so cancellation signals can
-            // be sent while the process is running.
-            // Fire-and-forget: receiver may be dropped during shutdown.
-            let _ = events.send(TurnEvent::PidUpdate(child.id()));
-
-            let raw_stdout = Arc::new(Mutex::new(String::new()));
-            let raw_stderr = Arc::new(Mutex::new(String::new()));
-
-            let stdout_task = {
-                let stdout = child.stdout.take().ok_or_else(|| {
-                    AgentError::Io("stdout pipe unavailable after spawn".to_string())
-                })?;
-                let raw_stdout = Arc::clone(&raw_stdout);
-                let events = events.clone();
-
-                tokio::spawn(stream_stdout(stdout, kind, events, raw_stdout))
+            let observer = CliTurnObserver {
+                events: events.clone(),
+                kind,
             };
-
-            let stderr_task = {
-                let stderr = child.stderr.take().ok_or_else(|| {
-                    AgentError::Io("stderr pipe unavailable after spawn".to_string())
-                })?;
-                let raw_stderr = Arc::clone(&raw_stderr);
-
-                tokio::spawn(async move {
-                    let mut reader = tokio::io::BufReader::new(stderr).lines();
-                    while let Ok(Some(line)) = reader.next_line().await {
-                        if let Ok(mut buf) = raw_stderr.lock() {
-                            buf.push_str(&line);
-                            buf.push('\n');
-                        }
-                    }
-                })
-            };
-            let stdin_write_task = stdin::spawn_optional_stdin_write(
-                child.stdin.take(),
-                stdin_payload,
-                "stdin pipe unavailable after spawn",
-                AgentError::Io,
-            );
-
-            // Task join: panic in the spawned task is not recoverable here.
-            let _ = stdout_task.await;
-            // Task join: panic in the spawned task is not recoverable here.
-            let _ = stderr_task.await;
-
-            let exit_status = child.wait().await.ok();
-            stdin::await_optional_stdin_write(
-                stdin_write_task,
-                "stdin write task failed",
-                AgentError::Io,
+            let output = execution::execute_cli_command(
+                backend.as_ref(),
+                kind,
+                build_request,
+                &observer,
+                None,
             )
-            .await?;
+            .await
+            .map_err(map_cli_turn_execution_error)?;
 
-            // Clear the PID slot now that the child has exited.
-            // Fire-and-forget: receiver may be dropped during shutdown.
-            let _ = events.send(TurnEvent::PidUpdate(None));
-
-            let killed_by_signal = exit_status
-                .as_ref()
-                .is_some_and(|status| status.signal().is_some());
-
-            if killed_by_signal {
-                return Err(AgentError::Backend(
-                    "[Stopped] Agent interrupted by user.".to_string(),
-                ));
+            match output.exit_status {
+                CliExitStatus::Signaled(_) => {
+                    return Err(AgentError::Backend(
+                        "[Stopped] Agent interrupted by user.".to_string(),
+                    ));
+                }
+                CliExitStatus::NonZero(exit_code) => {
+                    return Err(format_cli_turn_exit_error(
+                        kind,
+                        exit_code,
+                        &output.stdout,
+                        &output.stderr,
+                    ));
+                }
+                CliExitStatus::Success => {}
             }
 
-            let stdout_text = raw_stdout.lock().map(|buf| buf.clone()).unwrap_or_default();
-            let stderr_text = raw_stderr.lock().map(|buf| buf.clone()).unwrap_or_default();
-            if exit_status.as_ref().is_some_and(|status| !status.success()) {
-                return Err(format_cli_turn_exit_error(
-                    kind,
-                    exit_status.and_then(|status| status.code()),
-                    &stdout_text,
-                    &stderr_text,
-                ));
-            }
-
-            let parsed = agent::parse_response(kind, &stdout_text, &stderr_text);
+            let parsed = agent::parse_response(kind, &output.stdout, &output.stderr);
             let assistant_message =
                 parse_or_repair_cli_response(kind, &parsed.content, &req, &backend, &events)
                     .await?;
@@ -319,45 +282,6 @@ fn non_empty_content(content: &str) -> Option<&str> {
     Some(trimmed_content)
 }
 
-/// Reads stdout line-by-line, classifying each line and forwarding loader
-/// updates.
-///
-/// Only non-response-content stream lines are forwarded as
-/// [`TurnEvent::ThoughtDelta`]. Final assistant transcript output is parsed
-/// from the accumulated raw stdout after the process exits. The raw bytes are
-/// also accumulated in `raw_buffer` for final response parsing.
-async fn stream_stdout(
-    stdout: tokio::process::ChildStdout,
-    kind: AgentKind,
-    events: mpsc::UnboundedSender<TurnEvent>,
-    raw_buffer: Arc<Mutex<String>>,
-) {
-    let mut reader = tokio::io::BufReader::new(stdout).lines();
-
-    while let Ok(Some(line)) = reader.next_line().await {
-        if let Ok(mut buf) = raw_buffer.lock() {
-            buf.push_str(&line);
-            buf.push('\n');
-        }
-
-        let Some((text, is_response_content)) = agent::parse_stream_output_line(kind, &line) else {
-            continue;
-        };
-
-        if is_response_content {
-            continue;
-        }
-
-        let trimmed_text = text.trim();
-        if trimmed_text.is_empty() {
-            continue;
-        }
-
-        // Fire-and-forget: receiver may be dropped during shutdown.
-        let _ = events.send(TurnEvent::ThoughtDelta(trimmed_text.to_string()));
-    }
-}
-
 /// Maximum wall-clock time for one protocol-repair CLI subprocess.
 ///
 /// Repair turns ask the agent to re-emit a single JSON object, so they
@@ -395,63 +319,58 @@ async fn execute_cli_repair_turn(
         reasoning_level,
         request_kind,
     };
-    let command = backend
-        .build_command(build_request)
-        .map_err(|error| format!("repair command build failed: {error}"))?;
-    let repair_stdin_payload = agent::build_command_stdin_payload(kind, build_request)
-        .map_err(|error| format!("repair stdin payload build failed: {error}"))?;
+    execute_cli_repair_command(backend, kind, build_request, REPAIR_TURN_TIMEOUT).await
+}
 
-    let mut tokio_command = tokio::process::Command::from(command);
-    tokio_command
-        .stdin(if repair_stdin_payload.is_some() {
-            std::process::Stdio::piped()
-        } else {
-            std::process::Stdio::null()
-        })
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .kill_on_drop(true);
-
-    let mut child = tokio_command
-        .spawn()
-        .map_err(|error| format!("repair process spawn failed: {error}"))?;
-
-    let repair_stdin_write_task = stdin::spawn_optional_stdin_write(
-        child.stdin.take(),
-        repair_stdin_payload,
-        "repair stdin pipe unavailable after spawn",
-        std::convert::identity,
-    );
-
-    let output = tokio::time::timeout(REPAIR_TURN_TIMEOUT, child.wait_with_output())
-        .await
-        .map_err(|_| {
-            format!(
-                "repair process timed out after {}s",
-                REPAIR_TURN_TIMEOUT.as_secs()
-            )
-        })?
-        .map_err(|error| format!("repair process execution failed: {error}"))?;
-
-    stdin::await_optional_stdin_write(
-        repair_stdin_write_task,
-        "repair stdin write task failed",
-        std::convert::identity,
+/// Executes one prepared repair command with an explicit deadline.
+async fn execute_cli_repair_command(
+    backend: &dyn AgentBackend,
+    kind: AgentKind,
+    build_request: BuildCommandRequest<'_>,
+    timeout: std::time::Duration,
+) -> Result<String, String> {
+    let output = execution::execute_cli_command(
+        backend,
+        kind,
+        build_request,
+        &CollectingCliObserver,
+        Some(timeout),
     )
-    .await?;
+    .await
+    .map_err(|error| format!("repair {error}"))?;
 
-    if !output.status.success() {
-        return Err(format!(
-            "repair process exited with status {}",
-            output.status
-        ));
+    match output.exit_status {
+        CliExitStatus::NonZero(exit_code) => {
+            return Err(format!(
+                "repair process exited with code {}",
+                exit_code.map_or_else(|| "unknown".to_string(), |code| code.to_string())
+            ));
+        }
+        CliExitStatus::Signaled(signal) => {
+            return Err(format!("repair process was interrupted by signal {signal}"));
+        }
+        CliExitStatus::Success => {}
     }
 
-    let stdout_text = String::from_utf8_lossy(&output.stdout).into_owned();
-    let stderr_text = String::from_utf8_lossy(&output.stderr).into_owned();
-    let parsed = agent::parse_response(kind, &stdout_text, &stderr_text);
+    let parsed = agent::parse_response(kind, &output.stdout, &output.stderr);
 
     Ok(parsed.content)
+}
+
+/// Maps shared execution failures into the existing channel error categories.
+fn map_cli_turn_execution_error(error: CliExecutionError) -> AgentError {
+    match error {
+        CliExecutionError::CommandBuild(error) => {
+            AgentError::Backend(format!("Failed to build command: {error}"))
+        }
+        CliExecutionError::Spawn(error) => {
+            AgentError::Io(format!("Failed to spawn process: {error}"))
+        }
+        CliExecutionError::StdinBuild(error) => {
+            AgentError::Backend(format!("Failed to build command stdin payload: {error}"))
+        }
+        error => AgentError::Io(error.to_string()),
+    }
 }
 
 /// Formats one failed CLI turn into a user-facing error.
@@ -516,6 +435,150 @@ mod tests {
         }
 
         events
+    }
+
+    #[test]
+    fn test_map_cli_turn_execution_error_preserves_error_categories() {
+        // Arrange
+        let command_error = CliExecutionError::CommandBuild(
+            crate::agent::AgentBackendError::CommandBuild("command".to_string()),
+        );
+        let spawn_error = CliExecutionError::Spawn(std::io::Error::other("spawn unavailable"));
+        let stdin_error = CliExecutionError::StdinBuild(
+            crate::agent::AgentBackendError::CommandBuild("stdin".to_string()),
+        );
+        let io_error = CliExecutionError::StdinWrite("write unavailable".to_string());
+
+        // Act
+        let command_message = map_cli_turn_execution_error(command_error).to_string();
+        let spawn_message = map_cli_turn_execution_error(spawn_error).to_string();
+        let stdin_message = map_cli_turn_execution_error(stdin_error).to_string();
+        let io_message = map_cli_turn_execution_error(io_error).to_string();
+
+        // Assert
+        assert_eq!(command_message, "Failed to build command: command");
+        assert_eq!(spawn_message, "Failed to spawn process: spawn unavailable");
+        assert_eq!(
+            stdin_message,
+            "Failed to build command stdin payload: stdin"
+        );
+        assert_eq!(io_message, "stdin delivery failed: write unavailable");
+    }
+
+    #[test]
+    fn test_cli_turn_observer_ignores_blank_progress_text() {
+        // Arrange
+        let (events, mut event_receiver) = mpsc::unbounded_channel();
+        let observer = CliTurnObserver {
+            events,
+            kind: AgentKind::Codex,
+        };
+
+        // Act
+        observer.stdout_line(r#"{"type":"item.updated","item":{"type":"reasoning","text":"   "}}"#);
+
+        // Assert
+        assert!(event_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_execute_cli_repair_turn_reports_non_zero_exit() {
+        // Arrange
+        let folder = tempdir().expect("failed to create temp dir");
+        let request_kind = AgentRequestKind::SessionStart;
+        let mut backend = MockAgentBackend::new();
+        backend.expect_build_command().returning(|_| {
+            let mut command = std::process::Command::new("sh");
+            command.arg("-c").arg("exit 7");
+
+            Ok(command)
+        });
+
+        // Act
+        let error = execute_cli_repair_turn(
+            &backend,
+            AgentKind::Codex,
+            folder.path(),
+            "test-model",
+            &request_kind,
+            ReasoningLevel::default(),
+            "repair",
+        )
+        .await
+        .expect_err("repair command should fail");
+
+        // Assert
+        assert_eq!(error, "repair process exited with code 7");
+    }
+
+    #[tokio::test]
+    async fn test_execute_cli_repair_turn_reports_signal() {
+        // Arrange
+        let folder = tempdir().expect("failed to create temp dir");
+        let request_kind = AgentRequestKind::SessionStart;
+        let mut backend = MockAgentBackend::new();
+        backend.expect_build_command().returning(|_| {
+            let mut command = std::process::Command::new("sh");
+            command.arg("-c").arg("kill -9 $$");
+
+            Ok(command)
+        });
+
+        // Act
+        let error = execute_cli_repair_turn(
+            &backend,
+            AgentKind::Codex,
+            folder.path(),
+            "test-model",
+            &request_kind,
+            ReasoningLevel::default(),
+            "repair",
+        )
+        .await
+        .expect_err("repair command should be interrupted");
+
+        // Assert
+        assert_eq!(error, "repair process was interrupted by signal 9");
+    }
+
+    #[tokio::test]
+    async fn test_execute_cli_repair_turn_cleans_up_stdin_writer_after_timeout() {
+        // Arrange
+        let folder = tempdir().expect("failed to create temp dir");
+        let request_kind = AgentRequestKind::SessionStart;
+        let repair_prompt = "repair ".repeat(200_000);
+        let prompt_payload = TurnPrompt::from_agent_data(repair_prompt.clone());
+        let build_request = BuildCommandRequest {
+            attachments: &prompt_payload.attachments,
+            folder: folder.path(),
+            main_checkout_root: None,
+            replay_transcript: None,
+            model: "test-model",
+            prompt: &repair_prompt,
+            reasoning_level: ReasoningLevel::default(),
+            request_kind: &request_kind,
+        };
+        let mut backend = MockAgentBackend::new();
+        backend.expect_build_command().returning(|request| {
+            assert!(request.prompt.len() > 1_000_000);
+            let mut command = std::process::Command::new("sh");
+            command.arg("-c").arg("while :; do :; done");
+
+            Ok(command)
+        });
+
+        // Act
+        let error = execute_cli_repair_command(
+            &backend,
+            AgentKind::Claude,
+            build_request,
+            Duration::from_millis(20),
+        )
+        .await
+        .expect_err("repair command should time out");
+
+        // Assert
+        assert!(error.starts_with("repair process timed out after"));
     }
 
     #[test]

--- a/docs/site/content/docs/architecture/testability-boundaries.md
+++ b/docs/site/content/docs/architecture/testability-boundaries.md
@@ -40,7 +40,12 @@ enabling in-process TUI tests with `TestBackend`.
 The `ag-agent` crate keeps provider routers, parsers, and concrete transport adapters
 private. Application workflows that submit isolated utility prompts inject
 `OneShotClient`; provider and transport tests use the feature-gated crate-root mocks and
-helper factories rather than deep module paths.
+helper factories rather than deep module paths. CLI-backed session turns, one-shot
+prompts, and protocol-repair retries share one crate-private raw subprocess executor for
+command construction, stdin delivery, PID lifetime, stream collection, and exit
+classification. Adapter-specific observers translate those raw events into session
+updates, while one-shot callers consume the collected raw output; response parsing and
+repair policy stay in the owning adapter.
 
 ## Typed Errors Across Layers
 


### PR DESCRIPTION
- Adds a crate-private executor that builds commands, renders stdin, captures stdout and stderr concurrently, reports PID lifetime, enforces timeouts, and classifies exits.
- Reuses the executor for session turns, one-shot prompts, and protocol-repair turns while preserving adapter-specific event, parsing, and error behavior.
- Covers executor output, observer bridges, exit and timeout handling, and repair errors with tests, and documents the subprocess boundary.