### PR TITLE
Keep Esc from ending question turns

### DIFF
--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -22,12 +22,10 @@ const NO_ANSWER: &str = "no answer";
 /// `Tab` toggles focus between the question panel and the chat output for
 /// scrolling. When chat is focused, scroll keys (`j`/`k`/`Up`/`Down`/`g`/`G`/
 /// `Ctrl+d`/`Ctrl+u`) navigate the session transcript. `Enter` submits the
-/// typed answer (or `no answer` when blank), `Ctrl+C` and `Esc` end the
-/// entire turn without sending a reply while the answer input is focused
-/// (`Esc` additionally requires no open at-mention dropdown, so it stays
-/// available to dismiss that overlay; chat focus keeps both keys from ending
-/// the turn), and `q` returns to the sessions list while saving already-
-/// submitted answers for the next visit
+/// typed answer (or `no answer` when blank), `Ctrl+C` ends the entire turn
+/// without sending a reply while the answer input is focused, `Esc` dismisses
+/// an open at-mention dropdown without ending the turn, and `q` returns to the
+/// sessions list while saving already-submitted answers for the next visit
 /// (skipped while the user is actively typing a free-text answer so the
 /// character can still be inserted into the response).
 pub(crate) async fn handle_with_cache(
@@ -55,12 +53,6 @@ pub(crate) async fn handle_with_cache(
     }
 
     if is_active_at_mention(app) && handle_at_mention_key(app, key) {
-        return EventResult::Continue;
-    }
-
-    if is_plain_esc(key) {
-        end_turn_no_answer(app).await;
-
         return EventResult::Continue;
     }
 
@@ -95,11 +87,6 @@ fn is_answer_input_focused(app: &App) -> bool {
             ..
         }
     )
-}
-
-/// Returns whether `key` is an unmodified `Esc` press.
-fn is_plain_esc(key: KeyEvent) -> bool {
-    matches!(key.code, KeyCode::Esc) && key.modifiers.is_empty()
 }
 
 /// Returns whether `key` is a plain `q` press without modifiers.
@@ -1130,17 +1117,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_escape_ends_turn_and_transitions_to_view() {
-        // Arrange — answer focus with no at-mention overlay. Esc must mirror
-        // Ctrl+C and cancel the question turn without sending a reply.
+    async fn test_handle_escape_preserves_question_turn_and_draft() {
+        // Arrange
         let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
-        app.review_cache.insert(
-            "session-esc".into(),
-            crate::app::ReviewCacheEntry::Ready {
-                text: "Focused review".to_string(),
-                diff_hash: 42,
-            },
-        );
         app.mode = AppMode::Question {
             at_mention_state: None,
             session_id: "session-esc".into(),
@@ -1164,13 +1143,17 @@ mod tests {
         )
         .await;
 
-        // Assert — transitions to View mode with no reply sent.
+        // Assert
         assert!(matches!(
             app.mode,
-            AppMode::View {
+            AppMode::Question {
                 ref session_id,
+                ref input,
+                ref responses,
                 ..
             } if session_id == "session-esc"
+                && input.text() == "partial answer"
+                && responses.is_empty()
         ));
     }
 

--- a/crates/agentty/src/ui/layout.rs
+++ b/crates/agentty/src/ui/layout.rs
@@ -1175,7 +1175,7 @@ mod tests {
         );
         assert_eq!(
             answer_focus_line.to_string(),
-            "Tab: focus | Enter: send | Esc/Ctrl+C: end turn"
+            "Tab: focus | Enter: send | Ctrl+C: end turn"
         );
     }
 
@@ -1184,9 +1184,8 @@ mod tests {
         // Arrange — answer focus while navigating predefined options. The
         // runtime accepts plain `q` as an exit-to-list shortcut here, so the
         // footer must surface it. The at-mention overlay variant is also
-        // covered here so the footer swaps `Esc` to a dedicated cancel hint
-        // and drops it from the end-turn label whenever the dropdown owns the
-        // key, matching runtime behavior.
+        // covered here so the footer surfaces `Esc` as a dedicated cancel
+        // hint without advertising it as an end-turn shortcut.
 
         // Act
         let answer_focus_with_options =
@@ -1197,7 +1196,7 @@ mod tests {
         // Assert
         assert_eq!(
             answer_focus_with_options,
-            "Tab: focus | Enter: send | q: sessions | Esc/Ctrl+C: end turn"
+            "Tab: focus | Enter: send | q: sessions | Ctrl+C: end turn"
         );
         assert_eq!(
             answer_focus_with_overlay,

--- a/crates/agentty/src/ui/page/session_chat.rs
+++ b/crates/agentty/src/ui/page/session_chat.rs
@@ -545,7 +545,7 @@ fn render_question_panel(f: &mut Frame, bottom_area: Rect, state: &QuestionPanel
     } else {
         ("", 0)
     };
-    let input_placeholder = "Type answer (Enter: send, Esc: end turn)";
+    let input_placeholder = "Type answer";
     let at_mention_max_visible =
         layout::question_at_mention_max_visible(bottom_area, panel_areas.input_area, 10);
     let at_mention_menu = if is_free_text_mode {
@@ -589,8 +589,8 @@ fn render_question_panel(f: &mut Frame, bottom_area: Rect, state: &QuestionPanel
 /// `is_navigating_options` mirrors the runtime predicate that treats plain `q`
 /// as a sessions-list shortcut, so the footer can surface it whenever the
 /// shortcut is actually wired up. `is_at_mention_open` mirrors the runtime
-/// predicate that routes `Esc` to the at-mention dropdown so the end-turn
-/// hint can swap out while the overlay is visible.
+/// predicate that routes `Esc` to the at-mention dropdown so the footer can
+/// add a separate `Esc: cancel @` hint while the overlay is visible.
 fn render_question_help_footer(
     f: &mut Frame,
     area: Rect,

--- a/crates/agentty/src/ui/question_format.rs
+++ b/crates/agentty/src/ui/question_format.rs
@@ -88,8 +88,8 @@ pub(crate) fn question_option_lines(
 /// `q: Sessions` hint is surfaced whenever that predicate is satisfied so the
 /// shortcut stays discoverable in answer focus too, not only in chat focus.
 /// `is_at_mention_open` mirrors the runtime predicate that routes `Esc` to the
-/// at-mention dropdown dismissal, so the end-turn hint drops the `Esc` prefix
-/// and a `Esc: cancel @` hint is surfaced while the dropdown is visible.
+/// at-mention dropdown dismissal, so an `Esc: cancel @` hint is surfaced while
+/// the dropdown is visible.
 ///
 /// Footer entries follow the canonical composer-footer ordering shared with
 /// prompt mode: the `Tab` focus toggle first as the stable anchor, then the
@@ -120,16 +120,10 @@ pub fn question_help_footer_line(
     if !is_chat_focused {
         if is_at_mention_open {
             help_actions.push(help_action::HelpAction::new("cancel @", "Esc", "Cancel @"));
-            help_actions.push(help_action::HelpAction::new(
-                "end turn", "Ctrl+C", "End turn",
-            ));
-        } else {
-            help_actions.push(help_action::HelpAction::new(
-                "end turn",
-                "Esc/Ctrl+C",
-                "End turn",
-            ));
         }
+        help_actions.push(help_action::HelpAction::new(
+            "end turn", "Ctrl+C", "End turn",
+        ));
     }
 
     crate::ui::help_format::footer_line(&help_actions)

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -2917,9 +2917,9 @@ fn session_stop_turn_returns_to_review() -> E2eResult {
     Ok(())
 }
 
-/// Verify that answering one clarification question, leaving question mode
-/// with `q`, and reopening the session resumes at the next unanswered
-/// question instead of restarting from the first.
+/// Verify that `Esc` leaves a clarification question active, then answering
+/// one question, leaving with `q`, and reopening resumes at the next
+/// unanswered question instead of restarting from the first.
 #[test]
 fn session_question_resume_after_leaving_to_list() -> E2eResult {
     // Arrange
@@ -2939,6 +2939,11 @@ fn session_question_resume_after_leaving_to_list() -> E2eResult {
                     .capture_labeled(
                         "answer_focused",
                         "Question mode starts with the answer input focused",
+                    )
+                    .press_key("Escape")
+                    .wait_for_text(
+                        "Tab: focus | Enter: send | q: sessions | Ctrl+C: end turn",
+                        5000,
                     )
                     .press_key("Tab")
                     .wait_for_text("j/k: scroll", 5000)
@@ -2967,7 +2972,7 @@ fn session_question_resume_after_leaving_to_list() -> E2eResult {
                     Region::full(answer_focused_frame.cols(), answer_focused_frame.rows());
                 assertion::assert_text_in_region(
                     &answer_focused_frame,
-                    "Tab: focus | Enter: send | q: sessions | Esc/Ctrl+C: end turn",
+                    "Tab: focus | Enter: send | q: sessions | Ctrl+C: end turn",
                     &answer_focused_full,
                 );
 

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -339,7 +339,6 @@ exist:
 | `Alt+Enter` / `Shift+Enter`      | Insert newline                       |
 | `Ctrl+J` / `Ctrl+M`              | Insert newline (terminal fallback)   |
 | `Ctrl+C`                         | End turn without answering           |
-| `Esc`                            | End turn without answering           |
 | `Left` / `Right` / `Up` / `Down` | Move cursor                          |
 | `Backspace` / `Delete`           | Delete character                     |
 | `Home` / `End`                   | Move to start / end                  |


### PR DESCRIPTION
- Preserve the active question and draft when `Esc` is pressed.
- Show `Ctrl+C` as the end-turn shortcut and remove stale `Esc` hints.
- Cover question-mode resume behavior in the E2E test.