### PR TITLE
Centralize review comment selection

### DIFF
--- a/crates/agentty/src/app/prompt_intent.rs
+++ b/crates/agentty/src/app/prompt_intent.rs
@@ -9,7 +9,7 @@ use crate::app::{App, ReviewCacheEntry, diff_content_hash};
 use crate::domain::agent::{AgentSelection, ReasoningLevel};
 use crate::domain::composer::PromptAttachment;
 use crate::domain::review;
-use crate::domain::session::{SessionId, Status};
+use crate::domain::session::{Session, SessionId, Status};
 use crate::domain::transcript_notice::TranscriptNotice;
 use crate::domain::turn_prompt::{TurnPrompt, TurnPromptAttachment, TurnPromptTextSource};
 use crate::infra::clipboard_image;
@@ -120,9 +120,7 @@ impl App {
             .sessions()
             .iter()
             .find(|session| session.id == *session_id)
-            .is_some_and(|session| {
-                session.status.allows_review_actions() || session.status == Status::Question
-            });
+            .is_some_and(Session::allows_review_comment_reply);
         if !can_reply {
             return ReviewCommentResolutionOutcome::KeepReviewComments;
         }

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -697,6 +697,12 @@ impl Session {
             && self.status.allows_review_actions()
     }
 
+    /// Returns whether the session can submit an agent reply for actionable
+    /// forge review comments.
+    pub fn allows_review_comment_reply(&self) -> bool {
+        self.status.allows_review_actions() || self.status == Status::Question
+    }
+
     /// Returns whether this session belongs to a one-level stack beneath a
     /// parent session branch.
     pub fn is_stacked_child(&self) -> bool {
@@ -1223,6 +1229,37 @@ pub(crate) mod tests {
         assert!(!allows_child_fork);
         assert!(!allows_active_fork);
         assert!(!allows_done_fork);
+    }
+
+    #[test]
+    fn test_allows_review_comment_reply_accepts_review_or_question_sessions() {
+        // Arrange
+        let statuses = [Status::Review, Status::AgentReview, Status::Question];
+
+        // Act
+        let reply_permissions = statuses.map(|status| {
+            SessionFixtureBuilder::new()
+                .status(status)
+                .build()
+                .allows_review_comment_reply()
+        });
+
+        // Assert
+        assert_eq!(reply_permissions, [true, true, true]);
+    }
+
+    #[test]
+    fn test_allows_review_comment_reply_rejects_non_reply_session() {
+        // Arrange
+        let session = SessionFixtureBuilder::new()
+            .status(Status::InProgress)
+            .build();
+
+        // Act
+        let allows_reply = session.allows_review_comment_reply();
+
+        // Assert
+        assert!(!allows_reply);
     }
 
     #[test]

--- a/crates/agentty/src/presentation/review_comment.rs
+++ b/crates/agentty/src/presentation/review_comment.rs
@@ -1,15 +1,84 @@
-use ag_forge::{ReviewCommentSnapshot, ReviewCommentThread};
+use ag_forge::{ReviewComment, ReviewCommentSnapshot, ReviewCommentThread};
 
-/// Returns inline review threads in the unresolved-then-resolved order used
-/// by the review-comment page.
-pub(crate) fn grouped_threads(
+/// One row in the grouped review-comment selector projection.
+pub(crate) enum GroupedReviewCommentRow<'a> {
+    /// Selectable standalone comment or inline thread.
+    Entry(ReviewCommentEntry<'a>),
+    /// Non-selectable heading rendered before one populated group.
+    GroupLabel(&'static str),
+}
+
+/// One selectable review-comment entry and its detail source.
+#[derive(Clone, Copy)]
+pub(crate) enum ReviewCommentEntry<'a> {
+    /// Review-request-wide discussion comment without an inline thread ID.
+    General(&'a ReviewComment),
+    /// Forge review thread attached to a file or line range.
+    Thread(&'a ReviewCommentThread),
+}
+
+/// Returns the complete selector projection in unresolved, resolved, then
+/// standalone order, including labels for each populated group.
+pub(crate) fn grouped_review_comment_rows(
     snapshot: &ReviewCommentSnapshot,
-) -> impl Iterator<Item = &ReviewCommentThread> {
-    snapshot
-        .threads
-        .iter()
-        .filter(|thread| !thread.is_resolved)
-        .chain(snapshot.threads.iter().filter(|thread| thread.is_resolved))
+) -> Vec<GroupedReviewCommentRow<'_>> {
+    let mut rows = Vec::with_capacity(
+        snapshot
+            .threads
+            .len()
+            .saturating_add(snapshot.pr_level_comments.len())
+            .saturating_add(3),
+    );
+    append_group_rows(
+        &mut rows,
+        "Unresolved",
+        snapshot
+            .threads
+            .iter()
+            .filter(|thread| !thread.is_resolved)
+            .map(ReviewCommentEntry::Thread),
+    );
+    append_group_rows(
+        &mut rows,
+        "Resolved",
+        snapshot
+            .threads
+            .iter()
+            .filter(|thread| thread.is_resolved)
+            .map(ReviewCommentEntry::Thread),
+    );
+    append_group_rows(
+        &mut rows,
+        "Standalone",
+        snapshot
+            .pr_level_comments
+            .iter()
+            .map(ReviewCommentEntry::General),
+    );
+
+    rows
+}
+
+/// Returns only selectable entries from one materialized grouped projection.
+pub(crate) fn selectable_entries<'rows, 'snapshot>(
+    rows: &'rows [GroupedReviewCommentRow<'snapshot>],
+) -> impl Iterator<Item = ReviewCommentEntry<'snapshot>> + 'rows
+where
+    'snapshot: 'rows,
+{
+    rows.iter().filter_map(|row| match row {
+        GroupedReviewCommentRow::Entry(entry) => Some(*entry),
+        GroupedReviewCommentRow::GroupLabel(_) => None,
+    })
+}
+
+/// Returns the selected standalone comment or inline thread from one
+/// materialized grouped projection.
+pub(crate) fn selected_entry<'snapshot>(
+    rows: &[GroupedReviewCommentRow<'snapshot>],
+    selected_comment_index: usize,
+) -> Option<ReviewCommentEntry<'snapshot>> {
+    selectable_entries(rows).nth(selected_comment_index)
 }
 
 /// Returns the forge-native identifier for the selected grouped thread row.
@@ -17,9 +86,12 @@ pub(crate) fn selected_thread_id(
     snapshot: &ReviewCommentSnapshot,
     selected_comment_index: usize,
 ) -> Option<&str> {
-    grouped_threads(snapshot)
-        .nth(selected_comment_index)
-        .map(|thread| thread.id.as_str())
+    let rows = grouped_review_comment_rows(snapshot);
+
+    selected_entry(&rows, selected_comment_index).and_then(|entry| match entry {
+        ReviewCommentEntry::General(_) => None,
+        ReviewCommentEntry::Thread(thread) => Some(thread.id.as_str()),
+    })
 }
 
 /// Retargets a positional selection to the same forge thread in an updated
@@ -31,8 +103,11 @@ pub(crate) fn retarget_selected_index(
 ) -> usize {
     let selected_thread_id = previous_snapshot
         .and_then(|snapshot| selected_thread_id(snapshot, previous_selected_index));
+    let updated_rows = grouped_review_comment_rows(updated_snapshot);
     if let Some(updated_index) = selected_thread_id.and_then(|selected_thread_id| {
-        grouped_threads(updated_snapshot).position(|thread| thread.id == selected_thread_id)
+        selectable_entries(&updated_rows).position(
+            |entry| matches!(entry, ReviewCommentEntry::Thread(thread) if thread.id == selected_thread_id),
+        )
     }) {
         return updated_index;
     }
@@ -45,11 +120,108 @@ pub(crate) fn retarget_selected_index(
     previous_selected_index.min(updated_item_count.saturating_sub(1))
 }
 
+/// Adds one heading and its entries only when the group is populated.
+fn append_group_rows<'a>(
+    rows: &mut Vec<GroupedReviewCommentRow<'a>>,
+    label: &'static str,
+    entries: impl Iterator<Item = ReviewCommentEntry<'a>>,
+) {
+    let mut group_has_entries = false;
+    for entry in entries {
+        if !group_has_entries {
+            rows.push(GroupedReviewCommentRow::GroupLabel(label));
+            group_has_entries = true;
+        }
+        rows.push(GroupedReviewCommentRow::Entry(entry));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ag_forge::{ReviewComment, ReviewCommentAnchorSide};
 
     use super::*;
+
+    #[test]
+    fn test_grouped_review_comment_rows_include_populated_labels_and_entries() {
+        // Arrange
+        let mut snapshot =
+            snapshot_with_threads([thread("resolved", true), thread("unresolved", false)]);
+        snapshot.pr_level_comments.push(ReviewComment {
+            author: "reviewer".to_string(),
+            body: "Standalone comment".to_string(),
+        });
+
+        // Act
+        let rows = grouped_review_comment_rows(&snapshot);
+        let labels_and_entries = rows
+            .iter()
+            .map(|row| match row {
+                GroupedReviewCommentRow::Entry(ReviewCommentEntry::General(comment)) => {
+                    format!("comment:{}", comment.body)
+                }
+                GroupedReviewCommentRow::Entry(ReviewCommentEntry::Thread(thread)) => {
+                    format!("thread:{}", thread.id)
+                }
+                GroupedReviewCommentRow::GroupLabel(label) => format!("label:{label}"),
+            })
+            .collect::<Vec<_>>();
+
+        // Assert
+        assert_eq!(
+            labels_and_entries,
+            vec![
+                "label:Unresolved",
+                "thread:unresolved",
+                "label:Resolved",
+                "thread:resolved",
+                "label:Standalone",
+                "comment:Standalone comment",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_grouped_review_comment_rows_omit_empty_group_labels() {
+        // Arrange
+        let snapshot = snapshot_with_threads([thread("unresolved", false)]);
+
+        // Act
+        let labels = grouped_review_comment_rows(&snapshot)
+            .into_iter()
+            .filter_map(|row| match row {
+                GroupedReviewCommentRow::GroupLabel(label) => Some(label),
+                GroupedReviewCommentRow::Entry(_) => None,
+            })
+            .collect::<Vec<_>>();
+
+        // Assert
+        assert_eq!(labels, vec!["Unresolved"]);
+    }
+
+    #[test]
+    fn test_selectable_entries_reuses_materialized_grouped_rows() {
+        // Arrange
+        let mut snapshot = snapshot_with_threads([thread("thread", false)]);
+        snapshot.pr_level_comments.push(ReviewComment {
+            author: "reviewer".to_string(),
+            body: "Standalone comment".to_string(),
+        });
+        let rows = grouped_review_comment_rows(&snapshot);
+
+        // Act
+        let selected_entries = selectable_entries(&rows).collect::<Vec<_>>();
+
+        // Assert
+        assert!(matches!(
+            selected_entries[0],
+            ReviewCommentEntry::Thread(thread) if thread.id == "thread"
+        ));
+        assert!(matches!(
+            selected_entries[1],
+            ReviewCommentEntry::General(comment) if comment.body == "Standalone comment"
+        ));
+    }
 
     #[test]
     fn test_retarget_selected_index_follows_thread_between_resolution_groups() {

--- a/crates/agentty/src/ui/page/review_comment.rs
+++ b/crates/agentty/src/ui/page/review_comment.rs
@@ -10,7 +10,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
 
-use crate::domain::session::{Session, Status};
+use crate::domain::session::Session;
 use crate::presentation::{help_action, review_comment as review_comment_selection};
 use crate::ui::component::vertical_scrollbar::VerticalScrollbar;
 use crate::ui::diff_util::{DiffLine, DiffLineKind};
@@ -79,13 +79,15 @@ impl<'a> ReviewCommentPage<'a> {
 
     /// Renders the left comment selector for loaded, loading, empty, and error
     /// states.
-    fn render_comment_list(&self, frame: &mut Frame, area: Rect) {
-        let entries = self
-            .comment_snapshot
-            .map(comment_entries)
-            .unwrap_or_default();
-        let title = format!(" Comments ({}) ", entries.len());
-        let (items, selection_rows) = if entries.is_empty() {
+    fn render_comment_list(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        rows: &[review_comment_selection::GroupedReviewCommentRow<'_>],
+    ) {
+        let item_count = review_comment_item_count(self.comment_snapshot);
+        let title = format!(" Comments ({item_count}) ");
+        let (items, selection_rows) = if rows.is_empty() {
             (
                 vec![ListItem::new(comment_list_fallback(
                     self.comment_error,
@@ -94,7 +96,7 @@ impl<'a> ReviewCommentPage<'a> {
                 Vec::new(),
             )
         } else {
-            comment_list_items(&entries)
+            comment_list_items(rows)
         };
         let list = List::new(items)
             .block(
@@ -111,9 +113,9 @@ impl<'a> ReviewCommentPage<'a> {
             )
             .highlight_symbol("▶ ");
         let mut state = ListState::default();
-        if !entries.is_empty() {
+        if item_count > 0 {
             let selected_entry_index =
-                normalized_selection(self.selected_comment_index, entries.len());
+                normalized_selection(self.selected_comment_index, item_count);
             state.select(selection_rows.get(selected_entry_index).copied());
         }
 
@@ -122,10 +124,15 @@ impl<'a> ReviewCommentPage<'a> {
 
     /// Renders metadata, conversation text, and attached code context for the
     /// selected comment entry.
-    fn render_comment_detail(&self, frame: &mut Frame, area: Rect) {
+    fn render_comment_detail(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        rows: &[review_comment_selection::GroupedReviewCommentRow<'_>],
+    ) {
         let content_width = usize::from(area.width.saturating_sub(2).max(1));
         let lines = comment_detail_lines(
-            self.comment_snapshot,
+            self.comment_snapshot.map(|_| rows),
             self.comment_error,
             self.is_loading_comments,
             self.diff,
@@ -158,19 +165,19 @@ impl<'a> ReviewCommentPage<'a> {
 impl Page for ReviewCommentPage<'_> {
     fn render(&mut self, frame: &mut Frame, area: Rect) {
         let areas = diff_util::diff_page_areas(area);
+        let rows = self
+            .comment_snapshot
+            .map(review_comment_selection::grouped_review_comment_rows)
+            .unwrap_or_default();
 
-        self.render_comment_list(frame, areas.file_list_area);
-        self.render_comment_detail(frame, areas.diff_area);
+        self.render_comment_list(frame, areas.file_list_area, &rows);
+        self.render_comment_detail(frame, areas.diff_area, &rows);
 
-        let can_reply =
-            self.session.status.allows_review_actions() || self.session.status == Status::Question;
+        let can_reply = self.session.allows_review_comment_reply();
         let can_resolve_all =
             can_reply && review_comment_has_actionable_items(self.comment_snapshot);
-        let can_resolve_selected = can_reply
-            && review_comment_selected_is_actionable(
-                self.comment_snapshot,
-                self.selected_comment_index,
-            );
+        let can_resolve_selected =
+            can_reply && review_comment_selected_is_actionable(&rows, self.selected_comment_index);
         let footer = Paragraph::new(help_format::footer_line(
             &help_action::review_comment_footer_actions(can_resolve_all, can_resolve_selected),
         ));
@@ -191,8 +198,11 @@ pub(crate) fn review_comment_view_max_scroll_offset(
     let detail_area = diff_util::diff_page_areas(area).diff_area;
     let viewport_height = detail_area.height.saturating_sub(2);
     let content_width = usize::from(detail_area.width.saturating_sub(2).max(1));
+    let rows = comment_snapshot
+        .map(review_comment_selection::grouped_review_comment_rows)
+        .unwrap_or_default();
     let line_count = comment_detail_lines(
-        comment_snapshot,
+        comment_snapshot.map(|_| rows.as_slice()),
         comment_error,
         is_loading_comments,
         diff,
@@ -218,18 +228,12 @@ pub(crate) fn review_comment_item_count(snapshot: Option<&ReviewCommentSnapshot>
 /// Returns whether the selected inline thread can be sent to the session
 /// agent.
 pub(crate) fn review_comment_selected_is_actionable(
-    snapshot: Option<&ReviewCommentSnapshot>,
+    rows: &[review_comment_selection::GroupedReviewCommentRow<'_>],
     selected_comment_index: usize,
 ) -> bool {
-    let Some(snapshot) = snapshot else {
-        return false;
-    };
-
-    comment_entries(snapshot)
-        .get(selected_comment_index)
-        .is_some_and(
-            |entry| matches!(entry, CommentEntry::Thread(thread) if thread.is_actionable()),
-        )
+    review_comment_selection::selected_entry(rows, selected_comment_index).is_some_and(
+        |entry| matches!(entry, review_comment_selection::ReviewCommentEntry::Thread(thread) if thread.is_actionable()),
+    )
 }
 
 /// Returns whether the snapshot contains any actionable inline thread.
@@ -244,108 +248,65 @@ pub(crate) fn review_comment_has_actionable_items(
     })
 }
 
-/// Group applied to one review-comment selector entry.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum CommentGroup {
-    Unresolved,
-    Resolved,
-    Standalone,
-}
-
-impl CommentGroup {
-    /// Returns the user-facing group heading.
-    fn label(self) -> &'static str {
-        match self {
-            Self::Unresolved => "Unresolved",
-            Self::Resolved => "Resolved",
-            Self::Standalone => "Standalone",
-        }
-    }
-}
-
-/// One selectable left-panel row and its right-panel detail source.
-enum CommentEntry<'a> {
-    General(&'a ReviewComment),
-    Thread(&'a ReviewCommentThread),
-}
-
-impl CommentEntry<'_> {
-    /// Returns the selector group for this entry.
-    fn group(&self) -> CommentGroup {
-        match self {
-            Self::General(_) => CommentGroup::Standalone,
-            Self::Thread(thread) if thread.is_resolved => CommentGroup::Resolved,
-            Self::Thread(_) => CommentGroup::Unresolved,
-        }
-    }
-
-    /// Builds the compact label shown in the left selector.
-    fn label(&self) -> Line<'static> {
-        match self {
-            Self::General(comment) => Line::from(vec![
-                Span::styled("General", Style::default().fg(style::palette::accent())),
-                Span::styled(
-                    format!(" · {}", comment.author),
-                    Style::default().fg(style::palette::text_muted()),
-                ),
-            ]),
-            Self::Thread(thread) => {
-                let anchor = review_comment_format::thread_anchor(thread);
-                let author = thread
-                    .comments
-                    .first()
-                    .map_or("unknown", |comment| comment.author.as_str());
-
-                Line::from(vec![
-                    Span::styled(anchor, Style::default().fg(style::palette::accent())),
-                    Span::styled(
-                        format!(" · {author}"),
-                        Style::default().fg(style::palette::text_muted()),
-                    ),
-                ])
-            }
-        }
-    }
-}
-
-/// Flattens comments into unresolved, resolved, and standalone selector
-/// groups while preserving source order inside each group.
-fn comment_entries(snapshot: &ReviewCommentSnapshot) -> Vec<CommentEntry<'_>> {
-    review_comment_selection::grouped_threads(snapshot)
-        .map(CommentEntry::Thread)
-        .chain(snapshot.pr_level_comments.iter().map(CommentEntry::General))
-        .collect()
-}
-
 /// Builds group headings and selectable entry rows, returning each entry's
 /// corresponding list-row index.
-fn comment_list_items(entries: &[CommentEntry<'_>]) -> (Vec<ListItem<'static>>, Vec<usize>) {
-    let mut items = Vec::with_capacity(entries.len().saturating_add(3));
-    let mut selection_rows = Vec::with_capacity(entries.len());
-    let mut previous_group = None;
+fn comment_list_items(
+    rows: &[review_comment_selection::GroupedReviewCommentRow<'_>],
+) -> (Vec<ListItem<'static>>, Vec<usize>) {
+    let mut items = Vec::with_capacity(rows.len());
+    let mut selection_rows = Vec::with_capacity(rows.len());
 
-    for entry in entries {
-        let group = entry.group();
-        if previous_group != Some(group) {
-            items.push(ListItem::new(Line::from(Span::styled(
-                group.label(),
-                Style::default()
-                    .fg(style::palette::text_muted())
-                    .add_modifier(Modifier::BOLD),
-            ))));
-            previous_group = Some(group);
+    for row in rows {
+        match row {
+            review_comment_selection::GroupedReviewCommentRow::Entry(entry) => {
+                selection_rows.push(items.len());
+                items.push(ListItem::new(comment_entry_label(*entry)));
+            }
+            review_comment_selection::GroupedReviewCommentRow::GroupLabel(label) => {
+                items.push(ListItem::new(Line::from(Span::styled(
+                    *label,
+                    Style::default()
+                        .fg(style::palette::text_muted())
+                        .add_modifier(Modifier::BOLD),
+                ))));
+            }
         }
-
-        selection_rows.push(items.len());
-        items.push(ListItem::new(entry.label()));
     }
 
     (items, selection_rows)
 }
 
+/// Builds the compact label shown for one selectable comment entry.
+fn comment_entry_label(entry: review_comment_selection::ReviewCommentEntry<'_>) -> Line<'static> {
+    match entry {
+        review_comment_selection::ReviewCommentEntry::General(comment) => Line::from(vec![
+            Span::styled("General", Style::default().fg(style::palette::accent())),
+            Span::styled(
+                format!(" · {}", comment.author),
+                Style::default().fg(style::palette::text_muted()),
+            ),
+        ]),
+        review_comment_selection::ReviewCommentEntry::Thread(thread) => {
+            let anchor = review_comment_format::thread_anchor(thread);
+            let author = thread
+                .comments
+                .first()
+                .map_or("unknown", |comment| comment.author.as_str());
+
+            Line::from(vec![
+                Span::styled(anchor, Style::default().fg(style::palette::accent())),
+                Span::styled(
+                    format!(" · {author}"),
+                    Style::default().fg(style::palette::text_muted()),
+                ),
+            ])
+        }
+    }
+}
+
 /// Builds all visible rows for one selected comment detail.
 fn comment_detail_lines(
-    snapshot: Option<&ReviewCommentSnapshot>,
+    rows: Option<&[review_comment_selection::GroupedReviewCommentRow<'_>]>,
     comment_error: Option<&str>,
     is_loading_comments: bool,
     diff: &str,
@@ -353,23 +314,25 @@ fn comment_detail_lines(
     markdown_render_cache: &markdown::MarkdownRenderCache,
     width: usize,
 ) -> Vec<Line<'static>> {
-    let Some(snapshot) = snapshot else {
+    let Some(rows) = rows else {
         return vec![Line::from(comment_detail_fallback(
             comment_error,
             is_loading_comments,
         ))];
     };
-    let entries = comment_entries(snapshot);
-    let Some(entry) = entries.get(normalized_selection(selected_comment_index, entries.len()))
-    else {
+    let item_count = review_comment_selection::selectable_entries(rows).count();
+    let Some(entry) = review_comment_selection::selected_entry(
+        rows,
+        normalized_selection(selected_comment_index, item_count),
+    ) else {
         return vec![Line::from("No review comments.")];
     };
 
     match entry {
-        CommentEntry::General(comment) => {
+        review_comment_selection::ReviewCommentEntry::General(comment) => {
             general_comment_detail_lines(comment, markdown_render_cache, width)
         }
-        CommentEntry::Thread(thread) => {
+        review_comment_selection::ReviewCommentEntry::Thread(thread) => {
             thread_comment_detail_lines(thread, diff, markdown_render_cache, width)
         }
     }
@@ -1034,11 +997,12 @@ mod tests {
             pr_level_comments: Vec::new(),
             threads: vec![inline_thread(2)],
         };
+        let rows = review_comment_selection::grouped_review_comment_rows(&snapshot);
         let markdown_render_cache = markdown::MarkdownRenderCache::default();
 
         // Act
         let lines = comment_detail_lines(
-            Some(&snapshot),
+            Some(&rows),
             None,
             false,
             SAMPLE_DIFF,
@@ -1087,7 +1051,7 @@ mod tests {
     }
 
     #[test]
-    fn test_comment_entries_group_unresolved_resolved_and_standalone_rows() {
+    fn test_comment_list_items_map_grouped_rows_to_selectable_indexes() {
         // Arrange
         let mut resolved = inline_thread(3);
         resolved.id = "resolved".to_string();
@@ -1103,21 +1067,10 @@ mod tests {
         };
 
         // Act
-        let entries = comment_entries(&snapshot);
-        let (items, selection_rows) = comment_list_items(&entries);
+        let rows = review_comment_selection::grouped_review_comment_rows(&snapshot);
+        let (items, selection_rows) = comment_list_items(&rows);
 
         // Assert
-        assert_eq!(
-            entries.iter().map(CommentEntry::group).collect::<Vec<_>>(),
-            vec![
-                CommentGroup::Unresolved,
-                CommentGroup::Resolved,
-                CommentGroup::Standalone,
-            ]
-        );
-        assert!(matches!(entries[0], CommentEntry::Thread(thread) if thread.id == "unresolved"));
-        assert!(matches!(entries[1], CommentEntry::Thread(thread) if thread.id == "resolved"));
-        assert!(matches!(entries[2], CommentEntry::General(comment) if comment.author == "bob"));
         assert_eq!(items.len(), 6);
         assert_eq!(selection_rows, vec![1, 3, 5]);
     }
@@ -1140,13 +1093,14 @@ mod tests {
             }],
             threads: vec![current, resolved, outdated],
         };
+        let rows = review_comment_selection::grouped_review_comment_rows(&snapshot);
 
         // Act
-        let current_is_actionable = review_comment_selected_is_actionable(Some(&snapshot), 0);
-        let outdated_is_actionable = review_comment_selected_is_actionable(Some(&snapshot), 1);
-        let resolved_is_actionable = review_comment_selected_is_actionable(Some(&snapshot), 2);
-        let general_is_actionable = review_comment_selected_is_actionable(Some(&snapshot), 3);
-        let missing_is_actionable = review_comment_selected_is_actionable(Some(&snapshot), 99);
+        let current_is_actionable = review_comment_selected_is_actionable(&rows, 0);
+        let outdated_is_actionable = review_comment_selected_is_actionable(&rows, 1);
+        let resolved_is_actionable = review_comment_selected_is_actionable(&rows, 2);
+        let general_is_actionable = review_comment_selected_is_actionable(&rows, 3);
+        let missing_is_actionable = review_comment_selected_is_actionable(&rows, 99);
         let current_thread_id = review_comment_selection::selected_thread_id(&snapshot, 0);
         let general_thread_id = review_comment_selection::selected_thread_id(&snapshot, 3);
         let snapshot_has_actionable_items = review_comment_has_actionable_items(Some(&snapshot));
@@ -1160,7 +1114,7 @@ mod tests {
         assert_eq!(current_thread_id, Some("current"));
         assert_eq!(general_thread_id, None);
         assert!(snapshot_has_actionable_items);
-        assert!(!review_comment_selected_is_actionable(None, 0));
+        assert!(!review_comment_selected_is_actionable(&[], 0));
         assert!(!review_comment_has_actionable_items(None));
     }
 

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -81,11 +81,12 @@ For file-level detail, read the module docstrings directly.
 - `presentation.rs` and `presentation/`: Frontend-neutral interaction state shared by
   runtime input and UI output. They expose mode, help-action, prompt, settings-screen
   actions, editor, scroll, viewport, and semantic list-selection contracts without
-  importing Ratatui or `ui/` formatting. `presentation/review_comment.rs` preserves
-  forge-thread selection across grouped snapshot refreshes. `presentation/settings.rs`
-  owns settings row selection, selectors, launch-configuration editing through the
-  shared `InputState`, and render-ready settings snapshots; it returns typed persistence
-  operations to `app/setting.rs`.
+  importing Ratatui or `ui/` formatting. `presentation/review_comment.rs` owns review
+  comment group ordering and headings while preserving forge-thread selection across
+  grouped snapshot refreshes. `presentation/settings.rs` owns settings row selection,
+  selectors, launch-configuration editing through the shared `InputState`, and
+  render-ready settings snapshots; it returns typed persistence operations to
+  `app/setting.rs`.
 - `ui/`: Rendering — frame composition, mode-to-page routing, pages under `ui/page/`,
   reusable widgets under `ui/component/`, application-to-frame projection in
   `ui/app_render.rs`, Agentty theme adapters for `ag-tui-text`, plus diff, layout,


### PR DESCRIPTION
- Move grouped row ordering and headings into the presentation projection.
- Reuse session reply permissions across review comment actions.
- Test grouped rows, selection mapping, and reply permissions.