### PR TITLE
Prepare v0.13.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,36 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.13.5] - 2026-07-21
+
 ### Added
 
 - agentty: add a rendered markdown and Mermaid preview toggle for changed markdown files
   in diff view.
+- agentty: start a session directly from assigned issue details, using the issue URL as
+  the initial prompt.
+
+### Changed
+
+- agentty: group review comments by unresolved, resolved, and standalone state while
+  preserving thread selection across refreshes.
+- agentty: preserve prompt drafts when returning to `Sessions` and display `C` as the
+  done-session continuation shortcut.
+- agentty: centralize session action eligibility, prompt composer state, settings
+  presentation state, and agent CLI subprocess execution behind their owning runtime
+  boundaries.
+- docs: refresh the `README.md` navigation, homepage workflow highlights, and session
+  management showcase.
+- ci: enforce coverage checks on all builds and update the grouped GitHub Actions
+  dependencies.
+- deps: update `uuid` from `1.23.4` to `1.24.0`.
+- release: bump workspace crate metadata and lockfile package versions to `0.13.5`.
+
+### Contributors
+
+- @andagaev
+- @dependabot
+- @minev-dev
 
 ## [v0.13.4] - 2026-07-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "image",
  "mockall",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "mockall",
  "serde",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "mockall",
  "rustix",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "askama",
  "schemars 1.2.1",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "clap",
  "tempfile",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.13.4"
+version = "0.13.5"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -16,13 +16,13 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.13.4" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.13.4" }
-ag-forge = { path = "crates/ag-forge", version = "0.13.4" }
-ag-git = { path = "crates/ag-git", version = "0.13.4" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.13.4" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.13.4" }
-testty = { path = "crates/testty", version = "0.13.4" }
+ag-agent = { path = "crates/ag-agent", version = "0.13.5" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.13.5" }
+ag-forge = { path = "crates/ag-forge", version = "0.13.5" }
+ag-git = { path = "crates/ag-git", version = "0.13.5" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.13.5" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.13.5" }
+testty = { path = "crates/testty", version = "0.13.5" }
 async-trait = "0.1"
 agent-client-protocol = "1.2.0"
 assert_cmd = "2"


### PR DESCRIPTION
- Bump workspace crate versions and lockfile metadata.
- Document the release changes and contributors in `CHANGELOG.md`.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)