### PR TITLE
Allow Codex to edit worktree metadata

### DIFF
--- a/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
@@ -701,7 +701,7 @@ pub(super) fn build_turn_start_payload(
             "input": build_turn_input_items(&prompt),
             "cwd": folder.to_string_lossy(),
             "approvalPolicy": policy::approval_policy(),
-            "sandboxPolicy": policy::turn_sandbox_policy(),
+            "sandboxPolicy": policy::turn_sandbox_policy(folder),
             "model": model,
             "effort": reasoning_level.codex(),
             "summary": Value::Null,
@@ -1036,6 +1036,37 @@ mod tests {
             Some("existing-thread")
         );
         assert_eq!(params.get("model").and_then(Value::as_str), Some(model));
+    }
+
+    #[test]
+    fn build_turn_start_payload_allows_worktree_agents_edits() {
+        // Arrange
+        let folder = PathBuf::from("/tmp/agentty-codex-turn-start");
+
+        // Act
+        let payload = build_turn_start_payload(
+            &folder,
+            AgentModel::Gpt55.as_str(),
+            ReasoningLevel::Medium,
+            "thread-1",
+            "Update the repository instructions",
+            "turn-start-1",
+        );
+
+        // Assert
+        let sandbox_policy = payload
+            .pointer("/params/sandboxPolicy")
+            .expect("turn/start sandbox policy should be present");
+        assert_eq!(
+            sandbox_policy,
+            &serde_json::json!({
+                "type": "workspaceWrite",
+                "networkAccess": true,
+                "writableRoots": [
+                    folder.join(".agents").to_string_lossy(),
+                ],
+            })
+        );
     }
 
     #[test]

--- a/crates/ag-agent/src/agent/app_server/codex/policy.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/policy.rs
@@ -28,7 +28,7 @@ pub(super) struct PermissionModePolicy {
 ///
 /// The `never` approval policy keeps normal turns from blocking on user
 /// approvals, while the workspace-write sandbox still constrains filesystem
-/// writes to the session worktree and explicit extra workspace roots.
+/// writes to the session worktree and its explicit `.agents` root.
 const AUTO_EDIT_POLICY: PermissionModePolicy = PermissionModePolicy {
     approval_policy: "never",
     legacy_pre_action_decision: "approved",
@@ -40,6 +40,14 @@ const AUTO_EDIT_POLICY: PermissionModePolicy = PermissionModePolicy {
     turn_sandbox_type: "workspaceWrite",
     web_search_mode: "live",
 };
+
+/// Repository metadata directory that remains editable during Codex turns.
+///
+/// Codex protects this path by default even when it lives under the writable
+/// worktree. Listing it as an exact writable root reopens only this
+/// worktree-local directory while preserving the read-only `.git` and
+/// `.codex` boundaries.
+const EDITABLE_WORKTREE_METADATA_PATH: &str = ".agents";
 
 /// Pre-action approval request categories understood by Agentty.
 enum PreActionApprovalKind {
@@ -119,23 +127,19 @@ pub(super) fn thread_sandbox_mode() -> &'static str {
     permission_mode_policy(PermissionMode::default()).thread_sandbox_mode
 }
 
-/// Returns the turn-level sandbox policy object for one permission mode.
-pub(super) fn turn_sandbox_policy() -> Value {
+/// Returns the turn-level sandbox policy object for one session worktree.
+pub(super) fn turn_sandbox_policy(session_folder: &Path) -> Value {
     let policy = permission_mode_policy(PermissionMode::default());
-    let mut turn_sandbox_policy = serde_json::json!({
-        "type": policy.turn_sandbox_type
-    });
+    let writable_root = session_folder
+        .join(EDITABLE_WORKTREE_METADATA_PATH)
+        .to_string_lossy()
+        .into_owned();
 
-    if policy.turn_sandbox_type == "workspaceWrite"
-        && let Some(policy_object) = turn_sandbox_policy.as_object_mut()
-    {
-        policy_object.insert(
-            "networkAccess".to_string(),
-            Value::Bool(policy.turn_network_access),
-        );
-    }
-
-    turn_sandbox_policy
+    serde_json::json!({
+        "type": policy.turn_sandbox_type,
+        "networkAccess": policy.turn_network_access,
+        "writableRoots": [writable_root],
+    })
 }
 
 /// Returns per-thread config overrides for one permission mode.

--- a/docs/site/content/docs/agents/backends.md
+++ b/docs/site/content/docs/agents/backends.md
@@ -31,6 +31,10 @@ All backends accept pasted local prompt images from the Agentty composer (`Ctrl+
 `Ctrl+Shift+V`, or `Alt+V` in prompt mode) and run their turns non-interactively inside
 the session worktree.
 
+Codex can edit repository-local `.agents/` content inside that worktree, including
+project skills and instructions. Its `.git` and `.codex/` paths remain read-only during
+normal turns.
+
 Claude turns also allow Claude Code's `WebSearch` and `WebFetch` tools, so prompts that
 need current external information can use the web without an interactive permission
 grant. File edits remain scoped to the session worktree.

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -361,13 +361,14 @@ descendants it spawned.
 - Merge and `sync main` workflows require a clean target checkout before changing
   base-branch state.
 - Provider permission policies are scoped per transport: Codex turns run with a
-  non-interactive approval policy and workspace-write sandbox. Agentty immediately
-  declines MCP elicitations and grants no additional permission requests so an
-  app-server request cannot leave the turn waiting for interactive input. Codex tool
-  input requests receive an empty answer set for the same reason. Claude turns receive
-  session-scoped settings that deny writes to the known main checkout, Gemini ACP
-  requests prefer one-shot allow options, and CLI-backed providers run from the session
-  worktree process directory.
+  non-interactive approval policy and workspace-write sandbox. The Codex turn policy
+  explicitly reopens the worktree-local `.agents/` directory that Codex otherwise
+  protects while leaving `.git` and `.codex/` read-only. Agentty immediately declines
+  MCP elicitations and grants no additional permission requests so an app-server request
+  cannot leave the turn waiting for interactive input. Codex tool input requests receive
+  an empty answer set for the same reason. Claude turns receive session-scoped settings
+  that deny writes to the known main checkout, Gemini ACP requests prefer one-shot allow
+  options, and CLI-backed providers run from the session worktree process directory.
 
 ## Agent Interaction Protocol Flow
 


### PR DESCRIPTION
- Reopens worktree-local `.agents/` and `.codex/` directories while keeping `.git` read-only.
- Tests the turn payload and documents the editable metadata behavior.
- Latest cumulative state permits edits only within repository-local `.agents/`; `.codex/` and `.git` remain read-only.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)