### PR TITLE
Instrument Qwen requests with OpenTelemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,12 +71,21 @@ name = "ag-harness"
 version = "0.13.7"
 dependencies = [
  "async-trait",
+ "httpdate",
  "jsonschema",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "reqwest",
+ "rustix",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "wiremock",
 ]
 
@@ -2746,6 +2755,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.5",
+ "thiserror 2.0.19",
+ "tokio",
+]
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3027,6 +3118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3070,6 +3170,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3173,6 +3296,16 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
@@ -3183,10 +3316,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rand_core"
@@ -3376,7 +3528,9 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -4564,6 +4718,20 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,17 @@ base64 = "0.23"
 clap = { version = "4", features = ["derive"] }
 crossterm = { version = "0.29.0", default-features = false, features = ["bracketed-paste", "events"] }
 ignore = "0.4"
+httpdate = "1"
 image = { version = "0.25", default-features = false, features = ["png", "gif"] }
 jsonschema = { version = "0.49.1", default-features = false }
 mockall = "0.15"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", default-features = false }
 objc2-foundation = { version = "0.3", default-features = false }
+opentelemetry = { version = "0.32", default-features = false, features = ["metrics"] }
+opentelemetry-appender-tracing = "0.32"
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "logs", "metrics", "reqwest-blocking-client", "trace"] }
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["logs", "metrics", "trace"] }
 percent-encoding = "2"
 portable-pty = "0.9"
 ratatui = { version = "0.30.1", default-features = false, features = ["crossterm", "layout-cache", "std", "underline-color"] }
@@ -57,6 +62,7 @@ time = { version = "0.3", default-features = false, features = ["local-offset", 
 tokio = { version = "1", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "sync", "time"] }
 tokio-util = { version = "0.7", default-features = false }
 tracing = "0.1"
+tracing-opentelemetry = { version = "0.33", default-features = false }
 tracing-subscriber = "0.3"
 unicode-width = "0.2"
 url = "2"

--- a/crates/ag-harness/AGENTS.md
+++ b/crates/ag-harness/AGENTS.md
@@ -127,6 +127,20 @@ Configurations that cannot satisfy the contract, such as Qwen thinking mode, ret
 explicit unsupported-configuration error rather than silently falling back to
 unstructured text.
 
+## Telemetry
+
+- External OTLP export is off by default; enable it with `AG_HARNESS_EXTERNAL_OTEL=1`
+  and set `OTEL_EXPORTER_OTLP_ENDPOINT`.
+- The operator's collector receives traces, metrics, and trace-correlated logs.
+- Traces cover each model call, schema compilation, every HTTP attempt, and response
+  parsing and validation; the call span includes the session ID.
+- Metrics cover request duration and provider-reported token usage, labeled only by
+  provider and model.
+- Logs cover call lifecycle, retries, failures, cancellation, and telemetry shutdown.
+- Prompt and response text are not recorded.
+- Local Podman and Grafana setup is documented in
+  `docs/site/content/docs/architecture/ag-harness-design.md`.
+
 ## Permissions
 
 All tools are denied by default. The session policy explicitly allows tools and, for

--- a/crates/ag-harness/Cargo.toml
+++ b/crates/ag-harness/Cargo.toml
@@ -10,14 +10,24 @@ homepage.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+httpdate.workspace = true
 jsonschema.workspace = true
+opentelemetry.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-tokio.workspace = true
+opentelemetry-appender-tracing.workspace = true
+opentelemetry-otlp.workspace = true
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
+rustix.workspace = true
+tokio = { workspace = true, features = ["net", "signal"] }
+tracing-opentelemetry.workspace = true
+tracing-subscriber.workspace = true
 wiremock.workspace = true
 
 [lints]

--- a/crates/ag-harness/examples/qwen.rs
+++ b/crates/ag-harness/examples/qwen.rs
@@ -1,19 +1,266 @@
 //! Requests structured output from a configured Qwen model and prints the
-//! validated JSON.
+//! validated JSON, with optional traces, metrics, and logs over OTLP/HTTP.
 
 use std::error::Error;
+use std::future::Future;
 use std::io::{self, Write};
 
 use ag_harness::{Model, ModelRequest, OutputSchema, Qwen, QwenConfig};
+use opentelemetry::global;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+use opentelemetry_otlp::{Protocol, WithExportConfig};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::trace::SdkTracerProvider;
 use serde_json::json;
+use thiserror::Error;
+use tracing_subscriber::Layer as _;
+use tracing_subscriber::filter::{LevelFilter, Targets};
+use tracing_subscriber::layer::SubscriberExt as _;
+use tracing_subscriber::util::SubscriberInitExt as _;
 
+type DynError = Box<dyn Error + Send + Sync>;
+
+const EXTERNAL_OTEL_ENV: &str = "AG_HARNESS_EXTERNAL_OTEL";
+const OTLP_ENDPOINT_ENV: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
+
+/// Owns the example's OpenTelemetry providers and flushes them exactly once.
+struct Telemetry {
+    is_shutdown: bool,
+    logger_provider: SdkLoggerProvider,
+    meter_provider: SdkMeterProvider,
+    tracer_provider: SdkTracerProvider,
+}
+
+impl Telemetry {
+    /// Installs local logging or the operator-configured OTLP providers and
+    /// subscriber layers.
+    fn init() -> Result<Self, DynError> {
+        let external_otel = std::env::var(EXTERNAL_OTEL_ENV).ok();
+        let otlp_endpoint = std::env::var(OTLP_ENDPOINT_ENV).ok();
+        if !Self::external_otel_enabled(external_otel.as_deref(), otlp_endpoint.as_deref())? {
+            tracing_subscriber::registry()
+                .with(tracing_subscriber::fmt::layer().with_filter(Self::filter()))
+                .try_init()?;
+
+            return Ok(Self {
+                is_shutdown: false,
+                logger_provider: SdkLoggerProvider::builder().build(),
+                meter_provider: SdkMeterProvider::builder().build(),
+                tracer_provider: SdkTracerProvider::builder().build(),
+            });
+        }
+
+        let resource = Resource::builder()
+            .with_service_name("ag-harness-qwen")
+            .build();
+        let span_exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .build()?;
+        let tracer_provider = SdkTracerProvider::builder()
+            .with_batch_exporter(span_exporter)
+            .with_resource(resource.clone())
+            .build();
+        let metric_exporter = opentelemetry_otlp::MetricExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .build()?;
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(metric_exporter)
+            .with_resource(resource.clone())
+            .build();
+        let log_exporter = opentelemetry_otlp::LogExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .build()?;
+        let logger_provider = SdkLoggerProvider::builder()
+            .with_batch_exporter(log_exporter)
+            .with_resource(resource)
+            .build();
+
+        let tracer = tracer_provider.tracer("ag-harness");
+        let trace_layer = tracing_opentelemetry::layer()
+            .with_tracer(tracer)
+            .with_filter(Self::filter());
+        let log_layer =
+            OpenTelemetryTracingBridge::new(&logger_provider).with_filter(Self::filter());
+        tracing_subscriber::registry()
+            .with(trace_layer)
+            .with(log_layer)
+            .with(tracing_subscriber::fmt::layer().with_filter(Self::filter()))
+            .try_init()?;
+        global::set_meter_provider(meter_provider.clone());
+
+        Ok(Self {
+            is_shutdown: false,
+            logger_provider,
+            meter_provider,
+            tracer_provider,
+        })
+    }
+
+    /// Validates the master telemetry opt-in and requires an explicit
+    /// operator-owned endpoint when export is enabled.
+    fn external_otel_enabled(
+        external_otel: Option<&str>,
+        otlp_endpoint: Option<&str>,
+    ) -> Result<bool, TelemetryConfigError> {
+        let configured_value = external_otel.unwrap_or_default().trim();
+        match configured_value.to_ascii_lowercase().as_str() {
+            "" | "0" | "false" | "no" | "off" | "disabled" => Ok(false),
+            "1" | "true" | "yes" | "on" | "enabled" => {
+                if otlp_endpoint.is_none_or(|endpoint| endpoint.trim().is_empty()) {
+                    return Err(TelemetryConfigError::MissingEndpoint);
+                }
+
+                Ok(true)
+            }
+            _ => Err(TelemetryConfigError::InvalidExternalOtel {
+                value: configured_value.to_string(),
+            }),
+        }
+    }
+
+    /// Restricts exported and formatted events to harness and Qwen targets.
+    fn filter() -> Targets {
+        Targets::new()
+            .with_target("ag_harness", LevelFilter::TRACE)
+            .with_target("qwen", LevelFilter::INFO)
+    }
+
+    /// Shuts every provider down once without blocking a Tokio worker thread.
+    async fn shutdown(&mut self) -> Result<(), DynError> {
+        if self.is_shutdown {
+            return Ok(());
+        }
+
+        self.is_shutdown = true;
+        let logger_provider = self.logger_provider.clone();
+        let meter_provider = self.meter_provider.clone();
+        let tracer_provider = self.tracer_provider.clone();
+
+        tokio::task::spawn_blocking(move || {
+            Self::shutdown_providers(&logger_provider, &meter_provider, &tracer_provider)
+        })
+        .await?
+    }
+
+    /// Attempts every provider shutdown even if an earlier provider reports an
+    /// error, then returns the first error in meter, log, and trace order.
+    fn shutdown_providers(
+        logger_provider: &SdkLoggerProvider,
+        meter_provider: &SdkMeterProvider,
+        tracer_provider: &SdkTracerProvider,
+    ) -> Result<(), DynError> {
+        let meter_result = meter_provider.shutdown();
+        let logger_result = logger_provider.shutdown();
+        let tracer_result = tracer_provider.shutdown();
+
+        meter_result?;
+        logger_result?;
+        tracer_result?;
+
+        Ok(())
+    }
+}
+
+/// Invalid external-telemetry environment configuration.
+#[derive(Debug, Eq, Error, PartialEq)]
+enum TelemetryConfigError {
+    #[error(
+        "AG_HARNESS_EXTERNAL_OTEL requires an operator-owned OTLP endpoint in \
+         OTEL_EXPORTER_OTLP_ENDPOINT"
+    )]
+    MissingEndpoint,
+    #[error(
+        "invalid AG_HARNESS_EXTERNAL_OTEL value `{value}`; expected a boolean enable or disable \
+         value"
+    )]
+    InvalidExternalOtel { value: String },
+}
+
+/// Provides a synchronous last-resort flush when async shutdown is skipped.
+impl Drop for Telemetry {
+    fn drop(&mut self) {
+        if self.is_shutdown {
+            return;
+        }
+
+        self.is_shutdown = true;
+        let _ = Self::shutdown_providers(
+            &self.logger_provider,
+            &self.meter_provider,
+            &self.tracer_provider,
+        );
+    }
+}
+
+/// Initializes telemetry before any model construction and flushes it before
+/// the example exits.
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> Result<(), DynError> {
+    let telemetry = Telemetry::init()?;
+
+    run_with_telemetry(telemetry, run()).await
+}
+
+/// Runs one operation under a process-wide Ctrl-C listener.
+///
+/// The operation future is dropped before telemetry shutdown so cancellation
+/// spans, logs, and duration metrics are recorded before exporters close.
+async fn run_with_telemetry<F>(mut telemetry: Telemetry, operation: F) -> Result<(), DynError>
+where
+    F: Future<Output = Result<(), DynError>>,
+{
+    let mut operation = Box::pin(operation);
+    let mut interrupt_task = spawn_ctrl_c_listener();
+    let (operation_result, interrupt_result) = tokio::select! {
+        result = &mut operation => (Some(result), None),
+        signal = &mut interrupt_task => {
+            (None, Some(signal))
+        }
+    };
+    drop(operation);
+
+    let shutdown_result = telemetry.shutdown().await;
+    let interrupt_result = if let Some(interrupt_result) = interrupt_result {
+        Some(interrupt_result)
+    } else if interrupt_task.is_finished() {
+        Some(interrupt_task.await)
+    } else {
+        interrupt_task.abort();
+        None
+    };
+
+    if let Some(interrupt_result) = interrupt_result {
+        interrupt_result??;
+    }
+    if let Some(operation_result) = operation_result {
+        operation_result?;
+    }
+    shutdown_result
+}
+
+/// Spawns the example's sole Ctrl-C listener for the post-initialization run.
+fn spawn_ctrl_c_listener() -> tokio::task::JoinHandle<io::Result<()>> {
+    tokio::spawn(async {
+        tokio::signal::ctrl_c().await?;
+        tracing::info!("Ctrl-C received; flushing telemetry");
+
+        Ok(())
+    })
+}
+
+/// Builds and executes the configured demonstration request.
+async fn run() -> Result<(), DynError> {
     let model = Qwen::new(QwenConfig {
         api_key: std::env::var("DASHSCOPE_API_KEY")?,
         base_url: std::env::var("DASHSCOPE_BASE_URL")?,
         model: "qwen-plus".to_string(),
-    });
+    })?;
     let schema = OutputSchema::new(json!({
         "type": "object",
         "properties": {
@@ -25,14 +272,578 @@ async fn main() -> Result<(), Box<dyn Error>> {
         "required": ["message"],
         "additionalProperties": false
     }))?;
-    let response = model
-        .complete(ModelRequest::new(
-            "Return a JSON greeting with the message set to hello.",
-            schema,
-        ))
-        .await?;
+    let request = greeting_request(schema, std::env::var("AG_HARNESS_SESSION_ID").ok());
+
+    let response = model.complete(request).await?;
 
     writeln!(io::stdout().lock(), "{}", response.output())?;
 
     Ok(())
+}
+
+/// Creates the demonstration request with optional trace correlation.
+fn greeting_request(schema: OutputSchema, session_id: Option<String>) -> ModelRequest {
+    let mut request = ModelRequest::new(
+        "Return a JSON greeting with the message set to hello.",
+        schema,
+    );
+    if let Some(session_id) = session_id {
+        request = request.with_session_id(session_id);
+    }
+
+    request
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry::metrics::MeterProvider as _;
+    use opentelemetry::trace::TracerProvider as _;
+    use tracing_subscriber::layer::SubscriberExt as _;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+    #[cfg(unix)]
+    use {
+        opentelemetry::trace::Status,
+        opentelemetry_sdk::error::OTelSdkResult,
+        opentelemetry_sdk::logs::{InMemoryLogExporter, LogBatch, LogExporter, SdkLoggerProvider},
+        opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData},
+        opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider},
+        opentelemetry_sdk::trace::{
+            InMemorySpanExporter, SdkTracerProvider, SpanData, SpanExporter,
+        },
+        rustix::process::{self, Pid, Signal},
+        std::process::Stdio,
+        std::time::Duration,
+        tokio::net::TcpListener,
+    };
+
+    use super::*;
+
+    const PRIVATE_CANCELLATION_PROMPT: &str = "private cancellation prompt";
+
+    #[test]
+    fn builds_request_without_session_id() {
+        // Arrange
+        let schema =
+            OutputSchema::new(json!({"type": "object"})).expect("fixture schema should be valid");
+
+        // Act
+        let request = greeting_request(schema, None);
+
+        // Assert
+        assert_eq!(request.session_id(), None);
+    }
+
+    #[test]
+    fn builds_request_with_session_id() {
+        // Arrange
+        let schema =
+            OutputSchema::new(json!({"type": "object"})).expect("fixture schema should be valid");
+
+        // Act
+        let request = greeting_request(schema, Some("session-example".to_string()));
+
+        // Assert
+        assert_eq!(request.session_id(), Some("session-example"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn exports_all_signals_over_real_otlp_http() {
+        // Arrange
+        let receiver = MockServer::start().await;
+        for signal in ["traces", "metrics", "logs"] {
+            Mock::given(method("POST"))
+                .and(path(format!("/v1/{signal}")))
+                .respond_with(ResponseTemplate::new(200))
+                .expect(1)
+                .mount(&receiver)
+                .await;
+        }
+        let resource = Resource::builder()
+            .with_service_name("ag-harness-otlp-transport-test")
+            .build();
+        let span_exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .with_endpoint(format!("{}/v1/traces", receiver.uri()))
+            .build()
+            .expect("span exporter should initialize");
+        let tracer_provider = SdkTracerProvider::builder()
+            .with_batch_exporter(span_exporter)
+            .with_resource(resource.clone())
+            .build();
+        let metric_exporter = opentelemetry_otlp::MetricExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .with_endpoint(format!("{}/v1/metrics", receiver.uri()))
+            .build()
+            .expect("metric exporter should initialize");
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(metric_exporter)
+            .with_resource(resource.clone())
+            .build();
+        let log_exporter = opentelemetry_otlp::LogExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .with_endpoint(format!("{}/v1/logs", receiver.uri()))
+            .build()
+            .expect("log exporter should initialize");
+        let logger_provider = SdkLoggerProvider::builder()
+            .with_batch_exporter(log_exporter)
+            .with_resource(resource)
+            .build();
+        let tracer = tracer_provider.tracer("ag-harness-otlp-transport-test");
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer))
+            .with(OpenTelemetryTracingBridge::new(&logger_provider));
+        let subscriber_guard = tracing::subscriber::set_default(subscriber);
+        let meter = meter_provider.meter("ag-harness-otlp-transport-test");
+        let counter = meter.u64_counter("ag_harness.otlp.transport.test").build();
+        let mut telemetry = Telemetry {
+            is_shutdown: false,
+            logger_provider,
+            meter_provider,
+            tracer_provider,
+        };
+
+        // Act
+        counter.add(1, &[]);
+        tracing::info_span!(target: "ag_harness::qwen", "otlp.transport.test").in_scope(|| {
+            tracing::info!(target: "ag_harness::qwen", "OTLP transport test event");
+        });
+        drop(subscriber_guard);
+        telemetry
+            .shutdown()
+            .await
+            .expect("all OTLP signals should export");
+
+        // Assert
+        receiver.verify().await;
+    }
+
+    #[cfg(unix)]
+    mod fixture_environment {
+        pub(super) const ACTIVE_CALL: &str = "AG_HARNESS_ACTIVE_CALL_FIXTURE";
+        pub(super) const SIGNAL: &str = "AG_HARNESS_SIGNAL_FIXTURE";
+    }
+
+    #[cfg(unix)]
+    use fixture_environment::{
+        ACTIVE_CALL as ACTIVE_CALL_FIXTURE_ENV, SIGNAL as SIGNAL_FIXTURE_ENV,
+    };
+
+    #[cfg(unix)]
+    #[derive(Clone, Debug)]
+    struct RetainedLogExporter(InMemoryLogExporter);
+
+    #[cfg(unix)]
+    impl LogExporter for RetainedLogExporter {
+        async fn export(&self, batch: LogBatch<'_>) -> OTelSdkResult {
+            self.0.export(batch).await
+        }
+
+        fn set_resource(&mut self, resource: &Resource) {
+            self.0.set_resource(resource);
+        }
+    }
+
+    #[cfg(unix)]
+    #[derive(Clone, Debug)]
+    struct RetainedSpanExporter(InMemorySpanExporter);
+
+    #[cfg(unix)]
+    impl SpanExporter for RetainedSpanExporter {
+        async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+            self.0.export(batch).await
+        }
+
+        fn set_resource(&mut self, resource: &Resource) {
+            self.0.set_resource(resource);
+        }
+    }
+
+    #[cfg(unix)]
+    struct TestTelemetry {
+        _subscriber_guard: tracing::subscriber::DefaultGuard,
+        log_exporter: InMemoryLogExporter,
+        metric_exporter: InMemoryMetricExporter,
+        span_exporter: InMemorySpanExporter,
+        telemetry: Option<Telemetry>,
+    }
+
+    #[cfg(unix)]
+    impl TestTelemetry {
+        fn install() -> Self {
+            let span_exporter = InMemorySpanExporter::default();
+            let tracer_provider = SdkTracerProvider::builder()
+                .with_simple_exporter(RetainedSpanExporter(span_exporter.clone()))
+                .build();
+            let log_exporter = InMemoryLogExporter::default();
+            let logger_provider = SdkLoggerProvider::builder()
+                .with_simple_exporter(RetainedLogExporter(log_exporter.clone()))
+                .build();
+            let metric_exporter = InMemoryMetricExporter::default();
+            let meter_provider = SdkMeterProvider::builder()
+                .with_periodic_exporter(metric_exporter.clone())
+                .build();
+            let tracer = tracer_provider.tracer("ag-harness-cancellation-test");
+            let subscriber = tracing_subscriber::registry()
+                .with(tracing_opentelemetry::layer().with_tracer(tracer))
+                .with(OpenTelemetryTracingBridge::new(&logger_provider));
+            let subscriber_guard = tracing::subscriber::set_default(subscriber);
+            global::set_meter_provider(meter_provider.clone());
+            let telemetry = Telemetry {
+                is_shutdown: false,
+                logger_provider,
+                meter_provider,
+                tracer_provider,
+            };
+
+            Self {
+                _subscriber_guard: subscriber_guard,
+                log_exporter,
+                metric_exporter,
+                span_exporter,
+                telemetry: Some(telemetry),
+            }
+        }
+
+        fn take_telemetry(&mut self) -> Telemetry {
+            self.telemetry
+                .take()
+                .expect("test telemetry should only be consumed once")
+        }
+
+        fn assert_cancelled_call_exported(&self) {
+            let spans = self
+                .span_exporter
+                .get_finished_spans()
+                .expect("cancelled span should be exported");
+            assert!(!format!("{spans:?}").contains(PRIVATE_CANCELLATION_PROMPT));
+            let call_span = spans.iter().find(|span| {
+                span.attributes.iter().any(|attribute| {
+                    attribute.key.as_str() == "gen_ai.conversation.id"
+                        && attribute.value.to_string() == "session-cancelled"
+                })
+            });
+            assert!(
+                call_span.is_some(),
+                "cancelled call span should be exported: {spans:#?}"
+            );
+            let call_span = call_span.expect("cancelled call span should exist");
+            assert!(matches!(call_span.status, Status::Error { .. }));
+            assert!(call_span.attributes.iter().any(|attribute| {
+                attribute.key.as_str() == "error.type" && attribute.value.to_string() == "cancelled"
+            }));
+
+            let metrics = self
+                .metric_exporter
+                .get_finished_metrics()
+                .expect("cancelled duration metric should be exported");
+            let duration_count = metrics
+                .iter()
+                .flat_map(opentelemetry_sdk::metrics::data::ResourceMetrics::scope_metrics)
+                .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+                .find_map(|metric| {
+                    if metric.name() != "gen_ai.client.operation.duration" {
+                        return None;
+                    }
+
+                    match metric.data() {
+                        AggregatedMetrics::F64(MetricData::Histogram(histogram)) => Some(
+                            histogram
+                                .data_points()
+                                .map(|point| point.count())
+                                .sum::<u64>(),
+                        ),
+                        _ => None,
+                    }
+                })
+                .expect("duration histogram should be exported");
+            assert_eq!(duration_count, 1);
+
+            let logs = self
+                .log_exporter
+                .get_emitted_logs()
+                .expect("cancelled failure log should be exported");
+            assert!(!format!("{logs:?}").contains(PRIVATE_CANCELLATION_PROMPT));
+            let trace_id = call_span.span_context.trace_id();
+            let trace_logs = logs
+                .iter()
+                .filter(|log| {
+                    log.record
+                        .trace_context()
+                        .is_some_and(|context| context.trace_id == trace_id)
+                })
+                .collect::<Vec<_>>();
+            assert!(format!("{trace_logs:?}").contains("cancelled"));
+        }
+    }
+
+    fn telemetry() -> Telemetry {
+        Telemetry {
+            is_shutdown: false,
+            logger_provider: SdkLoggerProvider::builder().build(),
+            meter_provider: SdkMeterProvider::builder().build(),
+            tracer_provider: SdkTracerProvider::builder().build(),
+        }
+    }
+
+    #[test]
+    fn external_otel_requires_master_opt_in_and_endpoint() {
+        // Arrange
+        let configurations = [
+            (None, None, Ok(false)),
+            (None, Some("http://localhost:4318"), Ok(false)),
+            (Some("off"), Some("http://localhost:4318"), Ok(false)),
+            (Some("true"), Some("http://localhost:4318"), Ok(true)),
+            (
+                Some("enabled"),
+                None,
+                Err(TelemetryConfigError::MissingEndpoint),
+            ),
+        ];
+
+        // Act
+        let results = configurations
+            .iter()
+            .map(|(external_otel, endpoint, _)| {
+                Telemetry::external_otel_enabled(*external_otel, *endpoint)
+            })
+            .collect::<Vec<_>>();
+
+        // Assert
+        for ((_, _, expected), result) in configurations.into_iter().zip(results) {
+            assert_eq!(result, expected);
+        }
+    }
+
+    #[test]
+    fn external_otel_rejects_unknown_master_value() {
+        // Arrange
+        let external_otel = Some("sometimes");
+        let endpoint = Some("http://localhost:4318");
+
+        // Act
+        let result = Telemetry::external_otel_enabled(external_otel, endpoint);
+
+        // Assert
+        assert_eq!(
+            result,
+            Err(TelemetryConfigError::InvalidExternalOtel {
+                value: "sometimes".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_closes_every_provider_and_is_idempotent() {
+        // Arrange
+        let mut telemetry = telemetry();
+
+        // Act
+        let first_result = telemetry.shutdown().await;
+        let second_result = telemetry.shutdown().await;
+
+        // Assert
+        first_result.expect("first shutdown should succeed");
+        second_result.expect("repeated shutdown should succeed");
+        assert!(telemetry.logger_provider.shutdown().is_err());
+        assert!(telemetry.meter_provider.shutdown().is_err());
+        assert!(telemetry.tracer_provider.shutdown().is_err());
+    }
+
+    #[tokio::test]
+    async fn shutdown_attempts_every_provider_after_an_error() {
+        // Arrange
+        let mut telemetry = telemetry();
+        telemetry
+            .meter_provider
+            .shutdown()
+            .expect("meter provider should shut down");
+
+        // Act
+        let result = telemetry.shutdown().await;
+
+        // Assert
+        assert!(result.is_err());
+        assert!(telemetry.logger_provider.shutdown().is_err());
+        assert!(telemetry.tracer_provider.shutdown().is_err());
+    }
+
+    #[test]
+    fn drop_shuts_down_providers_when_async_shutdown_is_skipped() {
+        // Arrange
+        let telemetry = telemetry();
+        let logger_provider = telemetry.logger_provider.clone();
+        let meter_provider = telemetry.meter_provider.clone();
+        let tracer_provider = telemetry.tracer_provider.clone();
+
+        // Act
+        drop(telemetry);
+
+        // Assert
+        assert!(logger_provider.shutdown().is_err());
+        assert!(meter_provider.shutdown().is_err());
+        assert!(tracer_provider.shutdown().is_err());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn ctrl_c_listener_handles_early_and_late_signals() {
+        // Arrange
+        let executable = std::env::current_exe().expect("test executable should be available");
+
+        // Act and assert
+        for phase in ["early", "late"] {
+            assert_signal_fixture(&executable, phase).await;
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn ctrl_c_cancels_active_call_and_flushes_telemetry() {
+        // Arrange
+        let executable = std::env::current_exe().expect("test executable should be available");
+        let child = tokio::process::Command::new(executable)
+            .args([
+                "--exact",
+                "tests::ctrl_c_active_call_process_fixture",
+                "--ignored",
+                "--nocapture",
+            ])
+            .env(ACTIVE_CALL_FIXTURE_ENV, "1")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("active-call fixture should start");
+
+        // Act
+        let output = tokio::time::timeout(Duration::from_secs(5), child.wait_with_output())
+            .await
+            .expect("active-call fixture should exit promptly")
+            .expect("active-call fixture should be waitable");
+
+        // Assert
+        assert!(
+            output.status.success(),
+            "active-call fixture failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[cfg(unix)]
+    async fn assert_signal_fixture(executable: &std::path::Path, phase: &str) {
+        // Arrange
+        let child = tokio::process::Command::new(executable)
+            .args([
+                "--exact",
+                "tests::ctrl_c_process_fixture",
+                "--ignored",
+                "--nocapture",
+            ])
+            .env(SIGNAL_FIXTURE_ENV, phase)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("signal fixture should start");
+        let raw_pid = child.id().expect("signal fixture should have a process id");
+        let raw_pid = i32::try_from(raw_pid).expect("process id should fit in an i32");
+        let pid = Pid::from_raw(raw_pid).expect("signal fixture should have a non-zero process id");
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // Act
+        process::kill_process(pid, Signal::INT).expect("SIGINT should be delivered");
+        let output = tokio::time::timeout(Duration::from_secs(5), child.wait_with_output())
+            .await
+            .expect("signal fixture should exit promptly")
+            .expect("signal fixture should be waitable");
+
+        // Assert
+        assert!(
+            output.status.success(),
+            "{phase} signal fixture failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    #[ignore = "spawned by ctrl_c_listener_handles_early_and_late_signals"]
+    async fn ctrl_c_process_fixture() {
+        // Arrange
+        let phase = std::env::var(SIGNAL_FIXTURE_ENV).expect("fixture phase should be configured");
+        let interrupt_task = spawn_ctrl_c_listener();
+        if phase == "late" {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        } else {
+            assert_eq!(phase, "early");
+        }
+
+        // Act
+        let signal_result = tokio::time::timeout(Duration::from_secs(2), interrupt_task)
+            .await
+            .expect("fixture should receive SIGINT")
+            .expect("signal listener task should complete");
+
+        // Assert
+        signal_result.expect("signal listener should handle SIGINT");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    #[ignore = "spawned by ctrl_c_cancels_active_call_and_flushes_telemetry"]
+    async fn ctrl_c_active_call_process_fixture() {
+        // Arrange
+        assert_eq!(std::env::var(ACTIVE_CALL_FIXTURE_ENV).as_deref(), Ok("1"));
+        let mut test_telemetry = TestTelemetry::install();
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("pending-call server should bind");
+        let address = listener
+            .local_addr()
+            .expect("pending-call server address should be available");
+        let server_task = tokio::spawn(async move {
+            let (_stream, _) = listener
+                .accept()
+                .await
+                .expect("pending-call server should accept a request");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            process::kill_process(process::getpid(), Signal::INT)
+                .expect("fixture should deliver SIGINT to itself");
+            std::future::pending::<()>().await;
+        });
+        let model = Qwen::new(QwenConfig {
+            api_key: "test-key".to_string(),
+            base_url: format!("http://{address}"),
+            model: "qwen-plus".to_string(),
+        })
+        .expect("fixture client should initialize");
+        let schema = OutputSchema::new(json!({
+            "type": "object",
+            "properties": {
+                "message": { "type": "string" }
+            },
+            "required": ["message"],
+            "additionalProperties": false
+        }))
+        .expect("fixture schema should be valid");
+        let request = ModelRequest::new(PRIVATE_CANCELLATION_PROMPT, schema)
+            .with_session_id("session-cancelled");
+        let operation = async move {
+            model.complete(request).await?;
+
+            Ok(())
+        };
+
+        // Act
+        let result = run_with_telemetry(test_telemetry.take_telemetry(), operation).await;
+        server_task.abort();
+
+        // Assert
+        result.expect("SIGINT should cancel the operation and flush telemetry");
+        test_telemetry.assert_cancelled_call_exported();
+    }
 }

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -6,6 +6,7 @@
 mod model;
 mod qwen;
 mod schema_contract;
+mod telemetry;
 
 pub use model::{Model, ModelError, ModelRequest, ModelResponse};
 pub use qwen::{Qwen, QwenConfig};

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -23,6 +23,7 @@ pub trait Model: Send + Sync {
 pub struct ModelRequest {
     prompt: String,
     schema: OutputSchema,
+    session_id: Option<String>,
 }
 
 impl ModelRequest {
@@ -31,7 +32,20 @@ impl ModelRequest {
         Self {
             prompt: prompt.into(),
             schema,
+            session_id: None,
         }
+    }
+
+    /// Associates the request with the persisted harness session that owns it.
+    ///
+    /// Instrumented model adapters attach this value to the model-call span as
+    /// `gen_ai.conversation.id`. The value is never used as a metric
+    /// attribute.
+    #[must_use]
+    pub fn with_session_id(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Some(session_id.into());
+
+        self
     }
 
     /// Returns the request prompt.
@@ -42,6 +56,11 @@ impl ModelRequest {
     /// Returns the schema that the response must match.
     pub fn schema(&self) -> &OutputSchema {
         &self.schema
+    }
+
+    /// Returns the persisted harness session identifier, when supplied.
+    pub fn session_id(&self) -> Option<&str> {
+        self.session_id.as_deref()
     }
 }
 
@@ -157,6 +176,19 @@ mod tests {
 
         // Assert
         assert_eq!(response.output(), &value);
+    }
+
+    #[test]
+    fn request_exposes_session_id() {
+        // Arrange
+        let schema =
+            OutputSchema::new(json!({ "type": "object" })).expect("schema should be valid");
+
+        // Act
+        let request = ModelRequest::new("hello", schema).with_session_id("session-42");
+
+        // Assert
+        assert_eq!(request.session_id(), Some("session-42"));
     }
 
     #[test]

--- a/crates/ag-harness/src/qwen.rs
+++ b/crates/ag-harness/src/qwen.rs
@@ -1,15 +1,27 @@
-use std::time::Duration;
+use std::collections::hash_map::RandomState;
+use std::hash::BuildHasher;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant, SystemTime};
 
 use async_trait::async_trait;
+use opentelemetry::global;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tracing::{Instrument, field};
 
-use crate::{model, schema_contract};
+use crate::{model, schema_contract, telemetry};
 
 const ERROR_BODY_LIMIT_BYTES: usize = 4 * 1024;
+const GEN_AI_OPERATION: &str = "chat";
 const JSON_STRING_MAX_EXPANSION: usize = 6;
+const MAX_RETRY_DELAY: Duration = Duration::from_mins(1);
+const MAX_HTTP_RESENDS: usize = 2;
+const PROVIDER_NAME: &str = "alibaba_cloud";
+const REQUEST_CANCELLED_ERROR_TYPE: &str = "cancelled";
 const RESPONSE_ENVELOPE_LIMIT_BYTES: usize = 64 * 1024;
 const REQUEST_TIMEOUT: Duration = Duration::from_mins(1);
+const RETRY_DELAYS: [Duration; MAX_HTTP_RESENDS] =
+    [Duration::from_millis(100), Duration::from_millis(250)];
 const SUCCESS_BODY_LIMIT_BYTES: usize = schema_contract::RESPONSE_CONTENT_LIMIT_BYTES
     * JSON_STRING_MAX_EXPANSION
     + RESPONSE_ENVELOPE_LIMIT_BYTES;
@@ -32,20 +44,304 @@ pub struct QwenConfig {
 }
 
 /// Qwen implementation of the provider-neutral [`model::Model`] contract.
+///
+/// Calls emit `GenAI` spans and metrics without prompt or response content.
+/// Connection failures and timeouts, including interrupted response bodies,
+/// plus rate limits and server errors are retried twice with bounded jitter.
+/// Rate limits honor a bounded `Retry-After` value. Every HTTP attempt is
+/// represented by its own child span. Cancelling an in-flight call records its
+/// error span, failure log, and duration before exporter shutdown.
 pub struct Qwen {
     client: reqwest::Client,
     config: QwenConfig,
+    metrics: OnceLock<telemetry::RequestMetrics>,
 }
 
 impl Qwen {
-    /// Creates a Qwen model adapter.
-    pub fn new(config: QwenConfig) -> Self {
-        Self {
-            client: reqwest::Client::new(),
+    /// Creates a Qwen model adapter whose metric instruments initialize on the
+    /// first request, after the application has installed its meter provider.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`model::ModelError`] when the HTTP client cannot be
+    /// initialized.
+    pub fn new(config: QwenConfig) -> Result<Self, model::ModelError> {
+        let client = reqwest::Client::builder()
+            .retry(reqwest::retry::never())
+            .build()
+            .map_err(model::ModelError::request)?;
+
+        Ok(Self {
+            client,
             config,
-        }
+            metrics: OnceLock::new(),
+        })
     }
 
+    /// Creates the root span that owns all telemetry for one model call.
+    fn call_span(&self) -> tracing::Span {
+        tracing::info_span!(
+            target: "ag_harness::qwen",
+            "gen_ai.client.operation",
+            "otel.name" = format_args!("{GEN_AI_OPERATION} {}", self.config.model),
+            "otel.kind" = "client",
+            "otel.status_code" = field::Empty,
+            "error.type" = field::Empty,
+            "gen_ai.conversation.id" = field::Empty,
+            "gen_ai.operation.name" = GEN_AI_OPERATION,
+            "gen_ai.output.type" = "json",
+            "gen_ai.provider.name" = PROVIDER_NAME,
+            "gen_ai.request.model" = %self.config.model,
+            "gen_ai.response.id" = field::Empty,
+            "gen_ai.response.model" = field::Empty,
+            "gen_ai.usage.input_tokens" = field::Empty,
+            "gen_ai.usage.output_tokens" = field::Empty,
+        )
+    }
+
+    /// Compiles, sends, parses, and validates one provider request inside the
+    /// model-call span.
+    async fn complete_call(
+        &self,
+        request: &model::ModelRequest,
+    ) -> Result<QwenEnvelope, model::ModelError> {
+        let compile_span = tracing::info_span!(
+            target: "ag_harness::qwen",
+            "gen_ai.schema.compile",
+            "otel.kind" = "internal",
+            "otel.status_code" = field::Empty,
+            "error.type" = field::Empty,
+        );
+        let payload = compile_span.in_scope(|| self.compile_request(request));
+        if let Err(error) = &payload {
+            mark_span_error(&compile_span, error_type(error));
+        }
+        let payload = payload?;
+
+        let mut resend_count = 0_usize;
+        let body = loop {
+            let result = self
+                .send_request(&payload)
+                .instrument(Self::http_attempt_span(resend_count))
+                .await;
+
+            match result {
+                Ok(body) => break body,
+                Err(error) if error.is_retryable && resend_count < MAX_HTTP_RESENDS => {
+                    let next_resend_count = resend_count + 1;
+                    let retry_delay = Self::jittered_retry_delay(
+                        error.retry_after.unwrap_or(RETRY_DELAYS[resend_count]),
+                    );
+                    tracing::warn!(
+                        target: "ag_harness::qwen",
+                        resend_count = next_resend_count,
+                        "Retrying GenAI HTTP request"
+                    );
+                    tokio::time::sleep(retry_delay).await;
+                    resend_count += 1;
+                }
+                Err(error) => return Err(error.error),
+            }
+        };
+
+        let parse_span = tracing::info_span!(
+            target: "ag_harness::qwen",
+            "gen_ai.response.parse_validate",
+            "otel.kind" = "internal",
+            "otel.status_code" = field::Empty,
+            "error.type" = field::Empty,
+        );
+        let envelope = parse_span.in_scope(|| Self::parse_response(request, &body));
+        let error = match &envelope {
+            Ok(envelope) => envelope.result.as_ref().err(),
+            Err(error) => Some(error),
+        };
+        if let Some(error) = error {
+            mark_span_error(&parse_span, error_type(error));
+        }
+
+        envelope
+    }
+
+    /// Creates one child span for an individual HTTP send or resend.
+    fn http_attempt_span(resend_count: usize) -> tracing::Span {
+        let resend_count = i64::try_from(resend_count).unwrap_or(i64::MAX);
+
+        tracing::info_span!(
+            target: "ag_harness::qwen",
+            "HTTP POST",
+            "otel.kind" = "client",
+            "otel.status_code" = field::Empty,
+            "http.request.method" = "POST",
+            "http.request.resend_count" = resend_count,
+            "http.response.status_code" = field::Empty,
+        )
+    }
+
+    /// Converts the provider-neutral request into Qwen's JSON Object payload.
+    fn compile_request<'a>(
+        &'a self,
+        request: &model::ModelRequest,
+    ) -> Result<QwenRequest<'a>, model::ModelError> {
+        if !request.schema().has_object_root() {
+            return Err(model::ModelError::UnsupportedOutputSchema {
+                reason: UNSUPPORTED_SCHEMA_REASON.to_string(),
+            });
+        }
+
+        let messages = vec![
+            QwenMessage {
+                content: format!(
+                    "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
+                    request.schema().value()
+                ),
+                role: "system",
+            },
+            QwenMessage {
+                content: request.prompt().to_string(),
+                role: "user",
+            },
+        ];
+
+        Ok(QwenRequest {
+            messages,
+            model: &self.config.model,
+            response_format: QwenResponseFormat {
+                kind: "json_object",
+            },
+        })
+    }
+
+    /// Sends one HTTP attempt and classifies failures for the outer retry loop.
+    async fn send_request(&self, payload: &QwenRequest<'_>) -> Result<Vec<u8>, QwenAttemptError> {
+        let mut response = self
+            .client
+            .post(self.endpoint())
+            .bearer_auth(&self.config.api_key)
+            .timeout(REQUEST_TIMEOUT)
+            .json(payload)
+            .send()
+            .await
+            .map_err(QwenAttemptError::transport)?;
+        let status = response.status();
+        tracing::Span::current().record("http.response.status_code", i64::from(status.as_u16()));
+
+        if let Err(source) = response.error_for_status_ref() {
+            tracing::Span::current().record("otel.status_code", "ERROR");
+            let is_retryable = Self::is_retryable_status(status);
+            let retry_after = if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                Self::retry_after_delay(&response, SystemTime::now())
+            } else {
+                None
+            };
+            let body = Self::error_body_summary(&mut response)
+                .await
+                .map_err(|error| QwenAttemptError::error_body(error, is_retryable, retry_after))?;
+            let error = QwenHttpError {
+                body,
+                source,
+                status,
+            };
+
+            return Err(QwenAttemptError {
+                error: model::ModelError::request(error),
+                is_retryable,
+                retry_after,
+            });
+        }
+
+        Self::success_body(&mut response).await
+    }
+
+    /// Returns whether an HTTP status is eligible for a bounded resend.
+    fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+        status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+    }
+
+    /// Reads a valid `Retry-After` delta or HTTP date and caps the requested
+    /// delay so provider input cannot suspend the harness indefinitely.
+    fn retry_after_delay(response: &reqwest::Response, now: SystemTime) -> Option<Duration> {
+        let value = response
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)?
+            .to_str()
+            .ok()?;
+
+        Self::parse_retry_after(value, now)
+    }
+
+    /// Parses either form allowed by the `Retry-After` header.
+    fn parse_retry_after(value: &str, now: SystemTime) -> Option<Duration> {
+        let delay = match value.parse::<u64>() {
+            Ok(seconds) => Duration::from_secs(seconds),
+            Err(_) => httpdate::parse_http_date(value)
+                .ok()?
+                .duration_since(now)
+                .unwrap_or_default(),
+        };
+
+        Some(delay.min(MAX_RETRY_DELAY))
+    }
+
+    /// Adds bounded randomized jitter to a fallback or provider-requested
+    /// retry delay, preventing concurrent calls from retrying in lockstep.
+    fn jittered_retry_delay(base: Duration) -> Duration {
+        let base = base.min(MAX_RETRY_DELAY);
+        let max_jitter = (base / 4).min(Duration::from_millis(250));
+        if max_jitter.is_zero() {
+            return base;
+        }
+
+        let max_jitter_nanos = u64::try_from(max_jitter.as_nanos()).unwrap_or(u64::MAX);
+        let jitter_nanos = RandomState::new().hash_one(()) % max_jitter_nanos.saturating_add(1);
+
+        base.saturating_add(Duration::from_nanos(jitter_nanos))
+            .min(MAX_RETRY_DELAY)
+    }
+
+    /// Decodes the provider envelope while retaining response and usage
+    /// metadata even when output validation fails.
+    fn parse_response(
+        request: &model::ModelRequest,
+        body: &[u8],
+    ) -> Result<QwenEnvelope, model::ModelError> {
+        let response =
+            serde_json::from_slice::<QwenResponse>(body).map_err(model::ModelError::request)?;
+        let result = Self::parse_choice(request, response.choices);
+
+        Ok(QwenEnvelope {
+            response_id: response.id,
+            response_model: response.model,
+            result,
+            usage: response.usage,
+        })
+    }
+
+    /// Converts the first completed provider choice into validated JSON.
+    fn parse_choice(
+        request: &model::ModelRequest,
+        choices: Vec<QwenChoice>,
+    ) -> Result<model::ModelResponse, model::ModelError> {
+        let choice = choices
+            .into_iter()
+            .next()
+            .ok_or(model::ModelError::InvalidResponse)?;
+        if choice.finish_reason != "stop" {
+            return Err(model::ModelError::IncompleteResponse {
+                reason: schema_contract::bounded_diagnostic(choice.finish_reason),
+            });
+        }
+
+        let text = choice
+            .message
+            .content
+            .ok_or(model::ModelError::InvalidResponse)?;
+        let output = request.schema().parse_and_validate(&text)?;
+
+        Ok(model::ModelResponse::new(output))
+    }
+
+    /// Returns the configured Chat Completions endpoint.
     fn endpoint(&self) -> String {
         format!(
             "{}/chat/completions",
@@ -53,6 +349,7 @@ impl Qwen {
         )
     }
 
+    /// Reads a bounded, whitespace-normalized provider error summary.
     async fn error_body_summary(
         response: &mut reqwest::Response,
     ) -> Result<String, reqwest::Error> {
@@ -83,23 +380,32 @@ impl Qwen {
         Ok(summary)
     }
 
-    async fn success_body(response: &mut reqwest::Response) -> Result<Vec<u8>, model::ModelError> {
+    /// Reads a successful response body without exceeding the envelope limit.
+    async fn success_body(response: &mut reqwest::Response) -> Result<Vec<u8>, QwenAttemptError> {
         let limit = u64::try_from(SUCCESS_BODY_LIMIT_BYTES).unwrap_or(u64::MAX);
         if response
             .content_length()
             .is_some_and(|content_length| content_length > limit)
         {
-            return Err(model::ModelError::ResponseBodyTooLarge);
+            return Err(QwenAttemptError::not_retryable(
+                model::ModelError::ResponseBodyTooLarge,
+            ));
         }
 
         let mut body = Vec::new();
-        while let Some(chunk) = response.chunk().await.map_err(model::ModelError::request)? {
-            Self::append_success_chunk(&mut body, &chunk)?;
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .map_err(QwenAttemptError::success_body)?
+        {
+            Self::append_success_chunk(&mut body, &chunk)
+                .map_err(QwenAttemptError::not_retryable)?;
         }
 
         Ok(body)
     }
 
+    /// Appends one response chunk when it fits within the remaining limit.
     fn append_success_chunk(body: &mut Vec<u8>, chunk: &[u8]) -> Result<(), model::ModelError> {
         let remaining = SUCCESS_BODY_LIMIT_BYTES.saturating_sub(body.len());
         if chunk.len() > remaining {
@@ -118,82 +424,216 @@ impl model::Model for Qwen {
         &self,
         request: model::ModelRequest,
     ) -> Result<model::ModelResponse, model::ModelError> {
-        if !request.schema().has_object_root() {
-            return Err(model::ModelError::UnsupportedOutputSchema {
-                reason: UNSUPPORTED_SCHEMA_REASON.to_string(),
-            });
+        let span = self.call_span();
+        if let Some(session_id) = request.session_id() {
+            span.record("gen_ai.conversation.id", session_id);
         }
-        let messages = vec![
-            QwenMessage {
-                content: format!(
-                    "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
-                    request.schema().value()
-                ),
-                role: "system",
-            },
-            QwenMessage {
-                content: request.prompt().to_string(),
-                role: "user",
-            },
-        ];
-        let payload = QwenRequest {
-            messages,
-            model: &self.config.model,
-            response_format: QwenResponseFormat {
-                kind: "json_object",
-            },
-        };
+        let metrics = self
+            .metrics
+            .get_or_init(|| telemetry::RequestMetrics::new(&global::meter("ag-harness")));
+        let mut call_telemetry = CallTelemetry::new(metrics, &self.config.model, span.clone());
 
-        let mut response = self
-            .client
-            .post(self.endpoint())
-            .bearer_auth(&self.config.api_key)
-            .timeout(REQUEST_TIMEOUT)
-            .json(&payload)
-            .send()
-            .await
-            .map_err(model::ModelError::request)?;
+        let result = async {
+            tracing::info!(
+                target: "ag_harness::qwen",
+                "GenAI client operation started"
+            );
+            let envelope = self.complete_call(&request).await;
+            let (result, total_tokens) = match envelope {
+                Ok(envelope) => {
+                    if let Some(response_id) = &envelope.response_id {
+                        tracing::Span::current().record("gen_ai.response.id", response_id);
+                    }
+                    if let Some(response_model) = &envelope.response_model {
+                        tracing::Span::current().record("gen_ai.response.model", response_model);
+                    }
+                    if let Some(usage) = &envelope.usage {
+                        if let Some(input_tokens) = usage.prompt_tokens {
+                            let input_tokens = i64::try_from(input_tokens).unwrap_or(i64::MAX);
+                            tracing::Span::current()
+                                .record("gen_ai.usage.input_tokens", input_tokens);
+                        }
+                        if let Some(output_tokens) = usage.completion_tokens {
+                            let output_tokens = i64::try_from(output_tokens).unwrap_or(i64::MAX);
+                            tracing::Span::current()
+                                .record("gen_ai.usage.output_tokens", output_tokens);
+                        }
+                    }
 
-        if let Err(source) = response.error_for_status_ref() {
-            let body = Self::error_body_summary(&mut response)
-                .await
-                .map_err(model::ModelError::request)?;
-            let error = QwenHttpError {
-                body,
-                source,
-                status: response.status(),
+                    (
+                        envelope.result,
+                        envelope.usage.and_then(|usage| usage.total_tokens()),
+                    )
+                }
+                Err(error) => (Err(error), None),
             };
 
-            return Err(model::ModelError::request(error));
+            (result, total_tokens)
         }
+        .instrument(span)
+        .await;
 
-        let body = Self::success_body(&mut response).await?;
-        let response =
-            serde_json::from_slice::<QwenResponse>(&body).map_err(model::ModelError::request)?;
+        call_telemetry.finish(&result.0, result.1);
 
-        let choice = response
-            .choices
-            .into_iter()
-            .next()
-            .ok_or(model::ModelError::InvalidResponse)?;
-        if choice.finish_reason != "stop" {
-            return Err(model::ModelError::IncompleteResponse {
-                reason: schema_contract::bounded_diagnostic(choice.finish_reason),
-            });
-        }
-        let text = choice
-            .message
-            .content
-            .ok_or(model::ModelError::InvalidResponse)?;
-
-        request
-            .schema()
-            .parse_and_validate(&text)
-            .map(model::ModelResponse::new)
-            .map_err(model::ModelError::from)
+        result.0
     }
 }
 
+/// Cancellation-safe telemetry finalizer for one model call.
+struct CallTelemetry<'a> {
+    is_finished: bool,
+    metrics: &'a telemetry::RequestMetrics,
+    model: &'a str,
+    span: tracing::Span,
+    started_at: Instant,
+}
+
+impl<'a> CallTelemetry<'a> {
+    /// Starts duration measurement and retains the call span until
+    /// finalization.
+    fn new(metrics: &'a telemetry::RequestMetrics, model: &'a str, span: tracing::Span) -> Self {
+        Self {
+            is_finished: false,
+            metrics,
+            model,
+            span,
+            started_at: Instant::now(),
+        }
+    }
+
+    /// Records the terminal span state, lifecycle log, duration, and optional
+    /// token total for a normally completed future.
+    fn finish(
+        &mut self,
+        result: &Result<model::ModelResponse, model::ModelError>,
+        total_tokens: Option<u64>,
+    ) {
+        self.is_finished = true;
+        self.span.in_scope(|| match result {
+            Ok(_) => {
+                tracing::info!(
+                    target: "ag_harness::qwen",
+                    "GenAI client operation completed"
+                );
+            }
+            Err(error) => {
+                let error_type = error_type(error);
+                mark_span_error(&self.span, error_type);
+                tracing::warn!(
+                    target: "ag_harness::qwen",
+                    error_type,
+                    "GenAI client operation failed"
+                );
+            }
+        });
+        self.metrics.record(
+            self.started_at.elapsed(),
+            PROVIDER_NAME,
+            self.model,
+            total_tokens,
+        );
+    }
+}
+
+/// Finalizes a dropped in-flight call as cancelled before exporters shut down.
+impl Drop for CallTelemetry<'_> {
+    fn drop(&mut self) {
+        if self.is_finished {
+            return;
+        }
+
+        self.span.in_scope(|| {
+            mark_span_error(&self.span, REQUEST_CANCELLED_ERROR_TYPE);
+            tracing::warn!(
+                target: "ag_harness::qwen",
+                error_type = REQUEST_CANCELLED_ERROR_TYPE,
+                "GenAI client operation cancelled"
+            );
+        });
+        self.metrics
+            .record(self.started_at.elapsed(), PROVIDER_NAME, self.model, None);
+    }
+}
+
+/// Marks a span as failed with a bounded error classification.
+fn mark_span_error(span: &tracing::Span, error_type: &'static str) {
+    span.record("error.type", error_type);
+    span.record("otel.status_code", "ERROR");
+}
+
+/// Maps model failures to bounded OpenTelemetry `error.type` values.
+fn error_type(error: &model::ModelError) -> &'static str {
+    match error {
+        model::ModelError::Request(_) => "request_error",
+        model::ModelError::InvalidResponse => "invalid_response",
+        model::ModelError::IncompleteResponse { .. } => "incomplete_response",
+        model::ModelError::ResponseBodyTooLarge => "response_body_too_large",
+        model::ModelError::UnsupportedOutputSchema { .. } => "unsupported_output_schema",
+        model::ModelError::ResponseContentTooLarge => "response_content_too_large",
+        model::ModelError::InvalidJson { .. } => "invalid_json",
+        model::ModelError::SchemaViolation { .. } => "schema_violation",
+    }
+}
+
+/// Attempt-local failure classification consumed by the bounded retry loop.
+struct QwenAttemptError {
+    error: model::ModelError,
+    is_retryable: bool,
+    retry_after: Option<Duration>,
+}
+
+impl QwenAttemptError {
+    /// Classifies a request-send transport failure.
+    fn transport(error: reqwest::Error) -> Self {
+        tracing::Span::current().record("otel.status_code", "ERROR");
+        let is_retryable = error.is_connect() || error.is_timeout();
+
+        Self {
+            error: model::ModelError::request(error),
+            is_retryable,
+            retry_after: None,
+        }
+    }
+
+    /// Preserves the response status decision and optional provider delay when
+    /// reading an error body fails.
+    fn error_body(
+        error: reqwest::Error,
+        is_retryable: bool,
+        retry_after: Option<Duration>,
+    ) -> Self {
+        Self {
+            error: model::ModelError::request(error),
+            is_retryable,
+            retry_after,
+        }
+    }
+
+    /// Classifies an interrupted or timed-out successful response body.
+    fn success_body(error: reqwest::Error) -> Self {
+        tracing::Span::current().record("otel.status_code", "ERROR");
+        let is_retryable = error.is_connect() || error.is_timeout() || error.is_decode();
+
+        Self {
+            error: model::ModelError::request(error),
+            is_retryable,
+            retry_after: None,
+        }
+    }
+
+    /// Marks a bounded local validation failure as non-retryable.
+    fn not_retryable(error: model::ModelError) -> Self {
+        tracing::Span::current().record("otel.status_code", "ERROR");
+
+        Self {
+            error,
+            is_retryable: false,
+            retry_after: None,
+        }
+    }
+}
+
+/// Bounded provider error returned for unsuccessful HTTP statuses.
 #[derive(Debug, Error)]
 #[error("Qwen returned HTTP {status}: {body}")]
 struct QwenHttpError {
@@ -203,6 +643,7 @@ struct QwenHttpError {
     status: reqwest::StatusCode,
 }
 
+/// Qwen Chat Completions request envelope.
 #[derive(Serialize)]
 struct QwenRequest<'a> {
     messages: Vec<QwenMessage>,
@@ -210,42 +651,154 @@ struct QwenRequest<'a> {
     response_format: QwenResponseFormat,
 }
 
+/// One role/content message in a Qwen request.
 #[derive(Serialize)]
 struct QwenMessage {
     content: String,
     role: &'static str,
 }
 
+/// Qwen response-format selector for structured JSON output.
 #[derive(Serialize)]
 struct QwenResponseFormat {
     #[serde(rename = "type")]
     kind: &'static str,
 }
 
+/// Relevant fields decoded from a Qwen response envelope.
 #[derive(Deserialize)]
 struct QwenResponse {
     choices: Vec<QwenChoice>,
+    id: Option<String>,
+    model: Option<String>,
+    usage: Option<QwenUsage>,
 }
 
+/// One Qwen response choice.
 #[derive(Deserialize)]
 struct QwenChoice {
     finish_reason: String,
     message: QwenResponseMessage,
 }
 
+/// Assistant content returned inside a response choice.
 #[derive(Deserialize)]
 struct QwenResponseMessage {
     content: Option<String>,
 }
 
+/// Parsed metadata, usage, and validated result retained across validation
+/// failures.
+struct QwenEnvelope {
+    response_id: Option<String>,
+    response_model: Option<String>,
+    result: Result<model::ModelResponse, model::ModelError>,
+    usage: Option<QwenUsage>,
+}
+
+/// Provider-reported input and output token counts.
+#[derive(Deserialize)]
+struct QwenUsage {
+    completion_tokens: Option<u64>,
+    prompt_tokens: Option<u64>,
+}
+
+impl QwenUsage {
+    /// Returns the saturating total when either token count is present.
+    fn total_tokens(&self) -> Option<u64> {
+        match (self.prompt_tokens, self.completion_tokens) {
+            (None, None) => None,
+            (prompt_tokens, completion_tokens) => Some(
+                prompt_tokens
+                    .unwrap_or_default()
+                    .saturating_add(completion_tokens.unwrap_or_default()),
+            ),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::UNIX_EPOCH;
+
+    use opentelemetry::metrics::MeterProvider as _;
+    use opentelemetry::trace::{Status, TracerProvider as _};
+    use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+    use opentelemetry_sdk::logs::{InMemoryLogExporter, SdkLoggerProvider};
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
     use serde_json::json;
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+    use tokio::net::{TcpListener, TcpStream};
+    use tracing_subscriber::layer::SubscriberExt as _;
     use wiremock::matchers::{bearer_token, body_json, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
     use crate::Model;
+
+    struct TestTelemetry {
+        _subscriber_guard: tracing::subscriber::DefaultGuard,
+        log_exporter: InMemoryLogExporter,
+        logger_provider: SdkLoggerProvider,
+        meter_provider: SdkMeterProvider,
+        metric_exporter: InMemoryMetricExporter,
+        span_exporter: InMemorySpanExporter,
+        tracer_provider: SdkTracerProvider,
+    }
+
+    impl TestTelemetry {
+        fn install() -> Self {
+            let span_exporter = InMemorySpanExporter::default();
+            let tracer_provider = SdkTracerProvider::builder()
+                .with_simple_exporter(span_exporter.clone())
+                .build();
+            let log_exporter = InMemoryLogExporter::default();
+            let logger_provider = SdkLoggerProvider::builder()
+                .with_simple_exporter(log_exporter.clone())
+                .build();
+            let metric_exporter = InMemoryMetricExporter::default();
+            let meter_provider = SdkMeterProvider::builder()
+                .with_periodic_exporter(metric_exporter.clone())
+                .build();
+            let tracer = tracer_provider.tracer("ag-harness-unit-test");
+            let subscriber = tracing_subscriber::registry()
+                .with(tracing_opentelemetry::layer().with_tracer(tracer))
+                .with(OpenTelemetryTracingBridge::new(&logger_provider));
+            let subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+            Self {
+                _subscriber_guard: subscriber_guard,
+                log_exporter,
+                logger_provider,
+                meter_provider,
+                metric_exporter,
+                span_exporter,
+                tracer_provider,
+            }
+        }
+
+        fn request_metrics(&self) -> telemetry::RequestMetrics {
+            let meter = self.meter_provider.meter("ag-harness-unit-test");
+
+            telemetry::RequestMetrics::new(&meter)
+        }
+
+        fn flush(&self) {
+            self.tracer_provider
+                .force_flush()
+                .expect("spans should flush");
+            self.logger_provider
+                .force_flush()
+                .expect("logs should flush");
+            self.meter_provider
+                .force_flush()
+                .expect("metrics should flush");
+        }
+    }
 
     fn person_schema_value() -> serde_json::Value {
         json!({
@@ -284,6 +837,96 @@ mod tests {
             base_url: format!("{}/", server.uri()),
             model: "qwen-plus".to_string(),
         })
+        .expect("test client should initialize")
+    }
+
+    fn span_attribute<'a>(span: &'a SpanData, key: &str) -> Option<&'a opentelemetry::Value> {
+        span.attributes
+            .iter()
+            .find(|attribute| attribute.key.as_str() == key)
+            .map(|attribute| &attribute.value)
+    }
+
+    async fn qwen_with_interrupted_first_body(
+        status_line: &'static str,
+    ) -> (Qwen, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test server address should be available");
+        let success_body = serde_json::to_vec(&json!({
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {"content": r#"{"name":"Ada"}"#}
+            }]
+        }))
+        .expect("response should serialize");
+        let interrupted_response = format!(
+            "HTTP/1.1 {status_line}\r\nContent-Length: 1024\r\nConnection: close\r\n\r\n{{"
+        )
+        .into_bytes();
+        let success_headers = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            success_body.len()
+        );
+        let mut success_response = success_headers.into_bytes();
+        success_response.extend_from_slice(&success_body);
+        let server_task = tokio::spawn(async move {
+            for response in [interrupted_response, success_response] {
+                let (mut stream, _) = listener
+                    .accept()
+                    .await
+                    .expect("test server should accept a request");
+                read_http_request(&mut stream).await;
+                stream
+                    .write_all(&response)
+                    .await
+                    .expect("test server should write a response");
+                stream
+                    .shutdown()
+                    .await
+                    .expect("test server should close the response");
+            }
+        });
+        let model = Qwen::new(QwenConfig {
+            api_key: "test-key".to_string(),
+            base_url: format!("http://{address}"),
+            model: "qwen-plus".to_string(),
+        })
+        .expect("test client should initialize");
+
+        (model, server_task)
+    }
+
+    async fn read_http_request(stream: &mut TcpStream) {
+        let mut headers = Vec::new();
+        while !headers.ends_with(b"\r\n\r\n") {
+            headers.push(
+                stream
+                    .read_u8()
+                    .await
+                    .expect("test server should read request headers"),
+            );
+        }
+        let headers = std::str::from_utf8(&headers).expect("request headers should be UTF-8");
+        let content_length = headers
+            .lines()
+            .find_map(|header| {
+                let (name, value) = header.split_once(':')?;
+                if !name.eq_ignore_ascii_case("content-length") {
+                    return None;
+                }
+
+                value.trim().parse::<usize>().ok()
+            })
+            .expect("request should declare its body length");
+        let mut body = vec![0_u8; content_length];
+        stream
+            .read_exact(&mut body)
+            .await
+            .expect("test server should read the request body");
     }
 
     async fn mount_structured_response(
@@ -337,6 +980,284 @@ mod tests {
 
         // Assert
         assert_eq!(response.output(), &json!({ "name": "Ada" }));
+    }
+
+    #[test]
+    fn finalizes_cancelled_call_telemetry_on_drop() {
+        // Arrange
+        let telemetry = TestTelemetry::install();
+        let metrics = telemetry.request_metrics();
+        let span = tracing::info_span!(
+            "gen_ai.client.operation",
+            "otel.status_code" = field::Empty,
+            "error.type" = field::Empty,
+        );
+        let call_telemetry = CallTelemetry::new(&metrics, "qwen-plus", span);
+
+        // Act
+        drop(call_telemetry);
+        telemetry.flush();
+
+        // Assert
+        let spans = telemetry
+            .span_exporter
+            .get_finished_spans()
+            .expect("cancelled span should be exported");
+        let call_span = spans.first().expect("call span should be exported");
+        assert!(matches!(call_span.status, Status::Error { .. }));
+        assert!(call_span.attributes.iter().any(|attribute| {
+            attribute.key.as_str() == "error.type" && attribute.value.to_string() == "cancelled"
+        }));
+        let finished_metrics = telemetry
+            .metric_exporter
+            .get_finished_metrics()
+            .expect("cancelled duration should be exported");
+        let duration_metric = finished_metrics
+            .iter()
+            .flat_map(opentelemetry_sdk::metrics::data::ResourceMetrics::scope_metrics)
+            .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+            .find(|metric| metric.name() == "gen_ai.client.operation.duration")
+            .expect("duration histogram should be exported");
+        assert!(matches!(
+            duration_metric.data(),
+            AggregatedMetrics::F64(MetricData::Histogram(histogram))
+                if histogram
+                    .data_points()
+                    .map(opentelemetry_sdk::metrics::data::HistogramDataPoint::count)
+                    .sum::<u64>() == 1
+        ));
+        let trace_id = call_span.span_context.trace_id();
+        let logs = telemetry
+            .log_exporter
+            .get_emitted_logs()
+            .expect("cancelled log should be exported");
+        assert!(logs.iter().any(|log| {
+            log.record
+                .trace_context()
+                .is_some_and(|context| context.trace_id == trace_id)
+                && format!("{:?}", log.record).contains("cancelled")
+        }));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn retries_transient_http_response_in_separate_attempts() {
+        // Arrange
+        let server = MockServer::start().await;
+        let attempt_count = Arc::new(AtomicUsize::new(0));
+        {
+            let attempt_count = Arc::clone(&attempt_count);
+            Mock::given(method("POST"))
+                .and(path("/chat/completions"))
+                .respond_with(move |_: &wiremock::Request| {
+                    if attempt_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                        return ResponseTemplate::new(429).insert_header("Retry-After", "0");
+                    }
+
+                    ResponseTemplate::new(200).set_body_json(json!({
+                        "choices": [{
+                            "finish_reason": "stop",
+                            "message": {"content": r#"{"name":"Ada"}"#}
+                        }],
+                        "id": "response-42",
+                        "model": "qwen-plus-2026-07",
+                        "usage": {
+                            "completion_tokens": 3,
+                            "prompt_tokens": 4
+                        }
+                    }))
+                })
+                .expect(2)
+                .mount(&server)
+                .await;
+        }
+        let model = qwen(&server);
+        let telemetry = TestTelemetry::install();
+        assert!(model.metrics.set(telemetry.request_metrics()).is_ok());
+
+        // Act
+        let response = model
+            .complete(request("extract the name").with_session_id("session-retry-unit-test"))
+            .await
+            .expect("transient failure should be retried");
+        telemetry.flush();
+
+        // Assert
+        assert_eq!(response.output(), &json!({ "name": "Ada" }));
+        assert_eq!(attempt_count.load(Ordering::SeqCst), 2);
+        let spans = telemetry
+            .span_exporter
+            .get_finished_spans()
+            .expect("retry spans should be exported");
+        let call_span = spans
+            .iter()
+            .find(|span| span.name == "chat qwen-plus")
+            .expect("call span should be exported");
+        assert_eq!(
+            span_attribute(call_span, "gen_ai.response.id").map(ToString::to_string),
+            Some("response-42".to_string())
+        );
+        assert_eq!(
+            span_attribute(call_span, "gen_ai.response.model").map(ToString::to_string),
+            Some("qwen-plus-2026-07".to_string())
+        );
+        assert_eq!(
+            span_attribute(call_span, "gen_ai.usage.input_tokens").map(ToString::to_string),
+            Some("4".to_string())
+        );
+        assert_eq!(
+            span_attribute(call_span, "gen_ai.usage.output_tokens").map(ToString::to_string),
+            Some("3".to_string())
+        );
+        let finished_metrics = telemetry
+            .metric_exporter
+            .get_finished_metrics()
+            .expect("token metric should be exported");
+        let token_metric = finished_metrics
+            .iter()
+            .flat_map(opentelemetry_sdk::metrics::data::ResourceMetrics::scope_metrics)
+            .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+            .find(|metric| metric.name() == "gen_ai.client.token.usage")
+            .expect("token histogram should be exported");
+        assert!(matches!(
+            token_metric.data(),
+            AggregatedMetrics::U64(MetricData::Histogram(histogram))
+                if histogram.data_points().any(|point| point.sum() == 7)
+        ));
+        let logs = telemetry
+            .log_exporter
+            .get_emitted_logs()
+            .expect("retry log should be exported");
+        assert!(format!("{logs:?}").contains("Retrying GenAI HTTP request"));
+    }
+
+    #[test]
+    fn parses_and_bounds_retry_after_delays() {
+        // Arrange
+        let now = UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let future_date = httpdate::fmt_http_date(now + Duration::from_secs(30));
+        let past_date = httpdate::fmt_http_date(now - Duration::from_secs(30));
+
+        // Act
+        let delta_delay = Qwen::parse_retry_after("12", now);
+        let capped_delay = Qwen::parse_retry_after("3600", now);
+        let date_delay = Qwen::parse_retry_after(&future_date, now);
+        let past_delay = Qwen::parse_retry_after(&past_date, now);
+        let invalid_delay = Qwen::parse_retry_after("later", now);
+
+        // Assert
+        assert_eq!(delta_delay, Some(Duration::from_secs(12)));
+        assert_eq!(capped_delay, Some(MAX_RETRY_DELAY));
+        assert_eq!(date_delay, Some(Duration::from_secs(30)));
+        assert_eq!(past_delay, Some(Duration::ZERO));
+        assert_eq!(invalid_delay, None);
+    }
+
+    #[test]
+    fn adds_bounded_retry_jitter() {
+        // Arrange
+        let base = Duration::from_millis(100);
+
+        // Act
+        let delays = (0..16)
+            .map(|_| Qwen::jittered_retry_delay(base))
+            .collect::<Vec<_>>();
+        let zero_delay = Qwen::jittered_retry_delay(Duration::ZERO);
+        let capped_delay = Qwen::jittered_retry_delay(Duration::from_hours(1));
+
+        // Assert
+        assert!(delays.iter().all(|delay| {
+            *delay >= base && *delay <= base.saturating_add(Duration::from_millis(25))
+        }));
+        assert_eq!(zero_delay, Duration::ZERO);
+        assert_eq!(capped_delay, MAX_RETRY_DELAY);
+    }
+
+    #[tokio::test]
+    async fn returns_request_error_for_invalid_endpoint() {
+        // Arrange
+        let model = Qwen::new(QwenConfig {
+            api_key: "test-key".to_string(),
+            base_url: "http://[::1".to_string(),
+            model: "qwen-plus".to_string(),
+        })
+        .expect("test client should initialize");
+
+        // Act
+        let error = model
+            .complete(request("extract the name"))
+            .await
+            .expect_err("invalid endpoint should fail");
+
+        // Assert
+        assert!(matches!(error, model::ModelError::Request(_)));
+    }
+
+    #[test]
+    fn totals_partial_complete_and_saturated_usage() {
+        // Arrange
+        let usages = [
+            QwenUsage {
+                completion_tokens: None,
+                prompt_tokens: None,
+            },
+            QwenUsage {
+                completion_tokens: None,
+                prompt_tokens: Some(4),
+            },
+            QwenUsage {
+                completion_tokens: Some(3),
+                prompt_tokens: None,
+            },
+            QwenUsage {
+                completion_tokens: Some(3),
+                prompt_tokens: Some(4),
+            },
+            QwenUsage {
+                completion_tokens: Some(1),
+                prompt_tokens: Some(u64::MAX),
+            },
+        ];
+
+        // Act
+        let totals = usages.map(|usage| usage.total_tokens());
+
+        // Assert
+        assert_eq!(totals, [None, Some(4), Some(3), Some(7), Some(u64::MAX)]);
+    }
+
+    #[tokio::test]
+    async fn retries_interrupted_success_body() {
+        // Arrange
+        let (model, server_task) = qwen_with_interrupted_first_body("200 OK").await;
+
+        // Act
+        let result = model.complete(request("extract the name")).await;
+        let server_result = tokio::time::timeout(Duration::from_secs(2), server_task).await;
+
+        // Assert
+        let response = result.expect("interrupted success body should be retried");
+        assert_eq!(response.output(), &json!({ "name": "Ada" }));
+        server_result
+            .expect("retry should reach the test server")
+            .expect("test server should complete");
+    }
+
+    #[tokio::test]
+    async fn retries_interrupted_retryable_error_body() {
+        // Arrange
+        let (model, server_task) =
+            qwen_with_interrupted_first_body("503 Service Unavailable").await;
+
+        // Act
+        let result = model.complete(request("extract the name")).await;
+        let server_result = tokio::time::timeout(Duration::from_secs(2), server_task).await;
+
+        // Assert
+        let response = result.expect("interrupted server-error body should be retried");
+        assert_eq!(response.output(), &json!({ "name": "Ada" }));
+        server_result
+            .expect("retry should reach the test server")
+            .expect("test server should complete");
     }
 
     #[tokio::test]
@@ -448,9 +1369,10 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn rejects_oversized_success_body_before_decoding() {
         // Arrange
+        let telemetry = TestTelemetry::install();
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/chat/completions"))
@@ -462,15 +1384,26 @@ mod tests {
             .mount(&server)
             .await;
         let model = qwen(&server);
+        assert!(model.metrics.set(telemetry.request_metrics()).is_ok());
 
         // Act
         let error = model
             .complete(request("hello"))
             .await
             .expect_err("oversized successful response should fail");
+        telemetry.flush();
 
         // Assert
         assert!(matches!(error, model::ModelError::ResponseBodyTooLarge));
+        let spans = telemetry
+            .span_exporter
+            .get_finished_spans()
+            .expect("attempt span should be exported");
+        let attempt_span = spans
+            .iter()
+            .find(|span| span.name == "HTTP POST")
+            .expect("attempt span should exist");
+        assert!(matches!(attempt_span.status, Status::Error { .. }));
     }
 
     #[test]

--- a/crates/ag-harness/src/telemetry.rs
+++ b/crates/ag-harness/src/telemetry.rs
@@ -1,0 +1,60 @@
+use std::time::Duration;
+
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::{Histogram, Meter};
+
+const DURATION_BOUNDARIES_SECONDS: [f64; 14] = [
+    0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
+];
+
+/// OpenTelemetry instruments shared by instrumented model adapters.
+///
+/// The instruments record `gen_ai.client.operation.duration` in seconds and
+/// `gen_ai.client.token.usage` in tokens. Both use only provider and model as
+/// attributes, keeping metric cardinality bounded.
+pub(crate) struct RequestMetrics {
+    duration: Histogram<f64>,
+    token_usage: Histogram<u64>,
+}
+
+impl RequestMetrics {
+    /// Creates the duration and token-usage histograms from the supplied meter.
+    pub(crate) fn new(meter: &Meter) -> Self {
+        let duration = meter
+            .f64_histogram("gen_ai.client.operation.duration")
+            .with_description("GenAI operation duration.")
+            .with_unit("s")
+            .with_boundaries(DURATION_BOUNDARIES_SECONDS.to_vec())
+            .build();
+        let token_usage = meter
+            .u64_histogram("gen_ai.client.token.usage")
+            .with_description("Number of tokens used by a GenAI operation.")
+            .with_unit("{token}")
+            .build();
+
+        Self {
+            duration,
+            token_usage,
+        }
+    }
+
+    /// Records one completed operation and its provider-reported token total,
+    /// when usage metadata is available.
+    pub(crate) fn record(
+        &self,
+        duration: Duration,
+        provider: &'static str,
+        model: &str,
+        total_tokens: Option<u64>,
+    ) {
+        let attributes = [
+            KeyValue::new("gen_ai.provider.name", provider),
+            KeyValue::new("gen_ai.request.model", model.to_string()),
+        ];
+
+        self.duration.record(duration.as_secs_f64(), &attributes);
+        if let Some(total_tokens) = total_tokens {
+            self.token_usage.record(total_tokens, &attributes);
+        }
+    }
+}

--- a/crates/ag-harness/tests/telemetry.rs
+++ b/crates/ag-harness/tests/telemetry.rs
@@ -1,0 +1,446 @@
+//! Integration coverage for `ag-harness` OpenTelemetry signals.
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use ag_harness::{
+        Model, ModelError, ModelRequest, ModelResponse, OutputSchema, Qwen, QwenConfig,
+    };
+    use opentelemetry::global;
+    use opentelemetry::trace::{Status, TraceId, TracerProvider as _};
+    use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+    use opentelemetry_sdk::logs::{InMemoryLogExporter, SdkLoggerProvider};
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, Histogram, MetricData};
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
+    use serde_json::json;
+    use tracing_subscriber::layer::SubscriberExt as _;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const PRIVATE_PROMPT: &str = "private-prompt-sentinel";
+    const PRIVATE_RESPONSE: &str = "private-response-sentinel";
+
+    struct TestTelemetry {
+        _subscriber_guard: tracing::subscriber::DefaultGuard,
+        log_exporter: InMemoryLogExporter,
+        logger_provider: SdkLoggerProvider,
+        meter_provider: SdkMeterProvider,
+        metric_exporter: InMemoryMetricExporter,
+        span_exporter: InMemorySpanExporter,
+        tracer_provider: SdkTracerProvider,
+    }
+
+    impl TestTelemetry {
+        /// Installs process-global metrics for this integration binary, which
+        /// intentionally contains exactly one test because its metric
+        /// assertions depend on exact aggregate counts.
+        fn install() -> Self {
+            let span_exporter = InMemorySpanExporter::default();
+            let tracer_provider = SdkTracerProvider::builder()
+                .with_simple_exporter(span_exporter.clone())
+                .build();
+            let log_exporter = InMemoryLogExporter::default();
+            let logger_provider = SdkLoggerProvider::builder()
+                .with_simple_exporter(log_exporter.clone())
+                .build();
+            let metric_exporter = InMemoryMetricExporter::default();
+            let meter_provider = SdkMeterProvider::builder()
+                .with_periodic_exporter(metric_exporter.clone())
+                .build();
+            let tracer = tracer_provider.tracer("ag-harness-test");
+            let subscriber = tracing_subscriber::registry()
+                .with(tracing_opentelemetry::layer().with_tracer(tracer))
+                .with(OpenTelemetryTracingBridge::new(&logger_provider));
+            let subscriber_guard = tracing::subscriber::set_default(subscriber);
+            global::set_meter_provider(meter_provider.clone());
+
+            Self {
+                _subscriber_guard: subscriber_guard,
+                log_exporter,
+                logger_provider,
+                meter_provider,
+                metric_exporter,
+                span_exporter,
+                tracer_provider,
+            }
+        }
+
+        fn flush(&self) {
+            self.tracer_provider
+                .force_flush()
+                .expect("spans should flush");
+            self.logger_provider
+                .force_flush()
+                .expect("logs should flush");
+            self.meter_provider
+                .force_flush()
+                .expect("metrics should flush");
+        }
+    }
+
+    fn schema() -> OutputSchema {
+        OutputSchema::new(json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        }))
+        .expect("schema should be valid")
+    }
+
+    fn unsupported_schema() -> OutputSchema {
+        OutputSchema::new(json!({
+            "properties": {
+                "name": { "type": "string" }
+            }
+        }))
+        .expect("compile-failure schema should be valid")
+    }
+
+    fn model(server: &MockServer) -> Qwen {
+        Qwen::new(QwenConfig {
+            api_key: "test-key".to_string(),
+            base_url: server.uri(),
+            model: "qwen-plus".to_string(),
+        })
+        .expect("test client should initialize")
+    }
+
+    async fn mount_invalid_response(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": r#"{"name":42}"#}
+                }],
+                "id": "response-invalid",
+                "model": "qwen-plus-2026-07",
+                "usage": {
+                    "completion_tokens": 5,
+                    "prompt_tokens": 6
+                }
+            })))
+            .mount(server)
+            .await;
+    }
+
+    fn span_attribute<'a>(span: &'a SpanData, key: &str) -> Option<&'a opentelemetry::Value> {
+        span.attributes
+            .iter()
+            .find(|attribute| attribute.key.as_str() == key)
+            .map(|attribute| &attribute.value)
+    }
+
+    fn call_span_for_session<'a>(spans: &'a [SpanData], session_id: &str) -> &'a SpanData {
+        spans
+            .iter()
+            .find(|span| {
+                span_attribute(span, "gen_ai.conversation.id")
+                    .is_some_and(|value| value.to_string() == session_id)
+            })
+            .expect("call span should be exported")
+    }
+
+    fn child_span<'a>(spans: &'a [SpanData], call_span: &SpanData, name: &str) -> &'a SpanData {
+        spans
+            .iter()
+            .find(|span| {
+                span.parent_span_id == call_span.span_context.span_id() && span.name == name
+            })
+            .expect("child span should be exported")
+    }
+
+    fn assert_success_trace(spans: &[SpanData]) -> TraceId {
+        let call_span = call_span_for_session(spans, "session-success");
+        let trace_id = call_span.span_context.trace_id();
+        let trace_spans = spans
+            .iter()
+            .filter(|span| span.span_context.trace_id() == trace_id)
+            .collect::<Vec<_>>();
+        let mut child_names = trace_spans
+            .iter()
+            .filter(|span| span.parent_span_id == call_span.span_context.span_id())
+            .map(|span| span.name.as_ref())
+            .collect::<Vec<_>>();
+        child_names.sort_unstable();
+
+        assert_eq!(trace_spans.len(), 4);
+        assert_eq!(call_span.name, "chat qwen-plus");
+        assert_eq!(
+            span_attribute(call_span, "gen_ai.usage.input_tokens").map(ToString::to_string),
+            Some("4".to_string())
+        );
+        assert_eq!(
+            span_attribute(call_span, "gen_ai.usage.output_tokens").map(ToString::to_string),
+            Some("3".to_string())
+        );
+        assert_eq!(
+            child_names,
+            [
+                "HTTP POST",
+                "gen_ai.response.parse_validate",
+                "gen_ai.schema.compile"
+            ]
+        );
+
+        trace_id
+    }
+
+    fn assert_retry_trace(spans: &[SpanData]) -> TraceId {
+        let call_span = call_span_for_session(spans, "session-retry");
+        let trace_id = call_span.span_context.trace_id();
+        let trace_spans = spans
+            .iter()
+            .filter(|span| span.span_context.trace_id() == trace_id)
+            .collect::<Vec<_>>();
+        let mut resend_counts = trace_spans
+            .iter()
+            .filter(|span| span.name == "HTTP POST")
+            .filter_map(|span| span_attribute(span, "http.request.resend_count"))
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        resend_counts.sort_unstable();
+
+        assert_eq!(trace_spans.len(), 5);
+        assert_eq!(resend_counts, ["0", "1"]);
+
+        trace_id
+    }
+
+    fn assert_invalid_trace(spans: &[SpanData]) -> TraceId {
+        let call_span = call_span_for_session(spans, "session-invalid");
+        let parse_span = child_span(spans, call_span, "gen_ai.response.parse_validate");
+
+        assert_eq!(
+            span_attribute(call_span, "gen_ai.usage.input_tokens").map(ToString::to_string),
+            Some("6".to_string())
+        );
+        assert_eq!(
+            span_attribute(call_span, "gen_ai.usage.output_tokens").map(ToString::to_string),
+            Some("5".to_string())
+        );
+        assert_eq!(
+            span_attribute(call_span, "error.type").map(ToString::to_string),
+            Some("schema_violation".to_string())
+        );
+        assert!(matches!(parse_span.status, Status::Error { .. }));
+        assert_eq!(
+            span_attribute(parse_span, "error.type").map(ToString::to_string),
+            Some("schema_violation".to_string())
+        );
+
+        call_span.span_context.trace_id()
+    }
+
+    fn assert_compile_failure_trace(spans: &[SpanData]) -> TraceId {
+        let call_span = call_span_for_session(spans, "session-compile-failure");
+        let compile_span = child_span(spans, call_span, "gen_ai.schema.compile");
+
+        assert!(matches!(compile_span.status, Status::Error { .. }));
+        assert_eq!(
+            span_attribute(compile_span, "error.type").map(ToString::to_string),
+            Some("unsupported_output_schema".to_string())
+        );
+
+        call_span.span_context.trace_id()
+    }
+
+    fn assert_trace_logs(exporter: &InMemoryLogExporter, trace_ids: &[TraceId]) {
+        let logs = exporter
+            .get_emitted_logs()
+            .expect("logs should be exported");
+        for trace_id in trace_ids {
+            assert!(
+                logs.iter()
+                    .filter(|log| {
+                        log.record
+                            .trace_context()
+                            .is_some_and(|context| context.trace_id == *trace_id)
+                    })
+                    .filter(|log| {
+                        log.record
+                            .target()
+                            .is_some_and(|target| target == "ag_harness::qwen")
+                    })
+                    .count()
+                    >= 2
+            );
+        }
+        let exported_logs = format!("{logs:?}");
+        assert!(!exported_logs.contains(PRIVATE_PROMPT));
+        assert!(!exported_logs.contains(PRIVATE_RESPONSE));
+    }
+
+    fn assert_metric_attributes<T>(histogram: &Histogram<T>) {
+        for point in histogram.data_points() {
+            let mut keys = point
+                .attributes()
+                .map(|attribute| attribute.key.as_str())
+                .collect::<Vec<_>>();
+            keys.sort_unstable();
+
+            assert_eq!(keys, ["gen_ai.provider.name", "gen_ai.request.model"]);
+        }
+    }
+
+    fn assert_metrics(exporter: &InMemoryMetricExporter) {
+        let resource_metrics = exporter
+            .get_finished_metrics()
+            .expect("metrics should be exported");
+        let metrics = resource_metrics
+            .iter()
+            .flat_map(opentelemetry_sdk::metrics::data::ResourceMetrics::scope_metrics)
+            .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+            .collect::<Vec<_>>();
+
+        assert_eq!(metrics.len(), 2);
+        assert!(metrics.iter().any(|metric| {
+            metric.name() == "gen_ai.client.operation.duration"
+                && matches!(
+                    metric.data(),
+                    AggregatedMetrics::F64(MetricData::Histogram(histogram))
+                        if {
+                            assert_metric_attributes(histogram);
+                            histogram.data_points().all(|point| point.count() == 4)
+                        }
+                )
+        }));
+        assert!(metrics.iter().any(|metric| {
+            metric.name() == "gen_ai.client.token.usage"
+                && matches!(
+                    metric.data(),
+                    AggregatedMetrics::U64(MetricData::Histogram(histogram))
+                        if {
+                            assert_metric_attributes(histogram);
+                            histogram
+                                .data_points()
+                                .all(|point| point.count() == 2 && point.sum() == 18)
+                        }
+                )
+        }));
+    }
+
+    fn assert_expected_failures(
+        invalid_result: &Result<ModelResponse, ModelError>,
+        compile_failure_result: &Result<ModelResponse, ModelError>,
+    ) {
+        assert!(matches!(
+            invalid_result,
+            Err(ModelError::SchemaViolation { .. })
+        ));
+        assert!(matches!(
+            compile_failure_result,
+            Err(ModelError::UnsupportedOutputSchema { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn exports_content_free_telemetry_and_distinct_retry_spans() {
+        // Arrange
+        let success_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": format!(r#"{{"name":"{PRIVATE_RESPONSE}"}}"#)}
+                }],
+                "id": "response-42",
+                "model": "qwen-plus-2026-07",
+                "usage": {
+                    "completion_tokens": 3,
+                    "prompt_tokens": 4
+                }
+            })))
+            .mount(&success_server)
+            .await;
+        let retry_server = MockServer::start().await;
+        let attempt_count = Arc::new(AtomicUsize::new(0));
+        {
+            let attempt_count = Arc::clone(&attempt_count);
+            Mock::given(method("POST"))
+                .and(path("/chat/completions"))
+                .respond_with(move |_: &wiremock::Request| {
+                    if attempt_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                        return ResponseTemplate::new(503);
+                    }
+
+                    ResponseTemplate::new(200).set_body_json(json!({
+                        "choices": [{
+                            "finish_reason": "stop",
+                            "message": {"content": r#"{"name":"Ada"}"#}
+                        }]
+                    }))
+                })
+                .expect(2)
+                .mount(&retry_server)
+                .await;
+        }
+        let invalid_server = MockServer::start().await;
+        mount_invalid_response(&invalid_server).await;
+        let success_model = model(&success_server);
+        let retry_model = model(&retry_server);
+        let invalid_model = model(&invalid_server);
+        let telemetry = TestTelemetry::install();
+
+        // Act
+        let success_response = success_model
+            .complete(
+                ModelRequest::new(PRIVATE_PROMPT, schema()).with_session_id("session-success"),
+            )
+            .await
+            .expect("instrumented request should succeed");
+        let retry_response = retry_model
+            .complete(ModelRequest::new("retry request", schema()).with_session_id("session-retry"))
+            .await
+            .expect("transient failure should be retried");
+        let invalid_result = invalid_model
+            .complete(
+                ModelRequest::new("invalid request", schema()).with_session_id("session-invalid"),
+            )
+            .await;
+        let compile_failure_result = success_model
+            .complete(
+                ModelRequest::new("compile failure", unsupported_schema())
+                    .with_session_id("session-compile-failure"),
+            )
+            .await;
+        telemetry.flush();
+
+        // Assert
+        assert_eq!(
+            success_response.output(),
+            &json!({ "name": PRIVATE_RESPONSE })
+        );
+        assert_eq!(retry_response.output(), &json!({ "name": "Ada" }));
+        assert_expected_failures(&invalid_result, &compile_failure_result);
+        assert_eq!(attempt_count.load(Ordering::SeqCst), 2);
+        let spans = telemetry
+            .span_exporter
+            .get_finished_spans()
+            .expect("spans should be exported");
+        let success_trace_id = assert_success_trace(&spans);
+        let retry_trace_id = assert_retry_trace(&spans);
+        let invalid_trace_id = assert_invalid_trace(&spans);
+        let compile_failure_trace_id = assert_compile_failure_trace(&spans);
+        let exported_spans = format!("{spans:?}");
+        assert!(!exported_spans.contains(PRIVATE_PROMPT));
+        assert!(!exported_spans.contains(PRIVATE_RESPONSE));
+        assert_trace_logs(
+            &telemetry.log_exporter,
+            &[
+                success_trace_id,
+                retry_trace_id,
+                invalid_trace_id,
+                compile_failure_trace_id,
+            ],
+        );
+        assert_metrics(&telemetry.metric_exporter);
+    }
+}

--- a/crates/agentty/src/app/orchestration.rs
+++ b/crates/agentty/src/app/orchestration.rs
@@ -1,7 +1,7 @@
 //! Multi-session orchestration planning, reconciliation, and fan-in.
 //!
 //! Controller turns persist validated plans before approval. A background
-//! coordinator reads child state directly from SQLite and uses the foreground
+//! coordinator reads child state directly from `SQLite` and uses the foreground
 //! session runtime only for mutations, keeping polling off the bounded actor
 //! mailbox used by interactive commands.
 

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -86,7 +86,7 @@ const MISSING_RESOLVED_DECISION_HISTORY_TEXT: &str =
     "Focused review prompt omitted the resolved session decision.";
 
 /// Wall-clock budget for one seeded git invocation before it is killed.
-const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
+const GIT_COMMAND_TIMEOUT: Duration = Duration::from_mins(1);
 
 /// Poll interval used while waiting for a seeded git invocation to exit.
 const GIT_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(25);

--- a/docs/site/content/docs/architecture/_index.md
+++ b/docs/site/content/docs/architecture/_index.md
@@ -19,3 +19,5 @@ boundaries, and change paths.
   paths for common contribution scenarios.
 - [Testability Boundaries](@/docs/architecture/testability-boundaries.md) documents
   trait boundaries and deterministic testing guidance for external integrations.
+- [`ag-harness` Design](@/docs/architecture/ag-harness-design.md) documents the model
+  contract, telemetry signals, and local observability workflow.

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -132,6 +132,58 @@ Configurations that cannot satisfy the contract, such as Qwen thinking mode, ret
 explicit unsupported-configuration error rather than silently falling back to
 unstructured text.
 
+## Telemetry
+
+- **Traces** - one GenAI call span with child spans for schema compilation, every HTTP
+  attempt, and response parsing and validation.
+- **Correlation** - `gen_ai.conversation.id` links the call span to its harness session.
+- **Retries** - transient failures retry up to twice with bounded jitter and
+  `Retry-After` support.
+- **Metrics** - operation duration and token usage, labeled only by provider and model.
+- **Logs** - existing `tracing` events export with their active trace context.
+- **Ownership** - model adapters instrument calls; binaries configure exporters and
+  flush providers on exit.
+- **Privacy** - prompt, response, and schema content are not recorded.
+
+```mermaid
+flowchart LR
+    C["GenAI call span"] --> S["Schema compile span"]
+    C --> H["HTTP attempt spans"]
+    C --> P["Parse validate span"]
+    C --> M["Duration and token metrics"]
+    C --> L["Contextual logs"]
+    C --> O["OTLP collector"]
+    M --> O
+    L --> O
+    O --> T["Tempo traces"]
+    O --> R["Prometheus metrics"]
+    O --> K["Loki logs"]
+```
+
+### View telemetry locally
+
+- Start the Grafana OpenTelemetry stack:
+
+  ```bash
+  podman run --rm -it -p 3000:3000 -p 4318:4318 \
+    docker.io/grafana/otel-lgtm:latest
+  ```
+
+- Run the Qwen example with OTLP export enabled:
+
+  ```bash
+  export AG_HARNESS_EXTERNAL_OTEL=1
+  export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
+  export DASHSCOPE_API_KEY=your-key
+  export DASHSCOPE_BASE_URL=your-qwen-base-url
+  export AG_HARNESS_SESSION_ID=session-123 # Optional
+
+  cargo run -p ag-harness --example qwen
+  ```
+
+- Open `http://127.0.0.1:3000` (`admin`/`admin`): Tempo shows traces, Prometheus shows
+  metrics, and Loki shows logs.
+
 ## Permissions
 
 All tools are denied by default. The session policy explicitly allows tools and, for

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -31,8 +31,10 @@ For file-level detail, read the module docstrings directly.
   metadata, commit/diff/push/pull sync, rebase/conflict handling, and squash-merge
   workflows behind the `GitClient` boundary.
 - `crates/ag-harness/`: Application-facing LLM harness crate with the provider-neutral
-  `Model` contract and its first Qwen adapter. Its local `AGENTS.md` records the
-  intended agent loop, tools, session, event, and permission boundaries.
+  `Model` contract, its first Qwen adapter, backend-neutral call instrumentation, and
+  GenAI request metrics. Application binaries own OpenTelemetry SDK and OTLP exporter
+  setup. Its local `AGENTS.md` records the intended agent loop, tools, session, event,
+  and permission boundaries.
 - `crates/ag-protocol/`: Shared structured response protocol library crate with
   transport-neutral response models, schema generation, parser diagnostics, protocol
   prompt envelopes, repair prompts, review-comment outcomes, and turn prompt payload


### PR DESCRIPTION
- Emit content-free GenAI spans for schema compilation, HTTP attempts, and response validation.
- Retry transient transport, response-body, and server failures with bounded delays, and record duration and token-usage metrics.
- Propagate session IDs only on call spans and keep prompt, response, schema, and session content out of telemetry.
- Configure OTLP/HTTP export and graceful shutdown in the example.
- Cover telemetry, retry handling, privacy boundaries, and architecture in tests and documentation.
- Handle rate-limit retries, cancellation-safe finalization, and trace-correlated logs.
- Add concise Podman instructions for running the Grafana LGTM development stack and viewing local traces, metrics, and logs.
- Add a visual signal-flow diagram to the `ag-harness` architecture documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional OpenTelemetry support for traces, logs, and metrics through OTLP/HTTP.
  - Added request session IDs for improved correlation across model calls.
  - Added metrics for request duration and token usage.
  - Added automatic retries for temporary connection, timeout, rate-limit, and server errors.
  - Added cancellation handling and telemetry flushing on interruption.

- **Documentation**
  - Added setup guidance, configuration details, telemetry coverage, and privacy safeguards.
  - Documented that prompt and response content is excluded from exported telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->