### PR TITLE
Release version 0.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.13.6] - 2026-07-22
+
 ### Added
 
 - agentty: batch linked review comments by marking each actionable thread to address or
@@ -16,6 +18,17 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - agentty: replace Gemini 3.5 Flash and Gemini 3.1 Flash-Lite with Gemini 3.6 Flash and
   Gemini 3.5 Flash-Lite, migrating persisted selections to their replacements.
+- agentty: centralize review comment selection and grouped-row presentation.
+- testty: refresh the `README.md` header layout.
+- ci: run E2E workflows in a pinned Linux/amd64 image and update the Zizmor action from
+  `0.5.7` to `0.6.0`.
+- release: bump workspace crate metadata and lockfile package versions to `0.13.6`.
+
+### Contributors
+
+- @andagaev
+- @dependabot
+- @minev-dev
 
 ## [v0.13.5] - 2026-07-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "image",
  "mockall",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "mockall",
  "serde",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "mockall",
  "rustix",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "askama",
  "schemars 1.2.1",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "clap",
  "tempfile",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.13.5"
+version = "0.13.6"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -16,13 +16,13 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.13.5" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.13.5" }
-ag-forge = { path = "crates/ag-forge", version = "0.13.5" }
-ag-git = { path = "crates/ag-git", version = "0.13.5" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.13.5" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.13.5" }
-testty = { path = "crates/testty", version = "0.13.5" }
+ag-agent = { path = "crates/ag-agent", version = "0.13.6" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.13.6" }
+ag-forge = { path = "crates/ag-forge", version = "0.13.6" }
+ag-git = { path = "crates/ag-git", version = "0.13.6" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.13.6" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.13.6" }
+testty = { path = "crates/testty", version = "0.13.6" }
 async-trait = "0.1"
 agent-client-protocol = "1.2.0"
 assert_cmd = "2"


### PR DESCRIPTION
- Add grouped review comment selection and presentation.
- Update Gemini models and migrate persisted selections.
- Refresh the testty README header and pin E2E workflows to Linux/amd64.
- Update the Zizmor action to 0.6.0.
- Bump workspace package metadata and lockfile versions.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)