### PR TITLE
Retire obsolete model ids and migrate active sessions

### DIFF
--- a/crates/ag-agent/src/agent/app_server/codex/client.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/client.rs
@@ -126,7 +126,7 @@ mod tests {
         let folder = std::env::temp_dir().join(format!(
             "agentty-codex-runtime-state-{thread_id}-{latest_input_tokens}"
         ));
-        let mut state = CodexRuntimeState::new(folder, AgentModel::Gpt55.as_str().to_string());
+        let mut state = CodexRuntimeState::new(folder, AgentModel::Gpt56Sol.as_str().to_string());
         state.thread_id = thread_id.to_string();
         state.latest_input_tokens = latest_input_tokens;
 
@@ -179,7 +179,7 @@ mod tests {
         let gpt_56_sol_model = AgentModel::Gpt56Sol.as_str();
         let gpt_56_terra_model = AgentModel::Gpt56Terra.as_str();
         let gpt_56_luna_model = AgentModel::Gpt56Luna.as_str();
-        let gpt_55_model = AgentModel::Gpt55.as_str();
+        let gpt_55_model = AgentModel::Gpt56Sol.as_str();
         let spark_model = AgentModel::Gpt53CodexSpark.as_str();
 
         // Act
@@ -269,7 +269,7 @@ mod tests {
         let thread_id = lifecycle::start_thread(
             &mut transport,
             folder.path(),
-            AgentModel::Gpt55.as_str(),
+            AgentModel::Gpt56Sol.as_str(),
             ReasoningLevel::default(),
         )
         .await;
@@ -358,7 +358,7 @@ mod tests {
         let thread = lifecycle::start_or_resume_thread(
             &mut transport,
             folder.path(),
-            AgentModel::Gpt55.as_str(),
+            AgentModel::Gpt56Sol.as_str(),
             Some("thread-existing"),
             ReasoningLevel::default(),
         )
@@ -451,7 +451,7 @@ mod tests {
         let result = lifecycle::execute_turn_event_loop(
             &mut transport,
             folder.path(),
-            AgentModel::Gpt55.as_str(),
+            AgentModel::Gpt56Sol.as_str(),
             "thread-1",
             "Implement the task",
             ReasoningLevel::default(),
@@ -762,7 +762,7 @@ mod tests {
         // Act
         let payload = lifecycle::build_thread_start_payload(
             folder.path(),
-            AgentModel::Gpt55.as_str(),
+            AgentModel::Gpt56Sol.as_str(),
             ReasoningLevel::default(),
             "thread-start-1",
         );
@@ -922,7 +922,7 @@ mod tests {
         // Act
         let payload = lifecycle::build_turn_start_payload(
             folder.path(),
-            AgentModel::Gpt55.as_str(),
+            AgentModel::Gpt56Sol.as_str(),
             ReasoningLevel::default(),
             "thread-123",
             "Implement the task",

--- a/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
@@ -925,7 +925,7 @@ mod tests {
             folder: runtime_parent.path().join("missing-runtime"),
             live_transcript: None,
             main_checkout_root: None,
-            model: AgentModel::Gpt55.as_str().to_string(),
+            model: AgentModel::Gpt56Sol.as_str().to_string(),
             personality: crate::channel::PersonalityPrompt::active(
                 "Review carefully.".to_string(),
                 true,
@@ -955,7 +955,7 @@ mod tests {
     fn codex_runtime_state_new_initializes_zero_tokens_and_empty_thread_id() {
         // Arrange
         let folder = PathBuf::from("/tmp/agentty-codex-state");
-        let model = AgentModel::Gpt55.as_str().to_string();
+        let model = AgentModel::Gpt56Sol.as_str().to_string();
 
         // Act
         let state = CodexRuntimeState::new(folder.clone(), model.clone());
@@ -972,7 +972,7 @@ mod tests {
     fn build_thread_start_payload_carries_method_id_cwd_and_model() {
         // Arrange
         let folder = PathBuf::from("/tmp/agentty-codex-thread-start");
-        let model = AgentModel::Gpt55.as_str();
+        let model = AgentModel::Gpt56Sol.as_str();
 
         // Act
         let payload =
@@ -1011,7 +1011,7 @@ mod tests {
     #[test]
     fn build_thread_resume_payload_uses_thread_id_for_resume() {
         // Arrange
-        let model = AgentModel::Gpt55.as_str();
+        let model = AgentModel::Gpt56Sol.as_str();
 
         // Act
         let payload = build_thread_resume_payload(
@@ -1046,7 +1046,7 @@ mod tests {
         // Act
         let payload = build_turn_start_payload(
             &folder,
-            AgentModel::Gpt55.as_str(),
+            AgentModel::Gpt56Sol.as_str(),
             ReasoningLevel::Medium,
             "thread-1",
             "Update the repository instructions",

--- a/crates/ag-agent/src/agent/app_server/codex/policy.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/policy.rs
@@ -103,12 +103,7 @@ pub(super) const AUTO_COMPACT_INPUT_TOKEN_THRESHOLD_128K_CONTEXT: u64 = 120_000;
 pub(super) fn auto_compact_input_token_threshold(model: &str) -> u64 {
     let is_1050k_context_model = matches!(
         AgentKind::Codex.parse_model(model),
-        Some(
-            AgentModel::Gpt56Sol
-                | AgentModel::Gpt56Terra
-                | AgentModel::Gpt56Luna
-                | AgentModel::Gpt55
-        )
+        Some(AgentModel::Gpt56Sol | AgentModel::Gpt56Terra | AgentModel::Gpt56Luna)
     );
     if is_1050k_context_model {
         return AUTO_COMPACT_INPUT_TOKEN_THRESHOLD_1050K_CONTEXT;

--- a/crates/ag-agent/src/agent/claude.rs
+++ b/crates/ag-agent/src/agent/claude.rs
@@ -283,7 +283,7 @@ mod tests {
                 folder: temp_directory.path(),
                 main_checkout_root: None,
                 replay_transcript: None,
-                model: "claude-opus-4-8",
+                model: "claude-opus-5",
                 personality_prompt: None,
                 prompt: "Use Opus",
                 reasoning_level: ReasoningLevel::default(),
@@ -298,7 +298,7 @@ mod tests {
             .map(|value| value.to_string_lossy().into_owned());
 
         // Assert
-        assert_eq!(anthropic_model, Some("claude-opus-4-8".to_string()));
+        assert_eq!(anthropic_model, Some("claude-opus-5".to_string()));
     }
 
     #[test]

--- a/crates/ag-agent/src/agent/codex.rs
+++ b/crates/ag-agent/src/agent/codex.rs
@@ -61,7 +61,7 @@ mod tests {
                 folder: temp_directory.path(),
                 main_checkout_root: None,
                 replay_transcript: None,
-                model: "gpt-5.5",
+                model: "gpt-5.6-sol",
                 personality_prompt: None,
                 prompt: "Run checks",
                 reasoning_level: crate::model::agent::ReasoningLevel::High,
@@ -92,7 +92,7 @@ mod tests {
                 folder: temp_directory.path(),
                 main_checkout_root: None,
                 replay_transcript: None,
-                model: "gpt-5.5",
+                model: "gpt-5.6-sol",
                 personality_prompt: None,
                 prompt: "Continue edits",
                 reasoning_level: crate::model::agent::ReasoningLevel::High,
@@ -108,7 +108,13 @@ mod tests {
         // Assert
         assert_eq!(
             arguments,
-            vec!["--model", "gpt-5.5", "app-server", "--listen", "stdio://"]
+            vec![
+                "--model",
+                "gpt-5.6-sol",
+                "app-server",
+                "--listen",
+                "stdio://"
+            ]
         );
     }
 
@@ -168,7 +174,7 @@ mod tests {
                 folder: temp_directory.path(),
                 main_checkout_root: None,
                 replay_transcript: None,
-                model: "gpt-5.5",
+                model: "gpt-5.6-sol",
                 personality_prompt: None,
                 prompt: "Generate title",
                 reasoning_level: crate::model::agent::ReasoningLevel::Low,

--- a/crates/ag-agent/src/agent/submission.rs
+++ b/crates/ag-agent/src/agent/submission.rs
@@ -571,7 +571,7 @@ mod tests {
                 agent_kind: AgentKind::Codex,
                 child_pid: None,
                 folder: temp_directory.path().to_path_buf(),
-                model: AgentModel::Gpt55,
+                model: AgentModel::Gpt56Sol,
                 prompt: "Generate title".to_string(),
                 request_kind: AgentRequestKind::UtilityPrompt,
                 reasoning_level: ReasoningLevel::default(),
@@ -653,7 +653,7 @@ mod tests {
                 agent_kind: AgentKind::Codex,
                 child_pid: None,
                 folder: temp_directory.path().to_path_buf(),
-                model: AgentModel::Gpt55,
+                model: AgentModel::Gpt56Sol,
                 prompt: "Generate title".to_string(),
                 request_kind: AgentRequestKind::UtilityPrompt,
                 reasoning_level: ReasoningLevel::default(),
@@ -798,7 +798,7 @@ mod tests {
                 agent_kind: AgentKind::Codex,
                 child_pid: None,
                 folder: temp_directory.path().to_path_buf(),
-                model: AgentModel::Gpt55,
+                model: AgentModel::Gpt56Sol,
                 prompt: "Generate title".to_string(),
                 request_kind: AgentRequestKind::UtilityPrompt,
                 reasoning_level: ReasoningLevel::default(),
@@ -837,7 +837,7 @@ mod tests {
                 agent_kind: AgentKind::Codex,
                 child_pid: None,
                 folder: temp_directory.path().to_path_buf(),
-                model: AgentModel::Gpt55,
+                model: AgentModel::Gpt56Sol,
                 prompt: "Generate title".to_string(),
                 request_kind: AgentRequestKind::UtilityPrompt,
                 reasoning_level: ReasoningLevel::default(),
@@ -1026,7 +1026,7 @@ mod tests {
             .expect_run_turn()
             .times(1)
             .returning(|request, _| {
-                assert_eq!(request.model, AgentModel::Gpt55.as_str());
+                assert_eq!(request.model, AgentModel::Gpt56Sol.as_str());
                 assert!(matches!(
                     request.request_kind,
                     AgentRequestKind::UtilityPrompt
@@ -1058,7 +1058,7 @@ mod tests {
                 agent_kind: AgentKind::Codex,
                 child_pid: None,
                 folder: temp_directory.path().to_path_buf(),
-                model: AgentModel::Gpt55,
+                model: AgentModel::Gpt56Sol,
                 prompt: "Generate title".to_string(),
                 request_kind: AgentRequestKind::UtilityPrompt,
                 reasoning_level: ReasoningLevel::default(),
@@ -1106,7 +1106,7 @@ mod tests {
                 agent_kind: AgentKind::Codex,
                 child_pid: Some(Arc::clone(&child_pid)),
                 folder: temp_directory.path().to_path_buf(),
-                model: AgentModel::Gpt55,
+                model: AgentModel::Gpt56Sol,
                 prompt: "Generate title".to_string(),
                 request_kind: AgentRequestKind::UtilityPrompt,
                 reasoning_level: ReasoningLevel::default(),
@@ -1135,7 +1135,7 @@ mod tests {
             .expect_run_turn()
             .times(2)
             .returning(|request, _| {
-                assert_eq!(request.model, AgentModel::Gpt55.as_str());
+                assert_eq!(request.model, AgentModel::Gpt56Sol.as_str());
 
                 Box::pin(async {
                     Ok(AppServerTurnResponse {
@@ -1160,7 +1160,7 @@ mod tests {
                 agent_kind: AgentKind::Codex,
                 child_pid: None,
                 folder: temp_directory.path().to_path_buf(),
-                model: AgentModel::Gpt55,
+                model: AgentModel::Gpt56Sol,
                 prompt: "Generate title".to_string(),
                 request_kind: AgentRequestKind::UtilityPrompt,
                 reasoning_level: ReasoningLevel::default(),
@@ -1215,7 +1215,7 @@ mod tests {
                 agent_kind: AgentKind::Codex,
                 child_pid: None,
                 folder: temp_directory.path().to_path_buf(),
-                model: AgentModel::Gpt55,
+                model: AgentModel::Gpt56Sol,
                 prompt: "Generate title".to_string(),
                 request_kind: AgentRequestKind::SessionStart,
                 reasoning_level: ReasoningLevel::default(),

--- a/crates/ag-agent/src/channel/app_server.rs
+++ b/crates/ag-agent/src/channel/app_server.rs
@@ -293,7 +293,7 @@ mod tests {
             continuation: crate::channel::TurnContinuation::fresh(),
             folder: PathBuf::from("/tmp"),
             main_checkout_root: Some(PathBuf::from("/tmp/main")),
-            model: "gpt-5.5".to_string(),
+            model: "gpt-5.6-sol".to_string(),
             personality: crate::channel::PersonalityPrompt::default(),
             prompt: "Do something".into(),
             reasoning_level: ReasoningLevel::default(),

--- a/crates/ag-agent/src/model/agent.rs
+++ b/crates/ag-agent/src/model/agent.rs
@@ -90,20 +90,16 @@ pub enum AgentModel {
     Gpt56Terra,
     /// Codex Luna model backed by `gpt-5.6-luna`.
     Gpt56Luna,
-    /// Codex model backed by `gpt-5.5`.
-    Gpt55,
     /// Fast Gemini model backed by `gemini-3.6-flash`.
     Gemini36Flash,
-    /// Fast Gemini model backed by `gemini-3.5-flash`.
-    Gemini35Flash,
+    /// Lightweight Gemini model backed by `gemini-3.5-flash-lite`.
+    Gemini35FlashLite,
     /// Higher-quality Gemini model backed by `gemini-3.1-pro`.
     Gemini31Pro,
     /// Codex spark model backed by `gpt-5.3-codex-spark`.
     Gpt53CodexSpark,
     /// Claude Opus model backed by `claude-opus-5`.
     ClaudeOpus5,
-    /// Claude Opus model backed by `claude-opus-4-8`.
-    ClaudeOpus48,
     /// Claude Sonnet model backed by `claude-sonnet-5`.
     ClaudeSonnet5,
     /// Claude Fable model backed by `claude-fable-5`.
@@ -181,13 +177,11 @@ impl AgentModel {
             Self::Gpt56Sol => "gpt-5.6-sol",
             Self::Gpt56Terra => "gpt-5.6-terra",
             Self::Gpt56Luna => "gpt-5.6-luna",
-            Self::Gpt55 => "gpt-5.5",
             Self::Gemini36Flash => "gemini-3.6-flash",
-            Self::Gemini35Flash => "gemini-3.5-flash",
+            Self::Gemini35FlashLite => "gemini-3.5-flash-lite",
             Self::Gemini31Pro => "gemini-3.1-pro",
             Self::Gpt53CodexSpark => "gpt-5.3-codex-spark",
             Self::ClaudeOpus5 => "claude-opus-5",
-            Self::ClaudeOpus48 => "claude-opus-4-8",
             Self::ClaudeSonnet5 => "claude-sonnet-5",
             Self::ClaudeFable5 => "claude-fable-5",
             Self::ClaudeHaiku4520251001 => "claude-haiku-4-5-20251001",
@@ -202,11 +196,12 @@ impl AgentModel {
         self.as_str()
     }
 
-    /// Parses one persisted model identifier and upgrades retired aliases.
+    /// Parses one persisted model identifier and upgrades retired ids to
+    /// their replacement models.
     ///
-    /// Stored retired Gemini, Claude, and Codex aliases are migrated forward
-    /// so existing projects and sessions continue loading after model
-    /// removals.
+    /// Stored retired Gemini, Claude, and Codex ids are migrated forward
+    /// through [`AgentModel::retired_replacement`] so existing projects and
+    /// sessions continue loading after model retirements.
     /// Raw `gemini-*` ids parse to shared Gemini model variants; persisted
     /// session agents decide whether Gemini or Antigravity owns the session.
     ///
@@ -214,16 +209,48 @@ impl AgentModel {
     /// Returns an error when `value` is not a known current or retired model
     /// identifier.
     pub fn parse_persisted(value: &str) -> Result<Self, String> {
-        match value {
-            "gemini-3-flash-preview" => Ok(Self::Gemini36Flash),
-            "gemini-3.5-flash-lite" | "gemini-3.1-flash-lite-preview" => Ok(Self::Gemini35Flash),
-            "gemini-3.1-pro-preview" => Ok(Self::Gemini31Pro),
-            "claude-opus-4-6" | "claude-opus-4-7" => Ok(Self::ClaudeOpus48),
-            "claude-sonnet-4-6" => Ok(Self::ClaudeSonnet5),
-            "gpt-5.4-mini" => Ok(Self::Gpt56Luna),
-            "gpt-5.4" => Ok(Self::Gpt55),
-            _ => value.parse(),
+        if let Some(replacement) = Self::retired_replacement(value) {
+            return Ok(replacement);
         }
+
+        value.parse()
+    }
+
+    /// Returns the current replacement model for a retired persisted model
+    /// id, or `None` when `value` is not a retired id.
+    ///
+    /// This registry is the single source of truth for model retirement.
+    /// Retiring a model means removing its selectable [`AgentModel`] variant
+    /// and mapping its persisted id to the replacement model here. Retired
+    /// ids never appear in selectable model lists; they stay in the database
+    /// as history for finished sessions, while sessions that are still active
+    /// are switched to the replacement automatically.
+    #[must_use]
+    pub fn retired_replacement(value: &str) -> Option<Self> {
+        const RETIRED_MODEL_REPLACEMENTS: &[(&str, AgentModel)] = &[
+            ("gemini-3-pro-preview", AgentModel::Gemini31Pro),
+            ("gemini-3-flash-preview", AgentModel::Gemini36Flash),
+            ("gemini-3.5-flash", AgentModel::Gemini35FlashLite),
+            ("gemini-3.1-pro-preview", AgentModel::Gemini31Pro),
+            (
+                "gemini-3.1-flash-lite-preview",
+                AgentModel::Gemini35FlashLite,
+            ),
+            ("claude-opus-4-8", AgentModel::ClaudeOpus5),
+            ("claude-opus-4-6", AgentModel::ClaudeOpus5),
+            ("claude-opus-4-7", AgentModel::ClaudeOpus5),
+            ("claude-sonnet-4-6", AgentModel::ClaudeSonnet5),
+            ("gpt-5.5", AgentModel::Gpt56Sol),
+            ("gpt-5.4-mini", AgentModel::Gpt56Luna),
+            ("gpt-5.4", AgentModel::Gpt56Sol),
+            ("gpt-5.3-codex", AgentModel::Gpt56Sol),
+            ("gpt-5.2-codex", AgentModel::Gpt53CodexSpark),
+        ];
+
+        RETIRED_MODEL_REPLACEMENTS
+            .iter()
+            .find(|(retired_id, _)| *retired_id == value)
+            .map(|(_, replacement)| *replacement)
     }
 }
 
@@ -443,7 +470,7 @@ impl ReasoningLevel {
     /// Returns the Claude `--effort` value for this level.
     ///
     /// Maps `XHigh` and `Max` to `"max"`, which is currently only supported on
-    /// `claude-opus-5` and `claude-opus-4-8`. The Claude CLI enforces this
+    /// `claude-opus-5`. The Claude CLI enforces this
     /// restriction and will surface an error for other models.
     pub fn claude(self) -> &'static str {
         match self {
@@ -487,15 +514,13 @@ impl FromStr for AgentModel {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "gemini-3.6-flash" => Ok(Self::Gemini36Flash),
-            "gemini-3.5-flash" => Ok(Self::Gemini35Flash),
+            "gemini-3.5-flash-lite" => Ok(Self::Gemini35FlashLite),
             "gemini-3.1-pro" => Ok(Self::Gemini31Pro),
             "gpt-5.6-sol" => Ok(Self::Gpt56Sol),
             "gpt-5.6-terra" => Ok(Self::Gpt56Terra),
             "gpt-5.6-luna" => Ok(Self::Gpt56Luna),
-            "gpt-5.5" => Ok(Self::Gpt55),
             "gpt-5.3-codex-spark" => Ok(Self::Gpt53CodexSpark),
             "claude-opus-5" => Ok(Self::ClaudeOpus5),
-            "claude-opus-4-8" => Ok(Self::ClaudeOpus48),
             "claude-sonnet-5" => Ok(Self::ClaudeSonnet5),
             "claude-fable-5" => Ok(Self::ClaudeFable5),
             "claude-haiku-4-5-20251001" => Ok(Self::ClaudeHaiku4520251001),
@@ -513,14 +538,14 @@ impl AgentSelectionMetadata for AgentModel {
         match self {
             Self::Gemini31Pro => "Higher-quality Gemini model for deeper reasoning.",
             Self::Gemini36Flash => "Fast Gemini model for agentic and multimodal tasks.",
-            Self::Gemini35Flash => "Fast Gemini model for balanced agentic workloads.",
+            Self::Gemini35FlashLite => {
+                "Lightweight Gemini model for fast, cost-conscious workloads."
+            }
             Self::Gpt56Sol => "Newest Codex model for the strongest coding performance.",
             Self::Gpt56Terra => "Current Codex model for balanced coding performance.",
             Self::Gpt56Luna => "Current Codex model for lighter coding iterations.",
-            Self::Gpt55 => "Newer Codex model with stronger coding performance when available.",
             Self::Gpt53CodexSpark => "Codex spark model for quick coding iterations.",
             Self::ClaudeOpus5 => "Latest Claude Opus model for complex tasks.",
-            Self::ClaudeOpus48 => "Claude Opus 4.8 model for complex tasks.",
             Self::ClaudeSonnet5 => "Balanced Claude model for quality and latency.",
             Self::ClaudeFable5 => "Claude Fable model for creative, narrative-heavy tasks.",
             Self::ClaudeHaiku4520251001 => "Fast Claude model for lighter tasks.",
@@ -570,17 +595,16 @@ impl AgentKind {
         const ANTIGRAVITY_MODELS: &[AgentModel] = &[
             AgentModel::Gemini31Pro,
             AgentModel::Gemini36Flash,
-            AgentModel::Gemini35Flash,
+            AgentModel::Gemini35FlashLite,
         ];
         const GEMINI_MODELS: &[AgentModel] = &[
             AgentModel::Gemini31Pro,
             AgentModel::Gemini36Flash,
-            AgentModel::Gemini35Flash,
+            AgentModel::Gemini35FlashLite,
         ];
         const CLAUDE_MODELS: &[AgentModel] = &[
             AgentModel::ClaudeFable5,
             AgentModel::ClaudeOpus5,
-            AgentModel::ClaudeOpus48,
             AgentModel::ClaudeSonnet5,
             AgentModel::ClaudeHaiku4520251001,
         ];
@@ -588,7 +612,6 @@ impl AgentKind {
             AgentModel::Gpt56Sol,
             AgentModel::Gpt56Terra,
             AgentModel::Gpt56Luna,
-            AgentModel::Gpt55,
             AgentModel::Gpt53CodexSpark,
         ];
 
@@ -694,14 +717,12 @@ mod tests {
         let parsed_sol = codex_kind.parse_model("gpt-5.6-sol");
         let parsed_terra = codex_kind.parse_model("gpt-5.6-terra");
         let parsed_luna = codex_kind.parse_model("gpt-5.6-luna");
-        let parsed_55 = codex_kind.parse_model("gpt-5.5");
         let parsed_spark = codex_kind.parse_model("gpt-5.3-codex-spark");
 
         // Assert
         assert_eq!(parsed_sol, Some(AgentModel::Gpt56Sol));
         assert_eq!(parsed_terra, Some(AgentModel::Gpt56Terra));
         assert_eq!(parsed_luna, Some(AgentModel::Gpt56Luna));
-        assert_eq!(parsed_55, Some(AgentModel::Gpt55));
         assert_eq!(parsed_spark, Some(AgentModel::Gpt53CodexSpark));
     }
 
@@ -715,12 +736,12 @@ mod tests {
         // Act
         let parsed_pro = antigravity_kind.parse_model("gemini-3.1-pro");
         let parsed_flash_36 = antigravity_kind.parse_model("gemini-3.6-flash");
-        let parsed_flash_35 = antigravity_kind.parse_model("gemini-3.5-flash");
+        let parsed_flash_35_lite = antigravity_kind.parse_model("gemini-3.5-flash-lite");
 
         // Assert
         assert_eq!(parsed_pro, Some(AgentModel::Gemini31Pro));
         assert_eq!(parsed_flash_36, Some(AgentModel::Gemini36Flash));
-        assert_eq!(parsed_flash_35, Some(AgentModel::Gemini35Flash));
+        assert_eq!(parsed_flash_35_lite, Some(AgentModel::Gemini35FlashLite));
     }
 
     #[test]
@@ -744,7 +765,7 @@ mod tests {
         let models = [
             AgentModel::Gemini31Pro,
             AgentModel::Gemini36Flash,
-            AgentModel::Gemini35Flash,
+            AgentModel::Gemini35FlashLite,
         ];
 
         // Act
@@ -756,7 +777,7 @@ mod tests {
             [
                 "Higher-quality Gemini model for deeper reasoning.",
                 "Fast Gemini model for agentic and multimodal tasks.",
-                "Fast Gemini model for balanced agentic workloads.",
+                "Lightweight Gemini model for fast, cost-conscious workloads.",
             ]
         );
     }
@@ -807,7 +828,6 @@ mod tests {
         let parsed_haiku_45 = claude_kind.parse_model("claude-haiku-4-5-20251001");
         let opus_5_id = AgentModel::ClaudeOpus5.as_str();
         let opus_5_description = AgentModel::ClaudeOpus5.description();
-        let opus_48_description = AgentModel::ClaudeOpus48.description();
 
         // Assert
         assert_eq!(parsed_opus_5, Some(AgentModel::ClaudeOpus5));
@@ -819,10 +839,54 @@ mod tests {
             opus_5_description,
             "Latest Claude Opus model for complex tasks."
         );
+    }
+
+    #[test]
+    /// Ensures the retirement registry maps retired ids to replacements and
+    /// leaves current ids unmapped.
+    fn test_retired_replacement_maps_only_retired_ids() {
+        // Arrange
+        let retired_ids = [
+            ("gemini-3-pro-preview", AgentModel::Gemini31Pro),
+            ("gemini-3-flash-preview", AgentModel::Gemini36Flash),
+            ("gemini-3.5-flash", AgentModel::Gemini35FlashLite),
+            ("gemini-3.1-pro-preview", AgentModel::Gemini31Pro),
+            (
+                "gemini-3.1-flash-lite-preview",
+                AgentModel::Gemini35FlashLite,
+            ),
+            ("claude-opus-4-8", AgentModel::ClaudeOpus5),
+            ("claude-opus-4-6", AgentModel::ClaudeOpus5),
+            ("claude-opus-4-7", AgentModel::ClaudeOpus5),
+            ("claude-sonnet-4-6", AgentModel::ClaudeSonnet5),
+            ("gpt-5.5", AgentModel::Gpt56Sol),
+            ("gpt-5.4-mini", AgentModel::Gpt56Luna),
+            ("gpt-5.4", AgentModel::Gpt56Sol),
+            ("gpt-5.3-codex", AgentModel::Gpt56Sol),
+            ("gpt-5.2-codex", AgentModel::Gpt53CodexSpark),
+        ];
+
+        // Act
+        let replacements =
+            retired_ids.map(|(retired_id, _)| AgentModel::retired_replacement(retired_id));
+        let selectable_parses = retired_ids.map(|(retired_id, _)| retired_id.parse::<AgentModel>());
+        let current_replacements = [
+            "gemini-3.1-pro",
+            "gemini-3.6-flash",
+            "gemini-3.5-flash-lite",
+            "claude-opus-5",
+        ]
+        .map(AgentModel::retired_replacement);
+        let unknown_replacement = AgentModel::retired_replacement("not-a-model");
+
+        // Assert
         assert_eq!(
-            opus_48_description,
-            "Claude Opus 4.8 model for complex tasks."
+            replacements,
+            retired_ids.map(|(_, replacement)| Some(replacement))
         );
+        assert!(selectable_parses.iter().all(Result::is_err));
+        assert_eq!(current_replacements, [None; 4]);
+        assert_eq!(unknown_replacement, None);
     }
 
     #[test]
@@ -847,20 +911,23 @@ mod tests {
             AgentModel::parse_persisted("gemini-3.1-flash-lite-preview");
 
         // Assert
-        assert_eq!(parsed_opus_46, Ok(AgentModel::ClaudeOpus48));
-        assert_eq!(parsed_opus_47, Ok(AgentModel::ClaudeOpus48));
+        assert_eq!(parsed_opus_46, Ok(AgentModel::ClaudeOpus5));
+        assert_eq!(parsed_opus_47, Ok(AgentModel::ClaudeOpus5));
         assert_eq!(parsed_sonnet_46, Ok(AgentModel::ClaudeSonnet5));
         assert_eq!(parsed_sonnet_5, Ok(AgentModel::ClaudeSonnet5));
         assert_eq!(parsed_gpt_54_mini, Ok(AgentModel::Gpt56Luna));
-        assert_eq!(parsed_gpt_54, Ok(AgentModel::Gpt55));
+        assert_eq!(parsed_gpt_54, Ok(AgentModel::Gpt56Sol));
         assert_eq!(parsed_gemini_36_flash, Ok(AgentModel::Gemini36Flash));
-        assert_eq!(parsed_gemini_35_flash, Ok(AgentModel::Gemini35Flash));
+        assert_eq!(parsed_gemini_35_flash, Ok(AgentModel::Gemini35FlashLite));
         assert_eq!(parsed_gemini_3_flash_preview, Ok(AgentModel::Gemini36Flash));
-        assert_eq!(parsed_gemini_35_flash_lite, Ok(AgentModel::Gemini35Flash));
+        assert_eq!(
+            parsed_gemini_35_flash_lite,
+            Ok(AgentModel::Gemini35FlashLite)
+        );
         assert_eq!(parsed_gemini_31_pro_preview, Ok(AgentModel::Gemini31Pro));
         assert_eq!(
             parsed_gemini_31_flash_lite_preview,
-            Ok(AgentModel::Gemini35Flash)
+            Ok(AgentModel::Gemini35FlashLite)
         );
     }
 
@@ -899,10 +966,10 @@ mod tests {
     fn test_parse_persisted_session_agent_model_resolves_saved_google_models() {
         // Arrange
         let persisted_selections = [
+            ("gemini", "gemini-3.5-flash-lite"),
             ("gemini", "gemini-3.5-flash"),
-            ("gemini", "gemini-3.1-flash-lite-preview"),
+            ("antigravity", "gemini-3.5-flash-lite"),
             ("antigravity", "gemini-3.5-flash"),
-            ("antigravity", "gemini-3.1-flash-lite-preview"),
         ];
 
         // Act
@@ -914,10 +981,10 @@ mod tests {
         assert_eq!(
             migrated_selections,
             [
-                AgentSelection::new(AgentKind::Gemini, AgentModel::Gemini35Flash),
-                AgentSelection::new(AgentKind::Gemini, AgentModel::Gemini35Flash),
-                AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini35Flash),
-                AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini35Flash),
+                AgentSelection::new(AgentKind::Gemini, AgentModel::Gemini35FlashLite),
+                AgentSelection::new(AgentKind::Gemini, AgentModel::Gemini35FlashLite),
+                AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini35FlashLite),
+                AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini35FlashLite),
             ]
         );
     }
@@ -933,7 +1000,7 @@ mod tests {
 
         // Assert
         assert_eq!(selection.kind(), AgentKind::Claude);
-        assert_eq!(selection.model(), AgentModel::ClaudeOpus48);
+        assert_eq!(selection.model(), AgentModel::ClaudeOpus5);
     }
 
     #[test]
@@ -958,17 +1025,16 @@ mod tests {
 
         // Act
         let migrated_flash = parse_persisted_session_agent_model(None, "gemini-3.5-flash");
-        let migrated_flash_lite =
-            parse_persisted_session_agent_model(None, "gemini-3.1-flash-lite-preview");
+        let loaded_flash_lite = parse_persisted_session_agent_model(None, "gemini-3.5-flash-lite");
 
         // Assert
         assert_eq!(
             migrated_flash,
-            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini35Flash)
+            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini35FlashLite)
         );
         assert_eq!(
-            migrated_flash_lite,
-            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini35Flash)
+            loaded_flash_lite,
+            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini35FlashLite)
         );
     }
 
@@ -1012,7 +1078,6 @@ mod tests {
             AgentModel::Gpt56Sol,
             AgentModel::Gpt56Terra,
             AgentModel::Gpt56Luna,
-            AgentModel::Gpt55,
             AgentModel::Gpt53CodexSpark,
         ];
 
@@ -1021,8 +1086,8 @@ mod tests {
         let unsupported = models.map(|model| AgentKind::Claude.supports_model(model));
 
         // Assert
-        assert_eq!(supported, [true; 5]);
-        assert_eq!(unsupported, [false; 5]);
+        assert_eq!(supported, [true; 4]);
+        assert_eq!(unsupported, [false; 4]);
     }
 
     #[test]
@@ -1031,7 +1096,6 @@ mod tests {
         // Arrange
         let models = [
             AgentModel::ClaudeOpus5,
-            AgentModel::ClaudeOpus48,
             AgentModel::ClaudeSonnet5,
             AgentModel::ClaudeFable5,
             AgentModel::ClaudeHaiku4520251001,
@@ -1042,8 +1106,8 @@ mod tests {
         let unsupported = models.map(|model| AgentKind::Codex.supports_model(model));
 
         // Assert
-        assert_eq!(supported, [true; 5]);
-        assert_eq!(unsupported, [false; 5]);
+        assert_eq!(supported, [true; 4]);
+        assert_eq!(unsupported, [false; 4]);
     }
 
     #[test]
@@ -1053,7 +1117,7 @@ mod tests {
         let models = [
             AgentModel::Gemini31Pro,
             AgentModel::Gemini36Flash,
-            AgentModel::Gemini35Flash,
+            AgentModel::Gemini35FlashLite,
         ];
 
         // Act
@@ -1073,15 +1137,15 @@ mod tests {
     /// transports.
     fn test_antigravity_provider_model_str_returns_raw_gemini_model() {
         // Arrange
-        let model = AgentModel::Gemini35Flash;
+        let model = AgentModel::Gemini35FlashLite;
 
         // Act
         let persisted_model = model.as_str();
         let provider_model = model.provider_model_str();
 
         // Assert
-        assert_eq!(persisted_model, "gemini-3.5-flash");
-        assert_eq!(provider_model, "gemini-3.5-flash");
+        assert_eq!(persisted_model, "gemini-3.5-flash-lite");
+        assert_eq!(provider_model, "gemini-3.5-flash-lite");
     }
 
     #[test]
@@ -1147,11 +1211,10 @@ mod tests {
                 AgentModel::Gpt56Sol,
                 AgentModel::Gpt56Terra,
                 AgentModel::Gpt56Luna,
-                AgentModel::Gpt55,
                 AgentModel::Gpt53CodexSpark,
                 AgentModel::Gemini31Pro,
                 AgentModel::Gemini36Flash,
-                AgentModel::Gemini35Flash,
+                AgentModel::Gemini35FlashLite,
             ]
         );
     }
@@ -1172,7 +1235,7 @@ mod tests {
             vec![
                 AgentModel::Gemini31Pro,
                 AgentModel::Gemini36Flash,
-                AgentModel::Gemini35Flash,
+                AgentModel::Gemini35FlashLite,
             ]
         );
     }
@@ -1182,9 +1245,9 @@ mod tests {
     /// when possible.
     fn test_resolve_model_for_available_agent_kinds_prefers_available_fallback() {
         // Arrange
-        let unavailable_model = AgentModel::ClaudeOpus48;
+        let unavailable_model = AgentModel::ClaudeOpus5;
         let available_agent_kinds = [AgentKind::Codex, AgentKind::Antigravity];
-        let fallback_model = AgentModel::Gpt55;
+        let fallback_model = AgentModel::Gpt56Terra;
 
         // Act
         let resolved_model = resolve_model_for_available_agent_kinds(
@@ -1194,7 +1257,7 @@ mod tests {
         );
 
         // Assert
-        assert_eq!(resolved_model, AgentModel::Gpt55);
+        assert_eq!(resolved_model, AgentModel::Gpt56Terra);
     }
 
     #[test]
@@ -1202,7 +1265,7 @@ mod tests {
     /// default when the preferred fallback is also unavailable.
     fn test_resolve_model_for_available_agent_kinds_uses_first_available_default() {
         // Arrange
-        let unavailable_model = AgentModel::ClaudeOpus48;
+        let unavailable_model = AgentModel::ClaudeOpus5;
         let available_agent_kinds = [AgentKind::Codex, AgentKind::Antigravity];
         let unavailable_fallback_model = AgentModel::ClaudeSonnet5;
 

--- a/crates/agentty/src/app/branch_publish.rs
+++ b/crates/agentty/src/app/branch_publish.rs
@@ -916,7 +916,7 @@ mod tests {
             .expect("failed to insert project");
         database
             .sessions()
-            .insert_session("session-id", "gpt-5.5", "main", "Review", project_id)
+            .insert_session("session-id", "gpt-5.6-sol", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
 
@@ -997,7 +997,7 @@ mod tests {
             .expect("failed to insert project");
         database
             .sessions()
-            .insert_session("session-id", "gpt-5.5", "main", "Review", project_id)
+            .insert_session("session-id", "gpt-5.6-sol", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         let session_folder = PathBuf::from("/tmp/session-worktree");
@@ -1202,7 +1202,7 @@ mod tests {
             .expect("failed to insert project");
         database
             .sessions()
-            .insert_session("session-id", "gpt-5.5", "main", "Review", project_id)
+            .insert_session("session-id", "gpt-5.6-sol", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         let session_folder = PathBuf::from("/tmp/session-worktree");
@@ -1242,7 +1242,7 @@ mod tests {
             .expect("failed to insert project");
         database
             .sessions()
-            .insert_session("session-id", "gpt-5.5", "main", "Review", project_id)
+            .insert_session("session-id", "gpt-5.6-sol", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         let session_folder = PathBuf::from("/tmp/session-worktree");
@@ -1283,7 +1283,7 @@ mod tests {
             .expect("failed to insert project");
         database
             .sessions()
-            .insert_session("session-id", "gpt-5.5", "main", "Review", project_id)
+            .insert_session("session-id", "gpt-5.6-sol", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         let session_folder = PathBuf::from("/tmp/session-worktree");
@@ -1331,7 +1331,7 @@ mod tests {
             .expect("failed to insert project");
         database
             .sessions()
-            .insert_session("session-id", "gpt-5.5", "main", "Review", project_id)
+            .insert_session("session-id", "gpt-5.6-sol", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         let session_folder = PathBuf::from("/tmp/session-worktree");
@@ -1441,7 +1441,7 @@ mod tests {
             .expect("failed to insert project");
         database
             .sessions()
-            .insert_session("session-id", "gpt-5.5", "main", "Review", project_id)
+            .insert_session("session-id", "gpt-5.6-sol", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         let session_folder = PathBuf::from("/tmp/session-worktree");
@@ -1517,7 +1517,7 @@ mod tests {
             .expect("failed to insert project");
         database
             .sessions()
-            .insert_session("session-id", "gpt-5.5", "main", "Review", project_id)
+            .insert_session("session-id", "gpt-5.6-sol", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         let session_folder = PathBuf::from("/tmp/session-worktree");
@@ -1568,7 +1568,7 @@ mod tests {
             .expect("failed to insert project");
         database
             .sessions()
-            .insert_session("session-id", "gpt-5.5", "main", "Review", project_id)
+            .insert_session("session-id", "gpt-5.6-sol", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         let session_folder = PathBuf::from("/tmp/session-worktree");

--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc;
 use super::events::AppEvent;
 use super::state::{App, AppClients};
 use crate::app::service::{AppServiceDeps, AppServices};
-use crate::app::session::SessionManager;
+use crate::app::session::{SessionManager, migrate_active_sessions_off_retired_models};
 use crate::app::setting::SettingsManager;
 use crate::app::startup::{AppStartup, StartupProjectContext, StartupSessionLoadContext};
 use crate::app::{AppError, review, sync, task};
@@ -278,8 +278,8 @@ impl App {
         );
     }
 
-    /// Loads the startup project state and builds the repository bundle used
-    /// by the app layer.
+    /// Migrates project-independent session state before loading the startup
+    /// project context.
     ///
     /// # Errors
     /// Returns an error if startup project metadata cannot be persisted or
@@ -290,6 +290,7 @@ impl App {
         repositories: &AppRepositories,
         clients: &AppClients,
     ) -> Result<StartupProjectContext, AppError> {
+        migrate_active_sessions_off_retired_models(repositories).await;
         let current_project_id =
             AppStartup::persist_startup_project(repositories, working_dir, git_branch.as_deref())
                 .await?;

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -184,7 +184,7 @@ async fn seed_persisted_review_session(
         .sessions()
         .insert_session(
             session_id,
-            AgentModel::Gpt55.as_str(),
+            AgentModel::Gpt56Sol.as_str(),
             "main",
             &Status::Review.to_string(),
             project_id,
@@ -432,7 +432,7 @@ async fn test_switch_project_reloads_project_scoped_settings() {
         .upsert_project_setting(
             second_project_id,
             SettingName::DefaultSmartModel,
-            AgentModel::Gpt55.as_str(),
+            AgentModel::Gpt56Sol.as_str(),
         )
         .await
         .expect("failed to persist second project smart model");
@@ -473,7 +473,7 @@ async fn test_switch_project_reloads_project_scoped_settings() {
     // Assert
     assert_eq!(
         app.settings.default_smart_selection.model(),
-        AgentModel::Gpt55
+        AgentModel::Gpt56Sol
     );
     assert_eq!(app.settings.launch_configuration, "cargo test");
     assert!(!app.settings_presentation.is_selector_dropdown_open());
@@ -1076,7 +1076,7 @@ async fn test_new_prefers_active_session_for_initial_selection() {
         .sessions()
         .insert_session(
             active_session_id,
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "main",
             &Status::Review.to_string(),
             project_id,
@@ -1087,7 +1087,7 @@ async fn test_new_prefers_active_session_for_initial_selection() {
         .sessions()
         .insert_session(
             archive_session_id,
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "main",
             &Status::Done.to_string(),
             project_id,
@@ -1218,7 +1218,7 @@ async fn test_new_with_clients_falls_back_from_stale_active_project_and_loads_cu
         .sessions()
         .insert_session(
             current_session_id,
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "main",
             &Status::Review.to_string(),
             current_project_id,
@@ -1229,7 +1229,7 @@ async fn test_new_with_clients_falls_back_from_stale_active_project_and_loads_cu
         .sessions()
         .insert_session(
             missing_session_id,
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "main",
             &Status::Review.to_string(),
             missing_project_id,
@@ -1400,7 +1400,7 @@ async fn persist_selected_session(app: &App) {
     app.services
         .db()
         .sessions()
-        .insert_session("session-1", "gpt-5.5", "main", "Review", project_id)
+        .insert_session("session-1", "gpt-5.6-sol", "main", "Review", project_id)
         .await
         .expect("failed to insert session");
 }
@@ -3250,7 +3250,7 @@ async fn apply_app_events_review_request_status_survives_same_batch_sync_refresh
         .sessions()
         .insert_session(
             session_id,
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "main",
             &Status::Review.to_string(),
             project_id,
@@ -4574,7 +4574,7 @@ async fn apply_app_events_refresh_projects_reloads_project_active_session_count(
         .sessions()
         .insert_session(
             "session-active",
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "main",
             &Status::Review.to_string(),
             project_id,
@@ -4882,7 +4882,7 @@ async fn test_continue_terminal_session_opens_draft_prompt_for_done_session_with
     app.services
         .db()
         .sessions()
-        .insert_session("done-source", "gpt-5.5", "release", "Done", project_id)
+        .insert_session("done-source", "gpt-5.6-sol", "release", "Done", project_id)
         .await
         .expect("failed to insert source session row");
     let merged_commit_hash = "704de31d0f4b5a1234567890abcdef1234567890";
@@ -4978,7 +4978,7 @@ async fn test_continue_terminal_session_falls_back_to_persisted_context_without_
     app.services
         .db()
         .sessions()
-        .insert_session("done-source", "gpt-5.5", "main", "Done", project_id)
+        .insert_session("done-source", "gpt-5.6-sol", "main", "Done", project_id)
         .await
         .expect("failed to insert source session row");
     let source_session = crate::test_support::SessionFixtureBuilder::new()
@@ -5634,7 +5634,7 @@ async fn insert_review_session_with_data_dir(app: &App, session_id: &str) {
         .sessions()
         .insert_session(
             session_id,
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "main",
             &Status::Review.to_string(),
             app.active_project_id(),
@@ -5812,7 +5812,7 @@ async fn manual_sync_surfaces_restack_failure_and_keeps_parent_merged() {
         .sessions()
         .insert_stacked_draft_session(
             "child-session",
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "wt/parent",
             &Status::Draft.to_string(),
             session_id,
@@ -5920,7 +5920,7 @@ async fn test_apply_review_request_status_update_persists_summary() {
         .sessions()
         .insert_session(
             session_id,
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "main",
             &Status::Review.to_string(),
             project_id,
@@ -5978,7 +5978,7 @@ async fn test_apply_review_request_status_update_closed_cancels_session() {
         .sessions()
         .insert_session(
             session_id,
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "main",
             &Status::Review.to_string(),
             project_id,
@@ -6037,7 +6037,7 @@ async fn test_apply_review_request_status_update_closed_cancels_stacked_child() 
         .sessions()
         .insert_session(
             session_id,
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "main",
             &Status::Review.to_string(),
             project_id,
@@ -6049,7 +6049,7 @@ async fn test_apply_review_request_status_update_closed_cancels_stacked_child() 
         .sessions()
         .insert_stacked_draft_session(
             child_session_id,
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "wt/session",
             &Status::Draft.to_string(),
             session_id,
@@ -6235,7 +6235,7 @@ async fn test_apply_review_request_status_update_merged_restacks_stacked_child()
         .sessions()
         .insert_stacked_draft_session(
             child_session_id,
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "wt/session",
             &Status::Draft.to_string(),
             session_id,

--- a/crates/agentty/src/app/review.rs
+++ b/crates/agentty/src/app/review.rs
@@ -586,13 +586,13 @@ mod tests {
     #[test]
     fn review_loading_message_uses_requested_model_name() {
         // Arrange
-        let review_model = AgentModel::Gpt55;
+        let review_model = AgentModel::Gpt56Sol;
 
         // Act
         let message = review_loading_message(review_model);
 
         // Assert
-        assert_eq!(message, "Reviewing changes with gpt-5.5");
+        assert_eq!(message, "Reviewing changes with gpt-5.6-sol");
     }
 
     #[test]
@@ -676,7 +676,7 @@ mod tests {
         );
 
         // Act
-        hydrate_review_transients(&review_cache, &mut session_state, AgentModel::Gpt55);
+        hydrate_review_transients(&review_cache, &mut session_state, AgentModel::Gpt56Sol);
 
         // Assert
         assert!(
@@ -698,7 +698,7 @@ mod tests {
             &HashMap::new(),
             &mut session_state,
             &session_id,
-            AgentModel::Gpt55,
+            AgentModel::Gpt56Sol,
         );
 
         // Assert
@@ -722,7 +722,7 @@ mod tests {
             &review_cache,
             &mut session_state,
             &session_id,
-            AgentModel::Gpt55,
+            AgentModel::Gpt56Sol,
         );
 
         // Assert
@@ -752,7 +752,7 @@ mod tests {
             &review_cache,
             &mut session_state,
             &session_id,
-            AgentModel::Gpt55,
+            AgentModel::Gpt56Sol,
         );
 
         // Assert
@@ -777,7 +777,7 @@ mod tests {
             &HashMap::new(),
             &mut session_state,
             "missing-session",
-            AgentModel::Gpt55,
+            AgentModel::Gpt56Sol,
         );
 
         // Assert

--- a/crates/agentty/src/app/session.rs
+++ b/crates/agentty/src/app/session.rs
@@ -19,5 +19,7 @@ pub(crate) use core::{
 pub use error::SessionError;
 pub(crate) use state::SessionGitStatus;
 pub use state::SessionState;
-pub(crate) use workflow::load::SessionLoadInput;
+pub(crate) use workflow::load::{
+    SessionLoadInput, migrate_active_sessions_off_retired_models, migrate_session_off_retired_model,
+};
 pub(crate) use workflow::refresh::SyncReviewRequestOutcome;

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -773,7 +773,7 @@ fn test_session_manager_with_clock(
             is_draft: false,
             agent: crate::domain::agent::AgentSelection::new(
                 crate::domain::agent::AgentKind::Codex,
-                AgentModel::Gpt55,
+                AgentModel::Gpt56Sol,
             ),
             parent_session_id: None,
             personality_id: None,
@@ -801,7 +801,7 @@ fn test_session_manager_with_clock(
 
     SessionManager::new(
         SessionDefaults {
-            model: AgentModel::Gpt55,
+            model: AgentModel::Gpt56Sol,
         },
         Arc::new(git::MockGitClient::new()),
         state,
@@ -1073,7 +1073,7 @@ async fn create_and_start_session(app: &mut App, prompt: &str) {
             &session_id,
             prompt,
             Arc::new(start_backend),
-            AgentModel::ClaudeOpus48,
+            AgentModel::ClaudeOpus5,
         )
         .await;
 }
@@ -1712,7 +1712,7 @@ async fn test_create_session_keeps_default_smart_model_setting_when_session_mode
         .expect("failed to create first session");
     app.set_session_model(
         &first_session_id,
-        AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+        AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
     )
     .await
     .expect("failed to set session model");
@@ -1795,7 +1795,7 @@ async fn test_create_session_persists_default_smart_model_setting_when_last_used
     // Act
     app.set_session_model(
         &first_session_id,
-        AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+        AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
     )
     .await
     .expect("failed to set session model");
@@ -1823,7 +1823,7 @@ async fn test_create_session_persists_default_smart_model_setting_when_last_used
     // Assert
     assert_eq!(
         default_smart_model_setting,
-        Some(AgentModel::Gpt55.as_str().to_string())
+        Some(AgentModel::Gpt56Sol.as_str().to_string())
     );
     assert_eq!(
         default_smart_agent_setting,
@@ -1836,7 +1836,7 @@ async fn test_create_session_persists_default_smart_model_setting_when_last_used
         .find(|session| session.id == second_session_id)
         .expect("missing second session");
     assert_eq!(second_session.agent.kind(), AgentKind::Codex);
-    assert_eq!(second_session.agent.model(), AgentModel::Gpt55);
+    assert_eq!(second_session.agent.model(), AgentModel::Gpt56Sol);
 }
 
 #[tokio::test]
@@ -2042,7 +2042,7 @@ async fn test_replace_title_generation_task_aborts_superseded_task() {
     );
     let mut session_manager = SessionManager::new(
         SessionDefaults {
-            model: AgentModel::Gpt55,
+            model: AgentModel::Gpt56Sol,
         },
         Arc::new(git::MockGitClient::new()),
         state,
@@ -2099,7 +2099,7 @@ async fn test_clear_title_generation_task_if_matches_ignores_stale_generation() 
     );
     let mut session_manager = SessionManager::new(
         SessionDefaults {
-            model: AgentModel::Gpt55,
+            model: AgentModel::Gpt56Sol,
         },
         Arc::new(git::MockGitClient::new()),
         state,
@@ -2134,7 +2134,7 @@ async fn test_clear_title_generation_task_if_matches_removes_matching_generation
     );
     let mut session_manager = SessionManager::new(
         SessionDefaults {
-            model: AgentModel::Gpt55,
+            model: AgentModel::Gpt56Sol,
         },
         Arc::new(git::MockGitClient::new()),
         state,
@@ -2969,7 +2969,7 @@ async fn test_load_existing_sessions() {
     assert_eq!(app.sessions.sessions()[0].id, "12345678");
     assert_eq!(
         app.sessions.sessions()[0].agent.model(),
-        AgentModel::ClaudeOpus48
+        AgentModel::ClaudeOpus5
     );
     assert_eq!(app.sessions.sessions()[0].prompt, "Existing");
     let output = session_replay_text(&app.sessions.sessions()[0]);
@@ -2988,13 +2988,7 @@ async fn test_create_session_uses_default_smart_model_setting_and_most_recent_pe
         .await
         .expect("failed to upsert project");
     db.sessions()
-        .insert_session(
-            "alpha0001",
-            "gemini-3-flash-preview",
-            "main",
-            "Done",
-            project_id,
-        )
+        .insert_session("alpha0001", "gemini-3.6-flash", "main", "Done", project_id)
         .await
         .expect("failed to insert alpha0001");
     db.sessions()
@@ -3060,17 +3054,11 @@ async fn test_load_existing_sessions_ordered_by_updated_at_desc() {
         .await
         .expect("failed to upsert project");
     db.sessions()
-        .insert_session("alpha000", "claude-opus-4-8", "main", "Done", project_id)
+        .insert_session("alpha000", "claude-opus-5", "main", "Done", project_id)
         .await
         .expect("failed to insert alpha000");
     db.sessions()
-        .insert_session(
-            "beta0000",
-            "gemini-3-flash-preview",
-            "main",
-            "Done",
-            project_id,
-        )
+        .insert_session("beta0000", "gemini-3.6-flash", "main", "Done", project_id)
         .await
         .expect("failed to insert beta0000");
 
@@ -3119,15 +3107,15 @@ async fn test_load_sessions_aggregates_daily_activity() {
         .await
         .expect("failed to upsert project");
     db.sessions()
-        .insert_session("alpha000", "claude-opus-4-8", "main", "Done", project_id)
+        .insert_session("alpha000", "claude-opus-5", "main", "Done", project_id)
         .await
         .expect("failed to insert alpha000");
     db.sessions()
-        .insert_session("beta0000", "claude-opus-4-8", "main", "Done", project_id)
+        .insert_session("beta0000", "claude-opus-5", "main", "Done", project_id)
         .await
         .expect("failed to insert beta0000");
     db.sessions()
-        .insert_session("gamma000", "claude-opus-4-8", "main", "Done", project_id)
+        .insert_session("gamma000", "claude-opus-5", "main", "Done", project_id)
         .await
         .expect("failed to insert gamma000");
     let seconds_per_day = 86_400_i64;
@@ -3209,11 +3197,11 @@ async fn test_load_sessions_keeps_daily_activity_after_session_deletion() {
         .await
         .expect("failed to upsert project");
     db.sessions()
-        .insert_session("alpha000", "claude-opus-4-8", "main", "Done", project_id)
+        .insert_session("alpha000", "claude-opus-5", "main", "Done", project_id)
         .await
         .expect("failed to insert alpha000");
     db.sessions()
-        .insert_session("beta0000", "claude-opus-4-8", "main", "Done", project_id)
+        .insert_session("beta0000", "claude-opus-5", "main", "Done", project_id)
         .await
         .expect("failed to insert beta0000");
     db.activity()
@@ -3269,7 +3257,7 @@ async fn test_refresh_sessions_if_needed_reloads_and_preserves_selection() {
     db.sessions()
         .insert_session(
             "alpha000",
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "main",
             "InProgress",
             project_id,
@@ -3277,7 +3265,7 @@ async fn test_refresh_sessions_if_needed_reloads_and_preserves_selection() {
         .await
         .expect("failed to insert alpha000");
     db.sessions()
-        .insert_session("beta0000", "claude-opus-4-8", "main", "Done", project_id)
+        .insert_session("beta0000", "claude-opus-5", "main", "Done", project_id)
         .await
         .expect("failed to insert beta0000");
     db.sessions()
@@ -3339,7 +3327,7 @@ async fn test_periodic_session_refresh_preserves_focused_review_states() {
         db.sessions()
             .insert_session(
                 session_id,
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 &Status::Review.to_string(),
                 project_id,
@@ -3430,7 +3418,7 @@ async fn test_refresh_sessions_if_needed_remaps_view_mode_index() {
     db.sessions()
         .insert_session(
             "alpha000",
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "main",
             "InProgress",
             project_id,
@@ -3438,7 +3426,7 @@ async fn test_refresh_sessions_if_needed_remaps_view_mode_index() {
         .await
         .expect("failed to insert alpha000");
     db.sessions()
-        .insert_session("beta0000", "claude-opus-4-8", "main", "Done", project_id)
+        .insert_session("beta0000", "claude-opus-5", "main", "Done", project_id)
         .await
         .expect("failed to insert beta0000");
     db.sessions()
@@ -3507,13 +3495,7 @@ async fn test_load_done_session_without_folder_kept() {
         .await
         .expect("failed to upsert project");
     db.sessions()
-        .insert_session(
-            "missing01",
-            "gemini-3-flash-preview",
-            "main",
-            "Done",
-            project_id,
-        )
+        .insert_session("missing01", "gemini-3.6-flash", "main", "Done", project_id)
         .await
         .expect("failed to insert");
 
@@ -3545,7 +3527,7 @@ async fn test_load_in_progress_session_without_folder_skipped() {
     db.sessions()
         .insert_session(
             "missing02",
-            "gemini-3-flash-preview",
+            "gemini-3.6-flash",
             "main",
             "InProgress",
             project_id,
@@ -3660,7 +3642,7 @@ async fn test_reply_turn_completion_persists_session_size() {
             &session_id,
             "compute size after turn",
             Arc::new(backend),
-            AgentModel::ClaudeOpus48,
+            AgentModel::ClaudeOpus5,
         )
         .await;
     wait_for_status_with_retries(&mut app, &session_id, Status::AgentReview, 200, true).await;
@@ -4481,7 +4463,7 @@ async fn test_spawn_session_task_skips_commit_when_nothing_to_commit() {
             &session_id,
             "NoChanges",
             Arc::new(mock),
-            AgentModel::ClaudeOpus48,
+            AgentModel::ClaudeOpus5,
         )
         .await;
 
@@ -5725,7 +5707,7 @@ async fn test_cancel_session_triggers_app_server_shutdown() {
         .expect("failed to create session");
     app.set_session_model(
         &session_id,
-        AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+        AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
     )
     .await
     .expect("failed to set app-server model");
@@ -5799,7 +5781,7 @@ async fn test_done_status_triggers_app_server_shutdown() {
         .expect("failed to create session");
     app.set_session_model(
         &session_id,
-        AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+        AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
     )
     .await
     .expect("failed to set app-server model");

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -3135,7 +3135,7 @@ mod tests {
 
         SessionManager::new(
             SessionDefaults {
-                model: AgentModel::Gpt55,
+                model: AgentModel::Gpt56Sol,
             },
             Arc::new(git::MockGitClient::new()),
             state,
@@ -4565,7 +4565,7 @@ mod tests {
 
         SessionManager::new(
             SessionDefaults {
-                model: AgentModel::Gpt55,
+                model: AgentModel::Gpt56Sol,
             },
             Arc::new(git::MockGitClient::new()),
             state,
@@ -4792,7 +4792,7 @@ mod tests {
             .set_session_model(
                 &services,
                 "session-id",
-                AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+                AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
             )
             .await
             .expect("set session model should succeed");
@@ -4818,14 +4818,14 @@ mod tests {
         let emitted_event = event_rx.try_recv().expect("model event expected");
 
         // Assert
-        assert_eq!(persisted_model, AgentModel::Gpt55.as_str());
+        assert_eq!(persisted_model, AgentModel::Gpt56Sol.as_str());
         assert!(cleared_provider.is_none());
         assert!(cleared_instruction.is_none());
         assert_eq!(
             emitted_event,
             AppEvent::SessionModelUpdated {
                 session_id: "session-id".into(),
-                session_agent: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+                session_agent: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
             }
         );
         assert!(session_manager.should_replay_history("session-id"));
@@ -4897,7 +4897,7 @@ mod tests {
             .set_session_model(
                 &services,
                 "missing",
-                AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+                AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
             )
             .await;
 

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -7,7 +7,9 @@ use ag_git::GitClient;
 
 use super::{draft, session_folder};
 use crate::app::SessionManager;
-use crate::domain::agent::{AgentSelection, ReasoningLevel, parse_persisted_session_agent_model};
+use crate::domain::agent::{
+    AgentModel, AgentSelection, ReasoningLevel, parse_persisted_session_agent_model,
+};
 use crate::domain::question::QuestionItem;
 use crate::domain::session::{
     DailyActivity, ReviewRequest, ReviewRequestSummary, Session, SessionDiffState,
@@ -76,6 +78,59 @@ struct LoadedSessionInput {
     size: SessionSize,
 }
 
+/// Migrates every non-terminal session across all saved projects away from
+/// retired persisted model ids.
+///
+/// Query and persistence failures are best-effort so startup remains usable
+/// with a degraded database. Individual UI and API loads repeat the same
+/// migration for the row they read.
+pub(crate) async fn migrate_active_sessions_off_retired_models(db: &AppRepositories) {
+    let Ok(rows) = db.sessions().load_active_session_agent_models().await else {
+        return;
+    };
+
+    for row in rows {
+        let session_status = row.status.parse::<Status>().unwrap_or(Status::Done);
+        migrate_session_off_retired_model(db, &row.id, &row.agent, &row.model, session_status)
+            .await;
+    }
+}
+
+/// Resolves one persisted provider/model pair and persists the replacement
+/// when its model is retired and the session is still active.
+///
+/// Terminal rows (`Merged`, `Done`, `Canceled`) keep the retired model id in
+/// the database as a historical record. Persistence failures are ignored so
+/// session reads still return the in-memory replacement.
+pub(crate) async fn migrate_session_off_retired_model(
+    db: &AppRepositories,
+    session_id: &str,
+    persisted_agent: &str,
+    persisted_model: &str,
+    session_status: Status,
+) -> AgentSelection {
+    let session_agent = parse_persisted_session_agent_model(Some(persisted_agent), persisted_model);
+    if matches!(
+        session_status,
+        Status::Merged | Status::Done | Status::Canceled
+    ) || AgentModel::retired_replacement(persisted_model).is_none()
+    {
+        return session_agent;
+    }
+
+    let session_agent_kind = session_agent.kind().to_string();
+    db.sessions()
+        .update_active_session_agent_model(
+            session_id,
+            &session_agent_kind,
+            session_agent.model().as_str(),
+        )
+        .await
+        .ok();
+
+    session_agent
+}
+
 impl SessionManager {
     /// Loads session models from the database using the provided filesystem
     /// boundary to decide which session folders exist.
@@ -90,7 +145,10 @@ impl SessionManager {
     /// `Canceled`) override stale in-memory status.
     ///
     /// Retired persisted model ids are upgraded to their current replacement
-    /// models while rows are loaded.
+    /// models while rows are loaded. Sessions that are still active also have
+    /// the replacement persisted so future turns run on the current model;
+    /// terminal sessions keep their retired model id in the database as a
+    /// historical record.
     ///
     /// New handles are inserted for sessions that don't have entries yet.
     ///
@@ -207,7 +265,6 @@ impl SessionManager {
             return;
         }
         session_worktree_availability.insert(session_id.clone(), has_session_folder);
-        let session_agent = parse_persisted_session_agent_model(Some(&row.agent), &row.model);
 
         let (session_detail, loaded_transcript) =
             load_active_session_detail(db, *active_session_id, &row.id).await;
@@ -229,6 +286,9 @@ impl SessionManager {
 
                 (persisted_status, transcript)
             };
+        let session_agent =
+            migrate_session_off_retired_model(db, &row.id, &row.agent, &row.model, session_status)
+                .await;
         let review_request = parse_review_request(&row);
         let draft_attachments =
             draft::load_staged_draft_attachments(*fs_client, base, &session_id).await;
@@ -788,7 +848,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 session_id,
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -873,7 +933,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 session_with_worktree_id,
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "Draft",
                 project_id,
@@ -883,7 +943,7 @@ mod tests {
         db.sessions()
             .insert_draft_session(
                 session_without_worktree_id,
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "Draft",
                 project_id,
@@ -935,13 +995,7 @@ mod tests {
 
         let session_id = "test-session";
         db.sessions()
-            .insert_session(
-                session_id,
-                "gemini-3-flash-preview",
-                "main",
-                "Review",
-                project_id,
-            )
+            .insert_session(session_id, "gemini-3.6-flash", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         db.sessions()
@@ -1029,13 +1083,7 @@ mod tests {
 
         let session_id = "inactive-session";
         db.sessions()
-            .insert_session(
-                session_id,
-                "gemini-3-flash-preview",
-                "main",
-                "Review",
-                project_id,
-            )
+            .insert_session(session_id, "gemini-3.6-flash", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         db.sessions()
@@ -1112,13 +1160,7 @@ mod tests {
 
         let session_id = "active-session";
         db.sessions()
-            .insert_session(
-                session_id,
-                "gemini-3-flash-preview",
-                "main",
-                "Review",
-                project_id,
-            )
+            .insert_session(session_id, "gemini-3.6-flash", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         db.sessions()
@@ -1208,13 +1250,7 @@ mod tests {
 
         let session_id = "test-session";
         db.sessions()
-            .insert_session(
-                session_id,
-                "gemini-3-flash-preview",
-                "main",
-                "Done",
-                project_id,
-            )
+            .insert_session(session_id, "gemini-3.6-flash", "main", "Done", project_id)
             .await
             .expect("failed to insert session");
 
@@ -1257,6 +1293,315 @@ mod tests {
         assert_eq!(handle_status, Status::Done);
     }
 
+    /// Ensures still-active sessions on a retired model are switched to the
+    /// replacement model both in memory and in the database.
+    #[tokio::test]
+    async fn test_load_sessions_switches_active_session_off_retired_model() {
+        // Arrange
+        let db = AppRepositories::in_memory().await;
+        let project_id = db
+            .projects()
+            .upsert_project("/tmp/test", None)
+            .await
+            .expect("failed to upsert project");
+        let session_id = "retired-active-session";
+        db.sessions()
+            .insert_session(session_id, "claude-opus-4-6", "main", "Review", project_id)
+            .await
+            .expect("failed to insert session");
+        let base_path = Path::new("/virtual/session-base");
+        let mock_fs_client = create_folder_lookup_mock(vec![session_folder(base_path, session_id)]);
+        let mut handles: HashMap<SessionId, SessionHandles> = HashMap::new();
+
+        // Act
+        let (sessions, _, _) = SessionManager::load_sessions_with_fs_client(
+            SessionLoadInput {
+                active_project_id: project_id,
+                active_session_id: None,
+                base: base_path,
+                clock: &RealClock,
+                db: &db,
+                fs_client: &mock_fs_client,
+                working_dir: Path::new("/tmp/test"),
+            },
+            &mut handles,
+        )
+        .await;
+
+        // Assert
+        let session = sessions
+            .iter()
+            .find(|session| session.id == session_id)
+            .expect("missing reloaded session");
+        assert_eq!(session.agent.model(), AgentModel::ClaudeOpus5);
+        let row = db
+            .sessions()
+            .load_session(session_id)
+            .await
+            .expect("failed to load session row")
+            .expect("missing session row");
+        assert_eq!(row.model, "claude-opus-5");
+        assert_eq!(row.agent, "claude");
+    }
+
+    /// Ensures automatic model migration does not make an old session appear
+    /// recently active.
+    #[tokio::test]
+    async fn test_migrate_session_preserves_updated_at() {
+        // Arrange
+        let (db, pool) = AppRepositories::in_memory_with_pool().await;
+        let project_id = db
+            .projects()
+            .upsert_project("/tmp/test", None)
+            .await
+            .expect("failed to upsert project");
+        let session_id = "retired-timestamp-session";
+        db.sessions()
+            .insert_session(session_id, "claude-opus-4-6", "main", "Review", project_id)
+            .await
+            .expect("failed to insert session");
+        sqlx::query(
+            r"
+UPDATE session
+SET updated_at = ?
+WHERE id = ?
+",
+        )
+        .bind(123_i64)
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .expect("failed to set historical timestamp");
+
+        // Act
+        migrate_session_off_retired_model(
+            &db,
+            session_id,
+            "claude",
+            "claude-opus-4-6",
+            Status::Review,
+        )
+        .await;
+
+        // Assert
+        let row = db
+            .sessions()
+            .load_session(session_id)
+            .await
+            .expect("failed to load migrated session")
+            .expect("missing migrated session");
+        assert_eq!(row.agent, "claude");
+        assert_eq!(row.model, "claude-opus-5");
+        assert_eq!(row.updated_at, 123);
+    }
+
+    /// Ensures startup migration covers active sessions outside the currently
+    /// loaded project while retaining terminal-session history.
+    #[tokio::test]
+    async fn test_migrate_active_sessions_off_retired_models_covers_inactive_projects() {
+        // Arrange
+        let db = AppRepositories::in_memory().await;
+        let active_project_id = db
+            .projects()
+            .upsert_project("/tmp/active", None)
+            .await
+            .expect("failed to upsert active project");
+        let inactive_project_id = db
+            .projects()
+            .upsert_project("/tmp/inactive", None)
+            .await
+            .expect("failed to upsert inactive project");
+        db.sessions()
+            .insert_session(
+                "active-project-session",
+                "claude-opus-4-6",
+                "main",
+                "Review",
+                active_project_id,
+            )
+            .await
+            .expect("failed to insert active-project session");
+        db.sessions()
+            .insert_session(
+                "inactive-project-session",
+                "gemini-3.5-flash",
+                "main",
+                "Review",
+                inactive_project_id,
+            )
+            .await
+            .expect("failed to insert inactive-project session");
+        db.sessions()
+            .insert_session(
+                "inactive-project-finished",
+                "gemini-3.5-flash",
+                "main",
+                "Done",
+                inactive_project_id,
+            )
+            .await
+            .expect("failed to insert finished inactive-project session");
+
+        // Act
+        migrate_active_sessions_off_retired_models(&db).await;
+
+        // Assert
+        let active_project_row = db
+            .sessions()
+            .load_session("active-project-session")
+            .await
+            .expect("failed to load active-project session")
+            .expect("missing active-project session");
+        let inactive_project_row = db
+            .sessions()
+            .load_session("inactive-project-session")
+            .await
+            .expect("failed to load inactive-project session")
+            .expect("missing inactive-project session");
+        let finished_row = db
+            .sessions()
+            .load_session("inactive-project-finished")
+            .await
+            .expect("failed to load finished inactive-project session")
+            .expect("missing finished inactive-project session");
+        assert_eq!(active_project_row.model, "claude-opus-5");
+        assert_eq!(active_project_row.agent, "claude");
+        assert_eq!(inactive_project_row.model, "gemini-3.5-flash-lite");
+        assert_eq!(inactive_project_row.agent, "antigravity");
+        assert_eq!(finished_row.model, "gemini-3.5-flash");
+    }
+
+    /// Ensures a terminal transition after the migration read wins the race
+    /// and preserves the retired model id as history.
+    #[tokio::test]
+    async fn test_migrate_session_preserves_retired_model_after_terminal_transition() {
+        // Arrange
+        let db = AppRepositories::in_memory().await;
+        let project_id = db
+            .projects()
+            .upsert_project("/tmp/test", None)
+            .await
+            .expect("failed to upsert project");
+        let race_cases = [
+            ("race-merged", "Merged"),
+            ("race-done", "Done"),
+            ("race-canceled", "Canceled"),
+        ];
+        for (session_id, _) in race_cases {
+            db.sessions()
+                .insert_session(session_id, "claude-opus-4-6", "main", "Review", project_id)
+                .await
+                .expect("failed to insert active session");
+        }
+        let stale_rows = db
+            .sessions()
+            .load_active_session_agent_models()
+            .await
+            .expect("failed to load active sessions");
+        for (session_id, terminal_status) in race_cases {
+            db.sessions()
+                .update_session_status_with_timing_at(session_id, terminal_status, 1)
+                .await
+                .expect("failed to persist terminal transition");
+        }
+
+        // Act
+        for row in stale_rows {
+            let stale_status = row
+                .status
+                .parse::<Status>()
+                .expect("active status should parse");
+            migrate_session_off_retired_model(&db, &row.id, &row.agent, &row.model, stale_status)
+                .await;
+        }
+
+        // Assert
+        for (session_id, terminal_status) in race_cases {
+            let row = db
+                .sessions()
+                .load_session(session_id)
+                .await
+                .expect("failed to load transitioned session")
+                .expect("missing transitioned session");
+            assert_eq!(row.status, terminal_status);
+            assert_eq!(row.agent, "claude");
+            assert_eq!(row.model, "claude-opus-4-6");
+        }
+    }
+
+    /// Ensures startup remains usable when active-session migration cannot
+    /// query a degraded database.
+    #[tokio::test]
+    async fn test_migrate_active_sessions_off_retired_models_ignores_query_failures() {
+        // Arrange
+        let (db, pool) = AppRepositories::in_memory_with_pool().await;
+        sqlx::query("DROP TABLE session")
+            .execute(&pool)
+            .await
+            .expect("session table should be dropped");
+
+        // Act
+        migrate_active_sessions_off_retired_models(&db).await;
+
+        // Assert
+        assert!(
+            db.sessions()
+                .load_active_session_agent_models()
+                .await
+                .is_err()
+        );
+    }
+
+    /// Ensures finished sessions keep their retired model id in the database
+    /// as history while loading with the replacement model in memory.
+    #[tokio::test]
+    async fn test_load_sessions_keeps_retired_model_in_db_for_finished_session() {
+        // Arrange
+        let db = AppRepositories::in_memory().await;
+        let project_id = db
+            .projects()
+            .upsert_project("/tmp/test", None)
+            .await
+            .expect("failed to upsert project");
+        let session_id = "retired-finished-session";
+        db.sessions()
+            .insert_session(session_id, "claude-opus-4-6", "main", "Done", project_id)
+            .await
+            .expect("failed to insert session");
+        let base_path = Path::new("/virtual/session-base");
+        let mock_fs_client = create_folder_lookup_mock(Vec::new());
+        let mut handles: HashMap<SessionId, SessionHandles> = HashMap::new();
+
+        // Act
+        let (sessions, _, _) = SessionManager::load_sessions_with_fs_client(
+            SessionLoadInput {
+                active_project_id: project_id,
+                active_session_id: None,
+                base: base_path,
+                clock: &RealClock,
+                db: &db,
+                fs_client: &mock_fs_client,
+                working_dir: Path::new("/tmp/test"),
+            },
+            &mut handles,
+        )
+        .await;
+
+        // Assert
+        let session = sessions
+            .iter()
+            .find(|session| session.id == session_id)
+            .expect("missing reloaded session");
+        assert_eq!(session.agent.model(), AgentModel::ClaudeOpus5);
+        let row = db
+            .sessions()
+            .load_session(session_id)
+            .await
+            .expect("failed to load session row")
+            .expect("missing session row");
+        assert_eq!(row.model, "claude-opus-4-6");
+    }
+
     /// Ensures persisted review-request metadata is mapped onto loaded session
     /// snapshots.
     #[tokio::test]
@@ -1284,13 +1629,7 @@ mod tests {
 
         let session_id = "test-session";
         db.sessions()
-            .insert_session(
-                session_id,
-                "gemini-3-flash-preview",
-                "main",
-                "Done",
-                project_id,
-            )
+            .insert_session(session_id, "gemini-3.6-flash", "main", "Done", project_id)
             .await
             .expect("failed to insert session");
         db.reviews()
@@ -1472,7 +1811,7 @@ mod tests {
             in_progress_total_seconds: 0,
             input_tokens: 0,
             is_draft: false,
-            model: "gpt-5.5".to_string(),
+            model: "gpt-5.6-sol".to_string(),
             output_tokens: 0,
             parent_session_id: None,
             personality_id: None,

--- a/crates/agentty/src/app/session/workflow/merge.rs
+++ b/crates/agentty/src/app/session/workflow/merge.rs
@@ -3790,7 +3790,7 @@ mod tests {
         input
             .db
             .sessions()
-            .insert_session("session-123", "gpt-5.5", "main", "Merging", project_id)
+            .insert_session("session-123", "gpt-5.6-sol", "main", "Merging", project_id)
             .await
             .expect("failed to insert merge session row");
         let db = input.db.clone();
@@ -3864,7 +3864,7 @@ mod tests {
         input
             .db
             .sessions()
-            .insert_session("session-123", "gpt-5.5", "main", "Merging", project_id)
+            .insert_session("session-123", "gpt-5.6-sol", "main", "Merging", project_id)
             .await
             .expect("failed to insert merge session row");
         let db = input.db.clone();
@@ -3930,7 +3930,7 @@ mod tests {
             .await
             .expect("failed to upsert project");
         db.sessions()
-            .insert_session("sess-local", "gpt-5.5", "main", "Review", project_id)
+            .insert_session("sess-local", "gpt-5.6-sol", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         let mut mock_git_client = git::MockGitClient::new();
@@ -3964,7 +3964,7 @@ mod tests {
             .await
             .expect("failed to upsert project");
         db.sessions()
-            .insert_session("sess-remote", "gpt-5.5", "main", "Review", project_id)
+            .insert_session("sess-remote", "gpt-5.6-sol", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         db.sessions()
@@ -4009,7 +4009,7 @@ mod tests {
             .await
             .expect("failed to upsert project");
         db.sessions()
-            .insert_session("child-session", "gpt-5.5", "main", "Review", project_id)
+            .insert_session("child-session", "gpt-5.6-sol", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         db.sessions()
@@ -4053,7 +4053,7 @@ mod tests {
             .await
             .expect("failed to upsert project");
         db.sessions()
-            .insert_session("sess-fetch", "gpt-5.5", "main", "Review", project_id)
+            .insert_session("sess-fetch", "gpt-5.6-sol", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         db.sessions()
@@ -4579,7 +4579,7 @@ mod tests {
             .await
             .expect("failed to insert project");
         db.sessions()
-            .insert_session("session-123", "gpt-5.5", "main", "Merging", project_id)
+            .insert_session("session-123", "gpt-5.6-sol", "main", "Merging", project_id)
             .await
             .expect("failed to insert merge session row");
         let status = Arc::new(Mutex::new(Status::Merging));
@@ -5051,7 +5051,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess-rebase",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "Rebasing",
                 project_id,
@@ -5199,7 +5199,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess-rebase",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "Rebasing",
                 project_id,
@@ -5552,7 +5552,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess-no-push",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "Rebasing",
                 project_id,

--- a/crates/agentty/src/app/session/workflow/post_turn.rs
+++ b/crates/agentty/src/app/session/workflow/post_turn.rs
@@ -779,7 +779,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "session-id",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,

--- a/crates/agentty/src/app/session/workflow/published_branch.rs
+++ b/crates/agentty/src/app/session/workflow/published_branch.rs
@@ -697,7 +697,7 @@ mod tests {
                 one_shot_client: Arc::new(one_shot_client),
                 session_agent: AgentSelection::new(
                     crate::domain::agent::AgentKind::Codex,
-                    crate::domain::agent::AgentModel::Gpt55,
+                    crate::domain::agent::AgentModel::Gpt56Sol,
                 ),
                 session_summary: "The same goal now includes the completed body.".to_string(),
             },
@@ -1061,7 +1061,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "session-id",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "Review",
                 project_id,

--- a/crates/agentty/src/app/session/workflow/task.rs
+++ b/crates/agentty/src/app/session/workflow/task.rs
@@ -1531,7 +1531,7 @@ mod tests {
             .expect("failed to upsert project");
         database
             .sessions()
-            .insert_session("session-id", "gpt-5.5", "main", "Review", project_id)
+            .insert_session("session-id", "gpt-5.6-sol", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         database
@@ -1573,7 +1573,7 @@ mod tests {
     async fn test_append_workflow_notice_updates_live_and_durable_workflow_transcript() {
         // Arrange
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, AgentModel::Gpt55.as_str()).await;
+        insert_review_session(&database, AgentModel::Gpt56Sol.as_str()).await;
         let (app_event_tx, _app_event_rx) = mpsc::unbounded_channel();
         let transcript = Arc::new(Mutex::new(SessionTranscript::default()));
         let session_update_versions = Arc::default();
@@ -1623,7 +1623,7 @@ mod tests {
     async fn test_append_session_transcript_message_updates_live_and_durable_typed_transcript() {
         // Arrange
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, AgentModel::Gpt55.as_str()).await;
+        insert_review_session(&database, AgentModel::Gpt56Sol.as_str()).await;
         let (app_event_tx, _app_event_rx) = mpsc::unbounded_channel();
         let transcript = Arc::new(Mutex::new(SessionTranscript::default()));
         let session_update_versions = Arc::default();
@@ -1708,7 +1708,7 @@ mod tests {
             .sessions()
             .insert_session(
                 "session-id",
-                "gpt-5.5",
+                "gpt-5.6-sol",
                 "main",
                 &Status::Draft.to_string(),
                 project_id,
@@ -1789,7 +1789,7 @@ mod tests {
     async fn test_status_transition_from_services_updates_handle_and_persistence() {
         // Arrange
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, "gpt-5.5").await;
+        insert_review_session(&database, "gpt-5.6-sol").await;
         let handles = SessionHandles::new(Status::Review);
         let (app_event_tx, _app_event_rx) = mpsc::unbounded_channel();
         let services = AppServices::new_with_agent_clis(
@@ -1997,7 +1997,7 @@ mod tests {
             "Adds the release dashboard.",
             "Build release dashboard",
             &one_shot_client,
-            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
             "The session now builds a release dashboard.",
         )
         .await
@@ -2034,7 +2034,7 @@ mod tests {
             "Generated body",
             "Generated title",
             &one_shot_client,
-            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
             "Current session summary",
         )
         .await
@@ -2071,7 +2071,7 @@ mod tests {
             "Generated body",
             "Generated title",
             &one_shot_client,
-            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
             "Current session summary",
         )
         .await
@@ -2108,7 +2108,7 @@ mod tests {
             "Generated body",
             "Generated title",
             &one_shot_client,
-            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
             "Current session summary",
         )
         .await
@@ -2146,7 +2146,7 @@ mod tests {
             "Updated generated details.",
             "Generated title",
             &one_shot_client,
-            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
             "Current session summary",
         )
         .await
@@ -2419,7 +2419,7 @@ mod tests {
                 Box::pin(async { Err(GitError::OutputParse("commit failed".to_string())) })
             });
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, AgentModel::Gpt55.as_str()).await;
+        insert_review_session(&database, AgentModel::Gpt56Sol.as_str()).await;
         let (app_event_tx, _app_event_rx) = mpsc::unbounded_channel();
         let transcript = Arc::new(Mutex::new(SessionTranscript::default()));
         let context = AssistContext {
@@ -2430,7 +2430,7 @@ mod tests {
             git_client: Arc::new(mock_git_client),
             id: "session-id".to_string(),
             one_shot_client: Arc::new(MockOneShotClient::new()),
-            session_agent: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            session_agent: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
             session_update_versions: Arc::default(),
             transcript: Arc::clone(&transcript),
         };
@@ -2453,7 +2453,7 @@ mod tests {
     async fn test_run_commit_assist_for_error_uses_injected_one_shot_client() {
         // Arrange
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, AgentModel::Gpt55.as_str()).await;
+        insert_review_session(&database, AgentModel::Gpt56Sol.as_str()).await;
         let transcript = Arc::new(Mutex::new(SessionTranscript::default()));
         let mut one_shot_client = MockOneShotClient::new();
         one_shot_client
@@ -2473,7 +2473,7 @@ mod tests {
             git_client: Arc::new(MockGitClient::new()),
             id: "session-id".to_string(),
             one_shot_client: Arc::new(one_shot_client),
-            session_agent: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            session_agent: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
             session_update_versions: Arc::default(),
             transcript: Arc::clone(&transcript),
         };
@@ -2532,7 +2532,7 @@ mod tests {
                 })
             });
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, AgentModel::Gpt55.as_str()).await;
+        insert_review_session(&database, AgentModel::Gpt56Sol.as_str()).await;
         let (app_event_tx, _app_event_rx) = mpsc::unbounded_channel();
         let transcript = Arc::new(Mutex::new(SessionTranscript::default()));
         let mut one_shot_client = MockOneShotClient::new();
@@ -2548,7 +2548,7 @@ mod tests {
             git_client: Arc::new(mock_git_client),
             id: "session-id".to_string(),
             one_shot_client: Arc::new(one_shot_client),
-            session_agent: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            session_agent: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
             session_update_versions: Arc::default(),
             transcript: Arc::clone(&transcript),
         };
@@ -2587,7 +2587,7 @@ mod tests {
                 })
             });
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, AgentModel::Gpt55.as_str()).await;
+        insert_review_session(&database, AgentModel::Gpt56Sol.as_str()).await;
         let (app_event_tx, _app_event_rx) = mpsc::unbounded_channel();
         let transcript = Arc::new(Mutex::new(SessionTranscript::default()));
         let context = AssistContext {
@@ -2598,7 +2598,7 @@ mod tests {
             git_client: Arc::new(mock_git_client),
             id: "session-id".to_string(),
             one_shot_client: Arc::new(MockOneShotClient::new()),
-            session_agent: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            session_agent: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
             session_update_versions: Arc::default(),
             transcript: Arc::clone(&transcript),
         };
@@ -2640,7 +2640,7 @@ mod tests {
             .times(1)
             .returning(|_| Box::pin(async { Ok::<_, GitError>(true) }));
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, AgentModel::Gpt55.as_str()).await;
+        insert_review_session(&database, AgentModel::Gpt56Sol.as_str()).await;
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
         let transcript = Arc::new(Mutex::new(SessionTranscript::default()));
         let context = AssistContext {
@@ -2651,7 +2651,7 @@ mod tests {
             git_client: Arc::new(mock_git_client),
             id: "session-id".to_string(),
             one_shot_client: Arc::new(MockOneShotClient::new()),
-            session_agent: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            session_agent: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
             session_update_versions: Arc::default(),
             transcript: Arc::clone(&transcript),
         };
@@ -2691,7 +2691,7 @@ mod tests {
     async fn test_load_include_coauthored_by_agentty_setting_defaults_to_false() {
         // Arrange
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, AgentModel::Gpt55.as_str()).await;
+        insert_review_session(&database, AgentModel::Gpt56Sol.as_str()).await;
 
         // Act
         let include_coauthored_by_agentty =
@@ -2708,7 +2708,7 @@ mod tests {
     async fn test_load_include_coauthored_by_agentty_setting_defaults_invalid_value_to_false() {
         // Arrange
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, AgentModel::Gpt55.as_str()).await;
+        insert_review_session(&database, AgentModel::Gpt56Sol.as_str()).await;
         let project_id = database
             .sessions()
             .load_session_project_id("session-id")
@@ -2775,7 +2775,7 @@ mod tests {
             .times(1)
             .returning(|_| Box::pin(async { Ok::<_, GitError>("abc1234".to_string()) }));
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, AgentModel::Gpt55.as_str()).await;
+        insert_review_session(&database, AgentModel::Gpt56Sol.as_str()).await;
         let summary_payload = "- Session branch updates README formatting.".to_string();
         database
             .sessions()
@@ -2800,7 +2800,7 @@ mod tests {
             git_client: Arc::new(mock_git_client),
             id: "session-id".to_string(),
             one_shot_client: Arc::new(one_shot_client),
-            session_agent: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            session_agent: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
             session_update_versions: Arc::default(),
             transcript: Arc::clone(&transcript),
         };
@@ -2843,7 +2843,7 @@ mod tests {
     async fn test_load_auto_commit_agent_setting_prefers_project_fast_selection() {
         // Arrange
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, AgentModel::Gpt55.as_str()).await;
+        insert_review_session(&database, AgentModel::Gpt56Sol.as_str()).await;
         let project_id = database
             .sessions()
             .load_session_project_id("session-id")
@@ -2882,7 +2882,7 @@ mod tests {
         let auto_commit_agent = SessionTaskService::load_auto_commit_agent_setting(
             &database,
             "session-id",
-            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
         )
         .await;
 
@@ -2899,7 +2899,7 @@ mod tests {
     async fn test_load_auto_commit_agent_setting_falls_back_through_defaults() {
         // Arrange
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, AgentModel::Gpt55.as_str()).await;
+        insert_review_session(&database, AgentModel::Gpt56Sol.as_str()).await;
         let project_id = database
             .sessions()
             .load_session_project_id("session-id")
@@ -2929,7 +2929,7 @@ mod tests {
         let smart_fallback_agent = SessionTaskService::load_auto_commit_agent_setting(
             &database,
             "session-id",
-            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
         )
         .await;
 
@@ -2950,14 +2950,14 @@ mod tests {
         let session_fallback_agent = SessionTaskService::load_auto_commit_agent_setting(
             &database,
             "session-id",
-            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
         )
         .await;
 
         // Assert
         assert_eq!(
             session_fallback_agent,
-            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55)
+            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol)
         );
     }
 
@@ -2967,7 +2967,7 @@ mod tests {
     async fn test_run_agent_assist_task_unwraps_one_shot_answer_without_raw_json() {
         // Arrange
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, AgentModel::ClaudeOpus48.as_str()).await;
+        insert_review_session(&database, AgentModel::ClaudeOpus5.as_str()).await;
         let (app_event_tx, _app_event_rx) = mpsc::unbounded_channel();
         let transcript = Arc::new(Mutex::new(SessionTranscript::default()));
         let child_pid = Arc::new(Mutex::new(None));
@@ -2991,7 +2991,7 @@ mod tests {
             id: "session-id".to_string(),
             one_shot_client: Arc::new(one_shot_client),
             prompt: "Resolve conflict".to_string(),
-            session_agent: AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus48),
+            session_agent: AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus5),
             session_update_versions: Arc::default(),
             transcript: Arc::clone(&transcript),
         })
@@ -3026,7 +3026,7 @@ mod tests {
     async fn test_run_agent_assist_task_rejects_plain_text_output() {
         // Arrange
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, AgentModel::ClaudeOpus48.as_str()).await;
+        insert_review_session(&database, AgentModel::ClaudeOpus5.as_str()).await;
         let (app_event_tx, _app_event_rx) = mpsc::unbounded_channel();
         let transcript = Arc::new(Mutex::new(SessionTranscript::default()));
         let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
@@ -3047,7 +3047,7 @@ mod tests {
             id: "session-id".to_string(),
             one_shot_client: Arc::new(one_shot_client),
             prompt: "Resolve conflict".to_string(),
-            session_agent: AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus48),
+            session_agent: AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus5),
             session_update_versions: Arc::default(),
             transcript: Arc::clone(&transcript),
         })
@@ -3081,7 +3081,7 @@ mod tests {
     async fn test_run_agent_assist_task_returns_error_for_non_zero_exit_status() {
         // Arrange
         let database = AppRepositories::in_memory().await;
-        insert_review_session(&database, AgentModel::ClaudeOpus48.as_str()).await;
+        insert_review_session(&database, AgentModel::ClaudeOpus5.as_str()).await;
         let (app_event_tx, _app_event_rx) = mpsc::unbounded_channel();
         let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
         let mut one_shot_client = MockOneShotClient::new();
@@ -3100,7 +3100,7 @@ mod tests {
             id: "session-id".to_string(),
             one_shot_client: Arc::new(one_shot_client),
             prompt: "Resolve conflict".to_string(),
-            session_agent: AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus48),
+            session_agent: AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus5),
             session_update_versions: Arc::default(),
             transcript: Arc::new(Mutex::new(SessionTranscript::default())),
         })

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -1212,7 +1212,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -1680,7 +1680,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -2441,7 +2441,7 @@ mod tests {
             continuation: TurnContinuation::fresh(),
             folder: context.folder.clone(),
             main_checkout_root: None,
-            model: "gemini-3-flash-preview".to_string(),
+            model: "gemini-3.6-flash".to_string(),
             personality: ag_agent::PersonalityPrompt::default(),
             prompt: "test".into(),
             reasoning_level: ReasoningLevel::default(),
@@ -2515,7 +2515,7 @@ mod tests {
             continuation: TurnContinuation::fresh(),
             folder: context.folder.clone(),
             main_checkout_root: None,
-            model: "gemini-3-flash-preview".to_string(),
+            model: "gemini-3.6-flash".to_string(),
             personality: ag_agent::PersonalityPrompt::default(),
             prompt: "test".into(),
             reasoning_level: ReasoningLevel::default(),
@@ -2725,7 +2725,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -2997,7 +2997,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -3323,7 +3323,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -3531,7 +3531,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -3626,7 +3626,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -3722,7 +3722,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -3833,7 +3833,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -3937,7 +3937,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -4030,7 +4030,7 @@ mod tests {
             .await
             .expect("failed to upsert project");
         db.sessions()
-            .insert_session("sess1", "gpt-5.5", "main", "InProgress", project_id)
+            .insert_session("sess1", "gpt-5.6-sol", "main", "InProgress", project_id)
             .await
             .expect("failed to insert session");
 
@@ -4082,7 +4082,7 @@ mod tests {
             review_comment_thread_ids: Vec::new(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Codex,
-                AgentModel::Gpt55,
+                AgentModel::Gpt56Sol,
             ),
         };
         let status = apply_worker_turn_result(&context, turn_metadata, turn_result)
@@ -4140,7 +4140,7 @@ mod tests {
             .await
             .expect("failed to upsert project");
         db.sessions()
-            .insert_session("sess1", "gpt-5.5", "main", "Rebasing", project_id)
+            .insert_session("sess1", "gpt-5.6-sol", "main", "Rebasing", project_id)
             .await
             .expect("failed to insert session");
         db.sessions()
@@ -4312,7 +4312,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Codex,
-                AgentModel::Gpt55,
+                AgentModel::Gpt56Sol,
             ),
             status: Arc::clone(&status),
         };
@@ -4387,7 +4387,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -4446,13 +4446,7 @@ mod tests {
             .await
             .expect("failed to upsert project");
         db.sessions()
-            .insert_session(
-                "sess1",
-                "gemini-3-flash-preview",
-                "main",
-                "Rebasing",
-                project_id,
-            )
+            .insert_session("sess1", "gemini-3.6-flash", "main", "Rebasing", project_id)
             .await
             .expect("failed to insert session");
         db.operations()
@@ -4504,7 +4498,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -4574,7 +4568,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -4649,7 +4643,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -4745,7 +4739,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,

--- a/crates/agentty/src/app/session_api.rs
+++ b/crates/agentty/src/app/session_api.rs
@@ -9,6 +9,7 @@ use ag_session::{
 };
 use async_trait::async_trait;
 
+use crate::app::session::migrate_session_off_retired_model;
 use crate::app::{App, AppError, SessionError};
 use crate::domain::turn_prompt::TurnPrompt;
 use crate::infra::db::{SessionMessageRow, SessionReviewRequestRow, SessionRow};
@@ -52,6 +53,18 @@ impl SessionBackend for App {
         else {
             return Ok(None);
         };
+        let session_status = row
+            .status
+            .parse::<SessionStatus>()
+            .unwrap_or(SessionStatus::Done);
+        migrate_session_off_retired_model(
+            self.services.db(),
+            &row.id,
+            &row.agent,
+            &row.model,
+            session_status,
+        )
+        .await;
         let message_rows = self
             .services
             .db()
@@ -498,6 +511,56 @@ mod tests {
         );
         assert_eq!(missing_session, None);
         assert_eq!(stacked_session.settings.parent_session_id, Some(session_id));
+    }
+
+    #[tokio::test]
+    async fn app_backend_migrates_retired_model_for_inactive_project_lookup() {
+        // Arrange
+        let (mut app, _temp_dir) = crate::test_support::new_git_test_app().await;
+        let inactive_project_id = app
+            .services
+            .db()
+            .projects()
+            .upsert_project("/inactive-project", Some("main".to_string()))
+            .await
+            .expect("inactive project should persist");
+        let session_id = SessionId::from("inactive-retired-session");
+        app.services
+            .db()
+            .sessions()
+            .insert_session(
+                &session_id,
+                "gemini-3.5-flash",
+                "main",
+                "Review",
+                inactive_project_id,
+            )
+            .await
+            .expect("retired-model session should persist");
+
+        // Act
+        let loaded_session = SessionService::new(&mut app)
+            .get_session(&session_id)
+            .await
+            .expect("session lookup should succeed")
+            .expect("session should exist");
+        let persisted_row = app
+            .services
+            .db()
+            .sessions()
+            .load_session(&session_id)
+            .await
+            .expect("migrated session should load")
+            .expect("migrated session should exist");
+
+        // Assert
+        assert_eq!(loaded_session.settings.project_id, inactive_project_id);
+        assert_eq!(
+            loaded_session.settings.agent,
+            ag_agent::AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini35FlashLite)
+        );
+        assert_eq!(persisted_row.agent, "antigravity");
+        assert_eq!(persisted_row.model, "gemini-3.5-flash-lite");
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/setting.rs
+++ b/crates/agentty/src/app/setting.rs
@@ -89,10 +89,11 @@ pub(crate) async fn load_default_fast_agent_selection_from_repositories(
         SettingName::DefaultFastAgent,
         SettingName::DefaultFastModel,
         fallback_selection,
+        available_agent_kinds,
     )
     .await
     {
-        return resolve_available_selection(selection, available_agent_kinds);
+        return selection;
     }
 
     load_default_smart_agent_selection_from_repositories(
@@ -123,10 +124,11 @@ pub(crate) async fn load_default_smart_agent_selection_from_repositories(
         SettingName::DefaultSmartAgent,
         SettingName::DefaultSmartModel,
         fallback_selection,
+        available_agent_kinds,
     )
     .await
     {
-        return resolve_available_selection(selection, available_agent_kinds);
+        return selection;
     }
 
     fallback_selection
@@ -196,11 +198,10 @@ impl SettingsManager {
             SettingName::DefaultReviewAgent,
             SettingName::DefaultReviewModel,
             default_smart_agent,
+            &available_agent_kinds,
         )
         .await
-        .map_or(default_smart_agent, |selection| {
-            resolve_available_selection(selection, &available_agent_kinds)
-        });
+        .unwrap_or(default_smart_agent);
         let reasoning_level = repositories
             .settings()
             .load_project_reasoning_level(project_id)
@@ -549,43 +550,56 @@ fn resolve_available_selection(
     AgentSelection::new(agent_kind, model)
 }
 
-/// Loads a model setting and parses it into an [`AgentModel`].
-///
-/// Retired persisted model ids are upgraded to their current replacement
-/// models before the value is returned.
-async fn load_model_setting(
-    repositories: &AppRepositories,
-    project_id: Option<i64>,
-    setting_name: SettingName,
-) -> Option<AgentModel> {
-    let project_id = project_id?;
-
-    repositories
-        .settings()
-        .get_project_setting(project_id, setting_name)
-        .await
-        .unwrap_or(None)
-        .and_then(|setting_value| AgentModel::parse_persisted(&setting_value).ok())
-}
-
 /// Loads one project-scoped model setting and its owning agent setting.
 ///
 /// Older projects may only have a model key; in that case the fallback
-/// selection and available-provider resolution decide ownership.
+/// selection and available-provider resolution decide ownership. Retired
+/// model ids are atomically replaced along with their resolved owning agent.
 async fn load_model_selection_setting(
     repositories: &AppRepositories,
     project_id: Option<i64>,
     agent_setting_name: SettingName,
     model_setting_name: SettingName,
     fallback_selection: AgentSelection,
+    available_agent_kinds: &[AgentKind],
 ) -> Option<AgentSelection> {
-    let model = load_model_setting(repositories, project_id, model_setting_name).await?;
-    let agent_kind = load_agent_setting(repositories, project_id, agent_setting_name)
+    let project_id = project_id?;
+    let setting_value = repositories
+        .settings()
+        .get_project_setting(project_id, model_setting_name)
+        .await
+        .unwrap_or(None)?;
+    let is_retired = AgentModel::retired_replacement(&setting_value).is_some();
+    let model = AgentModel::parse_persisted(&setting_value).ok()?;
+    let agent_kind = load_agent_setting(repositories, Some(project_id), agent_setting_name)
         .await
         .filter(|agent_kind| agent_kind.supports_model(model))
         .unwrap_or_else(|| fallback_agent_kind_for_model(model, fallback_selection.kind()));
+    let resolved_selection = resolve_available_selection(
+        AgentSelection::new(agent_kind, model),
+        available_agent_kinds,
+    );
 
-    Some(AgentSelection::new(agent_kind, model))
+    if is_retired {
+        let _ = repositories
+            .settings()
+            .upsert_project_settings(
+                project_id,
+                vec![
+                    (
+                        model_setting_name,
+                        resolved_selection.model().as_str().to_string(),
+                    ),
+                    (
+                        agent_setting_name,
+                        resolved_selection.kind().name().to_string(),
+                    ),
+                ],
+            )
+            .await;
+    }
+
+    Some(resolved_selection)
 }
 
 /// Loads one project-scoped agent setting.
@@ -662,6 +676,14 @@ mod tests {
 
     /// Builds app services backed by an in-memory database for settings tests.
     async fn test_services() -> (AppServices, i64) {
+        test_services_with_available_agent_kinds(AgentKind::ALL.to_vec()).await
+    }
+
+    /// Builds settings test services with a caller-provided provider
+    /// availability snapshot.
+    async fn test_services_with_available_agent_kinds(
+        available_agent_kinds: Vec<AgentKind>,
+    ) -> (AppServices, i64) {
         let database = AppRepositories::in_memory().await;
         let project_id = database
             .projects()
@@ -675,7 +697,7 @@ mod tests {
             event_tx,
             crate::app::service::AppServiceDeps {
                 app_server_client_override: Some(Arc::new(MockAppServerClient::new())),
-                available_agent_kinds: AgentKind::ALL.to_vec(),
+                available_agent_kinds: available_agent_kinds.clone(),
                 clipboard_image_client_override: None,
                 fs_client: Arc::new(fs::MockFsClient::new()),
                 git_client: Arc::new(git::MockGitClient::new()),
@@ -684,7 +706,7 @@ mod tests {
                 repositories: database.clone(),
                 review_request_client: Arc::new(forge::MockReviewRequestClient::new()),
             },
-            crate::domain::agent::AgentCliInfo::from_kinds(AgentKind::ALL),
+            crate::domain::agent::AgentCliInfo::from_kinds(&available_agent_kinds),
         );
 
         (services, project_id)
@@ -1051,7 +1073,7 @@ mod tests {
             .upsert_project_setting(
                 project_id,
                 SettingName::DefaultSmartModel,
-                AgentModel::Gpt55.as_str(),
+                AgentModel::Gpt56Sol.as_str(),
             )
             .await
             .expect("failed to persist smart model");
@@ -1065,7 +1087,7 @@ mod tests {
         .await;
 
         // Assert
-        assert_eq!(loaded_model, AgentModel::Gpt55);
+        assert_eq!(loaded_model, AgentModel::Gpt56Sol);
     }
 
     #[tokio::test]
@@ -1157,7 +1179,7 @@ mod tests {
         // Assert
         assert_eq!(
             fallback_fast_selection,
-            AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus48)
+            AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus5)
         );
 
         // Arrange
@@ -1167,7 +1189,7 @@ mod tests {
             .upsert_project_setting(
                 project_id,
                 SettingName::DefaultFastModel,
-                AgentModel::Gpt55.as_str(),
+                AgentModel::Gpt56Sol.as_str(),
             )
             .await
             .expect("failed to persist fast model");
@@ -1183,7 +1205,7 @@ mod tests {
         // Assert
         assert_eq!(
             explicit_fast_selection,
-            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55)
+            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol)
         );
     }
 
@@ -1197,7 +1219,7 @@ mod tests {
             .upsert_project_setting(
                 project_id,
                 SettingName::DefaultSmartModel,
-                AgentModel::Gpt55.as_str(),
+                AgentModel::Gpt56Sol.as_str(),
             )
             .await
             .expect("failed to persist project smart model");
@@ -1217,7 +1239,7 @@ mod tests {
             .upsert_project_setting(
                 project_id,
                 SettingName::DefaultReviewModel,
-                "claude-opus-4-6",
+                AgentModel::ClaudeOpus5.as_str(),
             )
             .await
             .expect("failed to persist review model");
@@ -1259,7 +1281,7 @@ mod tests {
         // Assert
         assert_eq!(
             settings.default_smart_selection,
-            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55)
+            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol)
         );
         assert_eq!(
             settings.default_fast_selection,
@@ -1267,13 +1289,89 @@ mod tests {
         );
         assert_eq!(
             settings.default_review_selection,
-            AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus48)
+            AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus5)
         );
         assert_eq!(settings.launch_configuration, "nvim .");
         assert_eq!(settings.reasoning_level, ReasoningLevel::Low);
         assert_eq!(settings.theme, ColorTheme::Green);
         assert!(!settings.include_coauthored_by_agentty);
         assert!(settings.use_last_used_model_as_default);
+    }
+
+    #[tokio::test]
+    async fn settings_manager_new_persists_replacements_for_retired_model_defaults() {
+        // Arrange
+        let available_agent_kinds =
+            vec![AgentKind::Codex, AgentKind::Antigravity, AgentKind::Claude];
+        let (services, project_id) =
+            test_services_with_available_agent_kinds(available_agent_kinds).await;
+        services
+            .db()
+            .settings()
+            .upsert_project_settings(
+                project_id,
+                vec![
+                    (SettingName::DefaultSmartModel, "gpt-5.5".to_string()),
+                    (
+                        SettingName::DefaultFastModel,
+                        "gemini-3-flash-preview".to_string(),
+                    ),
+                    (
+                        SettingName::DefaultReviewModel,
+                        "claude-opus-4-6".to_string(),
+                    ),
+                ],
+            )
+            .await
+            .expect("failed to persist retired model defaults");
+
+        // Act
+        let manager = settings_manager(&services, project_id).await;
+        let settings = manager.settings();
+
+        // Assert
+        assert_eq!(
+            settings.default_smart_selection,
+            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol)
+        );
+        assert_eq!(
+            settings.default_fast_selection,
+            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash)
+        );
+        assert_eq!(
+            settings.default_review_selection,
+            AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus5)
+        );
+
+        let expected_persisted_settings = [
+            (
+                SettingName::DefaultSmartModel,
+                AgentModel::Gpt56Sol.as_str(),
+            ),
+            (SettingName::DefaultSmartAgent, AgentKind::Codex.name()),
+            (
+                SettingName::DefaultFastModel,
+                AgentModel::Gemini36Flash.as_str(),
+            ),
+            (SettingName::DefaultFastAgent, AgentKind::Antigravity.name()),
+            (
+                SettingName::DefaultReviewModel,
+                AgentModel::ClaudeOpus5.as_str(),
+            ),
+            (SettingName::DefaultReviewAgent, AgentKind::Claude.name()),
+        ];
+
+        for (setting_name, expected_value) in expected_persisted_settings {
+            assert_eq!(
+                services
+                    .db()
+                    .settings()
+                    .get_project_setting(project_id, setting_name)
+                    .await
+                    .expect("failed to load migrated project setting"),
+                Some(expected_value.to_string())
+            );
+        }
     }
 
     #[tokio::test]
@@ -1361,8 +1459,8 @@ mod tests {
         // Arrange
         let (services, project_id) = test_services().await;
         let mut manager = settings_manager(&services, project_id).await;
-        let fast_selection = AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55);
-        let review_selection = AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus48);
+        let fast_selection = AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol);
+        let review_selection = AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus5);
 
         // Act
         manager
@@ -1398,7 +1496,7 @@ mod tests {
                 .get_project_setting(project_id, SettingName::DefaultFastModel)
                 .await
                 .expect("failed to load fast model"),
-            Some(AgentModel::Gpt55.as_str().to_string())
+            Some(AgentModel::Gpt56Sol.as_str().to_string())
         );
         assert_eq!(
             services
@@ -1416,7 +1514,7 @@ mod tests {
                 .get_project_setting(project_id, SettingName::DefaultReviewModel)
                 .await
                 .expect("failed to load review model"),
-            Some(AgentModel::ClaudeOpus48.as_str().to_string())
+            Some(AgentModel::ClaudeOpus5.as_str().to_string())
         );
         assert_eq!(
             services
@@ -1687,13 +1785,13 @@ mod tests {
         // Arrange
         let mut manager = new_settings_manager();
         manager.fixture_view_mut().default_fast_selection =
-            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55);
+            AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol);
 
         // Act
         let rows = manager.settings_rows();
 
         // Assert
-        assert_eq!(rows[3].1, "codex/gpt-5.5");
+        assert_eq!(rows[3].1, "codex/gpt-5.6-sol");
     }
 
     #[test]
@@ -1701,13 +1799,13 @@ mod tests {
         // Arrange
         let mut manager = new_settings_manager();
         manager.fixture_view_mut().default_review_selection =
-            AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus48);
+            AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus5);
 
         // Act
         let rows = manager.settings_rows();
 
         // Assert
-        assert_eq!(rows[4].1, "claude/claude-opus-4-8");
+        assert_eq!(rows[4].1, "claude/claude-opus-5");
     }
 
     #[test]

--- a/crates/agentty/src/domain/composer.rs
+++ b/crates/agentty/src/domain/composer.rs
@@ -1637,7 +1637,6 @@ mod tests {
                 "gpt-5.6-sol".to_string(),
                 "gpt-5.6-terra".to_string(),
                 "gpt-5.6-luna".to_string(),
-                "gpt-5.5".to_string(),
                 "gpt-5.3-codex-spark".to_string(),
             ]
         );

--- a/crates/agentty/src/infra/db.rs
+++ b/crates/agentty/src/infra/db.rs
@@ -25,8 +25,9 @@ pub(crate) use review::SqliteReviewRepository;
 pub use review::{ReviewRepository, SessionReviewRequestRow};
 pub(crate) use session::SqliteSessionRepository;
 pub use session::{
-    ForkSessionSnapshot, PersistedSessionCreation, SessionDetailRow, SessionFocusedReviewRow,
-    SessionListRow, SessionMessageRow, SessionRepository, SessionRow, SessionTurnMetadata,
+    ForkSessionSnapshot, PersistedSessionCreation, SessionAgentModelRow, SessionDetailRow,
+    SessionFocusedReviewRow, SessionListRow, SessionMessageRow, SessionRepository, SessionRow,
+    SessionTurnMetadata,
 };
 pub(crate) use setting::{SettingRepository, SqliteSettingRepository};
 pub(crate) use usage::SqliteUsageRepository;

--- a/crates/agentty/src/infra/db/connection_test.rs
+++ b/crates/agentty/src/infra/db/connection_test.rs
@@ -100,7 +100,7 @@ async fn insert_session_fixture(
 ) {
     database
         .sessions()
-        .insert_session(session_id, "gpt-5.5", base_branch, status, project_id)
+        .insert_session(session_id, "gpt-5.6-sol", base_branch, status, project_id)
         .await
         .expect("failed to insert session fixture");
 }
@@ -790,7 +790,7 @@ async fn test_insert_stacked_draft_session_persists_parent_session_id() {
         .sessions()
         .insert_stacked_draft_session(
             "child-session",
-            "gpt-5.5",
+            "gpt-5.6-sol",
             "wt/parent-session",
             "Draft",
             "parent-session",
@@ -826,7 +826,7 @@ async fn test_restack_child_sessions_after_parent_merge_clears_active_children()
         .sessions()
         .insert_stacked_draft_session(
             "child-session",
-            "gpt-5.5",
+            "gpt-5.6-sol",
             "wt/parent-session",
             "Draft",
             "parent-session",
@@ -838,7 +838,7 @@ async fn test_restack_child_sessions_after_parent_merge_clears_active_children()
         .sessions()
         .insert_stacked_draft_session(
             "review-child",
-            "gpt-5.5",
+            "gpt-5.6-sol",
             "wt/parent-session",
             "Review",
             "parent-session",
@@ -850,7 +850,7 @@ async fn test_restack_child_sessions_after_parent_merge_clears_active_children()
         .sessions()
         .insert_stacked_draft_session(
             "canceled-child",
-            "gpt-5.5",
+            "gpt-5.6-sol",
             "wt/parent-session",
             "Canceled",
             "parent-session",
@@ -914,7 +914,7 @@ async fn test_delete_session_retargets_children_base_branch() {
         .sessions()
         .insert_stacked_draft_session(
             "child-session",
-            "gpt-5.5",
+            "gpt-5.6-sol",
             "wt/parent-session",
             "Draft",
             "parent-session",
@@ -926,7 +926,7 @@ async fn test_delete_session_retargets_children_base_branch() {
         .sessions()
         .insert_stacked_draft_session(
             "canceled-child",
-            "gpt-5.5",
+            "gpt-5.6-sol",
             "wt/parent-session",
             "Canceled",
             "parent-session",
@@ -970,7 +970,7 @@ async fn test_load_pending_stack_restack_session_ids_returns_only_review_ready_p
         .sessions()
         .insert_stacked_draft_session(
             "still-stacked",
-            "gpt-5.5",
+            "gpt-5.6-sol",
             "wt/parent-session",
             "Review",
             "parent-session",
@@ -1530,14 +1530,14 @@ async fn test_setting_round_trip_supports_default_smart_fast_and_review_models()
         .expect("failed to persist default smart model");
     database
         .settings()
-        .upsert_setting(SettingName::DefaultFastModel, AgentModel::Gpt55.as_str())
+        .upsert_setting(SettingName::DefaultFastModel, AgentModel::Gpt56Sol.as_str())
         .await
         .expect("failed to persist default fast model");
     database
         .settings()
         .upsert_setting(
             SettingName::DefaultReviewModel,
-            AgentModel::ClaudeOpus48.as_str(),
+            AgentModel::ClaudeOpus5.as_str(),
         )
         .await
         .expect("failed to persist default review model");
@@ -1566,11 +1566,11 @@ async fn test_setting_round_trip_supports_default_smart_fast_and_review_models()
     );
     assert_eq!(
         default_fast_model,
-        Some(AgentModel::Gpt55.as_str().to_string())
+        Some(AgentModel::Gpt56Sol.as_str().to_string())
     );
     assert_eq!(
         default_review_model,
-        Some(AgentModel::ClaudeOpus48.as_str().to_string())
+        Some(AgentModel::ClaudeOpus5.as_str().to_string())
     );
 }
 
@@ -1778,7 +1778,7 @@ async fn test_session_provider_conversation_id_round_trip_and_clear() {
         .expect("failed to upsert project");
     database
         .sessions()
-        .insert_session("session-a", "gpt-5.5", "main", "Done", project_id)
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Done", project_id)
         .await
         .expect("failed to insert session");
 
@@ -1822,7 +1822,7 @@ async fn test_session_instruction_conversation_id_round_trip_and_clear() {
         .expect("failed to upsert project");
     database
         .sessions()
-        .insert_session("session-a", "gpt-5.5", "main", "Done", project_id)
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Done", project_id)
         .await
         .expect("failed to insert session");
     let instruction_conversation_id = Some("thread-123");
@@ -1870,7 +1870,7 @@ async fn test_session_published_upstream_ref_round_trip_and_clear() {
         .expect("failed to upsert project");
     database
         .sessions()
-        .insert_session("session-a", "gpt-5.5", "main", "Review", project_id)
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Review", project_id)
         .await
         .expect("failed to insert session");
 
@@ -1923,7 +1923,7 @@ async fn test_load_session_published_upstream_ref_returns_stored_value() {
         .expect("failed to upsert project");
     database
         .sessions()
-        .insert_session("session-load", "gpt-5.5", "main", "Review", project_id)
+        .insert_session("session-load", "gpt-5.6-sol", "main", "Review", project_id)
         .await
         .expect("failed to insert session");
     database
@@ -1959,7 +1959,7 @@ async fn test_load_session_published_upstream_ref_returns_none_when_unset() {
         .expect("failed to upsert project");
     database
         .sessions()
-        .insert_session("session-unset", "gpt-5.5", "main", "Review", project_id)
+        .insert_session("session-unset", "gpt-5.6-sol", "main", "Review", project_id)
         .await
         .expect("failed to insert session");
 
@@ -2005,7 +2005,7 @@ async fn test_session_merged_commit_hash_round_trip_and_clear() {
         .expect("failed to upsert project");
     database
         .sessions()
-        .insert_session("session-a", "gpt-5.5", "main", "Done", project_id)
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Done", project_id)
         .await
         .expect("failed to insert session");
 
@@ -2049,7 +2049,7 @@ async fn test_session_review_request_round_trip_and_clear() {
         .expect("failed to upsert project");
     database
         .sessions()
-        .insert_session("session-a", "gpt-5.5", "main", "Review", project_id)
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Review", project_id)
         .await
         .expect("failed to insert session");
     let review_request = review_request_fixture();
@@ -2100,7 +2100,7 @@ async fn test_insert_session_creation_activity_at_persists_timestamp() {
         .expect("failed to upsert project");
     database
         .sessions()
-        .insert_session("session-a", "gpt-5.5", "main", "Done", project_id)
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Done", project_id)
         .await
         .expect("failed to insert session");
 
@@ -2133,7 +2133,7 @@ async fn test_insert_session_creation_activity_at_ignores_duplicates_per_session
         .expect("failed to upsert project");
     database
         .sessions()
-        .insert_session("session-a", "gpt-5.5", "main", "Done", project_id)
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Done", project_id)
         .await
         .expect("failed to insert session");
 
@@ -2171,7 +2171,7 @@ async fn test_load_session_activity_timestamps_keeps_deleted_session_history() {
         .expect("failed to upsert project");
     database
         .sessions()
-        .insert_session("session-a", "gpt-5.5", "main", "Done", project_id)
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Done", project_id)
         .await
         .expect("failed to insert first session");
     database
@@ -2181,7 +2181,7 @@ async fn test_load_session_activity_timestamps_keeps_deleted_session_history() {
         .expect("failed to persist first activity event");
     database
         .sessions()
-        .insert_session("session-b", "gpt-5.5", "main", "Done", project_id)
+        .insert_session("session-b", "gpt-5.6-sol", "main", "Done", project_id)
         .await
         .expect("failed to insert second session");
     database
@@ -2219,17 +2219,17 @@ async fn test_load_session_activity_timestamps_preserves_event_order() {
         .expect("failed to upsert project");
     database
         .sessions()
-        .insert_session("session-a", "gpt-5.5", "main", "Done", project_id)
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Done", project_id)
         .await
         .expect("failed to insert first session");
     database
         .sessions()
-        .insert_session("session-b", "gpt-5.5", "main", "Done", project_id)
+        .insert_session("session-b", "gpt-5.6-sol", "main", "Done", project_id)
         .await
         .expect("failed to insert second session");
     database
         .sessions()
-        .insert_session("session-c", "gpt-5.5", "main", "Done", project_id)
+        .insert_session("session-c", "gpt-5.6-sol", "main", "Done", project_id)
         .await
         .expect("failed to insert third session");
 
@@ -2289,7 +2289,7 @@ async fn test_load_projects_with_stats_returns_session_counts_tokens_and_last_up
         .expect("failed to upsert project");
     database
         .sessions()
-        .insert_session("session-a", "gpt-5.5", "main", "Done", project_id)
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Done", project_id)
         .await
         .expect("failed to insert session-a");
     database
@@ -2300,7 +2300,7 @@ async fn test_load_projects_with_stats_returns_session_counts_tokens_and_last_up
                 applied_personality_id: None,
                 applied_personality_prompt_hash: None,
                 instruction_conversation_id: None,
-                model: AgentModel::Gpt55.as_str().to_string(),
+                model: AgentModel::Gpt56Sol.as_str().to_string(),
                 provider_conversation_id: None,
                 questions_json: "[]".to_string(),
                 summary: String::new(),
@@ -2317,7 +2317,7 @@ async fn test_load_projects_with_stats_returns_session_counts_tokens_and_last_up
         .expect("failed to persist session-a token metadata");
     database
         .sessions()
-        .insert_session("session-b", "gpt-5.5", "main", "Done", project_id)
+        .insert_session("session-b", "gpt-5.6-sol", "main", "Done", project_id)
         .await
         .expect("failed to insert session-b");
     database
@@ -2328,7 +2328,7 @@ async fn test_load_projects_with_stats_returns_session_counts_tokens_and_last_up
                 applied_personality_id: None,
                 applied_personality_prompt_hash: None,
                 instruction_conversation_id: None,
-                model: AgentModel::Gpt55.as_str().to_string(),
+                model: AgentModel::Gpt56Sol.as_str().to_string(),
                 provider_conversation_id: None,
                 questions_json: "[]".to_string(),
                 summary: String::new(),
@@ -2400,7 +2400,7 @@ async fn test_load_session_project_id_returns_associated_project() {
         .expect("failed to insert project");
     database
         .sessions()
-        .insert_session("session-a", "gpt-5.5", "main", "Done", project_id)
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Done", project_id)
         .await
         .expect("failed to insert session");
 
@@ -2428,7 +2428,7 @@ async fn test_load_session_summary_returns_persisted_summary() {
         .expect("failed to insert project");
     database
         .sessions()
-        .insert_session("session-a", "gpt-5.5", "main", "Done", project_id)
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Done", project_id)
         .await
         .expect("failed to insert session");
     database
@@ -2461,7 +2461,7 @@ async fn test_load_session_focused_reviews_for_project_returns_persisted_review(
         .expect("failed to insert project");
     database
         .sessions()
-        .insert_session("session-a", "gpt-5.5", "main", "Review", project_id)
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Review", project_id)
         .await
         .expect("failed to insert session");
     database
@@ -2505,7 +2505,7 @@ async fn test_update_session_focused_review_clears_persisted_review() {
         .expect("failed to insert project");
     database
         .sessions()
-        .insert_session("session-a", "gpt-5.5", "main", "Review", project_id)
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Review", project_id)
         .await
         .expect("failed to insert session");
     database
@@ -2549,7 +2549,7 @@ async fn test_persist_session_turn_metadata_rolls_back_on_failure() {
         .expect("failed to insert project");
     database
         .sessions()
-        .insert_session("session-a", "gpt-5.5", "main", "Review", project_id)
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Review", project_id)
         .await
         .expect("failed to insert session");
     database
@@ -2571,7 +2571,7 @@ async fn test_persist_session_turn_metadata_rolls_back_on_failure() {
                 applied_personality_id: None,
                 applied_personality_prompt_hash: None,
                 instruction_conversation_id: Some("instruction-thread".to_string()),
-                model: AgentModel::Gpt55.as_str().to_string(),
+                model: AgentModel::Gpt56Sol.as_str().to_string(),
                 provider_conversation_id: Some("thread-123".to_string()),
                 questions_json: r#"[{"text":"Need tests?"}]"#.to_string(),
                 summary: r#"{"turn":"Updated the worker.","session":"Session state changed."}"#

--- a/crates/agentty/src/infra/db/session.rs
+++ b/crates/agentty/src/infra/db/session.rs
@@ -190,6 +190,19 @@ pub struct SessionListRow {
     pub updated_at: i64,
 }
 
+/// Minimal provider/model row used to migrate active sessions across projects.
+#[derive(sqlx::FromRow)]
+pub struct SessionAgentModelRow {
+    /// Persisted agent provider kind for this session.
+    pub agent: String,
+    /// Stable session identifier.
+    pub id: String,
+    /// Persisted agent model identifier.
+    pub model: String,
+    /// Persisted lifecycle status string.
+    pub status: String,
+}
+
 /// Transcript-detail row loaded lazily for the session being viewed.
 pub struct SessionDetailRow {
     /// Initial or staged prompt text.
@@ -321,6 +334,10 @@ pub trait SessionRepository: Send + Sync {
     /// Loads one complete persisted session row by stable identifier.
     async fn load_session(&self, session_id: &str) -> Result<Option<SessionRow>, DbError>;
 
+    /// Loads provider/model metadata for every non-terminal session across
+    /// projects.
+    async fn load_active_session_agent_models(&self) -> Result<Vec<SessionAgentModelRow>, DbError>;
+
     #[cfg(test)]
     /// Loads all sessions ordered by most recent update.
     async fn load_sessions(&self) -> Result<Vec<SessionRow>, DbError>;
@@ -450,6 +467,15 @@ pub trait SessionRepository: Send + Sync {
 
     /// Updates the persisted agent provider and model for a session.
     async fn update_session_agent_model(
+        &self,
+        id: &str,
+        agent: &str,
+        model: &str,
+    ) -> Result<(), DbError>;
+
+    /// Updates the persisted agent provider and model only while the session
+    /// remains non-terminal, without changing its activity timestamp.
+    async fn update_active_session_agent_model(
         &self,
         id: &str,
         agent: &str,
@@ -1311,6 +1337,24 @@ WHERE session.id = ?
         Ok(row.map(SessionJoinRow::into_session_row))
     }
 
+    async fn load_active_session_agent_models(&self) -> Result<Vec<SessionAgentModelRow>, DbError> {
+        let rows = sqlx::query_as::<_, SessionAgentModelRow>(
+            r"
+SELECT agent,
+       id,
+       model,
+       status
+FROM session
+WHERE status NOT IN ('Merged', 'Done', 'Canceled')
+ORDER BY id
+",
+        )
+        .fetch_all(&self.0)
+        .await?;
+
+        Ok(rows)
+    }
+
     #[cfg(test)]
     async fn load_sessions(&self) -> Result<Vec<SessionRow>, DbError> {
         let rows = sqlx::query_as!(
@@ -1910,6 +1954,69 @@ WHERE id = ?
         Ok(())
     }
 
+    async fn update_active_session_agent_model(
+        &self,
+        id: &str,
+        agent: &str,
+        model: &str,
+    ) -> Result<(), DbError> {
+        let mut transaction = self.0.begin().await?;
+        let updated_at = sqlx::query_scalar::<_, i64>(
+            r"
+SELECT updated_at
+FROM session
+WHERE id = ?
+",
+        )
+        .bind(id)
+        .fetch_optional(&mut *transaction)
+        .await?;
+        let Some(updated_at) = updated_at else {
+            transaction.commit().await?;
+
+            return Ok(());
+        };
+        let temporary_updated_at = if updated_at == i64::MIN {
+            i64::MAX
+        } else {
+            i64::MIN
+        };
+        let update_result = sqlx::query(
+            r"
+UPDATE session
+SET agent = ?,
+    model = ?,
+    updated_at = ?
+WHERE id = ?
+  AND status NOT IN ('Merged', 'Done', 'Canceled')
+",
+        )
+        .bind(agent)
+        .bind(model)
+        .bind(temporary_updated_at)
+        .bind(id)
+        .execute(&mut *transaction)
+        .await?;
+        if update_result.rows_affected() > 0 {
+            sqlx::query(
+                r"
+UPDATE session
+SET updated_at = ?
+WHERE id = ?
+  AND updated_at = ?
+",
+            )
+            .bind(updated_at)
+            .bind(id)
+            .bind(temporary_updated_at)
+            .execute(&mut *transaction)
+            .await?;
+        }
+        transaction.commit().await?;
+
+        Ok(())
+    }
+
     async fn clear_session_draft_flag(&self, id: &str) -> Result<(), DbError> {
         sqlx::query!(
             r"
@@ -2392,7 +2499,7 @@ mod tests {
                 in_progress_total_seconds: 0,
                 input_tokens: 11,
                 is_draft: false,
-                model: "gpt-5.5".to_string(),
+                model: "gpt-5.6-sol".to_string(),
                 output_tokens: 29,
                 parent_session_id: Some("parent-session".to_string()),
                 personality_id: Some("reviewer".to_string()),
@@ -2497,14 +2604,20 @@ WHERE id = ?
             .expect("failed to upsert project");
         database
             .sessions()
-            .insert_session("parent-session", "gpt-5.5", "main", "Review", project_id)
+            .insert_session(
+                "parent-session",
+                "gpt-5.6-sol",
+                "main",
+                "Review",
+                project_id,
+            )
             .await
             .expect("failed to insert parent session");
         database
             .sessions()
             .insert_stacked_draft_session(
                 "source-session",
-                "gpt-5.5",
+                "gpt-5.6-sol",
                 "wt/parent",
                 "Review",
                 "parent-session",
@@ -2541,7 +2654,7 @@ WHERE id = ?
                     applied_personality_id: Some("reviewer".to_string()),
                     applied_personality_prompt_hash: Some("personality-hash".to_string()),
                     instruction_conversation_id: None,
-                    model: "gpt-5.5".to_string(),
+                    model: "gpt-5.6-sol".to_string(),
                     provider_conversation_id: None,
                     questions_json: "[]".to_string(),
                     summary: String::new(),
@@ -2765,7 +2878,7 @@ WHERE id = ?
         // Act
         database
             .sessions()
-            .insert_session("session-a", "gpt-5.5", "main", "Draft", project_id)
+            .insert_session("session-a", "gpt-5.6-sol", "main", "Draft", project_id)
             .await
             .expect("failed to insert session");
         let session = database
@@ -2793,7 +2906,7 @@ WHERE id = ?
         for session_id in ["a-older", "z-newer"] {
             database
                 .sessions()
-                .insert_session(session_id, "gpt-5.5", "main", "Review", project_id)
+                .insert_session(session_id, "gpt-5.6-sol", "main", "Review", project_id)
                 .await
                 .expect("failed to insert session");
         }
@@ -2890,7 +3003,7 @@ WHERE id IN ('a-older', 'z-newer')
             .expect("failed to upsert project");
         database
             .sessions()
-            .insert_draft_session("draft-session", "gpt-5.5", "main", "Draft", project_id)
+            .insert_draft_session("draft-session", "gpt-5.6-sol", "main", "Draft", project_id)
             .await
             .expect("failed to insert draft session");
 

--- a/crates/agentty/src/presentation/settings.rs
+++ b/crates/agentty/src/presentation/settings.rs
@@ -846,13 +846,13 @@ mod tests {
         SettingsView {
             available_model_selections: vec![
                 smart_selection,
-                AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
-                AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus48),
+                AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
+                AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeOpus5),
             ],
-            default_fast_selection: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt55),
+            default_fast_selection: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
             default_review_selection: AgentSelection::new(
                 AgentKind::Claude,
-                AgentModel::ClaudeOpus48,
+                AgentModel::ClaudeOpus5,
             ),
             default_smart_selection: smart_selection,
             include_coauthored_by_agentty: false,

--- a/crates/agentty/src/runtime/mode/at_mention.rs
+++ b/crates/agentty/src/runtime/mode/at_mention.rs
@@ -351,7 +351,7 @@ mod tests {
                 is_draft: false,
                 agent: crate::domain::agent::AgentSelection::new(
                     crate::domain::agent::AgentKind::Codex,
-                    AgentModel::Gpt55,
+                    AgentModel::Gpt56Sol,
                 ),
                 parent_session_id: None,
                 personality_id: None,
@@ -379,7 +379,7 @@ mod tests {
 
         SessionManager::new(
             SessionDefaults {
-                model: AgentModel::Gpt55,
+                model: AgentModel::Gpt56Sol,
             },
             Arc::new(git::MockGitClient::new()),
             state,

--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -950,7 +950,7 @@ mod tests {
         app.sessions.push_session(
             crate::test_support::SessionFixtureBuilder::new()
                 .id(session_id)
-                .model(AgentModel::Gpt55)
+                .model(AgentModel::Gpt56Sol)
                 .status(Status::AgentReview)
                 .build(),
         );
@@ -1481,7 +1481,7 @@ mod tests {
             .sessions()
             .insert_session(
                 session_id,
-                "gemini-3-flash-preview",
+                "gemini-3.6-flash",
                 "main",
                 "InProgress",
                 project_id,

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -1775,7 +1775,7 @@ mod tests {
         );
         app.sessions.sessions_mut()[0].agent = crate::domain::agent::AgentSelection::new(
             crate::domain::agent::AgentKind::Codex,
-            AgentModel::Gpt55,
+            AgentModel::Gpt56Sol,
         );
         app.sessions.sessions_mut()[0].status = Status::AgentReview;
         let output_width = 14;
@@ -1840,7 +1840,7 @@ mod tests {
         let (mut app, _base_dir, session_id) = new_test_app_with_session().await;
         app.settings.default_review_selection = crate::domain::agent::AgentSelection::new(
             crate::domain::agent::AgentKind::Claude,
-            AgentModel::ClaudeOpus48,
+            AgentModel::ClaudeOpus5,
         );
         app.sessions.sessions_mut()[0].status = Status::Review;
         let session_folder = app.sessions.sessions()[0].folder.clone();
@@ -1859,7 +1859,7 @@ mod tests {
         let (review_status_message, review_text) = app.review_view_state(&view_context.session_id);
         assert_eq!(
             review_status_message,
-            Some(review_loading_message(AgentModel::ClaudeOpus48))
+            Some(review_loading_message(AgentModel::ClaudeOpus5))
         );
         assert_eq!(review_text, None);
         assert_eq!(app.sessions.sessions()[0].status, Status::AgentReview);
@@ -2357,7 +2357,7 @@ mod tests {
         let (mut app, _base_dir, session_id) = new_test_app_with_session().await;
         app.settings.default_review_selection = crate::domain::agent::AgentSelection::new(
             crate::domain::agent::AgentKind::Claude,
-            AgentModel::ClaudeOpus48,
+            AgentModel::ClaudeOpus5,
         );
         app.review_cache.insert(
             session_id.clone().into(),
@@ -2376,7 +2376,7 @@ mod tests {
         let (review_status_message, review_text) = app.review_view_state(&view_context.session_id);
         assert_eq!(
             review_status_message,
-            Some(review_loading_message(AgentModel::ClaudeOpus48))
+            Some(review_loading_message(AgentModel::ClaudeOpus5))
         );
         assert_eq!(review_text, None);
     }

--- a/crates/agentty/src/ui/layout.rs
+++ b/crates/agentty/src/ui/layout.rs
@@ -513,7 +513,7 @@ mod tests {
         session.title = Some("This is a very long timer-aware session header title".to_string());
         session.agent = crate::domain::agent::AgentSelection::new(
             crate::domain::agent::AgentKind::Codex,
-            AgentModel::Gpt55,
+            AgentModel::Gpt56Sol,
         );
         session.in_progress_started_at = Some(0);
 
@@ -550,7 +550,7 @@ mod tests {
         let mut session = session_fixture();
         session.agent = crate::domain::agent::AgentSelection::new(
             crate::domain::agent::AgentKind::Codex,
-            AgentModel::Gpt55,
+            AgentModel::Gpt56Sol,
         );
         session.stats.added_lines = 9;
         session.stats.deleted_lines = 3;
@@ -564,9 +564,9 @@ mod tests {
         // Assert
         assert!(early_metadata.contains("Lines: +9 / -3"));
         assert!(early_metadata.contains("Timer: 30s"));
-        assert!(early_metadata.contains("Model: gpt-5.5"));
+        assert!(early_metadata.contains("Model: gpt-5.6-sol"));
         assert!(
-            early_metadata.find("Model: gpt-5.5") < early_metadata.find("Reasoning: high"),
+            early_metadata.find("Model: gpt-5.6-sol") < early_metadata.find("Reasoning: high"),
             "model should appear before reasoning in metadata text"
         );
         assert!(later_metadata.contains("Timer: 1h1m0s"));
@@ -1273,7 +1273,7 @@ mod tests {
         let status_line = session_output_status_line(
             Status::AgentReview,
             None,
-            Some("Reviewing changes with gpt-5.5"),
+            Some("Reviewing changes with gpt-5.6-sol"),
         )
         .expect("agent-review sessions should render a status line");
 
@@ -1281,7 +1281,7 @@ mod tests {
         assert!(
             status_line
                 .to_string()
-                .contains("Reviewing changes with gpt-5.5")
+                .contains("Reviewing changes with gpt-5.6-sol")
         );
     }
 

--- a/crates/agentty/src/ui/page/session_list.rs
+++ b/crates/agentty/src/ui/page/session_list.rs
@@ -684,7 +684,7 @@ mod tests {
             crate::test_support::titled_session_fixture("active-2", Status::Review);
         medium_session.agent = crate::domain::agent::AgentSelection::new(
             crate::domain::agent::AgentKind::Codex,
-            AgentModel::Gpt55,
+            AgentModel::Gpt56Sol,
         );
         medium_session.reasoning_level_override = Some(ReasoningLevel::Medium);
         let sessions = vec![default_session, medium_session];
@@ -724,7 +724,7 @@ mod tests {
         let mut session = crate::test_support::titled_session_fixture("session-1", Status::Review);
         session.agent = crate::domain::agent::AgentSelection::new(
             crate::domain::agent::AgentKind::Codex,
-            AgentModel::Gpt55,
+            AgentModel::Gpt56Sol,
         );
         session.reasoning_level_override = Some(ReasoningLevel::High);
         let sessions = vec![session];
@@ -741,7 +741,7 @@ mod tests {
         // Assert
         let buffer = terminal.backend().buffer();
         let fallback_cell = &buffer.content()[0];
-        let model_cell = find_text_start_cell(buffer, "gpt-5.5").unwrap_or(fallback_cell);
+        let model_cell = find_text_start_cell(buffer, "gpt-5.6-sol").unwrap_or(fallback_cell);
         let reasoning_cell = find_text_start_cell(buffer, "high").unwrap_or(fallback_cell);
 
         assert_eq!(model_cell.fg, style::palette::text());
@@ -759,7 +759,7 @@ mod tests {
         let mut session = crate::test_support::titled_session_fixture("session-1", Status::Review);
         session.agent = crate::domain::agent::AgentSelection::new(
             crate::domain::agent::AgentKind::Codex,
-            AgentModel::Gpt55,
+            AgentModel::Gpt56Sol,
         );
         let sessions = vec![session];
 
@@ -774,7 +774,7 @@ mod tests {
         // Assert
         let buffer = terminal.backend().buffer();
         let fallback_cell = &buffer.content()[0];
-        let model_cell = find_text_start_cell(buffer, "gpt-5.5").unwrap_or(fallback_cell);
+        let model_cell = find_text_start_cell(buffer, "gpt-5.6-sol").unwrap_or(fallback_cell);
 
         assert_eq!(model_cell.bg, style::palette::surface_selection());
     }
@@ -789,7 +789,7 @@ mod tests {
         let mut session = crate::test_support::titled_session_fixture("session-1", Status::Review);
         session.agent = crate::domain::agent::AgentSelection::new(
             crate::domain::agent::AgentKind::Codex,
-            AgentModel::Gpt55,
+            AgentModel::Gpt56Sol,
         );
         session.reasoning_level_override = Some(ReasoningLevel::Medium);
         let sessions = vec![session];
@@ -804,7 +804,7 @@ mod tests {
 
         // Assert
         let text = buffer_text(terminal.backend().buffer());
-        assert!(text.contains("gpt-5.5 [medium]"));
+        assert!(text.contains("gpt-5.6-sol [medium]"));
     }
 
     #[test]
@@ -854,7 +854,7 @@ mod tests {
         let mut session = crate::test_support::titled_session_fixture("session-1", Status::Review);
         session.agent = crate::domain::agent::AgentSelection::new(
             crate::domain::agent::AgentKind::Codex,
-            AgentModel::Gpt55,
+            AgentModel::Gpt56Sol,
         );
         session.reasoning_level_override = Some(ReasoningLevel::High);
         let sessions = vec![session];
@@ -869,7 +869,7 @@ mod tests {
 
         // Assert
         let text = buffer_text(terminal.backend().buffer());
-        assert!(text.contains("gpt-5.5 [high]"));
+        assert!(text.contains("gpt-5.6-sol [high]"));
     }
 
     #[test]

--- a/crates/agentty/src/ui/session_format.rs
+++ b/crates/agentty/src/ui/session_format.rs
@@ -455,14 +455,14 @@ mod tests {
         let mut session = SessionFixtureBuilder::new().build();
         session.agent = crate::domain::agent::AgentSelection::new(
             crate::domain::agent::AgentKind::Codex,
-            AgentModel::Gpt55,
+            AgentModel::Gpt56Sol,
         );
 
         // Act
         let metadata_text = session_metadata_text(&session, 160, ReasoningLevel::default(), 0);
 
         // Assert
-        assert!(metadata_text.contains("Agent: codex  Model: gpt-5.5"));
+        assert!(metadata_text.contains("Agent: codex  Model: gpt-5.6-sol"));
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/confirmation.rs
+++ b/crates/agentty/tests/e2e/confirmation.rs
@@ -16,7 +16,7 @@ type E2eResult = Result<(), Box<dyn std::error::Error>>;
 fn seed_cancelable_draft_session(env: &BuilderEnv) -> E2eResult {
     common::seed_session(
         env,
-        SessionSeed::draft("draft-cancel-0001", "gpt-5.5", "main", "Draft")
+        SessionSeed::draft("draft-cancel-0001", "gpt-5.6-sol", "main", "Draft")
             .with_title("Cancel staged draft from list"),
     )
 }
@@ -27,8 +27,8 @@ fn seed_cancelable_running_session(env: &BuilderEnv) -> E2eResult {
 
     common::seed_session(
         env,
-        SessionSeed::regular(session_id, "gpt-5.5", "main", "InProgress")
-            .with_title("Cancel running session from list"),
+        SessionSeed::regular(session_id, "gpt-5.6-sol", "main", "InProgress")
+            .with_title("Cancel running session"),
     )?;
 
     let worktree_name = &session_id[..8];
@@ -46,14 +46,14 @@ fn seed_cancelable_stacked_child_session(env: &BuilderEnv) -> E2eResult {
 
     common::seed_session(
         env,
-        SessionSeed::regular(parent_session_id, "gpt-5.5", "main", "Review")
+        SessionSeed::regular(parent_session_id, "gpt-5.6-sol", "main", "Review")
             .with_title("Parent for child cancel"),
     )?;
     common::seed_session(
         env,
         SessionSeed::stacked_draft(
             child_session_id,
-            "gpt-5.5",
+            "gpt-5.6-sol",
             "wt/parentca",
             "Draft",
             parent_session_id,
@@ -243,7 +243,7 @@ fn running_session_cancel_confirmation() -> E2eResult {
                 scenario
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::switch_to_tab("Sessions"))
-                    .wait_for_text("Cancel running session from list", 5000)
+                    .wait_for_text("Cancel running session", 5000)
                     .viewing_pause_ms(1500)
                     .capture_labeled(
                         "running_row",
@@ -267,11 +267,7 @@ fn running_session_cancel_confirmation() -> E2eResult {
             |frame, report| {
                 let list_frame = common::frame_from_capture(&report.captures[0]);
                 let list_full = Region::full(list_frame.cols(), list_frame.rows());
-                assertion::assert_text_in_region(
-                    &list_frame,
-                    "Cancel running session from list",
-                    &list_full,
-                );
+                assertion::assert_text_in_region(&list_frame, "Cancel running session", &list_full);
                 assertion::assert_text_in_region(&list_frame, "c: cancel", &list_full);
 
                 let confirmation_frame = common::frame_from_capture(&report.captures[1]);

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -111,7 +111,7 @@ fn seed_session_with_beautified_agent_error(
 ) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
         env,
-        SessionSeed::regular("agent-error-0001", "claude-opus-4-8", "main", "Review")
+        SessionSeed::regular("agent-error-0001", "claude-opus-5", "main", "Review")
             .with_title("Readable agent error"),
     )?;
 
@@ -187,7 +187,7 @@ printf '%s\n' '{"type":"result","subtype":"success","result":"{\"answer\":\"Crea
 fn seed_session_with_markdown_table(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
         env,
-        SessionSeed::regular("markdown-table-0001", "claude-opus-4-8", "main", "Review")
+        SessionSeed::regular("markdown-table-0001", "claude-opus-5", "main", "Review")
             .with_title("Markdown table output"),
     )?;
 
@@ -219,7 +219,7 @@ fn seed_session_with_markdown_table(env: &BuilderEnv) -> Result<(), Box<dyn std:
 fn seed_session_with_user_markdown(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
         env,
-        SessionSeed::regular("user-markdown-0001", "claude-opus-4-8", "main", "Review")
+        SessionSeed::regular("user-markdown-0001", "claude-opus-5", "main", "Review")
             .with_title("User markdown prompt"),
     )?;
 
@@ -272,7 +272,7 @@ fn seed_session_with_inline_markdown_punctuation(
 ) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
         env,
-        SessionSeed::regular("inline-md-0001", "claude-opus-4-8", "main", "Review")
+        SessionSeed::regular("inline-md-0001", "claude-opus-5", "main", "Review")
             .with_title("Inline markdown punctuation"),
     )?;
 
@@ -302,7 +302,7 @@ fn seed_session_with_inline_markdown_punctuation(
 fn seed_session_with_mermaid_output(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
         env,
-        SessionSeed::regular("mermaid-chat-0001", "claude-opus-4-8", "main", "Review")
+        SessionSeed::regular("mermaid-chat-0001", "claude-opus-5", "main", "Review")
             .with_title("Mermaid diagram output"),
     )?;
 
@@ -362,7 +362,7 @@ fn seed_session_with_cyclic_mermaid_output(
 ) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
         env,
-        SessionSeed::regular("cyclic-mermaid-0001", "claude-opus-4-8", "main", "Review")
+        SessionSeed::regular("cyclic-mermaid-0001", "claude-opus-5", "main", "Review")
             .with_title("Cyclic Mermaid output"),
     )?;
 
@@ -406,7 +406,7 @@ fn seed_session_with_typed_marker_collision(
     let session_id = "typed-marker-0001";
     common::seed_session(
         env,
-        SessionSeed::regular(session_id, "gpt-5.5", "main", "Review")
+        SessionSeed::regular(session_id, "gpt-5.6-sol", "main", "Review")
             .with_title("Typed marker collision"),
     )?;
 
@@ -517,7 +517,7 @@ printf '{{"type":"result","subtype":"success","result":"{{\\"answer\\":\\"## Rev
 fn seed_review_ready_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
         env,
-        SessionSeed::regular("review-shortcut-0001", "gpt-5.5", "main", "Review")
+        SessionSeed::regular("review-shortcut-0001", "gpt-5.6-sol", "main", "Review")
             .with_title("Review-ready session shortcuts"),
     )?;
 
@@ -681,7 +681,7 @@ fn seed_session_with_published_branch_push_notice(
 
     common::seed_session(
         env,
-        SessionSeed::regular(session_id, "gpt-5.5", "main", "Review")
+        SessionSeed::regular(session_id, "gpt-5.6-sol", "main", "Review")
             .with_title("Published push notice"),
     )?;
 
@@ -740,7 +740,7 @@ fn seed_agent_review_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error:
             .sessions()
             .insert_session(
                 "agent-review-sync-0001",
-                "gpt-5.5",
+                "gpt-5.6-sol",
                 "main",
                 "AgentReview",
                 project_id,
@@ -767,14 +767,14 @@ fn seed_review_ready_parent_with_review_child(
 ) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
         env,
-        SessionSeed::regular("stack-parent-0001", "gpt-5.5", "main", "Review")
+        SessionSeed::regular("stack-parent-0001", "gpt-5.6-sol", "main", "Review")
             .with_title("Parent stack review"),
     )?;
     common::seed_session(
         env,
         SessionSeed::stacked_draft(
             "stack-child-0001",
-            "gpt-5.5",
+            "gpt-5.6-sol",
             "wt/stack-pa",
             "Review",
             "stack-parent-0001",
@@ -797,7 +797,7 @@ fn seed_pending_post_merge_restack_child(
     let parent_tip = seed_child_worktree_for_onto_rebase(&env.workdir, &child_worktree)?;
     common::seed_session(
         env,
-        SessionSeed::regular("stack-restack-child-0001", "gpt-5.5", "main", "Review")
+        SessionSeed::regular("stack-restack-child-0001", "gpt-5.6-sol", "main", "Review")
             .with_title("Pending post-merge child sync"),
     )?;
 
@@ -823,8 +823,13 @@ fn seed_failing_pending_post_merge_restack_child(
     let _parent_tip = seed_child_worktree_for_onto_rebase(&env.workdir, &child_worktree)?;
     common::seed_session(
         env,
-        SessionSeed::regular("stack-restack-failure-0001", "gpt-5.5", "main", "Review")
-            .with_title("Blocked post-merge child sync"),
+        SessionSeed::regular(
+            "stack-restack-failure-0001",
+            "gpt-5.6-sol",
+            "main",
+            "Review",
+        )
+        .with_title("Blocked post-merge child sync"),
     )?;
 
     let runtime = common::seed_runtime()?;
@@ -907,12 +912,12 @@ fn seed_sessions_with_matching_update_times(
 ) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
         env,
-        SessionSeed::regular("a-older", "gpt-5.5", "main", "Review")
+        SessionSeed::regular("a-older", "gpt-5.6-sol", "main", "Review")
             .with_title("Older created session"),
     )?;
     common::seed_session(
         env,
-        SessionSeed::regular("z-newer", "gpt-5.5", "main", "Review")
+        SessionSeed::regular("z-newer", "gpt-5.6-sol", "main", "Review")
             .with_title("Newer created session"),
     )?;
 
@@ -1266,7 +1271,7 @@ fn seed_sessions_with_persisted_focused_reviews(
     // Seeding in the other order makes row 0 depend on that boundary.
     common::seed_session(
         env,
-        SessionSeed::regular("second-review-0001", "gpt-5.5", "main", "Review")
+        SessionSeed::regular("second-review-0001", "gpt-5.6-sol", "main", "Review")
             .with_title("Second persisted review"),
     )?;
 
@@ -1299,7 +1304,7 @@ fn seed_sessions_with_persisted_focused_reviews(
 fn seed_running_stop_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
         env,
-        SessionSeed::regular(RUNNING_STOP_SESSION_ID, "gpt-5.5", "main", "InProgress")
+        SessionSeed::regular(RUNNING_STOP_SESSION_ID, "gpt-5.6-sol", "main", "InProgress")
             .with_title("Running session stop"),
     )?;
 
@@ -1325,7 +1330,7 @@ fn seed_running_stop_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error:
 fn seed_rebasing_queue_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
         env,
-        SessionSeed::regular(REBASING_QUEUE_SESSION_ID, "gpt-5.5", "main", "Rebasing")
+        SessionSeed::regular(REBASING_QUEUE_SESSION_ID, "gpt-5.6-sol", "main", "Rebasing")
             .with_title("Rebasing message queue"),
     )?;
 
@@ -1361,8 +1366,13 @@ fn seed_rebasing_queue_session(env: &BuilderEnv) -> Result<(), Box<dyn std::erro
 fn seed_question_resume_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
         env,
-        SessionSeed::regular(QUESTION_RESUME_SESSION_ID, "gpt-5.5", "main", "Question")
-            .with_title("Question resume session"),
+        SessionSeed::regular(
+            QUESTION_RESUME_SESSION_ID,
+            "gpt-5.6-sol",
+            "main",
+            "Question",
+        )
+        .with_title("Question resume session"),
     )?;
 
     let session_worktree =
@@ -1716,7 +1726,7 @@ fn seed_dirty_fork_source_session(env: &BuilderEnv) -> Result<(), Box<dyn std::e
 fn seed_binary_diff_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
         env,
-        SessionSeed::regular(BINARY_DIFF_SESSION_ID, "gpt-5.5", "main", "Review")
+        SessionSeed::regular(BINARY_DIFF_SESSION_ID, "gpt-5.6-sol", "main", "Review")
             .with_title("Binary diff session"),
     )?;
 
@@ -1963,14 +1973,14 @@ fn seed_stacked_at_lookup_session(env: &BuilderEnv) -> Result<(), Box<dyn std::e
     let child_session_id = "atchildx-0001";
     common::seed_session(
         env,
-        SessionSeed::regular(parent_session_id, "gpt-5.5", "main", "Review")
+        SessionSeed::regular(parent_session_id, "gpt-5.6-sol", "main", "Review")
             .with_title("Parent with lookup file"),
     )?;
     common::seed_session(
         env,
         SessionSeed::stacked_draft(
             child_session_id,
-            "gpt-5.5",
+            "gpt-5.6-sol",
             "wt/atparent",
             "Draft",
             parent_session_id,
@@ -1994,7 +2004,7 @@ fn seed_done_session_for_continuation(env: &BuilderEnv) -> Result<(), Box<dyn st
     let merged_commit_hash = "704de31d0f4b5a1234567890abcdef1234567890";
     common::seed_session(
         env,
-        SessionSeed::regular("done-continue-0001", "gpt-5.5", "main", "Done")
+        SessionSeed::regular("done-continue-0001", "gpt-5.6-sol", "main", "Done")
             .with_title("Continue terminal session"),
     )?;
 
@@ -2021,7 +2031,7 @@ fn seed_done_session_for_continuation(env: &BuilderEnv) -> Result<(), Box<dyn st
 fn seed_active_loader_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
         env,
-        SessionSeed::regular(LOADER_SESSION_ID, "gpt-5.5", "main", "InProgress")
+        SessionSeed::regular(LOADER_SESSION_ID, "gpt-5.6-sol", "main", "InProgress")
             .with_title("Loader session"),
     )?;
 
@@ -2040,7 +2050,7 @@ fn seed_session_with_scrollable_output(env: &BuilderEnv) -> Result<(), Box<dyn s
 
     common::seed_session(
         env,
-        SessionSeed::regular(SESSION_ID, "gpt-5.5", "main", "Review")
+        SessionSeed::regular(SESSION_ID, "gpt-5.6-sol", "main", "Review")
             .with_title("Scrollable output"),
     )?;
 
@@ -2364,7 +2374,7 @@ fn session_list_model_reasoning_level() -> E2eResult {
                 scenario
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::switch_to_tab("Sessions"))
-                    .wait_for_text("gpt-5.5 [medium]", 5000)
+                    .wait_for_text("gpt-5.6-sol [medium]", 5000)
                     .capture_labeled(
                         "model_reasoning",
                         "Session row model column with reasoning level",
@@ -2372,7 +2382,7 @@ fn session_list_model_reasoning_level() -> E2eResult {
             },
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(frame, "gpt-5.5 [medium]", &full);
+                assertion::assert_text_in_region(frame, "gpt-5.6-sol [medium]", &full);
             },
         )?;
 
@@ -2431,7 +2441,7 @@ fn existing_session_keeps_persisted_reasoning_label() -> E2eResult {
                 scenario
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::switch_to_tab("Sessions"))
-                    .wait_for_text("gpt-5.5 [high]", 5000)
+                    .wait_for_text("gpt-5.6-sol [high]", 5000)
                     .compose(&common::switch_to_tab("Inbox"))
                     .compose(&common::switch_to_tab("Issues"))
                     .compose(&common::switch_to_tab("Settings"))
@@ -2443,7 +2453,7 @@ fn existing_session_keeps_persisted_reasoning_label() -> E2eResult {
                     .press_key("BackTab")
                     .press_key("BackTab")
                     .press_key("BackTab")
-                    .wait_for_text("gpt-5.5 [high]", 5000)
+                    .wait_for_text("gpt-5.6-sol [high]", 5000)
                     .capture_labeled(
                         "active_reasoning",
                         "Existing session retains persisted reasoning",
@@ -2451,7 +2461,7 @@ fn existing_session_keeps_persisted_reasoning_label() -> E2eResult {
             },
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(frame, "gpt-5.5 [high]", &full);
+                assertion::assert_text_in_region(frame, "gpt-5.6-sol [high]", &full);
             },
         )?;
 
@@ -2472,7 +2482,7 @@ fn session_chat_header_agent_model() -> E2eResult {
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::switch_to_tab("Sessions"))
                     .press_key("Enter")
-                    .wait_for_text("Agent: codex  Model: gpt-5.5", 5000)
+                    .wait_for_text("Agent: codex  Model: gpt-5.6-sol", 5000)
                     .capture_labeled(
                         "agent_model_header",
                         "Session chat header showing agent before model",
@@ -2480,7 +2490,7 @@ fn session_chat_header_agent_model() -> E2eResult {
             },
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(frame, "Agent: codex  Model: gpt-5.5", &full);
+                assertion::assert_text_in_region(frame, "Agent: codex  Model: gpt-5.6-sol", &full);
             },
         )?;
 
@@ -2558,7 +2568,7 @@ fn session_list_selected_row_remains_readable_under_dark_horizon() -> E2eResult 
                 let selected_row_region =
                     Region::new(0, selected_title.rect.row, sessions_frame.cols(), 1);
                 sessions_frame
-                    .find_text_in_region("gpt-5.5", &selected_row_region)
+                    .find_text_in_region("gpt-5.6-sol", &selected_row_region)
                     .into_iter()
                     .next()
                     .expect("expected selected session model to be visible");
@@ -3880,7 +3890,7 @@ fn gemini_model_picker_lists_current_models() -> E2eResult {
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "gemini-3.6-flash", &full);
-                assertion::assert_text_in_region(frame, "gemini-3.5-flash", &full);
+                assertion::assert_text_in_region(frame, "gemini-3.5-flash-lite", &full);
             },
         )?;
 
@@ -3921,9 +3931,54 @@ fn claude_model_picker_lists_current_models() -> E2eResult {
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "claude-fable-5", &full);
                 assertion::assert_text_in_region(frame, "claude-opus-5", &full);
-                assertion::assert_text_in_region(frame, "claude-opus-4-8", &full);
                 assertion::assert_text_in_region(frame, "claude-sonnet-5", &full);
                 assertion::assert_text_in_region(frame, "claude-haiku-4-5-20251001", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Seeds one still-active review session whose persisted model id has been
+/// retired in favor of `gemini-3.5-flash-lite`.
+fn seed_active_session_with_retired_model(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    common::seed_session(
+        env,
+        SessionSeed::regular("retired-model-0001", "gemini-3.5-flash", "main", "Review")
+            .with_title("Retired model"),
+    )?;
+
+    std::fs::create_dir_all(env.agentty_root.join("wt").join("retired-"))?;
+
+    Ok(())
+}
+
+/// Verify that a still-active session stored on a retired model id is
+/// switched automatically to the replacement model.
+#[test]
+fn retired_model_session_switches_to_replacement() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("retired_model_session_switches_to_replacement")
+        .with_git()
+        .setup(seed_active_session_with_retired_model)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .wait_for_text("gemini-3.5-flash-lite", 5000)
+                    .capture_labeled(
+                        "retired_model_replacement",
+                        "Active session switched to the replacement model",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Retired model", &full);
+                assertion::assert_text_in_region(frame, "gemini-3.5-flash-lite", &full);
+                assertion::assert_match_count(frame, "gemini-3.5-flash [medium]", 0);
             },
         )?;
 
@@ -3967,7 +4022,6 @@ fn codex_model_picker_lists_current_models() -> E2eResult {
                 assertion::assert_text_in_region(frame, "gpt-5.6-sol", &full);
                 assertion::assert_text_in_region(frame, "gpt-5.6-terra", &full);
                 assertion::assert_text_in_region(frame, "gpt-5.6-luna", &full);
-                assertion::assert_text_in_region(frame, "gpt-5.5", &full);
                 assertion::assert_text_in_region(frame, "gpt-5.3-codex-spark", &full);
             },
         )?;
@@ -4008,7 +4062,7 @@ fn antigravity_model_picker_includes_gemini_models() -> E2eResult {
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "gemini-3.1-pro", &full);
                 assertion::assert_text_in_region(frame, "gemini-3.6-flash", &full);
-                assertion::assert_text_in_region(frame, "gemini-3.5-flash", &full);
+                assertion::assert_text_in_region(frame, "gemini-3.5-flash-lite", &full);
             },
         )?;
 

--- a/crates/agentty/tests/e2e/setting.rs
+++ b/crates/agentty/tests/e2e/setting.rs
@@ -28,7 +28,7 @@ fn seed_gemini_settings_cli_stub(env: &BuilderEnv) -> Result<(), Box<dyn std::er
 /// Seeds deterministic selector values for the settings navigation test.
 ///
 /// Persists the three model selectors to `claude-opus-4-6` so the test can
-/// verify Agentty upgrades retired stored model ids to `claude-opus-4-8`
+/// verify Agentty upgrades retired stored model ids to `claude-opus-5`
 /// before row navigation changes the visible selector values.
 fn seed_settings_navigation_models(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     let canonical_workdir = env.workdir.canonicalize()?;
@@ -120,7 +120,7 @@ fn settings_tab_shows_content() {
 /// Opens the Settings tab and presses `j` multiple times to move the
 /// selection down, then `k` to move back up. The test confirms the selected
 /// row by seeding deterministic retired Opus model values, observing startup
-/// migration to `claude-opus-4-8`, and then checking which selector advances
+/// migration to `claude-opus-5`, and then checking which selector advances
 /// through the current Claude model list after each dropdown selection.
 #[test]
 fn settings_jk_navigation() {
@@ -185,16 +185,16 @@ fn settings_jk_navigation() {
 
                 let initial_frame = common::frame_from_capture(&report.captures[0]);
                 assertion::assert_match_count(&initial_frame, "claude-opus-4-6", 0);
-                assertion::assert_match_count(&initial_frame, "claude/claude-opus-4-8", 3);
+                assertion::assert_match_count(&initial_frame, "claude/claude-opus-5", 3);
 
                 let moved_down_frame = common::frame_from_capture(&report.captures[1]);
                 assertion::assert_match_count(&moved_down_frame, "claude-opus-4-6", 0);
-                assertion::assert_match_count(&moved_down_frame, "claude/claude-opus-4-8", 2);
+                assertion::assert_match_count(&moved_down_frame, "claude/claude-opus-5", 2);
                 assertion::assert_match_count(&moved_down_frame, "claude/claude-sonnet-5", 1);
 
                 let moved_up_frame = common::frame_from_capture(&report.captures[2]);
                 assertion::assert_match_count(&moved_up_frame, "claude-opus-4-6", 0);
-                assertion::assert_match_count(&moved_up_frame, "claude/claude-opus-4-8", 1);
+                assertion::assert_match_count(&moved_up_frame, "claude/claude-opus-5", 1);
                 assertion::assert_match_count(&moved_up_frame, "claude/claude-sonnet-5", 2);
             },
         )

--- a/crates/agentty/tests/protocol_compliance_e2e.rs
+++ b/crates/agentty/tests/protocol_compliance_e2e.rs
@@ -28,13 +28,13 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(15);
 /// Maximum duration allowed for provider CLI readiness preflight checks.
 const PROVIDER_PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Verifies real Codex (`gpt-5.5`) turn execution through
+/// Verifies real Codex (`gpt-5.6-sol`) turn execution through
 /// `create_agent_channel()` yields a non-empty protocol `answer`.
 #[tokio::test]
 #[ignore = "requires real Codex CLI credentials and network"]
 async fn codex_protocol_compliance_e2e() {
     // Arrange
-    let model = AgentModel::Gpt55;
+    let model = AgentModel::Gpt56Sol;
     if provider_preflight_skip_reason(AgentKind::Codex)
         .await
         .is_some()

--- a/docs/site/content/docs/agents/backends.md
+++ b/docs/site/content/docs/agents/backends.md
@@ -160,7 +160,7 @@ unless a session-specific override is active. Antigravity receives `--effort low
 `--effort medium`, or `--effort high`; `xhigh` and `max` map to its highest supported
 value, `--effort high`. Codex receives `max` as a distinct reasoning effort. For Claude,
 both `xhigh` and `max` map to `--effort max`, which is currently only supported by
-`claude-opus-5` and `claude-opus-4-8`.
+`claude-opus-5`.
 
 ## Available Models
 
@@ -173,13 +173,12 @@ Both providers share the same Gemini model ids:
 
 - `gemini-3.1-pro` (default): Higher-quality Gemini model for deeper reasoning.
 - `gemini-3.6-flash`: Fast Gemini model for agentic and multimodal tasks.
-- `gemini-3.5-flash`: Fast Gemini model for balanced agentic workloads.
+- `gemini-3.5-flash-lite`: Lightweight Gemini model for fast, cost-conscious workloads.
 
 ### Claude Models
 
 - `claude-fable-5` (default): Claude Fable model for creative, narrative-heavy tasks.
 - `claude-opus-5`: Latest Claude Opus model for complex tasks.
-- `claude-opus-4-8`: Claude Opus 4.8 model for complex tasks.
 - `claude-sonnet-5`: Balanced Claude model for quality and latency.
 - `claude-haiku-4-5-20251001`: Fast Claude model for lighter tasks.
 
@@ -188,14 +187,25 @@ Both providers share the same Gemini model ids:
 - `gpt-5.6-sol` (default): Newest Codex model for the strongest coding performance.
 - `gpt-5.6-terra`: Current Codex model for balanced coding performance.
 - `gpt-5.6-luna`: Current Codex model for lighter coding iterations.
-- `gpt-5.5`: Newer Codex model with stronger coding performance when available.
 - `gpt-5.3-codex-spark`: Codex spark model for quick coding iterations.
 
-Stored project defaults or session rows that reference a retired model id (such as
-`gemini-3-flash-preview`, `gemini-3.5-flash-lite`, `gemini-3.1-pro-preview`,
-`gemini-3.1-flash-lite-preview`, `claude-opus-4-6`, `claude-opus-4-7`,
-`claude-sonnet-4-6`, `gpt-5.4`, or `gpt-5.4-mini`) are upgraded to the current supported
-replacement when Agentty loads them.
+### Retired Models
+
+When a model is retired in favor of a replacement (for example, a new Claude Opus
+release superseding the previous one), Agentty upgrades stored references automatically:
+
+- Model pickers for new sessions list only the current models above; retired ids (such
+  as `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-3.5-flash`,
+  `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `claude-opus-4-8`,
+  `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `gpt-5.5`, `gpt-5.4`,
+  `gpt-5.4-mini`, `gpt-5.3-codex`, or `gpt-5.2-codex`) are never selectable.
+- Stored project defaults that reference a retired model id are upgraded to the current
+  supported replacement when Agentty loads them.
+- Sessions that are still active are switched to the replacement model automatically,
+  and the switch is persisted so every following turn runs on the current model.
+- Finished sessions (`Merged`, `Done`, or `Canceled`) keep the retired model id in the
+  database as a historical record and are displayed with the replacement model when
+  reopened.
 
 ## Switching Models
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -49,6 +49,7 @@ flowchart TD
   main["main.rs"]
   db["Database::open()<br/>sqlite open + WAL + foreign keys + migrations"]
   app_new["App::new()"]
+  model_migration["Migrate active retired models<br/>across saved projects"]
   scan["Startup-only home-directory project scan<br/>then project/session snapshot load"]
   fail_ops["Fail unfinished operations from previous run"]
   background["Spawn app background tasks"]
@@ -65,7 +66,8 @@ flowchart TD
 
   main --> db
   main --> app_new
-  app_new --> scan
+  app_new --> model_migration
+  model_migration --> scan
   app_new --> fail_ops
   app_new --> background
   main --> runtime
@@ -176,12 +178,13 @@ derived data instead of recomputing the render twice per frame.
 future non-TUI callers. `SessionService` accepts a `SessionBackend` trait object and
 offers create, complete by-id lookup, send, merge, and review-request operations.
 `app/session_api.rs` implements that port for `App`: commands reuse the existing worker
-and merge workflows, while lookup joins the persisted session settings and ordered
-messages into one frontend-neutral aggregate. The adapter deliberately contains no
-orchestrator policy, so a future orchestrator can own sequencing while calling the same
-API as the current frontend. `CreateSessionRequest` carries an explicit project id; the
-current `App` adapter validates that it matches the loaded project context, while
-another host can resolve project contexts independently.
+and merge workflows, while lookup migrates an active retired model reference and joins
+the persisted session settings and ordered messages into one frontend-neutral aggregate.
+The adapter deliberately contains no orchestrator policy, so a future orchestrator can
+own sequencing while calling the same API as the current frontend.
+`CreateSessionRequest` carries an explicit project id; the current `App` adapter
+validates that it matches the loaded project context, while another host can resolve
+project contexts independently.
 
 ```mermaid
 flowchart LR
@@ -278,6 +281,8 @@ restart-safe:
 - Before enqueue: insert `session_operation` row (`queued`).
 - Worker transitions: `queued -> running -> done/failed/canceled`.
 - Cancel requests are persisted and checked before command execution.
+- On startup, active sessions across every saved project are migrated from retired model
+  ids to their current provider/model replacements before project-scoped snapshots load.
 - On startup, unfinished operations are failed with reason `Interrupted by app restart`,
   interrupted rebase operations abort stale in-progress git rebase metadata, and
   impacted sessions are reset to `Review`. Pending post-merge stacked-child syncs are


### PR DESCRIPTION
- Centralize retired model ids and replacement mappings while removing retired variants from selectable provider lists.
- Resolve replacement models against available providers and persist the resolved provider/model pair for retired project defaults.
- Upgrade persisted settings and active sessions to current replacements while preserving retired ids for finished-session history.
- Extend migration to active sessions across all projects and programmatic API reads while retaining terminal-session history.
- Guard active-session model updates against concurrent terminal transitions.
- Preserve session activity timestamps during active-session model updates.
- Update model, session-loading, UI, end-to-end, and backend documentation coverage.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)