### PR TITLE
Add ag-harness scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ag-harness"
+version = "0.13.6"
+
+[[package]]
 name = "ag-protocol"
 version = "0.13.6"
 dependencies = [

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -13,6 +13,7 @@ Contains the workspace member crates.
   across the workspace.
 - `crates/ag-git/` holds reusable git, worktree, sync, rebase, and squash-merge
   operations shared across the workspace.
+- `crates/ag-harness/` is the planned application-facing LLM harness facade.
 - `crates/ag-protocol/` holds structured agent response contracts, protocol parsing,
   schema generation, and transport-neutral turn prompt payloads shared across frontends
   and agent adapters.

--- a/crates/ag-harness/AGENTS.md
+++ b/crates/ag-harness/AGENTS.md
@@ -1,9 +1,3 @@
-+++
-title = "ag-harness Design"
-description = "Design for the planned ag-harness runtime."
-weight = 6
-+++
-
 # `ag-harness` - a light LLM harness
 
 `ag-harness` is the base layer between an application and an LLM. Rust-native,

--- a/crates/ag-harness/CLAUDE.md
+++ b/crates/ag-harness/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/ag-harness/Cargo.toml
+++ b/crates/ag-harness/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ag-harness"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+description.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lints]
+workspace = true

--- a/crates/ag-harness/GEMINI.md
+++ b/crates/ag-harness/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -1,0 +1,4 @@
+//! Lightweight, Rust-native LLM harness for application-facing agent workflows.
+//!
+//! The crate is currently a scaffold. Its planned architecture and boundaries
+//! are documented in the crate-level `AGENTS.md`.

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -30,6 +30,9 @@ For file-level detail, read the module docstrings directly.
 - `crates/ag-git/`: Shared git library crate with worktree creation, repository
   metadata, commit/diff/push/pull sync, rebase/conflict handling, and squash-merge
   workflows behind the `GitClient` boundary.
+- `crates/ag-harness/`: Planned application-facing LLM harness facade. The crate is
+  currently a scaffold; its local `AGENTS.md` records the intended agent loop, tools,
+  session, event, and permission boundaries.
 - `crates/ag-protocol/`: Shared structured response protocol library crate with
   transport-neutral response models, schema generation, parser diagnostics, protocol
   prompt envelopes, repair prompts, review-comment outcomes, and turn prompt payload


### PR DESCRIPTION
- Adds the initial Rust facade crate and lockfile package entry.
- Documents its planned agent loop, tools, sessions, events, permissions, and model tiers.
- Records the crate in the workspace and architecture maps.
- Documents the planned API.
- Removes redundant process-model documentation from the harness guide.
- Documents structured output and identifies Qwen as the first provider.
- Refines the next-iteration roadmap into end-to-end stages.
- Simplifies the harness structured-output guidance to describe structured communication without provider-specific contract details.
- Synchronizes the crate-local and docs-site design guidance.