### PR TITLE
Update Gemini model lineup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - agentty: batch linked review comments by marking each actionable thread to address or
   deny before submitting one session-agent turn.
 
+### Changed
+
+- agentty: replace Gemini 3.5 Flash and Gemini 3.1 Flash-Lite with Gemini 3.6 Flash and
+  Gemini 3.5 Flash-Lite, migrating persisted selections to their replacements.
+
 ## [v0.13.5] - 2026-07-21
 
 ### Added

--- a/crates/ag-agent/src/agent/antigravity.rs
+++ b/crates/ag-agent/src/agent/antigravity.rs
@@ -510,7 +510,7 @@ mod tests {
             local_image_path: attachment_directory.join("one.png"),
         };
         let backend = AntigravityBackend;
-        let requested_model = "gemini-3.5-flash";
+        let requested_model = "gemini-3.6-flash";
 
         // Act
         let command = AgentBackend::build_command(

--- a/crates/ag-agent/src/agent/gemini.rs
+++ b/crates/ag-agent/src/agent/gemini.rs
@@ -66,7 +66,7 @@ mod tests {
                 folder: temp_directory.path(),
                 main_checkout_root: None,
                 replay_transcript: None,
-                model: "gemini-3.5-flash",
+                model: "gemini-3.6-flash",
                 prompt: "Generate title",
                 reasoning_level: ReasoningLevel::default(),
                 request_kind: &utility_request_kind(),
@@ -79,7 +79,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         // Assert
-        assert_eq!(args, vec!["--acp", "--model", "gemini-3.5-flash"]);
+        assert_eq!(args, vec!["--acp", "--model", "gemini-3.6-flash"]);
         assert_eq!(command.get_current_dir(), Some(temp_directory.path()));
     }
 }

--- a/crates/ag-agent/src/model/agent.rs
+++ b/crates/ag-agent/src/model/agent.rs
@@ -94,11 +94,10 @@ pub enum AgentModel {
     Gpt55,
     /// Fast Gemini preview model backed by `gemini-3-flash-preview`.
     Gemini3FlashPreview,
-    /// Fast Gemini model backed by `gemini-3.5-flash`.
-    Gemini35Flash,
-    /// Lightweight Gemini preview model backed by
-    /// `gemini-3.1-flash-lite-preview`.
-    Gemini31FlashLitePreview,
+    /// Fast Gemini model backed by `gemini-3.6-flash`.
+    Gemini36Flash,
+    /// Lightweight Gemini model backed by `gemini-3.5-flash-lite`.
+    Gemini35FlashLite,
     /// Higher-quality Gemini preview model backed by `gemini-3.1-pro-preview`.
     Gemini31ProPreview,
     /// Codex spark model backed by `gpt-5.3-codex-spark`.
@@ -184,8 +183,8 @@ impl AgentModel {
             Self::Gpt56Luna => "gpt-5.6-luna",
             Self::Gpt55 => "gpt-5.5",
             Self::Gemini3FlashPreview => "gemini-3-flash-preview",
-            Self::Gemini35Flash => "gemini-3.5-flash",
-            Self::Gemini31FlashLitePreview => "gemini-3.1-flash-lite-preview",
+            Self::Gemini36Flash => "gemini-3.6-flash",
+            Self::Gemini35FlashLite => "gemini-3.5-flash-lite",
             Self::Gemini31ProPreview => "gemini-3.1-pro-preview",
             Self::Gpt53CodexSpark => "gpt-5.3-codex-spark",
             Self::ClaudeOpus48 => "claude-opus-4-8",
@@ -205,9 +204,9 @@ impl AgentModel {
 
     /// Parses one persisted model identifier and upgrades retired aliases.
     ///
-    /// Stored retired Claude Opus, Claude Sonnet, and Codex aliases are
-    /// migrated forward so existing projects and sessions continue loading
-    /// after model removals.
+    /// Stored retired Gemini, Claude, and Codex aliases are migrated forward
+    /// so existing projects and sessions continue loading after model
+    /// removals.
     /// Raw `gemini-*` ids parse to shared Gemini model variants; persisted
     /// session agents decide whether Gemini or Antigravity owns the session.
     ///
@@ -216,6 +215,8 @@ impl AgentModel {
     /// identifier.
     pub fn parse_persisted(value: &str) -> Result<Self, String> {
         match value {
+            "gemini-3.5-flash" => Ok(Self::Gemini36Flash),
+            "gemini-3.1-flash-lite-preview" => Ok(Self::Gemini35FlashLite),
             "claude-opus-4-6" | "claude-opus-4-7" => Ok(Self::ClaudeOpus48),
             "claude-sonnet-4-6" => Ok(Self::ClaudeSonnet5),
             "gpt-5.4-mini" => Ok(Self::Gpt56Luna),
@@ -473,8 +474,8 @@ impl FromStr for AgentModel {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "gemini-3-flash-preview" => Ok(Self::Gemini3FlashPreview),
-            "gemini-3.5-flash" => Ok(Self::Gemini35Flash),
-            "gemini-3.1-flash-lite-preview" => Ok(Self::Gemini31FlashLitePreview),
+            "gemini-3.6-flash" => Ok(Self::Gemini36Flash),
+            "gemini-3.5-flash-lite" => Ok(Self::Gemini35FlashLite),
             "gemini-3.1-pro-preview" => Ok(Self::Gemini31ProPreview),
             "gpt-5.6-sol" => Ok(Self::Gpt56Sol),
             "gpt-5.6-terra" => Ok(Self::Gpt56Terra),
@@ -498,9 +499,9 @@ impl AgentSelectionMetadata for AgentModel {
     fn description(&self) -> &'static str {
         match self {
             Self::Gemini31ProPreview => "Higher-quality Gemini model for deeper reasoning.",
-            Self::Gemini35Flash => "Fast Gemini model for current Flash workloads.",
-            Self::Gemini31FlashLitePreview => {
-                "Lightweight Gemini model for fast, cost-conscious iterations."
+            Self::Gemini36Flash => "Fast Gemini model for agentic and multimodal tasks.",
+            Self::Gemini35FlashLite => {
+                "Lightweight Gemini model for fast, cost-conscious workloads."
             }
             Self::Gemini3FlashPreview => "Fast Gemini model for quick iterations.",
             Self::Gpt56Sol => "Newest Codex model for the strongest coding performance.",
@@ -557,14 +558,14 @@ impl AgentKind {
     pub fn models(self) -> &'static [AgentModel] {
         const ANTIGRAVITY_MODELS: &[AgentModel] = &[
             AgentModel::Gemini31ProPreview,
-            AgentModel::Gemini35Flash,
-            AgentModel::Gemini31FlashLitePreview,
+            AgentModel::Gemini36Flash,
+            AgentModel::Gemini35FlashLite,
             AgentModel::Gemini3FlashPreview,
         ];
         const GEMINI_MODELS: &[AgentModel] = &[
             AgentModel::Gemini31ProPreview,
-            AgentModel::Gemini35Flash,
-            AgentModel::Gemini31FlashLitePreview,
+            AgentModel::Gemini36Flash,
+            AgentModel::Gemini35FlashLite,
             AgentModel::Gemini3FlashPreview,
         ];
         const CLAUDE_MODELS: &[AgentModel] = &[
@@ -702,10 +703,10 @@ mod tests {
         let antigravity_kind = AgentKind::Antigravity;
 
         // Act
-        let parsed_model = antigravity_kind.parse_model("gemini-3.5-flash");
+        let parsed_model = antigravity_kind.parse_model("gemini-3.6-flash");
 
         // Assert
-        assert_eq!(parsed_model, Some(AgentModel::Gemini35Flash));
+        assert_eq!(parsed_model, Some(AgentModel::Gemini36Flash));
     }
 
     #[test]
@@ -716,10 +717,29 @@ mod tests {
         let gemini_kind = AgentKind::Gemini;
 
         // Act
-        let parsed_model = gemini_kind.parse_model("gemini-3.5-flash");
+        let parsed_model = gemini_kind.parse_model("gemini-3.6-flash");
 
         // Assert
-        assert_eq!(parsed_model, Some(AgentModel::Gemini35Flash));
+        assert_eq!(parsed_model, Some(AgentModel::Gemini36Flash));
+    }
+
+    #[test]
+    /// Ensures current Gemini models expose their user-facing descriptions.
+    fn test_current_gemini_models_have_current_descriptions() {
+        // Arrange
+        let models = [AgentModel::Gemini36Flash, AgentModel::Gemini35FlashLite];
+
+        // Act
+        let descriptions = models.map(|model| model.description());
+
+        // Assert
+        assert_eq!(
+            descriptions,
+            [
+                "Fast Gemini model for agentic and multimodal tasks.",
+                "Lightweight Gemini model for fast, cost-conscious workloads.",
+            ]
+        );
     }
 
     #[test]
@@ -785,7 +805,10 @@ mod tests {
         let parsed_sonnet_5 = AgentModel::parse_persisted("claude-sonnet-5");
         let parsed_gpt_54_mini = AgentModel::parse_persisted("gpt-5.4-mini");
         let parsed_gpt_54 = AgentModel::parse_persisted("gpt-5.4");
+        let parsed_gemini_36_flash = AgentModel::parse_persisted("gemini-3.6-flash");
         let parsed_gemini_35_flash = AgentModel::parse_persisted("gemini-3.5-flash");
+        let parsed_gemini_31_flash_lite_preview =
+            AgentModel::parse_persisted("gemini-3.1-flash-lite-preview");
 
         // Assert
         assert_eq!(parsed_opus_46, Ok(AgentModel::ClaudeOpus48));
@@ -794,7 +817,12 @@ mod tests {
         assert_eq!(parsed_sonnet_5, Ok(AgentModel::ClaudeSonnet5));
         assert_eq!(parsed_gpt_54_mini, Ok(AgentModel::Gpt56Luna));
         assert_eq!(parsed_gpt_54, Ok(AgentModel::Gpt55));
-        assert_eq!(parsed_gemini_35_flash, Ok(AgentModel::Gemini35Flash));
+        assert_eq!(parsed_gemini_36_flash, Ok(AgentModel::Gemini36Flash));
+        assert_eq!(parsed_gemini_35_flash, Ok(AgentModel::Gemini36Flash));
+        assert_eq!(
+            parsed_gemini_31_flash_lite_preview,
+            Ok(AgentModel::Gemini35FlashLite)
+        );
     }
 
     #[test]
@@ -804,7 +832,7 @@ mod tests {
         // Arrange
 
         // Act
-        let selection = parse_persisted_session_agent_model(Some("codex"), "gemini-3.5-flash");
+        let selection = parse_persisted_session_agent_model(Some("codex"), "gemini-3.6-flash");
 
         // Assert
         assert_eq!(selection.kind(), AgentKind::Codex);
@@ -819,11 +847,40 @@ mod tests {
 
         // Act
         let selection =
-            parse_persisted_session_agent_model(Some("antigravity"), "gemini-3.5-flash");
+            parse_persisted_session_agent_model(Some("antigravity"), "gemini-3.6-flash");
 
         // Assert
         assert_eq!(selection.kind(), AgentKind::Antigravity);
-        assert_eq!(selection.model(), AgentModel::Gemini35Flash);
+        assert_eq!(selection.model(), AgentModel::Gemini36Flash);
+    }
+
+    #[test]
+    /// Ensures retired Gemini models migrate while preserving the saved
+    /// Google provider.
+    fn test_parse_persisted_session_agent_model_migrates_retired_saved_google_models() {
+        // Arrange
+        let persisted_selections = [
+            ("gemini", "gemini-3.5-flash"),
+            ("gemini", "gemini-3.1-flash-lite-preview"),
+            ("antigravity", "gemini-3.5-flash"),
+            ("antigravity", "gemini-3.1-flash-lite-preview"),
+        ];
+
+        // Act
+        let migrated_selections = persisted_selections.map(|(agent_value, model_value)| {
+            parse_persisted_session_agent_model(Some(agent_value), model_value)
+        });
+
+        // Assert
+        assert_eq!(
+            migrated_selections,
+            [
+                AgentSelection::new(AgentKind::Gemini, AgentModel::Gemini36Flash),
+                AgentSelection::new(AgentKind::Gemini, AgentModel::Gemini35FlashLite),
+                AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash),
+                AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini35FlashLite),
+            ]
+        );
     }
 
     #[test]
@@ -847,11 +904,33 @@ mod tests {
         // Arrange
 
         // Act
-        let selection = parse_persisted_session_agent_model(None, "gemini-3.5-flash");
+        let selection = parse_persisted_session_agent_model(None, "gemini-3.6-flash");
 
         // Assert
         assert_eq!(selection.kind(), AgentKind::Antigravity);
-        assert_eq!(selection.model(), AgentModel::Gemini35Flash);
+        assert_eq!(selection.model(), AgentModel::Gemini36Flash);
+    }
+
+    #[test]
+    /// Ensures retired Gemini models in rows without a saved provider migrate
+    /// through the legacy Antigravity compatibility path.
+    fn test_parse_persisted_session_agent_model_migrates_retired_legacy_gemini_rows() {
+        // Arrange
+
+        // Act
+        let migrated_flash = parse_persisted_session_agent_model(None, "gemini-3.5-flash");
+        let migrated_flash_lite =
+            parse_persisted_session_agent_model(None, "gemini-3.1-flash-lite-preview");
+
+        // Assert
+        assert_eq!(
+            migrated_flash,
+            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash)
+        );
+        assert_eq!(
+            migrated_flash_lite,
+            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini35FlashLite)
+        );
     }
 
     #[test]
@@ -933,8 +1012,8 @@ mod tests {
         // Arrange
         let models = [
             AgentModel::Gemini31ProPreview,
-            AgentModel::Gemini35Flash,
-            AgentModel::Gemini31FlashLitePreview,
+            AgentModel::Gemini36Flash,
+            AgentModel::Gemini35FlashLite,
             AgentModel::Gemini3FlashPreview,
         ];
 
@@ -955,15 +1034,15 @@ mod tests {
     /// transports.
     fn test_antigravity_provider_model_str_returns_raw_gemini_model() {
         // Arrange
-        let model = AgentModel::Gemini31FlashLitePreview;
+        let model = AgentModel::Gemini35FlashLite;
 
         // Act
         let persisted_model = model.as_str();
         let provider_model = model.provider_model_str();
 
         // Assert
-        assert_eq!(persisted_model, "gemini-3.1-flash-lite-preview");
-        assert_eq!(provider_model, "gemini-3.1-flash-lite-preview");
+        assert_eq!(persisted_model, "gemini-3.5-flash-lite");
+        assert_eq!(provider_model, "gemini-3.5-flash-lite");
     }
 
     #[test]
@@ -1020,8 +1099,8 @@ mod tests {
                 AgentModel::Gpt55,
                 AgentModel::Gpt53CodexSpark,
                 AgentModel::Gemini31ProPreview,
-                AgentModel::Gemini35Flash,
-                AgentModel::Gemini31FlashLitePreview,
+                AgentModel::Gemini36Flash,
+                AgentModel::Gemini35FlashLite,
                 AgentModel::Gemini3FlashPreview,
             ]
         );
@@ -1042,8 +1121,8 @@ mod tests {
             selectable_models,
             vec![
                 AgentModel::Gemini31ProPreview,
-                AgentModel::Gemini35Flash,
-                AgentModel::Gemini31FlashLitePreview,
+                AgentModel::Gemini36Flash,
+                AgentModel::Gemini35FlashLite,
                 AgentModel::Gemini3FlashPreview,
             ]
         );
@@ -1094,7 +1173,7 @@ mod tests {
     /// run the selected model.
     fn test_resolve_agent_selection_for_model_preserves_preferred_shared_provider() {
         // Arrange
-        let model = AgentModel::Gemini35Flash;
+        let model = AgentModel::Gemini36Flash;
         let available_agent_kinds = [AgentKind::Gemini, AgentKind::Antigravity];
 
         // Act
@@ -1116,7 +1195,7 @@ mod tests {
     /// preferred provider cannot run the selected model.
     fn test_resolve_agent_selection_for_model_uses_available_provider_order() {
         // Arrange
-        let model = AgentModel::Gemini35Flash;
+        let model = AgentModel::Gemini36Flash;
         let available_agent_kinds = [AgentKind::Gemini, AgentKind::Antigravity];
 
         // Act

--- a/crates/agentty/src/app/setting.rs
+++ b/crates/agentty/src/app/setting.rs
@@ -1092,7 +1092,7 @@ mod tests {
         let loaded_selection = load_default_smart_agent_setting(
             &services,
             Some(project_id),
-            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini35Flash),
+            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash),
         )
         .await;
 

--- a/crates/agentty/src/app/task.rs
+++ b/crates/agentty/src/app/task.rs
@@ -1050,12 +1050,12 @@ mod tests {
         // Arrange
         let session_folder = Path::new("/tmp/review-assist-provider");
         let review_selection =
-            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini35Flash);
+            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash);
         let review_diff = "diff --git a/src/lib.rs b/src/lib.rs";
         let mut one_shot_client = agent::MockOneShotClient::new();
         one_shot_client.expect_submit().returning(|request| {
             assert_eq!(request.agent_kind, AgentKind::Antigravity);
-            assert_eq!(request.model, AgentModel::Gemini35Flash);
+            assert_eq!(request.model, AgentModel::Gemini36Flash);
 
             Ok(agent::OneShotSubmission {
                 response: AgentResponse::plain("Review completed."),

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -3349,12 +3349,12 @@ fn stacked_session_start_waits_for_parent_review() -> E2eResult {
     Ok(())
 }
 
-/// Verify that the prompt `/model` picker exposes the current Gemini Flash
-/// model when the Gemini CLI is locally available.
+/// Verify that the prompt `/model` picker exposes the current Gemini models
+/// when the Gemini CLI is locally available.
 #[test]
-fn gemini_model_picker_includes_current_flash() -> E2eResult {
+fn gemini_model_picker_lists_current_models() -> E2eResult {
     // Arrange, Act, Assert
-    FeatureTest::new("gemini_model_picker_includes_current_flash")
+    FeatureTest::new("gemini_model_picker_lists_current_models")
         .with_git()
         .setup(seed_failing_gemini_cli_stub)
         .run(
@@ -3372,15 +3372,16 @@ fn gemini_model_picker_includes_current_flash() -> E2eResult {
                     .press_key("Enter")
                     .wait_for_text("/model Agent", 3000)
                     .press_key("Enter")
-                    .wait_for_text("gemini-3.5-flash", 3000)
+                    .wait_for_text("gemini-3.6-flash", 3000)
                     .capture_labeled(
                         "gemini_model_picker",
-                        "Gemini model picker includes current Flash",
+                        "Gemini model picker lists current models",
                     )
             },
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(frame, "gemini-3.5-flash", &full);
+                assertion::assert_text_in_region(frame, "gemini-3.6-flash", &full);
+                assertion::assert_text_in_region(frame, "gemini-3.5-flash-lite", &full);
             },
         )?;
 
@@ -3456,7 +3457,7 @@ fn antigravity_model_picker_includes_gemini_models() -> E2eResult {
                     .wait_for_text("/model Agent", 3000)
                     .press_key("Down")
                     .press_key("Enter")
-                    .wait_for_text("gemini-3.5-flash", 3000)
+                    .wait_for_text("gemini-3.6-flash", 3000)
                     .capture_labeled(
                         "antigravity_model_picker",
                         "Antigravity model picker includes Gemini models",
@@ -3465,7 +3466,8 @@ fn antigravity_model_picker_includes_gemini_models() -> E2eResult {
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "gemini-3.1-pro-preview", &full);
-                assertion::assert_text_in_region(frame, "gemini-3.5-flash", &full);
+                assertion::assert_text_in_region(frame, "gemini-3.6-flash", &full);
+                assertion::assert_text_in_region(frame, "gemini-3.5-flash-lite", &full);
             },
         )?;
 

--- a/docs/site/content/docs/agents/backends.md
+++ b/docs/site/content/docs/agents/backends.md
@@ -146,9 +146,8 @@ entries with different trade-offs between speed, quality, and cost.
 Both providers share the same Gemini model ids:
 
 - `gemini-3.1-pro-preview` (default): Higher-quality Gemini model for deeper reasoning.
-- `gemini-3.5-flash`: Fast Gemini model for current Flash workloads.
-- `gemini-3.1-flash-lite-preview`: Lightweight Gemini model for fast, cost-conscious
-  iterations.
+- `gemini-3.6-flash`: Fast Gemini model for agentic and multimodal tasks.
+- `gemini-3.5-flash-lite`: Lightweight Gemini model for fast, cost-conscious workloads.
 - `gemini-3-flash-preview`: Fast Gemini model for quick iterations.
 
 ### Claude Models
@@ -167,8 +166,9 @@ Both providers share the same Gemini model ids:
 - `gpt-5.3-codex-spark`: Codex spark model for quick coding iterations.
 
 Stored project defaults or session rows that reference a retired model id (such as
-`claude-opus-4-6`, `claude-opus-4-7`, `claude-sonnet-4-6`, `gpt-5.4`, or `gpt-5.4-mini`)
-are upgraded to the current supported replacement when Agentty loads them.
+`gemini-3.5-flash`, `gemini-3.1-flash-lite-preview`, `claude-opus-4-6`,
+`claude-opus-4-7`, `claude-sonnet-4-6`, `gpt-5.4`, or `gpt-5.4-mini`) are upgraded to
+the current supported replacement when Agentty loads them.
 
 ## Switching Models
 


### PR DESCRIPTION
- The model lineup replaces Gemini 3.5 Flash and Gemini 3.1 Flash-Lite Preview with Gemini 3.6 Flash and Gemini 3.5 Flash-Lite.
- Persisted project and session selections migrate to their replacement models.
- Gemini provider documentation and model-picker coverage reflect the current models.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)