### PR TITLE
Handle outdated threads and no-change outcomes

### DIFF
--- a/crates/ag-forge/src/model.rs
+++ b/crates/ag-forge/src/model.rs
@@ -363,10 +363,12 @@ pub struct ReviewCommentThread {
 }
 
 impl ReviewCommentThread {
-    /// Returns whether this thread is unresolved and still anchored to the
-    /// current review diff.
+    /// Returns whether this thread remains open for a reply and resolution.
+    ///
+    /// Outdated threads remain actionable because their forge-native thread
+    /// identifiers survive after their original line anchors become stale.
     pub fn is_actionable(&self) -> bool {
-        !self.is_resolved && self.is_outdated != Some(true)
+        !self.is_resolved
     }
 }
 
@@ -623,7 +625,7 @@ mod tests {
     }
 
     #[test]
-    fn review_comment_thread_is_actionable_only_when_current_and_unresolved() {
+    fn review_comment_thread_is_actionable_when_unresolved_even_if_outdated() {
         // Arrange
         let actionable = review_comment_thread();
         let mut resolved = review_comment_thread();
@@ -634,7 +636,7 @@ mod tests {
         // Act, Assert
         assert!(actionable.is_actionable());
         assert!(!resolved.is_actionable());
-        assert!(!outdated.is_actionable());
+        assert!(outdated.is_actionable());
     }
 
     #[test]

--- a/crates/ag-protocol/src/model.rs
+++ b/crates/ag-protocol/src/model.rs
@@ -84,9 +84,11 @@ pub struct AgentResponseSummary {
     description = "Disposition reported for one targeted forge review thread."
 )]
 pub enum ReviewCommentResolution {
-    /// The agent addressed the review thread in the worktree.
+    /// The agent completed the requested action and the thread can be
+    /// resolved after its reply is posted.
     Fixed,
-    /// The agent determined that no code or documentation change was needed.
+    /// The agent determined that no code or documentation change was needed;
+    /// its explanatory reply is posted while the thread remains open.
     NoChangeNeeded,
 }
 

--- a/crates/agentty/src/app/prompt_intent.rs
+++ b/crates/agentty/src/app/prompt_intent.rs
@@ -503,8 +503,8 @@ pub(crate) fn build_apply_review_prompt(suggestions: &str) -> TurnPrompt {
 /// Builds an agent-facing review-comment prompt and its forge thread
 /// allowlist.
 ///
-/// Resolved and outdated threads are excluded. Standalone discussion comments
-/// are read-only because they have no forge-side thread identifier.
+/// Resolved threads are excluded. Standalone discussion comments are
+/// read-only because they have no forge-side thread identifier.
 pub(crate) fn build_resolve_review_comment_prompt(
     snapshot: &ReviewCommentSnapshot,
     selections: &[ReviewCommentActionSelection],
@@ -564,6 +564,12 @@ fn append_review_thread_prompt(
         action.prompt_label()
     );
     let _ = writeln!(review_comments, "Path: {}", thread.path);
+    if thread.is_outdated == Some(true) {
+        let _ = writeln!(
+            review_comments,
+            "Anchor status: outdated; inspect the current file instead of trusting the line anchor"
+        );
+    }
     let _ = writeln!(
         review_comments,
         "Anchor: {:?}, start line: {}, end line: {}",
@@ -636,10 +642,10 @@ mod tests {
         assert!(prompt.text.contains("````text\n"));
         assert!(prompt.text.contains("```markdown\nexample\n```"));
     }
-    /// Ensures the all-comments prompt includes only unresolved, current
-    /// thread IDs.
+    /// Ensures the all-comments prompt includes unresolved current and
+    /// outdated thread IDs.
     #[test]
-    fn test_build_resolve_review_comment_prompt_filters_non_actionable_threads() {
+    fn test_build_resolve_review_comment_prompt_filters_resolved_threads() {
         // Arrange
         let snapshot = review_comment_snapshot();
 
@@ -653,7 +659,10 @@ mod tests {
             .expect("snapshot should contain actionable comments");
 
         // Assert
-        assert_eq!(thread_ids, vec!["thread-current".to_string()]);
+        assert_eq!(
+            thread_ids,
+            vec!["thread-current".to_string(), "thread-outdated".to_string()]
+        );
         assert!(!prompt.text.contains("Update the overview."));
         assert!(prompt.text.contains("Thread ID: thread-current"));
         assert!(prompt.text.contains("Requested action: Address"));
@@ -664,7 +673,11 @@ mod tests {
                 .contains("Anchor: New, start line: 11, end line: 12")
         );
         assert!(!prompt.text.contains("thread-resolved"));
-        assert!(!prompt.text.contains("thread-outdated"));
+        assert!(prompt.text.contains("Thread ID: thread-outdated"));
+        assert!(prompt.text.contains("Requested action: Deny"));
+        assert!(prompt.text.contains(
+            "Anchor status: outdated; inspect the current file instead of trusting the line anchor"
+        ));
         assert!(prompt.attachments.is_empty());
         assert_eq!(prompt.text_source, TurnPromptTextSource::UserPrompt);
     }
@@ -689,7 +702,7 @@ mod tests {
         assert_eq!(thread_ids, vec!["thread-current".to_string()]);
     }
 
-    /// Ensures selected non-actionable and out-of-range rows cannot start a
+    /// Ensures selected resolved and out-of-range rows cannot start a
     /// resolution turn.
     #[test]
     fn test_build_resolve_review_comment_prompt_rejects_non_actionable_selection() {
@@ -699,10 +712,6 @@ mod tests {
             "thread-resolved",
             ReviewCommentAction::Address,
         )];
-        let outdated_selection = vec![review_comment_selection(
-            "thread-outdated",
-            ReviewCommentAction::Deny,
-        )];
         let missing_selection = vec![review_comment_selection(
             "thread-missing",
             ReviewCommentAction::Address,
@@ -710,13 +719,11 @@ mod tests {
 
         // Act
         let resolved = build_resolve_review_comment_prompt(&snapshot, &resolved_selection);
-        let outdated = build_resolve_review_comment_prompt(&snapshot, &outdated_selection);
         let missing = build_resolve_review_comment_prompt(&snapshot, &missing_selection);
         let empty = build_resolve_review_comment_prompt(&snapshot, &[]);
 
         // Assert
         assert!(resolved.is_none());
-        assert!(outdated.is_none());
         assert!(missing.is_none());
         assert!(empty.is_none());
     }

--- a/crates/agentty/src/app/session/workflow/post_turn.rs
+++ b/crates/agentty/src/app/session/workflow/post_turn.rs
@@ -8,7 +8,7 @@ use ag_agent as agent;
 use ag_agent::{AgentError, OneShotClient, TurnResult};
 use ag_forge as forge;
 use ag_git::GitClient;
-use ag_protocol::{AgentResponse, ReviewCommentOutcome, ReviewCommentResolution};
+use ag_protocol::{AgentResponse, ReviewCommentOutcome};
 use serde_json;
 use tokio::sync::mpsc;
 use tracing::warn;
@@ -438,7 +438,7 @@ async fn apply_successful_turn_result(
     } else {
         Status::Question
     };
-    let review_comment_outcomes = fixed_review_comment_outcomes(
+    let review_comment_outcomes = valid_review_comment_outcomes(
         &turn_metadata.review_comment_thread_ids,
         &assistant_message.review_comment_outcomes,
     );
@@ -484,9 +484,9 @@ async fn apply_successful_turn_result(
     Ok(target_status)
 }
 
-/// Returns deduplicated fixed outcomes whose thread identifiers were
-/// explicitly allowlisted for this turn.
-fn fixed_review_comment_outcomes(
+/// Returns deduplicated outcomes whose thread identifiers were explicitly
+/// allowlisted for this turn and whose replies are nonblank.
+fn valid_review_comment_outcomes(
     allowed_thread_ids: &[String],
     outcomes: &[ReviewCommentOutcome],
 ) -> Vec<ReviewCommentOutcome> {
@@ -498,7 +498,6 @@ fn fixed_review_comment_outcomes(
 
     outcomes
         .iter()
-        .filter(|outcome| outcome.resolution == ReviewCommentResolution::Fixed)
         .filter(|outcome| allowed_thread_ids.contains(outcome.thread_id.as_str()))
         .filter(|outcome| !outcome.reply.trim().is_empty())
         .filter(|outcome| accepted_thread_ids.insert(outcome.thread_id.clone()))
@@ -660,6 +659,7 @@ fn turn_applied_follow_up_tasks(_assistant_message: &AgentResponse) -> Vec<Sessi
 mod tests {
     use ag_agent::MockOneShotClient;
     use ag_git::MockGitClient;
+    use ag_protocol::ReviewCommentResolution;
 
     use super::*;
     use crate::domain::agent::{AgentKind, AgentModel, AgentSelection};
@@ -693,7 +693,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fixed_review_comment_outcomes_filters_and_normalizes_agent_output() {
+    fn test_valid_review_comment_outcomes_filters_and_normalizes_agent_output() {
         // Arrange
         let allowed_thread_ids = vec!["thread-fixed".to_string(), "thread-other".to_string()];
         let outcomes = vec![
@@ -725,16 +725,23 @@ mod tests {
         ];
 
         // Act
-        let accepted = fixed_review_comment_outcomes(&allowed_thread_ids, &outcomes);
+        let accepted = valid_review_comment_outcomes(&allowed_thread_ids, &outcomes);
 
         // Assert
         assert_eq!(
             accepted,
-            vec![ReviewCommentOutcome {
-                reply: "Applied the validation.".to_string(),
-                resolution: ReviewCommentResolution::Fixed,
-                thread_id: "thread-fixed".to_string(),
-            }]
+            vec![
+                ReviewCommentOutcome {
+                    reply: "Applied the validation.".to_string(),
+                    resolution: ReviewCommentResolution::Fixed,
+                    thread_id: "thread-fixed".to_string(),
+                },
+                ReviewCommentOutcome {
+                    reply: "No change needed.".to_string(),
+                    resolution: ReviewCommentResolution::NoChangeNeeded,
+                    thread_id: "thread-other".to_string(),
+                }
+            ]
         );
     }
 

--- a/crates/agentty/src/app/session/workflow/published_branch.rs
+++ b/crates/agentty/src/app/session/workflow/published_branch.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use ag_agent::OneShotClient;
 use ag_forge as forge;
 use ag_git::GitClient;
-use ag_protocol::ReviewCommentOutcome;
+use ag_protocol::{ReviewCommentOutcome, ReviewCommentResolution};
 use tokio::sync::{OwnedMutexGuard, mpsc};
 use uuid::Uuid;
 
@@ -42,7 +42,7 @@ pub(super) struct PublishedBranchAutoPushStartInput {
     pub(super) one_shot_client: Arc<dyn OneShotClient>,
     /// Published upstream reference that provides the remote branch target.
     pub(super) published_upstream_ref: String,
-    /// Fixed review-thread outcomes eligible for post-push forge updates.
+    /// Valid review-thread outcomes eligible for post-push forge updates.
     pub(super) review_comment_outcomes: Vec<ReviewCommentOutcome>,
     /// Forge boundary used for optional linked PR/MR metadata refresh.
     pub(super) review_request_client: Arc<dyn forge::ReviewRequestClient>,
@@ -163,7 +163,7 @@ pub(super) struct ReviewRequestMetadataEvaluationInput {
 
 /// Owned dependencies for forge thread replies and resolution after push.
 pub(super) struct ReviewCommentResolutionInput {
-    /// Fixed, allowlisted outcomes reported by the completed agent turn.
+    /// Valid, allowlisted outcomes reported by the completed agent turn.
     pub(super) outcomes: Vec<ReviewCommentOutcome>,
     /// Forge boundary used to post replies and resolve review threads.
     pub(super) review_request_client: Arc<dyn forge::ReviewRequestClient>,
@@ -225,18 +225,30 @@ async fn run_published_branch_auto_push_task(input: PublishedBranchAutoPushInput
     }
 }
 
-/// Posts agent-authored replies and resolves their allowlisted review threads
+/// Posts agent-authored replies and resolves fixed allowlisted review threads
 /// after the updated branch is visible on the forge.
 async fn resolve_review_comments_after_push(
     input: &PublishedBranchAutoPushInput,
     resolution_input: &ReviewCommentResolutionInput,
 ) {
+    let expected_reply_count = resolution_input.outcomes.len();
+    let expected_resolution_count = resolution_input
+        .outcomes
+        .iter()
+        .filter(|outcome| outcome.resolution == ReviewCommentResolution::Fixed)
+        .count();
     let linked_review_request = match load_open_review_request(input).await {
         Ok(Some(linked_review_request)) => linked_review_request,
         Ok(None) => return,
         Err(error) => {
-            append_review_comment_resolution_notice(input, 0, resolution_input.outcomes.len())
-                .await;
+            append_review_comment_resolution_notice(
+                input,
+                0,
+                expected_reply_count,
+                0,
+                expected_resolution_count,
+            )
+            .await;
             tracing::warn!(
                 session_id = %input.session_id,
                 %error,
@@ -249,8 +261,14 @@ async fn resolve_review_comments_after_push(
     let repo_url = match input.git_client.repo_url(input.folder.clone()).await {
         Ok(repo_url) => repo_url,
         Err(error) => {
-            append_review_comment_resolution_notice(input, 0, resolution_input.outcomes.len())
-                .await;
+            append_review_comment_resolution_notice(
+                input,
+                0,
+                expected_reply_count,
+                0,
+                expected_resolution_count,
+            )
+            .await;
             tracing::warn!(
                 session_id = %input.session_id,
                 %error,
@@ -267,8 +285,14 @@ async fn resolve_review_comments_after_push(
     {
         Ok(remote) => remote,
         Err(error) => {
-            append_review_comment_resolution_notice(input, 0, resolution_input.outcomes.len())
-                .await;
+            append_review_comment_resolution_notice(
+                input,
+                0,
+                expected_reply_count,
+                0,
+                expected_resolution_count,
+            )
+            .await;
             let error_detail = error.detail_message();
             tracing::warn!(
                 session_id = %input.session_id,
@@ -280,13 +304,39 @@ async fn resolve_review_comments_after_push(
         }
     };
 
+    let (replied_count, resolved_count) = post_review_comment_outcomes(
+        input,
+        resolution_input,
+        &remote,
+        &linked_review_request.summary.display_id,
+    )
+    .await;
+    append_review_comment_resolution_notice(
+        input,
+        replied_count,
+        expected_reply_count,
+        resolved_count,
+        expected_resolution_count,
+    )
+    .await;
+}
+
+/// Posts each accepted reply and resolves only fixed outcomes.
+async fn post_review_comment_outcomes(
+    input: &PublishedBranchAutoPushInput,
+    resolution_input: &ReviewCommentResolutionInput,
+    remote: &forge::ForgeRemote,
+    display_id: &str,
+) -> (usize, usize) {
+    let mut replied_count = 0;
     let mut resolved_count = 0;
+
     for outcome in &resolution_input.outcomes {
         let reply_result = resolution_input
             .review_request_client
             .reply_to_thread(
                 remote.clone(),
-                linked_review_request.summary.display_id.clone(),
+                display_id.to_string(),
                 outcome.thread_id.clone(),
                 outcome.reply.clone(),
             )
@@ -297,9 +347,13 @@ async fn resolve_review_comments_after_push(
                 session_id = %input.session_id,
                 thread_id = %outcome.thread_id,
                 error = %error_detail,
-                "failed to reply to resolved review thread"
+                "failed to reply to review thread"
             );
 
+            continue;
+        }
+        replied_count += 1;
+        if outcome.resolution == ReviewCommentResolution::NoChangeNeeded {
             continue;
         }
 
@@ -307,7 +361,7 @@ async fn resolve_review_comments_after_push(
             .review_request_client
             .resolve_thread(
                 remote.clone(),
-                linked_review_request.summary.display_id.clone(),
+                display_id.to_string(),
                 outcome.thread_id.clone(),
             )
             .await;
@@ -325,26 +379,30 @@ async fn resolve_review_comments_after_push(
         }
     }
 
-    append_review_comment_resolution_notice(input, resolved_count, resolution_input.outcomes.len())
-        .await;
+    (replied_count, resolved_count)
 }
 
 /// Appends a concise durable result for post-push review-thread updates.
 async fn append_review_comment_resolution_notice(
     input: &PublishedBranchAutoPushInput,
+    replied_count: usize,
+    expected_reply_count: usize,
     resolved_count: usize,
-    total_count: usize,
+    expected_resolution_count: usize,
 ) {
-    let message = if resolved_count == total_count {
-        TranscriptNotice::ReviewComments.format(format!(
-            "Replied to and resolved {resolved_count} review thread(s)."
-        ))
-    } else {
-        TranscriptNotice::ReviewCommentsWarning.format(format!(
-            "Resolved {resolved_count} of {total_count} review thread(s). Reopen review comments \
-             to retry the remaining threads."
-        ))
-    };
+    let message =
+        if replied_count == expected_reply_count && resolved_count == expected_resolution_count {
+            TranscriptNotice::ReviewComments.format(format!(
+                "Replied to {replied_count} review thread(s) and resolved {resolved_count} fixed \
+                 thread(s)."
+            ))
+        } else {
+            TranscriptNotice::ReviewCommentsWarning.format(format!(
+                "Replied to {replied_count} of {expected_reply_count} review thread(s) and \
+                 resolved {resolved_count} of {expected_resolution_count} fixed thread(s). Reopen \
+                 review comments to retry the remaining threads."
+            ))
+        };
     SessionTaskService::append_workflow_notice(
         &input.transcript,
         &input.db,
@@ -719,8 +777,55 @@ mod tests {
         // Assert
         assert_eq!(
             last_transcript_message(&transcript),
-            "[Review Comments Warning] Resolved 0 of 2 review thread(s). Reopen review comments \
-             to retry the remaining threads."
+            "[Review Comments Warning] Replied to 1 of 2 review thread(s) and resolved 0 of 2 \
+             fixed thread(s). Reopen review comments to retry the remaining threads."
+        );
+    }
+
+    #[tokio::test]
+    async fn review_comment_resolution_replies_to_all_outcomes_and_resolves_only_fixed() {
+        // Arrange
+        let db = linked_review_request_db().await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_repo_url().once().returning(|_| {
+            Box::pin(async { Ok("https://github.com/agentty-xyz/agentty.git".to_string()) })
+        });
+        let mut review_request_client = MockReviewRequestClient::new();
+        review_request_client
+            .expect_detect_remote()
+            .once()
+            .returning(|_| Ok(github_remote()));
+        review_request_client
+            .expect_reply_to_thread()
+            .withf(|_, _, thread_id, body| {
+                (thread_id == "no-change" && body == "The current implementation is already safe.")
+                    || (thread_id == "fixed" && body == "Addressed fixed.")
+            })
+            .times(2)
+            .returning(|_, _, _, _| Box::pin(async { Ok(()) }));
+        review_request_client
+            .expect_resolve_thread()
+            .withf(|_, _, thread_id| thread_id == "fixed")
+            .once()
+            .returning(|_, _, _| Box::pin(async { Ok(()) }));
+        let (input, transcript) = resolution_test_input(
+            db,
+            git_client,
+            review_request_client,
+            vec![no_change_outcome("no-change"), fixed_outcome("fixed")],
+        );
+        let resolution_input = input
+            .review_comment_resolution
+            .as_ref()
+            .expect("resolution input should exist");
+
+        // Act
+        resolve_review_comments_after_push(&input, resolution_input).await;
+
+        // Assert
+        assert_eq!(
+            last_transcript_message(&transcript),
+            "[Review Comments] Replied to 2 review thread(s) and resolved 1 fixed thread(s)."
         );
     }
 
@@ -754,8 +859,8 @@ mod tests {
         // Assert
         assert_eq!(
             last_transcript_message(&transcript),
-            "[Review Comments Warning] Resolved 0 of 1 review thread(s). Reopen review comments \
-             to retry the remaining threads."
+            "[Review Comments Warning] Replied to 0 of 1 review thread(s) and resolved 0 of 1 \
+             fixed thread(s). Reopen review comments to retry the remaining threads."
         );
     }
 
@@ -790,8 +895,8 @@ mod tests {
         // Assert
         assert_eq!(
             last_transcript_message(&transcript),
-            "[Review Comments Warning] Resolved 0 of 1 review thread(s). Reopen review comments \
-             to retry the remaining threads."
+            "[Review Comments Warning] Replied to 0 of 1 review thread(s) and resolved 0 of 1 \
+             fixed thread(s). Reopen review comments to retry the remaining threads."
         );
     }
 
@@ -845,8 +950,8 @@ mod tests {
         // Assert
         assert_eq!(
             last_transcript_message(&transcript),
-            "[Review Comments Warning] Resolved 0 of 1 review thread(s). Reopen review comments \
-             to retry the remaining threads."
+            "[Review Comments Warning] Replied to 0 of 1 review thread(s) and resolved 0 of 1 \
+             fixed thread(s). Reopen review comments to retry the remaining threads."
         );
     }
 
@@ -906,6 +1011,15 @@ mod tests {
         ReviewCommentOutcome {
             reply: format!("Addressed {thread_id}."),
             resolution: ag_protocol::ReviewCommentResolution::Fixed,
+            thread_id: thread_id.to_string(),
+        }
+    }
+
+    /// Builds one no-change outcome that receives a reply but remains open.
+    fn no_change_outcome(thread_id: &str) -> ReviewCommentOutcome {
+        ReviewCommentOutcome {
+            reply: "The current implementation is already safe.".to_string(),
+            resolution: ag_protocol::ReviewCommentResolution::NoChangeNeeded,
             thread_id: thread_id.to_string(),
         }
     }

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -3516,7 +3516,7 @@ mod tests {
         assert_eq!(status, Status::Review);
         assert_eq!(
             notice.trim(),
-            "[Review Comments] Replied to and resolved 1 review thread(s)."
+            "[Review Comments] Replied to 1 review thread(s) and resolved 1 fixed thread(s)."
         );
     }
 

--- a/crates/agentty/src/presentation/review_comment.rs
+++ b/crates/agentty/src/presentation/review_comment.rs
@@ -19,8 +19,9 @@ pub(crate) enum ReviewCommentEntry<'a> {
     Thread(&'a ReviewCommentThread),
 }
 
-/// Returns the complete selector projection in unresolved, resolved, then
-/// standalone order, including labels for each populated group.
+/// Returns the complete selector projection in unresolved, outdated,
+/// resolved, then standalone order, including labels for each populated
+/// group.
 pub(crate) fn grouped_review_comment_rows(
     snapshot: &ReviewCommentSnapshot,
 ) -> Vec<GroupedReviewCommentRow<'_>> {
@@ -29,7 +30,7 @@ pub(crate) fn grouped_review_comment_rows(
             .threads
             .len()
             .saturating_add(snapshot.pr_level_comments.len())
-            .saturating_add(3),
+            .saturating_add(4),
     );
     append_group_rows(
         &mut rows,
@@ -37,7 +38,16 @@ pub(crate) fn grouped_review_comment_rows(
         snapshot
             .threads
             .iter()
-            .filter(|thread| !thread.is_resolved)
+            .filter(|thread| !thread.is_resolved && thread.is_outdated != Some(true))
+            .map(ReviewCommentEntry::Thread),
+    );
+    append_group_rows(
+        &mut rows,
+        "Outdated",
+        snapshot
+            .threads
+            .iter()
+            .filter(|thread| !thread.is_resolved && thread.is_outdated == Some(true))
             .map(ReviewCommentEntry::Thread),
     );
     append_group_rows(
@@ -209,8 +219,16 @@ mod tests {
     #[test]
     fn test_grouped_review_comment_rows_include_populated_labels_and_entries() {
         // Arrange
-        let mut snapshot =
-            snapshot_with_threads([thread("resolved", true), thread("unresolved", false)]);
+        let mut outdated = thread("outdated", false);
+        outdated.is_outdated = Some(true);
+        let mut resolved_outdated = thread("resolved-outdated", true);
+        resolved_outdated.is_outdated = Some(true);
+        let mut snapshot = snapshot_with_threads([
+            thread("resolved", true),
+            outdated,
+            resolved_outdated,
+            thread("unresolved", false),
+        ]);
         snapshot.pr_level_comments.push(ReviewComment {
             author: "reviewer".to_string(),
             body: "Standalone comment".to_string(),
@@ -237,8 +255,11 @@ mod tests {
             vec![
                 "label:Unresolved",
                 "thread:unresolved",
+                "label:Outdated",
+                "thread:outdated",
                 "label:Resolved",
                 "thread:resolved",
+                "thread:resolved-outdated",
                 "label:Standalone",
                 "comment:Standalone comment",
             ]

--- a/crates/agentty/src/ui/page/review_comment.rs
+++ b/crates/agentty/src/ui/page/review_comment.rs
@@ -429,6 +429,10 @@ fn code_context_lines(
     diff: &str,
     width: usize,
 ) -> Vec<Line<'static>> {
+    if thread.is_outdated == Some(true) {
+        return vec![muted_line("Original code context unavailable.")];
+    }
+
     if thread.anchor_side == ReviewCommentAnchorSide::File {
         return vec![muted_line(
             "This file-level comment is not attached to a code line.",
@@ -1033,6 +1037,28 @@ mod tests {
     }
 
     #[test]
+    fn test_code_context_lines_explain_outdated_anchor_without_current_diff_context() {
+        // Arrange
+        let mut thread = inline_thread(2);
+        thread.is_outdated = Some(true);
+
+        // Act
+        let lines = code_context_lines(&thread, SAMPLE_DIFF, 80);
+
+        // Assert
+        assert_eq!(
+            lines.iter().map(Line::to_string).collect::<Vec<_>>(),
+            vec!["Original code context unavailable."]
+        );
+        assert!(
+            lines
+                .iter()
+                .flat_map(|line| &line.spans)
+                .all(|span| span.style.bg.is_none())
+        );
+    }
+
+    #[test]
     fn test_code_context_lines_cover_old_side_and_missing_anchor_fallbacks() {
         // Arrange
         let mut old_thread = inline_thread(1);
@@ -1171,7 +1197,7 @@ mod tests {
     }
 
     #[test]
-    fn test_review_comment_actionability_excludes_resolved_outdated_and_missing_rows() {
+    fn test_review_comment_actionability_includes_outdated_unresolved_rows() {
         // Arrange
         let mut current = inline_thread(2);
         current.id = "current".to_string();
@@ -1203,7 +1229,7 @@ mod tests {
         assert!(!general_is_actionable);
         assert!(current_is_actionable);
         assert!(!resolved_is_actionable);
-        assert!(!outdated_is_actionable);
+        assert!(outdated_is_actionable);
         assert!(!missing_is_actionable);
         assert_eq!(current_thread_id, Some("current"));
         assert_eq!(general_thread_id, None);

--- a/crates/agentty/src/ui/review_comment_format.rs
+++ b/crates/agentty/src/ui/review_comment_format.rs
@@ -20,8 +20,8 @@ pub(crate) fn append_comment_bodies(
     }
 }
 
-/// Renders the `path:start-end · side · N comments · resolved/unresolved`
-/// header shared by review-detail and diff comment panels.
+/// Renders the anchor, side, comment count, resolution, and optional outdated
+/// metadata shared by review-detail and diff comment panels.
 pub(crate) fn thread_header_line(
     thread: &ReviewCommentThread,
     anchor_style: Style,
@@ -111,7 +111,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_thread_header_line_includes_outdated_resolution_metadata() {
+    fn test_thread_header_line_includes_resolution_and_outdated_metadata() {
         // Arrange
         let thread = ReviewCommentThread {
             anchor_side: ReviewCommentAnchorSide::Old,

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1615,7 +1615,7 @@ case "$*" in
     exit 0
     ;;
   *"api --hostname github.com graphql"*)
-    printf '%s\n' '{"data":{"repository":{"pullRequest":{"comments":{"nodes":[{"author":{"login":"carol"},"body":"Thanks for documenting the behavior."}]},"reviewThreads":{"nodes":[{"id":"thread-inline","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":2,"path":"src/main.rs","startLine":1,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"alice"},"body":"Please explain why this review output is needed."}]}},{"id":"thread-file","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":null,"path":"src/main.rs","startLine":null,"subjectType":"FILE","comments":{"nodes":[{"author":{"login":"bob"},"body":"Please review the whole file."}]}},{"id":"thread-resolved","diffSide":"RIGHT","isOutdated":false,"isResolved":true,"line":3,"path":"src/main.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"dana"},"body":"This thread is complete."}]}}]}}}}}'
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"comments":{"nodes":[{"author":{"login":"carol"},"body":"Thanks for documenting the behavior."}]},"reviewThreads":{"nodes":[{"id":"thread-inline","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":2,"path":"src/main.rs","startLine":1,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"alice"},"body":"Please explain why this review output is needed."}]}},{"id":"thread-file","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":null,"path":"src/main.rs","startLine":null,"subjectType":"FILE","comments":{"nodes":[{"author":{"login":"bob"},"body":"Please review the whole file."}]}},{"id":"thread-outdated","diffSide":"RIGHT","isOutdated":true,"isResolved":false,"line":2,"path":"old.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"erin"},"body":"This comment refers to an earlier diff."}]}},{"id":"thread-resolved","diffSide":"RIGHT","isOutdated":false,"isResolved":true,"line":3,"path":"src/main.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"dana"},"body":"This thread is complete."}]}},{"id":"thread-resolved-outdated","diffSide":"LEFT","isOutdated":true,"isResolved":true,"line":4,"path":"ro.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"frank"},"body":"This resolved thread refers to an earlier diff."}]}}]}}}}}'
     ;;
   *"pr view"*)
     printf '%s\n' '{"number":42,"title":"Review-ready session shortcuts","state":"OPEN","url":"https://github.com/agentty-xyz/agentty/pull/42","baseRefName":"main","headRefName":"wt/review-s","isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"REVIEW_REQUIRED","mergedAt":null}'
@@ -4553,51 +4553,100 @@ fn test_session_review_comments() -> E2eResult {
                         "file_review_comment",
                         "File-level review comment without a synthetic code anchor",
                     )
+                    .press_key("j")
+                    .wait_for_text("Original code context unavailable.", 5000)
+                    .wait_for_text("a: address", 5000)
+                    .press_key("a")
+                    .wait_for_text("[A]", 5000)
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled(
+                        "outdated_review_comment",
+                        "Outdated comment without misleading current diff context",
+                    )
             },
             |frame, report| {
                 let inline_frame = common::frame_from_capture(&report.captures[0]);
-                let inline_full = Region::full(inline_frame.cols(), inline_frame.rows());
-                let page_text = inline_frame.text_in_region(&inline_full);
-                let code_context_index = page_text
-                    .find("Code context")
-                    .expect("code context section should be visible");
-                let conversation_index = page_text
-                    .find("Conversation")
-                    .expect("conversation section should be visible");
+                assert_inline_review_comment(&inline_frame);
 
-                assertion::assert_text_in_region(&inline_frame, "Comments (4)", &inline_full);
-                assertion::assert_text_in_region(&inline_frame, "Unresolved", &inline_full);
-                assertion::assert_text_in_region(&inline_frame, "Resolved", &inline_full);
-                assertion::assert_text_in_region(&inline_frame, "Standalone", &inline_full);
-                assertion::assert_text_in_region(&inline_frame, "src/main.rs:1-2", &inline_full);
-                assertion::assert_text_in_region(&inline_frame, "Conversation", &inline_full);
+                let file_frame = common::frame_from_capture(&report.captures[1]);
+                let file_full = Region::full(file_frame.cols(), file_frame.rows());
+                assertion::assert_text_in_region(&file_frame, "file  ·  1 comments", &file_full);
                 assertion::assert_text_in_region(
-                    &inline_frame,
-                    "Please explain why this review output is needed.",
-                    &inline_full,
-                );
-                assertion::assert_text_in_region(&inline_frame, "Code context", &inline_full);
-                assertion::assert_text_in_region(
-                    &inline_frame,
-                    "println!(\"review\")",
-                    &inline_full,
-                );
-                assert!(code_context_index < conversation_index);
-
-                let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(frame, "file  ·  1 comments", &full);
-                assertion::assert_text_in_region(
-                    frame,
+                    &file_frame,
                     "This file-level comment is not attached to a code line.",
-                    &full,
+                    &file_full,
                 );
-                assertion::assert_text_in_region(frame, "Please review the whole file.", &full);
-                assertion::assert_not_visible(frame, "println!(\"review\")");
-                assertion::assert_text_in_region(frame, "j/k: select comment", &full);
+                assertion::assert_text_in_region(
+                    &file_frame,
+                    "Please review the whole file.",
+                    &file_full,
+                );
+                assertion::assert_not_visible(&file_frame, "println!(\"review\")");
+
+                assert_outdated_review_comment(frame);
             },
         )?;
 
     Ok(())
+}
+
+/// Verifies grouped row placement and inline code-context rendering.
+fn assert_inline_review_comment(frame: &TerminalFrame) {
+    let full = Region::full(frame.cols(), frame.rows());
+    let page_text = frame.text_in_region(&full);
+
+    assertion::assert_text_in_region(frame, "Comments (6)", &full);
+    assertion::assert_text_in_region(frame, "Unresolved", &full);
+    assertion::assert_text_in_region(frame, "Outdated", &full);
+    assertion::assert_text_in_region(frame, "Resolved", &full);
+    assertion::assert_text_in_region(frame, "Standalone", &full);
+    assertion::assert_text_in_region(frame, "src/main.rs:1-2", &full);
+    assertion::assert_text_in_region(frame, "Conversation", &full);
+    assertion::assert_text_in_region(
+        frame,
+        "Please explain why this review output is needed.",
+        &full,
+    );
+    assertion::assert_text_in_region(frame, "Code context", &full);
+    assertion::assert_text_in_region(frame, "println!(\"review\")", &full);
+    assert!(
+        matches!(
+            (
+                page_text.find("Code context"),
+                page_text.find("Conversation"),
+                page_text.find("Outdated"),
+                page_text.find("old.rs:2"),
+                page_text.find("Resolved"),
+                page_text.find("ro.rs:4"),
+            ),
+            (
+                Some(code_context_index),
+                Some(conversation_index),
+                Some(outdated_group_index),
+                Some(outdated_thread_index),
+                Some(resolved_group_index),
+                Some(resolved_outdated_thread_index),
+            ) if code_context_index < conversation_index
+                && outdated_group_index < outdated_thread_index
+                && outdated_thread_index < resolved_group_index
+                && resolved_group_index < resolved_outdated_thread_index
+        ),
+        "unexpected review comment layout:\n{page_text}"
+    );
+}
+
+/// Verifies that an outdated thread stays actionable without stale context.
+fn assert_outdated_review_comment(frame: &TerminalFrame) {
+    let full = Region::full(frame.cols(), frame.rows());
+
+    assertion::assert_text_in_region(frame, "unresolved  ·  outdated", &full);
+    assertion::assert_text_in_region(frame, "Original code context unavailable.", &full);
+    assertion::assert_text_in_region(frame, "This comment refers to an earlier diff.", &full);
+    assertion::assert_text_in_region(frame, "[A]", &full);
+    assertion::assert_not_visible(frame, "println!(\"review\")");
+    assertion::assert_text_in_region(frame, "a: address", &full);
+    assertion::assert_text_in_region(frame, "d: den", &full);
+    assertion::assert_text_in_region(frame, "j/k: select comment", &full);
 }
 
 /// Verify that pressing `d` while the chat transcript is focused in the reply

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -545,11 +545,13 @@ orchestration paths:
   `AppEvent` to update only the still-open comments page. Inline code context is derived
   from the already loaded current diff. From a reply-capable session, `a` marks an
   actionable thread to address, `d` marks it to deny, and `Enter` renders every marked
-  thread plus its requested action into one `TurnPrompt`. The selected forge thread IDs
-  are recorded in turn metadata. Post-turn handling accepts only deduplicated `fixed`
-  outcomes with an allowlisted ID and nonblank reply. After auto-commit and a successful
-  published-branch push, the worker posts each reply and then resolves that thread
-  through `ReviewRequestClient`; failed pushes never mutate forge thread state.
+  thread plus its requested action into one `TurnPrompt`; outdated threads include an
+  explicit stale-anchor marker. The selected forge thread IDs are recorded in turn
+  metadata. Post-turn handling accepts deduplicated outcomes with an allowlisted ID and
+  nonblank reply. After auto-commit and a successful published-branch push, the worker
+  posts every accepted reply and resolves only outcomes reported as `fixed` through
+  `ReviewRequestClient`; `no_change_needed` outcomes remain open, and failed pushes
+  never mutate forge thread state.
 - Assigned-issue refresh: the Issues tab resolves the active project remote and runs a
   repository-scoped, generation-scoped `gh search issues` task through
   `ReviewRequestClient`; stale completions are discarded before the list cache is

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -207,12 +207,16 @@ Publish (`p`), sync (`r`), and stacked behavior are described in
 ## Review Comments
 
 The review-comments page uses the same split layout as diff view. The left panel lists
-unresolved threads, resolved threads, and standalone review-request comments in separate
-groups; the right panel shows the selected comment's author and thread state, current
-diff context for its attached line or range, and then the conversation. File-level
-comments explicitly show that they have no attached code line instead of highlighting an
-arbitrary diff row. Inline snippets use the same gutters and added/removed line colors
-as diff view.
+unresolved, outdated, and resolved threads plus standalone review-request comments in
+separate groups. The Outdated group contains unresolved threads with stale anchors;
+resolved threads stay in the Resolved group even when their anchors are outdated. The
+right panel shows the selected comment's author, resolution state, outdated-anchor
+metadata when applicable, current diff context for its attached line or range, and then
+the conversation. Outdated threads explicitly report that their original context is
+unavailable instead of mapping the stale anchor onto the current diff. File-level
+comments similarly show that they have no attached code line instead of highlighting an
+arbitrary diff row. Current inline snippets use the same gutters and added/removed line
+colors as diff view.
 
 | Key           | Action                                                  |
 | ------------- | ------------------------------------------------------- |
@@ -226,9 +230,9 @@ as diff view.
 Actionable rows start with `[ ]`, then show `[A]` for address or `[D]` for deny.
 Pressing the same action again clears that row; pressing the other action replaces it.
 `a`, `d`, and `Enter` appear only while the session can accept a turn, and `Enter`
-appears only after at least one row is marked. Resolved and outdated inline threads are
-not actionable. Standalone comments are also read-only because they have no forge thread
-ID.
+appears only after at least one row is marked. Unresolved outdated threads remain
+actionable through their forge thread ID, although their original code context is no
+longer available. Resolved threads and standalone comments are read-only.
 
 ## Publish Popup
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -420,11 +420,14 @@ publish popup for the linked forge review request:
   rebuttal.
 - Agent-driven review-comment turns report one structured outcome for each submitted
   inline thread. After Agentty commits the work and successfully pushes an already
-  published branch, it posts the agent's concise reply and resolves only allowlisted
-  threads reported as `fixed`. Threads reported as `no_change_needed`, unknown thread
-  IDs, blank replies, resolved threads, and outdated threads remain open. Reply or
-  resolution failures produce a `[Review Comments Warning]` transcript notice and do not
-  block the successful branch push.
+  published branch, it posts the agent's concise reply for every valid allowlisted
+  outcome and resolves only threads reported as `fixed`. Threads reported as
+  `no_change_needed` receive their explanatory reply but remain open. Unknown thread
+  IDs, blank replies, and resolved threads are ignored. Unresolved outdated threads
+  remain actionable through their forge thread ID while their stale line anchor is
+  omitted from current diff context. Reply or resolution failures produce a
+  `[Review Comments Warning]` transcript notice and do not block the successful branch
+  push.
 
 <a id="usage-review-request-prerequisites"></a> Publishing needs regular Git
 authentication (credential helper or PAT for HTTPS remotes, SSH key for SSH remotes)


### PR DESCRIPTION
- Keep unresolved outdated threads actionable while showing unavailable context.
- Keep resolved outdated threads in the resolved group and show their resolution state.
- Reply to valid outcomes and leave no-change outcomes open while resolving only fixed threads.
- Cover the behavior with unit and E2E tests and updated documentation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)