### PR TITLE
Add Qwen model adapter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,14 @@ repos:
         always_run: true
         pass_filenames: false
         stages: [manual]
+      - id: test-ag-harness-src
+        name: cargo nextest ag-harness src
+        description: Source tests for `crates/ag-harness/src`.
+        entry: cargo nextest run --locked --profile ci -p ag-harness --lib
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [manual]
       - id: test-ag-protocol-src
         name: cargo nextest ag-protocol src
         description: Source tests for `crates/ag-protocol/src`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,9 @@ validation commands. See Quality Gates for when to run what.
 - Compile check: `prek run cargo-check --files <paths>`
 - Lint: `prek run clippy --files <paths>`
 - Test one crate: `prek run test-agentty-src` (also `test-ag-agent-src`,
-  `test-ag-git-src`, `test-testty-src`, `test-ag-forge-src`, `test-ag-protocol-src`,
-  `test-ag-session-src`, `test-ag-clipboard-src`, `test-ag-xtask-src`)
+  `test-ag-git-src`, `test-testty-src`, `test-ag-forge-src`, `test-ag-harness-src`,
+  `test-ag-protocol-src`, `test-ag-session-src`, `test-ag-clipboard-src`,
+  `test-ag-xtask-src`)
 - Focused E2E test:
   `cargo nextest run --locked --profile ci -p agentty --test e2e <test-filter>`
 - Format markdown: `prek run mdformat --files <paths>`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,15 @@ dependencies = [
 [[package]]
 name = "ag-harness"
 version = "0.13.7"
+dependencies = [
+ "async-trait",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "wiremock",
+]
 
 [[package]]
 name = "ag-protocol"
@@ -135,7 +144,7 @@ dependencies = [
  "shell-words",
  "tracing",
  "uuid",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -262,7 +271,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -273,7 +282,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -351,6 +360,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,7 +411,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -439,7 +458,7 @@ dependencies = [
  "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -488,6 +507,29 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "base64"
@@ -662,6 +704,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -747,6 +791,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +816,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compact_str"
@@ -794,6 +857,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -990,6 +1063,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1184,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,7 +1217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1130,7 +1227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1304,6 +1401,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1553,19 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -1467,11 +1583,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1501,6 +1619,25 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1597,12 +1734,117 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1821,6 +2063,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,6 +2088,65 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.19",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1955,6 +2262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,7 +2339,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2106,7 +2419,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2133,6 +2446,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2191,6 +2514,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-float"
@@ -2422,7 +2751,7 @@ dependencies = [
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2526,6 +2855,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand 0.10.1",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2577,6 +2963,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "ratatui"
@@ -2727,6 +3122,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,7 +3197,82 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2773,6 +3294,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2817,6 +3347,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3037,6 +3590,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3064,7 +3633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3296,6 +3865,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3326,6 +3901,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -3363,7 +3947,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3376,7 +3960,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3597,7 +4181,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3609,6 +4193,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3634,6 +4228,51 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -3692,6 +4331,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -3766,6 +4411,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -3871,6 +4522,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3905,6 +4565,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3971,6 +4645,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4079,7 +4782,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4149,12 +4852,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -4172,6 +4948,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -4348,6 +5147,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ objc2-foundation = { version = "0.3", default-features = false }
 percent-encoding = "2"
 portable-pty = "0.9"
 ratatui = { version = "0.30.1", default-features = false, features = ["crossterm", "layout-cache", "std", "underline-color"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls"] }
 rustc-hash = "2"
 rustix = { version = "1.1", features = ["event", "fs", "process"] }
 schemars = { version = "1", features = ["derive"] }
@@ -60,6 +61,7 @@ unicode-width = "0.2"
 url = "2"
 uuid = { version = "1", features = ["v4"] }
 vt100 = "0.16"
+wiremock = "0.6.5"
 x11rb = "0.14"
 
 [workspace.lints.rust]

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -13,7 +13,8 @@ Contains the workspace member crates.
   across the workspace.
 - `crates/ag-git/` holds reusable git, worktree, sync, rebase, and squash-merge
   operations shared across the workspace.
-- `crates/ag-harness/` is the planned application-facing LLM harness facade.
+- `crates/ag-harness/` holds the application-facing LLM harness contract and model
+  adapters, beginning with Qwen.
 - `crates/ag-protocol/` holds structured agent response contracts, protocol parsing,
   schema generation, and transport-neutral turn prompt payloads shared across frontends
   and agent adapters.

--- a/crates/ag-harness/AGENTS.md
+++ b/crates/ag-harness/AGENTS.md
@@ -35,6 +35,10 @@ agentty/
 │   ├── ag-harness-core       # loop, tools, sessions, context, storage
 ```
 
+The current foundation lives entirely in `ag-harness`: the provider-neutral `Model`
+contract accepts a text `ModelRequest` and returns a text `ModelResponse`. `Qwen` is its
+first adapter and uses the OpenAI-compatible Chat Completions API.
+
 ## Session management
 
 - One host process manages multiple independent sessions.
@@ -107,7 +111,21 @@ sequenceDiagram
 
 ## Structured output
 
-The harness uses structured input and output to communicate with models.
+The next model-contract iteration evolves the current text-only response into
+provider-neutral structured output:
+
+- The caller supplies the expected JSON shape as a provider-independent schema.
+- Each adapter uses the strongest structured-output mechanism its provider supports,
+  then the harness parses and validates the returned JSON against the caller's schema.
+- Provider-specific request fields remain inside the adapter. For Qwen, the adapter uses
+  JSON Object mode and performs schema validation in the harness because Qwen guarantees
+  valid JSON, not schema conformance.
+- Every new model adapter must implement these structured-output semantics before it is
+  added.
+
+Configurations that cannot satisfy the contract, such as Qwen thinking mode, return an
+explicit unsupported-configuration error rather than silently falling back to
+unstructured text.
 
 ## Permissions
 
@@ -152,11 +170,12 @@ best cost and performance:
 
 ## Next iterations
 
-1. **Model round trip.** Integrate one Qwen model API and complete a typed
-   prompt-response flow.
+1. **Structured model output.** Add the provider-neutral schema contract, Qwen JSON
+   Object mode translation, parsing, validation, and typed errors described above.
 1. **Tool round trip.** Support one model-requested tool through execution to the final
    response.
-1. **Second provider.** Integrate another model API through the same contract.
+1. **Second provider.** Integrate another model API through the structured-output
+   contract.
 
 ## Roadmap
 

--- a/crates/ag-harness/Cargo.toml
+++ b/crates/ag-harness/Cargo.toml
@@ -8,5 +8,16 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[dependencies]
+async-trait.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+tokio.workspace = true
+wiremock.workspace = true
+
 [lints]
 workspace = true

--- a/crates/ag-harness/examples/qwen.rs
+++ b/crates/ag-harness/examples/qwen.rs
@@ -1,0 +1,23 @@
+//! Sends a fixed prompt to a configured Qwen model and prints its response.
+
+use std::error::Error;
+use std::io;
+use std::io::Write;
+
+use ag_harness::{Model, ModelRequest, Qwen, QwenConfig};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let model = Qwen::new(QwenConfig {
+        api_key: std::env::var("DASHSCOPE_API_KEY")?,
+        base_url: std::env::var("DASHSCOPE_BASE_URL")?,
+        model: "qwen-plus".to_string(),
+    });
+    let response = model
+        .complete(ModelRequest::text("Reply with exactly: hello"))
+        .await?;
+
+    writeln!(io::stdout().lock(), "{}", response.text())?;
+
+    Ok(())
+}

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -1,4 +1,9 @@
 //! Lightweight, Rust-native LLM harness for application-facing agent workflows.
 //!
-//! The crate is currently a scaffold. Its planned architecture and boundaries
-//! are documented in the crate-level `AGENTS.md`.
+//! The crate provides a provider-neutral model contract and model adapters.
+
+mod model;
+mod qwen;
+
+pub use model::{Model, ModelError, ModelRequest, ModelResponse};
+pub use qwen::{Qwen, QwenConfig};

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -1,0 +1,117 @@
+use std::error::Error;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+/// A model backend that completes provider-neutral requests.
+#[async_trait]
+pub trait Model: Send + Sync {
+    /// Completes one model request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] when the provider request fails or its response
+    /// cannot be converted to the provider-neutral response.
+    async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError>;
+}
+
+/// Provider-neutral input for one model request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ModelRequest {
+    prompt: String,
+}
+
+impl ModelRequest {
+    /// Creates a text-only model request.
+    pub fn text(prompt: impl Into<String>) -> Self {
+        Self {
+            prompt: prompt.into(),
+        }
+    }
+
+    /// Returns the request prompt.
+    pub fn prompt(&self) -> &str {
+        &self.prompt
+    }
+}
+
+/// Provider-neutral output from one model request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ModelResponse {
+    text: String,
+}
+
+impl ModelResponse {
+    /// Creates a text-only model response.
+    pub fn from_text(text: impl Into<String>) -> Self {
+        Self { text: text.into() }
+    }
+
+    /// Returns the model's response text.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+}
+
+/// Failure returned while completing a model request.
+#[derive(Debug, Error)]
+pub enum ModelError {
+    /// The provider request or response decoding failed.
+    #[error("model request failed: {0}")]
+    Request(#[source] Box<dyn Error + Send + Sync>),
+    /// The provider returned a successful response without assistant text.
+    #[error("model returned no response text")]
+    InvalidResponse,
+}
+
+impl ModelError {
+    pub(crate) fn request(error: impl Error + Send + Sync + 'static) -> Self {
+        Self::Request(Box::new(error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use super::*;
+
+    #[test]
+    fn text_request_contains_prompt() {
+        // Arrange and Act
+        let request = ModelRequest::text("hello");
+
+        // Assert
+        assert_eq!(request.prompt(), "hello");
+    }
+
+    #[test]
+    fn text_response_exposes_text() {
+        // Arrange and Act
+        let response = ModelResponse::from_text("hello");
+
+        // Assert
+        assert_eq!(response.text(), "hello");
+    }
+
+    #[test]
+    fn invalid_response_error_has_user_facing_message() {
+        // Arrange and Act
+        let message = ModelError::InvalidResponse.to_string();
+
+        // Assert
+        assert_eq!(message, "model returned no response text");
+    }
+
+    #[test]
+    fn request_error_includes_source_message() {
+        // Arrange
+        let source = io::Error::other("connection refused");
+
+        // Act
+        let message = ModelError::request(source).to_string();
+
+        // Assert
+        assert_eq!(message, "model request failed: connection refused");
+    }
+}

--- a/crates/ag-harness/src/qwen.rs
+++ b/crates/ag-harness/src/qwen.rs
@@ -1,0 +1,311 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::model;
+
+const ERROR_BODY_LIMIT_BYTES: usize = 4 * 1024;
+const REQUEST_TIMEOUT: Duration = Duration::from_mins(1);
+
+/// Configuration for a Qwen model served through Alibaba Cloud Model Studio's
+/// OpenAI-compatible API.
+pub struct QwenConfig {
+    /// API key sent as a bearer token.
+    pub api_key: String,
+    /// API base URL ending in the OpenAI-compatible version path.
+    pub base_url: String,
+    /// Qwen model identifier sent with each request.
+    pub model: String,
+}
+
+/// Qwen implementation of the provider-neutral [`model::Model`] contract.
+pub struct Qwen {
+    client: reqwest::Client,
+    config: QwenConfig,
+}
+
+impl Qwen {
+    /// Creates a Qwen model adapter.
+    pub fn new(config: QwenConfig) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            config,
+        }
+    }
+
+    fn endpoint(&self) -> String {
+        format!(
+            "{}/chat/completions",
+            self.config.base_url.trim_end_matches('/')
+        )
+    }
+
+    async fn error_body_summary(
+        response: &mut reqwest::Response,
+    ) -> Result<String, reqwest::Error> {
+        let mut body = Vec::new();
+        let mut is_truncated = false;
+
+        while let Some(chunk) = response.chunk().await? {
+            let remaining = ERROR_BODY_LIMIT_BYTES.saturating_sub(body.len());
+
+            if chunk.len() > remaining {
+                body.extend_from_slice(&chunk[..remaining]);
+                is_truncated = true;
+
+                break;
+            }
+
+            body.extend_from_slice(&chunk);
+        }
+
+        let mut summary = String::from_utf8_lossy(&body)
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        if is_truncated {
+            summary.push_str(" ...");
+        }
+
+        Ok(summary)
+    }
+}
+
+#[async_trait]
+impl model::Model for Qwen {
+    async fn complete(
+        &self,
+        request: model::ModelRequest,
+    ) -> Result<model::ModelResponse, model::ModelError> {
+        let payload = QwenRequest {
+            messages: [QwenMessage {
+                content: request.prompt(),
+                role: "user",
+            }],
+            model: &self.config.model,
+        };
+
+        let mut response = self
+            .client
+            .post(self.endpoint())
+            .bearer_auth(&self.config.api_key)
+            .timeout(REQUEST_TIMEOUT)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(model::ModelError::request)?;
+
+        if let Err(source) = response.error_for_status_ref() {
+            let body = Self::error_body_summary(&mut response)
+                .await
+                .map_err(model::ModelError::request)?;
+            let error = QwenHttpError {
+                body,
+                source,
+                status: response.status(),
+            };
+
+            return Err(model::ModelError::request(error));
+        }
+
+        let response = response
+            .json::<QwenResponse>()
+            .await
+            .map_err(model::ModelError::request)?;
+
+        let text = response
+            .choices
+            .into_iter()
+            .next()
+            .and_then(|choice| choice.message.content)
+            .ok_or(model::ModelError::InvalidResponse)?;
+
+        Ok(model::ModelResponse::from_text(text))
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Qwen returned HTTP {status}: {body}")]
+struct QwenHttpError {
+    body: String,
+    #[source]
+    source: reqwest::Error,
+    status: reqwest::StatusCode,
+}
+
+#[derive(Serialize)]
+struct QwenRequest<'a> {
+    messages: [QwenMessage<'a>; 1],
+    model: &'a str,
+}
+
+#[derive(Serialize)]
+struct QwenMessage<'a> {
+    content: &'a str,
+    role: &'static str,
+}
+
+#[derive(Deserialize)]
+struct QwenResponse {
+    choices: Vec<QwenChoice>,
+}
+
+#[derive(Deserialize)]
+struct QwenChoice {
+    message: QwenResponseMessage,
+}
+
+#[derive(Deserialize)]
+struct QwenResponseMessage {
+    content: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use wiremock::matchers::{bearer_token, body_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+    use crate::Model;
+
+    fn qwen(server: &MockServer) -> Qwen {
+        Qwen::new(QwenConfig {
+            api_key: "test-key".to_string(),
+            base_url: format!("{}/", server.uri()),
+            model: "qwen-plus".to_string(),
+        })
+    }
+
+    #[tokio::test]
+    async fn completes_text_request() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(bearer_token("test-key"))
+            .and(body_json(json!({
+                "messages": [{"content": "hello", "role": "user"}],
+                "model": "qwen-plus"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{"message": {"content": "Hello!"}}]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let model = qwen(&server);
+
+        // Act
+        let response = model
+            .complete(model::ModelRequest::text("hello"))
+            .await
+            .expect("Qwen request should succeed");
+
+        // Assert
+        assert_eq!(response.text(), "Hello!");
+    }
+
+    #[tokio::test]
+    async fn rejects_successful_response_without_text() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": []
+            })))
+            .mount(&server)
+            .await;
+        let model = qwen(&server);
+
+        // Act
+        let error = model
+            .complete(model::ModelRequest::text("hello"))
+            .await
+            .expect_err("missing response text should fail");
+
+        // Assert
+        assert!(matches!(error, model::ModelError::InvalidResponse));
+    }
+
+    #[tokio::test]
+    async fn returns_request_error_for_http_failure() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": {"message": "invalid API key"}
+            })))
+            .mount(&server)
+            .await;
+        let model = qwen(&server);
+
+        // Act
+        let error = model
+            .complete(model::ModelRequest::text("hello"))
+            .await
+            .expect_err("HTTP failure should fail");
+
+        // Assert
+        assert_eq!(
+            error.to_string(),
+            "model request failed: Qwen returned HTTP 401 Unauthorized: \
+             {\"error\":{\"message\":\"invalid API key\"}}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bounds_http_error_body() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(500).set_body_string("x".repeat(ERROR_BODY_LIMIT_BYTES + 1)),
+            )
+            .mount(&server)
+            .await;
+        let model = qwen(&server);
+
+        // Act
+        let error = model
+            .complete(model::ModelRequest::text("hello"))
+            .await
+            .expect_err("HTTP failure should fail");
+        let message = error.to_string();
+
+        // Assert
+        assert_eq!(
+            message,
+            format!(
+                "model request failed: Qwen returned HTTP 500 Internal Server Error: {} ...",
+                "x".repeat(ERROR_BODY_LIMIT_BYTES)
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn returns_request_error_for_malformed_response() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not JSON"))
+            .mount(&server)
+            .await;
+        let model = qwen(&server);
+
+        // Act
+        let error = model
+            .complete(model::ModelRequest::text("hello"))
+            .await
+            .expect_err("malformed response should fail");
+
+        // Assert
+        assert!(matches!(error, model::ModelError::Request(_)));
+    }
+}

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -41,6 +41,10 @@ agentty/
 │   ├── ag-harness-core       # loop, tools, sessions, context, storage
 ```
 
+The current foundation lives entirely in `ag-harness`: the provider-neutral `Model`
+contract accepts a text `ModelRequest` and returns a text `ModelResponse`. `Qwen` is its
+first adapter and uses the OpenAI-compatible Chat Completions API.
+
 ## Session management
 
 - One host process manages multiple independent sessions.
@@ -113,7 +117,21 @@ sequenceDiagram
 
 ## Structured output
 
-The harness uses structured input and output to communicate with models.
+The next model-contract iteration evolves the current text-only response into
+provider-neutral structured output:
+
+- The caller supplies the expected JSON shape as a provider-independent schema.
+- Each adapter uses the strongest structured-output mechanism its provider supports,
+  then the harness parses and validates the returned JSON against the caller's schema.
+- Provider-specific request fields remain inside the adapter. For Qwen, the adapter uses
+  JSON Object mode and performs schema validation in the harness because Qwen guarantees
+  valid JSON, not schema conformance.
+- Every new model adapter must implement these structured-output semantics before it is
+  added.
+
+Configurations that cannot satisfy the contract, such as Qwen thinking mode, return an
+explicit unsupported-configuration error rather than silently falling back to
+unstructured text.
 
 ## Permissions
 
@@ -158,11 +176,12 @@ best cost and performance:
 
 ## Next iterations
 
-1. **Model round trip.** Integrate one Qwen model API and complete a typed
-   prompt-response flow.
+1. **Structured model output.** Add the provider-neutral schema contract, Qwen JSON
+   Object mode translation, parsing, validation, and typed errors described above.
 1. **Tool round trip.** Support one model-requested tool through execution to the final
    response.
-1. **Second provider.** Integrate another model API through the same contract.
+1. **Second provider.** Integrate another model API through the structured-output
+   contract.
 
 ## Roadmap
 

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -30,9 +30,9 @@ For file-level detail, read the module docstrings directly.
 - `crates/ag-git/`: Shared git library crate with worktree creation, repository
   metadata, commit/diff/push/pull sync, rebase/conflict handling, and squash-merge
   workflows behind the `GitClient` boundary.
-- `crates/ag-harness/`: Planned application-facing LLM harness facade. The crate is
-  currently a scaffold; its local `AGENTS.md` records the intended agent loop, tools,
-  session, event, and permission boundaries.
+- `crates/ag-harness/`: Application-facing LLM harness crate with the provider-neutral
+  `Model` contract and its first Qwen adapter. Its local `AGENTS.md` records the
+  intended agent loop, tools, session, event, and permission boundaries.
 - `crates/ag-protocol/`: Shared structured response protocol library crate with
   transport-neutral response models, schema generation, parser diagnostics, protocol
   prompt envelopes, repair prompts, review-comment outcomes, and turn prompt payload


### PR DESCRIPTION
- Define a provider-neutral text request and response contract.
- Implement Qwen Chat Completions requests with validation and bounded error summaries.
- Add WireMock coverage, an example, dependencies, and a source-test hook.
- Update harness architecture documentation for the first adapter.
- Document the Qwen adapter and structured-output roadmap in harness architecture guidance.
- Add workspace dependencies and lockfile updates.
- Resolve the rebase conflict and repair the rebased lockfile.