### PR TITLE
Merged review sessions remain read-only until target sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- agentty: keep remotely merged review sessions read-only in Active until manual target
+  sync archives them and restacks any child sessions.
+
 ## [v0.13.3] - 2026-07-17
 
 ### Added

--- a/crates/agentty/src/AGENTS.md
+++ b/crates/agentty/src/AGENTS.md
@@ -18,8 +18,9 @@
   - `Question` is set when a completed turn returns structured clarification questions.
   - When agent response finishes, all changes are auto-committed and status is set to
     `Review` or `Question`.
-  - `Done` can be entered after local merge cleanup succeeds, or when review request
-    sync detects an upstream merge.
+  - Review request sync records an upstream merge as read-only `Merged`; only a
+    successful manual target-branch sync advances it to `Done` and starts cleanup.
+  - `Done` can also be entered after local merge cleanup succeeds.
   - While agent is preparing a response, status is `InProgress`.
 
 ## Docs Sync

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -841,30 +841,23 @@ impl App {
         let focused_review_persistence = apply_review_updates(
             &mut self.review_cache,
             self.sessions.state_mut(),
-            event_batch.review_updates,
+            std::mem::take(&mut event_batch.review_updates),
         );
         self.persist_focused_review_updates(focused_review_persistence)
             .await;
 
-        for branch_publish_action_update in event_batch.branch_publish_action_updates {
+        for branch_publish_action_update in
+            std::mem::take(&mut event_batch.branch_publish_action_updates)
+        {
             self.apply_branch_publish_action_update(branch_publish_action_update)
                 .await;
         }
 
-        let applied_review_request_status_update = event_batch
-            .review_request_status_updates
-            .iter()
-            .any(|update| update.generation == sync_generation_for_review_updates);
-        for review_request_status_update in event_batch.review_request_status_updates {
-            if review_request_status_update.generation != sync_generation_for_review_updates {
-                continue;
-            }
-            self.apply_review_request_status_update(review_request_status_update)
-                .await;
-        }
-        if applied_review_request_status_update {
-            self.publish_sync_context();
-        }
+        self.apply_review_request_status_updates_and_synced_merges(
+            &mut event_batch,
+            sync_generation_for_review_updates,
+        )
+        .await;
 
         self.apply_session_progress_updates(std::mem::take(
             &mut event_batch.session_progress_updates,
@@ -931,6 +924,35 @@ impl App {
 
         if should_mark_dirty {
             self.mark_dirty();
+        }
+    }
+
+    async fn apply_review_request_status_updates_and_synced_merges(
+        &mut self,
+        event_batch: &mut AppEventBatch,
+        sync_generation: u64,
+    ) {
+        let review_request_status_updates =
+            std::mem::take(&mut event_batch.review_request_status_updates);
+        let applied_review_request_status_update = review_request_status_updates
+            .iter()
+            .any(|update| update.generation == sync_generation);
+        for review_request_status_update in review_request_status_updates {
+            if review_request_status_update.generation != sync_generation {
+                continue;
+            }
+            self.apply_review_request_status_update(review_request_status_update)
+                .await;
+        }
+        if applied_review_request_status_update {
+            self.publish_sync_context();
+        }
+
+        if let Some(Ok(sync_main_outcome)) = event_batch.sync_main_result.as_mut() {
+            let default_branch = sync_main_outcome.default_branch.clone();
+            sync_main_outcome.deferred_merged_session_ids = self
+                .finalize_merged_sessions_after_main_sync(&default_branch)
+                .await;
         }
     }
 
@@ -1748,7 +1770,7 @@ impl App {
                 session_head_hash, ..
             } => {
                 if let Some(warning) = self
-                    .complete_externally_merged_session(&session_id, session_head_hash)
+                    .record_externally_merged_session(&session_id, session_head_hash)
                     .await
                 {
                     self.append_output_for_session(
@@ -1766,14 +1788,119 @@ impl App {
         }
     }
 
-    /// Marks one externally merged session `Done`, persists continuation
-    /// commit-hash metadata when available, and returns any warning from
-    /// worktree cleanup.
+    /// Records one externally merged session as read-only `Merged` without
+    /// starting local cleanup or stacked-child restacking.
+    pub(super) async fn record_externally_merged_session(
+        &self,
+        session_id: &str,
+        session_head_hash: Option<String>,
+    ) -> Option<String> {
+        let Ok(handles) = self.sessions.session_handles_or_err(session_id) else {
+            return None;
+        };
+        let mut warnings = Vec::new();
+
+        if let Some(session_head_hash) = session_head_hash
+            && let Err(error) = self
+                .services
+                .db()
+                .sessions()
+                .update_session_merged_commit_hash(session_id, Some(session_head_hash))
+                .await
+        {
+            warnings.push(format!("Merged commit hash persistence failed: {error}"));
+        }
+
+        let status_transition =
+            StatusTransition::from_services(&self.services, handles, session_id);
+        if !status_transition.apply(Status::Merged).await {
+            warnings.push("Could not mark the merged session read-only".to_string());
+        }
+
+        (!warnings.is_empty()).then(|| warnings.join("\n"))
+    }
+
+    /// Finalizes read-only merged sessions targeting the branch updated by a
+    /// successful user-triggered main sync.
+    async fn finalize_merged_sessions_after_main_sync(
+        &mut self,
+        default_branch: &str,
+    ) -> Vec<SessionId> {
+        let mut deferred_session_ids = Vec::new();
+        let session_ids = self
+            .sessions
+            .sessions()
+            .iter()
+            .filter(|session| {
+                session
+                    .review_request
+                    .as_ref()
+                    .is_some_and(|review_request| {
+                        review_request.summary.target_branch == default_branch
+                    })
+                    && self
+                        .sessions
+                        .session_handles_or_err(&session.id)
+                        .ok()
+                        .and_then(|handles| handles.status.lock().ok().map(|status| *status))
+                        == Some(Status::Merged)
+            })
+            .map(|session| session.id.clone())
+            .collect::<Vec<_>>();
+
+        for session_id in session_ids {
+            let session_head_hash = match self
+                .services
+                .db()
+                .sessions()
+                .load_session_merged_commit_hash(&session_id)
+                .await
+            {
+                Ok(session_head_hash) => session_head_hash,
+                Err(error) => {
+                    self.append_output_for_session(
+                        &session_id,
+                        &TranscriptNotice::ReviewRequestSyncWarning
+                            .format(format!("Merged commit hash load failed: {error}")),
+                    )
+                    .await;
+                    deferred_session_ids.push(session_id);
+
+                    continue;
+                }
+            };
+
+            if let Some(warning) = self
+                .complete_externally_merged_session(&session_id, session_head_hash)
+                .await
+            {
+                self.append_output_for_session(
+                    &session_id,
+                    &TranscriptNotice::ReviewRequestSyncWarning.format(warning),
+                )
+                .await;
+            }
+            if self
+                .sessions
+                .session_handles_or_err(&session_id)
+                .ok()
+                .and_then(|handles| handles.status.lock().ok().map(|status| *status))
+                == Some(Status::Merged)
+            {
+                deferred_session_ids.push(session_id);
+            }
+        }
+
+        deferred_session_ids
+    }
+
+    /// Marks one externally merged session `Done` after manual target sync,
+    /// persists child restack intent, and returns any finalization warning.
     ///
     /// The session is still moved to `Done` when cleanup fails because the
     /// merge already happened upstream, but the caller should surface the
     /// warning to the user.
-    async fn complete_externally_merged_session(
+    pub(super) async fn complete_externally_merged_session(
         &self,
         session_id: &str,
         session_head_hash: Option<String>,
@@ -1784,26 +1911,7 @@ impl App {
         let Ok(handles) = self.sessions.session_handles_or_err(session_id) else {
             return None;
         };
-        let should_schedule_cleanup = handles
-            .status
-            .lock()
-            .is_ok_and(|status| *status != Status::Done);
-
         let mut warnings = Vec::new();
-
-        let commit_hash_persistence_error = if let Some(session_head_hash) = &session_head_hash {
-            self.services
-                .db()
-                .sessions()
-                .update_session_merged_commit_hash(session_id, Some(session_head_hash.clone()))
-                .await
-                .err()
-        } else {
-            None
-        };
-        if let Some(error) = commit_hash_persistence_error {
-            warnings.push(format!("Merged commit hash persistence failed: {error}"));
-        }
 
         let folder = session.folder.clone();
         let base_branch = session.base_branch.clone();
@@ -1825,21 +1933,19 @@ impl App {
                 );
             }
             Err(error) => {
-                warnings.push(format!("Stacked child restack failed: {error}"));
+                return Some(format!("Stacked child restack intent failed: {error}"));
             }
         }
 
         let status_transition =
             StatusTransition::from_services(&self.services, handles, session_id);
         let status_applied = status_transition.apply(Status::Done).await;
-        if should_schedule_cleanup && status_applied {
-            self.spawn_externally_merged_session_cleanup(
-                session_id,
-                folder,
-                source_branch,
-                handles,
-            );
+        if !status_applied {
+            warnings.push("Could not archive the merged session".to_string());
+
+            return Some(warnings.join("\n"));
         }
+        self.spawn_externally_merged_session_cleanup(session_id, folder, source_branch, handles);
 
         (!warnings.is_empty()).then(|| warnings.join("\n"))
     }
@@ -2026,13 +2132,28 @@ impl App {
         let conflict_summary =
             Self::sync_conflict_summary(&sync_main_outcome.resolved_conflict_files);
 
-        sync_message::format_sync_success_message(
+        let mut message = sync_message::format_sync_success_message(
             &pulled_summary,
             &pulled_titles,
             &pushed_summary,
             &pushed_titles,
             &conflict_summary,
-        )
+        );
+        if !sync_main_outcome.deferred_merged_session_ids.is_empty() {
+            let session_ids = sync_main_outcome
+                .deferred_merged_session_ids
+                .iter()
+                .map(|session_id| format!("- `{session_id}`"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            message.push_str(
+                "\n\n## Merged sessions still waiting\nThese sessions could not be archived or \
+                 restacked. Review their workflow warning, then retry the sync:\n",
+            );
+            message.push_str(&session_ids);
+        }
+
+        message
     }
 
     /// Returns pulled commit titles formatted as an indented list.

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -1101,6 +1101,14 @@ impl App {
     /// submission. Returns `true` when the reply command was enqueued on the
     /// session worker.
     pub async fn reply(&mut self, session_id: &str, prompt: impl Into<TurnPrompt>) -> bool {
+        if self
+            .sessions
+            .session_or_err(session_id)
+            .is_ok_and(|session| session.status.is_read_only())
+        {
+            return false;
+        }
+
         self.clear_review_output(session_id);
         let _ = self
             .services
@@ -1337,6 +1345,17 @@ impl App {
 
             self.set_follow_up_task_launched_session_id(session_id, position, None)
                 .await?;
+        }
+
+        if self
+            .sessions
+            .session_or_err(session_id)?
+            .status
+            .is_read_only()
+        {
+            return Err(AppError::Workflow(
+                "Merged sessions cannot launch new follow-up tasks".to_string(),
+            ));
         }
 
         let sibling_session_id = self.create_session().await?;

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -1814,7 +1814,7 @@ async fn push_session_branch_succeeds_without_review_request_link_for_unsupporte
 }
 
 #[tokio::test]
-async fn apply_branch_publish_action_update_sets_inline_success() {
+async fn apply_app_events_branch_publish_action_sets_inline_success() {
     // Arrange
     let session_folder = tempdir().expect("failed to create temp dir");
     let mut app = new_test_app_with_selected_session(
@@ -1826,8 +1826,8 @@ async fn apply_branch_publish_action_update_sets_inline_success() {
     app.mode = AppMode::List;
 
     // Act
-    app.apply_branch_publish_action_update(BranchPublishActionUpdate {
-        result: Ok(BranchPublishTaskSuccess::Pushed {
+    app.apply_app_events(AppEvent::BranchPublishActionCompleted {
+        result: Box::new(Ok(BranchPublishTaskSuccess::Pushed {
             branch_name: "wt/session-1".to_string(),
             review_request_creation: Some(crate::app::branch_publish::ReviewRequestCreationInfo {
                 forge_kind: forge::ForgeKind::GitHub,
@@ -1837,7 +1837,7 @@ async fn apply_branch_publish_action_update_sets_inline_success() {
                 ),
             }),
             upstream_reference: "origin/wt/session-1".to_string(),
-        }),
+        })),
         session_id: "session-1".into(),
     })
     .await;
@@ -2219,6 +2219,8 @@ fn sync_main_popup_mode_success_message_tracks_project_and_branch() {
         project_name: "agentty".to_string(),
     };
     let sync_main_outcome = SyncMainOutcome {
+        default_branch: "develop".to_string(),
+        deferred_merged_session_ids: Vec::new(),
         pulled_commit_titles: vec![
             "Add audit log indexing".to_string(),
             "Fix merge conflict prompt wording".to_string(),
@@ -2260,6 +2262,38 @@ fn sync_main_popup_mode_success_message_tracks_project_and_branch() {
         assert_eq!(message, expected_message);
         assert_eq!(project_name.as_deref(), Some("agentty"));
     }
+}
+
+#[test]
+fn sync_main_popup_mode_lists_merged_sessions_that_still_need_attention() {
+    // Arrange
+    let sync_popup_context = SyncPopupContext {
+        default_branch: "main".to_string(),
+        project_name: "agentty".to_string(),
+    };
+    let sync_main_outcome = SyncMainOutcome {
+        default_branch: "main".to_string(),
+        deferred_merged_session_ids: vec!["session-a".into(), "session-b".into()],
+        pulled_commit_titles: Vec::new(),
+        pulled_commits: Some(1),
+        pushed_commit_titles: Vec::new(),
+        pushed_commits: Some(0),
+        resolved_conflict_files: Vec::new(),
+    };
+
+    // Act
+    let mode = App::sync_main_popup_mode(Ok(sync_main_outcome), &sync_popup_context);
+
+    // Assert
+    assert!(matches!(
+        mode,
+        AppMode::SyncBlockedPopup { message, title, .. }
+            if title == "Sync complete"
+                && message.contains("Merged sessions still waiting")
+                && message.contains("`session-a`")
+                && message.contains("`session-b`")
+                && message.contains("retry the sync")
+    ));
 }
 
 #[tokio::test]
@@ -2747,6 +2781,8 @@ fn app_event_batch_collect_event_marks_successful_sync_for_git_status_refresh() 
     // Act
     event_batch.collect_event(AppEvent::SyncMainCompleted {
         result: Ok(SyncMainOutcome {
+            default_branch: "main".to_string(),
+            deferred_merged_session_ids: Vec::new(),
             pulled_commit_titles: vec!["Upstream fix".to_string()],
             pulled_commits: Some(1),
             pushed_commit_titles: vec!["Local tweak".to_string()],
@@ -2760,10 +2796,11 @@ fn app_event_batch_collect_event_marks_successful_sync_for_git_status_refresh() 
     assert!(matches!(
         event_batch.sync_main_result,
         Some(Ok(SyncMainOutcome {
-            pulled_commits: Some(1),
-            pushed_commits: Some(2),
-            ..
-        }))
+                default_branch,
+                pulled_commits: Some(1),
+                pushed_commits: Some(2),
+                ..
+        })) if default_branch == "main"
     ));
 }
 
@@ -3115,6 +3152,8 @@ async fn apply_app_events_review_request_status_survives_same_batch_sync_refresh
         .event_sender()
         .send(AppEvent::SyncMainCompleted {
             result: Ok(SyncMainOutcome {
+                default_branch: "main".to_string(),
+                deferred_merged_session_ids: Vec::new(),
                 pulled_commit_titles: Vec::new(),
                 pulled_commits: Some(0),
                 pushed_commit_titles: Vec::new(),
@@ -4019,6 +4058,42 @@ async fn launch_or_open_selected_follow_up_task_opens_existing_sibling_session()
             ..
         } if session_id == "session-2"
     ));
+}
+
+#[tokio::test]
+async fn merged_session_rejects_unlaunched_follow_up_task() {
+    // Arrange
+    let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    let mut source_session =
+        crate::test_support::session_fixture_with_folder(PathBuf::from("/tmp/source-session"));
+    source_session.status = Status::Merged;
+    source_session.follow_up_tasks = vec![SessionFollowUpTask {
+        id: 1,
+        launched_session_id: None,
+        position: 0,
+        text: "Must wait for local merge integration.".to_string(),
+    }];
+    app.sessions.push_session(source_session);
+
+    // Act
+    let action = app.selected_follow_up_task_action("session-1");
+    let reply_enqueued = app.reply("session-1", "must stay read-only").await;
+    let result = app
+        .launch_or_open_selected_follow_up_task("session-1")
+        .await;
+
+    // Assert
+    assert_eq!(action, None);
+    assert!(!reply_enqueued);
+    assert!(matches!(
+        result,
+        Err(AppError::Workflow(message))
+            if message == "Merged sessions cannot launch new follow-up tasks"
+    ));
+    assert_eq!(app.sessions.sessions().len(), 1);
 }
 
 #[tokio::test]
@@ -5300,6 +5375,262 @@ fn test_review_request_summary(
     }
 }
 
+async fn insert_review_session_with_data_dir(app: &App, session_id: &str) {
+    app.services
+        .db()
+        .sessions()
+        .insert_session(
+            session_id,
+            "gemini-3-flash-preview",
+            "main",
+            &Status::Review.to_string(),
+            app.active_project_id(),
+        )
+        .await
+        .expect("failed to insert session");
+    let session_folder_name = session_id.chars().take(8).collect::<String>();
+    fs::create_dir_all(
+        app.services
+            .base_path()
+            .join(session_folder_name)
+            .join(SESSION_DATA_DIR),
+    )
+    .expect("failed to create session data dir");
+}
+
+async fn new_test_app_with_database_pool() -> (App, sqlx::SqlitePool, tempfile::TempDir) {
+    let base_dir = tempdir().expect("failed to create temp dir");
+    let base_path = base_dir.path().to_path_buf();
+    let (database, pool) = AppRepositories::in_memory_with_pool().await;
+    let clients = crate::test_support::test_app_clients_with_mock_app_server()
+        .with_tmux_client(Arc::new(MockTmuxClient::new()));
+    let app = App::new_with_clients(base_path.clone(), base_path, None, database, clients)
+        .await
+        .expect("failed to build app");
+
+    (app, pool, base_dir)
+}
+
+fn merged_review_request_status_update(
+    session_id: &str,
+    display_id: &str,
+    session_head_hash: &str,
+) -> ReviewRequestStatusUpdate {
+    ReviewRequestStatusUpdate {
+        generation: 0,
+        result: Ok(SyncReviewRequestTaskResult {
+            outcome: session::SyncReviewRequestOutcome::Merged {
+                display_id: display_id.to_string(),
+                session_head_hash: Some(session_head_hash.to_string()),
+            },
+            summary: Some(test_review_request_summary(
+                display_id,
+                ReviewRequestState::Merged,
+            )),
+        }),
+        session_id: session_id.into(),
+    }
+}
+
+fn successful_manual_sync(default_branch: &str, pulled_commits: u32) -> AppEvent {
+    AppEvent::SyncMainCompleted {
+        result: Ok(SyncMainOutcome {
+            default_branch: default_branch.to_string(),
+            deferred_merged_session_ids: Vec::new(),
+            pulled_commit_titles: Vec::new(),
+            pulled_commits: Some(pulled_commits),
+            pushed_commit_titles: Vec::new(),
+            pushed_commits: Some(0),
+            resolved_conflict_files: Vec::new(),
+        }),
+    }
+}
+
+#[tokio::test]
+async fn externally_merged_helpers_ignore_missing_session_runtime_state() {
+    // Arrange
+    let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    app.sessions.push_session(
+        crate::test_support::SessionFixtureBuilder::new()
+            .id("snapshot-only")
+            .status(Status::Merged)
+            .build(),
+    );
+
+    // Act
+    let record_result = app
+        .record_externally_merged_session("snapshot-only", None)
+        .await;
+    let missing_session_result = app
+        .complete_externally_merged_session("missing", None)
+        .await;
+    let missing_handles_result = app
+        .complete_externally_merged_session("snapshot-only", None)
+        .await;
+
+    // Assert
+    assert_eq!(record_result, None);
+    assert_eq!(missing_session_result, None);
+    assert_eq!(missing_handles_result, None);
+}
+
+#[tokio::test]
+async fn record_externally_merged_session_reports_persistence_failures() {
+    // Arrange
+    let (mut app, pool, _base_dir) = new_test_app_with_database_pool().await;
+    let session_id = "session-persist-failure";
+    insert_review_session_with_data_dir(&app, session_id).await;
+    app.refresh_sessions_now().await;
+    sqlx::query(
+        "CREATE TRIGGER fail_merged_hash BEFORE UPDATE OF merged_commit_hash ON session BEGIN \
+         SELECT RAISE(FAIL, 'merged hash failed'); END",
+    )
+    .execute(&pool)
+    .await
+    .expect("failed to install merged hash trigger");
+    let handles = app
+        .sessions
+        .session_handles_or_err(session_id)
+        .expect("expected session handles");
+    *handles.status.lock().expect("status lock poisoned") = Status::Done;
+
+    // Act
+    let warning = app
+        .record_externally_merged_session(session_id, Some("abc1234".to_string()))
+        .await
+        .expect("persistence failures should produce a warning");
+
+    // Assert
+    assert!(warning.contains("Merged commit hash persistence failed"));
+    assert!(warning.contains("Could not mark the merged session read-only"));
+    assert_eq!(
+        app.sessions
+            .session_or_err(session_id)
+            .expect("expected session")
+            .status,
+        Status::Review
+    );
+}
+
+#[tokio::test]
+async fn manual_sync_defers_merged_session_when_commit_hash_cannot_load() {
+    // Arrange
+    let (mut app, pool, _base_dir) = new_test_app_with_database_pool().await;
+    let session_id = "session-load-failure";
+    insert_review_session_with_data_dir(&app, session_id).await;
+    app.refresh_sessions_now().await;
+    let update = merged_review_request_status_update(session_id, "#12", "abc1234");
+    app.apply_review_request_status_update(update).await;
+    app.process_pending_app_events().await;
+    pool.close().await;
+
+    // Act
+    app.apply_app_events(successful_manual_sync("main", 1))
+        .await;
+
+    // Assert
+    assert_eq!(
+        app.sessions
+            .session_or_err(session_id)
+            .expect("expected session")
+            .status,
+        Status::Merged
+    );
+    assert!(matches!(
+        app.mode,
+        AppMode::SyncBlockedPopup { ref message, .. }
+            if message.contains("Merged sessions still waiting")
+                && message.contains(session_id)
+    ));
+}
+
+#[tokio::test]
+async fn manual_sync_surfaces_restack_failure_and_keeps_parent_merged() {
+    // Arrange
+    let (mut app, pool, _base_dir) = new_test_app_with_database_pool().await;
+    let project_id = app.active_project_id();
+    let session_id = "session-restack-failure";
+    insert_review_session_with_data_dir(&app, session_id).await;
+    app.services
+        .db()
+        .sessions()
+        .insert_stacked_draft_session(
+            "child-session",
+            "gemini-3-flash-preview",
+            "wt/parent",
+            &Status::Draft.to_string(),
+            session_id,
+            project_id,
+        )
+        .await
+        .expect("failed to insert child session");
+    app.refresh_sessions_now().await;
+    let update = merged_review_request_status_update(session_id, "#13", "abc1234");
+    app.apply_review_request_status_update(update).await;
+    app.process_pending_app_events().await;
+    sqlx::query(
+        "CREATE TRIGGER fail_restack BEFORE UPDATE OF parent_session_id ON session BEGIN SELECT \
+         RAISE(FAIL, 'restack failed'); END",
+    )
+    .execute(&pool)
+    .await
+    .expect("failed to install restack trigger");
+
+    // Act
+    app.apply_app_events(successful_manual_sync("main", 1))
+        .await;
+
+    // Assert
+    assert_eq!(
+        app.sessions
+            .session_or_err(session_id)
+            .expect("expected parent session")
+            .status,
+        Status::Merged
+    );
+    assert!(matches!(
+        app.mode,
+        AppMode::SyncBlockedPopup { ref message, .. }
+            if message.contains("Merged sessions still waiting")
+                && message.contains(session_id)
+    ));
+}
+
+#[tokio::test]
+async fn complete_externally_merged_session_reports_invalid_done_transition() {
+    // Arrange
+    let (mut app, _pool, _base_dir) = new_test_app_with_database_pool().await;
+    let session_id = "session-done-failure";
+    insert_review_session_with_data_dir(&app, session_id).await;
+    app.refresh_sessions_now().await;
+    let handles = app
+        .sessions
+        .session_handles_or_err(session_id)
+        .expect("expected session handles");
+    *handles.status.lock().expect("status lock poisoned") = Status::Draft;
+
+    // Act
+    let warning = app
+        .complete_externally_merged_session(session_id, Some("abc1234".to_string()))
+        .await
+        .expect("invalid transition should produce a warning");
+
+    // Assert
+    assert_eq!(warning, "Could not archive the merged session");
+    assert_eq!(
+        *app.sessions
+            .session_handles_or_err(session_id)
+            .expect("expected session handles")
+            .status
+            .lock()
+            .expect("status lock poisoned"),
+        Status::Draft
+    );
+}
+
 #[tokio::test]
 async fn test_apply_review_request_status_update_ignores_background_errors() {
     // Arrange
@@ -5516,33 +5847,14 @@ async fn test_apply_review_request_status_update_closed_cancels_stacked_child() 
 }
 
 #[tokio::test]
-async fn test_apply_review_request_status_update_merged_schedules_cleanup_once() {
+async fn merged_review_waits_for_successful_manual_sync_before_cleanup() {
     // Arrange
     let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
         Arc::new(MockTmuxClient::new()),
     )
     .await;
-    let project_id = app.active_project_id();
     let session_id = "session-merged";
-    app.services
-        .db()
-        .sessions()
-        .insert_session(
-            session_id,
-            "gemini-3-flash-preview",
-            "main",
-            &Status::Review.to_string(),
-            project_id,
-        )
-        .await
-        .expect("failed to insert session");
-    let session_folder_name = session_id.chars().take(8).collect::<String>();
-    let session_data_dir = app
-        .services
-        .base_path()
-        .join(session_folder_name)
-        .join(SESSION_DATA_DIR);
-    fs::create_dir_all(session_data_dir).expect("failed to create session data dir");
+    insert_review_session_with_data_dir(&app, session_id).await;
     app.refresh_sessions_now().await;
     let (cleanup_started_tx, mut cleanup_started_rx) = tokio::sync::mpsc::unbounded_channel();
     let cleanup_release = Arc::new(tokio::sync::Notify::new());
@@ -5572,37 +5884,37 @@ async fn test_apply_review_request_status_update_merged_schedules_cleanup_once()
         .returning(|_, _| Box::pin(async { Ok(()) }));
     install_mock_git_client(&mut app, mock_git_client);
 
-    let merged_update = || ReviewRequestStatusUpdate {
-        generation: 0,
-        result: Ok(SyncReviewRequestTaskResult {
-            outcome: session::SyncReviewRequestOutcome::Merged {
-                display_id: "#9".to_string(),
-                session_head_hash: Some("abc1234".to_string()),
-            },
-            summary: Some(test_review_request_summary(
-                "#9",
-                ReviewRequestState::Merged,
-            )),
-        }),
-        session_id: session_id.into(),
-    };
+    let merged_update = merged_review_request_status_update(session_id, "#9", "abc1234");
 
     // Act
     tokio::time::timeout(
         Duration::from_millis(250),
-        app.apply_review_request_status_update(merged_update()),
+        app.apply_review_request_status_update(merged_update),
     )
     .await
-    .expect("foreground status update should not wait for worktree cleanup");
+    .expect("foreground status update should not start worktree cleanup");
+    app.process_pending_app_events().await;
+    let status_before_sync = app
+        .sessions
+        .session_or_err(session_id)
+        .expect("expected session to remain loaded")
+        .status;
+    let cleanup_started_before_sync =
+        tokio::time::timeout(Duration::from_millis(50), cleanup_started_rx.recv()).await;
+    app.apply_app_events(successful_manual_sync("main", 1))
+        .await;
     app.process_pending_app_events().await;
     tokio::time::timeout(Duration::from_secs(1), cleanup_started_rx.recv())
         .await
-        .expect("cleanup task should start")
+        .expect("cleanup task should start after manual sync")
         .expect("cleanup task should report startup");
-    app.apply_review_request_status_update(merged_update())
-        .await;
 
     // Assert
+    assert_eq!(status_before_sync, Status::Merged);
+    assert!(
+        cleanup_started_before_sync.is_err(),
+        "remote merge detection must not start cleanup"
+    );
     let session = app
         .sessions
         .session_or_err(session_id)
@@ -5617,16 +5929,41 @@ async fn test_apply_review_request_status_update_merged_schedules_cleanup_once()
         .expect("failed to load merged commit hash")
         .expect("expected persisted merged commit hash");
     assert_eq!(merged_commit_hash, "abc1234");
-    assert!(
-        tokio::time::timeout(Duration::from_millis(50), cleanup_started_rx.recv())
-            .await
-            .is_err(),
-        "duplicate merged updates should not schedule another cleanup task"
-    );
 
     // Cleanup
     cleanup_release.notify_one();
     app.services.wait_for_cleanup_tasks().await;
+}
+
+#[tokio::test]
+async fn failed_or_unrelated_manual_sync_keeps_session_merged() {
+    // Arrange
+    let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    let session_id = "session-waiting";
+    insert_review_session_with_data_dir(&app, session_id).await;
+    app.refresh_sessions_now().await;
+    let update = merged_review_request_status_update(session_id, "#11", "def5678");
+    app.apply_review_request_status_update(update).await;
+    app.process_pending_app_events().await;
+
+    // Act
+    app.apply_app_events(successful_manual_sync("develop", 0))
+        .await;
+    app.apply_app_events(AppEvent::SyncMainCompleted {
+        result: Err(SyncSessionStartError::Other("sync failed".to_string())),
+    })
+    .await;
+    app.process_pending_app_events().await;
+
+    // Assert
+    let session = app
+        .sessions
+        .session_or_err(session_id)
+        .expect("expected merged session to remain loaded");
+    assert_eq!(session.status, Status::Merged);
 }
 
 #[tokio::test]
@@ -5639,18 +5976,7 @@ async fn test_apply_review_request_status_update_merged_restacks_stacked_child()
     let project_id = app.active_project_id();
     let session_id = "session-merged";
     let child_session_id = "session-child";
-    app.services
-        .db()
-        .sessions()
-        .insert_session(
-            session_id,
-            "gemini-3-flash-preview",
-            "main",
-            &Status::Review.to_string(),
-            project_id,
-        )
-        .await
-        .expect("failed to insert parent session");
+    insert_review_session_with_data_dir(&app, session_id).await;
     app.services
         .db()
         .sessions()
@@ -5670,34 +5996,41 @@ async fn test_apply_review_request_status_update_merged_restacks_stacked_child()
         .update_session_prompt(child_session_id, "Ready to start")
         .await
         .expect("failed to stage child prompt");
-    let session_folder_name = session_id.chars().take(8).collect::<String>();
-    let session_data_dir = app
-        .services
-        .base_path()
-        .join(session_folder_name)
-        .join(SESSION_DATA_DIR);
-    fs::create_dir_all(session_data_dir).expect("failed to create session data dir");
     app.refresh_sessions_now().await;
+    let mut mock_git_client = ag_git::MockGitClient::new();
+    mock_git_client
+        .expect_main_repo_root()
+        .times(1)
+        .returning(|_| {
+            Box::pin(async {
+                Err(ag_git::GitError::OutputParse(
+                    "test repository root unavailable".to_string(),
+                ))
+            })
+        });
+    mock_git_client
+        .expect_remove_worktree()
+        .times(1)
+        .returning(|_| Box::pin(async { Ok(()) }));
+    install_mock_git_client(&mut app, mock_git_client);
 
-    let task_result = SyncReviewRequestTaskResult {
-        outcome: session::SyncReviewRequestOutcome::Merged {
-            display_id: "#9".to_string(),
-            session_head_hash: Some("abc1234".to_string()),
-        },
-        summary: Some(test_review_request_summary(
-            "#9",
-            ReviewRequestState::Merged,
-        )),
-    };
-
-    let update = ReviewRequestStatusUpdate {
-        generation: 0,
-        result: Ok(task_result),
-        session_id: session_id.into(),
-    };
+    let update = merged_review_request_status_update(session_id, "#9", "abc1234");
 
     // Act
     app.apply_review_request_status_update(update).await;
+    app.process_pending_app_events().await;
+    let child_before_sync = app
+        .sessions
+        .session_or_err(child_session_id)
+        .expect("expected child before manual sync");
+    let parent_status_before_sync = app
+        .sessions
+        .session_or_err(session_id)
+        .expect("expected parent before manual sync")
+        .status;
+    let child_parent_before_sync = child_before_sync.parent_session_id.clone();
+    app.apply_app_events(successful_manual_sync("main", 1))
+        .await;
     app.process_pending_app_events().await;
     app.refresh_sessions_now().await;
     app.sessions
@@ -5705,6 +6038,8 @@ async fn test_apply_review_request_status_update_merged_restacks_stacked_child()
         .await;
 
     // Assert
+    assert_eq!(parent_status_before_sync, Status::Merged);
+    assert_eq!(child_parent_before_sync.as_deref(), Some(session_id));
     let child_session = app
         .sessions
         .session_or_err(child_session_id)
@@ -5726,4 +6061,5 @@ async fn test_apply_review_request_status_update_merged_restacks_stacked_child()
         .expect("missing persisted child session");
     assert_eq!(db_child_session.parent_session_id, None);
     assert_eq!(db_child_session.base_branch, "main");
+    app.services.wait_for_cleanup_tasks().await;
 }

--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -863,9 +863,12 @@ impl SessionManager {
             .iter()
             .find(|session| session.id == session_id)?;
 
-        session
-            .follow_up_task(position)
-            .map(crate::domain::session::SessionFollowUpTask::action)
+        let task = session.follow_up_task(position)?;
+        if session.status.is_read_only() && task.launched_session_id.is_none() {
+            return None;
+        }
+
+        Some(task.action())
     }
 
     /// Returns whether one session has more than one follow-up task.

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -1206,6 +1206,9 @@ impl SessionManager {
         let Ok(session) = self.session_or_err(session_id) else {
             return false;
         };
+        if session.status.is_read_only() {
+            return false;
+        }
         let session_agent = session.agent;
 
         self.reply_impl(services, session_id, prompt, Vec::new(), session_agent)
@@ -1227,6 +1230,9 @@ impl SessionManager {
         let Ok(session) = self.session_or_err(session_id) else {
             return false;
         };
+        if session.status.is_read_only() {
+            return false;
+        }
         let session_agent = session.agent;
 
         self.reply_impl(
@@ -1271,6 +1277,12 @@ impl SessionManager {
         if prompt.is_empty() {
             return Err(SessionError::Workflow(
                 "Cannot queue an empty chat message".to_string(),
+            ));
+        }
+
+        if self.session_or_err(session_id)?.status.is_read_only() {
+            return Err(SessionError::Workflow(
+                "Merged sessions cannot queue chat messages".to_string(),
             ));
         }
 
@@ -3409,6 +3421,43 @@ mod tests {
             "enqueue_message must not emit additional events (especially not RefreshSessions) so \
              the reducer skips the full DB-backed reload"
         );
+    }
+
+    #[tokio::test]
+    async fn merged_session_rejects_chat_submission_entry_points() {
+        // Arrange
+        let session = test_session("Prompt", Status::Merged, Some("Title"), "");
+        let database = database_with_session(&session).await;
+        let mut session_manager = session_manager_with_one_session(session);
+        let (services, mut event_rx) = test_services_with_event_receiver(
+            &database,
+            Arc::new(git::MockGitClient::new()),
+            Arc::new(forge::MockReviewRequestClient::new()),
+        );
+
+        // Act
+        let queue_result = session_manager.enqueue_message(&services, "session-id", "queued reply");
+        let reply_enqueued = session_manager
+            .reply(&services, "session-id", "reply")
+            .await;
+        let review_reply_enqueued = session_manager
+            .reply_to_review_comments(
+                &services,
+                "session-id",
+                "review reply",
+                vec!["thread-42".to_string()],
+            )
+            .await;
+
+        // Assert
+        assert!(matches!(
+            queue_result,
+            Err(SessionError::Workflow(message))
+                if message == "Merged sessions cannot queue chat messages"
+        ));
+        assert!(!reply_enqueued);
+        assert!(!review_reply_enqueued);
+        assert!(event_rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -481,7 +481,10 @@ fn should_skip_missing_folder_session(
         return false;
     }
 
-    if matches!(persisted_status, Status::Done | Status::Canceled) {
+    if matches!(
+        persisted_status,
+        Status::Merged | Status::Done | Status::Canceled
+    ) {
         return false;
     }
 
@@ -491,18 +494,21 @@ fn should_skip_missing_folder_session(
 
     !matches!(
         live_handle_status,
-        Some(Status::Merging | Status::Done | Status::Canceled)
+        Some(Status::Merging | Status::Merged | Status::Done | Status::Canceled)
     )
 }
 
 /// Merges one loaded status with the existing live-handle status.
 ///
 /// Existing handle status is kept for active transitions to prevent stale DB
-/// snapshots from clobbering in-memory updates. Persisted terminal statuses
-/// (`Done`, `Canceled`) take precedence so explicit DB transitions still appear
-/// after refresh.
+/// snapshots from clobbering in-memory updates. Persisted read-only and
+/// terminal statuses (`Merged`, `Done`, `Canceled`) take precedence so remote
+/// merge truth and explicit terminal transitions still appear after refresh.
 fn merge_loaded_session_status(status_from_db: Status, status_from_handle: Status) -> Status {
-    if matches!(status_from_db, Status::Done | Status::Canceled) {
+    if matches!(
+        status_from_db,
+        Status::Merged | Status::Done | Status::Canceled
+    ) {
         return status_from_db;
     }
 
@@ -1147,17 +1153,19 @@ mod tests {
     }
 
     #[test]
-    /// Verifies terminal DB statuses override stale in-memory handle statuses.
-    fn merge_loaded_session_status_prefers_terminal_status_from_db() {
+    /// Verifies read-only and terminal DB statuses override stale in-memory
+    /// handle statuses.
+    fn merge_loaded_session_status_prefers_read_only_and_terminal_status_from_db() {
         // Arrange
-        let status_from_db = Status::Done;
         let status_from_handle = Status::Draft;
 
         // Act
-        let merged_status = merge_loaded_session_status(status_from_db, status_from_handle);
+        let merged_status = merge_loaded_session_status(Status::Merged, status_from_handle);
+        let done_status = merge_loaded_session_status(Status::Done, status_from_handle);
 
         // Assert
-        assert_eq!(merged_status, Status::Done);
+        assert_eq!(merged_status, Status::Merged);
+        assert_eq!(done_status, Status::Done);
     }
 
     #[test]
@@ -1216,6 +1224,21 @@ mod tests {
 
         // Assert
         assert!(!should_skip);
+    }
+
+    #[test]
+    /// Verifies missing-folder rows stay visible when either persistence or
+    /// live state has already recorded a remote merge.
+    fn should_skip_missing_folder_session_keeps_merged_session() {
+        // Arrange, Act
+        let persisted_merged_should_skip =
+            should_skip_missing_folder_session(false, false, Status::Merged, Some(Status::Review));
+        let live_merged_should_skip =
+            should_skip_missing_folder_session(false, false, Status::Review, Some(Status::Merged));
+
+        // Assert
+        assert!(!persisted_merged_should_skip);
+        assert!(!live_merged_should_skip);
     }
 
     #[test]

--- a/crates/agentty/src/app/session/workflow/merge.rs
+++ b/crates/agentty/src/app/session/workflow/merge.rs
@@ -554,6 +554,10 @@ pub(crate) enum SyncSessionStartError {
 /// Summary of one completed main-branch sync run.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct SyncMainOutcome {
+    /// Local branch updated by the completed manual sync.
+    pub(crate) default_branch: String,
+    /// Merged sessions that could not be archived after the branch update.
+    pub(crate) deferred_merged_session_ids: Vec<SessionId>,
     /// Commit titles discovered upstream and pulled during sync.
     pub(crate) pulled_commit_titles: Vec<String>,
     /// Number of commits rebased from upstream into the local branch.
@@ -1697,6 +1701,8 @@ impl SessionManager {
         );
 
         Ok(SyncMainOutcome {
+            default_branch,
+            deferred_merged_session_ids: Vec::new(),
             pulled_commit_titles,
             pulled_commits,
             pushed_commit_titles,
@@ -3356,6 +3362,8 @@ mod tests {
     /// Returns the expected result for the successful assisted sync fixture.
     fn successful_sync_conflict_outcome() -> SyncMainOutcome {
         SyncMainOutcome {
+            default_branch: "main".to_string(),
+            deferred_merged_session_ids: Vec::new(),
             pulled_commit_titles: vec![
                 "Update changelog format".to_string(),
                 "Fix sync popup copy".to_string(),

--- a/crates/agentty/src/app/session/workflow/task.rs
+++ b/crates/agentty/src/app/session/workflow/task.rs
@@ -1061,7 +1061,12 @@ impl SessionTaskService {
     fn status_requires_full_refresh(status: Status) -> bool {
         matches!(
             status,
-            Status::InProgress | Status::Review | Status::Merging | Status::Done | Status::Canceled
+            Status::InProgress
+                | Status::Review
+                | Status::Merging
+                | Status::Merged
+                | Status::Done
+                | Status::Canceled
         )
     }
 
@@ -1445,6 +1450,7 @@ mod tests {
             Status::InProgress,
             Status::Review,
             Status::Merging,
+            Status::Merged,
             Status::Done,
             Status::Canceled,
         ];

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -170,6 +170,9 @@ pub enum Status {
     Rebasing,
     /// The session branch is being merged into its target branch.
     Merging,
+    /// The linked review request merged remotely and waits for a manual sync
+    /// of its local target branch before archival.
+    Merged,
     /// The session completed successfully.
     Done,
     /// The session was canceled before completion.
@@ -178,7 +181,7 @@ pub enum Status {
 
 impl Status {
     /// Ordered list of all session statuses used for UI sizing and iteration.
-    pub const ALL: [Status; 10] = [
+    pub const ALL: [Status; 11] = [
         Status::Draft,
         Status::InProgress,
         Status::Review,
@@ -187,6 +190,7 @@ impl Status {
         Status::Queued,
         Status::Rebasing,
         Status::Merging,
+        Status::Merged,
         Status::Done,
         Status::Canceled,
     ];
@@ -199,6 +203,11 @@ impl Status {
     /// Returns whether this status can seed a follow-on continuation session.
     pub fn allows_terminal_continuation(self) -> bool {
         matches!(self, Status::Done)
+    }
+
+    /// Returns whether this lifecycle state permits only local inspection.
+    pub fn is_read_only(self) -> bool {
+        matches!(self, Status::Merged)
     }
 
     /// Returns whether this status is stable enough for a stacked draft child
@@ -217,6 +226,7 @@ impl Status {
                 | Status::Queued
                 | Status::Rebasing
                 | Status::Merging
+                | Status::Merged
         )
     }
 
@@ -230,6 +240,9 @@ impl Status {
         if self == next {
             return true;
         }
+        if self == Status::Merged {
+            return next == Status::Done;
+        }
 
         matches!(
             (self, next),
@@ -239,6 +252,10 @@ impl Status {
                 | (Status::Review, Status::AgentReview)
                 | (Status::AgentReview, Status::Review)
                 | (
+                    Status::Review | Status::AgentReview,
+                    Status::Merged | Status::Done
+                )
+                | (
                     Status::Review | Status::AgentReview | Status::Question,
                     Status::InProgress
                         | Status::Queued
@@ -246,7 +263,6 @@ impl Status {
                         | Status::Merging
                         | Status::Canceled
                 )
-                | (Status::Review | Status::AgentReview, Status::Done)
                 | (
                     Status::Queued,
                     Status::Merging | Status::Review | Status::AgentReview
@@ -274,6 +290,7 @@ impl fmt::Display for Status {
             Status::Queued => write!(f, "Queued"),
             Status::Rebasing => write!(f, "Rebasing"),
             Status::Merging => write!(f, "Merging"),
+            Status::Merged => write!(f, "Merged"),
             Status::Done => write!(f, "Done"),
             Status::Canceled => write!(f, "Canceled"),
         }
@@ -293,6 +310,7 @@ impl FromStr for Status {
             "Queued" => Ok(Status::Queued),
             "Rebasing" => Ok(Status::Rebasing),
             "Merging" => Ok(Status::Merging),
+            "Merged" => Ok(Status::Merged),
             "Done" => Ok(Status::Done),
             "Canceled" => Ok(Status::Canceled),
             _ => Err(format!("Unknown status: {s}")),
@@ -633,7 +651,10 @@ impl Session {
     pub fn allows_stacked_child_creation(&self) -> bool {
         self.parent_session_id.is_none()
             && !self.is_draft_session()
-            && !matches!(self.status, Status::Done | Status::Canceled)
+            && !matches!(
+                self.status,
+                Status::Merged | Status::Done | Status::Canceled
+            )
     }
 
     /// Returns whether this session can be forked into a new independent
@@ -966,7 +987,7 @@ impl<'a> SessionStack<'a> {
             session.parent_session_id.is_some()
                 && !matches!(
                     session.status,
-                    Status::Draft | Status::Done | Status::Canceled
+                    Status::Draft | Status::Merged | Status::Done | Status::Canceled
                 )
         })
     }
@@ -1101,6 +1122,7 @@ pub(crate) mod tests {
             .status(Status::Review)
             .build();
         let done_session = SessionFixtureBuilder::new().status(Status::Done).build();
+        let merged_session = SessionFixtureBuilder::new().status(Status::Merged).build();
         let canceled_session = SessionFixtureBuilder::new()
             .status(Status::Canceled)
             .build();
@@ -1108,12 +1130,14 @@ pub(crate) mod tests {
         // Act
         let allows_draft_child = draft_session.allows_stacked_child_creation();
         let allows_nested_child = child_session.allows_stacked_child_creation();
+        let allows_merged_child = merged_session.allows_stacked_child_creation();
         let allows_done_child = done_session.allows_stacked_child_creation();
         let allows_canceled_child = canceled_session.allows_stacked_child_creation();
 
         // Assert
         assert!(!allows_draft_child);
         assert!(!allows_nested_child);
+        assert!(!allows_merged_child);
         assert!(!allows_done_child);
         assert!(!allows_canceled_child);
     }
@@ -1607,6 +1631,7 @@ pub(crate) mod tests {
             Status::Queued,
             Status::Rebasing,
             Status::Merging,
+            Status::Merged,
             Status::Done,
             Status::Canceled,
         ];
@@ -1628,6 +1653,29 @@ pub(crate) mod tests {
 
         // Assert
         assert!(can_transition);
+    }
+
+    #[test]
+    fn merged_status_is_read_only_and_only_transitions_to_done() {
+        // Arrange
+        let merged_status = Status::Merged;
+        let review_status = Status::Review;
+
+        // Act
+        let merged_is_read_only = merged_status.is_read_only();
+        let review_is_read_only = review_status.is_read_only();
+        let review_can_merge = review_status.can_transition_to(merged_status);
+        let merged_can_finish = merged_status.can_transition_to(Status::Done);
+        let merged_can_repeat = merged_status.can_transition_to(Status::Merged);
+        let merged_can_reopen = merged_status.can_transition_to(Status::Review);
+
+        // Assert
+        assert!(merged_is_read_only);
+        assert!(!review_is_read_only);
+        assert!(review_can_merge);
+        assert!(merged_can_finish);
+        assert!(merged_can_repeat);
+        assert!(!merged_can_reopen);
     }
 
     #[test]

--- a/crates/agentty/src/domain/session_order.rs
+++ b/crates/agentty/src/domain/session_order.rs
@@ -348,6 +348,7 @@ mod tests {
             crate::test_support::titled_session_fixture("done-1", Status::Done),
             crate::test_support::titled_session_fixture("canceled-1", Status::Canceled),
             crate::test_support::titled_session_fixture("active-2", Status::Draft),
+            crate::test_support::titled_session_fixture("merged-1", Status::Merged),
         ];
 
         // Act
@@ -365,6 +366,7 @@ mod tests {
                 "merge-1".to_string(),
                 "active-1".to_string(),
                 "active-2".to_string(),
+                "merged-1".to_string(),
                 "done-1".to_string(),
                 "canceled-1".to_string(),
             ]
@@ -411,6 +413,7 @@ mod tests {
             crate::test_support::titled_session_fixture("done-1", Status::Done),
             crate::test_support::titled_session_fixture("canceled-1", Status::Canceled),
             crate::test_support::titled_session_fixture("active-2", Status::Draft),
+            crate::test_support::titled_session_fixture("merged-1", Status::Merged),
         ];
 
         // Act
@@ -432,6 +435,7 @@ mod tests {
                 "Active".to_string(),
                 "active-1".to_string(),
                 "active-2".to_string(),
+                "merged-1".to_string(),
                 "Archive".to_string(),
                 "done-1".to_string(),
                 "canceled-1".to_string(),

--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -68,6 +68,9 @@ pub enum ViewSessionState {
     Done,
     /// Session was canceled locally; view mode stays read-only.
     Canceled,
+    /// Review request merged remotely; only read-only evidence and
+    /// navigation actions remain while local target sync is pending.
+    Merged,
     /// Session is currently running; queued replies, queued sync, and stop
     /// remain available while worktree-open and diff shortcuts are hidden.
     InProgress,
@@ -186,6 +189,7 @@ impl ViewActionSet {
             state.session_state,
             ViewSessionState::Review | ViewSessionState::AgentReview
         );
+        let can_show_diff = can_show_review || state.session_state == ViewSessionState::Merged;
 
         Self {
             continue_terminal_session: ViewActionAvailability::from_bool(matches!(
@@ -200,7 +204,7 @@ impl ViewActionSet {
             open_prompt: ViewActionAvailability::from_bool(can_open_prompt),
             open_worktree: ViewActionAvailability::from_bool(can_open_worktree),
             rebase_session: ViewActionAvailability::from_bool(can_rebase_session),
-            show_diff: ViewActionAvailability::from_bool(can_show_review),
+            show_diff: ViewActionAvailability::from_bool(can_show_diff),
             show_review: ViewActionAvailability::from_bool(can_show_review),
             stop_session: ViewActionAvailability::from_bool(
                 state.session_state == ViewSessionState::InProgress,
@@ -223,6 +227,7 @@ pub(crate) fn session_view_state(session: &Session) -> ViewSessionState {
         Status::Draft | Status::Question => ViewSessionState::Interactive,
         Status::Rebasing => ViewSessionState::Rebasing,
         Status::Merging | Status::Queued => ViewSessionState::MergeQueue,
+        Status::Merged => ViewSessionState::Merged,
         Status::Review => ViewSessionState::Review,
         Status::AgentReview => ViewSessionState::AgentReview,
     }
@@ -387,7 +392,12 @@ pub(crate) fn view_actions(state: ViewHelpState) -> Vec<HelpAction> {
 
     append_view_stop_action(&mut actions, action_set);
 
-    if state.can_start_staged_session.is_enabled() {
+    if state.can_start_staged_session.is_enabled()
+        && matches!(
+            state.session_state,
+            ViewSessionState::NewSession | ViewSessionState::StackedDraft
+        )
+    {
         actions.push(HelpAction::new("start", "s", "Start staged session"));
     }
 
@@ -522,7 +532,9 @@ fn append_view_review_actions(
         actions.push(HelpAction::new("fork", "F", "Fork session"));
     }
 
-    if let Some(publish_pull_request_action) = state.publish_pull_request_action {
+    if state.session_state != ViewSessionState::Merged
+        && let Some(publish_pull_request_action) = state.publish_pull_request_action
+    {
         actions.push(publish_pull_request_help_action(
             publish_pull_request_action,
         ));
@@ -925,6 +937,34 @@ mod tests {
 
         // Assert
         assert!(!actions.iter().any(|action| action.key == "o"));
+    }
+
+    #[test]
+    fn merged_view_actions_keep_diff_and_hide_mutating_actions() {
+        // Arrange
+        let state = ViewHelpState {
+            can_fork_session: ViewActionAvailability::Enabled,
+            can_merge_session_branch: ViewActionAvailability::Enabled,
+            can_mutate_session_branch: ViewActionAvailability::Enabled,
+            can_open_worktree: ViewActionAvailability::Enabled,
+            can_rebase_session_branch: ViewActionAvailability::Enabled,
+            reply_to_session: ViewActionAvailability::Enabled,
+            can_start_staged_session: ViewActionAvailability::Enabled,
+            publish_pull_request_action: Some(PublishBranchAction::PublishPullRequest),
+            session_state: ViewSessionState::Merged,
+        };
+
+        // Act
+        let actions = view_actions(state);
+        let session = SessionFixtureBuilder::new().status(Status::Merged).build();
+        let session_state = session_view_state(&session);
+
+        // Assert
+        assert_eq!(session_state, ViewSessionState::Merged);
+        assert!(actions.iter().any(|action| action.key == "d"));
+        for key in ["Enter", "/", "o", "p", "f", "F", "m", "r", "s", "c"] {
+            assert!(!actions.iter().any(|action| action.key == key));
+        }
     }
 
     #[test]

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -649,6 +649,7 @@ fn is_view_worktree_open_allowed(status: Status) -> bool {
     !matches!(
         status,
         Status::Done
+            | Status::Merged
             | Status::Canceled
             | Status::InProgress
             | Status::Rebasing
@@ -664,6 +665,7 @@ fn is_view_action_allowed(status: Status) -> bool {
     !matches!(
         status,
         Status::Done
+            | Status::Merged
             | Status::InProgress
             | Status::Rebasing
             | Status::Merging
@@ -686,7 +688,7 @@ fn is_view_chat_allowed(status: Status) -> bool {
 
 /// Returns whether the `d` shortcut can open the diff view.
 fn is_view_diff_allowed(status: Status) -> bool {
-    status.allows_review_actions()
+    status.allows_review_actions() || status == Status::Merged
 }
 
 /// Returns whether the `f` shortcut can open review content.
@@ -1319,7 +1321,7 @@ mod tests {
     #[test]
     fn test_is_view_worktree_open_allowed_returns_false_for_merge_queue_statuses() {
         // Arrange
-        let merge_queue_statuses = [Status::Queued, Status::Merging];
+        let merge_queue_statuses = [Status::Queued, Status::Merging, Status::Merged];
 
         // Act
         let can_open_for_statuses: Vec<bool> = merge_queue_statuses
@@ -1337,18 +1339,21 @@ mod tests {
         let canceled_status = Status::Canceled;
         let review_status = Status::Review;
         let in_progress_status = Status::InProgress;
+        let merged_status = Status::Merged;
         let done_status = Status::Done;
 
         // Act
         let canceled_allowed = is_view_action_allowed(canceled_status);
         let review_allowed = is_view_action_allowed(review_status);
         let in_progress_allowed = is_view_action_allowed(in_progress_status);
+        let merged_allowed = is_view_action_allowed(merged_status);
         let done_allowed = is_view_action_allowed(done_status);
 
         // Assert
         assert!(!canceled_allowed);
         assert!(review_allowed);
         assert!(!in_progress_allowed);
+        assert!(!merged_allowed);
         assert!(!done_allowed);
     }
 
@@ -1374,19 +1379,22 @@ mod tests {
     }
 
     #[test]
-    fn test_is_view_diff_allowed_only_for_review_status() {
+    fn test_is_view_diff_allowed_for_review_and_merged_status() {
         // Arrange
         let review_status = Status::Review;
+        let merged_status = Status::Merged;
         let new_status = Status::Draft;
         let in_progress_status = Status::InProgress;
 
         // Act
         let review_allowed = is_view_diff_allowed(review_status);
+        let merged_allowed = is_view_diff_allowed(merged_status);
         let new_allowed = is_view_diff_allowed(new_status);
         let in_progress_allowed = is_view_diff_allowed(in_progress_status);
 
         // Assert
         assert!(review_allowed);
+        assert!(merged_allowed);
         assert!(!new_allowed);
         assert!(!in_progress_allowed);
     }

--- a/crates/agentty/src/ui/session_format.rs
+++ b/crates/agentty/src/ui/session_format.rs
@@ -251,7 +251,11 @@ pub fn session_output_panel_border_style(status: Status) -> Style {
 pub(crate) fn session_output_uses_tachyon_loader(status: Status) -> bool {
     matches!(
         status,
-        Status::InProgress | Status::AgentReview | Status::Rebasing | Status::Merging
+        Status::InProgress
+            | Status::AgentReview
+            | Status::Rebasing
+            | Status::Merging
+            | Status::Merged
     )
 }
 
@@ -281,6 +285,7 @@ pub fn session_output_status_line(
             | Status::Queued
             | Status::Rebasing
             | Status::Merging
+            | Status::Merged
     ) {
         return None;
     }
@@ -344,6 +349,7 @@ fn session_output_status_message(
         Status::Queued => "Waiting in merge queue...".to_string(),
         Status::Rebasing => "Rebasing...".to_string(),
         Status::Merging => "Merging...".to_string(),
+        Status::Merged => "Waiting for manual local target sync...".to_string(),
         Status::Draft | Status::Review | Status::Question | Status::Done | Status::Canceled => {
             String::new()
         }
@@ -353,9 +359,11 @@ fn session_output_status_message(
 /// Returns the status indicator icon used for inline session-output messages.
 fn session_output_status_icon(status: Status) -> Icon {
     match status {
-        Status::InProgress | Status::AgentReview | Status::Rebasing | Status::Merging => {
-            Icon::TachyonLoader
-        }
+        Status::InProgress
+        | Status::AgentReview
+        | Status::Rebasing
+        | Status::Merging
+        | Status::Merged => Icon::TachyonLoader,
         Status::Queued
         | Status::Draft
         | Status::Review
@@ -465,6 +473,7 @@ mod tests {
             Status::AgentReview,
             Status::Rebasing,
             Status::Merging,
+            Status::Merged,
         ];
         let static_statuses = [
             Status::Draft,
@@ -482,5 +491,19 @@ mod tests {
         // Assert
         assert!(animated_results.into_iter().all(|uses_loader| uses_loader));
         assert!(static_results.into_iter().all(|uses_loader| !uses_loader));
+    }
+
+    #[test]
+    fn merged_session_output_explains_manual_sync_wait() {
+        // Arrange
+        let status = Status::Merged;
+
+        // Act
+        let message = session_output_status_message(status, None, None);
+        let icon = session_output_status_icon(status);
+
+        // Assert
+        assert_eq!(message, "Waiting for manual local target sync...");
+        assert!(matches!(icon, Icon::TachyonLoader));
     }
 }

--- a/crates/agentty/src/ui/style.rs
+++ b/crates/agentty/src/ui/style.rs
@@ -385,7 +385,7 @@ pub fn status_color(status: Status) -> Color {
         Status::Question => palette::question(),
         Status::Queued => palette::accent_soft(),
         Status::Rebasing | Status::Merging => palette::accent(),
-        Status::Done => palette::success(),
+        Status::Merged | Status::Done => palette::success(),
         Status::Canceled => palette::danger(),
     }
 }
@@ -398,7 +398,7 @@ pub fn status_icon(status: Status) -> Icon {
         Status::InProgress | Status::AgentReview | Status::Rebasing | Status::Merging => {
             Icon::current_spinner()
         }
-        Status::Done => Icon::Check,
+        Status::Merged | Status::Done => Icon::Check,
         Status::Canceled => Icon::Cross,
     }
 }
@@ -474,15 +474,17 @@ mod tests {
     }
 
     #[test]
-    fn status_color_returns_success_for_done() {
+    fn status_color_returns_success_for_merged_and_done() {
         // Arrange
         let _theme_scope = scoped_active_theme(ColorTheme::Current);
 
         // Act
-        let color = status_color(Status::Done);
+        let merged_color = status_color(Status::Merged);
+        let done_color = status_color(Status::Done);
 
         // Assert
-        assert_eq!(color, palette::success());
+        assert_eq!(merged_color, palette::success());
+        assert_eq!(done_color, palette::success());
     }
 
     #[test]
@@ -716,12 +718,14 @@ mod tests {
     }
 
     #[test]
-    fn status_icon_returns_check_for_done() {
-        // Arrange / Act
-        let icon = status_icon(Status::Done);
+    fn status_icon_returns_check_for_merged_and_done() {
+        // Arrange, Act
+        let merged_icon = status_icon(Status::Merged);
+        let done_icon = status_icon(Status::Done);
 
         // Assert
-        assert!(matches!(icon, Icon::Check));
+        assert!(matches!(merged_icon, Icon::Check));
+        assert!(matches!(done_icon, Icon::Check));
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1541,6 +1541,16 @@ fn seed_slow_merged_review_request_status(
 ) -> Result<(), Box<dyn std::error::Error>> {
     seed_review_ready_session_with_review_request(env)?;
 
+    let sync_origin = env.agentty_root.join("sync-origin.git");
+    std::fs::create_dir_all(&sync_origin)?;
+    run_git(&sync_origin, &["init", "--bare", "."])?;
+    let sync_origin_path = sync_origin.to_string_lossy().into_owned();
+    run_git(
+        &env.workdir,
+        &["remote", "add", "origin", sync_origin_path.as_str()],
+    )?;
+    run_git(&env.workdir, &["push", "--set-upstream", "origin", "main"])?;
+
     let gh_path = env.stub_bin.join("gh");
     std::fs::write(
         &gh_path,
@@ -4004,12 +4014,12 @@ fn review_request_sync_runs_in_background() -> E2eResult {
     Ok(())
 }
 
-/// Verify that externally merged status updates reach `Done` without waiting
-/// for slow worktree cleanup and the terminal remains navigable.
+/// Verify that a remote merge stays read-only `Merged` until the user syncs
+/// main, then moves to `Done` without waiting for slow worktree cleanup.
 #[test]
-fn test_merged_review_request_cleanup_responsive() -> E2eResult {
+fn test_merged_review_request_waits_for_manual_sync() -> E2eResult {
     // Arrange, Act, Assert
-    FeatureTest::new("merged_review_request_cleanup_responsive")
+    FeatureTest::new("merged_review_request_manual_sync")
         .with_git()
         .setup(seed_slow_merged_review_request_status)
         .run(
@@ -4017,21 +4027,50 @@ fn test_merged_review_request_cleanup_responsive() -> E2eResult {
                 scenario
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::switch_to_tab("Sessions"))
-                    .wait_for_text("Done", 2500)
+                    .wait_for_text("Merged", 10_000)
                     .capture_labeled(
                         "merged_status",
-                        "Merged session reaches Done before worktree cleanup finishes",
+                        "Merged session waits in Active for manual main sync",
                     )
-                    .press_key("Tab")
-                    .wait_for_text("Review Requests", 1000)
+                    .compose(&common::open_selected_session_view())
+                    .press_key("?")
+                    .wait_for_stable_frame(300, 5000)
                     .capture_labeled(
-                        "responsive_navigation",
-                        "Tab navigation remains responsive during worktree cleanup",
+                        "merged_read_only_actions",
+                        "Merged session exposes only read-only review actions",
+                    )
+                    .press_key("?")
+                    .press_key("q")
+                    .press_key("s")
+                    .wait_for_text("Sync complete", 10_000)
+                    .press_key("Enter")
+                    .wait_for_text("Done", 10_000)
+                    .capture_labeled(
+                        "merged_done_after_sync",
+                        "Manual main sync archives the merged session",
                     )
             },
-            |frame, _report| {
+            |frame, report| {
+                assert_eq!(report.captures.len(), 3);
+                let merged_frame = common::frame_from_capture(&report.captures[0]);
+                let merged_full = Region::full(merged_frame.cols(), merged_frame.rows());
+                assertion::assert_text_in_region(&merged_frame, "Active", &merged_full);
+                assertion::assert_text_in_region(&merged_frame, "Merged", &merged_full);
+
+                let read_only_frame = common::frame_from_capture(&report.captures[1]);
+                let read_only_full = Region::full(read_only_frame.cols(), read_only_frame.rows());
+                assertion::assert_text_in_region(&read_only_frame, "Show diff", &read_only_full);
+                let read_only_text = read_only_frame.text_in_region(&read_only_full);
+                for mutating_action in ["Reply", "Open commands menu", "Add to merge queue", "Sync"]
+                {
+                    assert!(
+                        !read_only_text.contains(mutating_action),
+                        "Merged help must hide `{mutating_action}`"
+                    );
+                }
+
                 let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(frame, "Review Requests", &full);
+                assertion::assert_text_in_region(frame, "Done", &full);
             },
         )?;
 
@@ -4053,7 +4092,11 @@ fn merged_review_request_cleanup_does_not_block_quit() -> E2eResult {
     let scenario = Scenario::new("merged_cleanup_quit")
         .compose(&common::wait_for_agentty_startup())
         .compose(&common::switch_to_tab("Sessions"))
-        .wait_for_text("Done", 2500)
+        .wait_for_text("Merged", 10_000)
+        .press_key("s")
+        .wait_for_text("Sync complete", 10_000)
+        .press_key("Enter")
+        .wait_for_text("Done", 10_000)
         .compose(&common::open_quit_dialog())
         .press_key("y");
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -118,8 +118,9 @@ loader updates), and applies side effects in stable order. Key behaviors:
   home-directory project discovery runs only during `App::new()`.
 - Git-status and review-request events carry a sync-context generation so stale
   completions are discarded after the active project or session changes.
-- Externally merged review requests transition sessions to `Done`; closed requests
-  transition them to `Canceled`.
+- Externally merged review requests transition sessions to read-only `Merged`; only a
+  successful user-triggered sync of the request's local target advances them to `Done`.
+  Closed requests transition editable sessions to `Canceled`.
 - Terminal statuses (`Done`, `Canceled`) drop per-session worker senders so workers can
   shut down their runtimes.
 
@@ -490,25 +491,32 @@ orchestration paths:
   later navigation. It holds the same branch-operation lock as post-turn auto-push, so
   overlapping requests queue rather than running concurrent force-pushes.
 - Background review-request sync: review-ready sessions with a published branch or
-  linked request are polled; merged requests move the session to `Done`, closed requests
-  to `Canceled`. Externally merged worktree and branch cleanup runs as a tracked
-  background task after the terminal transition so input and redraws do not wait for git
-  or filesystem removal. Repeated merged results for an already-`Done` session do not
-  schedule cleanup again. Cleanup-critical git subprocesses are cancellable and bounded
-  to 30 seconds; confirmed shutdown shares a five-second grace period across all tracked
-  cleanup tasks before canceling unfinished work. The Inbox tab loads comment snapshots
-  on demand with generation-scoped deduplication. Session view also loads comments on
-  demand for its linked review request: `AppMode::ReviewComments` renders immediately
-  with a loading state, `TaskService` resolves the session worktree remote through the
-  injected git/forge boundaries, falls back to the persisted review-request URL after
-  terminal-session worktree cleanup, and uses the matching `AppEvent` to update only the
-  still-open comments page. Inline code context is derived from the already loaded
-  current diff. From a reply-capable session, `a` or `A` renders actionable comment data
-  into a `TurnPrompt` and records the supplied forge thread IDs in turn metadata.
-  Post-turn handling accepts only deduplicated `fixed` outcomes with an allowlisted ID
-  and nonblank reply. After auto-commit and a successful published-branch push, the
-  worker posts each reply and then resolves that thread through `ReviewRequestClient`;
-  failed pushes never mutate forge thread state.
+  linked request are polled; merged requests persist the reviewed session-head hash and
+  move the session to read-only `Merged`, while closed requests move to `Canceled`.
+  `Merged` remains in the Active group and background refresh never archives, cleans up,
+  or restacks it. The manual target-branch sync path refreshes forge state before its
+  git work and applies terminal review updates only after sync succeeds. It then
+  finalizes matching `Merged` sessions by durably detaching stacked children, moving the
+  parent to `Done`, emitting child-restack work, and scheduling tracked worktree
+  cleanup. The successful `SyncMainOutcome` owns the exact synced branch, so the event
+  model cannot represent success without a finalization target. Restack or archival
+  persistence failures leave the parent safely in `Merged` and are listed in the sync
+  completion popup for retry. A failed sync or a successful sync of another branch
+  leaves the merged stack unchanged. Cleanup-critical git subprocesses are cancellable
+  and bounded to 30 seconds; confirmed shutdown shares a five-second grace period across
+  all tracked cleanup tasks before canceling unfinished work. The Inbox tab loads
+  comment snapshots on demand with generation-scoped deduplication. Session view also
+  loads comments on demand for its linked review request: `AppMode::ReviewComments`
+  renders immediately with a loading state, `TaskService` resolves the session worktree
+  remote through the injected git/forge boundaries, falls back to the persisted
+  review-request URL after terminal-session worktree cleanup, and uses the matching
+  `AppEvent` to update only the still-open comments page. Inline code context is derived
+  from the already loaded current diff. From a reply-capable session, `a` or `A` renders
+  actionable comment data into a `TurnPrompt` and records the supplied forge thread IDs
+  in turn metadata. Post-turn handling accepts only deduplicated `fixed` outcomes with
+  an allowlisted ID and nonblank reply. After auto-commit and a successful
+  published-branch push, the worker posts each reply and then resolves that thread
+  through `ReviewRequestClient`; failed pushes never mutate forge thread state.
 - Assigned-issue refresh: the Issues tab resolves the active project remote and runs a
   repository-scoped, generation-scoped `gh search issues` task through
   `ReviewRequestClient`; stale completions are discarded before the list cache is

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -188,6 +188,9 @@ State-specific differences:
 - Sessions with a linked pull request or merge request use `c` to open its comments page
   and hide `m`; merge the linked request through its forge instead of Agentty's local
   merge queue. Linked terminal sessions keep continuation available on `C`.
+- **Merged** sessions remain in Active and expose only read-only navigation, linked
+  review comments, and `d` for the diff until list-mode `s` successfully syncs their
+  local target branch.
 - **Done** sessions without a linked review request offer `c` to start a continuation
   draft (confirmation popup).
 - **Canceled**, **Queued**, and **Merging** sessions are otherwise read-only (`q`,

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -91,6 +91,7 @@ to the assist agent.
 | **Queued**      | Waiting in the merge queue.                                      |
 | **Rebasing**    | Session is syncing; follow-up messages queue behind the sync.    |
 | **Merging**     | Changes are being merged into the base branch.                   |
+| **Merged**      | Review merged remotely; waiting for manual local target sync.    |
 | **Done**        | Completed and merged; the worktree was removed.                  |
 | **Canceled**    | Canceled by the user; the worktree was removed.                  |
 
@@ -130,6 +131,7 @@ flowchart TB
     rebasing["Rebasing"]
     queued["Queued"]
     merging["Merging"]
+    merged["Merged"]
     done["Done"]
     canceled["Canceled"]
   end
@@ -163,7 +165,8 @@ flowchart TB
   queued --> merging
   merging --> done
   review -->|cancel| canceled
-  review -->|sync detects merge| done
+  review -->|forge reports merge| merged
+  merged -->|manual target sync| done
 
   class agent_review,rebasing auxiliary
   class done,canceled terminal
@@ -301,7 +304,8 @@ When a session without a linked review request merges, Agentty reuses the sessio
 clean main checkout and returns the session to **Review** if the preparatory rebase or
 squash-merge fails. After a pull request or merge request is linked, Agentty hides `m`
 and rejects local merge queueing; merge through the forge, and background review-request
-sync moves the session to **Done** when that remote merge completes.
+sync moves the session to read-only **Merged** when that remote merge completes. The
+session remains in Active until a successful manual main sync moves it to **Done**.
 
 When a session syncs (`r`), Agentty rebases the session branch: published sessions fetch
 first and rebase onto the remote base ref, unpublished sessions rebase onto the stored
@@ -405,8 +409,19 @@ sessions. The session list shows forge indicators next to the status label:
 | `✓ <id>`  | Review request `<id>` was merged.       |
 | `✗ <id>`  | Review request `<id>` was closed.       |
 
-When a sync detects that the review request was merged, the session moves straight to
-**Done**; a closed request moves it to **Canceled**.
+When background refresh detects that the review request was merged, the session moves to
+read-only **Merged** and remains in the Active group. Transcript and diff inspection
+stay available, while replies, session sync, merge, publishing, commands, and new
+follow-up tasks are disabled. Agentty does not archive or clean up the session during
+background refresh or startup.
+
+After the user manually syncs the review request's local target branch, Agentty moves
+the session to **Done**, archives it, cleans up its worktree in the background, and
+persists restack work for any stacked children. A failed sync or a sync of another
+branch leaves the session and its stack unchanged. Interrupted child restacks can resume
+after restart. If restack intent or archival cannot be persisted, the sync popup lists
+the session that remains in **Merged** so the user can inspect its workflow warning and
+retry safely. A closed request still moves an editable session to **Canceled**.
 
 ## Clarification Interaction Loop
 


### PR DESCRIPTION
- Remote merge detection records sessions as `Merged` without cleanup or child restacking.
- Successful manual target sync archives matching sessions and resumes stacked-child cleanup.
- Read-only sessions preserve inspection actions while blocking mutations.
- Antigravity sends schema prompts through stdin and avoids argv attachment-path validation.
- Tests and documentation cover the updated lifecycle and provider transport.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)