### PR TITLE
Enforce coverage checks on all builds

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -39,7 +39,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Upload coverage report
-        if: ${{ !cancelled() && github.event_name == 'pull_request' && hashFiles('coverage.lcov') != '' }}
+        if: ${{ !cancelled() && hashFiles('coverage.lcov') != '' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,6 @@ coverage:
     patch:
       default:
         informational: false
-        only_pulls: true
+        only_pulls: false
         target: 100%
         threshold: 0%


### PR DESCRIPTION
- Upload coverage reports whenever `coverage.lcov` exists.
- Apply patch coverage requirements beyond pull requests.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)