### PR TITLE
Add Claude Opus 5 model support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- agentty: add `claude-opus-5` to the Claude model picker.
+
 ## [v0.13.6] - 2026-07-22
 
 ### Added

--- a/crates/ag-agent/src/agent/claude.rs
+++ b/crates/ag-agent/src/agent/claude.rs
@@ -234,6 +234,40 @@ mod tests {
     }
 
     #[test]
+    /// Verifies Claude commands pass the selected Opus 5 model through the
+    /// Claude Code model environment variable.
+    fn test_claude_command_sets_anthropic_model_to_claude_opus_5() {
+        // Arrange
+        let temp_directory = tempdir().expect("failed to create temp dir");
+        let backend = ClaudeBackend;
+
+        // Act
+        let command = AgentBackend::build_command(
+            &backend,
+            BuildCommandRequest {
+                attachments: &[],
+                folder: temp_directory.path(),
+                main_checkout_root: None,
+                replay_transcript: None,
+                model: "claude-opus-5",
+                personality_prompt: None,
+                prompt: "Use Opus",
+                reasoning_level: ReasoningLevel::default(),
+                request_kind: &session_start_request_kind(),
+            },
+        )
+        .expect("command should build");
+        let anthropic_model = command
+            .get_envs()
+            .find(|(key, _value)| *key == OsStr::new("ANTHROPIC_MODEL"))
+            .and_then(|(_key, value)| value)
+            .map(|value| value.to_string_lossy().into_owned());
+
+        // Assert
+        assert_eq!(anthropic_model, Some("claude-opus-5".to_string()));
+    }
+
+    #[test]
     /// Verifies Claude commands pass the selected Opus 4.8 model through the
     /// Claude Code model environment variable.
     fn test_claude_command_sets_anthropic_model_to_claude_opus_48() {

--- a/crates/ag-agent/src/model/agent.rs
+++ b/crates/ag-agent/src/model/agent.rs
@@ -102,6 +102,8 @@ pub enum AgentModel {
     Gemini31ProPreview,
     /// Codex spark model backed by `gpt-5.3-codex-spark`.
     Gpt53CodexSpark,
+    /// Claude Opus model backed by `claude-opus-5`.
+    ClaudeOpus5,
     /// Claude Opus model backed by `claude-opus-4-8`.
     ClaudeOpus48,
     /// Claude Sonnet model backed by `claude-sonnet-5`.
@@ -187,6 +189,7 @@ impl AgentModel {
             Self::Gemini35FlashLite => "gemini-3.5-flash-lite",
             Self::Gemini31ProPreview => "gemini-3.1-pro-preview",
             Self::Gpt53CodexSpark => "gpt-5.3-codex-spark",
+            Self::ClaudeOpus5 => "claude-opus-5",
             Self::ClaudeOpus48 => "claude-opus-4-8",
             Self::ClaudeSonnet5 => "claude-sonnet-5",
             Self::ClaudeFable5 => "claude-fable-5",
@@ -442,8 +445,8 @@ impl ReasoningLevel {
     /// Returns the Claude `--effort` value for this level.
     ///
     /// Maps `XHigh` and `Max` to `"max"`, which is currently only supported on
-    /// `claude-opus-4-8`. The Claude CLI enforces this restriction and will
-    /// surface an error for other models.
+    /// `claude-opus-5` and `claude-opus-4-8`. The Claude CLI enforces this
+    /// restriction and will surface an error for other models.
     pub fn claude(self) -> &'static str {
         match self {
             Self::Low => "low",
@@ -494,6 +497,7 @@ impl FromStr for AgentModel {
             "gpt-5.6-luna" => Ok(Self::Gpt56Luna),
             "gpt-5.5" => Ok(Self::Gpt55),
             "gpt-5.3-codex-spark" => Ok(Self::Gpt53CodexSpark),
+            "claude-opus-5" => Ok(Self::ClaudeOpus5),
             "claude-opus-4-8" => Ok(Self::ClaudeOpus48),
             "claude-sonnet-5" => Ok(Self::ClaudeSonnet5),
             "claude-fable-5" => Ok(Self::ClaudeFable5),
@@ -521,7 +525,8 @@ impl AgentSelectionMetadata for AgentModel {
             Self::Gpt56Luna => "Current Codex model for lighter coding iterations.",
             Self::Gpt55 => "Newer Codex model with stronger coding performance when available.",
             Self::Gpt53CodexSpark => "Codex spark model for quick coding iterations.",
-            Self::ClaudeOpus48 => "Latest Claude Opus model for complex tasks.",
+            Self::ClaudeOpus5 => "Latest Claude Opus model for complex tasks.",
+            Self::ClaudeOpus48 => "Claude Opus 4.8 model for complex tasks.",
             Self::ClaudeSonnet5 => "Balanced Claude model for quality and latency.",
             Self::ClaudeFable5 => "Claude Fable model for creative, narrative-heavy tasks.",
             Self::ClaudeHaiku4520251001 => "Fast Claude model for lighter tasks.",
@@ -582,6 +587,7 @@ impl AgentKind {
         ];
         const CLAUDE_MODELS: &[AgentModel] = &[
             AgentModel::ClaudeFable5,
+            AgentModel::ClaudeOpus5,
             AgentModel::ClaudeOpus48,
             AgentModel::ClaudeSonnet5,
             AgentModel::ClaudeHaiku4520251001,
@@ -794,14 +800,28 @@ mod tests {
         let claude_kind = AgentKind::Claude;
 
         // Act
+        let parsed_opus_5 = claude_kind.parse_model("claude-opus-5");
         let parsed_sonnet_5 = claude_kind.parse_model("claude-sonnet-5");
         let parsed_fable_5 = claude_kind.parse_model("claude-fable-5");
         let parsed_haiku_45 = claude_kind.parse_model("claude-haiku-4-5-20251001");
+        let opus_5_id = AgentModel::ClaudeOpus5.as_str();
+        let opus_5_description = AgentModel::ClaudeOpus5.description();
+        let opus_48_description = AgentModel::ClaudeOpus48.description();
 
         // Assert
+        assert_eq!(parsed_opus_5, Some(AgentModel::ClaudeOpus5));
         assert_eq!(parsed_sonnet_5, Some(AgentModel::ClaudeSonnet5));
         assert_eq!(parsed_fable_5, Some(AgentModel::ClaudeFable5));
         assert_eq!(parsed_haiku_45, Some(AgentModel::ClaudeHaiku4520251001));
+        assert_eq!(opus_5_id, "claude-opus-5");
+        assert_eq!(
+            opus_5_description,
+            "Latest Claude Opus model for complex tasks."
+        );
+        assert_eq!(
+            opus_48_description,
+            "Claude Opus 4.8 model for complex tasks."
+        );
     }
 
     #[test]
@@ -1003,6 +1023,7 @@ mod tests {
     fn test_claude_models_are_supported_by_claude() {
         // Arrange
         let models = [
+            AgentModel::ClaudeOpus5,
             AgentModel::ClaudeOpus48,
             AgentModel::ClaudeSonnet5,
             AgentModel::ClaudeFable5,
@@ -1014,8 +1035,8 @@ mod tests {
         let unsupported = models.map(|model| AgentKind::Codex.supports_model(model));
 
         // Assert
-        assert_eq!(supported, [true; 4]);
-        assert_eq!(unsupported, [false; 4]);
+        assert_eq!(supported, [true; 5]);
+        assert_eq!(unsupported, [false; 5]);
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -3646,6 +3646,49 @@ fn gemini_model_picker_lists_current_models() -> E2eResult {
     Ok(())
 }
 
+/// Verify that the prompt `/model` picker exposes the current Claude models
+/// when the Claude CLI is locally available.
+#[test]
+fn claude_model_picker_lists_current_models() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("claude_model_picker_lists_current_models")
+        .with_git()
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .wait_for_text("Regular", 5000)
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .press_key("/")
+                    .write_text("model")
+                    .wait_for_text("Slash Command", 3000)
+                    .press_key("Enter")
+                    .wait_for_text("/model Agent", 3000)
+                    .press_key("Down")
+                    .press_key("Down")
+                    .press_key("Enter")
+                    .wait_for_text("claude-opus-5", 3000)
+                    .capture_labeled(
+                        "claude_model_picker",
+                        "Claude model picker lists current models",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "claude-fable-5", &full);
+                assertion::assert_text_in_region(frame, "claude-opus-5", &full);
+                assertion::assert_text_in_region(frame, "claude-opus-4-8", &full);
+                assertion::assert_text_in_region(frame, "claude-sonnet-5", &full);
+                assertion::assert_text_in_region(frame, "claude-haiku-4-5-20251001", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
 /// Verify that the prompt `/model` picker exposes the current Codex models in
 /// the expected order.
 #[test]

--- a/docs/site/content/docs/agents/backends.md
+++ b/docs/site/content/docs/agents/backends.md
@@ -148,7 +148,7 @@ unless a session-specific override is active. Antigravity receives `--effort low
 `--effort medium`, or `--effort high`; `xhigh` and `max` map to its highest supported
 value, `--effort high`. Codex receives `max` as a distinct reasoning effort. For Claude,
 both `xhigh` and `max` map to `--effort max`, which is currently only supported by
-`claude-opus-4-8`.
+`claude-opus-5` and `claude-opus-4-8`.
 
 ## Available Models
 
@@ -167,7 +167,8 @@ Both providers share the same Gemini model ids:
 ### Claude Models
 
 - `claude-fable-5` (default): Claude Fable model for creative, narrative-heavy tasks.
-- `claude-opus-4-8`: Latest Claude Opus model for complex tasks.
+- `claude-opus-5`: Latest Claude Opus model for complex tasks.
+- `claude-opus-4-8`: Claude Opus 4.8 model for complex tasks.
 - `claude-sonnet-5`: Balanced Claude model for quality and latency.
 - `claude-haiku-4-5-20251001`: Fast Claude model for lighter tasks.
 


### PR DESCRIPTION
- Supports `claude-opus-5` in Claude model selection and command execution.
- Covers model parsing, metadata, command environment, and picker behavior with tests.
- Documents the new model and max-effort support.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)