### PR TITLE
Parse Claude structured output responses

### DIFF
--- a/crates/ag-agent/src/agent/response_parser.rs
+++ b/crates/ag-agent/src/agent/response_parser.rs
@@ -16,6 +16,7 @@ pub(crate) struct ParsedResponse {
 #[derive(Deserialize)]
 struct ClaudeResponse {
     result: Option<String>,
+    structured_output: Option<serde_json::Value>,
     usage: Option<ClaudeUsage>,
 }
 
@@ -140,10 +141,11 @@ pub(super) fn parse_antigravity_stream_output_line(_stdout_line: &str) -> Option
 
 /// Parses one full Claude turn payload from stream-json stdout.
 ///
-/// Prefers the final non-empty `result` field when present. When Claude emits
-/// an empty or missing `result` field (observed in some stream-json runs), this
-/// falls back to the latest assistant stream message content so callers still
-/// receive the assistant reply instead of raw NDJSON.
+/// Prefers the final schema-validated `structured_output` or non-empty
+/// `result` field when present. When Claude emits neither field (observed in
+/// some stream-json runs), this falls back to the latest assistant stream
+/// message content so callers still receive the assistant reply instead of
+/// raw NDJSON.
 fn parse_claude_response(stdout: &str) -> Option<ParsedResponse> {
     let trimmed_stdout = stdout.trim();
     if trimmed_stdout.is_empty() {
@@ -499,7 +501,10 @@ pub(super) fn parse_codex_stream_output_line(stdout_line: &str) -> Option<(Strin
 
 fn parse_claude_response_payload(stdout: &str) -> Option<ParsedResponse> {
     let response = serde_json::from_str::<ClaudeResponse>(stdout).ok()?;
-    let content = response.result?;
+    let content = response
+        .structured_output
+        .map(|structured_output| structured_output.to_string())
+        .or(response.result)?;
     let stats = SessionStats {
         added_lines: 0,
         deleted_lines: 0,
@@ -605,12 +610,13 @@ fn extract_gemini_stream_stats(stdout_line: &str) -> Option<SessionStats> {
 /// result text and usage stats.
 ///
 /// Newer CLI variants can emit one JSON array containing init/assistant/result
-/// events rather than one flat object. This parser keeps the latest non-empty
-/// `result` string when present, otherwise falls back to assistant message
-/// text.
+/// events rather than one flat object. This parser keeps the latest
+/// schema-validated `structured_output` value, then the latest non-empty
+/// `result` string, and otherwise falls back to assistant message text.
 fn parse_claude_response_array_payload(stdout: &str) -> Option<ParsedResponse> {
     let events = serde_json::from_str::<serde_json::Value>(stdout).ok()?;
     let events = events.as_array()?;
+    let mut latest_structured_output_content: Option<String> = None;
     let mut latest_result_content: Option<String> = None;
     let mut latest_assistant_content: Option<String> = None;
     let mut latest_stats: Option<SessionStats> = None;
@@ -626,12 +632,20 @@ fn parse_claude_response_array_payload(stdout: &str) -> Option<ParsedResponse> {
             latest_result_content = Some(result_content.to_string());
         }
 
+        if let Some(structured_output) = event.get("structured_output")
+            && !structured_output.is_null()
+        {
+            latest_structured_output_content = Some(structured_output.to_string());
+        }
+
         if let Some(assistant_content) = extract_claude_stream_assistant_content(event) {
             latest_assistant_content = Some(assistant_content);
         }
     }
 
-    let content = latest_result_content.or(latest_assistant_content)?;
+    let content = latest_structured_output_content
+        .or(latest_result_content)
+        .or(latest_assistant_content)?;
     let stats = latest_stats.unwrap_or_default();
 
     Some(ParsedResponse { content, stats })
@@ -901,6 +915,27 @@ mod tests {
     }
 
     #[test]
+    fn test_claude_parse_response_reads_structured_output_payload() {
+        // Arrange
+        let stdout = concat!(
+            r#"{"type":"result","subtype":"success","result":"","structured_output":"#,
+            r#"{"answer":"Rendered response","questions":[],"summary":null},"#,
+            r#""usage":{"input_tokens":13,"output_tokens":9}}"#
+        );
+
+        // Act
+        let parsed = parse_claude_response_with_fallback(stdout, "");
+
+        // Assert
+        assert_eq!(
+            parsed.content,
+            r#"{"answer":"Rendered response","questions":[],"summary":null}"#
+        );
+        assert_eq!(parsed.stats.input_tokens, 13);
+        assert_eq!(parsed.stats.output_tokens, 9);
+    }
+
+    #[test]
     fn test_gemini_parse_response_reads_legacy_usage() {
         // Arrange
         let stdout = r#"{"response":"Planned response","stats":{"models":{"gemini":{"tokens":{"input":11,"candidates":7}}}}}"#;
@@ -1015,6 +1050,28 @@ mod tests {
         );
         assert_eq!(parsed.stats.input_tokens, 5);
         assert_eq!(parsed.stats.output_tokens, 3);
+    }
+
+    #[test]
+    fn test_claude_parse_response_reads_structured_output_from_json_array_payload() {
+        // Arrange
+        let stdout = concat!(
+            r#"[{"type":"system","subtype":"init"},"#,
+            r#"{"type":"result","subtype":"success","result":"","structured_output":"#,
+            r#"{"answer":"Array response","questions":[],"summary":null},"#,
+            r#""usage":{"input_tokens":7,"output_tokens":4}}]"#
+        );
+
+        // Act
+        let parsed = parse_claude_response_with_fallback(stdout, "");
+
+        // Assert
+        assert_eq!(
+            parsed.content,
+            r#"{"answer":"Array response","questions":[],"summary":null}"#
+        );
+        assert_eq!(parsed.stats.input_tokens, 7);
+        assert_eq!(parsed.stats.output_tokens, 4);
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -952,6 +952,9 @@ const PROTOCOL_FAILURE_PAYLOAD_FILLER: &str = "not-json-filler";
 /// report why the payload was rejected without reproducing the payload.
 const PROTOCOL_FAILURE_TAIL_MARKER: &str = "TAILOFPAYLOAD";
 
+/// Answer returned through Claude's schema-validated result field.
+const CLAUDE_STRUCTURED_RESPONSE_TEXT: &str = "Claude structured response rendered";
+
 /// Installs a Claude stub whose final payload is not protocol JSON.
 ///
 /// The payload is far longer than the excerpt budget and carries a marker at
@@ -972,6 +975,32 @@ if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
 cat > /dev/null 2>&1
 printf '%s\n' '{{"type":"system","subtype":"init"}}'
 printf '%s\n' '{{"type":"result","subtype":"success","result":"{payload}"}}'
+"#
+    );
+    std::fs::write(&claude_path, script)?;
+
+    #[cfg(unix)]
+    std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o755))?;
+
+    seed_project_settings(env, &[("DefaultSmartModel", "claude-haiku-4-5-20251001")])?;
+
+    Ok(())
+}
+
+/// Installs a Claude stub that returns its final protocol reply through
+/// `structured_output`, matching current Claude Code schema-validated turns.
+fn seed_claude_structured_output_project(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let claude_path = env.stub_bin.join("claude");
+    let script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
+cat > /dev/null 2>&1
+printf '%s\n' '{{"type":"system","subtype":"init"}}'
+printf '%s\n' '{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"tool_use","name":"StructuredOutput","input":{{"answer":"{CLAUDE_STRUCTURED_RESPONSE_TEXT}"}}}}]}}}}'
+printf '%s\n' '{{"type":"result","subtype":"success","result":"","structured_output":{{"answer":"{CLAUDE_STRUCTURED_RESPONSE_TEXT}","questions":[],"summary":null}},"usage":{{"input_tokens":8,"output_tokens":6}}}}'
 "#
     );
     std::fs::write(&claude_path, script)?;
@@ -1964,6 +1993,45 @@ fn test_session_invalid_protocol_output_is_bounded() -> E2eResult {
                 assertion::assert_text_in_region(frame, "embedded_json_candidate", &full);
                 assertion::assert_not_visible(frame, PROTOCOL_FAILURE_TAIL_MARKER);
                 assertion::assert_not_visible(frame, PROTOCOL_FAILURE_PAYLOAD_FILLER);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that schema-validated Claude results render their final answer
+/// instead of leaving a transient structured-output tool event in chat.
+#[test]
+fn test_claude_structured_output_response() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("claude_structured_output_response")
+        .with_git()
+        .setup(seed_claude_structured_output_project)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("Return a structured response")
+                    .wait_for_text("Return a structured response", 3000)
+                    .press_key("Enter")
+                    .wait_for_text(CLAUDE_STRUCTURED_RESPONSE_TEXT, 30000)
+                    .capture_labeled(
+                        "structured_response",
+                        "Claude schema-validated response renders in chat",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, CLAUDE_STRUCTURED_RESPONSE_TEXT, &full);
+                assertion::assert_not_visible(
+                    frame,
+                    "Agent output did not match the required JSON schema",
+                );
+                assertion::assert_not_visible(frame, "Working: tool use");
             },
         )?;
 

--- a/docs/site/content/docs/agents/backends.md
+++ b/docs/site/content/docs/agents/backends.md
@@ -72,6 +72,10 @@ describes subscription OAuth as intended for Claude Code and native Anthropic
 applications, while developer integrations should use API keys or supported cloud
 providers.
 
+Claude turns use the CLI's schema-validated structured result for the final chat
+response. Tool-use events remain transient progress updates and are replaced by the
+validated answer when the turn completes.
+
 If Claude session turns or utility prompts fail with `authentication_error`,
 `Failed to authenticate`, or `OAuth token has expired`, refresh the CLI session and
 retry:

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -395,7 +395,9 @@ optional `summary`):
    empty; review-comment prompts provide the only accepted thread-ID allowlist.
 1. Final output must parse as the shared protocol JSON object. Claude, Gemini, and Codex
    session turns fail closed on invalid output; Antigravity tries one protocol-repair
-   retry and then preserves non-empty plain text as `answer`.
+   retry and then preserves non-empty plain text as `answer`. Claude result events
+   prefer the schema-validated `structured_output` value over the legacy string-valued
+   `result` field before protocol parsing.
 1. Turn errors are rendered into the session transcript, so no failure surface
    reproduces provider output. A rejected payload surfaces the parse reason plus
    *derived* diagnostics only (response sizing, parser location, visible top-level


### PR DESCRIPTION
- Prefer schema-validated `structured_output` over legacy `result` and assistant fallback.
- Add unit and E2E coverage for structured responses.
- Document Claude’s structured result handling and precedence.