### PR TITLE
Bump version to 0.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,22 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.13.4] - 2026-07-18
+
 ### Changed
 
+- agentty: use `Ctrl+Z` as the shared input undo shortcut.
 - agentty: keep remotely merged review sessions read-only in Active until manual target
   sync archives them and restacks any child sessions.
+- deps: update `ignore` from `0.4.27` to `0.4.28`.
+- ci: update `taiki-e/install-action` from `2.82.11` to `2.83.1`.
+- release: bump workspace crate metadata and lockfile package versions to `0.13.4`.
+
+### Contributors
+
+- @andagaev
+- @dependabot
+- @minev-dev
 
 ## [v0.13.3] - 2026-07-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "image",
  "mockall",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "mockall",
  "serde",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "mockall",
  "rustix",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "askama",
  "schemars 1.2.1",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "clap",
  "tempfile",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.13.3"
+version = "0.13.4"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -16,13 +16,13 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.13.3" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.13.3" }
-ag-forge = { path = "crates/ag-forge", version = "0.13.3" }
-ag-git = { path = "crates/ag-git", version = "0.13.3" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.13.3" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.13.3" }
-testty = { path = "crates/testty", version = "0.13.3" }
+ag-agent = { path = "crates/ag-agent", version = "0.13.4" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.13.4" }
+ag-forge = { path = "crates/ag-forge", version = "0.13.4" }
+ag-git = { path = "crates/ag-git", version = "0.13.4" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.13.4" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.13.4" }
+testty = { path = "crates/testty", version = "0.13.4" }
 async-trait = "0.1"
 agent-client-protocol = "1.2.0"
 assert_cmd = "2"


### PR DESCRIPTION
- Record the v0.13.4 release changelog.
- Update workspace crate metadata and lockfile package versions to `0.13.4`.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)