### PR TITLE
Separates settings presentation state from persistence

### DIFF
--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -136,7 +136,7 @@ impl App {
             project_items,
             startup_working_dir.clone(),
         );
-        let settings = SettingsManager::new(&services, active_project_id).await;
+        let settings = Self::load_settings(&repositories, &services, active_project_id).await;
         let default_session_model = SessionManager::load_default_session_model(
             &services,
             Some(active_project_id),
@@ -167,6 +167,8 @@ impl App {
             mode: crate::presentation::app_mode::AppMode::List,
             needs_redraw: true,
             settings,
+            settings_presentation:
+                crate::presentation::settings::SettingsPresentationState::default(),
             tabs: crate::app::tab::TabManager::new(initial_tab),
             assigned_issue_generation: 0,
             assigned_issue_selected_index: None,
@@ -191,6 +193,20 @@ impl App {
             sync_main_runner,
             tmux_client: clients.tmux_client,
         })
+    }
+
+    /// Loads active-project settings from the feature-scoped dependencies.
+    async fn load_settings(
+        repositories: &AppRepositories,
+        services: &AppServices,
+        project_id: i64,
+    ) -> SettingsManager {
+        SettingsManager::from_repositories(
+            repositories.clone(),
+            services.available_agent_kinds(),
+            project_id,
+        )
+        .await
     }
 
     /// Loads persisted focused reviews for one project into the render cache.

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -64,6 +64,7 @@ use crate::infra::fs::{FsClient, RealFsClient};
 use crate::infra::project_discovery::{ProjectDiscoveryClient, RealProjectDiscoveryClient};
 use crate::infra::tmux::{RealTmuxClient, TmuxClient};
 use crate::presentation::app_mode::{AppMode, ChatFocus, ConfirmationViewMode};
+use crate::presentation::settings::SettingsPresentationState;
 
 /// Relative directory name used for session git worktrees within the
 /// `agentty` home directory.
@@ -221,6 +222,8 @@ pub struct App {
     /// Stores persisted and in-memory application settings for the active
     /// project.
     pub settings: SettingsManager,
+    /// Owns frontend-neutral selection and editor state for the settings tab.
+    pub(crate) settings_presentation: SettingsPresentationState,
     /// Manages the selected top-level list tab.
     pub tabs: TabManager,
     /// Monotonic assigned-issue refresh generation for rejecting stale task
@@ -685,7 +688,13 @@ impl App {
             project.path,
         );
         self.refresh_requested_reviews_if_inbox_tab(true);
-        self.settings = SettingsManager::new(&self.services, project.id).await;
+        self.settings = SettingsManager::from_repositories(
+            self.services.db().clone(),
+            self.services.available_agent_kinds(),
+            project.id,
+        )
+        .await;
+        self.settings_presentation = SettingsPresentationState::default();
         let default_session_model = SessionManager::load_default_session_model(
             &self.services,
             Some(project.id),

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -25,6 +25,7 @@ use crate::domain::setting::SettingName;
 use crate::infra::db::AppRepositories;
 use crate::infra::project_discovery::{HOME_PROJECT_SCAN_MAX_RESULTS, RealProjectDiscoveryClient};
 use crate::infra::tmux::{MockTmuxClient, TmuxClient};
+use crate::presentation::settings::SettingsAction;
 
 /// Builds one reducer-ready turn projection for tests.
 fn test_turn_applied_state(
@@ -366,6 +367,11 @@ async fn test_switch_project_reloads_project_scoped_settings() {
     )
     .await
     .expect("failed to build app");
+    let settings_view = app.settings.view();
+    let _ = app
+        .settings_presentation
+        .apply(&settings_view, SettingsAction::Activate);
+    assert!(app.settings_presentation.is_selector_dropdown_open());
 
     // Act
     app.switch_project(second_project_id)
@@ -378,6 +384,13 @@ async fn test_switch_project_reloads_project_scoped_settings() {
         AgentModel::Gpt55
     );
     assert_eq!(app.settings.launch_configuration, "cargo test");
+    assert!(!app.settings_presentation.is_selector_dropdown_open());
+    assert_eq!(
+        app.settings_presentation
+            .snapshot(&app.settings.view())
+            .selected_row_index,
+        Some(0)
+    );
 }
 
 #[tokio::test]

--- a/crates/agentty/src/app/setting.rs
+++ b/crates/agentty/src/app/setting.rs
@@ -4,11 +4,10 @@ use crate::app::AppServices;
 use crate::domain::agent::{
     self, AgentKind, AgentModel, AgentSelection, AgentSelectionMetadata, ReasoningLevel,
 };
-use crate::domain::input::{InputCommand, InputState};
-use crate::domain::selection::SelectionState;
 use crate::domain::setting::SettingName;
 use crate::domain::theme::ColorTheme;
 use crate::infra::db::AppRepositories;
+use crate::presentation::settings::{SettingsOperation, SettingsView};
 
 /// Loads the persisted smart-model default used for new sessions.
 ///
@@ -133,171 +132,6 @@ pub(crate) async fn load_default_smart_agent_selection_from_repositories(
     fallback_selection
 }
 
-/// Render-ready option for an open settings selector dropdown.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct SettingsSelectorDropdownOption {
-    pub label: String,
-}
-
-/// Render-ready snapshot for the currently open settings selector dropdown.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct SettingsSelectorDropdown {
-    pub options: Vec<SettingsSelectorDropdownOption>,
-    pub row_index: usize,
-    pub selected_index: usize,
-}
-
-/// Active interaction mode for the `Launch Configurations` list editor.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum LaunchConfigurationListEditorMode {
-    Add,
-    Browse,
-    Edit,
-}
-
-/// Render-ready snapshot for the `Launch Configurations` list editor overlay.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct LaunchConfigurationListEditorSnapshot {
-    pub commands: Vec<String>,
-    pub input: Option<InputState>,
-    pub mode: LaunchConfigurationListEditorMode,
-    pub selected_index: usize,
-}
-
-/// Declares how a settings row is edited.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum SettingControl {
-    CommandList,
-    Selector,
-}
-
-/// Backing table rows for the settings page.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum SettingRow {
-    ReasoningLevel,
-    DefaultSmartModel,
-    DefaultFastModel,
-    DefaultReviewModel,
-    IncludeCoauthoredByAgentty,
-    LaunchConfiguration,
-    Theme,
-}
-
-impl SettingRow {
-    const ALL: [Self; 7] = [
-        Self::Theme,
-        Self::ReasoningLevel,
-        Self::DefaultSmartModel,
-        Self::DefaultFastModel,
-        Self::DefaultReviewModel,
-        Self::IncludeCoauthoredByAgentty,
-        Self::LaunchConfiguration,
-    ];
-    /// Rows persisted once for the whole application.
-    const GLOBAL: [Self; 1] = [Self::Theme];
-    /// Rows persisted separately for each active project.
-    const PROJECT: [Self; 6] = [
-        Self::ReasoningLevel,
-        Self::DefaultSmartModel,
-        Self::DefaultFastModel,
-        Self::DefaultReviewModel,
-        Self::IncludeCoauthoredByAgentty,
-        Self::LaunchConfiguration,
-    ];
-    const ROW_COUNT: usize = Self::ALL.len();
-
-    /// Builds a row selector from the table row index.
-    fn from_index(index: usize) -> Self {
-        Self::ALL
-            .get(index)
-            .copied()
-            .unwrap_or(Self::ReasoningLevel)
-    }
-
-    /// Returns the display label for the row.
-    fn label(self) -> &'static str {
-        match self {
-            Self::ReasoningLevel => "Default Reasoning Level",
-            Self::DefaultSmartModel => "Default Smart Model",
-            Self::DefaultFastModel => "Default Fast Model",
-            Self::DefaultReviewModel => "Default Review Model",
-            Self::IncludeCoauthoredByAgentty => "Coauthored by Agentty",
-            Self::LaunchConfiguration => "Launch Configurations",
-            Self::Theme => "Theme",
-        }
-    }
-
-    /// Returns how this row is edited.
-    fn control(self) -> SettingControl {
-        match self {
-            Self::ReasoningLevel
-            | Self::DefaultSmartModel
-            | Self::DefaultFastModel
-            | Self::DefaultReviewModel
-            | Self::IncludeCoauthoredByAgentty
-            | Self::Theme => SettingControl::Selector,
-            Self::LaunchConfiguration => SettingControl::CommandList,
-        }
-    }
-
-    /// Returns this row's table index.
-    fn table_index(self) -> usize {
-        Self::ALL
-            .iter()
-            .position(|row| *row == self)
-            .unwrap_or_default()
-    }
-}
-
-/// Tracks the active selector dropdown and highlighted option.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct SelectorDropdownState {
-    row: SettingRow,
-    selected_index: usize,
-}
-
-/// Tracks state for the `Launch Configurations` list editor overlay.
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct LaunchConfigurationListEditorState {
-    commands: Vec<String>,
-    input: InputState,
-    mode: LaunchConfigurationListEditorMode,
-    selected_index: usize,
-}
-
-impl LaunchConfigurationListEditorState {
-    /// Creates a list editor state from the persisted newline-delimited
-    /// command setting.
-    fn from_launch_configuration(launch_configuration: &str) -> Self {
-        Self {
-            commands: parse_launch_configurations(launch_configuration),
-            input: InputState::default(),
-            mode: LaunchConfigurationListEditorMode::Browse,
-            selected_index: 0,
-        }
-    }
-
-    /// Returns the selected index clamped to the currently available command
-    /// rows.
-    fn selected_index(&self) -> usize {
-        self.selected_index
-            .min(self.commands.len().saturating_sub(1))
-    }
-
-    /// Moves selection to a valid command row after a list mutation.
-    fn clamp_selected_index(&mut self) {
-        self.selected_index = self.selected_index();
-    }
-
-    /// Returns whether the editor is in single-line input mode.
-    fn is_input_mode(&self) -> bool {
-        matches!(
-            self.mode,
-            LaunchConfigurationListEditorMode::Add | LaunchConfigurationListEditorMode::Edit
-        )
-    }
-}
-
 /// Manages user-configurable application settings.
 pub struct SettingsManager {
     /// Default agent/model selection used by fast-path workflows.
@@ -313,8 +147,6 @@ pub struct SettingsManager {
     ///
     /// Currently applied to Codex and Claude turns.
     pub reasoning_level: ReasoningLevel,
-    /// Frontend-neutral selected-row state for the settings page.
-    pub table_state: SelectionState,
     /// Active terminal color theme for the whole application.
     pub theme: ColorTheme,
     available_agent_kinds: Vec<AgentKind>,
@@ -324,30 +156,42 @@ pub struct SettingsManager {
     /// New projects start with this disabled until the user explicitly enables
     /// it.
     include_coauthored_by_agentty: bool,
-    launch_configuration_list_editor: Option<LaunchConfigurationListEditorState>,
     /// Active project identifier that owns these persisted settings.
     project_id: i64,
-    selector_dropdown: Option<SelectorDropdownState>,
+    repositories: AppRepositories,
     use_last_used_model_as_default: bool,
 }
 
 impl SettingsManager {
-    /// Creates a settings manager and loads persisted values from the database.
-    pub async fn new(services: &AppServices, project_id: i64) -> Self {
-        let available_agent_kinds = services.available_agent_kinds();
+    /// Loads persisted settings using only the repositories and available
+    /// provider capability required by this feature.
+    pub async fn from_repositories(
+        repositories: AppRepositories,
+        available_agent_kinds: Vec<AgentKind>,
+        project_id: i64,
+    ) -> Self {
         let default_smart_fallback = fallback_selection_for_available_model(
             AgentKind::Antigravity.default_model(),
             &available_agent_kinds,
         );
-        let default_smart_agent =
-            load_default_smart_agent_setting(services, Some(project_id), default_smart_fallback)
-                .await;
+        let default_smart_agent = load_default_smart_agent_selection_from_repositories(
+            &repositories,
+            Some(project_id),
+            default_smart_fallback,
+            &available_agent_kinds,
+        )
+        .await;
 
-        let default_fast_agent =
-            load_default_fast_agent_setting(services, Some(project_id), default_smart_agent).await;
+        let default_fast_agent = load_default_fast_agent_selection_from_repositories(
+            &repositories,
+            Some(project_id),
+            default_smart_agent,
+            &available_agent_kinds,
+        )
+        .await;
 
         let default_review_agent = load_model_selection_setting(
-            services.db(),
+            &repositories,
             Some(project_id),
             SettingName::DefaultReviewAgent,
             SettingName::DefaultReviewModel,
@@ -357,34 +201,34 @@ impl SettingsManager {
         .map_or(default_smart_agent, |selection| {
             resolve_available_selection(selection, &available_agent_kinds)
         });
-        let reasoning_level = load_reasoning_level_setting(services, Some(project_id)).await;
+        let reasoning_level = repositories
+            .settings()
+            .load_project_reasoning_level(project_id)
+            .await
+            .unwrap_or_default();
 
-        let launch_configuration = services
-            .db()
+        let launch_configuration = repositories
             .settings()
             .get_project_setting(project_id, SettingName::LaunchConfiguration)
             .await
             .unwrap_or(None)
             .unwrap_or_default();
 
-        let include_coauthored_by_agentty = load_project_bool_setting(
-            services,
+        let include_coauthored_by_agentty = load_project_bool_setting_from_repositories(
+            &repositories,
             Some(project_id),
             SettingName::IncludeCoauthoredByAgentty,
             false,
         )
         .await;
-        let use_last_used_model_as_default = load_project_bool_setting(
-            services,
+        let use_last_used_model_as_default = load_project_bool_setting_from_repositories(
+            &repositories,
             Some(project_id),
             SettingName::LastUsedModelAsDefault,
             false,
         )
         .await;
-        let theme = load_theme_setting(services).await;
-
-        let mut table_state = SelectionState::default();
-        table_state.select(Some(0));
+        let theme = load_theme_setting_from_repositories(&repositories).await;
 
         Self {
             default_fast_selection: default_fast_agent,
@@ -392,303 +236,12 @@ impl SettingsManager {
             default_smart_selection: default_smart_agent,
             launch_configuration,
             reasoning_level,
-            table_state,
             theme,
             available_agent_kinds,
             include_coauthored_by_agentty,
-            launch_configuration_list_editor: None,
             project_id,
-            selector_dropdown: None,
+            repositories,
             use_last_used_model_as_default,
-        }
-    }
-
-    /// Moves the settings selection to the next row.
-    pub fn next(&mut self) {
-        if !self.is_launch_configuration_list_editor_open() && !self.is_selector_dropdown_open() {
-            let next_index = (self.selected_row_index() + 1) % SettingRow::ROW_COUNT;
-            self.table_state.select(Some(next_index));
-        }
-    }
-
-    /// Moves the settings selection to the previous row.
-    pub fn previous(&mut self) {
-        if !self.is_launch_configuration_list_editor_open() && !self.is_selector_dropdown_open() {
-            let current_index = self.selected_row_index();
-            let previous_index = if current_index == 0 {
-                SettingRow::ROW_COUNT - 1
-            } else {
-                current_index - 1
-            };
-            self.table_state.select(Some(previous_index));
-        }
-    }
-
-    /// Handles the primary action for the selected setting row.
-    pub fn handle_enter(&mut self) {
-        let selected_row = self.selected_row();
-
-        match selected_row.control() {
-            SettingControl::Selector => {
-                self.open_selector_dropdown(selected_row);
-            }
-            SettingControl::CommandList => {
-                self.open_launch_configuration_list_editor();
-            }
-        }
-    }
-
-    /// Returns whether the `Launch Configurations` list editor is active.
-    #[must_use]
-    pub fn is_launch_configuration_list_editor_open(&self) -> bool {
-        self.launch_configuration_list_editor.is_some()
-    }
-
-    /// Returns whether the `Launch Configurations` editor is currently
-    /// accepting single-line text input.
-    #[must_use]
-    pub fn is_launch_configuration_list_editor_input_active(&self) -> bool {
-        self.launch_configuration_list_editor
-            .as_ref()
-            .is_some_and(LaunchConfigurationListEditorState::is_input_mode)
-    }
-
-    /// Returns whether a selector dropdown is currently open.
-    #[must_use]
-    pub fn is_selector_dropdown_open(&self) -> bool {
-        self.selector_dropdown.is_some()
-    }
-
-    /// Returns the render-ready `Launch Configurations` editor snapshot, when
-    /// it is open.
-    #[must_use]
-    pub fn launch_configuration_list_editor(
-        &self,
-    ) -> Option<LaunchConfigurationListEditorSnapshot> {
-        let editor = self.launch_configuration_list_editor.as_ref()?;
-        let input = editor.is_input_mode().then(|| editor.input.clone());
-
-        Some(LaunchConfigurationListEditorSnapshot {
-            commands: editor.commands.clone(),
-            input,
-            mode: editor.mode,
-            selected_index: editor.selected_index(),
-        })
-    }
-
-    /// Returns the render-ready selector dropdown snapshot, when one is open.
-    #[must_use]
-    pub fn selector_dropdown(&self) -> Option<SettingsSelectorDropdown> {
-        let selector_dropdown = self.selector_dropdown?;
-        let options = self.selector_options_for_row(selector_dropdown.row);
-        if options.is_empty() {
-            return None;
-        }
-
-        let selected_index = selector_dropdown
-            .selected_index
-            .min(options.len().saturating_sub(1));
-
-        Some(SettingsSelectorDropdown {
-            options: options
-                .into_iter()
-                .map(|option| SettingsSelectorDropdownOption {
-                    label: option.label,
-                })
-                .collect(),
-            row_index: selector_dropdown.row.table_index(),
-            selected_index,
-        })
-    }
-
-    /// Moves the active selector dropdown highlight to the next option.
-    pub fn next_selector_dropdown_option(&mut self) {
-        self.move_selector_dropdown_option(SelectorDropdownDirection::Next);
-    }
-
-    /// Moves the active selector dropdown highlight to the previous option.
-    pub fn previous_selector_dropdown_option(&mut self) {
-        self.move_selector_dropdown_option(SelectorDropdownDirection::Previous);
-    }
-
-    /// Closes the active selector dropdown without changing the setting value.
-    pub fn close_selector_dropdown(&mut self) {
-        self.selector_dropdown = None;
-    }
-
-    /// Applies the highlighted selector dropdown option and closes the
-    /// dropdown.
-    pub async fn select_selector_dropdown_option(&mut self, services: &AppServices) {
-        let Some(selector_dropdown) = self.selector_dropdown else {
-            return;
-        };
-
-        let options = self.selector_options_for_row(selector_dropdown.row);
-        let selected_value = options
-            .get(
-                selector_dropdown
-                    .selected_index
-                    .min(options.len().saturating_sub(1)),
-            )
-            .map(|option| option.value);
-
-        if let Some(selected_value) = selected_value {
-            self.apply_selector_value(services, selector_dropdown.row, selected_value)
-                .await;
-        }
-
-        self.close_selector_dropdown();
-    }
-
-    /// Closes the `Launch Configurations` list editor without saving any active
-    /// add/edit input.
-    pub fn close_launch_configuration_list_editor(&mut self) {
-        self.launch_configuration_list_editor = None;
-    }
-
-    /// Moves the `Launch Configurations` editor selection to the next command.
-    pub fn next_launch_configuration_list_editor_item(&mut self) {
-        self.move_launch_configuration_list_editor_selection(
-            LaunchConfigurationListDirection::Next,
-        );
-    }
-
-    /// Moves the `Launch Configurations` editor selection to the previous
-    /// command.
-    pub fn previous_launch_configuration_list_editor_item(&mut self) {
-        self.move_launch_configuration_list_editor_selection(
-            LaunchConfigurationListDirection::Previous,
-        );
-    }
-
-    /// Starts adding a command in the launch-configuration editor.
-    pub fn start_adding_launch_configuration(&mut self) {
-        let Some(editor) = &mut self.launch_configuration_list_editor else {
-            return;
-        };
-
-        editor.input = InputState::default();
-        editor.mode = LaunchConfigurationListEditorMode::Add;
-    }
-
-    /// Starts editing the selected command. If no command exists yet, this
-    /// starts add mode.
-    pub fn start_editing_selected_launch_configuration(&mut self) {
-        let Some(editor) = &mut self.launch_configuration_list_editor else {
-            return;
-        };
-
-        if editor.commands.is_empty() {
-            editor.input = InputState::default();
-            editor.mode = LaunchConfigurationListEditorMode::Add;
-
-            return;
-        }
-
-        let selected_index = editor.selected_index();
-        let selected_command = editor.commands[selected_index].clone();
-        editor.selected_index = selected_index;
-        editor.input = InputState::with_text(selected_command);
-        editor.mode = LaunchConfigurationListEditorMode::Edit;
-    }
-
-    /// Cancels add/edit input and returns to command browsing.
-    pub fn cancel_launch_configuration_input(&mut self) {
-        let Some(editor) = &mut self.launch_configuration_list_editor else {
-            return;
-        };
-
-        editor.input = InputState::default();
-        editor.mode = LaunchConfigurationListEditorMode::Browse;
-    }
-
-    /// Applies one shared editing command to the active launch-configuration
-    /// input field.
-    pub fn apply_launch_configuration_input_command(&mut self, command: InputCommand) {
-        let Some(editor) = &mut self.launch_configuration_list_editor else {
-            return;
-        };
-
-        if editor.is_input_mode() {
-            editor.input.apply(command);
-        }
-    }
-
-    /// Confirms the active add/edit input and persists the normalized command
-    /// list.
-    pub async fn confirm_launch_configuration_input(&mut self, services: &AppServices) {
-        if self.apply_launch_configuration_input() {
-            self.persist_launch_configuration_setting(services).await;
-        }
-    }
-
-    /// Deletes the selected launch configuration and persists the normalized
-    /// command list.
-    pub async fn delete_selected_launch_configuration(&mut self, services: &AppServices) {
-        if self.delete_selected_launch_configuration_from_editor() {
-            self.persist_launch_configuration_setting(services).await;
-        }
-    }
-
-    /// Moves the selected launch configuration down and persists the normalized
-    /// command list.
-    pub async fn move_selected_launch_configuration_down(&mut self, services: &AppServices) {
-        if self.reorder_selected_launch_configuration(LaunchConfigurationReorderDirection::Down) {
-            self.persist_launch_configuration_setting(services).await;
-        }
-    }
-
-    /// Moves the selected launch configuration up and persists the normalized
-    /// command list.
-    pub async fn move_selected_launch_configuration_up(&mut self, services: &AppServices) {
-        if self.reorder_selected_launch_configuration(LaunchConfigurationReorderDirection::Up) {
-            self.persist_launch_configuration_setting(services).await;
-        }
-    }
-
-    /// Returns settings table rows as `(name, value)` pairs.
-    #[must_use]
-    pub fn settings_rows(&self) -> Vec<(&'static str, String)> {
-        SettingRow::ALL
-            .iter()
-            .map(|row| (row.label(), self.display_value_for_row(*row)))
-            .collect()
-    }
-
-    /// Returns the global-scoped settings rows.
-    #[must_use]
-    pub fn global_settings_rows(&self) -> Vec<(&'static str, String)> {
-        SettingRow::GLOBAL
-            .iter()
-            .map(|row| (row.label(), self.display_value_for_row(*row)))
-            .collect()
-    }
-
-    /// Returns project-scoped settings rows.
-    #[must_use]
-    pub fn project_settings_rows(&self) -> Vec<(&'static str, String)> {
-        SettingRow::PROJECT
-            .iter()
-            .map(|row| (row.label(), self.display_value_for_row(*row)))
-            .collect()
-    }
-
-    /// Returns the footer hint text for the settings page.
-    #[must_use]
-    pub fn footer_hint(&self) -> &'static str {
-        if self
-            .launch_configuration_list_editor
-            .as_ref()
-            .is_some_and(LaunchConfigurationListEditorState::is_input_mode)
-        {
-            "Launch Configurations: type a command, Enter save, Esc cancel"
-        } else if self.is_launch_configuration_list_editor_open() {
-            "Launch Configurations: j/k move, a add, e/Enter edit, d delete, J/K reorder, Esc/q \
-             close"
-        } else if self.is_selector_dropdown_open() {
-            "Selecting setting value: j/k move, Enter select, Esc/q close"
-        } else {
-            "Settings: Enter opens selectors or command editor"
         }
     }
 
@@ -700,368 +253,66 @@ impl SettingsManager {
         parse_launch_configurations(self.launch_configuration.as_str())
     }
 
-    /// Returns the currently selected row index.
-    fn selected_row_index(&self) -> usize {
-        self.table_state
-            .selected()
-            .unwrap_or(0)
-            .min(SettingRow::ROW_COUNT - 1)
-    }
-
-    /// Returns the currently selected settings row.
-    fn selected_row(&self) -> SettingRow {
-        SettingRow::from_index(self.selected_row_index())
-    }
-
-    /// Opens a selector dropdown for the provided row.
-    fn open_selector_dropdown(&mut self, row: SettingRow) {
-        if !matches!(row.control(), SettingControl::Selector) {
-            return;
-        }
-
-        let options = self.selector_options_for_row(row);
-        if options.is_empty() {
-            return;
-        }
-
-        let selected_index = self.current_selector_option_index(row, &options);
-        self.selector_dropdown = Some(SelectorDropdownState {
-            row,
-            selected_index,
-        });
-    }
-
-    /// Moves the active selector dropdown highlight in the requested
-    /// direction.
-    fn move_selector_dropdown_option(&mut self, direction: SelectorDropdownDirection) {
-        let Some(selector_dropdown) = self.selector_dropdown else {
-            return;
-        };
-
-        let option_count = self.selector_options_for_row(selector_dropdown.row).len();
-        if option_count == 0 {
-            self.close_selector_dropdown();
-
-            return;
-        }
-
-        let selected_index = match direction {
-            SelectorDropdownDirection::Next => {
-                (selector_dropdown.selected_index + 1) % option_count
-            }
-            SelectorDropdownDirection::Previous => {
-                if selector_dropdown.selected_index == 0 {
-                    option_count - 1
-                } else {
-                    selector_dropdown.selected_index - 1
-                }
-            }
-        };
-
-        self.selector_dropdown = Some(SelectorDropdownState {
-            row: selector_dropdown.row,
-            selected_index,
-        });
-    }
-
-    /// Builds all options for the selector row in UI display order.
-    fn selector_options_for_row(&self, row: SettingRow) -> Vec<SettingSelectorOption> {
-        match row {
-            SettingRow::ReasoningLevel => ReasoningLevel::ALL
-                .iter()
-                .copied()
-                .map(|reasoning_level| SettingSelectorOption {
-                    label: reasoning_level.codex().to_string(),
-                    value: SettingSelectorValue::ReasoningLevel(reasoning_level),
-                })
+    /// Returns an immutable projection for the settings screen.
+    pub(crate) fn view(&self) -> SettingsView {
+        SettingsView {
+            available_model_selections: selectable_model_options(&self.available_agent_kinds)
+                .into_iter()
+                .map(ModelSelectorOption::selection)
                 .collect(),
-            SettingRow::DefaultSmartModel => self.default_smart_model_selector_options(),
-            SettingRow::DefaultFastModel | SettingRow::DefaultReviewModel => {
-                self.explicit_model_selector_options()
-            }
-            SettingRow::IncludeCoauthoredByAgentty => vec![
-                SettingSelectorOption {
-                    label: bool_setting_display(false),
-                    value: SettingSelectorValue::Bool(false),
-                },
-                SettingSelectorOption {
-                    label: bool_setting_display(true),
-                    value: SettingSelectorValue::Bool(true),
-                },
-            ],
-            SettingRow::LaunchConfiguration => Vec::new(),
-            SettingRow::Theme => ColorTheme::ALL
-                .iter()
-                .copied()
-                .map(|theme| SettingSelectorOption {
-                    label: theme.label().to_string(),
-                    value: SettingSelectorValue::Theme(theme),
-                })
-                .collect(),
+            default_fast_selection: self.default_fast_selection,
+            default_review_selection: self.default_review_selection,
+            default_smart_selection: self.default_smart_selection,
+            include_coauthored_by_agentty: self.include_coauthored_by_agentty,
+            launch_configuration: self.launch_configuration.clone(),
+            reasoning_level: self.reasoning_level,
+            theme: self.theme,
+            use_last_used_model_as_default: self.use_last_used_model_as_default,
         }
     }
 
-    /// Builds selector options for the smart-model setting, including the
-    /// dynamic last-used option.
-    fn default_smart_model_selector_options(&self) -> Vec<SettingSelectorOption> {
-        let mut options = self.explicit_model_selector_options();
-        options.push(SettingSelectorOption {
-            label: "Last used model as default".to_string(),
-            value: SettingSelectorValue::LastUsedModel,
-        });
-
-        options
-    }
-
-    /// Builds model selector options for locally available agent providers.
-    fn explicit_model_selector_options(&self) -> Vec<SettingSelectorOption> {
-        self.selectable_model_options()
-            .into_iter()
-            .map(|option| {
-                let selection = option.selection();
-
-                SettingSelectorOption {
-                    label: display_model_selector_value(selection),
-                    value: SettingSelectorValue::ModelSelection(selection),
-                }
-            })
-            .collect()
-    }
-
-    /// Finds the option index that currently matches the persisted row value.
-    fn current_selector_option_index(
-        &self,
-        row: SettingRow,
-        options: &[SettingSelectorOption],
-    ) -> usize {
-        options
-            .iter()
-            .position(|option| option.is_current_for(self, row))
-            .unwrap_or_default()
-    }
-
-    /// Applies one selected dropdown value to the target row.
-    async fn apply_selector_value(
-        &mut self,
-        services: &AppServices,
-        row: SettingRow,
-        value: SettingSelectorValue,
-    ) {
-        match (row, value) {
-            (SettingRow::ReasoningLevel, SettingSelectorValue::ReasoningLevel(reasoning_level)) => {
-                self.reasoning_level = reasoning_level;
-                self.persist_reasoning_level_setting(services).await;
-            }
-            (SettingRow::DefaultSmartModel, SettingSelectorValue::LastUsedModel) => {
-                self.use_last_used_model_as_default = true;
-                self.persist_default_smart_model_settings(services).await;
-            }
-            (SettingRow::DefaultSmartModel, SettingSelectorValue::ModelSelection(selection)) => {
-                self.default_smart_selection = selection;
-                self.use_last_used_model_as_default = false;
-                self.persist_default_smart_model_settings(services).await;
-            }
-            (SettingRow::DefaultFastModel, SettingSelectorValue::ModelSelection(selection)) => {
+    /// Applies and persists one value change requested by the settings screen.
+    pub(crate) async fn apply_operation(&mut self, operation: SettingsOperation) {
+        match operation {
+            SettingsOperation::DefaultFastSelection(selection) => {
                 self.default_fast_selection = selection;
-                self.persist_default_fast_model_setting(services).await;
+                self.persist_default_fast_model_setting().await;
             }
-            (SettingRow::DefaultReviewModel, SettingSelectorValue::ModelSelection(selection)) => {
+            SettingsOperation::DefaultReviewSelection(selection) => {
                 self.default_review_selection = selection;
-                self.persist_default_review_model_setting(services).await;
+                self.persist_default_review_model_setting().await;
             }
-            (SettingRow::IncludeCoauthoredByAgentty, SettingSelectorValue::Bool(is_enabled)) => {
-                self.include_coauthored_by_agentty = is_enabled;
-                self.persist_include_coauthored_by_agentty_setting(services)
-                    .await;
+            SettingsOperation::DefaultSmartSelection {
+                selection,
+                use_last_used_model_as_default,
+            } => {
+                self.default_smart_selection = selection;
+                self.use_last_used_model_as_default = use_last_used_model_as_default;
+                self.persist_default_smart_model_settings().await;
             }
-            (SettingRow::Theme, SettingSelectorValue::Theme(theme)) => {
-                self.theme = theme;
-                self.persist_theme_setting(services).await;
+            SettingsOperation::IncludeCoauthoredByAgentty(value) => {
+                self.include_coauthored_by_agentty = value;
+                self.persist_include_coauthored_by_agentty_setting().await;
             }
-            _ => {}
-        }
-    }
-
-    /// Opens the command list editor from the persisted launch-configuration
-    /// setting.
-    fn open_launch_configuration_list_editor(&mut self) {
-        self.launch_configuration_list_editor = Some(
-            LaunchConfigurationListEditorState::from_launch_configuration(
-                self.launch_configuration.as_str(),
-            ),
-        );
-    }
-
-    /// Moves the launch-configuration editor selection in the requested
-    /// direction.
-    fn move_launch_configuration_list_editor_selection(
-        &mut self,
-        direction: LaunchConfigurationListDirection,
-    ) {
-        let Some(editor) = &mut self.launch_configuration_list_editor else {
-            return;
-        };
-
-        if editor.commands.is_empty() || editor.is_input_mode() {
-            return;
-        }
-
-        let command_count = editor.commands.len();
-        editor.selected_index = match direction {
-            LaunchConfigurationListDirection::Next => (editor.selected_index + 1) % command_count,
-            LaunchConfigurationListDirection::Previous => {
-                if editor.selected_index == 0 {
-                    command_count - 1
-                } else {
-                    editor.selected_index - 1
-                }
+            SettingsOperation::LaunchConfiguration(value) => {
+                self.launch_configuration = value;
+                self.persist_launch_configuration_setting().await;
             }
-        };
-    }
-
-    /// Applies the active add/edit input to the command list.
-    fn apply_launch_configuration_input(&mut self) -> bool {
-        let Some(editor) = &mut self.launch_configuration_list_editor else {
-            return false;
-        };
-
-        if !editor.is_input_mode() {
-            return false;
-        }
-
-        let command = editor.input.text().trim().to_string();
-        match editor.mode {
-            LaunchConfigurationListEditorMode::Add => {
-                if !command.is_empty() {
-                    editor.commands.push(command);
-                    editor.selected_index = editor.commands.len().saturating_sub(1);
-                }
+            SettingsOperation::ReasoningLevel(value) => {
+                self.reasoning_level = value;
+                self.persist_reasoning_level_setting().await;
             }
-            LaunchConfigurationListEditorMode::Edit => {
-                if editor.commands.is_empty() {
-                    if !command.is_empty() {
-                        editor.commands.push(command);
-                        editor.selected_index = 0;
-                    }
-                } else {
-                    let selected_index = editor.selected_index();
-                    if command.is_empty() {
-                        editor.commands.remove(selected_index);
-                        editor.clamp_selected_index();
-                    } else {
-                        editor.commands[selected_index] = command;
-                        editor.selected_index = selected_index;
-                    }
-                }
+            SettingsOperation::Theme(value) => {
+                self.theme = value;
+                self.persist_theme_setting().await;
             }
-            LaunchConfigurationListEditorMode::Browse => {}
-        }
-
-        editor.input = InputState::default();
-        editor.mode = LaunchConfigurationListEditorMode::Browse;
-        self.sync_launch_configuration_from_editor();
-
-        true
-    }
-
-    /// Deletes the selected command from the launch-configuration editor.
-    fn delete_selected_launch_configuration_from_editor(&mut self) -> bool {
-        let Some(editor) = &mut self.launch_configuration_list_editor else {
-            return false;
-        };
-
-        if editor.commands.is_empty() || editor.is_input_mode() {
-            return false;
-        }
-
-        let selected_index = editor.selected_index();
-        editor.commands.remove(selected_index);
-        editor.clamp_selected_index();
-        self.sync_launch_configuration_from_editor();
-
-        true
-    }
-
-    /// Reorders the selected command in the launch-configuration editor.
-    fn reorder_selected_launch_configuration(
-        &mut self,
-        direction: LaunchConfigurationReorderDirection,
-    ) -> bool {
-        let Some(editor) = &mut self.launch_configuration_list_editor else {
-            return false;
-        };
-
-        if editor.commands.len() < 2 || editor.is_input_mode() {
-            return false;
-        }
-
-        let selected_index = editor.selected_index();
-        let next_index = match direction {
-            LaunchConfigurationReorderDirection::Down => {
-                if selected_index + 1 >= editor.commands.len() {
-                    return false;
-                }
-
-                selected_index + 1
-            }
-            LaunchConfigurationReorderDirection::Up => {
-                if selected_index == 0 {
-                    return false;
-                }
-
-                selected_index - 1
-            }
-        };
-
-        editor.commands.swap(selected_index, next_index);
-        editor.selected_index = next_index;
-        self.sync_launch_configuration_from_editor();
-
-        true
-    }
-
-    /// Synchronizes the persisted `launch_configuration` string from the
-    /// editor's normalized command list.
-    fn sync_launch_configuration_from_editor(&mut self) {
-        if let Some(editor) = &mut self.launch_configuration_list_editor {
-            editor.commands = normalize_launch_configurations(&editor.commands);
-            editor.clamp_selected_index();
-            self.launch_configuration = join_launch_configurations(&editor.commands);
-        }
-    }
-
-    /// Returns the text displayed for a row value.
-    fn display_value_for_row(&self, row: SettingRow) -> String {
-        match row {
-            SettingRow::ReasoningLevel => self.reasoning_level.codex().to_string(),
-            SettingRow::DefaultSmartModel => {
-                if self.use_last_used_model_as_default {
-                    "Last used model as default".to_string()
-                } else {
-                    display_model_selector_value(self.default_smart_selection)
-                }
-            }
-            SettingRow::DefaultFastModel => {
-                display_model_selector_value(self.default_fast_selection)
-            }
-            SettingRow::DefaultReviewModel => {
-                display_model_selector_value(self.default_review_selection)
-            }
-            SettingRow::IncludeCoauthoredByAgentty => {
-                bool_setting_display(self.include_coauthored_by_agentty)
-            }
-            SettingRow::LaunchConfiguration => {
-                display_launch_configuration_summary(&self.launch_configuration)
-            }
-            SettingRow::Theme => self.theme.label().to_string(),
         }
     }
 
     /// Persists the current `LaunchConfiguration` setting value.
-    async fn persist_launch_configuration_setting(&self, services: &AppServices) {
-        // Best-effort: settings persistence failure is non-critical.
-        let _ = services
-            .db()
+    async fn persist_launch_configuration_setting(&self) {
+        let _ = self
+            .repositories
             .settings()
             .upsert_project_setting(
                 self.project_id,
@@ -1071,19 +322,13 @@ impl SettingsManager {
             .await;
     }
 
-    /// Returns all selectable model options whose provider is locally
-    /// runnable.
-    fn selectable_model_options(&self) -> Vec<ModelSelectorOption> {
-        selectable_model_options(&self.available_agent_kinds)
-    }
-
     /// Atomically persists smart-model selector values (`DefaultSmartAgent`,
     /// `DefaultSmartModel`, and `LastUsedModelAsDefault`).
-    async fn persist_default_smart_model_settings(&self, services: &AppServices) {
+    async fn persist_default_smart_model_settings(&self) {
         let last_used_model_as_default_value = self.use_last_used_model_as_default.to_string();
 
-        if let Err(error) = services
-            .db()
+        if let Err(error) = self
+            .repositories
             .settings()
             .upsert_project_settings(
                 self.project_id,
@@ -1113,10 +358,10 @@ impl SettingsManager {
     }
 
     /// Persists the reasoning-level selector value (`ReasoningLevel`).
-    async fn persist_reasoning_level_setting(&self, services: &AppServices) {
+    async fn persist_reasoning_level_setting(&self) {
         // Best-effort: settings persistence failure is non-critical.
-        let _ = services
-            .db()
+        let _ = self
+            .repositories
             .settings()
             .set_project_reasoning_level(self.project_id, self.reasoning_level)
             .await;
@@ -1124,9 +369,9 @@ impl SettingsManager {
 
     /// Atomically persists the fast-model selector values (`DefaultFastAgent`
     /// and `DefaultFastModel`).
-    async fn persist_default_fast_model_setting(&self, services: &AppServices) {
-        if let Err(error) = services
-            .db()
+    async fn persist_default_fast_model_setting(&self) {
+        if let Err(error) = self
+            .repositories
             .settings()
             .upsert_project_settings(
                 self.project_id,
@@ -1153,9 +398,9 @@ impl SettingsManager {
 
     /// Atomically persists the review-model selector values
     /// (`DefaultReviewAgent` and `DefaultReviewModel`).
-    async fn persist_default_review_model_setting(&self, services: &AppServices) {
-        if let Err(error) = services
-            .db()
+    async fn persist_default_review_model_setting(&self) {
+        if let Err(error) = self
+            .repositories
             .settings()
             .upsert_project_settings(
                 self.project_id,
@@ -1182,12 +427,12 @@ impl SettingsManager {
 
     /// Persists the coauthor-trailer toggle for generated session commit
     /// messages.
-    async fn persist_include_coauthored_by_agentty_setting(&self, services: &AppServices) {
+    async fn persist_include_coauthored_by_agentty_setting(&self) {
         let include_coauthored_by_agentty = self.include_coauthored_by_agentty.to_string();
 
         // Best-effort: settings persistence failure is non-critical.
-        let _ = services
-            .db()
+        let _ = self
+            .repositories
             .settings()
             .upsert_project_setting(
                 self.project_id,
@@ -1198,81 +443,14 @@ impl SettingsManager {
     }
 
     /// Persists the global terminal color theme selection.
-    async fn persist_theme_setting(&self, services: &AppServices) {
+    async fn persist_theme_setting(&self) {
         // Best-effort: settings persistence failure is non-critical.
-        let _ = services
-            .db()
+        let _ = self
+            .repositories
             .settings()
             .upsert_setting(SettingName::Theme, self.theme.as_str())
             .await;
     }
-}
-
-/// Launch-configuration editor list navigation direction.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum LaunchConfigurationListDirection {
-    Next,
-    Previous,
-}
-
-/// Launch-configuration editor reorder direction.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum LaunchConfigurationReorderDirection {
-    Down,
-    Up,
-}
-
-/// Selector dropdown navigation direction.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum SelectorDropdownDirection {
-    Next,
-    Previous,
-}
-
-/// One selectable value in a settings dropdown.
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct SettingSelectorOption {
-    label: String,
-    value: SettingSelectorValue,
-}
-
-impl SettingSelectorOption {
-    /// Returns whether this option represents the manager's current row value.
-    fn is_current_for(&self, manager: &SettingsManager, row: SettingRow) -> bool {
-        match (row, self.value) {
-            (SettingRow::ReasoningLevel, SettingSelectorValue::ReasoningLevel(reasoning_level)) => {
-                manager.reasoning_level == reasoning_level
-            }
-            (SettingRow::DefaultSmartModel, SettingSelectorValue::LastUsedModel) => {
-                manager.use_last_used_model_as_default
-            }
-            (SettingRow::DefaultSmartModel, SettingSelectorValue::ModelSelection(selection)) => {
-                !manager.use_last_used_model_as_default
-                    && manager.default_smart_selection == selection
-            }
-            (SettingRow::DefaultFastModel, SettingSelectorValue::ModelSelection(selection)) => {
-                manager.default_fast_selection == selection
-            }
-            (SettingRow::DefaultReviewModel, SettingSelectorValue::ModelSelection(selection)) => {
-                manager.default_review_selection == selection
-            }
-            (SettingRow::IncludeCoauthoredByAgentty, SettingSelectorValue::Bool(is_enabled)) => {
-                manager.include_coauthored_by_agentty == is_enabled
-            }
-            (SettingRow::Theme, SettingSelectorValue::Theme(theme)) => manager.theme == theme,
-            _ => false,
-        }
-    }
-}
-
-/// Typed value carried by a selector dropdown option.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum SettingSelectorValue {
-    Bool(bool),
-    LastUsedModel,
-    ModelSelection(AgentSelection),
-    ReasoningLevel(ReasoningLevel),
-    Theme(ColorTheme),
 }
 
 /// One provider-owned model option shown by settings selectors.
@@ -1301,26 +479,10 @@ fn parse_launch_configurations(launch_configuration_setting: &str) -> Vec<String
         .collect()
 }
 
-/// Trims command entries and drops empty commands.
-fn normalize_launch_configurations(commands: &[String]) -> Vec<String> {
-    commands
-        .iter()
-        .map(|command| command.trim())
-        .filter(|command| !command.is_empty())
-        .map(std::string::ToString::to_string)
-        .collect()
-}
-
-/// Joins normalized command entries into the persisted setting value.
-fn join_launch_configurations(commands: &[String]) -> String {
-    normalize_launch_configurations(commands).join("\n")
-}
-
-/// Loads one project-scoped boolean setting, falling back to
-/// `default_value` when the project is missing or the persisted value is
-/// absent or invalid.
-async fn load_project_bool_setting(
-    services: &AppServices,
+/// Loads one project-scoped boolean setting through the narrow repository
+/// dependency used by [`SettingsManager`].
+async fn load_project_bool_setting_from_repositories(
+    repositories: &AppRepositories,
     project_id: Option<i64>,
     setting_name: SettingName,
     default_value: bool,
@@ -1329,42 +491,13 @@ async fn load_project_bool_setting(
         return default_value;
     };
 
-    services
-        .db()
+    repositories
         .settings()
         .get_project_setting(project_id, setting_name)
         .await
         .unwrap_or(None)
         .and_then(|setting_value| setting_value.parse::<bool>().ok())
         .unwrap_or(default_value)
-}
-
-/// Returns the human-readable value shown for one boolean selector row.
-fn bool_setting_display(setting_value: bool) -> String {
-    if setting_value {
-        "Enabled".to_string()
-    } else {
-        "Disabled".to_string()
-    }
-}
-
-/// Returns a model selector value prefixed with the option's real agent.
-fn display_model_selector_value(selection: AgentSelection) -> String {
-    format!("{}/{}", selection.kind(), selection.model().as_str())
-}
-
-/// Returns the compact table summary for configured launch configurations.
-fn display_launch_configuration_summary(launch_configuration_setting: &str) -> String {
-    let commands = parse_launch_configurations(launch_configuration_setting);
-    let Some(first_command) = commands.first() else {
-        return "(none)".to_string();
-    };
-
-    if commands.len() == 1 {
-        return first_command.clone();
-    }
-
-    format!("{} (+{} more)", first_command, commands.len() - 1)
 }
 
 /// Returns all selectable model options in settings display order for the
@@ -1497,33 +630,9 @@ fn fallback_selection_for_available_model(
     AgentSelection::new(agent_kind, model)
 }
 
-/// Loads the persisted reasoning-level setting.
-///
-/// Falls back to [`ReasoningLevel::default`] when the setting is missing
-/// or cannot be parsed.
-async fn load_reasoning_level_setting(
-    services: &AppServices,
-    project_id: Option<i64>,
-) -> ReasoningLevel {
-    let Some(project_id) = project_id else {
-        return ReasoningLevel::default();
-    };
-
-    services
-        .db()
-        .settings()
-        .load_project_reasoning_level(project_id)
-        .await
-        .unwrap_or_default()
-}
-
-/// Loads the persisted terminal color theme.
-///
-/// Unknown or missing values fall back to [`ColorTheme::default`], preserving
-/// the existing palette for current users.
-async fn load_theme_setting(services: &AppServices) -> ColorTheme {
-    services
-        .db()
+/// Loads the persisted terminal color theme through the settings repository.
+async fn load_theme_setting_from_repositories(repositories: &AppRepositories) -> ColorTheme {
+    repositories
         .settings()
         .get_setting(SettingName::Theme)
         .await
@@ -1544,8 +653,12 @@ mod tests {
 
     use super::*;
     use crate::db::AppRepositories;
-    use crate::domain::selection::SelectionState;
+    use crate::domain::input::InputCommand;
     use crate::infra::fs;
+    use crate::presentation::settings::{
+        LaunchConfigurationListEditorMode, LaunchConfigurationListEditorSnapshot, SettingsAction,
+        SettingsPresentationState, SettingsSelectorDropdown,
+    };
 
     /// Builds app services backed by an in-memory database for settings tests.
     async fn test_services() -> (AppServices, i64) {
@@ -1576,39 +689,234 @@ mod tests {
         (services, project_id)
     }
 
-    /// Selects one settings row by its table index.
-    fn select_row(manager: &mut SettingsManager, row_index: usize) {
-        manager.table_state.select(Some(row_index));
+    /// Test-local settings screen harness that composes production value and
+    /// presentation boundaries without extending `SettingsManager`.
+    struct SettingsTestHarness {
+        manager: Option<SettingsManager>,
+        presentation: SettingsPresentationState,
+        view: SettingsView,
     }
 
-    fn new_settings_manager() -> SettingsManager {
-        let mut table_state = SelectionState::default();
-        table_state.select(Some(0));
+    impl SettingsTestHarness {
+        fn new() -> Self {
+            let default_selection = AgentSelection::new(
+                AgentKind::Antigravity,
+                AgentKind::Antigravity.default_model(),
+            );
 
-        SettingsManager {
-            default_fast_selection: AgentSelection::new(
-                AgentKind::Antigravity,
-                AgentKind::Antigravity.default_model(),
-            ),
-            default_review_selection: AgentSelection::new(
-                AgentKind::Antigravity,
-                AgentKind::Antigravity.default_model(),
-            ),
-            default_smart_selection: AgentSelection::new(
-                AgentKind::Antigravity,
-                AgentKind::Antigravity.default_model(),
-            ),
-            launch_configuration: String::new(),
-            reasoning_level: ReasoningLevel::High,
-            table_state,
-            theme: ColorTheme::Current,
-            available_agent_kinds: AgentKind::ALL.to_vec(),
-            include_coauthored_by_agentty: false,
-            launch_configuration_list_editor: None,
-            project_id: 1,
-            selector_dropdown: None,
-            use_last_used_model_as_default: false,
+            Self {
+                manager: None,
+                presentation: SettingsPresentationState::default(),
+                view: SettingsView {
+                    available_model_selections: selectable_model_options(AgentKind::ALL)
+                        .into_iter()
+                        .map(ModelSelectorOption::selection)
+                        .collect(),
+                    default_fast_selection: default_selection,
+                    default_review_selection: default_selection,
+                    default_smart_selection: default_selection,
+                    include_coauthored_by_agentty: false,
+                    launch_configuration: String::new(),
+                    reasoning_level: ReasoningLevel::High,
+                    theme: ColorTheme::Current,
+                    use_last_used_model_as_default: false,
+                },
+            }
         }
+
+        fn from_manager(manager: SettingsManager) -> Self {
+            Self {
+                view: manager.view(),
+                manager: Some(manager),
+                presentation: SettingsPresentationState::default(),
+            }
+        }
+
+        fn apply(&mut self, action: SettingsAction) -> Option<SettingsOperation> {
+            self.presentation.apply(&self.view, action)
+        }
+
+        async fn apply_and_persist(&mut self, action: SettingsAction) {
+            let Some(operation) = self.apply(action) else {
+                return;
+            };
+
+            self.persist_operation(operation).await;
+        }
+
+        async fn persist_operation(&mut self, operation: SettingsOperation) {
+            let manager = self
+                .manager
+                .as_mut()
+                .expect("persisted settings test requires a manager");
+            manager.apply_operation(operation).await;
+            self.view = manager.view();
+        }
+
+        fn fixture_view_mut(&mut self) -> &mut SettingsView {
+            assert!(
+                self.manager.is_none(),
+                "persisted settings fixtures must be seeded through repositories"
+            );
+
+            &mut self.view
+        }
+
+        fn settings(&self) -> &SettingsManager {
+            self.manager
+                .as_ref()
+                .expect("test requires repository-backed settings")
+        }
+
+        fn next(&mut self) {
+            let _ = self.apply(SettingsAction::Next);
+        }
+
+        fn previous(&mut self) {
+            let _ = self.apply(SettingsAction::Previous);
+        }
+
+        fn handle_enter(&mut self) {
+            let _ = self.apply(SettingsAction::Activate);
+        }
+
+        fn is_launch_configuration_list_editor_open(&self) -> bool {
+            self.presentation.is_launch_configuration_list_editor_open()
+        }
+
+        fn is_selector_dropdown_open(&self) -> bool {
+            self.presentation.is_selector_dropdown_open()
+        }
+
+        fn launch_configuration_list_editor(
+            &self,
+        ) -> Option<LaunchConfigurationListEditorSnapshot> {
+            self.presentation
+                .snapshot(&self.view)
+                .launch_configuration_list_editor
+        }
+
+        fn launch_configurations(&self) -> Vec<String> {
+            parse_launch_configurations(self.view.launch_configuration.as_str())
+        }
+
+        fn selector_dropdown(&self) -> Option<SettingsSelectorDropdown> {
+            self.presentation.snapshot(&self.view).selector_dropdown
+        }
+
+        fn start_adding_launch_configuration(&mut self) {
+            let _ = self.apply(SettingsAction::StartAddingLaunchConfiguration);
+        }
+
+        fn start_editing_selected_launch_configuration(&mut self) {
+            let _ = self.apply(SettingsAction::EditLaunchConfiguration);
+        }
+
+        fn cancel_launch_configuration_input(&mut self) {
+            let _ = self.apply(SettingsAction::Cancel);
+        }
+
+        fn apply_launch_configuration_input_command(&mut self, command: InputCommand) {
+            let _ = self.apply(SettingsAction::Input(command));
+        }
+
+        fn next_launch_configuration_list_editor_item(&mut self) {
+            self.next();
+        }
+
+        fn next_selector_dropdown_option(&mut self) {
+            self.next();
+        }
+
+        async fn confirm_launch_configuration_input(&mut self) {
+            self.apply_and_persist(SettingsAction::Confirm).await;
+        }
+
+        async fn delete_selected_launch_configuration(&mut self) {
+            self.apply_and_persist(SettingsAction::DeleteLaunchConfiguration)
+                .await;
+        }
+
+        async fn move_selected_launch_configuration_down(&mut self) {
+            self.apply_and_persist(SettingsAction::MoveLaunchConfigurationDown)
+                .await;
+        }
+
+        async fn move_selected_launch_configuration_up(&mut self) {
+            self.apply_and_persist(SettingsAction::MoveLaunchConfigurationUp)
+                .await;
+        }
+
+        async fn select_selector_dropdown_option(&mut self) {
+            self.apply_and_persist(SettingsAction::Confirm).await;
+        }
+
+        fn settings_rows(&self) -> Vec<(&'static str, String)> {
+            let snapshot = self.presentation.snapshot(&self.view);
+
+            snapshot
+                .global_rows
+                .into_iter()
+                .chain(snapshot.project_rows)
+                .collect()
+        }
+
+        fn global_settings_rows(&self) -> Vec<(&'static str, String)> {
+            self.presentation.snapshot(&self.view).global_rows
+        }
+
+        fn project_settings_rows(&self) -> Vec<(&'static str, String)> {
+            self.presentation.snapshot(&self.view).project_rows
+        }
+
+        fn footer_hint(&self) -> &'static str {
+            self.presentation.snapshot(&self.view).footer_hint
+        }
+    }
+
+    /// Selects one settings row through the screen navigation action.
+    fn select_row(manager: &mut SettingsTestHarness, row_index: usize) {
+        for _ in 0..row_index {
+            manager.next();
+        }
+    }
+
+    /// Creates an in-memory settings-screen fixture.
+    fn new_settings_manager() -> SettingsTestHarness {
+        SettingsTestHarness::new()
+    }
+
+    /// Loads a settings screen through the production repository boundary.
+    async fn settings_manager(services: &AppServices, project_id: i64) -> SettingsTestHarness {
+        let manager = SettingsManager::from_repositories(
+            services.db().clone(),
+            services.available_agent_kinds(),
+            project_id,
+        )
+        .await;
+
+        SettingsTestHarness::from_manager(manager)
+    }
+
+    /// Persists a launch-configuration fixture before loading the production
+    /// settings boundary.
+    async fn settings_manager_with_launch_configuration(
+        services: &AppServices,
+        project_id: i64,
+        launch_configuration: &str,
+    ) -> SettingsTestHarness {
+        services
+            .db()
+            .settings()
+            .upsert_project_setting(
+                project_id,
+                SettingName::LaunchConfiguration,
+                launch_configuration,
+            )
+            .await
+            .expect("failed to persist launch-configuration fixture");
+
+        settings_manager(services, project_id).await
     }
 
     #[test]
@@ -1944,26 +1252,27 @@ mod tests {
             .expect("failed to persist theme setting");
 
         // Act
-        let manager = SettingsManager::new(&services, project_id).await;
+        let manager = settings_manager(&services, project_id).await;
+        let settings = manager.settings();
 
         // Assert
         assert_eq!(
-            manager.default_smart_selection,
+            settings.default_smart_selection,
             AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55)
         );
         assert_eq!(
-            manager.default_fast_selection,
+            settings.default_fast_selection,
             AgentSelection::new(AgentKind::Codex, AgentModel::Gpt53CodexSpark)
         );
         assert_eq!(
-            manager.default_review_selection,
+            settings.default_review_selection,
             AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus48)
         );
-        assert_eq!(manager.launch_configuration, "nvim .");
-        assert_eq!(manager.reasoning_level, ReasoningLevel::Low);
-        assert_eq!(manager.theme, ColorTheme::Green);
-        assert!(!manager.include_coauthored_by_agentty);
-        assert!(manager.use_last_used_model_as_default);
+        assert_eq!(settings.launch_configuration, "nvim .");
+        assert_eq!(settings.reasoning_level, ReasoningLevel::Low);
+        assert_eq!(settings.theme, ColorTheme::Green);
+        assert!(!settings.include_coauthored_by_agentty);
+        assert!(settings.use_last_used_model_as_default);
     }
 
     #[tokio::test]
@@ -1982,10 +1291,10 @@ mod tests {
             .expect("failed to persist invalid flag");
 
         // Act
-        let manager = SettingsManager::new(&services, project_id).await;
+        let manager = settings_manager(&services, project_id).await;
 
         // Assert
-        assert!(!manager.use_last_used_model_as_default);
+        assert!(!manager.settings().use_last_used_model_as_default);
     }
 
     #[tokio::test]
@@ -2004,10 +1313,10 @@ mod tests {
             .expect("failed to persist invalid coauthor flag");
 
         // Act
-        let manager = SettingsManager::new(&services, project_id).await;
+        let manager = settings_manager(&services, project_id).await;
 
         // Assert
-        assert!(!manager.include_coauthored_by_agentty);
+        assert!(!manager.settings().include_coauthored_by_agentty);
     }
 
     #[tokio::test]
@@ -2022,10 +1331,10 @@ mod tests {
             .expect("failed to persist invalid theme");
 
         // Act
-        let manager = SettingsManager::new(&services, project_id).await;
+        let manager = settings_manager(&services, project_id).await;
 
         // Assert
-        assert_eq!(manager.theme, ColorTheme::Current);
+        assert_eq!(manager.settings().theme, ColorTheme::Current);
     }
 
     #[tokio::test]
@@ -2040,10 +1349,83 @@ mod tests {
             .expect("failed to persist theme setting");
 
         // Act
-        let manager = SettingsManager::new(&services, project_id).await;
+        let manager = settings_manager(&services, project_id).await;
 
         // Assert
-        assert_eq!(manager.theme, ColorTheme::DarkHorizon);
+        assert_eq!(manager.settings().theme, ColorTheme::DarkHorizon);
+    }
+
+    #[tokio::test]
+    async fn apply_operation_persists_fast_review_and_reasoning_settings() {
+        // Arrange
+        let (services, project_id) = test_services().await;
+        let mut manager = settings_manager(&services, project_id).await;
+        let fast_selection = AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55);
+        let review_selection = AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus48);
+
+        // Act
+        manager
+            .persist_operation(SettingsOperation::DefaultFastSelection(fast_selection))
+            .await;
+        manager
+            .persist_operation(SettingsOperation::DefaultReviewSelection(review_selection))
+            .await;
+        manager
+            .persist_operation(SettingsOperation::ReasoningLevel(ReasoningLevel::Max))
+            .await;
+
+        // Assert
+        assert_eq!(manager.settings().default_fast_selection, fast_selection);
+        assert_eq!(
+            manager.settings().default_review_selection,
+            review_selection
+        );
+        assert_eq!(manager.settings().reasoning_level, ReasoningLevel::Max);
+        assert_eq!(
+            services
+                .db()
+                .settings()
+                .get_project_setting(project_id, SettingName::DefaultFastAgent)
+                .await
+                .expect("failed to load fast agent"),
+            Some(AgentKind::Codex.name().to_string())
+        );
+        assert_eq!(
+            services
+                .db()
+                .settings()
+                .get_project_setting(project_id, SettingName::DefaultFastModel)
+                .await
+                .expect("failed to load fast model"),
+            Some(AgentModel::Gpt55.as_str().to_string())
+        );
+        assert_eq!(
+            services
+                .db()
+                .settings()
+                .get_project_setting(project_id, SettingName::DefaultReviewAgent)
+                .await
+                .expect("failed to load review agent"),
+            Some(AgentKind::Claude.name().to_string())
+        );
+        assert_eq!(
+            services
+                .db()
+                .settings()
+                .get_project_setting(project_id, SettingName::DefaultReviewModel)
+                .await
+                .expect("failed to load review model"),
+            Some(AgentModel::ClaudeOpus48.as_str().to_string())
+        );
+        assert_eq!(
+            services
+                .db()
+                .settings()
+                .load_project_reasoning_level(project_id)
+                .await
+                .expect("failed to load reasoning level"),
+            ReasoningLevel::Max
+        );
     }
 
     #[test]
@@ -2055,7 +1437,13 @@ mod tests {
         manager.next();
 
         // Assert
-        assert_eq!(manager.table_state.selected(), Some(1));
+        assert_eq!(
+            manager
+                .presentation
+                .snapshot(&manager.view)
+                .selected_row_index,
+            Some(1)
+        );
     }
 
     #[test]
@@ -2067,7 +1455,13 @@ mod tests {
         manager.previous();
 
         // Assert
-        assert_eq!(manager.table_state.selected(), Some(6));
+        assert_eq!(
+            manager
+                .presentation
+                .snapshot(&manager.view)
+                .selected_row_index,
+            Some(6)
+        );
     }
 
     #[test]
@@ -2126,12 +1520,9 @@ mod tests {
     fn footer_hint_returns_launch_configuration_input_hint_when_input_is_active() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.launch_configuration_list_editor = Some(LaunchConfigurationListEditorState {
-            commands: Vec::new(),
-            input: InputState::default(),
-            mode: LaunchConfigurationListEditorMode::Add,
-            selected_index: 0,
-        });
+        select_row(&mut manager, 6);
+        manager.handle_enter();
+        manager.start_adding_launch_configuration();
 
         // Act
         let footer_hint = manager.footer_hint();
@@ -2147,10 +1538,7 @@ mod tests {
     fn footer_hint_returns_selector_dropdown_hint_when_dropdown_is_open() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.selector_dropdown = Some(SelectorDropdownState {
-            row: SettingRow::Theme,
-            selected_index: 0,
-        });
+        manager.handle_enter();
 
         // Act
         let footer_hint = manager.footer_hint();
@@ -2166,7 +1554,7 @@ mod tests {
     fn launch_configurations_returns_single_trimmed_command() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.launch_configuration = "  cargo test  ".to_string();
+        manager.fixture_view_mut().launch_configuration = "  cargo test  ".to_string();
 
         // Act
         let launch_configurations = manager.launch_configurations();
@@ -2179,7 +1567,8 @@ mod tests {
     fn launch_configurations_splits_newline_entries() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.launch_configuration = " cargo test \n npm run dev \n".to_string();
+        manager.fixture_view_mut().launch_configuration =
+            " cargo test \n npm run dev \n".to_string();
 
         // Act
         let launch_configurations = manager.launch_configurations();
@@ -2195,7 +1584,7 @@ mod tests {
     fn launch_configurations_does_not_split_double_pipe_entries() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.launch_configuration = "cargo test || npm run dev".to_string();
+        manager.fixture_view_mut().launch_configuration = "cargo test || npm run dev".to_string();
 
         // Act
         let launch_configurations = manager.launch_configurations();
@@ -2223,7 +1612,7 @@ mod tests {
     fn settings_rows_show_single_launch_configuration_summary() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.launch_configuration = "http://localhost:5173".to_string();
+        manager.fixture_view_mut().launch_configuration = "http://localhost:5173".to_string();
 
         // Act
         let rows = manager.settings_rows();
@@ -2236,7 +1625,8 @@ mod tests {
     fn settings_rows_show_multiple_launch_configuration_summary() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.launch_configuration = "cargo test\nnpm run dev\nlazygit".to_string();
+        manager.fixture_view_mut().launch_configuration =
+            "cargo test\nnpm run dev\nlazygit".to_string();
 
         // Act
         let rows = manager.settings_rows();
@@ -2249,7 +1639,7 @@ mod tests {
     fn settings_rows_show_last_used_model_as_default_value_when_enabled() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.use_last_used_model_as_default = true;
+        manager.fixture_view_mut().use_last_used_model_as_default = true;
 
         // Act
         let rows = manager.settings_rows();
@@ -2262,7 +1652,7 @@ mod tests {
     fn settings_rows_show_default_smart_model_with_agent_prefix() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.default_smart_selection =
+        manager.fixture_view_mut().default_smart_selection =
             AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini31ProPreview);
 
         // Act
@@ -2276,8 +1666,12 @@ mod tests {
     fn settings_rows_show_default_smart_model_with_real_gemini_agent() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.available_agent_kinds = vec![AgentKind::Gemini];
-        manager.default_smart_selection =
+        let view = manager.fixture_view_mut();
+        view.available_model_selections = selectable_model_options(&[AgentKind::Gemini])
+            .into_iter()
+            .map(ModelSelectorOption::selection)
+            .collect();
+        view.default_smart_selection =
             AgentSelection::new(AgentKind::Gemini, AgentModel::Gemini31ProPreview);
 
         // Act
@@ -2291,7 +1685,8 @@ mod tests {
     fn settings_rows_show_default_fast_model_value() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.default_fast_selection = AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55);
+        manager.fixture_view_mut().default_fast_selection =
+            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55);
 
         // Act
         let rows = manager.settings_rows();
@@ -2304,7 +1699,7 @@ mod tests {
     fn settings_rows_show_default_review_model_value() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.default_review_selection =
+        manager.fixture_view_mut().default_review_selection =
             AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus48);
 
         // Act
@@ -2318,7 +1713,7 @@ mod tests {
     fn settings_rows_show_coauthored_by_agentty_value() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.include_coauthored_by_agentty = false;
+        manager.fixture_view_mut().include_coauthored_by_agentty = false;
 
         // Act
         let rows = manager.settings_rows();
@@ -2331,7 +1726,7 @@ mod tests {
     fn settings_rows_show_reasoning_level_value() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.reasoning_level = ReasoningLevel::Max;
+        manager.fixture_view_mut().reasoning_level = ReasoningLevel::Max;
 
         // Act
         let rows = manager.settings_rows();
@@ -2344,7 +1739,7 @@ mod tests {
     fn settings_rows_show_theme_value() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.theme = ColorTheme::Green;
+        manager.fixture_view_mut().theme = ColorTheme::Green;
 
         // Act
         let rows = manager.settings_rows();
@@ -2357,7 +1752,7 @@ mod tests {
     fn handle_enter_opens_launch_configuration_list_editor() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.launch_configuration = "nvim .".to_string();
+        manager.fixture_view_mut().launch_configuration = "nvim .".to_string();
         select_row(&mut manager, 6);
 
         // Act
@@ -2383,8 +1778,30 @@ mod tests {
         manager.previous();
 
         // Assert
-        assert_eq!(manager.table_state.selected(), Some(6));
+        assert_eq!(
+            manager
+                .presentation
+                .snapshot(&manager.view)
+                .selected_row_index,
+            Some(6)
+        );
         assert!(manager.is_launch_configuration_list_editor_open());
+    }
+
+    #[test]
+    fn navigation_actions_do_not_request_launch_configuration_persistence() {
+        // Arrange
+        let mut manager = new_settings_manager();
+        select_row(&mut manager, 6);
+        manager.handle_enter();
+
+        // Act
+        let next_operation = manager.apply(SettingsAction::Next);
+        let previous_operation = manager.apply(SettingsAction::Previous);
+
+        // Assert
+        assert_eq!(next_operation, None);
+        assert_eq!(previous_operation, None);
     }
 
     #[test]
@@ -2399,7 +1816,13 @@ mod tests {
         manager.previous();
 
         // Assert
-        assert_eq!(manager.table_state.selected(), Some(0));
+        assert_eq!(
+            manager
+                .presentation
+                .snapshot(&manager.view)
+                .selected_row_index,
+            Some(0)
+        );
         assert!(manager.is_selector_dropdown_open());
     }
 
@@ -2407,7 +1830,7 @@ mod tests {
     fn cancel_launch_configuration_input_returns_to_browse_without_changing_value() {
         // Arrange
         let mut manager = new_settings_manager();
-        manager.launch_configuration = "old command".to_string();
+        manager.fixture_view_mut().launch_configuration = "old command".to_string();
         select_row(&mut manager, 6);
         manager.handle_enter();
         manager.start_adding_launch_configuration();
@@ -2420,7 +1843,7 @@ mod tests {
         let editor = manager
             .launch_configuration_list_editor()
             .expect("expected launch-configuration list editor");
-        assert_eq!(manager.launch_configuration, "old command");
+        assert_eq!(manager.view.launch_configuration, "old command");
         assert_eq!(editor.mode, LaunchConfigurationListEditorMode::Browse);
         assert!(editor.input.is_none());
     }
@@ -2429,7 +1852,7 @@ mod tests {
     async fn confirm_launch_configuration_input_adds_trimmed_command_and_persists_value() {
         // Arrange
         let (services, project_id) = test_services().await;
-        let mut manager = SettingsManager::new(&services, project_id).await;
+        let mut manager = settings_manager(&services, project_id).await;
         select_row(&mut manager, 6);
         manager.handle_enter();
         manager.start_adding_launch_configuration();
@@ -2438,10 +1861,10 @@ mod tests {
         manager.apply_launch_configuration_input_command(InputCommand::InsertText(
             " nvim ".to_string(),
         ));
-        manager.confirm_launch_configuration_input(&services).await;
+        manager.confirm_launch_configuration_input().await;
 
         // Assert
-        assert_eq!(manager.launch_configuration, "nvim");
+        assert_eq!(manager.settings().launch_configuration, "nvim");
         assert_eq!(
             services
                 .db()
@@ -2457,8 +1880,12 @@ mod tests {
     async fn confirm_launch_configuration_input_edits_selected_command_and_persists_value() {
         // Arrange
         let (services, project_id) = test_services().await;
-        let mut manager = SettingsManager::new(&services, project_id).await;
-        manager.launch_configuration = "cargo test\nnpm run dev".to_string();
+        let mut manager = settings_manager_with_launch_configuration(
+            &services,
+            project_id,
+            "cargo test\nnpm run dev",
+        )
+        .await;
         select_row(&mut manager, 6);
         manager.handle_enter();
         manager.next_launch_configuration_list_editor_item();
@@ -2472,10 +1899,13 @@ mod tests {
         }
 
         // Act
-        manager.confirm_launch_configuration_input(&services).await;
+        manager.confirm_launch_configuration_input().await;
 
         // Assert
-        assert_eq!(manager.launch_configuration, "cargo test\nlazygit");
+        assert_eq!(
+            manager.settings().launch_configuration,
+            "cargo test\nlazygit"
+        );
         assert_eq!(
             services
                 .db()
@@ -2491,8 +1921,12 @@ mod tests {
     async fn confirm_launch_configuration_input_drops_empty_edited_command() {
         // Arrange
         let (services, project_id) = test_services().await;
-        let mut manager = SettingsManager::new(&services, project_id).await;
-        manager.launch_configuration = "cargo test\nnpm run dev".to_string();
+        let mut manager = settings_manager_with_launch_configuration(
+            &services,
+            project_id,
+            "cargo test\nnpm run dev",
+        )
+        .await;
         select_row(&mut manager, 6);
         manager.handle_enter();
         manager.start_editing_selected_launch_configuration();
@@ -2502,10 +1936,10 @@ mod tests {
         }
 
         // Act
-        manager.confirm_launch_configuration_input(&services).await;
+        manager.confirm_launch_configuration_input().await;
 
         // Assert
-        assert_eq!(manager.launch_configuration, "npm run dev");
+        assert_eq!(manager.settings().launch_configuration, "npm run dev");
         assert_eq!(
             services
                 .db()
@@ -2521,19 +1955,24 @@ mod tests {
     async fn delete_selected_launch_configuration_persists_remaining_commands() {
         // Arrange
         let (services, project_id) = test_services().await;
-        let mut manager = SettingsManager::new(&services, project_id).await;
-        manager.launch_configuration = "cargo test\nnpm run dev\nlazygit".to_string();
+        let mut manager = settings_manager_with_launch_configuration(
+            &services,
+            project_id,
+            "cargo test\nnpm run dev\nlazygit",
+        )
+        .await;
         select_row(&mut manager, 6);
         manager.handle_enter();
         manager.next_launch_configuration_list_editor_item();
 
         // Act
-        manager
-            .delete_selected_launch_configuration(&services)
-            .await;
+        manager.delete_selected_launch_configuration().await;
 
         // Assert
-        assert_eq!(manager.launch_configuration, "cargo test\nlazygit");
+        assert_eq!(
+            manager.settings().launch_configuration,
+            "cargo test\nlazygit"
+        );
         assert_eq!(
             services
                 .db()
@@ -2549,22 +1988,24 @@ mod tests {
     async fn move_selected_launch_configuration_down_persists_reordered_commands() {
         // Arrange
         let (services, project_id) = test_services().await;
-        let mut manager = SettingsManager::new(&services, project_id).await;
-        manager.launch_configuration = "cargo test\nnpm run dev\nlazygit".to_string();
+        let mut manager = settings_manager_with_launch_configuration(
+            &services,
+            project_id,
+            "cargo test\nnpm run dev\nlazygit",
+        )
+        .await;
         select_row(&mut manager, 6);
         manager.handle_enter();
 
         // Act
-        manager
-            .move_selected_launch_configuration_down(&services)
-            .await;
+        manager.move_selected_launch_configuration_down().await;
 
         // Assert
         let editor = manager
             .launch_configuration_list_editor()
             .expect("expected launch-configuration list editor");
         assert_eq!(
-            manager.launch_configuration,
+            manager.settings().launch_configuration,
             "npm run dev\ncargo test\nlazygit"
         );
         assert_eq!(editor.selected_index, 1);
@@ -2583,16 +2024,16 @@ mod tests {
     async fn selector_dropdown_selects_coauthor_setting_and_persists_value() {
         // Arrange
         let (services, project_id) = test_services().await;
-        let mut manager = SettingsManager::new(&services, project_id).await;
+        let mut manager = settings_manager(&services, project_id).await;
         select_row(&mut manager, 5);
 
         // Act
         manager.handle_enter();
         manager.next_selector_dropdown_option();
-        manager.select_selector_dropdown_option(&services).await;
+        manager.select_selector_dropdown_option().await;
 
         // Assert
-        assert!(manager.include_coauthored_by_agentty);
+        assert!(manager.settings().include_coauthored_by_agentty);
         assert!(!manager.is_selector_dropdown_open());
         assert_eq!(
             services
@@ -2609,7 +2050,7 @@ mod tests {
     async fn selector_dropdown_selects_theme_setting_and_persists_value() {
         // Arrange
         let (services, project_id) = test_services().await;
-        let mut manager = SettingsManager::new(&services, project_id).await;
+        let mut manager = settings_manager(&services, project_id).await;
         select_row(&mut manager, 0);
 
         // Act
@@ -2622,8 +2063,8 @@ mod tests {
         assert_eq!(dropdown.options[1].label, "Agentty Green");
 
         manager.next_selector_dropdown_option();
-        manager.select_selector_dropdown_option(&services).await;
-        let selected_theme = manager.theme;
+        manager.select_selector_dropdown_option().await;
+        let selected_theme = manager.settings().theme;
         let persisted_theme = services
             .db()
             .settings()
@@ -2643,7 +2084,7 @@ mod tests {
     async fn launch_configuration_editor_apis_are_noops_without_open_editor() {
         // Arrange
         let (services, project_id) = test_services().await;
-        let mut manager = SettingsManager::new(&services, project_id).await;
+        let mut manager = settings_manager(&services, project_id).await;
 
         // Act
         manager.start_adding_launch_configuration();
@@ -2655,19 +2096,14 @@ mod tests {
         manager.apply_launch_configuration_input_command(InputCommand::MoveRight);
         manager.apply_launch_configuration_input_command(InputCommand::MoveHome);
         manager.apply_launch_configuration_input_command(InputCommand::MoveEnd);
-        manager.confirm_launch_configuration_input(&services).await;
-        manager
-            .delete_selected_launch_configuration(&services)
-            .await;
-        manager
-            .move_selected_launch_configuration_down(&services)
-            .await;
-        manager
-            .move_selected_launch_configuration_up(&services)
-            .await;
+        manager.confirm_launch_configuration_input().await;
+        manager.delete_selected_launch_configuration().await;
+        manager.move_selected_launch_configuration_down().await;
+        manager.move_selected_launch_configuration_up().await;
 
         // Assert
-        assert!(manager.launch_configuration.is_empty());
+        assert!(manager.settings().launch_configuration.is_empty());
+        assert!(!manager.is_selector_dropdown_open());
         assert_eq!(
             services
                 .db()
@@ -2683,11 +2119,35 @@ mod tests {
     async fn selector_dropdown_persists_last_used_flag_and_explicit_smart_model() {
         // Arrange
         let (services, project_id) = test_services().await;
-        let mut manager = SettingsManager::new(&services, project_id).await;
         let options = selectable_model_options(AgentKind::ALL);
         let last_option = *options.last().expect("model options should not be empty");
-        manager.default_smart_selection = last_option.selection();
-        manager.use_last_used_model_as_default = false;
+        services
+            .db()
+            .settings()
+            .upsert_project_setting(
+                project_id,
+                SettingName::DefaultSmartAgent,
+                last_option.agent_kind.name(),
+            )
+            .await
+            .expect("failed to persist smart agent fixture");
+        services
+            .db()
+            .settings()
+            .upsert_project_setting(
+                project_id,
+                SettingName::DefaultSmartModel,
+                last_option.model.as_str(),
+            )
+            .await
+            .expect("failed to persist smart model fixture");
+        services
+            .db()
+            .settings()
+            .upsert_project_setting(project_id, SettingName::LastUsedModelAsDefault, "false")
+            .await
+            .expect("failed to persist last-used fixture");
+        let mut manager = settings_manager(&services, project_id).await;
         select_row(&mut manager, 2);
 
         // Act
@@ -2697,10 +2157,10 @@ mod tests {
             .expect("expected smart model selector dropdown");
         assert_eq!(dropdown.selected_index, options.len() - 1);
         manager.next_selector_dropdown_option();
-        manager.select_selector_dropdown_option(&services).await;
+        manager.select_selector_dropdown_option().await;
 
         // Assert
-        assert!(manager.use_last_used_model_as_default);
+        assert!(manager.settings().use_last_used_model_as_default);
         assert_eq!(
             services
                 .db()
@@ -2714,11 +2174,14 @@ mod tests {
         // Act
         manager.handle_enter();
         manager.next_selector_dropdown_option();
-        manager.select_selector_dropdown_option(&services).await;
+        manager.select_selector_dropdown_option().await;
 
         // Assert
-        assert!(!manager.use_last_used_model_as_default);
-        assert_eq!(manager.default_smart_selection, options[0].selection());
+        assert!(!manager.settings().use_last_used_model_as_default);
+        assert_eq!(
+            manager.settings().default_smart_selection,
+            options[0].selection()
+        );
         assert_eq!(
             services
                 .db()

--- a/crates/agentty/src/app/view.rs
+++ b/crates/agentty/src/app/view.rs
@@ -4,13 +4,13 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::app::session_state::SessionGitStatus;
-use crate::app::{
-    App, AssignedIssueState, RequestedReviewState, SettingsManager, Tab, UpdateStatus,
-};
-use crate::domain::agent::AgentCliInfo;
+use crate::app::{App, AssignedIssueState, RequestedReviewState, Tab, UpdateStatus};
+use crate::domain::agent::{AgentCliInfo, ReasoningLevel};
 use crate::domain::project::ProjectListItem;
 use crate::domain::session::{DailyActivity, Session, SessionId};
+use crate::domain::theme::ColorTheme;
 use crate::presentation::app_mode::{AppMode, HelpContext};
+use crate::presentation::settings::SettingsScreenSnapshot;
 
 /// Focused-review display state for the visible session.
 pub(crate) struct SessionReviewView<'a> {
@@ -26,6 +26,7 @@ pub(crate) struct AppViewSnapshot<'a> {
     pub(crate) assigned_issues: &'a AssignedIssueState,
     pub(crate) available_agent_clis: Vec<AgentCliInfo>,
     pub(crate) current_tab: Tab,
+    pub(crate) default_reasoning_level: ReasoningLevel,
     pub(crate) git_branch: Option<&'a str>,
     pub(crate) git_status: Option<(u32, u32)>,
     pub(crate) git_upstream_ref: Option<&'a str>,
@@ -45,9 +46,10 @@ pub(crate) struct AppViewSnapshot<'a> {
     pub(crate) session_update_versions: &'a HashMap<SessionId, u64>,
     pub(crate) session_worktree_availability: &'a HashMap<SessionId, bool>,
     pub(crate) sessions: &'a [Session],
-    pub(crate) settings: &'a SettingsManager,
+    pub(crate) settings_screen: Option<SettingsScreenSnapshot>,
     pub(crate) stats_activity: &'a [DailyActivity],
     pub(crate) status_bar_fyi_rotation_index: u64,
+    pub(crate) theme: ColorTheme,
     pub(crate) update_status: Option<&'a UpdateStatus>,
     pub(crate) wall_clock_unix_seconds: i64,
     pub(crate) working_dir: &'a Path,
@@ -67,6 +69,9 @@ impl App {
         });
         let project = self.projects.render_parts();
         let sessions = self.sessions.render_parts();
+        let current_tab = self.tabs.current();
+        let settings_screen = (current_tab == Tab::Settings)
+            .then(|| self.settings_presentation.snapshot(&self.settings.view()));
 
         AppViewSnapshot {
             active_project_id: project.active_project_id,
@@ -74,7 +79,8 @@ impl App {
             assigned_issue_selected_index: self.assigned_issue_selected_index(),
             assigned_issues: &self.assigned_issues,
             available_agent_clis: self.services.available_agent_clis(),
-            current_tab: self.tabs.current(),
+            current_tab,
+            default_reasoning_level: self.settings.reasoning_level,
             git_branch: project.git_branch,
             git_status: project.git_status,
             git_upstream_ref: project.git_upstream_ref,
@@ -94,9 +100,10 @@ impl App {
             session_update_versions: &self.last_seen_session_update_versions,
             session_worktree_availability: sessions.session_worktree_availability,
             sessions: sessions.sessions,
-            settings: &self.settings,
+            settings_screen,
             stats_activity: sessions.stats_activity,
             status_bar_fyi_rotation_index,
+            theme: self.settings.theme,
             update_status: self.update_status.as_ref(),
             wall_clock_unix_seconds,
             working_dir: project.working_dir,
@@ -157,5 +164,21 @@ mod tests {
 
         // Assert
         assert_eq!(session_id, Some("session-id"));
+    }
+
+    #[tokio::test]
+    async fn view_snapshot_builds_settings_screen_only_for_settings_tab() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+
+        // Act
+        app.tabs.set(Tab::Sessions);
+        let sessions_tab_has_settings_screen = app.view_snapshot().settings_screen.is_some();
+        app.tabs.set(Tab::Settings);
+        let settings_tab_has_settings_screen = app.view_snapshot().settings_screen.is_some();
+
+        // Assert
+        assert!(!sessions_tab_has_settings_screen);
+        assert!(settings_tab_has_settings_screen);
     }
 }

--- a/crates/agentty/src/presentation.rs
+++ b/crates/agentty/src/presentation.rs
@@ -6,3 +6,4 @@ pub mod app_mode;
 pub mod help_action;
 /// Prompt composer history, attachment, and suggestion state.
 pub mod prompt;
+pub(crate) mod settings;

--- a/crates/agentty/src/presentation/settings.rs
+++ b/crates/agentty/src/presentation/settings.rs
@@ -1,0 +1,1086 @@
+//! Frontend-neutral settings screen state and actions.
+
+use crate::domain::agent::{AgentSelection, ReasoningLevel};
+use crate::domain::input::{InputCommand, InputState};
+use crate::domain::selection::SelectionState;
+use crate::domain::theme::ColorTheme;
+
+/// Immutable setting values and available choices required by the settings
+/// screen.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SettingsView {
+    pub(crate) available_model_selections: Vec<AgentSelection>,
+    pub(crate) default_fast_selection: AgentSelection,
+    pub(crate) default_review_selection: AgentSelection,
+    pub(crate) default_smart_selection: AgentSelection,
+    pub(crate) include_coauthored_by_agentty: bool,
+    pub(crate) launch_configuration: String,
+    pub(crate) reasoning_level: ReasoningLevel,
+    pub(crate) theme: ColorTheme,
+    pub(crate) use_last_used_model_as_default: bool,
+}
+
+/// One persistence operation requested by the settings screen.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum SettingsOperation {
+    DefaultFastSelection(AgentSelection),
+    DefaultReviewSelection(AgentSelection),
+    DefaultSmartSelection {
+        selection: AgentSelection,
+        use_last_used_model_as_default: bool,
+    },
+    IncludeCoauthoredByAgentty(bool),
+    LaunchConfiguration(String),
+    ReasoningLevel(ReasoningLevel),
+    Theme(ColorTheme),
+}
+
+/// A key-independent action supported by the settings screen.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum SettingsAction {
+    Activate,
+    Cancel,
+    Confirm,
+    DeleteLaunchConfiguration,
+    EditLaunchConfiguration,
+    Input(InputCommand),
+    MoveLaunchConfigurationDown,
+    MoveLaunchConfigurationUp,
+    Next,
+    Previous,
+    StartAddingLaunchConfiguration,
+}
+
+/// Render-ready option for an open settings selector dropdown.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SettingsSelectorDropdownOption {
+    pub label: String,
+}
+
+/// Render-ready snapshot for the currently open settings selector dropdown.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SettingsSelectorDropdown {
+    pub options: Vec<SettingsSelectorDropdownOption>,
+    pub row_index: usize,
+    pub selected_index: usize,
+}
+
+/// Active interaction mode for the `Launch Configurations` list editor.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LaunchConfigurationListEditorMode {
+    Add,
+    Browse,
+    Edit,
+}
+
+/// Render-ready snapshot for the `Launch Configurations` list editor overlay.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LaunchConfigurationListEditorSnapshot {
+    pub commands: Vec<String>,
+    pub input: Option<InputState>,
+    pub mode: LaunchConfigurationListEditorMode,
+    pub selected_index: usize,
+}
+
+/// Immutable data required to render one settings screen frame.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SettingsScreenSnapshot {
+    pub(crate) footer_hint: &'static str,
+    pub(crate) global_rows: Vec<(&'static str, String)>,
+    pub(crate) launch_configuration_list_editor: Option<LaunchConfigurationListEditorSnapshot>,
+    pub(crate) project_rows: Vec<(&'static str, String)>,
+    pub(crate) selected_row_index: Option<usize>,
+    pub(crate) selector_dropdown: Option<SettingsSelectorDropdown>,
+}
+
+/// Presentation-owned interaction state for the settings tab.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SettingsPresentationState {
+    launch_configuration_list_editor: Option<LaunchConfigurationListEditorState>,
+    selector_dropdown: Option<SelectorDropdownState>,
+    table_state: SelectionState,
+}
+
+impl Default for SettingsPresentationState {
+    fn default() -> Self {
+        let mut table_state = SelectionState::default();
+        table_state.select(Some(0));
+
+        Self {
+            launch_configuration_list_editor: None,
+            selector_dropdown: None,
+            table_state,
+        }
+    }
+}
+
+impl SettingsPresentationState {
+    /// Applies one semantic settings action and returns the persistence
+    /// request, if the action changed a setting value.
+    pub(crate) fn apply(
+        &mut self,
+        view: &SettingsView,
+        action: SettingsAction,
+    ) -> Option<SettingsOperation> {
+        match action {
+            SettingsAction::Activate => self.activate(view),
+            SettingsAction::Cancel => self.cancel(),
+            SettingsAction::Confirm => self.confirm(view),
+            SettingsAction::DeleteLaunchConfiguration => self.delete_launch_configuration(),
+            SettingsAction::EditLaunchConfiguration => self.edit_launch_configuration(),
+            SettingsAction::Input(command) => {
+                self.apply_launch_configuration_input(command);
+
+                None
+            }
+            SettingsAction::MoveLaunchConfigurationDown => {
+                self.move_launch_configuration(LaunchConfigurationReorderDirection::Down)
+            }
+            SettingsAction::MoveLaunchConfigurationUp => {
+                self.move_launch_configuration(LaunchConfigurationReorderDirection::Up)
+            }
+            SettingsAction::Next => {
+                self.next(view);
+
+                None
+            }
+            SettingsAction::Previous => {
+                self.previous(view);
+
+                None
+            }
+            SettingsAction::StartAddingLaunchConfiguration => {
+                self.start_adding_launch_configuration();
+
+                None
+            }
+        }
+    }
+
+    /// Returns whether the launch-configuration editor is open.
+    pub(crate) fn is_launch_configuration_list_editor_open(&self) -> bool {
+        self.launch_configuration_list_editor.is_some()
+    }
+
+    /// Returns whether the launch-configuration editor accepts text input.
+    pub(crate) fn is_launch_configuration_list_editor_input_active(&self) -> bool {
+        self.launch_configuration_list_editor
+            .as_ref()
+            .is_some_and(LaunchConfigurationListEditorState::is_input_mode)
+    }
+
+    /// Returns whether a setting selector is open.
+    pub(crate) fn is_selector_dropdown_open(&self) -> bool {
+        self.selector_dropdown.is_some()
+    }
+
+    /// Creates the immutable settings-screen projection consumed by the UI.
+    pub(crate) fn snapshot(&self, view: &SettingsView) -> SettingsScreenSnapshot {
+        SettingsScreenSnapshot {
+            footer_hint: self.footer_hint(),
+            global_rows: SettingRow::GLOBAL
+                .iter()
+                .map(|row| (row.label(), display_value_for_row(view, *row)))
+                .collect(),
+            launch_configuration_list_editor: self.launch_configuration_list_editor(),
+            project_rows: SettingRow::PROJECT
+                .iter()
+                .map(|row| (row.label(), display_value_for_row(view, *row)))
+                .collect(),
+            selected_row_index: self.table_state.selected(),
+            selector_dropdown: self.selector_dropdown(view),
+        }
+    }
+
+    fn activate(&mut self, view: &SettingsView) -> Option<SettingsOperation> {
+        if self.is_launch_configuration_list_editor_open() {
+            return self.edit_launch_configuration();
+        }
+
+        if self.is_selector_dropdown_open() {
+            return self.select_selector_dropdown_option(view);
+        }
+
+        match self.selected_row().control() {
+            SettingControl::CommandList => {
+                self.launch_configuration_list_editor = Some(
+                    LaunchConfigurationListEditorState::from_launch_configuration(
+                        view.launch_configuration.as_str(),
+                    ),
+                );
+            }
+            SettingControl::Selector => self.open_selector_dropdown(view, self.selected_row()),
+        }
+
+        None
+    }
+
+    fn cancel(&mut self) -> Option<SettingsOperation> {
+        if self.is_selector_dropdown_open() {
+            self.selector_dropdown = None;
+        } else if self.is_launch_configuration_list_editor_input_active() {
+            if let Some(editor) = &mut self.launch_configuration_list_editor {
+                editor.input = InputState::default();
+                editor.mode = LaunchConfigurationListEditorMode::Browse;
+            }
+        } else {
+            self.launch_configuration_list_editor = None;
+        }
+
+        None
+    }
+
+    fn confirm(&mut self, view: &SettingsView) -> Option<SettingsOperation> {
+        if self.is_selector_dropdown_open() {
+            return self.select_selector_dropdown_option(view);
+        }
+
+        let Some(editor) = &mut self.launch_configuration_list_editor else {
+            return None;
+        };
+
+        if editor.is_input_mode() {
+            return Some(apply_launch_configuration_input(editor));
+        }
+
+        self.edit_launch_configuration()
+    }
+
+    fn delete_launch_configuration(&mut self) -> Option<SettingsOperation> {
+        let editor = self.launch_configuration_list_editor.as_mut()?;
+        if editor.commands.is_empty() || editor.is_input_mode() {
+            return None;
+        }
+
+        editor.commands.remove(editor.selected_index());
+        editor.clamp_selected_index();
+
+        Some(SettingsOperation::LaunchConfiguration(
+            join_launch_configurations(&editor.commands),
+        ))
+    }
+
+    fn edit_launch_configuration(&mut self) -> Option<SettingsOperation> {
+        let Some(editor) = &mut self.launch_configuration_list_editor else {
+            return None;
+        };
+
+        if editor.commands.is_empty() {
+            editor.input = InputState::default();
+            editor.mode = LaunchConfigurationListEditorMode::Add;
+
+            return None;
+        }
+
+        let selected_index = editor.selected_index();
+        editor.input = InputState::with_text(editor.commands[selected_index].clone());
+        editor.mode = LaunchConfigurationListEditorMode::Edit;
+
+        None
+    }
+
+    fn apply_launch_configuration_input(&mut self, command: InputCommand) {
+        let Some(editor) = &mut self.launch_configuration_list_editor else {
+            return;
+        };
+
+        if editor.is_input_mode() {
+            editor.input.apply(command);
+        }
+    }
+
+    fn launch_configuration_list_editor(&self) -> Option<LaunchConfigurationListEditorSnapshot> {
+        let editor = self.launch_configuration_list_editor.as_ref()?;
+
+        Some(LaunchConfigurationListEditorSnapshot {
+            commands: editor.commands.clone(),
+            input: editor.is_input_mode().then(|| editor.input.clone()),
+            mode: editor.mode,
+            selected_index: editor.selected_index(),
+        })
+    }
+
+    fn move_launch_configuration(
+        &mut self,
+        direction: LaunchConfigurationReorderDirection,
+    ) -> Option<SettingsOperation> {
+        let editor = self.launch_configuration_list_editor.as_mut()?;
+        if editor.commands.len() < 2 || editor.is_input_mode() {
+            return None;
+        }
+
+        let selected_index = editor.selected_index();
+        let next_index = match direction {
+            LaunchConfigurationReorderDirection::Down
+                if selected_index + 1 < editor.commands.len() =>
+            {
+                selected_index + 1
+            }
+            LaunchConfigurationReorderDirection::Up if selected_index > 0 => selected_index - 1,
+            _ => return None,
+        };
+        editor.commands.swap(selected_index, next_index);
+        editor.selected_index = next_index;
+
+        Some(SettingsOperation::LaunchConfiguration(
+            join_launch_configurations(&editor.commands),
+        ))
+    }
+
+    fn next(&mut self, view: &SettingsView) {
+        if let Some(selector_dropdown) = self.selector_dropdown {
+            self.move_selector_dropdown_option(view, selector_dropdown, true);
+        } else if let Some(editor) = &mut self.launch_configuration_list_editor {
+            move_launch_configuration_list_editor_selection(editor, true);
+        } else {
+            let selected_index = self.selected_row_index();
+            self.table_state
+                .select(Some((selected_index + 1) % SettingRow::ROW_COUNT));
+        }
+    }
+
+    fn previous(&mut self, view: &SettingsView) {
+        if let Some(selector_dropdown) = self.selector_dropdown {
+            self.move_selector_dropdown_option(view, selector_dropdown, false);
+        } else if let Some(editor) = &mut self.launch_configuration_list_editor {
+            move_launch_configuration_list_editor_selection(editor, false);
+        } else {
+            let selected_index = self.selected_row_index();
+            let previous_index = selected_index
+                .checked_sub(1)
+                .unwrap_or(SettingRow::ROW_COUNT - 1);
+            self.table_state.select(Some(previous_index));
+        }
+    }
+
+    fn open_selector_dropdown(&mut self, view: &SettingsView, row: SettingRow) {
+        let options = selector_options_for_row(view, row);
+        if options.is_empty() {
+            return;
+        }
+
+        let selected_index = options
+            .iter()
+            .position(|option| option.is_current_for(view, row))
+            .unwrap_or_default();
+        self.selector_dropdown = Some(SelectorDropdownState {
+            row,
+            selected_index,
+        });
+    }
+
+    fn move_selector_dropdown_option(
+        &mut self,
+        view: &SettingsView,
+        selector_dropdown: SelectorDropdownState,
+        is_next: bool,
+    ) {
+        let option_count = selector_options_for_row(view, selector_dropdown.row).len();
+        if option_count == 0 {
+            self.selector_dropdown = None;
+
+            return;
+        }
+
+        let selected_index = if is_next {
+            (selector_dropdown.selected_index + 1) % option_count
+        } else {
+            selector_dropdown
+                .selected_index
+                .checked_sub(1)
+                .unwrap_or(option_count - 1)
+        };
+        self.selector_dropdown = Some(SelectorDropdownState {
+            row: selector_dropdown.row,
+            selected_index,
+        });
+    }
+
+    fn select_selector_dropdown_option(
+        &mut self,
+        view: &SettingsView,
+    ) -> Option<SettingsOperation> {
+        let selector_dropdown = self.selector_dropdown?;
+        let options = selector_options_for_row(view, selector_dropdown.row);
+        let value = options
+            .get(
+                selector_dropdown
+                    .selected_index
+                    .min(options.len().saturating_sub(1)),
+            )?
+            .value;
+        self.selector_dropdown = None;
+
+        settings_operation_for_selector(view, selector_dropdown.row, value)
+    }
+
+    fn selected_row_index(&self) -> usize {
+        self.table_state
+            .selected()
+            .unwrap_or_default()
+            .min(SettingRow::ROW_COUNT - 1)
+    }
+
+    fn selected_row(&self) -> SettingRow {
+        SettingRow::from_index(self.selected_row_index())
+    }
+
+    fn selector_dropdown(&self, view: &SettingsView) -> Option<SettingsSelectorDropdown> {
+        let selector_dropdown = self.selector_dropdown?;
+        let options = selector_options_for_row(view, selector_dropdown.row);
+        let selected_index = selector_dropdown
+            .selected_index
+            .min(options.len().saturating_sub(1));
+
+        Some(SettingsSelectorDropdown {
+            options: options
+                .into_iter()
+                .map(|option| SettingsSelectorDropdownOption {
+                    label: option.label,
+                })
+                .collect(),
+            row_index: selector_dropdown.row.table_index(),
+            selected_index,
+        })
+    }
+
+    fn start_adding_launch_configuration(&mut self) {
+        let Some(editor) = &mut self.launch_configuration_list_editor else {
+            return;
+        };
+
+        editor.input = InputState::default();
+        editor.mode = LaunchConfigurationListEditorMode::Add;
+    }
+
+    fn footer_hint(&self) -> &'static str {
+        if self.is_launch_configuration_list_editor_input_active() {
+            "Launch Configurations: type a command, Enter save, Esc cancel"
+        } else if self.is_launch_configuration_list_editor_open() {
+            "Launch Configurations: j/k move, a add, e/Enter edit, d delete, J/K reorder, Esc/q \
+             close"
+        } else if self.is_selector_dropdown_open() {
+            "Selecting setting value: j/k move, Enter select, Esc/q close"
+        } else {
+            "Settings: Enter opens selectors or command editor"
+        }
+    }
+}
+
+fn settings_operation_for_selector(
+    view: &SettingsView,
+    row: SettingRow,
+    value: SettingSelectorValue,
+) -> Option<SettingsOperation> {
+    match (row, value) {
+        (SettingRow::ReasoningLevel, SettingSelectorValue::ReasoningLevel(value)) => {
+            Some(SettingsOperation::ReasoningLevel(value))
+        }
+        (SettingRow::DefaultSmartModel, SettingSelectorValue::LastUsedModel) => {
+            Some(SettingsOperation::DefaultSmartSelection {
+                selection: view.default_smart_selection,
+                use_last_used_model_as_default: true,
+            })
+        }
+        (SettingRow::DefaultSmartModel, SettingSelectorValue::ModelSelection(selection)) => {
+            Some(SettingsOperation::DefaultSmartSelection {
+                selection,
+                use_last_used_model_as_default: false,
+            })
+        }
+        (SettingRow::DefaultFastModel, SettingSelectorValue::ModelSelection(selection)) => {
+            Some(SettingsOperation::DefaultFastSelection(selection))
+        }
+        (SettingRow::DefaultReviewModel, SettingSelectorValue::ModelSelection(selection)) => {
+            Some(SettingsOperation::DefaultReviewSelection(selection))
+        }
+        (SettingRow::IncludeCoauthoredByAgentty, SettingSelectorValue::Bool(value)) => {
+            Some(SettingsOperation::IncludeCoauthoredByAgentty(value))
+        }
+        (SettingRow::Theme, SettingSelectorValue::Theme(value)) => {
+            Some(SettingsOperation::Theme(value))
+        }
+        _ => None,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SettingControl {
+    CommandList,
+    Selector,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SettingRow {
+    ReasoningLevel,
+    DefaultSmartModel,
+    DefaultFastModel,
+    DefaultReviewModel,
+    IncludeCoauthoredByAgentty,
+    LaunchConfiguration,
+    Theme,
+}
+
+impl SettingRow {
+    const ALL: [Self; 7] = [
+        Self::Theme,
+        Self::ReasoningLevel,
+        Self::DefaultSmartModel,
+        Self::DefaultFastModel,
+        Self::DefaultReviewModel,
+        Self::IncludeCoauthoredByAgentty,
+        Self::LaunchConfiguration,
+    ];
+    const GLOBAL: [Self; 1] = [Self::Theme];
+    const PROJECT: [Self; 6] = [
+        Self::ReasoningLevel,
+        Self::DefaultSmartModel,
+        Self::DefaultFastModel,
+        Self::DefaultReviewModel,
+        Self::IncludeCoauthoredByAgentty,
+        Self::LaunchConfiguration,
+    ];
+    const ROW_COUNT: usize = Self::ALL.len();
+
+    fn from_index(index: usize) -> Self {
+        Self::ALL
+            .get(index)
+            .copied()
+            .unwrap_or(Self::ReasoningLevel)
+    }
+
+    fn control(self) -> SettingControl {
+        match self {
+            Self::LaunchConfiguration => SettingControl::CommandList,
+            _ => SettingControl::Selector,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::ReasoningLevel => "Default Reasoning Level",
+            Self::DefaultSmartModel => "Default Smart Model",
+            Self::DefaultFastModel => "Default Fast Model",
+            Self::DefaultReviewModel => "Default Review Model",
+            Self::IncludeCoauthoredByAgentty => "Coauthored by Agentty",
+            Self::LaunchConfiguration => "Launch Configurations",
+            Self::Theme => "Theme",
+        }
+    }
+
+    fn table_index(self) -> usize {
+        Self::ALL
+            .iter()
+            .position(|row| *row == self)
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SelectorDropdownState {
+    row: SettingRow,
+    selected_index: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct LaunchConfigurationListEditorState {
+    commands: Vec<String>,
+    input: InputState,
+    mode: LaunchConfigurationListEditorMode,
+    selected_index: usize,
+}
+
+impl LaunchConfigurationListEditorState {
+    fn from_launch_configuration(launch_configuration: &str) -> Self {
+        Self {
+            commands: parse_launch_configurations(launch_configuration),
+            input: InputState::default(),
+            mode: LaunchConfigurationListEditorMode::Browse,
+            selected_index: 0,
+        }
+    }
+
+    fn is_input_mode(&self) -> bool {
+        matches!(
+            self.mode,
+            LaunchConfigurationListEditorMode::Add | LaunchConfigurationListEditorMode::Edit
+        )
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_index
+            .min(self.commands.len().saturating_sub(1))
+    }
+
+    fn clamp_selected_index(&mut self) {
+        self.selected_index = self.selected_index();
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LaunchConfigurationReorderDirection {
+    Down,
+    Up,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SettingSelectorOption {
+    label: String,
+    value: SettingSelectorValue,
+}
+
+impl SettingSelectorOption {
+    fn is_current_for(&self, view: &SettingsView, row: SettingRow) -> bool {
+        match (row, self.value) {
+            (SettingRow::ReasoningLevel, SettingSelectorValue::ReasoningLevel(value)) => {
+                view.reasoning_level == value
+            }
+            (SettingRow::DefaultSmartModel, SettingSelectorValue::LastUsedModel) => {
+                view.use_last_used_model_as_default
+            }
+            (SettingRow::DefaultSmartModel, SettingSelectorValue::ModelSelection(value)) => {
+                !view.use_last_used_model_as_default && view.default_smart_selection == value
+            }
+            (SettingRow::DefaultFastModel, SettingSelectorValue::ModelSelection(value)) => {
+                view.default_fast_selection == value
+            }
+            (SettingRow::DefaultReviewModel, SettingSelectorValue::ModelSelection(value)) => {
+                view.default_review_selection == value
+            }
+            (SettingRow::IncludeCoauthoredByAgentty, SettingSelectorValue::Bool(value)) => {
+                view.include_coauthored_by_agentty == value
+            }
+            (SettingRow::Theme, SettingSelectorValue::Theme(value)) => view.theme == value,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SettingSelectorValue {
+    Bool(bool),
+    LastUsedModel,
+    ModelSelection(AgentSelection),
+    ReasoningLevel(ReasoningLevel),
+    Theme(ColorTheme),
+}
+
+fn apply_launch_configuration_input(
+    editor: &mut LaunchConfigurationListEditorState,
+) -> SettingsOperation {
+    let command = editor.input.text().trim().to_string();
+    match editor.mode {
+        LaunchConfigurationListEditorMode::Add if !command.is_empty() => {
+            editor.commands.push(command);
+            editor.selected_index = editor.commands.len().saturating_sub(1);
+        }
+        LaunchConfigurationListEditorMode::Edit
+            if editor.commands.is_empty() && !command.is_empty() =>
+        {
+            editor.commands.push(command);
+            editor.selected_index = 0;
+        }
+        LaunchConfigurationListEditorMode::Edit if !editor.commands.is_empty() => {
+            let selected_index = editor.selected_index();
+            if command.is_empty() {
+                editor.commands.remove(selected_index);
+                editor.clamp_selected_index();
+            } else {
+                editor.commands[selected_index] = command;
+            }
+        }
+        _ => {}
+    }
+    editor.input = InputState::default();
+    editor.mode = LaunchConfigurationListEditorMode::Browse;
+
+    SettingsOperation::LaunchConfiguration(join_launch_configurations(&editor.commands))
+}
+
+fn move_launch_configuration_list_editor_selection(
+    editor: &mut LaunchConfigurationListEditorState,
+    is_next: bool,
+) {
+    if editor.commands.is_empty() || editor.is_input_mode() {
+        return;
+    }
+
+    editor.selected_index = if is_next {
+        (editor.selected_index + 1) % editor.commands.len()
+    } else {
+        editor
+            .selected_index
+            .checked_sub(1)
+            .unwrap_or(editor.commands.len() - 1)
+    };
+}
+
+fn selector_options_for_row(view: &SettingsView, row: SettingRow) -> Vec<SettingSelectorOption> {
+    match row {
+        SettingRow::ReasoningLevel => ReasoningLevel::ALL
+            .iter()
+            .copied()
+            .map(|value| SettingSelectorOption {
+                label: value.codex().to_string(),
+                value: SettingSelectorValue::ReasoningLevel(value),
+            })
+            .collect(),
+        SettingRow::DefaultSmartModel => {
+            let mut options = model_selector_options(view);
+            options.push(SettingSelectorOption {
+                label: "Last used model as default".to_string(),
+                value: SettingSelectorValue::LastUsedModel,
+            });
+            options
+        }
+        SettingRow::DefaultFastModel | SettingRow::DefaultReviewModel => {
+            model_selector_options(view)
+        }
+        SettingRow::IncludeCoauthoredByAgentty => vec![
+            SettingSelectorOption {
+                label: bool_setting_display(false),
+                value: SettingSelectorValue::Bool(false),
+            },
+            SettingSelectorOption {
+                label: bool_setting_display(true),
+                value: SettingSelectorValue::Bool(true),
+            },
+        ],
+        SettingRow::LaunchConfiguration => Vec::new(),
+        SettingRow::Theme => ColorTheme::ALL
+            .iter()
+            .copied()
+            .map(|value| SettingSelectorOption {
+                label: value.label().to_string(),
+                value: SettingSelectorValue::Theme(value),
+            })
+            .collect(),
+    }
+}
+
+fn model_selector_options(view: &SettingsView) -> Vec<SettingSelectorOption> {
+    view.available_model_selections
+        .iter()
+        .copied()
+        .map(|selection| SettingSelectorOption {
+            label: display_model_selector_value(selection),
+            value: SettingSelectorValue::ModelSelection(selection),
+        })
+        .collect()
+}
+
+fn display_value_for_row(view: &SettingsView, row: SettingRow) -> String {
+    match row {
+        SettingRow::ReasoningLevel => view.reasoning_level.codex().to_string(),
+        SettingRow::DefaultSmartModel if view.use_last_used_model_as_default => {
+            "Last used model as default".to_string()
+        }
+        SettingRow::DefaultSmartModel => display_model_selector_value(view.default_smart_selection),
+        SettingRow::DefaultFastModel => display_model_selector_value(view.default_fast_selection),
+        SettingRow::DefaultReviewModel => {
+            display_model_selector_value(view.default_review_selection)
+        }
+        SettingRow::IncludeCoauthoredByAgentty => {
+            bool_setting_display(view.include_coauthored_by_agentty)
+        }
+        SettingRow::LaunchConfiguration => {
+            display_launch_configuration_summary(&view.launch_configuration)
+        }
+        SettingRow::Theme => view.theme.label().to_string(),
+    }
+}
+
+fn bool_setting_display(value: bool) -> String {
+    if value {
+        "Enabled".to_string()
+    } else {
+        "Disabled".to_string()
+    }
+}
+
+fn display_launch_configuration_summary(value: &str) -> String {
+    let commands = parse_launch_configurations(value);
+    let Some(first_command) = commands.first() else {
+        return "(none)".to_string();
+    };
+    if commands.len() == 1 {
+        return first_command.clone();
+    }
+
+    format!("{} (+{} more)", first_command, commands.len() - 1)
+}
+
+fn display_model_selector_value(selection: AgentSelection) -> String {
+    format!("{}/{}", selection.kind(), selection.model().as_str())
+}
+
+fn join_launch_configurations(commands: &[String]) -> String {
+    commands
+        .iter()
+        .map(|command| command.trim())
+        .filter(|command| !command.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn parse_launch_configurations(value: &str) -> Vec<String> {
+    value
+        .lines()
+        .map(str::trim)
+        .filter(|command| !command.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::agent::{AgentKind, AgentModel};
+
+    fn test_settings_view(launch_configuration: &str) -> SettingsView {
+        let smart_selection = AgentSelection::new(
+            AgentKind::Antigravity,
+            AgentKind::Antigravity.default_model(),
+        );
+
+        SettingsView {
+            available_model_selections: vec![
+                smart_selection,
+                AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+                AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus48),
+            ],
+            default_fast_selection: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            default_review_selection: AgentSelection::new(
+                AgentKind::Claude,
+                AgentModel::ClaudeOpus48,
+            ),
+            default_smart_selection: smart_selection,
+            include_coauthored_by_agentty: false,
+            launch_configuration: launch_configuration.to_string(),
+            reasoning_level: ReasoningLevel::High,
+            theme: ColorTheme::Current,
+            use_last_used_model_as_default: false,
+        }
+    }
+
+    fn select_row(state: &mut SettingsPresentationState, view: &SettingsView, row_index: usize) {
+        for _ in 0..row_index {
+            let operation = state.apply(view, SettingsAction::Next);
+            assert_eq!(operation, None);
+        }
+    }
+
+    #[test]
+    fn activate_reuses_open_selector_and_launch_editor() {
+        // Arrange
+        let empty_view = test_settings_view("");
+        let mut selector_state = SettingsPresentationState::default();
+        let mut editor_state = SettingsPresentationState::default();
+        select_row(&mut editor_state, &empty_view, 6);
+
+        // Act
+        let opened_selector = selector_state.apply(&empty_view, SettingsAction::Activate);
+        let selector_operation = selector_state.apply(&empty_view, SettingsAction::Activate);
+        let opened_editor = editor_state.apply(&empty_view, SettingsAction::Activate);
+        let editor_operation = editor_state.apply(&empty_view, SettingsAction::Activate);
+
+        // Assert
+        assert_eq!(opened_selector, None);
+        assert_eq!(
+            selector_operation,
+            Some(SettingsOperation::Theme(ColorTheme::Current))
+        );
+        assert_eq!(opened_editor, None);
+        assert_eq!(editor_operation, None);
+        assert!(editor_state.is_launch_configuration_list_editor_input_active());
+    }
+
+    #[test]
+    fn confirm_edits_and_saves_browse_editor() {
+        // Arrange
+        let view = test_settings_view("cargo test");
+        let mut state = SettingsPresentationState::default();
+        select_row(&mut state, &view, 6);
+        let _ = state.apply(&view, SettingsAction::Activate);
+
+        // Act
+        let edit_operation = state.apply(&view, SettingsAction::Confirm);
+        let save_operation = state.apply(&view, SettingsAction::Confirm);
+
+        // Assert
+        assert_eq!(edit_operation, None);
+        assert_eq!(
+            save_operation,
+            Some(SettingsOperation::LaunchConfiguration(
+                "cargo test".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn launch_editor_rejects_invalid_delete_and_reorder_actions() {
+        // Arrange
+        let one_command_view = test_settings_view("cargo test");
+        let mut one_command_state = SettingsPresentationState::default();
+        select_row(&mut one_command_state, &one_command_view, 6);
+        let _ = one_command_state.apply(&one_command_view, SettingsAction::Activate);
+        let two_command_view = test_settings_view("cargo test\nnpm run dev");
+        let mut two_command_state = SettingsPresentationState::default();
+        select_row(&mut two_command_state, &two_command_view, 6);
+        let _ = two_command_state.apply(&two_command_view, SettingsAction::Activate);
+        let _ = two_command_state.apply(&two_command_view, SettingsAction::Next);
+
+        // Act
+        let single_reorder = one_command_state.apply(
+            &one_command_view,
+            SettingsAction::MoveLaunchConfigurationDown,
+        );
+        let delete_operation =
+            one_command_state.apply(&one_command_view, SettingsAction::DeleteLaunchConfiguration);
+        let empty_delete =
+            one_command_state.apply(&one_command_view, SettingsAction::DeleteLaunchConfiguration);
+        let move_up =
+            two_command_state.apply(&two_command_view, SettingsAction::MoveLaunchConfigurationUp);
+        let first_row_move_up =
+            two_command_state.apply(&two_command_view, SettingsAction::MoveLaunchConfigurationUp);
+
+        // Assert
+        assert_eq!(single_reorder, None);
+        assert_eq!(
+            delete_operation,
+            Some(SettingsOperation::LaunchConfiguration(String::new()))
+        );
+        assert_eq!(empty_delete, None);
+        assert_eq!(
+            move_up,
+            Some(SettingsOperation::LaunchConfiguration(
+                "npm run dev\ncargo test".to_string()
+            ))
+        );
+        assert_eq!(first_row_move_up, None);
+    }
+
+    #[test]
+    fn empty_selector_options_close_or_remain_closed() {
+        // Arrange
+        let view = test_settings_view("");
+        let mut closed_state = SettingsPresentationState::default();
+        let mut stale_state = SettingsPresentationState {
+            selector_dropdown: Some(SelectorDropdownState {
+                row: SettingRow::LaunchConfiguration,
+                selected_index: 0,
+            }),
+            ..SettingsPresentationState::default()
+        };
+
+        // Act
+        closed_state.open_selector_dropdown(&view, SettingRow::LaunchConfiguration);
+        let navigation_operation = stale_state.apply(&view, SettingsAction::Next);
+
+        // Assert
+        assert!(!closed_state.is_selector_dropdown_open());
+        assert_eq!(navigation_operation, None);
+        assert!(!stale_state.is_selector_dropdown_open());
+    }
+
+    #[test]
+    fn selectors_cover_reasoning_fast_review_and_invalid_pairs() {
+        // Arrange
+        let view = test_settings_view("");
+
+        // Act
+        let operations = [
+            (1, SettingsOperation::ReasoningLevel(ReasoningLevel::High)),
+            (
+                3,
+                SettingsOperation::DefaultFastSelection(view.default_fast_selection),
+            ),
+            (
+                4,
+                SettingsOperation::DefaultReviewSelection(view.default_review_selection),
+            ),
+        ]
+        .map(|(row_index, expected_operation)| {
+            let mut state = SettingsPresentationState::default();
+            select_row(&mut state, &view, row_index);
+            let _ = state.apply(&view, SettingsAction::Activate);
+
+            (
+                state.apply(&view, SettingsAction::Confirm),
+                expected_operation,
+            )
+        });
+        let mismatched_option = SettingSelectorOption {
+            label: "Enabled".to_string(),
+            value: SettingSelectorValue::Bool(true),
+        };
+        let is_mismatched_current = mismatched_option.is_current_for(&view, SettingRow::Theme);
+        let invalid_operation = settings_operation_for_selector(
+            &view,
+            SettingRow::Theme,
+            SettingSelectorValue::Bool(true),
+        );
+
+        // Assert
+        for (operation, expected_operation) in operations {
+            assert_eq!(operation, Some(expected_operation));
+        }
+        assert!(!is_mismatched_current);
+        assert_eq!(invalid_operation, None);
+    }
+
+    #[test]
+    fn launch_input_handles_empty_edit_and_empty_add() {
+        // Arrange
+        let mut empty_edit = LaunchConfigurationListEditorState {
+            commands: Vec::new(),
+            input: InputState::with_text("nvim".to_string()),
+            mode: LaunchConfigurationListEditorMode::Edit,
+            selected_index: 0,
+        };
+        let mut empty_add = LaunchConfigurationListEditorState {
+            commands: Vec::new(),
+            input: InputState::default(),
+            mode: LaunchConfigurationListEditorMode::Add,
+            selected_index: 0,
+        };
+
+        // Act
+        let edit_operation = apply_launch_configuration_input(&mut empty_edit);
+        let add_operation = apply_launch_configuration_input(&mut empty_add);
+
+        // Assert
+        assert_eq!(
+            edit_operation,
+            SettingsOperation::LaunchConfiguration("nvim".to_string())
+        );
+        assert_eq!(
+            add_operation,
+            SettingsOperation::LaunchConfiguration(String::new())
+        );
+    }
+
+    #[test]
+    fn previous_launch_selection_wraps_and_all_row_options_are_available() {
+        // Arrange
+        let view = test_settings_view("");
+        let mut editor = LaunchConfigurationListEditorState {
+            commands: vec!["cargo test".to_string(), "npm run dev".to_string()],
+            input: InputState::default(),
+            mode: LaunchConfigurationListEditorMode::Browse,
+            selected_index: 0,
+        };
+
+        // Act
+        move_launch_configuration_list_editor_selection(&mut editor, false);
+        let reasoning_options = selector_options_for_row(&view, SettingRow::ReasoningLevel);
+        let fast_options = selector_options_for_row(&view, SettingRow::DefaultFastModel);
+        let launch_options = selector_options_for_row(&view, SettingRow::LaunchConfiguration);
+
+        // Assert
+        assert_eq!(editor.selected_index, 1);
+        assert_eq!(reasoning_options.len(), ReasoningLevel::ALL.len());
+        assert_eq!(fast_options.len(), view.available_model_selections.len());
+        assert!(launch_options.is_empty());
+    }
+}

--- a/crates/agentty/src/runtime/event.rs
+++ b/crates/agentty/src/runtime/event.rs
@@ -15,6 +15,7 @@ use tracing::debug;
 use crate::app::{App, AppEvent};
 use crate::domain::input::InputCommand;
 use crate::presentation::app_mode::AppMode;
+use crate::presentation::settings::SettingsAction;
 use crate::runtime::{EventResult, FRAME_INTERVAL, PresentationState, key_handler, mode};
 
 /// Maximum terminal input events processed in one foreground cycle.
@@ -288,12 +289,14 @@ async fn process_paste_event(app: &mut App, pasted_text: &str) {
 
     if matches!(&app.mode, AppMode::List)
         && app
-            .settings
+            .settings_presentation
             .is_launch_configuration_list_editor_input_active()
     {
         let text = mode::input_key::normalize_single_line_pasted_text(pasted_text);
-        app.settings
-            .apply_launch_configuration_input_command(InputCommand::InsertText(text));
+        let view = app.settings.view();
+        let _ = app
+            .settings_presentation
+            .apply(&view, SettingsAction::Input(InputCommand::InsertText(text)));
     }
 }
 
@@ -587,18 +590,26 @@ mod tests {
         let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
         app.tabs.set(crate::app::Tab::Settings);
         for _ in 0..6 {
-            app.settings.next();
+            let view = app.settings.view();
+            let _ = app.settings_presentation.apply(&view, SettingsAction::Next);
         }
-        app.settings.handle_enter();
-        app.settings.start_adding_launch_configuration();
+        let view = app.settings.view();
+        let _ = app
+            .settings_presentation
+            .apply(&view, SettingsAction::Activate);
+        let view = app.settings.view();
+        let _ = app
+            .settings_presentation
+            .apply(&view, SettingsAction::StartAddingLaunchConfiguration);
 
         // Act
         process_paste_event(&mut app, "cargo nextest run\r\nignored").await;
 
         // Assert
         let editor = app
-            .settings
-            .launch_configuration_list_editor()
+            .settings_presentation
+            .snapshot(&app.settings.view())
+            .launch_configuration_list_editor
             .expect("launch-configuration editor should be open");
         assert!(matches!(
             editor.input,

--- a/crates/agentty/src/runtime/mode/list.rs
+++ b/crates/agentty/src/runtime/mode/list.rs
@@ -11,6 +11,7 @@ use crate::presentation::help_action::{
     HelpAction, project_list_actions, session_list_actions, settings_actions,
 };
 use crate::presentation::prompt::{PromptAttachmentState, PromptHistoryState};
+use crate::presentation::settings::SettingsAction;
 use crate::runtime::EventResult;
 use crate::runtime::mode::confirmation::DEFAULT_OPTION_INDEX;
 use crate::runtime::mode::input_key;
@@ -25,12 +26,15 @@ use crate::runtime::mode::input_key;
 /// `Shift+Tab` cycles backward.
 pub(crate) async fn handle(app: &mut App, key: KeyEvent) -> io::Result<EventResult> {
     if app.tabs.current() == Tab::Settings
-        && app.settings.is_launch_configuration_list_editor_open()
+        && app
+            .settings_presentation
+            .is_launch_configuration_list_editor_open()
     {
         return handle_settings_launch_configuration_list_editor(app, key).await;
     }
 
-    if app.tabs.current() == Tab::Settings && app.settings.is_selector_dropdown_open() {
+    if app.tabs.current() == Tab::Settings && app.settings_presentation.is_selector_dropdown_open()
+    {
         return handle_settings_selector_dropdown(app, key).await;
     }
 
@@ -72,14 +76,14 @@ pub(crate) async fn handle(app: &mut App, key: KeyEvent) -> io::Result<EventResu
             Tab::Sessions => app.next(),
             Tab::Review => app.next_requested_review(),
             Tab::Issues => app.next_assigned_issue(),
-            Tab::Settings => app.settings.next(),
+            Tab::Settings => apply_settings_action(app, SettingsAction::Next).await,
         },
         KeyCode::Char('k') | KeyCode::Up => match app.tabs.current() {
             Tab::Projects => app.previous_project(),
             Tab::Sessions => app.previous(),
             Tab::Review => app.previous_requested_review(),
             Tab::Issues => app.previous_assigned_issue(),
-            Tab::Settings => app.settings.previous(),
+            Tab::Settings => apply_settings_action(app, SettingsAction::Previous).await,
         },
         KeyCode::Enter => return handle_enter_key(app).await,
         KeyCode::Char('c') if app.tabs.current() == Tab::Sessions => {
@@ -167,7 +171,7 @@ async fn handle_enter_key(app: &mut App) -> io::Result<EventResult> {
             }
         }
         Tab::Settings => {
-            app.settings.handle_enter();
+            apply_settings_action(app, SettingsAction::Activate).await;
         }
         Tab::Review => {
             app.open_selected_requested_review();
@@ -187,21 +191,19 @@ async fn handle_settings_selector_dropdown(
 ) -> io::Result<EventResult> {
     match key.code {
         KeyCode::Esc => {
-            app.settings.close_selector_dropdown();
+            apply_settings_action(app, SettingsAction::Cancel).await;
         }
         KeyCode::Char(character) if character.eq_ignore_ascii_case(&'q') => {
-            app.settings.close_selector_dropdown();
+            apply_settings_action(app, SettingsAction::Cancel).await;
         }
         KeyCode::Char('j') | KeyCode::Down => {
-            app.settings.next_selector_dropdown_option();
+            apply_settings_action(app, SettingsAction::Next).await;
         }
         KeyCode::Char('k') | KeyCode::Up => {
-            app.settings.previous_selector_dropdown_option();
+            apply_settings_action(app, SettingsAction::Previous).await;
         }
         KeyCode::Enter => {
-            app.settings
-                .select_selector_dropdown_option(&app.services)
-                .await;
+            apply_settings_action(app, SettingsAction::Confirm).await;
         }
         _ => {}
     }
@@ -215,7 +217,7 @@ async fn handle_settings_launch_configuration_list_editor(
     key: KeyEvent,
 ) -> io::Result<EventResult> {
     if app
-        .settings
+        .settings_presentation
         .is_launch_configuration_list_editor_input_active()
     {
         return handle_settings_launch_configuration_input(app, key).await;
@@ -223,38 +225,31 @@ async fn handle_settings_launch_configuration_list_editor(
 
     match key.code {
         KeyCode::Esc => {
-            app.settings.close_launch_configuration_list_editor();
+            apply_settings_action(app, SettingsAction::Cancel).await;
         }
         KeyCode::Char(character) if character.eq_ignore_ascii_case(&'q') => {
-            app.settings.close_launch_configuration_list_editor();
+            apply_settings_action(app, SettingsAction::Cancel).await;
         }
         KeyCode::Char('j') | KeyCode::Down => {
-            app.settings.next_launch_configuration_list_editor_item();
+            apply_settings_action(app, SettingsAction::Next).await;
         }
         KeyCode::Char('k') | KeyCode::Up => {
-            app.settings
-                .previous_launch_configuration_list_editor_item();
+            apply_settings_action(app, SettingsAction::Previous).await;
         }
         KeyCode::Char('J') => {
-            app.settings
-                .move_selected_launch_configuration_down(&app.services)
-                .await;
+            apply_settings_action(app, SettingsAction::MoveLaunchConfigurationDown).await;
         }
         KeyCode::Char('K') => {
-            app.settings
-                .move_selected_launch_configuration_up(&app.services)
-                .await;
+            apply_settings_action(app, SettingsAction::MoveLaunchConfigurationUp).await;
         }
         KeyCode::Char('a') => {
-            app.settings.start_adding_launch_configuration();
+            apply_settings_action(app, SettingsAction::StartAddingLaunchConfiguration).await;
         }
         KeyCode::Char('e') | KeyCode::Enter => {
-            app.settings.start_editing_selected_launch_configuration();
+            apply_settings_action(app, SettingsAction::EditLaunchConfiguration).await;
         }
         KeyCode::Char('d') => {
-            app.settings
-                .delete_selected_launch_configuration(&app.services)
-                .await;
+            apply_settings_action(app, SettingsAction::DeleteLaunchConfiguration).await;
         }
         _ => {}
     }
@@ -269,24 +264,35 @@ async fn handle_settings_launch_configuration_input(
 ) -> io::Result<EventResult> {
     match key.code {
         KeyCode::Enter => {
-            app.settings
-                .confirm_launch_configuration_input(&app.services)
-                .await;
+            apply_settings_action(app, SettingsAction::Confirm).await;
         }
         KeyCode::Esc => {
-            app.settings.cancel_launch_configuration_input();
+            apply_settings_action(app, SettingsAction::Cancel).await;
         }
         _ => {
             if let Some(command) =
                 input_key::command_for_key(key, input_key::InputCapabilities::SINGLE_LINE)
             {
-                app.settings
-                    .apply_launch_configuration_input_command(command);
+                apply_settings_action(app, SettingsAction::Input(command)).await;
             }
         }
     }
 
     Ok(EventResult::Continue)
+}
+
+/// Applies a semantic settings-screen action and persists any requested value
+/// change through the narrow settings application service.
+async fn apply_settings_action(app: &mut App, action: SettingsAction) {
+    let operation = {
+        let view = app.settings.view();
+
+        app.settings_presentation.apply(&view, action)
+    };
+
+    if let Some(operation) = operation {
+        app.settings.apply_operation(operation).await;
+    }
 }
 
 /// Starts the sync action that applies to the visible list tab.
@@ -380,14 +386,21 @@ mod tests {
             .expect("failed to create session for settings tests");
         app.tabs.set(Tab::Settings);
         let launch_configuration_row_index = app
-            .settings
-            .settings_rows()
+            .settings_presentation
+            .snapshot(&app.settings.view())
+            .project_rows
             .iter()
             .position(|(setting_name, _)| *setting_name == "Launch Configurations")
+            .map(|project_index| project_index + 1)
             .expect("missing Launch Configurations setting row");
-        app.settings
-            .table_state
-            .select(Some(launch_configuration_row_index));
+        for _ in 0..launch_configuration_row_index {
+            handle(
+                &mut app,
+                KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+            )
+            .await
+            .expect("failed to select Launch Configurations setting row");
+        }
 
         (app, base_dir)
     }
@@ -971,8 +984,9 @@ mod tests {
             .await
             .expect("failed to handle key");
         let editor = app
-            .settings
-            .launch_configuration_list_editor()
+            .settings_presentation
+            .snapshot(&app.settings.view())
+            .launch_configuration_list_editor
             .expect("expected launch-configuration list editor");
 
         // Assert
@@ -984,19 +998,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_settings_previous_key_wraps_to_launch_configuration_row() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+        app.tabs.set(Tab::Settings);
+
+        // Act
+        let event_result = handle(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+        )
+        .await
+        .expect("failed to move settings selection");
+
+        // Assert
+        assert!(matches!(event_result, EventResult::Continue));
+        assert_eq!(
+            app.settings_presentation
+                .snapshot(&app.settings.view())
+                .selected_row_index,
+            Some(6)
+        );
+    }
+
+    #[tokio::test]
     async fn test_handle_enter_key_opens_settings_selector_dropdown() {
         // Arrange
         let (mut app, _base_dir) = crate::test_support::new_test_app().await;
         app.tabs.set(Tab::Settings);
-        app.settings.table_state.select(Some(0));
 
         // Act
         let event_result = handle(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
             .await
             .expect("failed to handle key");
         let selector_dropdown = app
-            .settings
-            .selector_dropdown()
+            .settings_presentation
+            .snapshot(&app.settings.view())
+            .selector_dropdown
             .expect("expected settings selector dropdown");
 
         // Assert
@@ -1011,7 +1049,6 @@ mod tests {
         // Arrange
         let (mut app, _base_dir) = crate::test_support::new_test_app().await;
         app.tabs.set(Tab::Settings);
-        app.settings.table_state.select(Some(0));
         handle(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
             .await
             .expect("failed to open settings selector dropdown");
@@ -1030,7 +1067,7 @@ mod tests {
         // Assert
         assert!(matches!(event_result, EventResult::Continue));
         assert_eq!(app.settings.theme, ColorTheme::Green);
-        assert!(!app.settings.is_selector_dropdown_open());
+        assert!(!app.settings_presentation.is_selector_dropdown_open());
     }
 
     #[tokio::test]
@@ -1038,7 +1075,6 @@ mod tests {
         // Arrange
         let (mut app, _base_dir) = crate::test_support::new_test_app().await;
         app.tabs.set(Tab::Settings);
-        app.settings.table_state.select(Some(0));
         handle(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
             .await
             .expect("failed to open settings selector dropdown");
@@ -1053,8 +1089,39 @@ mod tests {
 
         // Assert
         assert!(matches!(event_result, EventResult::Continue));
-        assert!(!app.settings.is_selector_dropdown_open());
+        assert!(!app.settings_presentation.is_selector_dropdown_open());
         assert!(matches!(app.mode, AppMode::List));
+    }
+
+    #[tokio::test]
+    async fn test_settings_selector_previous_and_escape_close_dropdown() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+        app.tabs.set(Tab::Settings);
+        handle(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .await
+            .expect("failed to open settings selector dropdown");
+        handle(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+        )
+        .await
+        .expect("failed to move selector forward");
+
+        // Act
+        handle(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+        )
+        .await
+        .expect("failed to move selector backward");
+        let event_result = handle(&mut app, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+            .await
+            .expect("failed to close selector dropdown");
+
+        // Assert
+        assert!(matches!(event_result, EventResult::Continue));
+        assert!(!app.settings_presentation.is_selector_dropdown_open());
     }
 
     #[tokio::test]
@@ -1122,8 +1189,9 @@ mod tests {
         .await
         .expect("failed to handle key");
         let editor = app
-            .settings
-            .launch_configuration_list_editor()
+            .settings_presentation
+            .snapshot(&app.settings.view())
+            .launch_configuration_list_editor
             .expect("expected launch-configuration list editor");
         let input = editor.input.expect("expected active input");
 
@@ -1231,6 +1299,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_launch_configuration_editor_previous_move_up_and_q_close() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_app_for_settings().await;
+        app.settings.launch_configuration = "cargo test\nnpm run dev".to_string();
+        handle(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .await
+            .expect("failed to open settings command editor");
+        handle(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+        )
+        .await
+        .expect("failed to select second command");
+
+        // Act
+        handle(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+        )
+        .await
+        .expect("failed to select previous command");
+        handle(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+        )
+        .await
+        .expect("failed to reselect second command");
+        handle(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('K'), KeyModifiers::SHIFT),
+        )
+        .await
+        .expect("failed to move command up");
+        let event_result = handle(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
+        )
+        .await
+        .expect("failed to close launch-configuration editor");
+
+        // Assert
+        assert!(matches!(event_result, EventResult::Continue));
+        assert_eq!(app.settings.launch_configuration, "npm run dev\ncargo test");
+        assert!(
+            !app.settings_presentation
+                .is_launch_configuration_list_editor_open()
+        );
+    }
+
+    #[tokio::test]
     async fn test_launch_configuration_list_editor_esc_closes_from_browse() {
         // Arrange
         let (mut app, _base_dir) = new_test_app_for_settings().await;
@@ -1245,7 +1363,10 @@ mod tests {
 
         // Assert
         assert!(matches!(event_result, EventResult::Continue));
-        assert!(!app.settings.is_launch_configuration_list_editor_open());
+        assert!(
+            !app.settings_presentation
+                .is_launch_configuration_list_editor_open()
+        );
     }
 
     #[tokio::test]
@@ -1273,13 +1394,17 @@ mod tests {
             .await
             .expect("failed to handle Esc key");
         let editor = app
-            .settings
-            .launch_configuration_list_editor()
+            .settings_presentation
+            .snapshot(&app.settings.view())
+            .launch_configuration_list_editor
             .expect("expected launch-configuration list editor");
 
         // Assert
         assert!(matches!(event_result, EventResult::Continue));
-        assert!(app.settings.is_launch_configuration_list_editor_open());
+        assert!(
+            app.settings_presentation
+                .is_launch_configuration_list_editor_open()
+        );
         assert!(editor.input.is_none());
         assert_eq!(app.settings.launch_configuration, "");
     }

--- a/crates/agentty/src/ui/app_render.rs
+++ b/crates/agentty/src/ui/app_render.rs
@@ -26,7 +26,7 @@ pub(crate) fn render_app(
                 session_id: review.session_id,
                 text: review.text,
             });
-    let _theme_scope = style::scoped_active_theme(snapshot.settings.theme);
+    let _theme_scope = style::scoped_active_theme(snapshot.theme);
 
     super::render(
         frame,
@@ -37,6 +37,7 @@ pub(crate) fn render_app(
             active_project_id: snapshot.active_project_id,
             available_agent_clis: &snapshot.available_agent_clis,
             current_tab: snapshot.current_tab,
+            default_reasoning_level: snapshot.default_reasoning_level,
             git_branch: snapshot.git_branch,
             diff_layout_cache: render_cache_store.diff_layout_cache(),
             git_upstream_ref: snapshot.git_upstream_ref,
@@ -60,7 +61,7 @@ pub(crate) fn render_app(
             session_progress_messages: snapshot.session_progress_messages,
             session_update_versions: snapshot.session_update_versions,
             session_worktree_availability: snapshot.session_worktree_availability,
-            settings: snapshot.settings,
+            settings_screen: snapshot.settings_screen.as_ref(),
             stats_activity: snapshot.stats_activity,
             sessions: snapshot.sessions,
             status_bar_fyi_rotation_index: snapshot.status_bar_fyi_rotation_index,

--- a/crates/agentty/src/ui/component/launch_configuration_list_editor.rs
+++ b/crates/agentty/src/ui/component/launch_configuration_list_editor.rs
@@ -5,10 +5,10 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Wrap};
 
-use crate::app::setting::{
+use crate::domain::input::InputState;
+use crate::presentation::settings::{
     LaunchConfigurationListEditorMode, LaunchConfigurationListEditorSnapshot,
 };
-use crate::domain::input::InputState;
 use crate::ui::style::palette;
 use crate::ui::{Component, overlay};
 

--- a/crates/agentty/src/ui/page/setting.rs
+++ b/crates/agentty/src/ui/page/setting.rs
@@ -5,8 +5,8 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState, Wrap};
 
-use crate::app::setting::{SettingsManager, SettingsSelectorDropdown};
 use crate::presentation::help_action;
+use crate::presentation::settings::{SettingsScreenSnapshot, SettingsSelectorDropdown};
 use crate::ui::{Component, Page, component, layout, overlay, style};
 
 /// Uses row-background highlighting without a textual cursor glyph.
@@ -22,15 +22,15 @@ const DROPDOWN_WIDTH_PERCENT: u16 = 58;
 
 /// Renders the settings page table and inline editing hints.
 pub struct SettingsPage<'a> {
-    manager: &'a SettingsManager,
+    snapshot: &'a SettingsScreenSnapshot,
     project_name: Option<String>,
 }
 
 impl<'a> SettingsPage<'a> {
-    /// Creates a settings page renderer bound to the active project settings.
-    pub fn new(manager: &'a SettingsManager, project_name: Option<String>) -> Self {
+    /// Creates a settings page renderer bound to the active settings snapshot.
+    pub(crate) fn new(snapshot: &'a SettingsScreenSnapshot, project_name: Option<String>) -> Self {
         Self {
-            manager,
+            snapshot,
             project_name,
         }
     }
@@ -48,17 +48,17 @@ impl Page for SettingsPage<'_> {
         let areas = layout::tab_page_areas(area);
 
         let selected_style = Style::default().bg(style::palette::surface_selection());
-        let global_rows = settings_table_rows(self.manager.global_settings_rows());
-        let project_rows = settings_table_rows(self.manager.project_settings_rows());
+        let global_rows = settings_table_rows(&self.snapshot.global_rows);
+        let project_rows = settings_table_rows(&self.snapshot.project_rows);
         let global_row_count = global_rows.len();
 
         let project_section_title = self.project_section_title();
         let global_section_title = "Global settings".to_string();
 
         let global_table_state =
-            section_table_state(self.manager.table_state.selected(), 0, global_row_count);
+            section_table_state(self.snapshot.selected_row_index, 0, global_row_count);
         let project_table_state = section_table_state(
-            self.manager.table_state.selected(),
+            self.snapshot.selected_row_index,
             global_row_count,
             project_rows.len(),
         );
@@ -101,23 +101,23 @@ impl Page for SettingsPage<'_> {
         f.render_stateful_widget(global_table, table_chunks[0], &mut global_table_state);
         f.render_stateful_widget(project_table, table_chunks[1], &mut project_table_state);
 
-        let footer = Paragraph::new(settings_footer_line(self.manager));
+        let footer = Paragraph::new(settings_footer_line(self.snapshot));
 
         f.render_widget(footer, areas.footer_area);
 
-        if let Some(selector_dropdown) = self.manager.selector_dropdown() {
+        if let Some(selector_dropdown) = &self.snapshot.selector_dropdown {
             render_settings_selector_dropdown(
                 f,
                 areas.main_area,
                 &table_chunks,
                 global_row_count,
-                &selector_dropdown,
+                selector_dropdown,
             );
         }
 
-        if let Some(launch_configuration_editor) = self.manager.launch_configuration_list_editor() {
+        if let Some(launch_configuration_editor) = &self.snapshot.launch_configuration_list_editor {
             component::launch_configuration_list_editor::LaunchConfigurationListEditor::new(
-                &launch_configuration_editor,
+                launch_configuration_editor,
             )
             .render(f, areas.main_area);
         }
@@ -364,10 +364,10 @@ fn settings_selector_dropdown_option_line(
 /// Selector dropdowns and command-list editing keep using the
 /// manager-provided hint string, while list mode uses the shared styled
 /// help-action rendering.
-fn settings_footer_line(manager: &SettingsManager) -> Line<'static> {
+fn settings_footer_line(snapshot: &SettingsScreenSnapshot) -> Line<'static> {
     settings_footer_line_for_mode(
-        manager.is_launch_configuration_list_editor_open() || manager.is_selector_dropdown_open(),
-        manager.footer_hint(),
+        snapshot.launch_configuration_list_editor.is_some() || snapshot.selector_dropdown.is_some(),
+        snapshot.footer_hint,
     )
 }
 
@@ -383,12 +383,15 @@ fn settings_footer_line_for_mode(uses_inline_hint: bool, footer_hint: &str) -> L
 }
 
 /// Builds single-line settings table rows.
-fn settings_table_rows(settings_rows: Vec<(&'static str, String)>) -> Vec<Row<'static>> {
+fn settings_table_rows<'a>(settings_rows: &'a [(&'static str, String)]) -> Vec<Row<'a>> {
     settings_rows
-        .into_iter()
+        .iter()
         .map(|(setting_name, setting_value)| {
-            Row::new(vec![Cell::from(setting_name), Cell::from(setting_value)])
-                .style(Style::default().fg(style::palette::text()))
+            Row::new(vec![
+                Cell::from(*setting_name),
+                Cell::from(setting_value.as_str()),
+            ])
+            .style(Style::default().fg(style::palette::text()))
         })
         .collect()
 }
@@ -396,7 +399,7 @@ fn settings_table_rows(settings_rows: Vec<(&'static str, String)>) -> Vec<Row<'s
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::setting::SettingsSelectorDropdownOption;
+    use crate::presentation::settings::SettingsSelectorDropdownOption;
 
     #[test]
     fn test_row_highlight_symbol_uses_background_only_selection() {
@@ -425,7 +428,8 @@ mod tests {
     #[test]
     fn test_render_uses_palette_text_for_setting_rows() {
         // Arrange
-        let rows = settings_table_rows(vec![("Theme", "Agentty Default".to_string())]);
+        let settings_rows = [("Theme", "Agentty Default".to_string())];
+        let rows = settings_table_rows(&settings_rows);
         let table = Table::new(
             rows,
             [Constraint::Percentage(50), Constraint::Percentage(50)],

--- a/crates/agentty/src/ui/render.rs
+++ b/crates/agentty/src/ui/render.rs
@@ -7,8 +7,8 @@ use ratatui::widgets::TableState;
 
 use crate::app::session::session_branch;
 use crate::app::session_state::SessionGitStatus;
-use crate::app::{AssignedIssueState, RequestedReviewState, SettingsManager, Tab, UpdateStatus};
-use crate::domain::agent::AgentCliInfo;
+use crate::app::{AssignedIssueState, RequestedReviewState, Tab, UpdateStatus};
+use crate::domain::agent::{AgentCliInfo, ReasoningLevel};
 use crate::domain::project::ProjectListItem;
 use crate::domain::session::{DailyActivity, Session, SessionId};
 use crate::presentation::app_mode::{AppMode, ConfirmationViewMode, HelpContext};
@@ -51,6 +51,8 @@ pub struct RenderContext<'a> {
     pub available_agent_clis: &'a [AgentCliInfo],
     /// Active top-level tab selection.
     pub current_tab: Tab,
+    /// Active project-scoped reasoning level used by session pages.
+    pub default_reasoning_level: ReasoningLevel,
     /// Current local branch name for the active project.
     pub git_branch: Option<&'a str>,
     /// Shared cache for parsed and rendered diff-page layouts.
@@ -98,8 +100,8 @@ pub struct RenderContext<'a> {
     /// Whether each rendered session currently has a materialized worktree on
     /// disk, keyed by session id.
     pub session_worktree_availability: &'a HashMap<SessionId, bool>,
-    /// Mutable project-scoped settings snapshot.
-    pub settings: &'a SettingsManager,
+    /// Settings-screen projection when the active tab can render it.
+    pub(crate) settings_screen: Option<&'a crate::presentation::settings::SettingsScreenSnapshot>,
     /// Daily session activity series used by dashboard activity summaries.
     pub stats_activity: &'a [DailyActivity],
     /// Session rows available for rendering.

--- a/crates/agentty/src/ui/router.rs
+++ b/crates/agentty/src/ui/router.rs
@@ -4,12 +4,13 @@ use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::widgets::TableState;
 
-use crate::app::{AssignedIssueState, RequestedReviewState, SettingsManager, Tab};
+use crate::app::{AssignedIssueState, RequestedReviewState, Tab};
 use crate::domain::agent::{AgentCliInfo, ReasoningLevel};
 use crate::domain::input::InputState;
 use crate::domain::project::{ProjectListItem, ordered_project_items};
 use crate::domain::session::{DailyActivity, Session, SessionId};
 use crate::presentation::app_mode::{AppMode, ConfirmationIntent, ConfirmationViewMode};
+use crate::presentation::settings::SettingsScreenSnapshot;
 use crate::ui::overlay::{
     HelpOverlayRenderContext, SyncBlockedPopupRenderContext, ViewInfoPopupRenderContext,
 };
@@ -52,7 +53,7 @@ impl<'state> ListBackgroundRenderContext<'_, 'state> {
     /// Returns the active project-scoped reasoning level for list-restored
     /// session backgrounds.
     pub(crate) fn default_reasoning_level(&self) -> ReasoningLevel {
-        self.shared.settings.reasoning_level
+        self.shared.default_reasoning_level
     }
 
     /// Returns the shared session rows available to list-backed overlays.
@@ -71,6 +72,7 @@ pub(crate) struct RouteSharedContext<'a> {
     /// Locally available agent CLI executables and detected versions.
     available_agent_clis: &'a [AgentCliInfo],
     current_tab: Tab,
+    default_reasoning_level: ReasoningLevel,
     /// Cached most-recently-opened ordering over `projects`.
     mru_project_order: &'a [usize],
     project_table_state: &'a mut TableState,
@@ -79,7 +81,7 @@ pub(crate) struct RouteSharedContext<'a> {
     requested_review_table_state: &'a mut TableState,
     requested_reviews: &'a RequestedReviewState,
     sessions: &'a [Session],
-    settings: &'a SettingsManager,
+    settings_screen: Option<&'a SettingsScreenSnapshot>,
     stats_activity: &'a [DailyActivity],
     table_state: &'a mut TableState,
 }
@@ -237,6 +239,7 @@ pub(crate) fn route_frame(f: &mut Frame, area: Rect, context: RenderContext<'_>)
         active_prompt_outputs,
         available_agent_clis,
         current_tab,
+        default_reasoning_level,
         diff_layout_cache,
         markdown_render_cache,
         mode,
@@ -251,7 +254,7 @@ pub(crate) fn route_frame(f: &mut Frame, area: Rect, context: RenderContext<'_>)
         session_progress_messages,
         session_update_versions,
         session_worktree_availability,
-        settings,
+        settings_screen,
         stats_activity,
         sessions,
         table_state,
@@ -266,6 +269,7 @@ pub(crate) fn route_frame(f: &mut Frame, area: Rect, context: RenderContext<'_>)
         assigned_issues,
         available_agent_clis,
         current_tab,
+        default_reasoning_level,
         mru_project_order,
         project_table_state,
         projects,
@@ -273,14 +277,14 @@ pub(crate) fn route_frame(f: &mut Frame, area: Rect, context: RenderContext<'_>)
         requested_review_table_state,
         requested_reviews,
         sessions,
-        settings,
+        settings_screen,
         stats_activity,
         table_state,
     };
 
     let aux = RouteAuxContext {
         active_prompt_outputs,
-        default_reasoning_level: shared.settings.reasoning_level,
+        default_reasoning_level,
         diff_layout_cache,
         markdown_render_cache,
         output_layout_cache,
@@ -907,7 +911,7 @@ pub(crate) fn render_list_background(
             page::session_list::SessionListPage::new(
                 shared.sessions,
                 &mut *shared.table_state,
-                shared.settings.reasoning_level,
+                shared.default_reasoning_level,
                 wall_clock_unix_seconds,
             )
             .render(f, chunks[1]);
@@ -931,8 +935,10 @@ pub(crate) fn render_list_background(
         Tab::Settings => {
             let active_project_name =
                 active_project_name(shared.active_project_id, shared.projects);
-            page::setting::SettingsPage::new(shared.settings, active_project_name)
-                .render(f, chunks[1]);
+            if let Some(settings_screen) = shared.settings_screen {
+                page::setting::SettingsPage::new(settings_screen, active_project_name)
+                    .render(f, chunks[1]);
+            }
         }
     }
 }
@@ -955,6 +961,10 @@ mod tests {
     use crate::domain::agent::ReasoningLevel;
     use crate::domain::session::Status;
     use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
+    use crate::presentation::settings::{
+        LaunchConfigurationListEditorMode, LaunchConfigurationListEditorSnapshot,
+        SettingsSelectorDropdown, SettingsSelectorDropdownOption,
+    };
     use crate::test_support::SessionFixtureBuilder;
 
     /// Builds one deterministic session fixture for router render tests.
@@ -984,6 +994,101 @@ mod tests {
             .iter()
             .map(ratatui::buffer::Cell::symbol)
             .collect()
+    }
+
+    fn settings_screen_with_overlays() -> SettingsScreenSnapshot {
+        SettingsScreenSnapshot {
+            footer_hint: "Editing settings",
+            global_rows: vec![("Theme", "Agentty Default".to_string())],
+            launch_configuration_list_editor: Some(LaunchConfigurationListEditorSnapshot {
+                commands: vec!["cargo test".to_string()],
+                input: None,
+                mode: LaunchConfigurationListEditorMode::Browse,
+                selected_index: 0,
+            }),
+            project_rows: vec![("Launch Configurations", "cargo test".to_string())],
+            selected_row_index: Some(0),
+            selector_dropdown: Some(SettingsSelectorDropdown {
+                options: vec![SettingsSelectorDropdownOption {
+                    label: "Agentty Default".to_string(),
+                }],
+                row_index: 0,
+                selected_index: 0,
+            }),
+        }
+    }
+
+    fn render_list_tab(
+        current_tab: Tab,
+        settings_screen: Option<&SettingsScreenSnapshot>,
+    ) -> (String, ReasoningLevel) {
+        let backend = ratatui::backend::TestBackend::new(120, 30);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+        let mut assigned_issue_table_state = TableState::default();
+        let assigned_issues = AssignedIssueState::default();
+        let available_agent_clis = Vec::new();
+        let mut project_table_state = TableState::default();
+        let projects = Vec::new();
+        let mut requested_review_table_state = TableState::default();
+        let requested_reviews = RequestedReviewState::default();
+        let sessions = Vec::new();
+        let stats_activity = Vec::new();
+        let mut table_state = TableState::default();
+        let mut shared = RouteSharedContext {
+            active_project_id: 1,
+            assigned_issue_selected_index: None,
+            assigned_issue_table_state: &mut assigned_issue_table_state,
+            assigned_issues: &assigned_issues,
+            available_agent_clis: &available_agent_clis,
+            current_tab,
+            default_reasoning_level: ReasoningLevel::Max,
+            mru_project_order: &[],
+            project_table_state: &mut project_table_state,
+            projects: &projects,
+            requested_review_selected_index: None,
+            requested_review_table_state: &mut requested_review_table_state,
+            requested_reviews: &requested_reviews,
+            sessions: &sessions,
+            settings_screen,
+            stats_activity: &stats_activity,
+            table_state: &mut table_state,
+        };
+        let default_reasoning_level = shared.list_background().default_reasoning_level();
+
+        terminal
+            .draw(|frame| {
+                render_list_background(frame, frame.area(), shared.list_background(), 0);
+            })
+            .expect("failed to draw list tab");
+
+        (
+            buffer_text(terminal.backend().buffer()),
+            default_reasoning_level,
+        )
+    }
+
+    #[test]
+    fn render_list_background_renders_settings_snapshot_and_overlays() {
+        // Arrange
+        let settings_screen = settings_screen_with_overlays();
+
+        // Act
+        let (text, _) = render_list_tab(Tab::Settings, Some(&settings_screen));
+
+        // Assert
+        assert!(text.contains("Launch Configurations"));
+        assert!(text.contains("cargo test"));
+    }
+
+    #[test]
+    fn render_list_background_projects_reasoning_into_sessions_page() {
+        // Arrange
+
+        // Act
+        let (_, default_reasoning_level) = render_list_tab(Tab::Sessions, None);
+
+        // Assert
+        assert_eq!(default_reasoning_level, ReasoningLevel::Max);
     }
 
     #[test]

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -51,11 +51,11 @@ For file-level detail, read the module docstrings directly.
 - `main.rs` / `lib.rs`: Composition root — database bootstrap, `App` construction,
   runtime launch, and public module exports.
 - `app/`: Orchestration layer. Owns the `App` state, the `AppEvent` reducer, project and
-  settings managers, the merge queue, the sync orchestrator, branch publish, focused
-  review, and the session module (`app/session/`) with its per-session worker queues and
-  workflow steps (`lifecycle`, `turn`, `post_turn`, `merge`, `task`, `worker`). No
-  direct process, filesystem, or clock calls — everything external goes through `infra/`
-  traits.
+  settings persistence manager, the merge queue, the sync orchestrator, branch publish,
+  focused review, and the session module (`app/session/`) with its per-session worker
+  queues and workflow steps (`lifecycle`, `turn`, `post_turn`, `merge`, `task`,
+  `worker`). No direct process, filesystem, or clock calls — everything external goes
+  through `infra/` traits.
 - `domain/`: Pure business entities and logic — sessions and statuses, projects,
   settings keys, themes, structured questions, typed transcript messages, explicit
   transient-message slots and lifecycles, prompt-composer logic, the shared `InputState`
@@ -78,9 +78,12 @@ For file-level detail, read the module docstrings directly.
   `PresentationState`, including the shared `RenderCacheStore` used by input metrics and
   frame rendering.
 - `presentation.rs` and `presentation/`: Frontend-neutral interaction state shared by
-  runtime input and UI output. They expose mode, help-action, prompt, editor, scroll,
-  viewport, and semantic list-selection contracts without importing Ratatui or `ui/`
-  formatting.
+  runtime input and UI output. They expose mode, help-action, prompt, settings-screen
+  actions, editor, scroll, viewport, and semantic list-selection contracts without
+  importing Ratatui or `ui/` formatting. `presentation/settings.rs` owns settings row
+  selection, selectors, launch-configuration editing through the shared `InputState`,
+  and render-ready settings snapshots; it returns typed persistence operations to
+  `app/setting.rs`.
 - `ui/`: Rendering — frame composition, mode-to-page routing, pages under `ui/page/`,
   reusable widgets under `ui/component/`, application-to-frame projection in
   `ui/app_render.rs`, Agentty theme adapters for `ag-tui-text`, plus diff, layout,


### PR DESCRIPTION
- Adds settings snapshots and semantic actions for selection, selectors, and launch-configuration editing.
- Keeps `SettingsManager` focused on repository-backed loading and persistence.
- Routes runtime input, paste handling, and rendering through presentation snapshots and typed operations.
- Resets presentation state when switching projects and documents the new architecture boundary.
- Extends coverage for settings persistence, navigation, editing, and rendering paths.