### PR TITLE
Groups review comments by resolution state

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,16 +138,6 @@ agentty --help       # Show supported command-line options
 agentty --version    # Show the installed Agentty version
 ```
 
-The **Issues** tab uses the GitHub CLI to show open issues assigned to the authenticated
-user in the active project. Press `Enter` to load base issue details and the
-description; comments are not loaded in this iteration. Install `gh` and run
-`gh auth login` to enable it.
-
-For sessions linked to a GitHub pull request or GitLab merge request, press `c` in
-session view to browse review comments read-only. General comments and inline threads
-are listed on the left, with the selected conversation and attached current-diff context
-on the right.
-
 ## Documentation
 
 Documentation for installation and workflows is available at

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -38,6 +38,7 @@ use crate::domain::transcript_notice::TranscriptNotice;
 use crate::domain::transient_message::TransientMessageBody;
 use crate::presentation::app_mode::{AppMode, ChatFocus, ConfirmationViewMode};
 use crate::presentation::prompt::PromptAtMentionState;
+use crate::presentation::review_comment as review_comment_selection;
 
 /// Internal app events emitted by background workers and workflows.
 ///
@@ -967,6 +968,7 @@ impl App {
                 comment_error,
                 comment_snapshot,
                 is_loading_comments,
+                selected_comment_index,
                 session_id,
                 ..
             } = &mut self.mode
@@ -980,6 +982,11 @@ impl App {
             *is_loading_comments = false;
             match result {
                 Ok(snapshot) => {
+                    *selected_comment_index = review_comment_selection::retarget_selected_index(
+                        comment_snapshot.as_ref(),
+                        *selected_comment_index,
+                        &snapshot,
+                    );
                     *comment_error = None;
                     *comment_snapshot = Some(snapshot);
                 }
@@ -2221,6 +2228,10 @@ impl App {
 
 #[cfg(test)]
 mod tests {
+    use ag_forge::{
+        ReviewComment, ReviewCommentAnchorSide, ReviewCommentSnapshot, ReviewCommentThread,
+    };
+
     use super::*;
 
     #[tokio::test]
@@ -2253,6 +2264,46 @@ mod tests {
                 is_loading_comments: false,
                 ..
             }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_session_review_comment_refresh_retargets_selected_thread() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let previous_snapshot = review_comment_snapshot([
+            review_comment_thread("selected", false),
+            review_comment_thread("other", false),
+        ]);
+        let updated_snapshot = review_comment_snapshot([
+            review_comment_thread("selected", true),
+            review_comment_thread("other", false),
+        ]);
+        app.mode = AppMode::ReviewComments {
+            comment_error: None,
+            comment_snapshot: Some(previous_snapshot),
+            diff: String::new(),
+            is_loading_comments: true,
+            selected_comment_index: 0,
+            session_id: "session-id".into(),
+            scroll_offset: 0,
+        };
+
+        // Act
+        app.apply_app_events(AppEvent::SessionReviewCommentSnapshotLoaded {
+            result: Ok(updated_snapshot),
+            session_id: "session-id".into(),
+        })
+        .await;
+
+        // Assert
+        assert!(matches!(
+            app.mode,
+            AppMode::ReviewComments {
+                comment_snapshot: Some(ref snapshot),
+                selected_comment_index: 1,
+                ..
+            } if review_comment_selection::selected_thread_id(snapshot, 1) == Some("selected")
         ));
     }
 
@@ -2299,6 +2350,33 @@ mod tests {
                 ..
             } if error == "Failed to load review comments: authentication failed"
         ));
+    }
+
+    /// Builds a comment snapshot from inline thread fixtures.
+    fn review_comment_snapshot<const THREAD_COUNT: usize>(
+        threads: [ReviewCommentThread; THREAD_COUNT],
+    ) -> ReviewCommentSnapshot {
+        ReviewCommentSnapshot {
+            pr_level_comments: Vec::new(),
+            threads: Vec::from(threads),
+        }
+    }
+
+    /// Builds one current or resolved review-comment thread.
+    fn review_comment_thread(id: &str, is_resolved: bool) -> ReviewCommentThread {
+        ReviewCommentThread {
+            anchor_side: ReviewCommentAnchorSide::New,
+            comments: vec![ReviewComment {
+                author: "reviewer".to_string(),
+                body: "Review comment".to_string(),
+            }],
+            id: id.to_string(),
+            is_outdated: Some(false),
+            is_resolved,
+            line: Some(1),
+            path: "src/main.rs".to_string(),
+            start_line: None,
+        }
     }
 
     #[test]

--- a/crates/agentty/src/app/prompt_intent.rs
+++ b/crates/agentty/src/app/prompt_intent.rs
@@ -2,7 +2,7 @@ use std::fmt::Write as _;
 use std::path::PathBuf;
 
 use ag_agent as agent;
-use ag_forge::{ReviewComment, ReviewCommentSnapshot, ReviewCommentThread};
+use ag_forge::{ReviewCommentSnapshot, ReviewCommentThread};
 use tracing::warn;
 
 use crate::app::{App, ReviewCacheEntry, diff_content_hash};
@@ -21,12 +21,12 @@ const RESOLVE_REVIEW_COMMENT_PROMPT_TEMPLATE: &str =
     include_str!("template/resolve_review_comment_prompt.md");
 
 /// Review-comment subset selected for one agent resolution turn.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum ReviewCommentSelection {
-    /// Resolve every unresolved, current thread plus every general comment.
+    /// Resolve every unresolved, current inline thread.
     AllUnresolved,
-    /// Resolve the selectable comment row at this flattened index.
-    Selected(usize),
+    /// Resolve one inline thread identified by its forge-native ID.
+    SelectedThread(String),
 }
 
 /// Presentation navigation requested after a review-comment resolution attempt.
@@ -461,27 +461,18 @@ pub(crate) fn build_apply_review_prompt(suggestions: &str) -> TurnPrompt {
 /// Builds an agent-facing review-comment prompt and its forge thread
 /// allowlist.
 ///
-/// Resolved and outdated threads are excluded. General discussion comments
-/// are included as worktree inputs but have no forge-side outcome identifier.
+/// Resolved and outdated threads are excluded. Standalone discussion comments
+/// are read-only because they have no forge-side thread identifier.
 pub(crate) fn build_resolve_review_comment_prompt(
     snapshot: &ReviewCommentSnapshot,
     selection: ReviewCommentSelection,
 ) -> Option<(TurnPrompt, Vec<String>)> {
-    let (general_comments, threads) = selected_review_comments(snapshot, selection);
-    if general_comments.is_empty() && threads.is_empty() {
+    let threads = selected_review_comment_threads(snapshot, selection);
+    if threads.is_empty() {
         return None;
     }
 
     let mut review_comments = String::new();
-    for (index, comment) in general_comments.into_iter().enumerate() {
-        let _ = writeln!(
-            review_comments,
-            "General comment {}\nAuthor: {}\nBody:\n{}\n",
-            index + 1,
-            comment.author,
-            comment.body
-        );
-    }
     for thread in &threads {
         append_review_thread_prompt(&mut review_comments, thread);
     }
@@ -500,35 +491,24 @@ pub(crate) fn build_resolve_review_comment_prompt(
     Some((TurnPrompt::from_text(prompt), thread_ids))
 }
 
-/// Returns the general comments and actionable threads selected for a turn.
-fn selected_review_comments(
+/// Returns the actionable inline threads selected for a turn.
+fn selected_review_comment_threads(
     snapshot: &ReviewCommentSnapshot,
     selection: ReviewCommentSelection,
-) -> (Vec<&ReviewComment>, Vec<&ReviewCommentThread>) {
+) -> Vec<&ReviewCommentThread> {
     match selection {
-        ReviewCommentSelection::AllUnresolved => (
-            snapshot.pr_level_comments.iter().collect(),
-            snapshot
-                .threads
-                .iter()
-                .filter(|thread| thread.is_actionable())
-                .collect(),
-        ),
-        ReviewCommentSelection::Selected(selected_index) => {
-            if let Some(comment) = snapshot.pr_level_comments.get(selected_index) {
-                return (vec![comment], Vec::new());
-            }
-
-            let thread_index = selected_index.saturating_sub(snapshot.pr_level_comments.len());
-            let threads = snapshot
-                .threads
-                .get(thread_index)
-                .filter(|thread| thread.is_actionable())
-                .into_iter()
-                .collect();
-
-            (Vec::new(), threads)
-        }
+        ReviewCommentSelection::AllUnresolved => snapshot
+            .threads
+            .iter()
+            .filter(|thread| thread.is_actionable())
+            .collect(),
+        ReviewCommentSelection::SelectedThread(selected_thread_id) => snapshot
+            .threads
+            .iter()
+            .find(|thread| thread.id == selected_thread_id)
+            .filter(|thread| thread.is_actionable())
+            .into_iter()
+            .collect(),
     }
 }
 
@@ -559,7 +539,7 @@ fn append_review_thread_prompt(review_comments: &mut String, thread: &ReviewComm
 
 #[cfg(test)]
 mod tests {
-    use ag_forge::ReviewCommentAnchorSide;
+    use ag_forge::{ReviewComment, ReviewCommentAnchorSide};
 
     use super::*;
 
@@ -603,8 +583,8 @@ mod tests {
         assert!(prompt.text.contains("````text\n"));
         assert!(prompt.text.contains("```markdown\nexample\n```"));
     }
-    /// Ensures the all-comments prompt includes general discussion and only
-    /// unresolved, current thread IDs.
+    /// Ensures the all-comments prompt includes only unresolved, current
+    /// thread IDs.
     #[test]
     fn test_build_resolve_review_comment_prompt_filters_non_actionable_threads() {
         // Arrange
@@ -617,7 +597,7 @@ mod tests {
 
         // Assert
         assert_eq!(thread_ids, vec!["thread-current".to_string()]);
-        assert!(prompt.text.contains("General comment 1"));
+        assert!(!prompt.text.contains("Update the overview."));
         assert!(prompt.text.contains("Thread ID: thread-current"));
         assert!(prompt.text.contains("Path: src/current.rs"));
         assert!(
@@ -631,27 +611,22 @@ mod tests {
         assert_eq!(prompt.text_source, TurnPromptTextSource::UserPrompt);
     }
 
-    /// Ensures selected general and inline comments produce their respective
-    /// forge thread allowlists.
+    /// Ensures a selected inline thread produces its forge thread allowlist.
     #[test]
-    fn test_build_resolve_review_comment_prompt_selects_general_comment() {
+    fn test_build_resolve_review_comment_prompt_selects_inline_thread() {
         // Arrange
         let snapshot = review_comment_snapshot();
 
         // Act
-        let (prompt, thread_ids) =
-            build_resolve_review_comment_prompt(&snapshot, ReviewCommentSelection::Selected(0))
-                .expect("general comment should be selectable");
-        let (thread_prompt, selected_thread_ids) =
-            build_resolve_review_comment_prompt(&snapshot, ReviewCommentSelection::Selected(1))
-                .expect("current thread should be selectable");
+        let (prompt, thread_ids) = build_resolve_review_comment_prompt(
+            &snapshot,
+            ReviewCommentSelection::SelectedThread("thread-current".to_string()),
+        )
+        .expect("current thread should be selectable");
 
         // Assert
-        assert!(prompt.text.contains("General comment 1"));
-        assert!(!prompt.text.contains("Thread ID:"));
-        assert!(thread_ids.is_empty());
-        assert!(thread_prompt.text.contains("Thread ID: thread-current"));
-        assert_eq!(selected_thread_ids, vec!["thread-current".to_string()]);
+        assert!(prompt.text.contains("Thread ID: thread-current"));
+        assert_eq!(thread_ids, vec!["thread-current".to_string()]);
     }
 
     /// Ensures selected non-actionable and out-of-range rows cannot start a
@@ -662,12 +637,18 @@ mod tests {
         let snapshot = review_comment_snapshot();
 
         // Act
-        let resolved =
-            build_resolve_review_comment_prompt(&snapshot, ReviewCommentSelection::Selected(2));
-        let outdated =
-            build_resolve_review_comment_prompt(&snapshot, ReviewCommentSelection::Selected(3));
-        let missing =
-            build_resolve_review_comment_prompt(&snapshot, ReviewCommentSelection::Selected(99));
+        let resolved = build_resolve_review_comment_prompt(
+            &snapshot,
+            ReviewCommentSelection::SelectedThread("thread-resolved".to_string()),
+        );
+        let outdated = build_resolve_review_comment_prompt(
+            &snapshot,
+            ReviewCommentSelection::SelectedThread("thread-outdated".to_string()),
+        );
+        let missing = build_resolve_review_comment_prompt(
+            &snapshot,
+            ReviewCommentSelection::SelectedThread("thread-missing".to_string()),
+        );
 
         // Assert
         assert!(resolved.is_none());
@@ -680,18 +661,18 @@ mod tests {
     #[test]
     fn test_build_resolve_review_comment_prompt_escapes_comment_fence() {
         // Arrange
+        let mut thread =
+            review_comment_thread("thread-current", "src/current.rs", false, Some(false));
+        thread.comments[0].body = "Please preserve:\n```rust\nlet value = 1;\n```".to_string();
         let snapshot = ReviewCommentSnapshot {
-            pr_level_comments: vec![ReviewComment {
-                author: "reviewer".to_string(),
-                body: "Please preserve:\n```rust\nlet value = 1;\n```".to_string(),
-            }],
-            threads: Vec::new(),
+            pr_level_comments: Vec::new(),
+            threads: vec![thread],
         };
 
         // Act
         let (prompt, _) =
             build_resolve_review_comment_prompt(&snapshot, ReviewCommentSelection::AllUnresolved)
-                .expect("general comment should produce a prompt");
+                .expect("current thread should produce a prompt");
 
         // Assert
         assert!(prompt.text.contains("````text\n"));
@@ -860,7 +841,7 @@ mod tests {
             .resolve_session_review_comments(
                 &session_id,
                 &snapshot,
-                ReviewCommentSelection::Selected(99),
+                ReviewCommentSelection::SelectedThread("thread-missing".to_string()),
             )
             .await;
 

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -2568,7 +2568,7 @@ async fn test_resolve_session_review_comments_enqueues_turn_and_clears_focused_r
         .resolve_session_review_comments(
             &session_id,
             &snapshot,
-            ReviewCommentSelection::Selected(0),
+            ReviewCommentSelection::SelectedThread("thread-42".to_string()),
         )
         .await;
     done_rx.recv().await.expect("turn should start");

--- a/crates/agentty/src/presentation.rs
+++ b/crates/agentty/src/presentation.rs
@@ -6,4 +6,6 @@ pub mod app_mode;
 pub mod help_action;
 /// Prompt composer history, attachment, and suggestion state.
 pub mod prompt;
+/// Stable selection projection for grouped review-comment snapshots.
+pub(crate) mod review_comment;
 pub(crate) mod settings;

--- a/crates/agentty/src/presentation/review_comment.rs
+++ b/crates/agentty/src/presentation/review_comment.rs
@@ -1,0 +1,115 @@
+use ag_forge::{ReviewCommentSnapshot, ReviewCommentThread};
+
+/// Returns inline review threads in the unresolved-then-resolved order used
+/// by the review-comment page.
+pub(crate) fn grouped_threads(
+    snapshot: &ReviewCommentSnapshot,
+) -> impl Iterator<Item = &ReviewCommentThread> {
+    snapshot
+        .threads
+        .iter()
+        .filter(|thread| !thread.is_resolved)
+        .chain(snapshot.threads.iter().filter(|thread| thread.is_resolved))
+}
+
+/// Returns the forge-native identifier for the selected grouped thread row.
+pub(crate) fn selected_thread_id(
+    snapshot: &ReviewCommentSnapshot,
+    selected_comment_index: usize,
+) -> Option<&str> {
+    grouped_threads(snapshot)
+        .nth(selected_comment_index)
+        .map(|thread| thread.id.as_str())
+}
+
+/// Retargets a positional selection to the same forge thread in an updated
+/// snapshot, falling back to the nearest valid row if the thread disappeared.
+pub(crate) fn retarget_selected_index(
+    previous_snapshot: Option<&ReviewCommentSnapshot>,
+    previous_selected_index: usize,
+    updated_snapshot: &ReviewCommentSnapshot,
+) -> usize {
+    let selected_thread_id = previous_snapshot
+        .and_then(|snapshot| selected_thread_id(snapshot, previous_selected_index));
+    if let Some(updated_index) = selected_thread_id.and_then(|selected_thread_id| {
+        grouped_threads(updated_snapshot).position(|thread| thread.id == selected_thread_id)
+    }) {
+        return updated_index;
+    }
+
+    let updated_item_count = updated_snapshot
+        .threads
+        .len()
+        .saturating_add(updated_snapshot.pr_level_comments.len());
+
+    previous_selected_index.min(updated_item_count.saturating_sub(1))
+}
+
+#[cfg(test)]
+mod tests {
+    use ag_forge::{ReviewComment, ReviewCommentAnchorSide};
+
+    use super::*;
+
+    #[test]
+    fn test_retarget_selected_index_follows_thread_between_resolution_groups() {
+        // Arrange
+        let previous_snapshot =
+            snapshot_with_threads([thread("selected", false), thread("other", false)]);
+        let updated_snapshot =
+            snapshot_with_threads([thread("selected", true), thread("other", false)]);
+
+        // Act
+        let updated_index = retarget_selected_index(Some(&previous_snapshot), 0, &updated_snapshot);
+
+        // Assert
+        assert_eq!(updated_index, 1);
+        assert_eq!(
+            selected_thread_id(&updated_snapshot, updated_index),
+            Some("selected")
+        );
+    }
+
+    #[test]
+    fn test_retarget_selected_index_clamps_when_selected_thread_disappears() {
+        // Arrange
+        let previous_snapshot =
+            snapshot_with_threads([thread("first", false), thread("selected", false)]);
+        let updated_snapshot = snapshot_with_threads([thread("remaining", false)]);
+
+        // Act
+        let updated_index = retarget_selected_index(Some(&previous_snapshot), 1, &updated_snapshot);
+        let empty_index = retarget_selected_index(None, 4, &ReviewCommentSnapshot::default());
+
+        // Assert
+        assert_eq!(updated_index, 0);
+        assert_eq!(empty_index, 0);
+    }
+
+    /// Builds a snapshot from inline threads without standalone comments.
+    fn snapshot_with_threads<const THREAD_COUNT: usize>(
+        threads: [ReviewCommentThread; THREAD_COUNT],
+    ) -> ReviewCommentSnapshot {
+        ReviewCommentSnapshot {
+            pr_level_comments: Vec::new(),
+            threads: Vec::from(threads),
+        }
+    }
+
+    /// Builds one current or resolved inline thread.
+    fn thread(id: &str, is_resolved: bool) -> ReviewCommentThread {
+        ReviewCommentThread {
+            anchor_side: ReviewCommentAnchorSide::New,
+            comments: vec![ReviewComment {
+                author: "reviewer".to_string(),
+                body: "Review comment".to_string(),
+            }],
+            id: id.to_string(),
+            is_outdated: Some(false),
+            is_resolved,
+            line: Some(1),
+            path: "src/main.rs".to_string(),
+            start_line: None,
+        }
+    }
+}

--- a/crates/agentty/src/runtime/mode/review_comment.rs
+++ b/crates/agentty/src/runtime/mode/review_comment.rs
@@ -1,9 +1,11 @@
+use ag_forge::ReviewCommentSnapshot;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::Rect;
 
 use crate::app::App;
 use crate::app::prompt_intent::{ReviewCommentResolutionOutcome, ReviewCommentSelection};
 use crate::presentation::app_mode::AppMode;
+use crate::presentation::review_comment as review_comment_selection;
 use crate::runtime::EventResult;
 use crate::ui::{RenderCacheStore, page};
 
@@ -45,15 +47,11 @@ pub(crate) async fn handle_with_cache(
         return EventResult::Continue;
     };
     let item_count = page::review_comment::review_comment_item_count(comment_snapshot.as_ref());
-    let resolution_selection = match key.code {
-        KeyCode::Char('a') if key.modifiers == KeyModifiers::NONE => {
-            Some(ReviewCommentSelection::Selected(selected_comment_index))
-        }
-        KeyCode::Char('A') if key.modifiers == KeyModifiers::SHIFT => {
-            Some(ReviewCommentSelection::AllUnresolved)
-        }
-        _ => None,
-    };
+    let resolution_selection = review_comment_resolution_selection(
+        &key,
+        comment_snapshot.as_ref(),
+        selected_comment_index,
+    );
     if let (Some(selection), Some(snapshot)) = (resolution_selection, comment_snapshot.as_ref()) {
         let snapshot = snapshot.clone();
         app.mode = AppMode::ReviewComments {
@@ -122,6 +120,26 @@ pub(crate) async fn handle_with_cache(
     EventResult::Continue
 }
 
+/// Returns the thread-resolution action associated with one keypress and
+/// selected grouped comment row.
+fn review_comment_resolution_selection(
+    key: &KeyEvent,
+    comment_snapshot: Option<&ReviewCommentSnapshot>,
+    selected_comment_index: usize,
+) -> Option<ReviewCommentSelection> {
+    match key.code {
+        KeyCode::Char('a') if key.modifiers == KeyModifiers::NONE => comment_snapshot
+            .and_then(|snapshot| {
+                review_comment_selection::selected_thread_id(snapshot, selected_comment_index)
+            })
+            .map(|thread_id| ReviewCommentSelection::SelectedThread(thread_id.to_string())),
+        KeyCode::Char('A') if key.modifiers == KeyModifiers::SHIFT => {
+            Some(ReviewCommentSelection::AllUnresolved)
+        }
+        _ => None,
+    }
+}
+
 /// Applies presentation navigation returned by the review-comment workflow.
 fn apply_review_comment_resolution_outcome(app: &mut App, outcome: ReviewCommentResolutionOutcome) {
     match outcome {
@@ -186,6 +204,34 @@ mod tests {
                 start_line: None,
             }],
         }
+    }
+
+    #[test]
+    fn test_review_comment_resolution_selection_excludes_standalone_rows() {
+        // Arrange
+        let snapshot = comment_snapshot();
+        let selected_key = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
+        let all_key = KeyEvent::new(KeyCode::Char('A'), KeyModifiers::SHIFT);
+        let other_key = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE);
+
+        // Act
+        let selected = review_comment_resolution_selection(&selected_key, Some(&snapshot), 0);
+        let standalone = review_comment_resolution_selection(&selected_key, Some(&snapshot), 1);
+        let missing_snapshot = review_comment_resolution_selection(&selected_key, None, 0);
+        let all = review_comment_resolution_selection(&all_key, Some(&snapshot), 1);
+        let other = review_comment_resolution_selection(&other_key, Some(&snapshot), 0);
+
+        // Assert
+        assert_eq!(
+            selected,
+            Some(ReviewCommentSelection::SelectedThread(
+                "thread-id".to_string()
+            ))
+        );
+        assert_eq!(standalone, None);
+        assert_eq!(missing_snapshot, None);
+        assert_eq!(all, Some(ReviewCommentSelection::AllUnresolved));
+        assert_eq!(other, None);
     }
 
     #[tokio::test]

--- a/crates/agentty/src/ui/page/review_comment.rs
+++ b/crates/agentty/src/ui/page/review_comment.rs
@@ -11,7 +11,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
 
 use crate::domain::session::{Session, Status};
-use crate::presentation::help_action;
+use crate::presentation::{help_action, review_comment as review_comment_selection};
 use crate::ui::component::vertical_scrollbar::VerticalScrollbar;
 use crate::ui::diff_util::{DiffLine, DiffLineKind};
 use crate::ui::{Component, Page, diff_util, help_format, markdown, review_comment_format, style};
@@ -85,16 +85,16 @@ impl<'a> ReviewCommentPage<'a> {
             .map(comment_entries)
             .unwrap_or_default();
         let title = format!(" Comments ({}) ", entries.len());
-        let items = if entries.is_empty() {
-            vec![ListItem::new(comment_list_fallback(
-                self.comment_error,
-                self.is_loading_comments,
-            ))]
+        let (items, selection_rows) = if entries.is_empty() {
+            (
+                vec![ListItem::new(comment_list_fallback(
+                    self.comment_error,
+                    self.is_loading_comments,
+                ))],
+                Vec::new(),
+            )
         } else {
-            entries
-                .iter()
-                .map(|entry| ListItem::new(entry.label()))
-                .collect()
+            comment_list_items(&entries)
         };
         let list = List::new(items)
             .block(
@@ -112,10 +112,9 @@ impl<'a> ReviewCommentPage<'a> {
             .highlight_symbol("▶ ");
         let mut state = ListState::default();
         if !entries.is_empty() {
-            state.select(Some(normalized_selection(
-                self.selected_comment_index,
-                entries.len(),
-            )));
+            let selected_entry_index =
+                normalized_selection(self.selected_comment_index, entries.len());
+            state.select(selection_rows.get(selected_entry_index).copied());
         }
 
         frame.render_stateful_widget(list, area, &mut state);
@@ -216,8 +215,8 @@ pub(crate) fn review_comment_item_count(snapshot: Option<&ReviewCommentSnapshot>
     })
 }
 
-/// Returns whether the selected general comment or inline thread can be sent
-/// to the session agent.
+/// Returns whether the selected inline thread can be sent to the session
+/// agent.
 pub(crate) fn review_comment_selected_is_actionable(
     snapshot: Option<&ReviewCommentSnapshot>,
     selected_comment_index: usize,
@@ -225,28 +224,43 @@ pub(crate) fn review_comment_selected_is_actionable(
     let Some(snapshot) = snapshot else {
         return false;
     };
-    if selected_comment_index < snapshot.pr_level_comments.len() {
-        return true;
-    }
 
-    snapshot
-        .threads
-        .get(selected_comment_index.saturating_sub(snapshot.pr_level_comments.len()))
-        .is_some_and(ReviewCommentThread::is_actionable)
+    comment_entries(snapshot)
+        .get(selected_comment_index)
+        .is_some_and(
+            |entry| matches!(entry, CommentEntry::Thread(thread) if thread.is_actionable()),
+        )
 }
 
-/// Returns whether the snapshot contains any general comment or actionable
-/// inline thread.
+/// Returns whether the snapshot contains any actionable inline thread.
 pub(crate) fn review_comment_has_actionable_items(
     snapshot: Option<&ReviewCommentSnapshot>,
 ) -> bool {
     snapshot.is_some_and(|snapshot| {
-        !snapshot.pr_level_comments.is_empty()
-            || snapshot
-                .threads
-                .iter()
-                .any(ReviewCommentThread::is_actionable)
+        snapshot
+            .threads
+            .iter()
+            .any(ReviewCommentThread::is_actionable)
     })
+}
+
+/// Group applied to one review-comment selector entry.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CommentGroup {
+    Unresolved,
+    Resolved,
+    Standalone,
+}
+
+impl CommentGroup {
+    /// Returns the user-facing group heading.
+    fn label(self) -> &'static str {
+        match self {
+            Self::Unresolved => "Unresolved",
+            Self::Resolved => "Resolved",
+            Self::Standalone => "Standalone",
+        }
+    }
 }
 
 /// One selectable left-panel row and its right-panel detail source.
@@ -256,6 +270,15 @@ enum CommentEntry<'a> {
 }
 
 impl CommentEntry<'_> {
+    /// Returns the selector group for this entry.
+    fn group(&self) -> CommentGroup {
+        match self {
+            Self::General(_) => CommentGroup::Standalone,
+            Self::Thread(thread) if thread.is_resolved => CommentGroup::Resolved,
+            Self::Thread(_) => CommentGroup::Unresolved,
+        }
+    }
+
     /// Builds the compact label shown in the left selector.
     fn label(&self) -> Line<'static> {
         match self {
@@ -285,14 +308,39 @@ impl CommentEntry<'_> {
     }
 }
 
-/// Flattens general comments and inline threads into selector order.
+/// Flattens comments into unresolved, resolved, and standalone selector
+/// groups while preserving source order inside each group.
 fn comment_entries(snapshot: &ReviewCommentSnapshot) -> Vec<CommentEntry<'_>> {
-    snapshot
-        .pr_level_comments
-        .iter()
-        .map(CommentEntry::General)
-        .chain(snapshot.threads.iter().map(CommentEntry::Thread))
+    review_comment_selection::grouped_threads(snapshot)
+        .map(CommentEntry::Thread)
+        .chain(snapshot.pr_level_comments.iter().map(CommentEntry::General))
         .collect()
+}
+
+/// Builds group headings and selectable entry rows, returning each entry's
+/// corresponding list-row index.
+fn comment_list_items(entries: &[CommentEntry<'_>]) -> (Vec<ListItem<'static>>, Vec<usize>) {
+    let mut items = Vec::with_capacity(entries.len().saturating_add(3));
+    let mut selection_rows = Vec::with_capacity(entries.len());
+    let mut previous_group = None;
+
+    for entry in entries {
+        let group = entry.group();
+        if previous_group != Some(group) {
+            items.push(ListItem::new(Line::from(Span::styled(
+                group.label(),
+                Style::default()
+                    .fg(style::palette::text_muted())
+                    .add_modifier(Modifier::BOLD),
+            ))));
+            previous_group = Some(group);
+        }
+
+        selection_rows.push(items.len());
+        items.push(ListItem::new(entry.label()));
+    }
+
+    (items, selection_rows)
 }
 
 /// Builds all visible rows for one selected comment detail.
@@ -691,11 +739,13 @@ mod tests {
         let snapshot = comment_snapshot();
 
         // Act
-        let buffer = render_review_comment_page(Some(&snapshot), None, false, 0, 0, (100, 24));
+        let buffer = render_review_comment_page(Some(&snapshot), None, false, 1, 0, (100, 24));
         let text = buffer_text(&buffer);
 
         // Assert
         assert!(text.contains("Comments (2)"));
+        assert!(text.contains("Unresolved"));
+        assert!(text.contains("Standalone"));
         assert!(text.contains("General · alice"));
         assert!(text.contains("src/main.rs:2"));
         assert!(text.contains("Comment — Review comments session"));
@@ -717,7 +767,7 @@ mod tests {
         let snapshot = comment_snapshot();
 
         // Act
-        let buffer = render_review_comment_page(Some(&snapshot), None, false, 1, 0, (100, 14));
+        let buffer = render_review_comment_page(Some(&snapshot), None, false, 0, 0, (100, 14));
         let text = buffer_text(&buffer);
 
         // Assert
@@ -791,7 +841,7 @@ mod tests {
             None,
             false,
             SAMPLE_DIFF,
-            1,
+            0,
             Rect::new(0, 0, 80, 10),
             &markdown_render_cache,
         );
@@ -1037,6 +1087,42 @@ mod tests {
     }
 
     #[test]
+    fn test_comment_entries_group_unresolved_resolved_and_standalone_rows() {
+        // Arrange
+        let mut resolved = inline_thread(3);
+        resolved.id = "resolved".to_string();
+        resolved.is_resolved = true;
+        let mut unresolved = inline_thread(2);
+        unresolved.id = "unresolved".to_string();
+        let snapshot = ReviewCommentSnapshot {
+            pr_level_comments: vec![ReviewComment {
+                author: "bob".to_string(),
+                body: "Standalone note".to_string(),
+            }],
+            threads: vec![resolved, unresolved],
+        };
+
+        // Act
+        let entries = comment_entries(&snapshot);
+        let (items, selection_rows) = comment_list_items(&entries);
+
+        // Assert
+        assert_eq!(
+            entries.iter().map(CommentEntry::group).collect::<Vec<_>>(),
+            vec![
+                CommentGroup::Unresolved,
+                CommentGroup::Resolved,
+                CommentGroup::Standalone,
+            ]
+        );
+        assert!(matches!(entries[0], CommentEntry::Thread(thread) if thread.id == "unresolved"));
+        assert!(matches!(entries[1], CommentEntry::Thread(thread) if thread.id == "resolved"));
+        assert!(matches!(entries[2], CommentEntry::General(comment) if comment.author == "bob"));
+        assert_eq!(items.len(), 6);
+        assert_eq!(selection_rows, vec![1, 3, 5]);
+    }
+
+    #[test]
     fn test_review_comment_actionability_excludes_resolved_outdated_and_missing_rows() {
         // Arrange
         let mut current = inline_thread(2);
@@ -1056,19 +1142,23 @@ mod tests {
         };
 
         // Act
-        let general_is_actionable = review_comment_selected_is_actionable(Some(&snapshot), 0);
-        let current_is_actionable = review_comment_selected_is_actionable(Some(&snapshot), 1);
+        let current_is_actionable = review_comment_selected_is_actionable(Some(&snapshot), 0);
+        let outdated_is_actionable = review_comment_selected_is_actionable(Some(&snapshot), 1);
         let resolved_is_actionable = review_comment_selected_is_actionable(Some(&snapshot), 2);
-        let outdated_is_actionable = review_comment_selected_is_actionable(Some(&snapshot), 3);
+        let general_is_actionable = review_comment_selected_is_actionable(Some(&snapshot), 3);
         let missing_is_actionable = review_comment_selected_is_actionable(Some(&snapshot), 99);
+        let current_thread_id = review_comment_selection::selected_thread_id(&snapshot, 0);
+        let general_thread_id = review_comment_selection::selected_thread_id(&snapshot, 3);
         let snapshot_has_actionable_items = review_comment_has_actionable_items(Some(&snapshot));
 
         // Assert
-        assert!(general_is_actionable);
+        assert!(!general_is_actionable);
         assert!(current_is_actionable);
         assert!(!resolved_is_actionable);
         assert!(!outdated_is_actionable);
         assert!(!missing_is_actionable);
+        assert_eq!(current_thread_id, Some("current"));
+        assert_eq!(general_thread_id, None);
         assert!(snapshot_has_actionable_items);
         assert!(!review_comment_selected_is_actionable(None, 0));
         assert!(!review_comment_has_actionable_items(None));
@@ -1080,7 +1170,10 @@ mod tests {
         let mut resolved = inline_thread(2);
         resolved.is_resolved = true;
         let snapshot = ReviewCommentSnapshot {
-            pr_level_comments: Vec::new(),
+            pr_level_comments: vec![ReviewComment {
+                author: "bob".to_string(),
+                body: "Standalone note".to_string(),
+            }],
             threads: vec![resolved],
         };
 

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1462,7 +1462,7 @@ case "$*" in
     exit 0
     ;;
   *"api --hostname github.com graphql"*)
-    printf '%s\n' '{"data":{"repository":{"pullRequest":{"comments":{"nodes":[]},"reviewThreads":{"nodes":[{"id":"thread-inline","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":2,"path":"src/main.rs","startLine":1,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"alice"},"body":"Please explain why this review output is needed."}]}},{"id":"thread-file","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":null,"path":"src/main.rs","startLine":null,"subjectType":"FILE","comments":{"nodes":[{"author":{"login":"bob"},"body":"Please review the whole file."}]}}]}}}}}'
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"comments":{"nodes":[{"author":{"login":"carol"},"body":"Thanks for documenting the behavior."}]},"reviewThreads":{"nodes":[{"id":"thread-inline","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":2,"path":"src/main.rs","startLine":1,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"alice"},"body":"Please explain why this review output is needed."}]}},{"id":"thread-file","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":null,"path":"src/main.rs","startLine":null,"subjectType":"FILE","comments":{"nodes":[{"author":{"login":"bob"},"body":"Please review the whole file."}]}},{"id":"thread-resolved","diffSide":"RIGHT","isOutdated":false,"isResolved":true,"line":3,"path":"src/main.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"dana"},"body":"This thread is complete."}]}}]}}}}}'
     ;;
   *"pr view"*)
     printf '%s\n' '{"number":42,"title":"Review-ready session shortcuts","state":"OPEN","url":"https://github.com/agentty-xyz/agentty/pull/42","baseRefName":"main","headRefName":"wt/review-s","isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"REVIEW_REQUIRED","mergedAt":null}'
@@ -4250,7 +4250,10 @@ fn test_session_review_comments() -> E2eResult {
                     .find("Conversation")
                     .expect("conversation section should be visible");
 
-                assertion::assert_text_in_region(&inline_frame, "Comments (2)", &inline_full);
+                assertion::assert_text_in_region(&inline_frame, "Comments (4)", &inline_full);
+                assertion::assert_text_in_region(&inline_frame, "Unresolved", &inline_full);
+                assertion::assert_text_in_region(&inline_frame, "Resolved", &inline_full);
+                assertion::assert_text_in_region(&inline_frame, "Standalone", &inline_full);
                 assertion::assert_text_in_region(&inline_frame, "src/main.rs:1-2", &inline_full);
                 assertion::assert_text_in_region(&inline_frame, "Conversation", &inline_full);
                 assertion::assert_text_in_region(

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -81,10 +81,11 @@ For file-level detail, read the module docstrings directly.
 - `presentation.rs` and `presentation/`: Frontend-neutral interaction state shared by
   runtime input and UI output. They expose mode, help-action, prompt, settings-screen
   actions, editor, scroll, viewport, and semantic list-selection contracts without
-  importing Ratatui or `ui/` formatting. `presentation/settings.rs` owns settings row
-  selection, selectors, launch-configuration editing through the shared `InputState`,
-  and render-ready settings snapshots; it returns typed persistence operations to
-  `app/setting.rs`.
+  importing Ratatui or `ui/` formatting. `presentation/review_comment.rs` preserves
+  forge-thread selection across grouped snapshot refreshes. `presentation/settings.rs`
+  owns settings row selection, selectors, launch-configuration editing through the
+  shared `InputState`, and render-ready settings snapshots; it returns typed persistence
+  operations to `app/setting.rs`.
 - `ui/`: Rendering — frame composition, mode-to-page routing, pages under `ui/page/`,
   reusable widgets under `ui/component/`, application-to-frame projection in
   `ui/app_render.rs`, Agentty theme adapters for `ag-tui-text`, plus diff, layout,

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -205,23 +205,24 @@ Publish (`p`), sync (`r`), and stacked behavior are described in
 ## Review Comments
 
 The review-comments page uses the same split layout as diff view. The left panel lists
-general comments and inline threads; the right panel shows the selected comment's author
-and thread state, current diff context for its attached line or range, and then the
-conversation. File-level comments explicitly show that they have no attached code line
-instead of highlighting an arbitrary diff row. Inline snippets use the same gutters and
-added/removed line colors as diff view.
+unresolved threads, resolved threads, and standalone review-request comments in separate
+groups; the right panel shows the selected comment's author and thread state, current
+diff context for its attached line or range, and then the conversation. File-level
+comments explicitly show that they have no attached code line instead of highlighting an
+arbitrary diff row. Inline snippets use the same gutters and added/removed line colors
+as diff view.
 
-| Key           | Action                                             |
-| ------------- | -------------------------------------------------- |
-| `q` / `Esc`   | Return to session view                             |
-| `j` / `k`     | Select previous/next comment                       |
-| `Up` / `Down` | Scroll selected comment info                       |
-| `a`           | Address the selected actionable comment with agent |
-| `A`           | Address all actionable comments with the agent     |
+| Key           | Action                                            |
+| ------------- | ------------------------------------------------- |
+| `q` / `Esc`   | Return to session view                            |
+| `j` / `k`     | Select previous/next comment                      |
+| `Up` / `Down` | Scroll selected comment info                      |
+| `a`           | Address the selected actionable thread with agent |
+| `A`           | Address all actionable threads with the agent     |
 
 `a` and `A` appear only while the session can accept a turn. Resolved and outdated
-inline threads are not actionable; general discussion comments can be sent to the agent
-but cannot be resolved automatically because they have no forge thread ID.
+inline threads are not actionable. Standalone comments are also read-only because they
+have no forge thread ID.
 
 ## Publish Popup
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -49,15 +49,16 @@ output panel, with a metadata row showing the size bucket, `+added` / `-deleted`
 totals, the cumulative active-work timer, the current model, the effective reasoning
 level, and token usage. A linked pull-request or merge-request URL appears in the header
 when present. Press `c` on a linked review request to open its comments in a split page:
-comments and inline threads appear on the left, while the selected thread's metadata,
-attached current-diff context, and conversation appear on the right. In **Review**,
-**AgentReview**, or **Question**, press `a` to send the selected actionable comment to
-the active session agent or `A` to send every actionable comment. The timer ticks only
-while the session is actively working. A linked terminal session keeps `C` available for
-starting a continuation draft. File-level comments show an explicit no-line-context
-message instead of a synthetic code anchor. Each session stores the project reasoning
-default when it is created, so later default changes affect new sessions without
-relabeling existing ones.
+unresolved threads, resolved threads, and standalone review-request comments are grouped
+on the left, while the selected entry's metadata, attached current-diff context, and
+conversation appear on the right. In **Review**, **AgentReview**, or **Question**, press
+`a` to send the selected actionable inline thread to the active session agent or `A` to
+send every actionable inline thread. Standalone comments are read-only because they do
+not have forge thread IDs. The timer ticks only while the session is actively working. A
+linked terminal session keeps `C` available for starting a continuation draft.
+File-level comments show an explicit no-line-context message instead of a synthetic code
+anchor. Each session stores the project reasoning default when it is created, so later
+default changes affect new sessions without relabeling existing ones.
 
 The top status bar shows the current version and update status, and rotates short
 page-scoped `FYI:` messages once per minute in the **Sessions** list and session chat


### PR DESCRIPTION
- Groups review comments into unresolved, resolved, and standalone entries.
- Restricts agent resolution actions to actionable inline threads identified by forge IDs.
- Preserves selected thread identity across refreshed snapshots.
- Updates unit and E2E coverage plus user-facing documentation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)