### PR TITLE
Display personality source in slash command

### DIFF
--- a/crates/agentty/src/domain/composer.rs
+++ b/crates/agentty/src/domain/composer.rs
@@ -1007,7 +1007,7 @@ fn command_description(command: &str) -> &'static str {
     match command {
         "/apply" => "Verify focused-review suggestions, then apply the correct ones.",
         "/model" => "Choose an agent and model for this session.",
-        "/personality" => "Choose a personality for this session.",
+        "/personality" => "List: .agents/agents/. Choose a personality for this session.",
         "/reasoning" => "Override the reasoning level for this session.",
         _ => "Prompt slash command.",
     }
@@ -1379,7 +1379,7 @@ mod tests {
     fn test_slash_suggestion_list_for_command_stage_has_description() {
         // Arrange
         let composer = PromptComposerState::with_input_and_history(
-            InputState::with_text("/m".to_string()),
+            InputState::with_text("/pers".to_string()),
             AgentKind::ALL.to_vec(),
             Vec::new(),
         );
@@ -1395,8 +1395,10 @@ mod tests {
             PromptSuggestionList {
                 items: vec![PromptSuggestionItem {
                     badge: None,
-                    detail: Some("Choose an agent and model for this session.".to_string()),
-                    label: "/model".to_string(),
+                    detail: Some(
+                        "List: .agents/agents/. Choose a personality for this session.".to_string(),
+                    ),
+                    label: "/personality".to_string(),
                     metadata: None,
                 }],
                 selected_index: 0,

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -5186,6 +5186,11 @@ fn test_session_personality() -> E2eResult {
                     .press_key("/")
                     .write_text("personality")
                     .wait_for_text("Slash Command", 3000)
+                    .wait_for_text("List: .agents/agents/.", 3000)
+                    .capture_labeled(
+                        "personality_slash_command",
+                        "Personality source directory appears in the slash-command menu",
+                    )
                     .press_key("Enter")
                     .wait_for_text("None (default)", 3000)
                     .wait_for_text("Code Reviewer", 3000)
@@ -5204,7 +5209,15 @@ fn test_session_personality() -> E2eResult {
                     )
             },
             |frame, report| {
-                let picker_frame = common::frame_from_capture(&report.captures[0]);
+                let command_frame = common::frame_from_capture(&report.captures[0]);
+                let command_full = Region::full(command_frame.cols(), command_frame.rows());
+                assertion::assert_text_in_region(
+                    &command_frame,
+                    "List: .agents/agents/.",
+                    &command_full,
+                );
+
+                let picker_frame = common::frame_from_capture(&report.captures[1]);
                 let picker_full = Region::full(picker_frame.cols(), picker_frame.rows());
                 assertion::assert_text_in_region(&picker_frame, "None (default)", &picker_full);
                 assertion::assert_text_in_region(&picker_frame, "Code Reviewer", &picker_full);


### PR DESCRIPTION
- List `.agents/agents/` in the `/personality` command description.
- Verify the source-directory hint in unit and E2E coverage.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)