### PR TITLE
Start sessions from issue details

### DIFF
--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -2224,6 +2224,58 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    async fn test_issue_detail_success_preserves_action_error() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let project_id = app.projects.active_project_id();
+        let generation = app.assigned_issue_generation;
+        app.mode = AppMode::IssueDetail {
+            action_error: Some("Failed to start issue session: unavailable".to_string()),
+            detail: None,
+            error: None,
+            issue: ag_forge::AssignedIssue {
+                display_id: "#124".to_string(),
+                repository: "agentty-xyz/agentty".to_string(),
+                title: "Keep issue details reachable".to_string(),
+                updated_at: None,
+                web_url: "https://github.com/agentty-xyz/agentty/issues/124".to_string(),
+            },
+            scroll_offset: 0,
+        };
+
+        // Act
+        app.apply_issue_detail_update(IssueDetailUpdate {
+            display_id: "#124".to_string(),
+            generation,
+            project_id,
+            result: Ok(ag_forge::IssueDetail {
+                assignees: Vec::new(),
+                author: "octocat".to_string(),
+                body: Some("Loaded after the action failed.".to_string()),
+                created_at: None,
+                display_id: "#124".to_string(),
+                labels: Vec::new(),
+                repository: "agentty-xyz/agentty".to_string(),
+                state: "OPEN".to_string(),
+                title: "Keep issue details reachable".to_string(),
+                updated_at: None,
+                web_url: "https://github.com/agentty-xyz/agentty/issues/124".to_string(),
+            }),
+        });
+
+        // Assert
+        assert!(matches!(
+            app.mode,
+            AppMode::IssueDetail {
+                action_error: Some(ref action_error),
+                detail: Some(_),
+                error: None,
+                ..
+            } if action_error == "Failed to start issue session: unavailable"
+        ));
+    }
+
+    #[tokio::test]
     async fn test_session_review_comment_result_updates_matching_open_page() {
         // Arrange
         let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -445,11 +445,26 @@ impl App {
             self.services.review_request_client(),
         );
         self.mode = AppMode::IssueDetail {
+            action_error: None,
             detail: None,
             error: None,
             issue,
             scroll_offset: 0,
         };
+    }
+
+    /// Creates and starts a regular session instructed to address the linked
+    /// issue, then opens that session.
+    ///
+    /// # Errors
+    /// Returns an error if session creation fails. Initial prompt submission
+    /// failures are appended to the created session before it is opened.
+    pub(crate) async fn start_issue_session(&mut self, issue_url: &str) -> Result<(), AppError> {
+        let session_id = self.create_session().await?;
+        self.start_created_issue_session(&session_id, issue_url)
+            .await;
+
+        Ok(())
     }
 
     /// Moves selection to the next requested review in the `Inbox` tab.
@@ -1887,6 +1902,22 @@ impl App {
         );
 
         Ok(())
+    }
+
+    /// Starts one already-created issue session and opens it even when prompt
+    /// submission fails, keeping the recoverable session visible to the user.
+    async fn start_created_issue_session(&mut self, session_id: &str, issue_url: &str) {
+        if let Err(error) = self
+            .start_session(
+                session_id,
+                TurnPrompt::from_text(format!("Address this issue: {issue_url}")),
+            )
+            .await
+        {
+            self.append_output_for_session(session_id, &TranscriptNotice::Error.format(error))
+                .await;
+        }
+        self.open_session(session_id);
     }
 
     /// Opens one linked sibling session when it still exists in memory.

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -60,6 +60,69 @@ fn test_view_app_mode(session_id: &str) -> AppMode {
     }
 }
 
+#[tokio::test]
+async fn open_selected_assigned_issue_clears_action_error() {
+    // Arrange
+    let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+    let project_id = app.projects.active_project_id();
+    let issue = crate::test_support::assigned_issue_fixture();
+    app.replace_assigned_issues(project_id, vec![issue.clone()]);
+
+    // Act
+    app.open_selected_assigned_issue();
+
+    // Assert
+    assert!(matches!(
+        app.mode,
+        AppMode::IssueDetail {
+            action_error: None,
+            detail: None,
+            error: None,
+            issue: opened_issue,
+            scroll_offset: 0,
+        } if opened_issue == issue
+    ));
+}
+
+#[tokio::test]
+async fn start_created_issue_session_opens_session_when_command_persistence_fails() {
+    // Arrange
+    let (mut app, _base_dir, pool) = crate::test_support::new_git_test_app_with_pool().await;
+    let created_session_id = app
+        .create_session()
+        .await
+        .expect("issue session should be created");
+    sqlx::query("DROP TABLE session_operation")
+        .execute(&pool)
+        .await
+        .expect("session operation table should be removed");
+
+    // Act
+    app.start_created_issue_session(
+        &created_session_id,
+        "https://github.com/agentty-xyz/agentty/issues/124",
+    )
+    .await;
+
+    // Assert
+    let transcript = app
+        .sessions
+        .session_handles()
+        .get(created_session_id.as_str())
+        .and_then(|handles| handles.transcript.lock().ok())
+        .and_then(|transcript| transcript.replay_text())
+        .expect("failed issue start should remain visible in the transcript");
+    assert!(transcript.contains("[Error]"));
+    assert!(transcript.contains("no such table: session_operation"));
+    assert!(matches!(
+        app.mode,
+        AppMode::View {
+            ref session_id,
+            scroll_offset: None,
+        } if session_id == &SessionId::from(created_session_id.as_str())
+    ));
+}
+
 /// Builds one restorable prompt snapshot without attachments.
 fn test_prompt_mode_snapshot(session_id: SessionId) -> PromptModeSnapshot {
     PromptModeSnapshot {

--- a/crates/agentty/src/presentation/app_mode.rs
+++ b/crates/agentty/src/presentation/app_mode.rs
@@ -198,6 +198,8 @@ pub enum AppMode {
     /// Displays a selected assigned issue while its base details load and
     /// after the detail request completes.
     IssueDetail {
+        /// User-facing issue-session action failure.
+        action_error: Option<String>,
         /// Loaded base details, excluding comments.
         detail: Option<IssueDetail>,
         /// User-facing detail-load failure.

--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -370,6 +370,7 @@ pub(crate) fn issue_actions() -> Vec<HelpAction> {
 pub(crate) fn issue_detail_actions() -> Vec<HelpAction> {
     vec![
         HelpAction::new("back", "q/Esc", "Back to issues"),
+        HelpAction::new("address", "a", "Address issue in a new session"),
         HelpAction::new("scroll", "j/k", "Scroll issue details"),
         HelpAction::new("page", "Ctrl+d/u", "Scroll half page"),
         HelpAction::new("top/bottom", "g/G", "Jump to top or bottom"),
@@ -1787,7 +1788,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         // Assert
-        assert_eq!(issue_keys, ["q/Esc", "j/k", "Ctrl+d/u", "g/G"]);
+        assert_eq!(issue_keys, ["q/Esc", "a", "j/k", "Ctrl+d/u", "g/G"]);
         assert_eq!(diff_keys, ["q/Esc", "j/k", "Up/Down", "?"]);
         assert_eq!(comment_keys, ["q/Esc", "j/k", "Up/Down"]);
     }

--- a/crates/agentty/src/runtime/key_handler.rs
+++ b/crates/agentty/src/runtime/key_handler.rs
@@ -58,7 +58,8 @@ where
                     presentation.render_cache_store(),
                     content_area,
                     key,
-                ))
+                )
+                .await)
             }
             AppMode::SessionCreation { .. } => {
                 unreachable!("session creation mode is handled before dispatch matching")
@@ -1430,6 +1431,34 @@ mod tests {
                 scroll_offset: None,
             } if session_id == "session-id"
         ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_key_event_routes_issue_detail_back_shortcut() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.mode = AppMode::IssueDetail {
+            action_error: Some("Failed to start issue session".to_string()),
+            detail: None,
+            error: None,
+            issue: crate::test_support::assigned_issue_fixture(),
+            scroll_offset: 0,
+        };
+        let backend = ratatui::backend::TestBackend::new(120, 30);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+
+        // Act
+        let event_result = handle_key_event(
+            &mut app,
+            &PresentationState::default(),
+            &mut terminal,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(event_result, Ok(EventResult::Continue)));
+        assert!(matches!(app.mode, AppMode::List));
     }
 
     #[tokio::test]

--- a/crates/agentty/src/runtime/mode/detail.rs
+++ b/crates/agentty/src/runtime/mode/detail.rs
@@ -12,7 +12,45 @@ const ISSUE_DETAIL_PAGE_INSET: u16 = 3;
 const REVIEW_DETAIL_PAGE_INSET: u16 = 5;
 
 /// Handles key input while an issue or requested-review detail page is visible.
-pub(crate) fn handle_with_cache(
+pub(crate) async fn handle_with_cache(
+    app: &mut App,
+    render_cache_store: &RenderCacheStore,
+    content_area: Rect,
+    key: KeyEvent,
+) -> EventResult {
+    if key.code == KeyCode::Char('a')
+        && key.modifiers == KeyModifiers::NONE
+        && let AppMode::IssueDetail {
+            detail,
+            error,
+            issue,
+            scroll_offset,
+            ..
+        } = &app.mode
+    {
+        let detail = detail.clone();
+        let detail_error = error.clone();
+        let issue = issue.clone();
+        let issue_url = issue.web_url.clone();
+        let scroll_offset = *scroll_offset;
+        if let Err(error) = app.start_issue_session(&issue_url).await {
+            app.mode = AppMode::IssueDetail {
+                action_error: Some(format!("Failed to start issue session: {error}")),
+                detail,
+                error: detail_error,
+                issue,
+                scroll_offset,
+            };
+        }
+
+        return EventResult::Continue;
+    }
+
+    handle_detail_with_cache(app, render_cache_store, content_area, key)
+}
+
+/// Applies read-only navigation and scrolling for issue and review details.
+fn handle_detail_with_cache(
     app: &mut App,
     render_cache_store: &RenderCacheStore,
     content_area: Rect,
@@ -26,6 +64,7 @@ pub(crate) fn handle_with_cache(
 
     let (max_scroll_offset, half_page_inset) = match &app.mode {
         AppMode::IssueDetail {
+            action_error,
             detail,
             error,
             issue,
@@ -35,6 +74,7 @@ pub(crate) fn handle_with_cache(
                 issue,
                 detail.as_ref(),
                 error.as_deref(),
+                action_error.as_deref(),
                 content_area,
                 render_cache_store.markdown_render_cache(),
             ),
@@ -88,7 +128,7 @@ pub(crate) fn handle_with_cache(
 
 #[cfg(test)]
 fn handle(app: &mut App, content_area: Rect, key: KeyEvent) -> EventResult {
-    handle_with_cache(app, &RenderCacheStore::default(), content_area, key)
+    handle_detail_with_cache(app, &RenderCacheStore::default(), content_area, key)
 }
 
 /// Returns the half-page scroll step for one detail viewport.
@@ -114,6 +154,7 @@ mod tests {
         // Arrange
         let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
         app.mode = AppMode::IssueDetail {
+            action_error: None,
             detail: None,
             error: None,
             issue: assigned_issue(),
@@ -133,6 +174,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_handle_a_starts_session_for_issue_url() {
+        // Arrange
+        let (mut app, _base_dir) =
+            crate::test_support::new_git_test_app_with_mock_tmux_client().await;
+        let issue = assigned_issue();
+        let expected_prompt = format!("Address this issue: {}", issue.web_url);
+        app.mode = AppMode::IssueDetail {
+            action_error: None,
+            detail: None,
+            error: None,
+            issue,
+            scroll_offset: 0,
+        };
+
+        // Act
+        let event_result = handle_with_cache(
+            &mut app,
+            &RenderCacheStore::default(),
+            Rect::new(0, 0, 80, 20),
+            KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(event_result, EventResult::Continue));
+        assert_eq!(app.sessions.sessions().len(), 1);
+        assert_eq!(app.sessions.sessions()[0].prompt, expected_prompt);
+        assert!(matches!(app.mode, AppMode::View { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_handle_a_preserves_issue_detail_when_session_creation_fails() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let issue = assigned_issue();
+        let detail = issue_detail("Issue description remains visible.");
+        app.mode = AppMode::IssueDetail {
+            action_error: None,
+            detail: Some(detail),
+            error: None,
+            issue,
+            scroll_offset: 2,
+        };
+
+        // Act
+        let event_result = handle_with_cache(
+            &mut app,
+            &RenderCacheStore::default(),
+            Rect::new(0, 0, 80, 20),
+            KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(event_result, EventResult::Continue));
+        assert!(app.sessions.sessions().is_empty());
+        assert!(matches!(
+            app.mode,
+            AppMode::IssueDetail {
+                action_error: Some(ref error),
+                detail: Some(_),
+                error: None,
+                scroll_offset: 2,
+                ..
+            } if error.contains("Failed to start issue session:")
+        ));
+    }
+
+    #[tokio::test]
     async fn test_handle_scrolls_issue_detail_page_to_bottom() {
         // Arrange
         let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
@@ -144,10 +254,12 @@ mod tests {
             &issue,
             Some(&detail),
             None,
+            None,
             content_area,
             render_cache_store.markdown_render_cache(),
         );
         app.mode = AppMode::IssueDetail {
+            action_error: None,
             detail: Some(detail),
             error: None,
             issue,

--- a/crates/agentty/src/test_support.rs
+++ b/crates/agentty/src/test_support.rs
@@ -469,12 +469,31 @@ pub(crate) fn setup_test_git_repo(path: &Path) {
 pub(crate) async fn new_git_test_app_with_clients(
     clients: app::AppClients,
 ) -> (App, tempfile::TempDir) {
+    let (app, base_dir, _pool) = new_git_test_app_with_clients_and_pool(clients).await;
+
+    (app, base_dir)
+}
+
+/// Builds one git-backed app and exposes its shared database pool for tests
+/// that need to inject a persistence failure after app construction.
+#[cfg(test)]
+pub(crate) async fn new_git_test_app_with_pool() -> (App, tempfile::TempDir, sqlx::SqlitePool) {
+    new_git_test_app_with_clients_and_pool(test_app_clients()).await
+}
+
+/// Builds one git-backed app plus its shared database pool using the given
+/// clients.
+#[cfg(test)]
+async fn new_git_test_app_with_clients_and_pool(
+    clients: app::AppClients,
+) -> (App, tempfile::TempDir, sqlx::SqlitePool) {
     let base_dir = tempfile::tempdir().expect("failed to create temp dir");
     let base_path = base_dir.path().to_path_buf();
     setup_test_git_repo(base_dir.path());
     let database = Database::open_in_memory()
         .await
         .expect("failed to open in-memory db");
+    let pool = database.pool().clone();
     let app = App::new_with_clients(
         base_path.clone(),
         base_path,
@@ -485,7 +504,7 @@ pub(crate) async fn new_git_test_app_with_clients(
     .await
     .expect("failed to build app");
 
-    (app, base_dir)
+    (app, base_dir, pool)
 }
 
 /// Builds one git-backed app rooted at a retained temporary directory.
@@ -571,6 +590,18 @@ pub(crate) fn set_review_detail_mode(app: &mut App, review: ag_forge::RequestedR
         review,
         scroll_offset: 0,
     };
+}
+
+/// Builds one deterministic assigned-issue fixture for cross-module tests.
+#[cfg(test)]
+pub(crate) fn assigned_issue_fixture() -> ag_forge::AssignedIssue {
+    ag_forge::AssignedIssue {
+        display_id: "#124".to_string(),
+        repository: "agentty-xyz/agentty".to_string(),
+        title: "Keep issue details reachable".to_string(),
+        updated_at: None,
+        web_url: "https://github.com/agentty-xyz/agentty/issues/124".to_string(),
+    }
 }
 
 /// Returns the first rendered cell for a contiguous text match in a test

--- a/crates/agentty/src/ui/page/issue_detail.rs
+++ b/crates/agentty/src/ui/page/issue_detail.rs
@@ -8,8 +8,10 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 use crate::presentation::help_action;
 use crate::ui::{Page, help_format, layout, markdown, style};
 
-/// Page renderer for one selected GitHub issue and its base details.
+/// Page renderer for one selected GitHub issue, its base details, and the
+/// shortcut for starting an issue-addressing session.
 pub struct IssueDetailPage<'a> {
+    action_error: Option<&'a str>,
     detail: Option<&'a IssueDetail>,
     error: Option<&'a str>,
     issue: &'a AssignedIssue,
@@ -24,10 +26,12 @@ impl<'a> IssueDetailPage<'a> {
         issue: &'a AssignedIssue,
         detail: Option<&'a IssueDetail>,
         error: Option<&'a str>,
+        action_error: Option<&'a str>,
         markdown_render_cache: &'a markdown::MarkdownRenderCache,
         scroll_offset: u16,
     ) -> Self {
         Self {
+            action_error,
             detail,
             error,
             issue,
@@ -45,6 +49,7 @@ impl Page for IssueDetailPage<'_> {
             self.issue,
             self.detail,
             self.error,
+            self.action_error,
             self.markdown_render_cache,
             usize::from(content_area.width),
         ))
@@ -67,6 +72,7 @@ pub(crate) fn issue_detail_max_scroll_offset(
     issue: &AssignedIssue,
     detail: Option<&IssueDetail>,
     error: Option<&str>,
+    action_error: Option<&str>,
     area: Rect,
     markdown_render_cache: &markdown::MarkdownRenderCache,
 ) -> u16 {
@@ -80,6 +86,7 @@ pub(crate) fn issue_detail_max_scroll_offset(
         issue,
         detail,
         error,
+        action_error,
         markdown_render_cache,
         usize::from(content_area.width),
     )
@@ -93,13 +100,19 @@ fn issue_detail_lines(
     issue: &AssignedIssue,
     detail: Option<&IssueDetail>,
     error: Option<&str>,
+    action_error: Option<&str>,
     markdown_render_cache: &markdown::MarkdownRenderCache,
     width: usize,
 ) -> Vec<Line<'static>> {
+    let mut lines = action_error.map_or_else(Vec::new, |message| {
+        vec![error_line(message), Line::from("")]
+    });
     let Some(detail) = detail else {
-        return vec![Line::from(
+        lines.push(Line::from(
             error.unwrap_or("Loading issue details...").to_string(),
-        )];
+        ));
+
+        return lines;
     };
     if issue.display_id != detail.display_id {
         return vec![Line::from(
@@ -117,7 +130,7 @@ fn issue_detail_lines(
         .map(str::trim)
         .filter(|body| !body.is_empty())
         .unwrap_or("No description provided.");
-    let mut lines = vec![
+    lines.extend([
         field_line("Title", &detail.title),
         field_line("State", &detail.state),
         field_line("Author", &detail.author),
@@ -128,7 +141,7 @@ fn issue_detail_lines(
         field_line("URL", &detail.web_url),
         Line::from(""),
         section_label("Description"),
-    ];
+    ]);
     lines.extend(
         markdown_render_cache
             .render(description, width)
@@ -137,6 +150,14 @@ fn issue_detail_lines(
     );
 
     lines
+}
+
+/// Formats a user-facing issue-detail failure.
+fn error_line(text: &str) -> Line<'static> {
+    Line::from(Span::styled(
+        text.to_string(),
+        Style::default().fg(style::palette::danger()),
+    ))
 }
 
 /// Formats one metadata field as a bold label followed by its value.
@@ -221,11 +242,72 @@ mod tests {
         let markdown_render_cache = markdown::MarkdownRenderCache::default();
 
         // Act
-        let lines = issue_detail_lines(&issue, Some(&detail), None, &markdown_render_cache, 80);
+        let lines = issue_detail_lines(
+            &issue,
+            Some(&detail),
+            None,
+            None,
+            &markdown_render_cache,
+            80,
+        );
 
         // Assert
         assert_eq!(lines.len(), 1);
         assert!(lines[0].to_string().contains("do not match"));
+    }
+
+    #[test]
+    fn test_issue_detail_lines_preserves_loaded_detail_with_action_error() {
+        // Arrange
+        let issue = assigned_issue();
+        let detail = issue_detail();
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+
+        // Act
+        let lines = issue_detail_lines(
+            &issue,
+            Some(&detail),
+            None,
+            Some("Failed to start issue session: worktree unavailable"),
+            &markdown_render_cache,
+            80,
+        );
+        let rendered_text = lines
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Assert
+        assert!(rendered_text.contains("Failed to start issue session: worktree unavailable"));
+        assert!(rendered_text.contains("Title: Keep issue details reachable"));
+        assert!(rendered_text.contains("One description line."));
+    }
+
+    #[test]
+    fn test_issue_detail_lines_shows_action_error_while_details_load() {
+        // Arrange
+        let issue = assigned_issue();
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+
+        // Act
+        let lines = issue_detail_lines(
+            &issue,
+            None,
+            None,
+            Some("Failed to start issue session: worktree unavailable"),
+            &markdown_render_cache,
+            80,
+        );
+
+        // Assert
+        assert_eq!(lines.len(), 3);
+        assert!(
+            lines[0]
+                .to_string()
+                .contains("Failed to start issue session")
+        );
+        assert_eq!(lines[2].to_string(), "Loading issue details...");
     }
 
     #[test]
@@ -270,6 +352,7 @@ mod tests {
         let max_scroll_offset = issue_detail_max_scroll_offset(
             &issue,
             Some(&detail),
+            None,
             None,
             area,
             &markdown_render_cache,

--- a/crates/agentty/src/ui/router.rs
+++ b/crates/agentty/src/ui/router.rs
@@ -411,6 +411,7 @@ fn render_detail_mode(
 ) {
     match mode {
         AppMode::IssueDetail {
+            action_error,
             detail,
             error,
             issue,
@@ -419,6 +420,7 @@ fn render_detail_mode(
             issue,
             detail.as_ref(),
             error.as_deref(),
+            action_error.as_deref(),
             markdown_render_cache,
             *scroll_offset,
         )
@@ -1183,6 +1185,34 @@ mod tests {
         // Assert
         let text = buffer_text(terminal.backend().buffer());
         assert!(text.contains("sentinel"));
+    }
+
+    #[test]
+    fn render_detail_mode_renders_issue_action_error() {
+        // Arrange
+        let backend = ratatui::backend::TestBackend::new(80, 20);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+        let mode = AppMode::IssueDetail {
+            action_error: Some("Failed to start issue session".to_string()),
+            detail: None,
+            error: None,
+            issue: crate::test_support::assigned_issue_fixture(),
+            scroll_offset: 0,
+        };
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+
+        // Act
+        terminal
+            .draw(|frame| {
+                render_detail_mode(frame, frame.area(), &mode, &markdown_render_cache);
+            })
+            .expect("failed to draw issue detail");
+
+        // Assert
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(text.contains("Issue #124"));
+        assert!(text.contains("Failed to start issue session"));
+        assert!(text.contains("Loading issue details..."));
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/navigation.rs
+++ b/crates/agentty/tests/e2e/navigation.rs
@@ -492,6 +492,56 @@ fn test_assigned_github_issues() -> E2eResult {
     Ok(())
 }
 
+/// Verify an assigned GitHub issue can start a session with its link.
+#[test]
+fn test_address_assigned_github_issue() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("address_assigned_github_issue")
+        .with_git()
+        .with_terminal_size(120, 36)
+        .setup(seed_assigned_github_issues)
+        .zola(
+            "Address an assigned GitHub issue",
+            "Start an agent session from an assigned issue with its link included.",
+            46,
+        )
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .compose(&common::switch_to_tab("Inbox"))
+                    .compose(&common::switch_to_tab("Issues"))
+                    .wait_for_text("Keep issue list compact", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Description", 5000)
+                    .capture_labeled("issue_detail", "Issue detail with address action")
+                    .press_key("a")
+                    .wait_for_text(
+                        "Address this issue: https://github.com/agentty-xyz/agentty/issues/124",
+                        10000,
+                    )
+                    .viewing_pause_ms(1500)
+                    .capture_labeled("issue_session", "New session addressing the issue")
+            },
+            |frame, report| {
+                assert_eq!(report.captures.len(), 2);
+                let issue_frame = common::frame_from_capture(&report.captures[0]);
+                let issue_full = Region::full(issue_frame.cols(), issue_frame.rows());
+                assertion::assert_text_in_region(&issue_frame, "a: address", &issue_full);
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(
+                    frame,
+                    "Address this issue: https://github.com/agentty-xyz/agentty/issues/124",
+                    &full,
+                );
+            },
+        )?;
+
+    Ok(())
+}
+
 /// Verify that pressing `q` opens a quit confirmation dialog.
 ///
 /// The dialog should display the title "Confirm Quit" and the message

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -522,7 +522,13 @@ orchestration paths:
   repository-scoped, generation-scoped `gh search issues` task through
   `ReviewRequestClient`; stale completions are discarded before the list cache is
   rendered. Opening a selected row starts a generation-scoped `gh issue view` task for
-  base metadata and the description; the detail query does not request comments.
+  base metadata and the description; the detail query does not request comments. The
+  issue-detail `a` action creates a regular session, submits an initial prompt
+  containing the issue URL, and opens the new session view. Creation failures restore
+  the issue-detail mode with a distinct inline action error that survives a late detail
+  result. Submission failures after creation append a transcript error and open the
+  recoverable session instead of hiding it or escaping through the runtime key-handler
+  boundary.
 
 ## Persistence and Recovery Boundaries
 

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -138,9 +138,11 @@ to return to the review list.
 | `Tab` / `Shift+Tab` | Switch to next / previous tab                                    |
 | `?`                 | Help                                                             |
 
-On the read-only detail page, use `j` / `k` or `Up` / `Down` to scroll, `Ctrl+d` /
-`Ctrl+u` to move by half pages, `g` / `G` to jump to the top or bottom, and `q` / `Esc`
-to return to the issue list. Issue comments are not loaded in this iteration.
+On the detail page, press `a` to start a new session instructed to address the issue,
+with its URL included in the first prompt. Use `j` / `k` or `Up` / `Down` to scroll,
+`Ctrl+d` / `Ctrl+u` to move by half pages, `g` / `G` to jump to the top or bottom, and
+`q` / `Esc` to return to the issue list. Issue comments are not loaded in this
+iteration.
 
 ## Session View
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -34,8 +34,13 @@ tabs. Press `Tab` to move forward or `Shift+Tab` to move backward:
   active project repository. The table labels the non-empty result group **Assigned to
   you**. Press `s` to refresh, use `j` / `k` to move through the first `100` results,
   and press `Enter` to load a read-only detail page with base metadata and the
-  description. Comments are not loaded in this iteration. Install the GitHub CLI and run
-  `gh auth login` to enable this tab.
+  description. From issue details, press `a` to create and start a regular session whose
+  first prompt instructs the agent to address the issue and includes its URL. If session
+  creation fails, the issue details remain open and show the failure inline, even when
+  the detail fetch finishes later. If prompt submission fails after creation, Agentty
+  opens the recoverable session with the error in its transcript. Comments are not
+  loaded in this iteration. Install the GitHub CLI and run `gh auth login` to enable
+  this tab.
 - **Settings**: Configure the color theme, default reasoning level, smart/fast/review
   model defaults, the optional `Last used model as default` mode, the session commit
   coauthor trailer, and `Launch Configurations` for the active project.


### PR DESCRIPTION
- Binds `a` to create and open a regular session with the issue URL in its initial prompt.
- Preserves issue details and displays session startup failures inline, including when detail loading completes later.
- Keeps created sessions visible with transcript errors when prompt submission fails.
- Documents and covers the workflow in help text, usage and runtime docs, and E2E navigation tests.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)