### PR TITLE
Use parent worktrees for stacked draft lookups

### DIFF
--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -1678,9 +1678,12 @@ impl App {
         }
     }
 
-    /// Returns the lookup root for the session associated with an at-mention
-    /// event.
-    fn at_mention_lookup_root(&self, session_id: &str) -> PathBuf {
+    /// Returns the lookup root for one session's at-mention entries.
+    ///
+    /// Materialized sessions use their own worktree. An unmaterialized
+    /// stacked draft uses its parent worktree so files introduced by the
+    /// parent remain available before the child worktree is created.
+    pub(crate) fn at_mention_lookup_root(&self, session_id: &str) -> PathBuf {
         let project_working_dir = self.working_dir().to_path_buf();
 
         self.sessions.session_for_id(session_id).map_or_else(
@@ -1689,11 +1692,31 @@ impl App {
                 let project_working_dir = project_working_dir.clone();
                 let session_folder = session.folder.clone();
                 let has_session_folder = self.services.fs_client().is_dir(session_folder.clone());
+                if has_session_folder {
+                    return session_folder;
+                }
+                let parent_session_folder =
+                    session
+                        .parent_session_id
+                        .as_ref()
+                        .and_then(|parent_session_id| {
+                            self.sessions
+                                .session_for_id(parent_session_id)
+                                .map(|parent_session| parent_session.folder.clone())
+                        });
+                let has_parent_session_folder =
+                    parent_session_folder
+                        .as_ref()
+                        .is_some_and(|parent_session_folder| {
+                            self.services
+                                .fs_client()
+                                .is_dir(parent_session_folder.clone())
+                        });
 
                 at_mention_lookup_root(
                     project_working_dir,
-                    Some(session_folder),
-                    has_session_folder,
+                    parent_session_folder,
+                    has_parent_session_folder,
                 )
             },
         )

--- a/crates/agentty/src/runtime/mode/at_mention.rs
+++ b/crates/agentty/src/runtime/mode/at_mention.rs
@@ -8,7 +8,7 @@ use tokio::sync::mpsc;
 use crate::app::at_mention_task;
 use crate::app::session::SessionManager;
 use crate::app::{AppEvent, TaskService};
-use crate::domain::file_entry::{FileEntry, at_mention_lookup_root, filter_entries};
+use crate::domain::file_entry::{FileEntry, filter_entries};
 use crate::domain::input::InputState;
 use crate::domain::session::SessionId;
 use crate::presentation::prompt::PromptAtMentionState;
@@ -65,38 +65,6 @@ pub(crate) fn start_loading_entries(
     let cached_entries = session_manager.at_mention_index_for_root(&lookup_root);
 
     TaskService::spawn_at_mention_entries_task(event_tx, cached_entries, lookup_root, session_id);
-}
-
-/// Returns the directory that should back one active `@`-mention lookup.
-///
-/// Materialized sessions index their worktree folder. Unstarted draft sessions
-/// have no worktree yet, so the active project working directory is used until
-/// the deferred worktree exists.
-pub(crate) fn lookup_root(
-    project_working_dir: PathBuf,
-    session_folder: Option<PathBuf>,
-    has_session_folder: bool,
-) -> PathBuf {
-    at_mention_lookup_root(project_working_dir, session_folder, has_session_folder)
-}
-
-/// Returns the lookup root for an optional session folder after checking
-/// materialization through the injected filesystem boundary.
-pub(crate) fn lookup_root_for_session(
-    project_working_dir: PathBuf,
-    session_folder: Option<PathBuf>,
-    is_session_folder: impl FnOnce(PathBuf) -> bool,
-) -> PathBuf {
-    let Some(session_folder) = session_folder else {
-        return project_working_dir;
-    };
-    let has_session_folder = is_session_folder(session_folder.clone());
-
-    lookup_root(
-        project_working_dir,
-        Some(session_folder),
-        has_session_folder,
-    )
 }
 
 /// Clears one visible `@`-mention dropdown state.
@@ -163,7 +131,6 @@ fn format_mention_text(entry: &FileEntry) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Duration;
@@ -237,64 +204,6 @@ mod tests {
                 text: "@src/ ".to_string(),
             }
         );
-    }
-
-    #[test]
-    fn test_lookup_root_prefers_materialized_session_folder() {
-        // Arrange
-        let project_working_dir = PathBuf::from("/project");
-        let session_folder = PathBuf::from("/project/.agentty/session");
-
-        // Act
-        let lookup_root = lookup_root(project_working_dir, Some(session_folder.clone()), true);
-
-        // Assert
-        assert_eq!(lookup_root, session_folder);
-    }
-
-    #[test]
-    fn test_lookup_root_falls_back_to_project_working_dir_without_session_folder() {
-        // Arrange
-        let project_working_dir = PathBuf::from("/project");
-        let session_folder = PathBuf::from("/project/.agentty/session");
-
-        // Act
-        let lookup_root = lookup_root(project_working_dir.clone(), Some(session_folder), false);
-
-        // Assert
-        assert_eq!(lookup_root, project_working_dir);
-    }
-
-    #[test]
-    fn test_lookup_root_for_session_skips_filesystem_check_without_session_folder() {
-        // Arrange
-        let project_working_dir = PathBuf::from("/project");
-        let was_filesystem_checked = Cell::new(false);
-
-        // Act
-        let lookup_root = lookup_root_for_session(project_working_dir.clone(), None, |_| {
-            was_filesystem_checked.set(true);
-
-            true
-        });
-
-        // Assert
-        assert_eq!(lookup_root, project_working_dir);
-        assert!(!was_filesystem_checked.get());
-    }
-
-    #[test]
-    fn test_lookup_root_for_session_uses_materialized_session_folder() {
-        // Arrange
-        let project_working_dir = PathBuf::from("/project");
-        let session_folder = PathBuf::from("/project/.agentty/session");
-
-        // Act
-        let lookup_root =
-            lookup_root_for_session(project_working_dir, Some(session_folder.clone()), |_| true);
-
-        // Assert
-        assert_eq!(lookup_root, session_folder);
     }
 
     #[tokio::test]

--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -1067,19 +1067,11 @@ async fn apply_prompt_delete_range(app: &mut App, start: usize, end: usize) {
 /// Starts asynchronous loading of at-mention file entries for the prompt
 /// session.
 ///
-/// Draft sessions in `Draft` state defer worktree creation, so their composer
-/// indexes the active project working directory until the session folder is
-/// materialized.
+/// Draft sessions in `Draft` state defer worktree creation. Regular drafts
+/// index the active project working directory, while stacked drafts index the
+/// parent worktree until their own folder is materialized.
 fn activate_at_mention(app: &mut App, prompt_context: &PromptContext) {
-    let session_folder = app
-        .sessions
-        .session_at(prompt_context.session_index)
-        .map(|session| session.folder.clone());
-    let lookup_root = at_mention::lookup_root_for_session(
-        app.working_dir().to_path_buf(),
-        session_folder,
-        |session_folder| app.services.fs_client().is_dir(session_folder),
-    );
+    let lookup_root = app.at_mention_lookup_root(&prompt_context.session_id);
     let session_id = prompt_context.session_id.clone();
     let event_tx = app.services.event_sender();
 
@@ -3480,6 +3472,40 @@ mod tests {
                 session_id,
             } => {
                 assert_eq!(session_id, app.sessions.sessions()[0].id.as_str());
+                assert!(entries.contains(&FileEntry {
+                    is_dir: false,
+                    path: expected_path.to_string(),
+                }));
+            }
+            _ => unreachable!("expected at-mention entries event"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_prompt_char_loads_parent_worktree_entries_for_stacked_draft() {
+        // Arrange
+        let (mut app, base_dir) = new_test_draft_prompt_app("", None).await;
+        let parent_session_id = SessionId::from("parent-session");
+        let parent_folder = base_dir.path().join("parent-worktree");
+        let expected_path = "parent_lookup_target.txt";
+        std::fs::create_dir_all(&parent_folder).expect("failed to create parent worktree");
+        std::fs::write(parent_folder.join(expected_path), "parent")
+            .expect("failed to write parent worktree file");
+        app.sessions.sessions_mut()[0].parent_session_id = Some(parent_session_id.clone());
+        app.sessions.push_session(
+            crate::test_support::SessionFixtureBuilder::new()
+                .id(parent_session_id)
+                .folder(parent_folder)
+                .build(),
+        );
+
+        // Act
+        apply_prompt_input_command(&mut app, InputCommand::Insert('@')).await;
+        let next_event = wait_for_at_mention_entries_event(&mut app).await;
+
+        // Assert
+        match next_event {
+            crate::app::AppEvent::AtMentionEntriesLoaded { entries, .. } => {
                 assert!(entries.contains(&FileEntry {
                     is_dir: false,
                     path: expected_path.to_string(),

--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -540,17 +540,7 @@ fn sync_question_at_mention_state(app: &mut App) {
 /// Starts asynchronous loading of file entries for the question-mode
 /// at-mention dropdown.
 fn activate_question_at_mention(app: &mut App, session_id: &str) {
-    let session_folder = app
-        .sessions
-        .sessions()
-        .iter()
-        .find(|session| session.id == session_id)
-        .map(|session| session.folder.clone());
-    let lookup_root = at_mention::lookup_root_for_session(
-        app.working_dir().to_path_buf(),
-        session_folder,
-        |session_folder| app.services.fs_client().is_dir(session_folder),
-    );
+    let lookup_root = app.at_mention_lookup_root(session_id);
     let owned_session_id = SessionId::from(session_id);
     let event_tx = app.services.event_sender();
 
@@ -883,6 +873,70 @@ mod tests {
 
     /// Fake terminal size used by tests that don't exercise scrolling.
     const TEST_TERMINAL_SIZE: Rect = Rect::new(0, 0, 80, 24);
+
+    #[tokio::test]
+    async fn test_question_at_mention_loads_parent_worktree_entries_for_stacked_session() {
+        // Arrange
+        let (mut app, base_dir) = crate::test_support::new_test_app().await;
+        let parent_session_id = SessionId::from("parent-session");
+        let child_session_id = SessionId::from("child-session");
+        let parent_folder = base_dir.path().join("parent-worktree");
+        let expected_path = "parent_question_target.txt";
+        std::fs::create_dir_all(&parent_folder).expect("failed to create parent worktree");
+        std::fs::write(parent_folder.join(expected_path), "parent")
+            .expect("failed to write parent worktree file");
+        app.sessions.push_session(
+            crate::test_support::SessionFixtureBuilder::new()
+                .id(parent_session_id.clone())
+                .folder(parent_folder)
+                .build(),
+        );
+        app.sessions.push_session(
+            crate::test_support::SessionFixtureBuilder::new()
+                .id(child_session_id.clone())
+                .folder(base_dir.path().join("missing-child-worktree"))
+                .parent_session_id(Some(parent_session_id))
+                .status(Status::Question)
+                .build(),
+        );
+        app.mode = AppMode::Question {
+            at_mention_state: None,
+            current_index: 0,
+            focus: ChatFocus::Input,
+            input: InputState::with_text("@parent".to_string()),
+            questions: vec![QuestionItem::new("Which file?")],
+            responses: Vec::new(),
+            scroll_offset: None,
+            selected_option_index: None,
+            session_id: child_session_id.clone(),
+        };
+
+        // Act
+        sync_question_at_mention_state(&mut app);
+        let next_event = loop {
+            let next_event =
+                tokio::time::timeout(std::time::Duration::from_secs(1), app.next_app_event())
+                    .await
+                    .expect("at-mention event should arrive")
+                    .expect("at-mention event channel should stay open");
+            if matches!(next_event, AppEvent::AtMentionEntriesLoaded { .. }) {
+                break next_event;
+            }
+        };
+
+        // Assert
+        assert!(matches!(
+            next_event,
+            AppEvent::AtMentionEntriesLoaded {
+                entries,
+                session_id,
+            } if session_id == child_session_id
+                && entries.contains(&crate::domain::file_entry::FileEntry {
+                    is_dir: false,
+                    path: expected_path.to_string(),
+                })
+        ));
+    }
 
     #[tokio::test]
     async fn test_question_scroll_metrics_uses_default_review_model_for_loading_fallback() {

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1711,6 +1711,38 @@ fn seed_draft_at_lookup_project(env: &BuilderEnv) -> Result<(), Box<dyn std::err
     Ok(())
 }
 
+/// Seeds an unmaterialized stacked draft whose parent worktree contains a new
+/// file that is absent from the project checkout.
+fn seed_stacked_at_lookup_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    let parent_session_id = "atparent-0001";
+    let child_session_id = "atchildx-0001";
+    common::seed_session(
+        env,
+        SessionSeed::regular(parent_session_id, "gpt-5.5", "main", "Review")
+            .with_title("Parent with lookup file"),
+    )?;
+    common::seed_session(
+        env,
+        SessionSeed::stacked_draft(
+            child_session_id,
+            "gpt-5.5",
+            "wt/atparent",
+            "Draft",
+            parent_session_id,
+        )
+        .with_title("Stacked lookup child"),
+    )?;
+
+    let parent_worktree = env.agentty_root.join("wt").join("atparent");
+    std::fs::create_dir_all(&parent_worktree)?;
+    std::fs::write(
+        parent_worktree.join("parent_lookup_target.txt"),
+        "parent lookup target\n",
+    )?;
+
+    Ok(())
+}
+
 /// Seeds one done session whose merged commit hash can drive the continuation
 /// draft flow.
 fn seed_done_session_for_continuation(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
@@ -3728,6 +3760,37 @@ fn draft_session_at_lookup() -> E2eResult {
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "draft_lookup_target.txt", &full);
+                assertion::assert_text_in_region(frame, "Enter: stage draft", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that an unmaterialized stacked draft resolves `@` suggestions from
+/// its parent worktree.
+#[test]
+fn stacked_session_at_lookup() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("stacked_session_at_lookup")
+        .with_git()
+        .setup(seed_stacked_at_lookup_session)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .wait_for_text("Stacked lookup child", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Enter: add draft", 3000)
+                    .press_key("Enter")
+                    .wait_for_text("Enter: stage draft", 3000)
+                    .write_text("@parent_lookup")
+                    .wait_for_text("parent_lookup_target.txt", 5000)
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "parent_lookup_target.txt", &full);
                 assertion::assert_text_in_region(frame, "Enter: stage draft", &full);
             },
         )?;

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -500,7 +500,8 @@ Ghostty may consume `Cmd+Z` before Agentty or a surrounding `tmux` session recei
 
 `@` file lookups keep the raw `@path/to/file` text visible and highlighted in the
 composer and transcript; the agent-facing prompt rewrites them to quoted `path/to/file`
-tokens.
+tokens. Before a stacked draft materializes its own worktree, lookup suggestions come
+from the parent session worktree so newly created parent files remain available.
 
 If an agent command exits with an error, Agentty prints a short failure header followed
 by captured `stdout` and `stderr` sections, with JSONL provider events summarized into


### PR DESCRIPTION
- Resolve at-mention entries from the parent worktree before a stacked draft materializes its own.
- Cover prompt and question lookup flows with unit and E2E tests.
- Document stacked draft lookup behavior.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)