### PR TITLE
Pass reasoning effort to Antigravity

### DIFF
--- a/crates/ag-agent/src/agent/antigravity.rs
+++ b/crates/ag-agent/src/agent/antigravity.rs
@@ -48,7 +48,7 @@ impl AgentBackend for AntigravityBackend {
             prompt: _prompt,
             request_kind: _request_kind,
             replay_transcript: _replay_transcript,
-            reasoning_level: _reasoning_level,
+            reasoning_level,
         } = request;
         let mut command = Command::new("agy");
 
@@ -68,6 +68,8 @@ impl AgentBackend for AntigravityBackend {
             .arg(ANTIGRAVITY_PRINT_TIMEOUT)
             .arg("--model")
             .arg(model)
+            .arg("--effort")
+            .arg(reasoning_level.antigravity())
             .current_dir(folder)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
@@ -351,12 +353,53 @@ mod tests {
                 ANTIGRAVITY_PRINT_TIMEOUT.to_string(),
                 "--model".to_string(),
                 requested_model.to_string(),
+                "--effort".to_string(),
+                ReasoningLevel::default().antigravity().to_string(),
             ]
         );
         assert_eq!(command.get_current_dir(), Some(temp_directory.path()));
         assert_antigravity_project_state_patterns_ignored(&read_standard_git_exclude(
             temp_directory.path(),
         ));
+    }
+
+    #[test]
+    /// Verifies Antigravity receives every supported effort and caps higher
+    /// Agentty reasoning levels at the CLI's highest accepted value.
+    fn test_antigravity_build_command_passes_supported_effort() {
+        // Arrange
+        let temp_directory = visible_tempdir();
+        let backend = AntigravityBackend;
+        let cases = ReasoningLevel::ALL;
+
+        for reasoning_level in cases {
+            // Act
+            let command = AgentBackend::build_command(
+                &backend,
+                BuildCommandRequest {
+                    attachments: &[],
+                    folder: temp_directory.path(),
+                    main_checkout_root: None,
+                    replay_transcript: None,
+                    model: AgentModel::Gemini31ProPreview.provider_model_str(),
+                    prompt: "Write tests",
+                    reasoning_level,
+                    request_kind: &session_start_request_kind(),
+                },
+            )
+            .expect("command should build");
+            let args = command
+                .get_args()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>();
+            let effort_position = args
+                .iter()
+                .position(|arg| arg == "--effort")
+                .expect("--effort flag should be present");
+
+            // Assert
+            assert_eq!(args[effort_position + 1], reasoning_level.antigravity());
+        }
     }
 
     #[test]

--- a/crates/ag-agent/src/model/agent.rs
+++ b/crates/ag-agent/src/model/agent.rs
@@ -427,6 +427,18 @@ impl ReasoningLevel {
         }
     }
 
+    /// Returns the Antigravity `--effort` value for this level.
+    ///
+    /// Antigravity accepts `low`, `medium`, and `high`, so higher generic
+    /// reasoning levels map to its highest supported value.
+    pub fn antigravity(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High | Self::XHigh | Self::Max => "high",
+        }
+    }
+
     /// Returns the Claude `--effort` value for this level.
     ///
     /// Maps `XHigh` and `Max` to `"max"`, which is currently only supported on
@@ -1055,6 +1067,18 @@ mod tests {
         assert_eq!(ReasoningLevel::High.claude(), "high");
         assert_eq!(ReasoningLevel::XHigh.claude(), "max");
         assert_eq!(ReasoningLevel::Max.claude(), "max");
+    }
+
+    #[test]
+    /// Ensures Antigravity reasoning values stay within the CLI's accepted
+    /// `low`, `medium`, and `high` effort levels.
+    fn test_reasoning_level_antigravity_maps_all_levels() {
+        // Arrange / Act / Assert
+        assert_eq!(ReasoningLevel::Low.antigravity(), "low");
+        assert_eq!(ReasoningLevel::Medium.antigravity(), "medium");
+        assert_eq!(ReasoningLevel::High.antigravity(), "high");
+        assert_eq!(ReasoningLevel::XHigh.antigravity(), "high");
+        assert_eq!(ReasoningLevel::Max.antigravity(), "high");
     }
 
     #[test]

--- a/docs/site/content/docs/agents/backends.md
+++ b/docs/site/content/docs/agents/backends.md
@@ -129,12 +129,14 @@ selected model is stored with its backend as `agent/model`, which keeps shared G
 model ids tied to the selected Gemini or Antigravity provider. Stored defaults that
 point at an unavailable backend fall back to the first available backend default.
 
-<a id="backends-reasoning-level"></a> For Codex and Claude sessions, the **Settings**
-tab also exposes `Default Reasoning Level` (`low`, `medium`, `high`, `xhigh`, `max`).
-The selected level is persisted per project and is sent with turns unless a
-session-specific override is active. Codex receives `max` as a distinct reasoning
-effort. For Claude, both `xhigh` and `max` map to `--effort max`, which is currently
-only supported by `claude-opus-4-8`.
+<a id="backends-reasoning-level"></a> For Antigravity, Codex, and Claude sessions, the
+**Settings** tab also exposes `Default Reasoning Level` (`low`, `medium`, `high`,
+`xhigh`, `max`). The selected level is persisted per project and is sent with turns
+unless a session-specific override is active. Antigravity receives `--effort low`,
+`--effort medium`, or `--effort high`; `xhigh` and `max` map to its highest supported
+value, `--effort high`. Codex receives `max` as a distinct reasoning effort. For Claude,
+both `xhigh` and `max` map to `--effort max`, which is currently only supported by
+`claude-opus-4-8`.
 
 ## Available Models
 


### PR DESCRIPTION
- Map Agentty reasoning levels to Antigravity’s supported effort values.
- Cover all reasoning levels in backend command tests.
- Document the Antigravity effort mapping.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)