### PR TITLE
Run E2E workflows in a pinned image

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -134,8 +134,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Rust and `prek`
-        uses: ./.github/actions/setup-rust-prek
+      - name: Build the pinned E2E image
+        run: >-
+          docker build --platform linux/amd64
+          --file docker/e2e.Dockerfile --tag agentty-e2e docker
 
+      # The checkout is mounted read-only so `TESTTY_GIF_MODE=check` (set by
+      # the hook) verifies committed GIF hash sidecars without rewriting them.
       - name: Run end-to-end feature suite
-        run: prek run test-agentty-e2e --all-files --hook-stage manual
+        run: >-
+          docker run --rm --platform linux/amd64
+          --mount type=bind,source="$PWD",target=/workspace,readonly
+          --env CARGO_TARGET_DIR=/tmp/target
+          agentty-e2e
+          prek run test-agentty-e2e --all-files --hook-stage manual

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -10,6 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  E2E_IMAGE: ghcr.io/agentty-xyz/agentty-e2e@sha256:d348629b6c449d33f5285c9ef2b7ea0ac3c47fcf264b1ec7f3f4c58a6952a696
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -134,10 +135,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build the pinned E2E image
-        run: >-
-          docker build --platform linux/amd64
-          --file docker/e2e.Dockerfile --tag agentty-e2e docker
+      - name: Pull the pinned E2E image
+        run: docker pull "$E2E_IMAGE"
 
       # The checkout is mounted read-only so `TESTTY_GIF_MODE=check` (set by
       # the hook) verifies committed GIF hash sidecars without rewriting them.
@@ -146,5 +145,5 @@ jobs:
           docker run --rm --platform linux/amd64
           --mount type=bind,source="$PWD",target=/workspace,readonly
           --env CARGO_TARGET_DIR=/tmp/target
-          agentty-e2e
+          "$E2E_IMAGE"
           prek run test-agentty-e2e --all-files --hook-stage manual

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -56,11 +56,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Rust and `prek`
-        uses: ./.github/actions/setup-rust-prek
+      - name: Build the pinned E2E image
+        run: >-
+          docker build --platform linux/amd64
+          --file docker/e2e.Dockerfile --tag agentty-e2e docker
 
+      # The checkout is mounted read-only so `TESTTY_GIF_MODE=check` (set by
+      # the hook) verifies committed GIF hash sidecars without rewriting them.
       - name: Run end-to-end feature suite
-        run: prek run test-agentty-e2e --all-files --hook-stage manual
+        run: >-
+          docker run --rm --platform linux/amd64
+          --mount type=bind,source="$PWD",target=/workspace,readonly
+          --env CARGO_TARGET_DIR=/tmp/target
+          agentty-e2e
+          prek run test-agentty-e2e --all-files --hook-stage manual
 
   validate:
     name: Workspace checks

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  E2E_IMAGE: ghcr.io/agentty-xyz/agentty-e2e@sha256:d348629b6c449d33f5285c9ef2b7ea0ac3c47fcf264b1ec7f3f4c58a6952a696
+
 jobs:
   coverage:
     name: SonarQube
@@ -56,10 +59,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build the pinned E2E image
-        run: >-
-          docker build --platform linux/amd64
-          --file docker/e2e.Dockerfile --tag agentty-e2e docker
+      - name: Pull the pinned E2E image
+        run: docker pull "$E2E_IMAGE"
 
       # The checkout is mounted read-only so `TESTTY_GIF_MODE=check` (set by
       # the hook) verifies committed GIF hash sidecars without rewriting them.
@@ -68,7 +69,7 @@ jobs:
           docker run --rm --platform linux/amd64
           --mount type=bind,source="$PWD",target=/workspace,readonly
           --env CARGO_TARGET_DIR=/tmp/target
-          agentty-e2e
+          "$E2E_IMAGE"
           prek run test-agentty-e2e --all-files --hook-stage manual
 
   validate:

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -6,6 +6,9 @@ on:
 permissions:
   contents: read
 
+env:
+  E2E_IMAGE: ghcr.io/agentty-xyz/agentty-e2e@sha256:d348629b6c449d33f5285c9ef2b7ea0ac3c47fcf264b1ec7f3f4c58a6952a696
+
 jobs:
   validate:
     name: Release validation
@@ -26,10 +29,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build the pinned E2E image
-        run: >-
-          docker build --platform linux/amd64
-          --file docker/e2e.Dockerfile --tag agentty-e2e docker
+      - name: Pull the pinned E2E image
+        run: docker pull "$E2E_IMAGE"
 
       # The checkout is mounted read-only so `TESTTY_GIF_MODE=check` (set by
       # the hook) verifies committed GIF hash sidecars without rewriting them.
@@ -38,5 +39,5 @@ jobs:
           docker run --rm --platform linux/amd64
           --mount type=bind,source="$PWD",target=/workspace,readonly
           --env CARGO_TARGET_DIR=/tmp/target
-          agentty-e2e
+          "$E2E_IMAGE"
           prek run test-agentty-e2e --all-files --hook-stage manual

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -26,8 +26,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Rust and `prek`
-        uses: ./.github/actions/setup-rust-prek
+      - name: Build the pinned E2E image
+        run: >-
+          docker build --platform linux/amd64
+          --file docker/e2e.Dockerfile --tag agentty-e2e docker
 
+      # The checkout is mounted read-only so `TESTTY_GIF_MODE=check` (set by
+      # the hook) verifies committed GIF hash sidecars without rewriting them.
       - name: Run end-to-end feature suite
-        run: prek run test-agentty-e2e --all-files --hook-stage manual
+        run: >-
+          docker run --rm --platform linux/amd64
+          --mount type=bind,source="$PWD",target=/workspace,readonly
+          --env CARGO_TARGET_DIR=/tmp/target
+          agentty-e2e
+          prek run test-agentty-e2e --all-files --hook-stage manual

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,13 +356,17 @@ the full suite.
 - **User-visible UI behavior:** Satisfy the MANDATORY feature-test gate, then run the
   focused E2E workflow. For routine validation, run E2E feature tests with
   `TESTTY_GIF_MODE=check` so agents verify GIF freshness without launching VHS/Chrome.
-  Use `TESTTY_GIF_MODE=force` only when intentionally regenerating GIF assets, and run
-  it from an unsandboxed shell (a normal terminal, or one command explicitly approved to
-  bypass the agent sandbox): VHS records through localhost sockets (`ttyd` plus Chrome
-  DevTools), so a network-denied sandbox crashes `vhs` before Chrome launches — an error
-  easy to misdiagnose as a missing browser binary. Do not run the full E2E feature suite
-  locally; `.github/workflows/postsubmit.yml` runs `test-agentty-e2e` on GitHub after
-  merge to `main`.
+  When intentionally regenerating GIF assets, record in the pinned `linux/amd64` image
+  from `docker/e2e.Dockerfile` with `TESTTY_GIF_MODE=generate` so committed hash
+  sidecars match the container CI verifies them in; follow
+  `skills/feature-test/SKILL.md` for the exact commands. If recording on the host
+  instead, `TESTTY_GIF_MODE=force` must run from an unsandboxed shell (a normal
+  terminal, or one command explicitly approved to bypass the agent sandbox): VHS records
+  through localhost sockets (`ttyd` plus Chrome DevTools), so a network-denied sandbox
+  crashes `vhs` before Chrome launches — an error easy to misdiagnose as a missing
+  browser binary. Do not run the full E2E feature suite locally;
+  `.github/workflows/presubmit.yml` and `.github/workflows/postsubmit.yml` run
+  `test-agentty-e2e` in that image on GitHub.
 
 ### Autofix Discipline
 

--- a/crates/testty/docs/feature-gif-workflow.md
+++ b/crates/testty/docs/feature-gif-workflow.md
@@ -2,20 +2,25 @@
 
 Record a demo GIF for every feature test, and keep it in sync with the UI automatically.
 
-A feature test runs its scenario twice. The PTY run is the test: it captures text frames
-into a `ProofReport`, and every assertion reads those frames. The VHS run is the
-picture: the same scenario is compiled into a `.tape` and replayed by `vhs` to record
-the GIF. Nothing is ever asserted about the GIF.
+A feature test always runs its scenario through the PTY. That is the test: it captures
+text frames into a `ProofReport`, and every assertion reads those frames. `generate`
+mode also runs a stale scenario through VHS, while `force` mode always does so: the same
+steps are compiled into a `.tape` and replayed to record the GIF. Nothing is ever
+asserted about the GIF.
 
 ```mermaid
 graph TD
   S["Scenario steps"] --> PTY["PTY run"]
   PTY --> A["assert - the test"]
   PTY --> H["frame hash"]
-  H --> D{"matches sidecar?"}
+  H --> M{"mode?"}
+  M -->|check| G["pass or fail freshness"]
+  M -->|generate| D{"matches sidecar?"}
+  M -->|force| VHS
   D -->|yes| SKIP["keep committed gif"]
   D -->|no| VHS["vhs records new gif"]
-  VHS --> C["CI commits gif + hash"]
+  VHS --> R["developer reviews artifacts"]
+  R --> C["commit gif hash and poster"]
 ```
 
 ## Freshness
@@ -74,14 +79,20 @@ frame and stales every committed GIF hash at once.
 Redaction applies to the hash only — captured frames, assertions, and the recorded GIF
 still show the real value.
 
-## Recording in CI (planned)
+## Canonical container workflow
 
-No workflow installs `vhs` yet, so today a GIF is only ever recorded when someone opts
-in locally.
+Agentty checks feature GIF freshness in one pinned `linux/amd64` container defined by
+`docker/e2e.Dockerfile`. Presubmit, postsubmit, and release workflows pull the same GHCR
+image by digest, mount the checkout read-only, and run the suite in `check` mode. CI
+never records, rewrites, or commits feature artifacts.
 
-The intended end state is that presubmit installs `vhs`, runs the suite with `generate`,
-and commits the re-recorded GIFs alongside the change that moved the UI. Fork pull
-requests cannot be pushed to, so they would upload the GIFs as an artifact instead.
+When an intentional UI change makes a sidecar stale, a developer runs the affected test
+in that container with a writable checkout and `generate` mode. Only missing or stale
+GIFs are recorded. The developer reviews the changed GIF and hash sidecar, refreshes the
+matching PNG poster, and commits the three artifacts with the UI change.
 
-CI is then the only committer of GIFs. VHS output is not byte-identical across
-platforms, so recording locally and committing would churn every GIF.
+Use the exact digest-pinned recording command in `skills/feature-test/SKILL.md`. It runs
+the local container as the host UID and GID so Linux bind mounts remain writable, while
+CI keeps the image's fixed non-root user and read-only checkout. Recording in the same
+container that performs the freshness check prevents host-specific output from churning
+committed artifacts.

--- a/crates/testty/src/feature.rs
+++ b/crates/testty/src/feature.rs
@@ -380,7 +380,9 @@ impl FeatureDemo {
 
     /// Set the directory where GIF output and hash sidecars are written.
     ///
-    /// When not set, GIF generation is skipped entirely.
+    /// When not set, GIF generation is skipped entirely. A successful GIF
+    /// regeneration removes a same-named PNG so callers cannot mistake a
+    /// poster from the previous GIF for a current artifact.
     pub fn gif_output_dir(mut self, dir: impl Into<PathBuf>) -> Self {
         self.gif_output_dir = Some(dir.into());
 
@@ -441,9 +443,11 @@ impl FeatureDemo {
                     redactions: &self.redactions,
                 },
                 VhsContext {
-                    settings: &self.gif_settings,
                     binary_path,
+                    check_vhs: check_vhs_installed,
                     env_pairs,
+                    execute_tape: VhsTape::execute,
+                    settings: &self.gif_settings,
                 },
             ),
             None => GifStatus::NoOutputDir,
@@ -583,9 +587,11 @@ struct GifContext<'a> {
 /// individual pieces (settings, binary, environment) that VHS needs.
 #[derive(Clone, Copy)]
 struct VhsContext<'a> {
-    settings: &'a VhsTapeSettings,
     binary_path: &'a Path,
+    check_vhs: fn() -> Result<(), VhsError>,
     env_pairs: &'a [(&'a str, &'a str)],
+    execute_tape: fn(&VhsTape, &Path) -> Result<PathBuf, VhsError>,
+    settings: &'a VhsTapeSettings,
 }
 
 /// Parsed state of a committed feature-GIF hash sidecar.
@@ -671,7 +677,7 @@ fn generate_gif(
     // missing VHS binary must surface as a hard failure rather than a
     // silent skip. Other modes treat a missing VHS as a benign skip and
     // return `VhsNotInstalled`.
-    if let Err(err) = check_vhs_installed() {
+    if let Err(err) = (vhs.check_vhs)() {
         return vhs_missing_status(mode, err);
     }
 
@@ -689,11 +695,13 @@ fn generate_gif(
     // Trailing newline so the sidecar is a well-formed text file and
     // end-of-file fixers do not rewrite it after every regeneration.
     let hash_string = format!("{current_hash}\n");
-    let screenshot_path = output_dir.join(format!("{name}.png"));
+    let poster_path = output_dir.join(format!("{name}.png"));
+    let screenshot_path = output_dir.join(format!(".{name}.capture.png"));
 
-    let tape = VhsTape::from_scenario_with_settings(
+    let tape = VhsTape::from_scenario_with_output_path(
         scenario,
         vhs.binary_path,
+        &gif_path,
         &screenshot_path,
         vhs.env_pairs,
         vhs.settings,
@@ -701,16 +709,18 @@ fn generate_gif(
 
     let tape_path = output_dir.join(format!("{name}.tape"));
 
-    match tape.execute(&tape_path) {
+    match (vhs.execute_tape)(&tape, &tape_path) {
         Ok(_) => {
             let _ = std::fs::write(&hash_path, &hash_string);
             let _ = std::fs::remove_file(&tape_path);
             let _ = std::fs::remove_file(&screenshot_path);
+            let _ = std::fs::remove_file(&poster_path);
 
             GifStatus::Generated(gif_path)
         }
         Err(err) => {
             let _ = std::fs::remove_file(&tape_path);
+            let _ = std::fs::remove_file(&screenshot_path);
 
             GifStatus::TapeExecutionFailed(err)
         }
@@ -794,6 +804,28 @@ mod tests {
 
         // Assert
         assert_eq!(demo.gif_output_dir.as_deref(), Some(Path::new("/tmp/gifs")));
+    }
+
+    #[test]
+    fn feature_demo_run_wires_check_only_vhs_context() {
+        // Arrange
+        let temp = tempfile::TempDir::new().expect("failed to create temp dir");
+        let scenario = Scenario::new("run_context")
+            .wait_for_text("ready", 3_000)
+            .capture_labeled("ready", "Shell is ready");
+        let builder = PtySessionBuilder::new("/bin/sh").args(["-c", "printf 'ready\\n'; sleep 60"]);
+        let demo = FeatureDemo::new("run_context")
+            .gif_output_dir(temp.path())
+            .gif_mode(GifMode::CheckOnly);
+
+        // Act
+        let result = demo
+            .run(&scenario, builder, Path::new("/bin/true"), &[])
+            .expect("feature demo should run");
+
+        // Assert
+        assert!(matches!(result.gif_status, GifStatus::Stale { .. }));
+        assert!(result.frame.all_text().contains("ready"));
     }
 
     #[test]
@@ -1132,9 +1164,11 @@ mod tests {
         let binary = Path::new("/usr/bin/true");
         let env_pairs: &[(&str, &str)] = &[];
         let vhs = VhsContext {
-            settings: &settings,
             binary_path: binary,
+            check_vhs: check_vhs_installed,
             env_pairs,
+            execute_tape: VhsTape::execute,
+            settings: &settings,
         };
 
         // Act
@@ -1194,9 +1228,11 @@ mod tests {
         let binary = Path::new("/usr/bin/true");
         let env_pairs: &[(&str, &str)] = &[];
         let vhs = VhsContext {
-            settings: &settings,
             binary_path: binary,
+            check_vhs: check_vhs_installed,
             env_pairs,
+            execute_tape: VhsTape::execute,
+            settings: &settings,
         };
 
         // Act
@@ -1248,9 +1284,11 @@ mod tests {
         let binary = Path::new("/usr/bin/true");
         let env_pairs: &[(&str, &str)] = &[];
         let vhs = VhsContext {
-            settings: &settings,
             binary_path: binary,
+            check_vhs: check_vhs_installed,
             env_pairs,
+            execute_tape: VhsTape::execute,
+            settings: &settings,
         };
 
         // Act
@@ -1285,6 +1323,118 @@ mod tests {
                 .is_some_and(|err| err.contains("failed to parse hash sidecar")),
             "expected parse error, got {committed_error:?}",
         );
+    }
+
+    #[test]
+    fn generate_gif_success_invalidates_poster_and_cleans_recording_files() {
+        // Arrange
+        let temp = tempfile::TempDir::new().expect("failed to create temp dir");
+        let output_dir = temp.path();
+        let name = "generated";
+        let frame = TerminalFrame::new(80, 24, b"Hello");
+        let mut report = ProofReport::new(name);
+        report.add_capture("snap", "Snapshot", &frame);
+        let gif_path = output_dir.join(format!("{name}.gif"));
+        let hash_path = hash_sidecar_path(output_dir, name);
+        let poster_path = output_dir.join(format!("{name}.png"));
+        let screenshot_path = output_dir.join(format!(".{name}.capture.png"));
+        let tape_path = output_dir.join(format!("{name}.tape"));
+        let expected_hash = compute_frame_hash(&report, &[]);
+        std::fs::write(&poster_path, b"stale poster").expect("write poster");
+        let scenario = Scenario::new(name).capture();
+        let settings = VhsTapeSettings::feature_demo();
+        let vhs = test_vhs_context(&settings, vhs_available, successful_tape_execution);
+
+        // Act
+        let status = generate_gif(
+            &scenario,
+            &report,
+            name,
+            output_dir,
+            GifContext {
+                mode: GifMode::AlwaysGenerate,
+                redactions: &[],
+            },
+            vhs,
+        );
+
+        // Assert
+        assert!(matches!(status, GifStatus::Generated(path) if path == gif_path));
+        assert_eq!(
+            std::fs::read_to_string(&hash_path).expect("read hash"),
+            format!("{expected_hash}\n")
+        );
+        assert!(!poster_path.exists());
+        assert!(!screenshot_path.exists());
+        assert!(!tape_path.exists());
+    }
+
+    #[test]
+    fn generate_gif_failure_preserves_poster_and_cleans_recording_files() {
+        // Arrange
+        let temp = tempfile::TempDir::new().expect("failed to create temp dir");
+        let output_dir = temp.path();
+        let name = "failed";
+        let report = ProofReport::new(name);
+        let hash_path = hash_sidecar_path(output_dir, name);
+        let poster_path = output_dir.join(format!("{name}.png"));
+        let screenshot_path = output_dir.join(format!(".{name}.capture.png"));
+        let tape_path = output_dir.join(format!("{name}.tape"));
+        std::fs::write(&poster_path, b"valid poster").expect("write poster");
+        let scenario = Scenario::new(name).capture();
+        let settings = VhsTapeSettings::feature_demo();
+        let vhs = test_vhs_context(&settings, vhs_available, failed_tape_execution);
+
+        // Act
+        let status = generate_gif(
+            &scenario,
+            &report,
+            name,
+            output_dir,
+            GifContext {
+                mode: GifMode::AlwaysGenerate,
+                redactions: &[],
+            },
+            vhs,
+        );
+
+        // Assert
+        assert!(matches!(status, GifStatus::TapeExecutionFailed(_)));
+        assert!(poster_path.exists());
+        assert!(!hash_path.exists());
+        assert!(!screenshot_path.exists());
+        assert!(!tape_path.exists());
+    }
+
+    #[test]
+    fn generate_gif_missing_vhs_preserves_artifacts() {
+        // Arrange
+        let temp = tempfile::TempDir::new().expect("failed to create temp dir");
+        let output_dir = temp.path();
+        let name = "missing_vhs";
+        let report = ProofReport::new(name);
+        let poster_path = output_dir.join(format!("{name}.png"));
+        std::fs::write(&poster_path, b"valid poster").expect("write poster");
+        let scenario = Scenario::new(name);
+        let settings = VhsTapeSettings::feature_demo();
+        let vhs = test_vhs_context(&settings, vhs_unavailable, failed_tape_execution);
+
+        // Act
+        let status = generate_gif(
+            &scenario,
+            &report,
+            name,
+            output_dir,
+            GifContext {
+                mode: GifMode::GenerateIfStale,
+                redactions: &[],
+            },
+            vhs,
+        );
+
+        // Assert
+        assert!(matches!(status, GifStatus::VhsNotInstalled));
+        assert!(poster_path.exists());
     }
 
     #[test]
@@ -1401,5 +1551,50 @@ mod tests {
         assert_eq!(status.gif_path(), Some(Path::new("/tmp/feature.gif")));
         assert!(!status.is_failure());
         assert!(status.is_stale());
+    }
+
+    fn test_vhs_context(
+        settings: &VhsTapeSettings,
+        check_vhs: fn() -> Result<(), VhsError>,
+        execute_tape: fn(&VhsTape, &Path) -> Result<PathBuf, VhsError>,
+    ) -> VhsContext<'_> {
+        VhsContext {
+            binary_path: Path::new("/usr/bin/true"),
+            check_vhs,
+            env_pairs: &[],
+            execute_tape,
+            settings,
+        }
+    }
+
+    fn vhs_available() -> Result<(), VhsError> {
+        std::fs::metadata(".")
+            .map(|_| ())
+            .map_err(|err| VhsError::IoError(err.to_string()))
+    }
+
+    fn vhs_unavailable() -> Result<(), VhsError> {
+        Err(VhsError::NotInstalled(
+            "VHS unavailable in test".to_string(),
+        ))
+    }
+
+    fn successful_tape_execution(tape: &VhsTape, tape_path: &Path) -> Result<PathBuf, VhsError> {
+        stage_tape_execution(tape, tape_path)
+    }
+
+    fn failed_tape_execution(tape: &VhsTape, tape_path: &Path) -> Result<PathBuf, VhsError> {
+        let _ = stage_tape_execution(tape, tape_path)?;
+
+        Err(VhsError::ExecutionFailed("simulated failure".to_string()))
+    }
+
+    fn stage_tape_execution(tape: &VhsTape, tape_path: &Path) -> Result<PathBuf, VhsError> {
+        tape.write_to(tape_path)
+            .map_err(|err| VhsError::IoError(err.to_string()))?;
+        std::fs::write(tape.screenshot_path(), b"temporary screenshot")
+            .map_err(|err| VhsError::IoError(err.to_string()))?;
+
+        Ok(tape.screenshot_path().to_path_buf())
     }
 }

--- a/crates/testty/src/vhs.rs
+++ b/crates/testty/src/vhs.rs
@@ -113,12 +113,23 @@ impl VhsTape {
         env_vars: &[(&str, &str)],
         settings: &VhsTapeSettings,
     ) -> Self {
-        let content = compile_tape(scenario, binary_path, screenshot_path, env_vars, settings);
+        let gif_stem = screenshot_path
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy();
+        let gif_path = screenshot_path
+            .parent()
+            .unwrap_or(Path::new("."))
+            .join(format!("{gif_stem}.gif"));
 
-        Self {
-            content,
-            screenshot_path: screenshot_path.to_path_buf(),
-        }
+        Self::from_scenario_with_output_path(
+            scenario,
+            binary_path,
+            &gif_path,
+            screenshot_path,
+            env_vars,
+            settings,
+        )
     }
 
     /// Return the rendered tape content as a string.
@@ -185,6 +196,30 @@ impl VhsTape {
     pub fn screenshot_path(&self) -> &Path {
         &self.screenshot_path
     }
+
+    /// Compile a scenario while keeping GIF output separate from screenshots.
+    pub(crate) fn from_scenario_with_output_path(
+        scenario: &Scenario,
+        binary_path: &Path,
+        gif_path: &Path,
+        screenshot_path: &Path,
+        env_vars: &[(&str, &str)],
+        settings: &VhsTapeSettings,
+    ) -> Self {
+        let content = compile_tape(
+            scenario,
+            binary_path,
+            gif_path,
+            screenshot_path,
+            env_vars,
+            settings,
+        );
+
+        Self {
+            content,
+            screenshot_path: screenshot_path.to_path_buf(),
+        }
+    }
 }
 
 /// Errors from VHS tape operations.
@@ -211,23 +246,12 @@ pub enum VhsError {
 fn compile_tape(
     scenario: &Scenario,
     binary_path: &Path,
+    gif_path: &Path,
     screenshot_path: &Path,
     env_vars: &[(&str, &str)],
     settings: &VhsTapeSettings,
 ) -> String {
     let mut tape = String::new();
-
-    // Derive the GIF filename from the screenshot path stem so the output
-    // name matches the caller's expected feature name rather than the
-    // internal scenario name.
-    let gif_stem = screenshot_path
-        .file_stem()
-        .unwrap_or_default()
-        .to_string_lossy();
-    let gif_path = screenshot_path
-        .parent()
-        .unwrap_or(Path::new("."))
-        .join(format!("{gif_stem}.gif"));
 
     // Infallible: all `writeln!` calls below write to a String, which cannot fail.
     // Header settings.
@@ -476,6 +500,7 @@ mod tests {
         let tape = compile_tape(
             &scenario,
             Path::new("/usr/bin/echo"),
+            Path::new("/tmp/shot.gif"),
             Path::new("/tmp/shot.png"),
             &[],
             &settings,
@@ -497,6 +522,7 @@ mod tests {
         let tape = compile_tape(
             &scenario,
             Path::new("/usr/bin/echo"),
+            Path::new("/tmp/shot.gif"),
             Path::new("/tmp/shot.png"),
             &[("AGENTTY_ROOT", "/tmp/root")],
             &VhsTapeSettings::default(),
@@ -515,6 +541,7 @@ mod tests {
         let tape = compile_tape(
             &scenario,
             Path::new("/usr/bin/echo"),
+            Path::new("/tmp/shot.gif"),
             Path::new("/tmp/shot.png"),
             &[],
             &VhsTapeSettings::default(),
@@ -723,6 +750,7 @@ mod tests {
         let tape = compile_tape(
             &scenario,
             Path::new("/usr/bin/echo"),
+            Path::new("/tmp/shot.gif"),
             Path::new("/tmp/shot.png"),
             &[("KEY", "it's a value")],
             &VhsTapeSettings::default(),
@@ -743,6 +771,7 @@ mod tests {
         let tape = compile_tape(
             &scenario,
             Path::new("/usr/bin/echo"),
+            Path::new("/tmp/shot.gif"),
             Path::new("/tmp/shot.png"),
             &[],
             &VhsTapeSettings::default(),
@@ -761,6 +790,7 @@ mod tests {
         let tape = compile_tape(
             &scenario,
             Path::new("/usr/bin/echo"),
+            Path::new("/tmp/shot.gif"),
             Path::new("/tmp/shot.png"),
             &[("KEY", "val")],
             &VhsTapeSettings::default(),
@@ -791,6 +821,7 @@ mod tests {
         let tape = compile_tape(
             &scenario,
             Path::new("/path with spaces/bin"),
+            Path::new("/tmp/shot.gif"),
             Path::new("/tmp/shot.png"),
             &[],
             &VhsTapeSettings::default(),
@@ -850,6 +881,33 @@ mod tests {
         assert!(content.contains("Set Height 1600"));
         assert!(content.contains("Set Theme \"OneDark\""));
         assert!(content.contains("Set Framerate 30"));
+    }
+
+    #[test]
+    fn from_scenario_with_output_path_separates_gif_and_screenshot() {
+        // Arrange
+        let scenario = Scenario::new("separate_paths").capture();
+        let settings = VhsTapeSettings::feature_demo();
+        let gif_path = Path::new("/tmp/feature.gif");
+        let screenshot_path = Path::new("/tmp/.feature.capture.png");
+
+        // Act
+        let tape = VhsTape::from_scenario_with_output_path(
+            &scenario,
+            Path::new("/usr/bin/echo"),
+            gif_path,
+            screenshot_path,
+            &[],
+            &settings,
+        );
+
+        // Assert
+        assert!(tape.render().contains("Output \"/tmp/feature.gif\""));
+        assert!(
+            tape.render()
+                .contains("Screenshot \"/tmp/.feature.capture.png\"")
+        );
+        assert_eq!(tape.screenshot_path(), screenshot_path);
     }
 
     #[test]

--- a/docker/e2e.Dockerfile
+++ b/docker/e2e.Dockerfile
@@ -6,23 +6,26 @@
 # artifacts in the same image with a writable mount and
 # `TESTTY_GIF_MODE=generate` (see `skills/feature-test/SKILL.md`), which keeps
 # committed hashes portable between local recording and CI verification.
-# Every tool is pinned; upgrade pins deliberately and re-record affected GIFs.
+# Every tool is pinned; upgrade pins deliberately and re-verify the committed
+# GIF hash sidecars.
 FROM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
 
 ENV CARGO_HOME=/usr/local/cargo \
     RUSTUP_HOME=/usr/local/rustup \
+    CARGO_TARGET_DIR=/opt/target \
     PATH=/usr/local/cargo/bin:$PATH \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
     TZ=UTC \
-    # Chromium runs as root inside the container, so VHS must disable the
-    # Chromium sandbox to launch it.
+    # Unprivileged containers lack the kernel privileges Chromium's own
+    # sandbox needs, so VHS must disable it to launch Chromium.
     VHS_NO_SANDBOX=true
 
-# Build toolchain plus the VHS recording stack: `ttyd`, `ffmpeg`, Chromium,
-# and the JetBrains Mono font VHS renders with by default, all from the pinned
-# Debian release. `check` mode needs none of the recording stack, but one
-# shared image for checking and recording is what makes the hashes portable.
+# Build toolchain plus the VHS recording stack: `ffmpeg`, Chromium, and the
+# JetBrains Mono font VHS renders with by default, all from the pinned Debian
+# release (`ttyd` is pinned separately below). `check` mode needs none of the
+# recording stack, but one shared image for checking and recording is what
+# makes the hashes portable.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
@@ -35,9 +38,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     pkg-config \
     && rm -rf /var/lib/apt/lists/* \
-    # CI bind-mounts a checkout owned by the host runner user while the
-    # container runs as root; without this git refuses to operate on the
-    # repository and `prek` cannot enumerate files.
+    # CI bind-mounts a checkout owned by the host runner user; keep git
+    # working when that owner differs from the container user, so `prek` can
+    # enumerate files.
     && git config --system --add safe.directory /workspace
 
 # Pin the nightly toolchain to a date so image rebuilds keep the same
@@ -47,32 +50,68 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # committed GIF hash sidecars.
 ARG RUST_TOOLCHAIN=nightly-2026-07-15
 ENV RUSTUP_TOOLCHAIN=${RUST_TOOLCHAIN}
-RUN curl -fsSL https://sh.rustup.rs \
-    | sh -s -- -y --profile minimal --default-toolchain "${RUST_TOOLCHAIN}"
+
+# Install rustup from a pinned, checksum-verified `rustup-init` binary
+# instead of piping the install script into a shell. The digest comes from
+# the official `rustup-init.sha256` published next to the binary.
+ARG RUSTUP_VERSION=1.29.0
+ARG RUSTUP_INIT_SHA256=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
+RUN curl --proto '=https' --tlsv1.2 -fsSL \
+    "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init" \
+    -o /tmp/rustup-init \
+    && echo "${RUSTUP_INIT_SHA256} */tmp/rustup-init" | sha256sum -c - \
+    && chmod 0755 /tmp/rustup-init \
+    && /tmp/rustup-init -y --profile minimal --default-toolchain "${RUST_TOOLCHAIN}" \
+    && rm /tmp/rustup-init
 
 ARG NEXTEST_VERSION=0.9.140
-RUN curl -fsSL "https://get.nexte.st/${NEXTEST_VERSION}/linux" \
-    | tar -xz -C "${CARGO_HOME}/bin"
+ARG NEXTEST_SHA256=4ee9aaa0d0171a985a5d0eb735b87355894c1c455972e9674fb9fdbd1387c9a3
+RUN curl --proto '=https' --tlsv1.2 -fsSL \
+    "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${NEXTEST_VERSION}/cargo-nextest-${NEXTEST_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+    -o /tmp/nextest.tar.gz \
+    && echo "${NEXTEST_SHA256} */tmp/nextest.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/nextest.tar.gz -C "${CARGO_HOME}/bin" \
+    && rm /tmp/nextest.tar.gz
 
 # The `prek` pin matches `.github/actions/setup-rust-prek/action.yml`.
 ARG PREK_VERSION=0.4.3
+ARG PREK_SHA256=8a8210d64476657cac3e797afa109011d8d872c09e3a407f50c5a4dde063b381
 RUN mkdir /tmp/prek \
-    && curl -fsSL "https://github.com/j178/prek/releases/download/v${PREK_VERSION}/prek-x86_64-unknown-linux-gnu.tar.gz" \
-    | tar -xz -C /tmp/prek \
+    && curl --proto '=https' --tlsv1.2 -fsSL "https://github.com/j178/prek/releases/download/v${PREK_VERSION}/prek-x86_64-unknown-linux-gnu.tar.gz" \
+    -o /tmp/prek.tar.gz \
+    && echo "${PREK_SHA256} */tmp/prek.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/prek.tar.gz -C /tmp/prek \
     && install -m 0755 "$(find /tmp/prek -type f -name prek)" /usr/local/bin/prek \
-    && rm -rf /tmp/prek
+    && rm -rf /tmp/prek /tmp/prek.tar.gz
 
 # Debian bookworm does not package `ttyd`, so pin the upstream static binary.
 ARG TTYD_VERSION=1.7.7
-RUN curl -fsSL "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64" \
-    -o /usr/local/bin/ttyd \
-    && chmod 0755 /usr/local/bin/ttyd
+ARG TTYD_SHA256=8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55
+RUN curl --proto '=https' --tlsv1.2 -fsSL "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64" \
+    -o /tmp/ttyd \
+    && echo "${TTYD_SHA256} */tmp/ttyd" | sha256sum -c - \
+    && install -m 0755 /tmp/ttyd /usr/local/bin/ttyd \
+    && rm /tmp/ttyd
 
 ARG VHS_VERSION=0.11.0
+ARG VHS_SHA256=99cb634587eaae0473c1ea377db80c3a048c27f99fe0a7febb1a1e8cb7ee5009
 RUN mkdir /tmp/vhs \
-    && curl -fsSL "https://github.com/charmbracelet/vhs/releases/download/v${VHS_VERSION}/vhs_${VHS_VERSION}_Linux_x86_64.tar.gz" \
-    | tar -xz -C /tmp/vhs \
+    && curl --proto '=https' --tlsv1.2 -fsSL "https://github.com/charmbracelet/vhs/releases/download/v${VHS_VERSION}/vhs_${VHS_VERSION}_Linux_x86_64.tar.gz" \
+    -o /tmp/vhs.tar.gz \
+    && echo "${VHS_SHA256} */tmp/vhs.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/vhs.tar.gz -C /tmp/vhs \
     && install -m 0755 "$(find /tmp/vhs -type f -name vhs)" /usr/local/bin/vhs \
-    && rm -rf /tmp/vhs
+    && rm -rf /tmp/vhs /tmp/vhs.tar.gz
+
+# Run the suite as an unprivileged user. Uid 1001 matches the GitHub Actions
+# runner user that owns the bind-mounted checkout. Cargo only needs write
+# access to its registry caches and the baked-in target directory; the
+# toolchain itself stays root-owned and read-only.
+RUN useradd --uid 1001 --user-group --create-home agentty \
+    && install -d -o agentty -g agentty \
+    "${CARGO_HOME}/registry" "${CARGO_HOME}/git" "${CARGO_TARGET_DIR}"
+
+USER agentty
+ENV HOME=/home/agentty
 
 WORKDIR /workspace

--- a/docker/e2e.Dockerfile
+++ b/docker/e2e.Dockerfile
@@ -1,0 +1,78 @@
+# Canonical `linux/amd64` environment for the Agentty end-to-end feature suite.
+#
+# CI builds this image and runs the `test-agentty-e2e` hook inside it with a
+# read-only checkout, so `TESTTY_GIF_MODE=check` verifies committed GIF hash
+# sidecars without rewriting anything. Developers record or refresh feature
+# artifacts in the same image with a writable mount and
+# `TESTTY_GIF_MODE=generate` (see `skills/feature-test/SKILL.md`), which keeps
+# committed hashes portable between local recording and CI verification.
+# Every tool is pinned; upgrade pins deliberately and re-record affected GIFs.
+FROM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
+
+ENV CARGO_HOME=/usr/local/cargo \
+    RUSTUP_HOME=/usr/local/rustup \
+    PATH=/usr/local/cargo/bin:$PATH \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    TZ=UTC \
+    # Chromium runs as root inside the container, so VHS must disable the
+    # Chromium sandbox to launch it.
+    VHS_NO_SANDBOX=true
+
+# Build toolchain plus the VHS recording stack: `ttyd`, `ffmpeg`, Chromium,
+# and the JetBrains Mono font VHS renders with by default, all from the pinned
+# Debian release. `check` mode needs none of the recording stack, but one
+# shared image for checking and recording is what makes the hashes portable.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    chromium \
+    curl \
+    ffmpeg \
+    fonts-dejavu \
+    fonts-jetbrains-mono \
+    fonts-noto-color-emoji \
+    git \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/* \
+    # CI bind-mounts a checkout owned by the host runner user while the
+    # container runs as root; without this git refuses to operate on the
+    # repository and `prek` cannot enumerate files.
+    && git config --system --add safe.directory /workspace
+
+# Pin the nightly toolchain to a date so image rebuilds keep the same
+# compiler. `RUSTUP_TOOLCHAIN` overrides the floating `nightly` channel from
+# `rust-toolchain.toml` inside the container, so rustup never downloads a
+# newer nightly at run time. Bump the date deliberately and re-verify the
+# committed GIF hash sidecars.
+ARG RUST_TOOLCHAIN=nightly-2026-07-15
+ENV RUSTUP_TOOLCHAIN=${RUST_TOOLCHAIN}
+RUN curl -fsSL https://sh.rustup.rs \
+    | sh -s -- -y --profile minimal --default-toolchain "${RUST_TOOLCHAIN}"
+
+ARG NEXTEST_VERSION=0.9.140
+RUN curl -fsSL "https://get.nexte.st/${NEXTEST_VERSION}/linux" \
+    | tar -xz -C "${CARGO_HOME}/bin"
+
+# The `prek` pin matches `.github/actions/setup-rust-prek/action.yml`.
+ARG PREK_VERSION=0.4.3
+RUN mkdir /tmp/prek \
+    && curl -fsSL "https://github.com/j178/prek/releases/download/v${PREK_VERSION}/prek-x86_64-unknown-linux-gnu.tar.gz" \
+    | tar -xz -C /tmp/prek \
+    && install -m 0755 "$(find /tmp/prek -type f -name prek)" /usr/local/bin/prek \
+    && rm -rf /tmp/prek
+
+# Debian bookworm does not package `ttyd`, so pin the upstream static binary.
+ARG TTYD_VERSION=1.7.7
+RUN curl -fsSL "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64" \
+    -o /usr/local/bin/ttyd \
+    && chmod 0755 /usr/local/bin/ttyd
+
+ARG VHS_VERSION=0.11.0
+RUN mkdir /tmp/vhs \
+    && curl -fsSL "https://github.com/charmbracelet/vhs/releases/download/v${VHS_VERSION}/vhs_${VHS_VERSION}_Linux_x86_64.tar.gz" \
+    | tar -xz -C /tmp/vhs \
+    && install -m 0755 "$(find /tmp/vhs -type f -name vhs)" /usr/local/bin/vhs \
+    && rm -rf /tmp/vhs
+
+WORKDIR /workspace

--- a/docs/site/content/docs/contributing/managing-docs-with-zola.md
+++ b/docs/site/content/docs/contributing/managing-docs-with-zola.md
@@ -72,7 +72,9 @@ The `/features/` page auto-discovers entries from individual `.md` files in
    `crates/agentty/tests/e2e/`.
 1. Place the generated GIF in `static/features/`. `FeatureTest` writes this when VHS is
    installed; if GIF generation is skipped, do not add or keep the feature page until
-   the matching asset exists.
+   the matching asset exists. Successful GIF regeneration removes the previous
+   same-named PNG so it cannot remain as a stale poster; recreate and inspect the poster
+   before finalizing the feature.
 1. Create `content/features/<name>.md` with the following front matter:
    ```toml
    +++

--- a/skills/feature-test/SKILL.md
+++ b/skills/feature-test/SKILL.md
@@ -245,7 +245,9 @@ docker run --rm --platform linux/amd64 \
 ```
 
 Review the changed GIF and `.{name}.hash` sidecar, then refresh the PNG poster for every
-regenerated GIF (section 4) before committing all three together.
+regenerated GIF (section 4) before committing all three together. Successful generation
+removes the previous same-named PNG intentionally so a stale poster cannot pass the
+nonempty-poster integrity check; a failed recording preserves the last valid poster.
 
 ### Host recording caveats
 

--- a/skills/feature-test/SKILL.md
+++ b/skills/feature-test/SKILL.md
@@ -211,6 +211,44 @@ Routine agent validation must use `TESTTY_GIF_MODE=check` so the semantic PTY as
 still run while GIF freshness is checked without invoking VHS or launching Chrome. Use
 `TESTTY_GIF_MODE=force` only when intentionally regenerating GIF assets.
 
+### Record in the canonical container
+
+Committed hash sidecars must be produced by the same environment that CI verifies them
+in. `docker/e2e.Dockerfile` defines that environment: a pinned `linux/amd64` image with
+the Rust toolchain, `prek`, `cargo-nextest`, and the full VHS recording stack (`vhs`,
+`ttyd`, Chromium, `ffmpeg`, JetBrains Mono). Presubmit and postsubmit build this image
+and run the `test-agentty-e2e` hook inside it against a read-only checkout, so record
+GIFs in the same image instead of on the host. The host needs Docker only — no local
+Chrome or VHS — and the localhost-socket sandbox restriction below does not apply inside
+the container.
+
+Build the image (rebuild only when the Dockerfile changes):
+
+```sh
+docker build --platform linux/amd64 \
+  --file docker/e2e.Dockerfile --tag agentty-e2e docker
+```
+
+Record or refresh feature artifacts with a writable workspace mount and `generate` mode,
+which re-records only missing or stale GIFs. The two named volumes cache the cargo
+registry and build output between runs:
+
+```sh
+docker run --rm --platform linux/amd64 \
+  --mount type=bind,source="$PWD",target=/workspace \
+  --mount type=volume,source=agentty-e2e-cargo,target=/usr/local/cargo/registry \
+  --mount type=volume,source=agentty-e2e-target,target=/tmp/target \
+  --env CARGO_TARGET_DIR=/tmp/target \
+  --env TESTTY_GIF_MODE=generate \
+  agentty-e2e \
+  cargo nextest run --locked --profile ci -p agentty --test e2e test_{name}
+```
+
+Review the changed GIF and `.{name}.hash` sidecar, then refresh the PNG poster for every
+regenerated GIF (section 4) before committing all three together.
+
+### Host recording caveats
+
 `force` mode must run from an unsandboxed shell — a normal user terminal, or a single
 agent command explicitly approved to bypass the sandbox. VHS records through localhost
 sockets (`ttyd` plus the Chrome DevTools protocol), and sandboxed agent shells deny all

--- a/skills/feature-test/SKILL.md
+++ b/skills/feature-test/SKILL.md
@@ -216,38 +216,71 @@ still run while GIF freshness is checked without invoking VHS or launching Chrom
 Committed hash sidecars must be produced by the same environment that CI verifies them
 in. `docker/e2e.Dockerfile` defines that environment: a pinned `linux/amd64` image with
 the Rust toolchain, `prek`, `cargo-nextest`, and the full VHS recording stack (`vhs`,
-`ttyd`, Chromium, `ffmpeg`, JetBrains Mono). Presubmit and postsubmit build this image
-and run the `test-agentty-e2e` hook inside it against a read-only checkout, so record
-GIFs in the same image instead of on the host. The host needs Docker only — no local
-Chrome or VHS — and the localhost-socket sandbox restriction below does not apply inside
-the container.
-
-Build the image (rebuild only when the Dockerfile changes):
-
-```sh
-docker build --platform linux/amd64 \
-  --file docker/e2e.Dockerfile --tag agentty-e2e docker
-```
+`ttyd`, Chromium, `ffmpeg`, JetBrains Mono). Presubmit, postsubmit, and release checks
+pull this image from GHCR by digest and run the `test-agentty-e2e` hook inside it
+against a read-only checkout. Pull the same immutable digest for local recording instead
+of building or recording on the host. The host needs Docker only — no local Chrome or
+VHS — and the localhost-socket sandbox restriction below does not apply inside the
+container.
 
 Record or refresh feature artifacts with a writable workspace mount and `generate` mode,
-which re-records only missing or stale GIFs. The two named volumes cache the cargo
-registry and build output between runs:
+which re-records only missing or stale GIFs. Run the local container as the host user so
+Linux bind mounts remain writable. A host-owned cache directory provides writable home,
+Cargo, `prek`, and build locations while preserving them between runs:
 
 ```sh
+e2e_image=ghcr.io/agentty-xyz/agentty-e2e@sha256:d348629b6c449d33f5285c9ef2b7ea0ac3c47fcf264b1ec7f3f4c58a6952a696
+e2e_cache_root="${XDG_CACHE_HOME:-${HOME}/.cache}/agentty-e2e"
+mkdir -p \
+  "${e2e_cache_root}/home" \
+  "${e2e_cache_root}/cargo" \
+  "${e2e_cache_root}/prek" \
+  "${e2e_cache_root}/target"
+
+docker pull "${e2e_image}"
+
 docker run --rm --platform linux/amd64 \
+  --user "$(id -u):$(id -g)" \
   --mount type=bind,source="$PWD",target=/workspace \
-  --mount type=volume,source=agentty-e2e-cargo,target=/usr/local/cargo/registry \
-  --mount type=volume,source=agentty-e2e-target,target=/tmp/target \
-  --env CARGO_TARGET_DIR=/tmp/target \
+  --mount type=bind,source="${e2e_cache_root}",target=/cache \
+  --env HOME=/cache/home \
+  --env CARGO_HOME=/cache/cargo \
+  --env PREK_HOME=/cache/prek \
+  --env CARGO_TARGET_DIR=/cache/target \
   --env TESTTY_GIF_MODE=generate \
-  agentty-e2e \
+  "${e2e_image}" \
   cargo nextest run --locked --profile ci -p agentty --test e2e test_{name}
 ```
+
+The `--user` override is only for writable local recording. CI does not use it: the
+image retains its unprivileged UID 1001 default, and workflows mount the checkout
+read-only for `check` mode.
 
 Review the changed GIF and `.{name}.hash` sidecar, then refresh the PNG poster for every
 regenerated GIF (section 4) before committing all three together. Successful generation
 removes the previous same-named PNG intentionally so a stale poster cannot pass the
 nonempty-poster integrity check; a failed recording preserves the last valid poster.
+
+#### Refresh the canonical image
+
+Only maintainers changing `docker/e2e.Dockerfile` should build and publish a replacement
+image. Build the `linux/amd64` candidate, run the affected focused feature tests with
+the local tag, then push `latest` after authenticating Docker to GHCR with package-write
+permission:
+
+```sh
+docker build --platform linux/amd64 \
+  --file docker/e2e.Dockerfile \
+  --tag ghcr.io/agentty-xyz/agentty-e2e:latest docker
+
+docker push ghcr.io/agentty-xyz/agentty-e2e:latest
+```
+
+Copy the digest reported by `docker push` into every workflow `E2E_IMAGE` value and the
+local recording command above. Verify that the digest can be pulled without registry
+credentials so forked pull-request CI can use it. Re-record every feature affected by a
+tool, browser, font, or rendering change and refresh its PNG poster before committing
+the new digest and artifacts together.
 
 ### Host recording caveats
 


### PR DESCRIPTION
- Pin CI and local GIF recording to one immutable GHCR digest.
- Run checks in a canonical Linux/amd64 container and document its refresh workflow.
- Keep VHS captures separate from public GIF posters and remove stale posters after successful generation.
- Test recording outcomes and document the poster refresh workflow.