### PR TITLE
Display uppercase continuation shortcut

### DIFF
--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -478,19 +478,12 @@ pub(crate) fn view_footer_actions_with_review_comments(
     actions
 }
 
-/// Adds the comments shortcut before trailing navigation actions and remaps
-/// terminal continuation to `C` when both actions are available.
+/// Adds the comments shortcut before trailing navigation actions.
 fn append_review_comment_action(actions: &mut Vec<HelpAction>, is_available: bool) {
     if !is_available {
         return;
     }
 
-    if let Some(continue_action) = actions
-        .iter_mut()
-        .find(|action| action.key == "c" && action.footer_label == "continue")
-    {
-        continue_action.key = "C";
-    }
     let insertion_index = 1.min(actions.len());
     actions.insert(
         insertion_index,
@@ -545,7 +538,7 @@ fn append_view_review_actions(
 /// footer rows.
 fn append_view_continue_action(actions: &mut Vec<HelpAction>, action_set: ViewActionSet) {
     if action_set.continue_terminal_session.is_enabled() {
-        actions.push(HelpAction::new("continue", "c", "Continue in new session"));
+        actions.push(HelpAction::new("continue", "C", "Continue in new session"));
     }
 }
 
@@ -1305,7 +1298,11 @@ mod tests {
         let actions = view_actions(state);
 
         // Assert
-        assert!(actions.iter().any(|action| action.key == "c"));
+        assert!(actions.iter().any(|action| {
+            action.key == "C"
+                && action.footer_label == "continue"
+                && action.popup_label == "Continue in new session"
+        }));
         assert!(!actions.iter().any(|action| action.key == "p"));
         assert!(!actions.iter().any(|action| action.key == "Enter"));
         assert!(!actions.iter().any(|action| action.key == "d"));
@@ -1608,7 +1605,7 @@ mod tests {
         let actions = view_actions(state);
 
         // Assert
-        assert!(!actions.iter().any(|action| action.key == "c"));
+        assert!(!actions.iter().any(|action| action.key == "C"));
         assert!(!actions.iter().any(|action| action.key == "p"));
         assert!(!actions.iter().any(|action| action.key == "Enter"));
         assert!(!actions.iter().any(|action| action.key == "o"));
@@ -1635,7 +1632,7 @@ mod tests {
         let ordered_keys = actions.iter().map(|action| action.key).collect::<Vec<_>>();
 
         // Assert
-        assert_eq!(&ordered_keys[..4], ["q", "c", "j/k", "?"]);
+        assert_eq!(&ordered_keys[..4], ["q", "C", "j/k", "?"]);
     }
 
     #[test]

--- a/crates/agentty/src/ui/layout.rs
+++ b/crates/agentty/src/ui/layout.rs
@@ -663,7 +663,7 @@ mod tests {
         let help_text = view_footer_text(&session, true);
 
         // Assert
-        assert!(help_text.contains("c: continue"));
+        assert!(help_text.contains("C: continue"));
     }
 
     #[test]
@@ -1213,7 +1213,7 @@ mod tests {
         // Assert
         assert_eq!(
             done_line.to_string(),
-            "Press 'c' to continue in a new session."
+            "Press 'C' to continue in a new session."
         );
     }
 

--- a/crates/agentty/src/ui/page/session_chat.rs
+++ b/crates/agentty/src/ui/page/session_chat.rs
@@ -791,7 +791,7 @@ mod tests {
 
         // Assert
         let text = buffer_text(terminal.backend().buffer());
-        assert!(text.contains("c: continue"));
+        assert!(text.contains("C: continue"));
     }
 
     /// Verifies canceled terminal sessions render without a continuation
@@ -819,7 +819,7 @@ mod tests {
 
         // Assert
         let text = buffer_text(terminal.backend().buffer());
-        assert!(!text.contains("c: continue"));
+        assert!(!text.contains("C: continue"));
     }
 
     /// Verifies running sessions advertise sync as a queued action while

--- a/crates/agentty/src/ui/session_format.rs
+++ b/crates/agentty/src/ui/session_format.rs
@@ -262,7 +262,7 @@ pub(crate) fn session_output_uses_tachyon_loader(status: Status) -> bool {
 /// Builds the inline shortcut hint for continuing a completed session.
 pub fn session_output_done_line() -> Line<'static> {
     Line::from(vec![Span::styled(
-        "Press 'c' to continue in a new session.",
+        "Press 'C' to continue in a new session.",
         Style::default().fg(style::palette::text_subtle()),
     )])
 }

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -3746,7 +3746,7 @@ fn session_output_scrollbar_is_visible() -> E2eResult {
     Ok(())
 }
 
-/// Verify that pressing `c` in a terminal session opens a confirmation and,
+/// Verify that pressing `C` in a terminal session opens a confirmation and,
 /// after acceptance, stages the continuation message before focusing an empty
 /// draft composer.
 #[test]
@@ -3767,8 +3767,9 @@ fn terminal_session_continue_opens_seeded_prompt() -> E2eResult {
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::switch_to_tab("Sessions"))
                     .press_key("Enter")
-                    .wait_for_text("q: back", 5000)
-                    .press_key("c")
+                    .wait_for_text("C: continue", 5000)
+                    .wait_for_text("Press 'C' to continue in a new session.", 3000)
+                    .press_key("C")
                     .wait_for_text("Confirm Continue", 3000)
                     .viewing_pause_ms(1500)
                     .capture_labeled(

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -191,8 +191,7 @@ State-specific differences:
 - **Merged** sessions remain in Active and expose only read-only navigation, linked
   review comments, and `d` for the diff until list-mode `s` successfully syncs their
   local target branch.
-- **Done** sessions without a linked review request offer `c` to start a continuation
-  draft (confirmation popup).
+- **Done** sessions offer `C` to start a continuation draft (confirmation popup).
 - **Canceled**, **Queued**, and **Merging** sessions are otherwise read-only (`q`,
   scroll, help). Linked review requests remain available from any session state with
   `c`.

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -325,7 +325,7 @@ is skipped there.
 
 ### Continuing a Done Session
 
-Pressing `c` on a **Done** session opens a confirmation, then creates a brand-new draft
+Pressing `C` on a **Done** session opens a confirmation, then creates a brand-new draft
 session with a continuation message staged from the merged commit hash (or the saved
 summary when the hash is unavailable). **Canceled** sessions remain terminal and
 read-only.


### PR DESCRIPTION
- Use `C` for done-session continuation actions and prompts.
- Update UI tests, E2E coverage, and workflow documentation.