### PR TITLE
Stack over-wide Mermaid graphs vertically

### DIFF
--- a/crates/ag-tui-text/src/markdown.rs
+++ b/crates/ag-tui-text/src/markdown.rs
@@ -956,10 +956,7 @@ fn render_mermaid_block(
         source.push_str(raw_line);
     }
 
-    let diagram = mermaid::render_mermaid(&source)?;
-    if diagram.width > width {
-        return None;
-    }
+    let diagram = mermaid::render_mermaid_for_width(&source, width)?;
 
     Some((diagram.lines, next_line_index))
 }
@@ -2281,6 +2278,40 @@ mod tests {
     }
 
     #[test]
+    fn test_render_markdown_stacks_over_wide_left_right_mermaid_block() {
+        // Arrange
+        let input = concat!(
+            "```mermaid\n",
+            "flowchart LR\n",
+            "    Q[Qwen complete] --> T[Tracing spans and events]\n",
+            "    Q --> M[OTel metrics API]\n",
+            "    T --> S[Trace and log providers]\n",
+            "    M --> P[Meter provider]\n",
+            "    S --> O[OTLP HTTP protobuf]\n",
+            "    P --> O\n",
+            "    O --> C[Collector on port 4318]\n",
+            "    C --> B[Telemetry backends]\n",
+            "    B --> G[Grafana on port 3000]\n",
+            "```",
+        );
+
+        // Act
+        let lines = render_markdown(input, 80);
+        let text = lines
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Assert
+        assert!(text.contains("Qwen complete"));
+        assert!(text.contains("Tracing spans and events"));
+        assert!(text.contains("Grafana on port 3000"));
+        assert!(text.contains('▼'));
+        assert!(!text.contains("flowchart LR"));
+    }
+
+    #[test]
     fn test_render_markdown_keeps_code_fallback_for_mermaid_prefix_language() {
         // Arrange
         let input = "```mermaid-diagram\ngraph TD\n    A[Start] --> B[Finish]\n```";
@@ -2465,7 +2496,7 @@ mod tests {
     #[test]
     fn test_render_markdown_keeps_code_fallback_for_diagram_wider_than_width() {
         // Arrange
-        let input = "```mermaid\ngraph LR\n    A[Start] --> B[Finish]\n```";
+        let input = "```mermaid\ngraph TD\n    A[Start] --> B[Long finish label]\n```";
 
         // Act
         let lines = render_markdown(input, 10);
@@ -2476,7 +2507,7 @@ mod tests {
             .join("\n");
 
         // Assert
-        assert!(text.contains("graph LR"));
+        assert!(text.contains("graph TD"));
         assert!(!text.contains("┌"));
     }
 

--- a/crates/ag-tui-text/src/mermaid.rs
+++ b/crates/ag-tui-text/src/mermaid.rs
@@ -60,6 +60,24 @@ pub fn render_mermaid_with_settings(
     style::with_render_settings(settings, || render_mermaid_active_settings(source))
 }
 
+/// Renders a diagram within `max_width`, stacking an over-wide left-to-right
+/// graph from top to bottom before giving up on its terminal preview.
+pub(crate) fn render_mermaid_for_width(source: &str, max_width: usize) -> Option<MermaidDiagram> {
+    let diagram = render_mermaid_active_settings(source)?;
+    if diagram.width <= max_width {
+        return Some(diagram);
+    }
+
+    let mut graph = parse_graph(source)?;
+    if !matches!(graph.direction, FlowDirection::LeftRight) {
+        return None;
+    }
+    graph.direction = FlowDirection::TopDown;
+
+    let diagram = render_graph(graph)?;
+    (diagram.width <= max_width).then_some(diagram)
+}
+
 fn render_mermaid_active_settings(source: &str) -> Option<MermaidDiagram> {
     if !is_source_within_bounds(source) {
         return None;
@@ -70,6 +88,11 @@ fn render_mermaid_active_settings(source: &str) -> Option<MermaidDiagram> {
     }
 
     let graph = parse_graph(source)?;
+    render_graph(graph)
+}
+
+/// Lays out one parsed graph using its current direction.
+fn render_graph(graph: MermaidGraph) -> Option<MermaidDiagram> {
     if let Some(diagram) = draw_left_right_feedback_graph(&graph) {
         return Some(diagram);
     }

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -398,6 +398,49 @@ flowchart LR
     Ok(())
 }
 
+/// Seeds one review-ready session with a left-to-right telemetry flow that is
+/// wider than its session output panel and must use the compact layout.
+fn seed_session_with_compact_mermaid_output(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    common::seed_session(
+        env,
+        SessionSeed::regular("compact-mermaid-0001", "qwen3-coder-plus", "main", "Review")
+            .with_title("Compact Mermaid output"),
+    )?;
+
+    let runtime = common::seed_runtime()?;
+
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        database
+            .sessions()
+            .append_session_message(
+                "compact-mermaid-0001",
+                SessionMessageKind::AssistantAnswer,
+                "\
+```mermaid
+flowchart LR
+    Q[Qwen complete] --> T[Tracing spans and events]
+    Q --> M[OTel metrics API]
+    T --> S[Trace and log providers]
+    M --> P[Meter provider]
+    S --> O[OTLP HTTP protobuf]
+    P --> O
+    O --> C[Collector on port 4318]
+    C --> B[Telemetry backends]
+    B --> G[Grafana on port 3000]
+```
+",
+            )
+            .await
+    })?;
+
+    std::fs::create_dir_all(env.agentty_root.join("wt").join("compact-"))?;
+
+    Ok(())
+}
+
 /// Seeds one review-ready session whose assistant answer begins a line with a
 /// workflow-notice prefix that must remain assistant text.
 fn seed_session_with_typed_marker_collision(
@@ -5463,6 +5506,63 @@ fn session_view_cyclic_mermaid_output() -> E2eResult {
                     &full,
                 );
                 assertion::assert_not_visible(frame, "flowchart LR");
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify an over-wide left-to-right flowchart uses the compact top-down
+/// terminal layout instead of falling back to raw Mermaid source.
+#[test]
+fn session_view_compact_mermaid_output() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_compact_mermaid_output")
+        .with_terminal_size(100, 40)
+        .setup(seed_session_with_compact_mermaid_output)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("g")
+                    .wait_for_text("Qwen complete", 5000)
+                    .capture_labeled(
+                        "session_compact_mermaid_output_top",
+                        "Top of compacted over-wide Mermaid flow",
+                    )
+                    .write_text("G")
+                    .wait_for_text("Grafana on port 3000", 5000)
+                    .wait_for_stable_frame(300, 5000)
+                    .viewing_pause_ms(1500)
+                    .capture_labeled(
+                        "session_compact_mermaid_output_bottom",
+                        "Bottom of compacted over-wide Mermaid flow",
+                    )
+            },
+            |_frame, report| {
+                assert_eq!(report.captures.len(), 2);
+                let top_frame = common::frame_from_capture(&report.captures[0]);
+                let bottom_frame = common::frame_from_capture(&report.captures[1]);
+                let top_region = Region::full(top_frame.cols(), top_frame.rows());
+                let bottom_region = Region::full(bottom_frame.cols(), bottom_frame.rows());
+
+                assertion::assert_text_in_region(&top_frame, "Qwen complete", &top_region);
+                assertion::assert_text_in_region(
+                    &top_frame,
+                    "Tracing spans and events",
+                    &top_region,
+                );
+                assertion::assert_text_in_region(
+                    &bottom_frame,
+                    "Grafana on port 3000",
+                    &bottom_region,
+                );
+                assertion::assert_text_in_region(&bottom_frame, "▼", &bottom_region);
+                assertion::assert_not_visible(&top_frame, "flowchart LR");
+                assertion::assert_not_visible(&bottom_frame, "flowchart LR");
             },
         )?;
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -255,9 +255,10 @@ regardless of padding stored with the message content.
 <a id="usage-session-mermaid"></a> Complete ```` ```mermaid ```` fenced blocks in
 session output render as Unicode diagrams. Simple `graph`/`flowchart` diagrams with
 `TD`, `TB`, or `LR` direction are supported, including edges that span multiple layers
-and cyclic feedback paths. Each feedback edge renders as an independent return row
-beneath the layered graph so unrelated cycles remain visually separate; larger `LR`
-cycles use a compact top-down layout so they remain useful in terminal-width panels.
+and cyclic feedback paths. An `LR` graph that is wider than the session panel
+automatically uses a top-down layout when that compact form fits. Each feedback edge
+renders as an independent return row beneath the layered graph so unrelated cycles
+remain visually separate; larger `LR` cycles also use the compact top-down layout.
 Common node shapes (stadium, subroutine, cylinder, hexagon, and more) draw as rectangle
 or rounded boxes, `&` groups fan out into one edge per pair, subgraphs are flattened
 into the surrounding graph, and styling statements such as `style`, `classDef`,


### PR DESCRIPTION
- Re-layout wide left-to-right graphs top-to-bottom when the compact form fits.
- Add unit and end-to-end coverage for compact Mermaid session output.
- Document responsive Mermaid rendering in the workflow guide.