### PR TITLE
Support schema-validated structured model output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ name = "ag-harness"
 version = "0.13.7"
 dependencies = [
  "async-trait",
+ "jsonschema",
  "reqwest",
  "serde",
  "serde_json",
@@ -209,6 +210,20 @@ dependencies = [
  "tracing",
  "unicode-width",
  "uuid",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -552,7 +567,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -560,6 +584,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -633,6 +663,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +699,12 @@ name = "by_address"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -1063,6 +1105,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1253,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,8 +1323,19 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1357,6 +1425,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1471,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1571,9 +1660,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2159,6 +2250,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba783d17473c27cfd4d1d72785dc1c26d5faba8072f50fec4ebea179bec8f33d"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex 0.17.0",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2423,6 +2541,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,6 +2594,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2529,6 +2716,12 @@ checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "palette"
@@ -3090,6 +3283,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "referencing"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef39a30a317e883d1ef4c43aa849f90f480d90bb24904fd38266e61d6be58f2"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -3999,7 +4207,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bitflags 2.13.0",
- "fancy-regex",
+ "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
  "fixedbitset 0.4.2",
@@ -4358,6 +4566,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4456,6 +4670,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4472,6 +4696,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vt100"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ clap = { version = "4", features = ["derive"] }
 crossterm = { version = "0.29.0", default-features = false, features = ["bracketed-paste", "events"] }
 ignore = "0.4"
 image = { version = "0.25", default-features = false, features = ["png", "gif"] }
+jsonschema = { version = "0.40.0", default-features = false }
 mockall = "0.15"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", default-features = false }

--- a/crates/ag-harness/Cargo.toml
+++ b/crates/ag-harness/Cargo.toml
@@ -10,12 +10,13 @@ homepage.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+jsonschema.workspace = true
 reqwest.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-serde_json.workspace = true
 tokio.workspace = true
 wiremock.workspace = true
 

--- a/crates/ag-harness/examples/qwen.rs
+++ b/crates/ag-harness/examples/qwen.rs
@@ -1,10 +1,11 @@
-//! Sends a fixed prompt to a configured Qwen model and prints its response.
+//! Requests structured output from a configured Qwen model and prints the
+//! validated JSON.
 
 use std::error::Error;
-use std::io;
-use std::io::Write;
+use std::io::{self, Write};
 
-use ag_harness::{Model, ModelRequest, Qwen, QwenConfig};
+use ag_harness::{Model, ModelRequest, OutputSchema, Qwen, QwenConfig};
+use serde_json::json;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -13,11 +14,25 @@ async fn main() -> Result<(), Box<dyn Error>> {
         base_url: std::env::var("DASHSCOPE_BASE_URL")?,
         model: "qwen-plus".to_string(),
     });
+    let schema = OutputSchema::new(json!({
+        "type": "object",
+        "properties": {
+            "message": {
+                "type": "string",
+                "const": "hello"
+            }
+        },
+        "required": ["message"],
+        "additionalProperties": false
+    }))?;
     let response = model
-        .complete(ModelRequest::text("Reply with exactly: hello"))
+        .complete(ModelRequest::new(
+            "Return a JSON greeting with the message set to hello.",
+            schema,
+        ))
         .await?;
 
-    writeln!(io::stdout().lock(), "{}", response.text())?;
+    writeln!(io::stdout().lock(), "{}", response.output())?;
 
     Ok(())
 }

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -1,9 +1,12 @@
 //! Lightweight, Rust-native LLM harness for application-facing agent workflows.
 //!
-//! The crate provides a provider-neutral model contract and model adapters.
+//! The crate provides a provider-neutral model contract, validated structured
+//! output, and model adapters.
 
 mod model;
 mod qwen;
+mod schema_contract;
 
 pub use model::{Model, ModelError, ModelRequest, ModelResponse};
 pub use qwen::{Qwen, QwenConfig};
+pub use schema_contract::{OutputSchema, OutputSchemaError};

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -1,7 +1,10 @@
 use std::error::Error;
 
 use async_trait::async_trait;
+use serde_json::Value;
 use thiserror::Error;
+
+use crate::schema_contract::{OutputSchema, OutputValidationError};
 
 /// A model backend that completes provider-neutral requests.
 #[async_trait]
@@ -19,13 +22,15 @@ pub trait Model: Send + Sync {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ModelRequest {
     prompt: String,
+    schema: OutputSchema,
 }
 
 impl ModelRequest {
-    /// Creates a text-only model request.
-    pub fn text(prompt: impl Into<String>) -> Self {
+    /// Creates a model request whose response must match `schema`.
+    pub fn new(prompt: impl Into<String>, schema: OutputSchema) -> Self {
         Self {
             prompt: prompt.into(),
+            schema,
         }
     }
 
@@ -33,23 +38,28 @@ impl ModelRequest {
     pub fn prompt(&self) -> &str {
         &self.prompt
     }
+
+    /// Returns the schema that the response must match.
+    pub fn schema(&self) -> &OutputSchema {
+        &self.schema
+    }
 }
 
 /// Provider-neutral output from one model request.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ModelResponse {
-    text: String,
+    output: Value,
 }
 
 impl ModelResponse {
-    /// Creates a text-only model response.
-    pub fn from_text(text: impl Into<String>) -> Self {
-        Self { text: text.into() }
+    /// Creates a response from parsed JSON that passed the caller's schema.
+    pub fn new(output: Value) -> Self {
+        Self { output }
     }
 
-    /// Returns the model's response text.
-    pub fn text(&self) -> &str {
-        &self.text
+    /// Returns the parsed, schema-validated output.
+    pub fn output(&self) -> &Value {
+        &self.output
     }
 }
 
@@ -59,9 +69,42 @@ pub enum ModelError {
     /// The provider request or response decoding failed.
     #[error("model request failed: {0}")]
     Request(#[source] Box<dyn Error + Send + Sync>),
-    /// The provider returned a successful response without assistant text.
-    #[error("model returned no response text")]
+    /// The provider returned a successful response without assistant content.
+    #[error("model returned no response content")]
     InvalidResponse,
+    /// The provider stopped before completing the model response.
+    #[error("model response is incomplete: {reason}")]
+    IncompleteResponse {
+        /// Provider-specific reason generation stopped.
+        reason: String,
+    },
+    /// The successful provider response body exceeds the adapter safety limit.
+    #[error("model response body exceeds the size limit")]
+    ResponseBodyTooLarge,
+    /// The provider cannot represent the requested output schema.
+    #[error("provider cannot satisfy this output schema: {reason}")]
+    UnsupportedOutputSchema {
+        /// Provider-specific reason the schema cannot be represented.
+        reason: String,
+    },
+    /// The decoded provider response content exceeds the harness safety limit.
+    #[error("model response content exceeds the size limit")]
+    ResponseContentTooLarge,
+    /// The provider returned malformed JSON for a structured request.
+    #[error("model returned invalid JSON: {reason}")]
+    InvalidJson {
+        /// JSON parser diagnostic without the raw response body.
+        reason: String,
+    },
+    /// The returned JSON does not conform to the requested schema.
+    #[error("model output violates the schema at {path}: {reason}")]
+    SchemaViolation {
+        /// Bounded JSON Pointer-like path to the invalid value, or `$` for the
+        /// root.
+        path: String,
+        /// Validator diagnostic for the failed constraint.
+        reason: String,
+    },
 }
 
 impl ModelError {
@@ -70,28 +113,50 @@ impl ModelError {
     }
 }
 
+impl From<OutputValidationError> for ModelError {
+    fn from(error: OutputValidationError) -> Self {
+        match error {
+            OutputValidationError::InvalidJson(reason) => Self::InvalidJson { reason },
+            OutputValidationError::SchemaViolation { path, reason } => {
+                Self::SchemaViolation { path, reason }
+            }
+            OutputValidationError::TooLarge => Self::ResponseContentTooLarge,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io;
 
+    use serde_json::json;
+
     use super::*;
 
     #[test]
-    fn text_request_contains_prompt() {
-        // Arrange and Act
-        let request = ModelRequest::text("hello");
+    fn request_contains_prompt_and_schema() {
+        // Arrange
+        let schema =
+            OutputSchema::new(json!({ "type": "object" })).expect("schema should be valid");
+
+        // Act
+        let request = ModelRequest::new("hello", schema.clone());
 
         // Assert
         assert_eq!(request.prompt(), "hello");
+        assert_eq!(request.schema(), &schema);
     }
 
     #[test]
-    fn text_response_exposes_text() {
-        // Arrange and Act
-        let response = ModelResponse::from_text("hello");
+    fn response_exposes_validated_output() {
+        // Arrange
+        let value = json!({ "name": "Ada" });
+
+        // Act
+        let response = ModelResponse::new(value.clone());
 
         // Assert
-        assert_eq!(response.text(), "hello");
+        assert_eq!(response.output(), &value);
     }
 
     #[test]
@@ -100,7 +165,19 @@ mod tests {
         let message = ModelError::InvalidResponse.to_string();
 
         // Assert
-        assert_eq!(message, "model returned no response text");
+        assert_eq!(message, "model returned no response content");
+    }
+
+    #[test]
+    fn incomplete_response_error_includes_reason() {
+        // Arrange and Act
+        let message = ModelError::IncompleteResponse {
+            reason: "length".to_string(),
+        }
+        .to_string();
+
+        // Assert
+        assert_eq!(message, "model response is incomplete: length");
     }
 
     #[test]
@@ -113,5 +190,74 @@ mod tests {
 
         // Assert
         assert_eq!(message, "model request failed: connection refused");
+    }
+
+    #[test]
+    fn unsupported_schema_error_includes_reason() {
+        // Arrange and Act
+        let message = ModelError::UnsupportedOutputSchema {
+            reason: "top-level object required".to_string(),
+        }
+        .to_string();
+
+        // Assert
+        assert_eq!(
+            message,
+            "provider cannot satisfy this output schema: top-level object required"
+        );
+    }
+
+    #[test]
+    fn oversized_response_body_error_has_user_facing_message() {
+        // Arrange and Act
+        let message = ModelError::ResponseBodyTooLarge.to_string();
+
+        // Assert
+        assert_eq!(message, "model response body exceeds the size limit");
+    }
+
+    #[test]
+    fn converts_invalid_json_error() {
+        // Arrange
+        let error = OutputValidationError::InvalidJson("expected value".to_string());
+
+        // Act
+        let error = ModelError::from(error);
+
+        // Assert
+        assert_eq!(
+            error.to_string(),
+            "model returned invalid JSON: expected value"
+        );
+    }
+
+    #[test]
+    fn converts_schema_violation_error() {
+        // Arrange
+        let error = OutputValidationError::SchemaViolation {
+            path: "/name".to_string(),
+            reason: "wrong type".to_string(),
+        };
+
+        // Act
+        let error = ModelError::from(error);
+
+        // Assert
+        assert_eq!(
+            error.to_string(),
+            "model output violates the schema at /name: wrong type"
+        );
+    }
+
+    #[test]
+    fn converts_oversized_content_error() {
+        // Arrange and Act
+        let error = ModelError::from(OutputValidationError::TooLarge);
+
+        // Assert
+        assert_eq!(
+            error.to_string(),
+            "model response content exceeds the size limit"
+        );
     }
 }

--- a/crates/ag-harness/src/qwen.rs
+++ b/crates/ag-harness/src/qwen.rs
@@ -4,10 +4,21 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::model;
+use crate::{model, schema_contract};
 
 const ERROR_BODY_LIMIT_BYTES: usize = 4 * 1024;
+const JSON_STRING_MAX_EXPANSION: usize = 6;
+const RESPONSE_ENVELOPE_LIMIT_BYTES: usize = 64 * 1024;
 const REQUEST_TIMEOUT: Duration = Duration::from_mins(1);
+const SUCCESS_BODY_LIMIT_BYTES: usize = schema_contract::RESPONSE_CONTENT_LIMIT_BYTES
+    * JSON_STRING_MAX_EXPANSION
+    + RESPONSE_ENVELOPE_LIMIT_BYTES;
+const STRUCTURED_OUTPUT_INSTRUCTION: &str = concat!(
+    "Return only one JSON object. The object must validate against this JSON Schema. ",
+    "Do not include Markdown fences or any other text.\n\nJSON Schema:\n",
+);
+const UNSUPPORTED_SCHEMA_REASON: &str =
+    "Qwen JSON Object mode requires an explicit object root schema";
 
 /// Configuration for a Qwen model served through Alibaba Cloud Model Studio's
 /// OpenAI-compatible API.
@@ -71,6 +82,34 @@ impl Qwen {
 
         Ok(summary)
     }
+
+    async fn success_body(response: &mut reqwest::Response) -> Result<Vec<u8>, model::ModelError> {
+        let limit = u64::try_from(SUCCESS_BODY_LIMIT_BYTES).unwrap_or(u64::MAX);
+        if response
+            .content_length()
+            .is_some_and(|content_length| content_length > limit)
+        {
+            return Err(model::ModelError::ResponseBodyTooLarge);
+        }
+
+        let mut body = Vec::new();
+        while let Some(chunk) = response.chunk().await.map_err(model::ModelError::request)? {
+            Self::append_success_chunk(&mut body, &chunk)?;
+        }
+
+        Ok(body)
+    }
+
+    fn append_success_chunk(body: &mut Vec<u8>, chunk: &[u8]) -> Result<(), model::ModelError> {
+        let remaining = SUCCESS_BODY_LIMIT_BYTES.saturating_sub(body.len());
+        if chunk.len() > remaining {
+            return Err(model::ModelError::ResponseBodyTooLarge);
+        }
+
+        body.extend_from_slice(chunk);
+
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -79,12 +118,30 @@ impl model::Model for Qwen {
         &self,
         request: model::ModelRequest,
     ) -> Result<model::ModelResponse, model::ModelError> {
-        let payload = QwenRequest {
-            messages: [QwenMessage {
-                content: request.prompt(),
+        if !request.schema().has_object_root() {
+            return Err(model::ModelError::UnsupportedOutputSchema {
+                reason: UNSUPPORTED_SCHEMA_REASON.to_string(),
+            });
+        }
+        let messages = vec![
+            QwenMessage {
+                content: format!(
+                    "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
+                    request.schema().value()
+                ),
+                role: "system",
+            },
+            QwenMessage {
+                content: request.prompt().to_string(),
                 role: "user",
-            }],
+            },
+        ];
+        let payload = QwenRequest {
+            messages,
             model: &self.config.model,
+            response_format: QwenResponseFormat {
+                kind: "json_object",
+            },
         };
 
         let mut response = self
@@ -110,19 +167,30 @@ impl model::Model for Qwen {
             return Err(model::ModelError::request(error));
         }
 
-        let response = response
-            .json::<QwenResponse>()
-            .await
-            .map_err(model::ModelError::request)?;
+        let body = Self::success_body(&mut response).await?;
+        let response =
+            serde_json::from_slice::<QwenResponse>(&body).map_err(model::ModelError::request)?;
 
-        let text = response
+        let choice = response
             .choices
             .into_iter()
             .next()
-            .and_then(|choice| choice.message.content)
+            .ok_or(model::ModelError::InvalidResponse)?;
+        if choice.finish_reason != "stop" {
+            return Err(model::ModelError::IncompleteResponse {
+                reason: schema_contract::bounded_diagnostic(choice.finish_reason),
+            });
+        }
+        let text = choice
+            .message
+            .content
             .ok_or(model::ModelError::InvalidResponse)?;
 
-        Ok(model::ModelResponse::from_text(text))
+        request
+            .schema()
+            .parse_and_validate(&text)
+            .map(model::ModelResponse::new)
+            .map_err(model::ModelError::from)
     }
 }
 
@@ -137,14 +205,21 @@ struct QwenHttpError {
 
 #[derive(Serialize)]
 struct QwenRequest<'a> {
-    messages: [QwenMessage<'a>; 1],
+    messages: Vec<QwenMessage>,
     model: &'a str,
+    response_format: QwenResponseFormat,
 }
 
 #[derive(Serialize)]
-struct QwenMessage<'a> {
-    content: &'a str,
+struct QwenMessage {
+    content: String,
     role: &'static str,
+}
+
+#[derive(Serialize)]
+struct QwenResponseFormat {
+    #[serde(rename = "type")]
+    kind: &'static str,
 }
 
 #[derive(Deserialize)]
@@ -154,6 +229,7 @@ struct QwenResponse {
 
 #[derive(Deserialize)]
 struct QwenChoice {
+    finish_reason: String,
     message: QwenResponseMessage,
 }
 
@@ -171,6 +247,37 @@ mod tests {
     use super::*;
     use crate::Model;
 
+    fn person_schema_value() -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        })
+    }
+
+    fn person_schema() -> crate::OutputSchema {
+        crate::OutputSchema::new(person_schema_value()).expect("schema should be valid")
+    }
+
+    fn request(prompt: &str) -> model::ModelRequest {
+        model::ModelRequest::new(prompt, person_schema())
+    }
+
+    fn escaped_value_schema() -> crate::OutputSchema {
+        crate::OutputSchema::new(json!({
+            "type": "object",
+            "properties": {
+                "value": { "type": "string" }
+            },
+            "required": ["value"],
+            "additionalProperties": false
+        }))
+        .expect("schema should be valid")
+    }
+
     fn qwen(server: &MockServer) -> Qwen {
         Qwen::new(QwenConfig {
             api_key: "test-key".to_string(),
@@ -179,37 +286,334 @@ mod tests {
         })
     }
 
-    #[tokio::test]
-    async fn completes_text_request() {
-        // Arrange
-        let server = MockServer::start().await;
+    async fn mount_structured_response(
+        server: &MockServer,
+        prompt: &str,
+        schema: &serde_json::Value,
+        content: &str,
+    ) {
+        let schema_instruction = format!("{STRUCTURED_OUTPUT_INSTRUCTION}{schema}");
         Mock::given(method("POST"))
             .and(path("/chat/completions"))
             .and(bearer_token("test-key"))
             .and(body_json(json!({
-                "messages": [{"content": "hello", "role": "user"}],
-                "model": "qwen-plus"
+                "messages": [
+                    {"content": schema_instruction, "role": "system"},
+                    {"content": prompt, "role": "user"}
+                ],
+                "model": "qwen-plus",
+                "response_format": {"type": "json_object"}
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "choices": [{"message": {"content": "Hello!"}}]
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": content}
+                }]
             })))
             .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn completes_structured_request() {
+        // Arrange
+        let server = MockServer::start().await;
+        let schema_value = person_schema_value();
+        mount_structured_response(
+            &server,
+            "extract the name",
+            &schema_value,
+            r#"{"name":"Ada"}"#,
+        )
+        .await;
+        let model = qwen(&server);
+
+        // Act
+        let response = model
+            .complete(request("extract the name"))
+            .await
+            .expect("Qwen request should succeed");
+
+        // Assert
+        assert_eq!(response.output(), &json!({ "name": "Ada" }));
+    }
+
+    #[tokio::test]
+    async fn rejects_structured_response_stopped_for_length() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "length",
+                    "message": {"content": r#"{"name":"Ada"}"#}
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let model = qwen(&server);
+
+        // Act
+        let error = model
+            .complete(request("extract the name"))
+            .await
+            .expect_err("truncated response should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            model::ModelError::IncompleteResponse { reason } if reason == "length"
+        ));
+    }
+
+    #[tokio::test]
+    async fn bounds_incomplete_response_reason() {
+        // Arrange
+        let server = MockServer::start().await;
+        let finish_reason = "x".repeat(1024);
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": finish_reason.clone(),
+                    "message": {"content": r#"{"name":"Ada"}"#}
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let model = qwen(&server);
+
+        // Act
+        let error = model
+            .complete(request("extract the name"))
+            .await
+            .expect_err("incomplete response should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            model::ModelError::IncompleteResponse { reason }
+                if reason == schema_contract::bounded_diagnostic(finish_reason)
+        ));
+    }
+
+    #[tokio::test]
+    async fn accepts_near_limit_escaped_structured_output() {
+        // Arrange
+        let server = MockServer::start().await;
+        let empty_content =
+            serde_json::to_string(&json!({ "value": "" })).expect("content should serialize");
+        let value =
+            "\\".repeat((schema_contract::RESPONSE_CONTENT_LIMIT_BYTES - empty_content.len()) / 2);
+        let content =
+            serde_json::to_string(&json!({ "value": value })).expect("content should serialize");
+        let body = serde_json::to_vec(&json!({
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {"content": content}
+            }]
+        }))
+        .expect("response should serialize");
+        assert!(schema_contract::RESPONSE_CONTENT_LIMIT_BYTES - content.len() <= 1);
+        assert!(
+            body.len()
+                > schema_contract::RESPONSE_CONTENT_LIMIT_BYTES + RESPONSE_ENVELOPE_LIMIT_BYTES
+        );
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
             .mount(&server)
             .await;
         let model = qwen(&server);
 
         // Act
         let response = model
-            .complete(model::ModelRequest::text("hello"))
+            .complete(model::ModelRequest::new(
+                "return escaped content",
+                escaped_value_schema(),
+            ))
             .await
-            .expect("Qwen request should succeed");
+            .expect("near-limit escaped output should succeed");
 
         // Assert
-        assert_eq!(response.text(), "Hello!");
+        assert_eq!(
+            response
+                .output()
+                .get("value")
+                .and_then(serde_json::Value::as_str)
+                .map(str::len),
+            Some(value.len())
+        );
     }
 
     #[tokio::test]
-    async fn rejects_successful_response_without_text() {
+    async fn rejects_oversized_success_body_before_decoding() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(vec![
+                b'x';
+                SUCCESS_BODY_LIMIT_BYTES
+                    + 1
+            ]))
+            .mount(&server)
+            .await;
+        let model = qwen(&server);
+
+        // Act
+        let error = model
+            .complete(request("hello"))
+            .await
+            .expect_err("oversized successful response should fail");
+
+        // Assert
+        assert!(matches!(error, model::ModelError::ResponseBodyTooLarge));
+    }
+
+    #[test]
+    fn rejects_success_chunk_that_exceeds_remaining_capacity() {
+        // Arrange
+        let mut body = vec![0; SUCCESS_BODY_LIMIT_BYTES - 1];
+
+        // Act
+        let error = Qwen::append_success_chunk(&mut body, &[0, 1])
+            .expect_err("chunk exceeding the limit should fail");
+
+        // Assert
+        assert!(matches!(error, model::ModelError::ResponseBodyTooLarge));
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_response_content() {
+        // Arrange
+        let server = MockServer::start().await;
+        let content = "x".repeat(schema_contract::RESPONSE_CONTENT_LIMIT_BYTES + 1);
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": content}
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let model = qwen(&server);
+
+        // Act
+        let error = model
+            .complete(request("hello"))
+            .await
+            .expect_err("oversized response content should fail");
+
+        // Assert
+        assert!(matches!(error, model::ModelError::ResponseContentTooLarge));
+    }
+
+    #[tokio::test]
+    async fn rejects_schemas_without_explicit_object_root() {
+        // Arrange
+        let server = MockServer::start().await;
+        let model = qwen(&server);
+        let schema_values = [
+            json!({ "type": "array" }),
+            json!({ "not": { "type": "object" } }),
+            json!({
+                "$defs": {
+                    "result": { "type": "object" }
+                },
+                "$ref": "#/$defs/result"
+            }),
+        ];
+
+        // Act
+        let mut errors = Vec::new();
+        for schema_value in schema_values {
+            let schema = crate::OutputSchema::new(schema_value).expect("schema should be valid");
+            errors.push(
+                model
+                    .complete(model::ModelRequest::new("list names", schema))
+                    .await
+                    .expect_err("schema without an explicit object root should fail"),
+            );
+        }
+
+        // Assert
+        assert!(errors.into_iter().all(|error| matches!(
+            error,
+            model::ModelError::UnsupportedOutputSchema { reason }
+                if reason == UNSUPPORTED_SCHEMA_REASON
+        )));
+        assert!(
+            server
+                .received_requests()
+                .await
+                .expect("request recording should be enabled")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_malformed_structured_output() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": "not JSON"}
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let model = qwen(&server);
+
+        // Act
+        let error = model
+            .complete(request("extract the name"))
+            .await
+            .expect_err("malformed JSON should fail");
+
+        // Assert
+        assert!(matches!(error, model::ModelError::InvalidJson { .. }));
+    }
+
+    #[tokio::test]
+    async fn rejects_structured_output_schema_violation() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": r#"{"name":42}"#}
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let model = qwen(&server);
+
+        // Act
+        let error = model
+            .complete(request("extract the name"))
+            .await
+            .expect_err("schema violation should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            model::ModelError::SchemaViolation { path, reason }
+                if path == "/name" && reason.contains("string")
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_successful_response_without_content() {
         // Arrange
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -223,9 +627,9 @@ mod tests {
 
         // Act
         let error = model
-            .complete(model::ModelRequest::text("hello"))
+            .complete(request("hello"))
             .await
-            .expect_err("missing response text should fail");
+            .expect_err("missing response content should fail");
 
         // Assert
         assert!(matches!(error, model::ModelError::InvalidResponse));
@@ -246,7 +650,7 @@ mod tests {
 
         // Act
         let error = model
-            .complete(model::ModelRequest::text("hello"))
+            .complete(request("hello"))
             .await
             .expect_err("HTTP failure should fail");
 
@@ -273,7 +677,7 @@ mod tests {
 
         // Act
         let error = model
-            .complete(model::ModelRequest::text("hello"))
+            .complete(request("hello"))
             .await
             .expect_err("HTTP failure should fail");
         let message = error.to_string();
@@ -301,7 +705,7 @@ mod tests {
 
         // Act
         let error = model
-            .complete(model::ModelRequest::text("hello"))
+            .complete(request("hello"))
             .await
             .expect_err("malformed response should fail");
 

--- a/crates/ag-harness/src/schema_contract.rs
+++ b/crates/ag-harness/src/schema_contract.rs
@@ -1,0 +1,555 @@
+use std::fmt;
+use std::sync::Arc;
+
+use jsonschema::error::ValidationErrorKind;
+use jsonschema::{Draft, PatternOptions, ReferencingError, Validator};
+use serde_json::Value;
+use thiserror::Error;
+
+const DIAGNOSTIC_LIMIT_CHARS: usize = 512;
+const REGEX_DFA_LIMIT_BYTES: usize = 2 * 1024 * 1024;
+const REGEX_SIZE_LIMIT_BYTES: usize = 256 * 1024;
+const SCHEMA_LIMIT_BYTES: usize = 256 * 1024;
+pub(crate) const RESPONSE_CONTENT_LIMIT_BYTES: usize = 2 * 1024 * 1024;
+
+/// A validated, provider-independent JSON Schema for model output.
+#[derive(Clone)]
+pub struct OutputSchema {
+    schema: Value,
+    validator: Arc<Validator>,
+}
+
+impl OutputSchema {
+    /// Validates and compiles a JSON Schema for structured model output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutputSchemaError`] when the schema is oversized, references
+    /// an external resource, or is outside the harness's JSON Schema Draft
+    /// 2020-12 safety profile.
+    pub fn new(schema: Value) -> Result<Self, OutputSchemaError> {
+        if schema.to_string().len() > SCHEMA_LIMIT_BYTES {
+            return Err(OutputSchemaError::TooLarge);
+        }
+
+        let validator = jsonschema::options()
+            .with_draft(Draft::Draft202012)
+            .with_pattern_options(
+                PatternOptions::regex()
+                    .size_limit(REGEX_SIZE_LIMIT_BYTES)
+                    .dfa_size_limit(REGEX_DFA_LIMIT_BYTES),
+            )
+            .build(&schema)
+            .map_err(|error| {
+                if matches!(
+                    error.kind(),
+                    ValidationErrorKind::Referencing(ReferencingError::Unretrievable { .. })
+                ) {
+                    return OutputSchemaError::ExternalReference;
+                }
+
+                OutputSchemaError::Invalid {
+                    reason: bounded_diagnostic(error),
+                }
+            })?;
+
+        Ok(Self {
+            schema,
+            validator: Arc::new(validator),
+        })
+    }
+
+    /// Returns the underlying JSON Schema document.
+    pub fn value(&self) -> &Value {
+        &self.schema
+    }
+
+    pub(crate) fn has_object_root(&self) -> bool {
+        let Some(schema_type) = self.schema.get("type") else {
+            return false;
+        };
+
+        schema_type == "object"
+            || schema_type
+                .as_array()
+                .is_some_and(|types| types.iter().any(|schema_type| schema_type == "object"))
+    }
+
+    pub(crate) fn parse_and_validate(&self, output: &str) -> Result<Value, OutputValidationError> {
+        ensure_content_size(output)?;
+
+        let value = serde_json::from_str(output)
+            .map_err(|error| OutputValidationError::InvalidJson(bounded_diagnostic(error)))?;
+        if let Err(error) = self.validator.validate(&value) {
+            let path = match error.instance_path().as_str() {
+                "" => "$".to_string(),
+                path => bounded_diagnostic(path),
+            };
+
+            return Err(OutputValidationError::SchemaViolation {
+                path,
+                reason: bounded_diagnostic(error),
+            });
+        }
+
+        Ok(value)
+    }
+}
+
+impl fmt::Debug for OutputSchema {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OutputSchema")
+            .field("schema", &self.schema)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for OutputSchema {
+    fn eq(&self, other: &Self) -> bool {
+        self.schema == other.schema
+    }
+}
+
+impl Eq for OutputSchema {}
+
+/// Failure returned while constructing a structured-output schema.
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum OutputSchemaError {
+    /// The serialized schema exceeds the harness safety limit.
+    #[error("output schema exceeds the size limit")]
+    TooLarge,
+    /// The schema references a resource outside its own document.
+    #[error("output schema contains an external reference")]
+    ExternalReference,
+    /// The document is invalid or outside the harness safety profile.
+    #[error("invalid output schema: {reason}")]
+    Invalid {
+        /// Validator-provided reason the schema is invalid or unsupported.
+        reason: String,
+    },
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum OutputValidationError {
+    InvalidJson(String),
+    SchemaViolation { path: String, reason: String },
+    TooLarge,
+}
+
+pub(crate) fn ensure_content_size(output: &str) -> Result<(), OutputValidationError> {
+    if output.len() > RESPONSE_CONTENT_LIMIT_BYTES {
+        return Err(OutputValidationError::TooLarge);
+    }
+
+    Ok(())
+}
+
+pub(crate) fn bounded_diagnostic(reason: impl fmt::Display) -> String {
+    let reason = reason.to_string();
+    let mut characters = reason.chars();
+    let mut summary: String = characters.by_ref().take(DIAGNOSTIC_LIMIT_CHARS).collect();
+    if characters.next().is_some() {
+        summary.push_str(" ...");
+    }
+
+    summary
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn object_schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        })
+    }
+
+    #[test]
+    fn constructs_valid_schema() {
+        // Arrange
+        let value = object_schema();
+
+        // Act
+        let schema = OutputSchema::new(value.clone()).expect("schema should be valid");
+
+        // Assert
+        assert_eq!(schema.value(), &value);
+        assert!(schema.has_object_root());
+        assert_eq!(schema, schema.clone());
+        assert!(format!("{schema:?}").starts_with("OutputSchema"));
+    }
+
+    #[test]
+    fn identifies_object_root_in_type_array() {
+        // Arrange
+        let value = json!({ "type": ["object", "null"] });
+
+        // Act
+        let schema = OutputSchema::new(value).expect("schema should be valid");
+
+        // Assert
+        assert!(schema.has_object_root());
+    }
+
+    #[test]
+    fn identifies_schemas_without_explicit_object_root() {
+        // Arrange
+        let values = [
+            json!({ "type": "array" }),
+            json!({ "type": ["array", "null"] }),
+            json!({ "$ref": "#/$defs/result", "$defs": { "result": { "type": "object" } } }),
+        ];
+
+        // Act
+        let schemas = values.map(|value| OutputSchema::new(value).expect("schema should be valid"));
+
+        // Assert
+        assert!(schemas.iter().all(|schema| !schema.has_object_root()));
+    }
+
+    #[test]
+    fn rejects_oversized_schema() {
+        // Arrange
+        let value = json!({ "description": "x".repeat(SCHEMA_LIMIT_BYTES) });
+
+        // Act
+        let error = OutputSchema::new(value).expect_err("oversized schema should fail");
+
+        // Assert
+        assert_eq!(error, OutputSchemaError::TooLarge);
+        assert_eq!(error.to_string(), "output schema exceeds the size limit");
+    }
+
+    #[test]
+    fn rejects_invalid_schema() {
+        // Arrange
+        let value = json!({ "type": "not-a-json-type" });
+
+        // Act
+        let error = OutputSchema::new(value).expect_err("invalid schema should fail");
+
+        // Assert
+        assert!(matches!(error, OutputSchemaError::Invalid { .. }));
+        assert!(error.to_string().starts_with("invalid output schema:"));
+    }
+
+    #[test]
+    fn accepts_linear_regex_pattern() {
+        // Arrange
+        let value = json!({
+            "type": "string",
+            "pattern": "^(a+)+$"
+        });
+
+        // Act
+        let schema = OutputSchema::new(value).expect("linear regex should compile");
+
+        // Assert
+        assert!(schema.parse_and_validate(r#""aaaa""#).is_ok());
+    }
+
+    #[test]
+    fn rejects_backtracking_regex_pattern() {
+        // Arrange
+        let value = json!({
+            "type": "string",
+            "pattern": "(?=unsafe-lookaround)"
+        });
+
+        // Act
+        let error = OutputSchema::new(value).expect_err("lookaround should be rejected");
+
+        // Assert
+        assert!(matches!(
+            error,
+            OutputSchemaError::Invalid { reason } if reason.contains("regex")
+        ));
+    }
+
+    #[test]
+    fn rejects_regex_exceeding_compiled_size_limit() {
+        // Arrange
+        let value = json!({
+            "type": "string",
+            "pattern": "a{100000}"
+        });
+
+        // Act
+        let error = OutputSchema::new(value).expect_err("oversized regex should be rejected");
+
+        // Assert
+        assert!(matches!(error, OutputSchemaError::Invalid { .. }));
+    }
+
+    #[test]
+    fn rejects_nested_external_reference() {
+        // Arrange
+        let value = json!({
+            "allOf": [
+                { "$ref": "https://example.com/schema.json" }
+            ]
+        });
+
+        // Act
+        let error = OutputSchema::new(value).expect_err("external reference should fail");
+
+        // Assert
+        assert_eq!(error, OutputSchemaError::ExternalReference);
+        assert_eq!(
+            error.to_string(),
+            "output schema contains an external reference"
+        );
+    }
+
+    #[test]
+    fn rejects_external_dynamic_reference() {
+        // Arrange
+        let value = json!({
+            "$dynamicRef": "https://example.com/schema.json"
+        });
+
+        // Act
+        let error = OutputSchema::new(value).expect_err("external dynamic reference should fail");
+
+        // Assert
+        assert_eq!(error, OutputSchemaError::ExternalReference);
+    }
+
+    #[test]
+    fn accepts_external_reference_as_literal_instance_data() {
+        // Arrange
+        let literal = json!({ "$ref": "https://example.com/value" });
+        let value = json!({ "const": literal });
+
+        // Act
+        let schema = OutputSchema::new(value).expect("literal reference should be valid");
+        let output = schema
+            .parse_and_validate(r#"{"$ref":"https://example.com/value"}"#)
+            .expect("matching literal should validate");
+
+        // Assert
+        assert_eq!(output, literal);
+    }
+
+    #[test]
+    fn rejects_missing_local_reference_as_invalid() {
+        // Arrange
+        let value = json!({ "$ref": "#/$defs/missing" });
+
+        // Act
+        let error = OutputSchema::new(value).expect_err("missing reference should fail");
+
+        // Assert
+        assert!(matches!(error, OutputSchemaError::Invalid { .. }));
+    }
+
+    #[test]
+    fn accepts_nested_local_reference() {
+        // Arrange
+        let value = json!({
+            "$defs": {
+                "name": { "type": "string" }
+            },
+            "type": "object",
+            "properties": {
+                "name": { "$ref": "#/$defs/name" }
+            }
+        });
+
+        // Act
+        let schema = OutputSchema::new(value).expect("schema should be valid");
+
+        // Assert
+        assert!(schema.has_object_root());
+    }
+
+    #[test]
+    fn validates_root_local_reference() {
+        // Arrange
+        let value = json!({
+            "$defs": {
+                "result": {
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                        "name": { "type": "string" }
+                    }
+                }
+            },
+            "$ref": "#/$defs/result"
+        });
+
+        // Act
+        let schema = OutputSchema::new(value).expect("schema should be valid");
+        let output = schema
+            .parse_and_validate(r#"{"name":"Ada"}"#)
+            .expect("output should be valid");
+
+        // Assert
+        assert_eq!(output, json!({ "name": "Ada" }));
+        assert!(!schema.has_object_root());
+    }
+
+    #[test]
+    fn parses_valid_structured_output() {
+        // Arrange
+        let schema = OutputSchema::new(object_schema()).expect("schema should be valid");
+
+        // Act
+        let value = schema
+            .parse_and_validate(r#"{"name":"Ada"}"#)
+            .expect("output should be valid");
+
+        // Assert
+        assert_eq!(value, json!({ "name": "Ada" }));
+    }
+
+    #[test]
+    fn rejects_malformed_structured_output() {
+        // Arrange
+        let schema = OutputSchema::new(object_schema()).expect("schema should be valid");
+
+        // Act
+        let error = schema
+            .parse_and_validate("not JSON")
+            .expect_err("malformed output should fail");
+
+        // Assert
+        assert!(matches!(error, OutputValidationError::InvalidJson(_)));
+    }
+
+    #[test]
+    fn rejects_oversized_structured_output() {
+        // Arrange
+        let schema = OutputSchema::new(object_schema()).expect("schema should be valid");
+        let output = "x".repeat(RESPONSE_CONTENT_LIMIT_BYTES + 1);
+
+        // Act
+        let error = schema
+            .parse_and_validate(&output)
+            .expect_err("oversized output should fail");
+
+        // Assert
+        assert_eq!(error, OutputValidationError::TooLarge);
+    }
+
+    #[test]
+    fn reports_nested_schema_violation() {
+        // Arrange
+        let schema = OutputSchema::new(object_schema()).expect("schema should be valid");
+
+        // Act
+        let error = schema
+            .parse_and_validate(r#"{"name":42}"#)
+            .expect_err("schema violation should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            OutputValidationError::SchemaViolation { path, reason }
+                if path == "/name" && reason.contains("string")
+        ));
+    }
+
+    #[test]
+    fn bounds_long_schema_violation_path() {
+        // Arrange
+        let schema = OutputSchema::new(json!({
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+        }))
+        .expect("schema should be valid");
+        let property = "x".repeat(DIAGNOSTIC_LIMIT_CHARS);
+        let output = format!(r#"{{"{property}":42}}"#);
+
+        // Act
+        let error = schema
+            .parse_and_validate(&output)
+            .expect_err("schema violation should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            OutputValidationError::SchemaViolation { path, reason }
+                if path == format!("/{} ...", "x".repeat(DIAGNOSTIC_LIMIT_CHARS - 1))
+                    && reason.contains("string")
+        ));
+    }
+
+    #[test]
+    fn reports_root_schema_violation() {
+        // Arrange
+        let schema = OutputSchema::new(object_schema()).expect("schema should be valid");
+
+        // Act
+        let error = schema
+            .parse_and_validate("[]")
+            .expect_err("root schema violation should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            OutputValidationError::SchemaViolation { path, .. } if path == "$"
+        ));
+    }
+
+    #[test]
+    fn reports_missing_required_property() {
+        // Arrange
+        let schema = OutputSchema::new(object_schema()).expect("schema should be valid");
+
+        // Act
+        let error = schema
+            .parse_and_validate("{}")
+            .expect_err("missing required property should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            OutputValidationError::SchemaViolation { reason, .. }
+                if reason.contains("required")
+        ));
+    }
+
+    #[test]
+    fn reports_disallowed_additional_property() {
+        // Arrange
+        let schema = OutputSchema::new(object_schema()).expect("schema should be valid");
+
+        // Act
+        let error = schema
+            .parse_and_validate(r#"{"name":"Ada","role":"engineer"}"#)
+            .expect_err("additional property should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            OutputValidationError::SchemaViolation { reason, .. }
+                if reason.contains("Additional properties")
+        ));
+    }
+
+    #[test]
+    fn bounds_long_diagnostic() {
+        // Arrange
+        let reason = "é".repeat(DIAGNOSTIC_LIMIT_CHARS + 1);
+
+        // Act
+        let summary = bounded_diagnostic(reason);
+
+        // Assert
+        assert_eq!(
+            summary,
+            format!("{} ...", "é".repeat(DIAGNOSTIC_LIMIT_CHARS))
+        );
+    }
+}

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -42,8 +42,8 @@ agentty/
 ```
 
 The current foundation lives entirely in `ag-harness`: the provider-neutral `Model`
-contract accepts a text `ModelRequest` and returns a text `ModelResponse`. `Qwen` is its
-first adapter and uses the OpenAI-compatible Chat Completions API.
+contract requires an `OutputSchema` on every `ModelRequest` and returns validated JSON
+in `ModelResponse`. `Qwen` is its first adapter.
 
 ## Session management
 
@@ -117,8 +117,7 @@ sequenceDiagram
 
 ## Structured output
 
-The next model-contract iteration evolves the current text-only response into
-provider-neutral structured output:
+The model contract requires provider-neutral structured output:
 
 - The caller supplies the expected JSON shape as a provider-independent schema.
 - Each adapter uses the strongest structured-output mechanism its provider supports,
@@ -176,8 +175,6 @@ best cost and performance:
 
 ## Next iterations
 
-1. **Structured model output.** Add the provider-neutral schema contract, Qwen JSON
-   Object mode translation, parsing, validation, and typed errors described above.
 1. **Tool round trip.** Support one model-requested tool through execution to the final
    response.
 1. **Second provider.** Integrate another model API through the structured-output


### PR DESCRIPTION
- Extend the provider-neutral model contract with text and JSON Schema-backed requests and typed responses.
- Compile bounded Draft 2020-12 schemas and validate structured output locally with explicit errors.
- Send Qwen structured requests through JSON Object mode and reject schemas incompatible with object output.
- Reject incomplete Qwen generations before structured output validation.
- Bound provider response bodies and decoded content before deserialization and validation.
- Bound validation diagnostics and schema-violation paths while preserving typed structured-output errors.
- Update tests, examples, documentation, and dependencies for the structured-output contract.
- Add a runnable repository example for bounded, locally validated Qwen structured output.
- The provider-neutral contract requires every request to carry an output schema and returns validated JSON.
- Tests, the example, dependencies, and architecture docs cover the structured-output contract.