### PR TITLE
Highlight file lookups in user prompts

### DIFF
--- a/crates/agentty/src/ui/markdown.rs
+++ b/crates/agentty/src/ui/markdown.rs
@@ -258,7 +258,9 @@ fn render_user_prompt_markdown_block(prompt_lines: &[String], width: usize) -> V
     lines
 }
 
-fn user_prompt_content_line_spans(
+/// Preserves markdown styling while highlighting plain `@` lookup tokens in
+/// rendered user prompt content.
+pub(crate) fn user_prompt_content_line_spans(
     rendered_spans: impl IntoIterator<Item = Span<'static>>,
 ) -> Vec<Span<'static>> {
     let mut spans = Vec::new();

--- a/crates/agentty/src/ui/session_output_assembly.rs
+++ b/crates/agentty/src/ui/session_output_assembly.rs
@@ -724,7 +724,10 @@ fn append_user_prompt(
             prompt_block::user_prompt_prefix_style()
         };
         lines.push(prompt_block::user_prompt_markdown_line(
-            restored_user_prompt_spans(rendered_line, indent_marker),
+            markdown::user_prompt_content_line_spans(restored_user_prompt_spans(
+                rendered_line,
+                indent_marker,
+            )),
             prefix,
             prefix_style,
             inner_width,
@@ -906,6 +909,30 @@ mod tests {
 
         // Assert
         assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn test_user_prompt_highlights_at_lookup_file() {
+        // Arrange
+        let mut lines = Vec::new();
+        let lookup = "@crates/agentty/src/ui/markdown.rs";
+
+        // Act
+        append_user_prompt(
+            &mut lines,
+            &format!("Review {lookup} before replying"),
+            80,
+            None,
+        );
+
+        // Assert
+        let lookup_span = lines
+            .iter()
+            .flat_map(|line| &line.spans)
+            .find(|span| span.content.as_ref() == lookup)
+            .expect("file lookup should render as one highlighted span");
+        assert_eq!(lookup_span.style.fg, Some(style::palette::info()));
+        assert_eq!(lookup_span.style.bg, Some(style::palette::surface_prompt()));
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -229,7 +229,7 @@ fn seed_session_with_user_markdown(env: &BuilderEnv) -> Result<(), Box<dyn std::
                 "user-markdown-0001",
                 SessionMessageKind::UserPrompt,
                 "\
-Use **bold** and `code`.
+Use **bold** and `code`. Review @crates/agentty/src/ui/markdown.rs.
 
 | Input | Meaning |
 | --- | --- |
@@ -2257,6 +2257,11 @@ fn session_view_user_prompt_markdown_output() -> E2eResult {
             },
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(
+                    frame,
+                    "@crates/agentty/src/ui/markdown.rs",
+                    &full,
+                );
                 assertion::assert_text_in_region(frame, "Use bold and code.", &full);
                 assertion::assert_text_in_region(frame, "User prompt", &full);
                 assertion::assert_text_in_region(frame, "Markdown", &full);

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -498,8 +498,9 @@ captured draft.
 On macOS, use `Ctrl+Z` rather than `Cmd+Z` for input undo. Terminal applications such as
 Ghostty may consume `Cmd+Z` before Agentty or a surrounding `tmux` session receives it.
 
-`@` file lookups keep the raw `@path/to/file` text visible in the composer and
-transcript; the agent-facing prompt rewrites them to quoted `path/to/file` tokens.
+`@` file lookups keep the raw `@path/to/file` text visible and highlighted in the
+composer and transcript; the agent-facing prompt rewrites them to quoted `path/to/file`
+tokens.
 
 If an agent command exits with an error, Agentty prints a short failure header followed
 by captured `stdout` and `stderr` sections, with JSONL provider events summarized into


### PR DESCRIPTION
- Preserve markdown styling while highlighting lookup tokens in transcript output.
- Cover lookup styling in unit and E2E session tests.
- Document highlighted lookup text in workflow documentation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)