### PR TITLE
Allow slash commands for stacked review parents

### DIFF
--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -179,8 +179,11 @@ impl ViewActionSet {
                     | ViewSessionState::AgentReview
             );
         let can_open_prompt = can_open_view_prompt(state.session_state, state.reply_to_session);
-        let can_launch_configuration =
-            can_open_view_command(state.session_state, state.can_mutate_session_branch);
+        let can_launch_configuration = can_open_view_command(
+            state.session_state,
+            state.can_mutate_session_branch,
+            state.reply_to_session,
+        );
         let can_merge_session =
             can_merge_view_session(state.session_state, state.can_merge_session_branch);
         let can_rebase_session =
@@ -566,10 +569,11 @@ fn can_open_view_prompt(
 }
 
 /// Returns whether a session state can open slash commands in view mode under
-/// stack branch-mutation constraints.
+/// stack branch-mutation and reply constraints.
 fn can_open_view_command(
     session_state: ViewSessionState,
     can_mutate_session_branch: ViewActionAvailability,
+    reply_to_session: ViewActionAvailability,
 ) -> bool {
     if matches!(
         session_state,
@@ -578,7 +582,7 @@ fn can_open_view_command(
         return true;
     }
 
-    can_mutate_session_branch.is_enabled()
+    (can_mutate_session_branch.is_enabled() || reply_to_session.is_enabled())
         && matches!(
             session_state,
             ViewSessionState::Interactive
@@ -1088,7 +1092,7 @@ mod tests {
     }
 
     #[test]
-    fn test_view_actions_review_keeps_reply_merge_and_sync_when_stack_blocks_commands() {
+    fn test_view_actions_review_keeps_commands_when_stack_allows_reply() {
         // Arrange
         let state = ViewHelpState {
             can_fork_session: ViewActionAvailability::Enabled,
@@ -1111,9 +1115,33 @@ mod tests {
         assert!(actions.iter().any(|action| action.key == "p"));
         assert!(actions.iter().any(|action| action.key == "o"));
         assert!(actions.iter().any(|action| action.key == "Enter"));
-        assert!(!actions.iter().any(|action| action.key == "/"));
+        assert!(actions.iter().any(|action| action.key == "/"));
         assert!(actions.iter().any(|action| action.key == "m"));
         assert!(actions.iter().any(|action| action.key == "r"));
+    }
+
+    #[test]
+    fn test_review_actions_hide_commands_when_mutation_and_reply_are_blocked() {
+        // Arrange
+        let state = ViewHelpState {
+            can_fork_session: ViewActionAvailability::Enabled,
+            can_merge_session_branch: ViewActionAvailability::Enabled,
+            can_mutate_session_branch: ViewActionAvailability::Disabled,
+            can_rebase_session_branch: ViewActionAvailability::Enabled,
+            can_open_worktree: ViewActionAvailability::Enabled,
+            reply_to_session: ViewActionAvailability::Disabled,
+            can_start_staged_session: ViewActionAvailability::Disabled,
+            publish_pull_request_action: Some(PublishBranchAction::PublishPullRequest),
+            session_state: ViewSessionState::Review,
+        };
+
+        // Act
+        let actions = view_actions(state);
+        let footer_actions = view_footer_actions(state);
+
+        // Assert
+        assert!(!actions.iter().any(|action| action.key == "/"));
+        assert!(!footer_actions.iter().any(|action| action.key == "/"));
     }
 
     #[test]
@@ -1137,7 +1165,7 @@ mod tests {
         // Assert
         assert!(actions.iter().any(|action| action.key == "m"));
         assert!(!actions.iter().any(|action| action.key == "r"));
-        assert!(!actions.iter().any(|action| action.key == "/"));
+        assert!(actions.iter().any(|action| action.key == "/"));
     }
 
     #[test]
@@ -1372,7 +1400,7 @@ mod tests {
     }
 
     #[test]
-    fn test_view_footer_actions_review_keeps_reply_merge_and_sync_when_stack_blocks_commands() {
+    fn test_view_footer_actions_review_keeps_commands_when_stack_allows_reply() {
         // Arrange
         let state = ViewHelpState {
             can_fork_session: ViewActionAvailability::Enabled,
@@ -1394,7 +1422,7 @@ mod tests {
         assert!(actions.iter().any(|action| action.key == "f"));
         assert!(actions.iter().any(|action| action.key == "p"));
         assert!(actions.iter().any(|action| action.key == "Enter"));
-        assert!(!actions.iter().any(|action| action.key == "/"));
+        assert!(actions.iter().any(|action| action.key == "/"));
         assert!(actions.iter().any(|action| action.key == "m"));
         assert!(actions.iter().any(|action| action.key == "r"));
     }
@@ -1420,7 +1448,7 @@ mod tests {
         // Assert
         assert!(actions.iter().any(|action| action.key == "m"));
         assert!(!actions.iter().any(|action| action.key == "r"));
-        assert!(!actions.iter().any(|action| action.key == "/"));
+        assert!(actions.iter().any(|action| action.key == "/"));
     }
 
     #[test]

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -171,7 +171,9 @@ impl ViewSessionSnapshot {
             return false;
         }
 
-        self.can_edit_without_branch_work() || self.can_mutate_session_branch()
+        self.can_edit_without_branch_work()
+            || self.can_mutate_session_branch()
+            || self.can_reply_to_session()
     }
 
     /// Returns whether image paste can open a draft prompt composer directly
@@ -2925,6 +2927,94 @@ mod tests {
                 && session_id == &view_context.session_id
         ));
         assert!(app.prompt_progress.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_handle_view_key_slash_opens_for_reply_enabled_stacked_parent() {
+        // Arrange
+        let (mut app, _base_dir, session_id) = new_test_app_with_session().await;
+        app.mode = AppMode::View {
+            session_id: session_id.clone().into(),
+            scroll_offset: Some(2),
+        };
+        let view_context = view_context(&mut app).expect("expected view context");
+        let mut pending_update = ViewPendingUpdate::from_context(&view_context);
+        let mut view_session_snapshot = reply_enabled_review_snapshot();
+        view_session_snapshot.mutate_session_branch = ViewActionState::Disabled;
+        let view_key_context = ViewKeyContext {
+            context: &view_context,
+            metrics: ChatScrollMetrics {
+                total_lines: 10,
+                view_height: 5,
+            },
+            session_snapshot: &view_session_snapshot,
+        };
+
+        // Act
+        let should_apply = handle_view_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE),
+            view_key_context,
+            &mut pending_update,
+        )
+        .await;
+
+        // Assert
+        assert!(should_apply);
+        assert!(matches!(
+            app.mode,
+            AppMode::Prompt {
+                ref input,
+                ref session_id,
+                scroll_offset: Some(2),
+                ..
+            } if input.text() == "/"
+                && input.cursor == 1
+                && session_id == &view_context.session_id
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_view_key_slash_stays_closed_when_mutation_and_reply_are_blocked() {
+        // Arrange
+        let (mut app, _base_dir, session_id) = new_test_app_with_session().await;
+        app.mode = AppMode::View {
+            session_id: session_id.clone().into(),
+            scroll_offset: Some(2),
+        };
+        let view_context = view_context(&mut app).expect("expected view context");
+        let mut pending_update = ViewPendingUpdate::from_context(&view_context);
+        let mut view_session_snapshot = reply_enabled_review_snapshot();
+        view_session_snapshot.mutate_session_branch = ViewActionState::Disabled;
+        view_session_snapshot.reply_to_session = ViewActionState::Disabled;
+        let view_key_context = ViewKeyContext {
+            context: &view_context,
+            metrics: ChatScrollMetrics {
+                total_lines: 10,
+                view_height: 5,
+            },
+            session_snapshot: &view_session_snapshot,
+        };
+
+        // Act
+        let should_apply = handle_view_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE),
+            view_key_context,
+            &mut pending_update,
+        )
+        .await;
+
+        // Assert
+        assert!(should_apply);
+        assert!(matches!(
+            app.mode,
+            AppMode::View {
+                ref session_id,
+                scroll_offset: Some(2),
+            } if session_id == &view_context.session_id
+        ));
+        assert_eq!(pending_update.scroll_offset, Some(2));
     }
 
     #[tokio::test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -3378,7 +3378,8 @@ fn stacked_session_creation() -> E2eResult {
 
 /// Verify that a review-ready parent can still open the reply composer, sync
 /// the stack, and queue merge after its stacked child has also reached review,
-/// while slash commands remain hidden until the child is terminal or unlinked.
+/// while direct slash entry opens the same command menu available after
+/// entering the reply composer.
 #[test]
 fn stacked_parent_merge_remains_available_with_review_child() -> E2eResult {
     // Arrange, Act, Assert
@@ -3396,16 +3397,36 @@ fn stacked_parent_merge_remains_available_with_review_child() -> E2eResult {
                     .wait_for_text("Enter: reply", 5000)
                     .capture_labeled(
                         "parent_review",
-                        "Parent review session with reply and sync available",
+                        "Parent review session with reply, commands, and sync available",
+                    )
+                    .press_key("/")
+                    .wait_for_text("Slash Command", 3000)
+                    .capture_labeled(
+                        "parent_slash_commands",
+                        "Direct slash entry opens commands for a stacked parent",
                     )
             },
-            |frame, _report| {
+            |frame, report| {
+                let parent_frame = common::frame_from_capture(&report.captures[0]);
+                let parent_full = Region::full(parent_frame.cols(), parent_frame.rows());
+                assertion::assert_text_in_region(
+                    &parent_frame,
+                    "Parent stack review",
+                    &parent_full,
+                );
+                assertion::assert_text_in_region(&parent_frame, "Enter: reply", &parent_full);
+                assertion::assert_text_in_region(&parent_frame, "/: commands menu", &parent_full);
+                assertion::assert_text_in_region(
+                    &parent_frame,
+                    "m: add to merge queue",
+                    &parent_full,
+                );
+                assertion::assert_text_in_region(&parent_frame, "r: sync", &parent_full);
+
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "Parent stack review", &full);
-                assertion::assert_text_in_region(frame, "Enter: reply", &full);
-                assertion::assert_not_visible(frame, "/: commands menu");
-                assertion::assert_text_in_region(frame, "m: add to merge queue", &full);
-                assertion::assert_text_in_region(frame, "r: sync", &full);
+                assertion::assert_text_in_region(frame, "Slash Command", &full);
+                assertion::assert_text_in_region(frame, "/model", &full);
             },
         )?;
 

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -185,8 +185,8 @@ State-specific differences:
   `Alt+V` open the composer with an image paste; stacked drafts also hide `m` and show
   `s` only when the parent is review-ready and the stack is idle.
 - **Question** sessions hide `r` until they return to review-ready state.
-- Review-ready stacked parents with a materialized child keep `Enter`, `m`, and `r`
-  while the stack is idle, but hide `/` until the child is terminal or no longer linked.
+- Review-ready stacked parents with a materialized child keep `Enter`, `/`, `m`, and `r`
+  while the stack is idle.
 - Sessions with a linked pull request or merge request use `c` to open its comments page
   and hide `m`; merge the linked request through its forge instead of Agentty's local
   merge queue. Linked terminal sessions keep continuation available on `C`.

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -368,8 +368,8 @@ read-only.
 Stacked drafts show `s` start only when the parent is in **Review** or **AgentReview**
 and no stack member is running, queued, syncing, merging, or waiting on a question.
 While a materialized child is linked, the parent keeps `Enter` replies, `m` merge
-queueing, and `r` sync but hides slash commands. Syncing the parent (or completing a
-parent turn) rebases review-ready children onto the refreshed parent branch
+queueing, `r` sync, and direct `/` access to slash commands. Syncing the parent (or
+completing a parent turn) rebases review-ready children onto the refreshed parent branch
 automatically. When the parent merges, children are retargeted onto the parent's base
 branch and review-ready children are synced with `git rebase --onto` so they keep only
 their own commits. If an automatic child sync cannot start or complete, the affected


### PR DESCRIPTION
- Keep direct slash entry available when a review-ready stacked parent can reply.
- Preserve slash-command gating when both mutation and reply are blocked.
- Update action coverage, E2E coverage, and keybinding and workflow documentation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)