### PR TITLE
Done sessions use c for continuation

### DIFF
--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -432,14 +432,17 @@ pub(crate) fn view_actions(state: ViewHelpState) -> Vec<HelpAction> {
     actions
 }
 
-/// Returns full session-view help actions with linked review comments on `c`
-/// and terminal continuation on `C` when both actions are available.
+/// Returns full session-view help actions with linked review comments when
+/// available outside terminal `Done` sessions.
 pub(crate) fn view_actions_with_review_comments(
     state: ViewHelpState,
     can_view_review_comments: bool,
 ) -> Vec<HelpAction> {
     let mut actions = view_actions(state);
-    append_review_comment_action(&mut actions, can_view_review_comments);
+    append_review_comment_action(
+        &mut actions,
+        can_view_review_comments && state.session_state != ViewSessionState::Done,
+    );
 
     actions
 }
@@ -470,14 +473,17 @@ pub(crate) fn view_footer_actions(state: ViewHelpState) -> Vec<HelpAction> {
     actions
 }
 
-/// Returns compact session-view footer actions with linked review comments on
-/// `c` and terminal continuation on `C` when both actions are available.
+/// Returns compact session-view footer actions with linked review comments
+/// when available outside terminal `Done` sessions.
 pub(crate) fn view_footer_actions_with_review_comments(
     state: ViewHelpState,
     can_view_review_comments: bool,
 ) -> Vec<HelpAction> {
     let mut actions = view_footer_actions(state);
-    append_review_comment_action(&mut actions, can_view_review_comments);
+    append_review_comment_action(
+        &mut actions,
+        can_view_review_comments && state.session_state != ViewSessionState::Done,
+    );
 
     actions
 }
@@ -542,7 +548,7 @@ fn append_view_review_actions(
 /// footer rows.
 fn append_view_continue_action(actions: &mut Vec<HelpAction>, action_set: ViewActionSet) {
     if action_set.continue_terminal_session.is_enabled() {
-        actions.push(HelpAction::new("continue", "C", "Continue in new session"));
+        actions.push(HelpAction::new("continue", "c", "Continue in new session"));
     }
 }
 
@@ -1335,7 +1341,7 @@ mod tests {
 
         // Assert
         assert!(actions.iter().any(|action| {
-            action.key == "C"
+            action.key == "c"
                 && action.footer_label == "continue"
                 && action.popup_label == "Continue in new session"
         }));
@@ -1641,7 +1647,7 @@ mod tests {
         let actions = view_actions(state);
 
         // Assert
-        assert!(!actions.iter().any(|action| action.key == "C"));
+        assert!(!actions.iter().any(|action| action.key == "c"));
         assert!(!actions.iter().any(|action| action.key == "p"));
         assert!(!actions.iter().any(|action| action.key == "Enter"));
         assert!(!actions.iter().any(|action| action.key == "o"));
@@ -1668,11 +1674,11 @@ mod tests {
         let ordered_keys = actions.iter().map(|action| action.key).collect::<Vec<_>>();
 
         // Assert
-        assert_eq!(&ordered_keys[..4], ["q", "C", "j/k", "?"]);
+        assert_eq!(&ordered_keys[..4], ["q", "c", "j/k", "?"]);
     }
 
     #[test]
-    fn test_view_footer_actions_linked_review_uses_c_for_comments_before_other_actions() {
+    fn test_view_actions_done_hide_linked_review_comments() {
         // Arrange
         let state = ViewHelpState {
             can_fork_session: ViewActionAvailability::Enabled,
@@ -1687,17 +1693,21 @@ mod tests {
         };
 
         // Act
-        let actions = view_footer_actions_with_review_comments(state, true);
+        let full_actions = view_actions_with_review_comments(state, true);
+        let footer_actions = view_footer_actions_with_review_comments(state, true);
 
         // Assert
-        assert_eq!(actions[1].key, "c");
-        assert_eq!(actions[1].popup_label, "Show review comments");
-        assert_eq!(actions.iter().filter(|action| action.key == "c").count(), 1);
-        assert!(actions.iter().any(|action| {
-            action.key == "C"
-                && action.footer_label == "continue"
-                && action.popup_label == "Continue in new session"
-        }));
+        for actions in [&full_actions, &footer_actions] {
+            assert_eq!(actions.iter().filter(|action| action.key == "c").count(), 1);
+            assert!(actions.iter().any(|action| {
+                action.key == "c" && action.popup_label == "Continue in new session"
+            }));
+            assert!(
+                !actions
+                    .iter()
+                    .any(|action| action.popup_label == "Show review comments")
+            );
+        }
     }
 
     #[test]

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -346,7 +346,10 @@ async fn handle_primary_view_key(
 
             return Some(false);
         }
-        KeyCode::Char('c' | 'C') if is_continue_terminal_shortcut(key, view_session_snapshot) => {
+        KeyCode::Char('c')
+            if key.modifiers == event::KeyModifiers::NONE
+                && view_session_snapshot.can_continue_terminal_session() =>
+        {
             open_continue_confirmation(app, view_context);
 
             return Some(false);
@@ -388,22 +391,6 @@ async fn handle_primary_view_key(
     }
 
     Some(true)
-}
-
-fn is_continue_terminal_shortcut(
-    key: KeyEvent,
-    view_session_snapshot: &ViewSessionSnapshot,
-) -> bool {
-    let has_supported_modifiers = matches!(
-        key.modifiers,
-        event::KeyModifiers::NONE | event::KeyModifiers::SHIFT
-    );
-    let has_unambiguous_key =
-        key.code == KeyCode::Char('C') || !view_session_snapshot.can_open_review_comments();
-
-    has_supported_modifiers
-        && view_session_snapshot.can_continue_terminal_session()
-        && has_unambiguous_key
 }
 
 /// Handles workflow actions in session view such as diff, publish, review,
@@ -623,7 +610,9 @@ fn view_session_snapshot(app: &App, view_context: &ViewContext) -> Option<ViewSe
             app.sessions
                 .can_reply_to_session_in_stack(view_context.session_id.as_str()),
         ),
-        review_comments: ViewActionState::from_bool(session.has_review_request()),
+        review_comments: ViewActionState::from_bool(
+            session.has_review_request() && session_status != Status::Done,
+        ),
         session_state: help_action::session_view_state(session),
         session_status,
         start_staged_session: ViewActionState::from_bool(
@@ -2680,7 +2669,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_linked_terminal_session_routes_c_to_comments_and_shift_c_to_continue() {
+    async fn test_linked_done_session_routes_c_to_continue_without_comments() {
         // Arrange
         let (mut app, _base_dir, session_id) = new_test_app_with_session().await;
         let session = app
@@ -2702,46 +2691,20 @@ mod tests {
                 web_url: "https://github.com/agentty-xyz/agentty/pull/42".to_string(),
             },
         });
+        session.status = Status::Done;
         app.mode = AppMode::View {
-            session_id: session_id.into(),
+            session_id: session_id.clone().into(),
             scroll_offset: Some(0),
         };
         let view_context = view_context(&mut app).expect("expected view context");
         let pending_update = ViewPendingUpdate::from_context(&view_context);
-        let view_session_snapshot = ViewSessionSnapshot {
-            continue_terminal_session: ViewActionState::Enabled,
-            fork_session: ViewActionState::Disabled,
-            follow_up_task_action: None,
-            merge_session_branch: ViewActionState::Disabled,
-            mutate_session_branch: ViewActionState::Disabled,
-            open_worktree: ViewActionState::Disabled,
-            publish_pull_request_action: None,
-            rebase_session_branch: ViewActionState::Disabled,
-            reply_to_session: ViewActionState::Disabled,
-            review_comments: ViewActionState::Enabled,
-            session_state: ViewSessionState::Done,
-            session_status: Status::Done,
-            start_staged_session: ViewActionState::Disabled,
-        };
+        let view_session_snapshot =
+            view_session_snapshot(&app, &view_context).expect("expected session snapshot");
 
         // Act
-        let lowercase_continues = is_continue_terminal_shortcut(
-            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE),
-            &view_session_snapshot,
-        );
-        let uppercase_continues = is_continue_terminal_shortcut(
-            KeyEvent::new(KeyCode::Char('C'), KeyModifiers::SHIFT),
-            &view_session_snapshot,
-        );
-
-        // Assert
-        assert!(!lowercase_continues);
-        assert!(uppercase_continues);
-
-        // Act
-        let comments_result = handle_primary_view_key(
+        let uppercase_result = handle_primary_view_key(
             &mut app,
-            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('C'), KeyModifiers::SHIFT),
             &view_context,
             &view_session_snapshot,
             &pending_update,
@@ -2749,13 +2712,14 @@ mod tests {
         .await;
 
         // Assert
-        assert_eq!(comments_result, Some(false));
-        assert!(matches!(app.mode, AppMode::ReviewComments { .. }));
+        assert_eq!(uppercase_result, None);
+        assert!(!view_session_snapshot.can_open_review_comments());
+        assert!(matches!(app.mode, AppMode::View { .. }));
 
         // Act
         let continue_result = handle_primary_view_key(
             &mut app,
-            KeyEvent::new(KeyCode::Char('C'), KeyModifiers::SHIFT),
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE),
             &view_context,
             &view_session_snapshot,
             &pending_update,

--- a/crates/agentty/src/ui/layout.rs
+++ b/crates/agentty/src/ui/layout.rs
@@ -663,7 +663,8 @@ mod tests {
         let help_text = view_footer_text(&session, true);
 
         // Assert
-        assert!(help_text.contains("C: continue"));
+        assert!(help_text.contains("c: continue"));
+        assert!(!help_text.contains("comments"));
     }
 
     #[test]
@@ -1226,7 +1227,7 @@ mod tests {
         // Assert
         assert_eq!(
             done_line.to_string(),
-            "Press 'C' to continue in a new session."
+            "Press 'c' to continue in a new session."
         );
     }
 

--- a/crates/agentty/src/ui/page/session_chat.rs
+++ b/crates/agentty/src/ui/page/session_chat.rs
@@ -805,7 +805,8 @@ mod tests {
 
         // Assert
         let text = buffer_text(terminal.backend().buffer());
-        assert!(text.contains("C: continue"));
+        assert!(text.contains("c: continue"));
+        assert!(!text.contains("comments"));
     }
 
     /// Verifies canceled terminal sessions render without a continuation
@@ -833,7 +834,7 @@ mod tests {
 
         // Assert
         let text = buffer_text(terminal.backend().buffer());
-        assert!(!text.contains("C: continue"));
+        assert!(!text.contains("c: continue"));
     }
 
     /// Verifies running sessions advertise sync as a queued action while

--- a/crates/agentty/src/ui/session_format.rs
+++ b/crates/agentty/src/ui/session_format.rs
@@ -262,7 +262,7 @@ pub(crate) fn session_output_uses_tachyon_loader(status: Status) -> bool {
 /// Builds the inline shortcut hint for continuing a completed session.
 pub fn session_output_done_line() -> Line<'static> {
     Line::from(vec![Span::styled(
-        "Press 'C' to continue in a new session.",
+        "Press 'c' to continue in a new session.",
         Style::default().fg(style::palette::text_subtle()),
     )])
 }

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -2012,12 +2012,29 @@ fn seed_done_session_for_continuation(env: &BuilderEnv) -> Result<(), Box<dyn st
 
     runtime.block_on(async {
         let database = common::open_database(env).await?;
+        let review_request = ReviewRequest {
+            last_refreshed_at: 55,
+            summary: ReviewRequestSummary {
+                display_id: "#42".to_string(),
+                forge_kind: ForgeKind::GitHub,
+                source_branch: "wt/done-continue".to_string(),
+                state: ReviewRequestState::Merged,
+                status_summary: Some("Merged".to_string()),
+                target_branch: "main".to_string(),
+                title: "Completed review request".to_string(),
+                web_url: "https://github.com/agentty-xyz/agentty/pull/42".to_string(),
+            },
+        };
         database
             .sessions()
             .update_session_merged_commit_hash(
                 "done-continue-0001",
                 Some(merged_commit_hash.to_string()),
             )
+            .await?;
+        database
+            .reviews()
+            .update_session_review_request("done-continue-0001", Some(review_request))
             .await?;
 
         Ok::<(), Box<dyn std::error::Error>>(())
@@ -4462,7 +4479,7 @@ fn session_output_scrollbar_is_visible() -> E2eResult {
     Ok(())
 }
 
-/// Verify that pressing `C` in a terminal session opens a confirmation and,
+/// Verify that pressing `c` in a terminal session opens a confirmation and,
 /// after acceptance, stages the continuation message before focusing an empty
 /// draft composer.
 #[test]
@@ -4483,9 +4500,14 @@ fn terminal_session_continue_opens_seeded_prompt() -> E2eResult {
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::switch_to_tab("Sessions"))
                     .press_key("Enter")
-                    .wait_for_text("C: continue", 5000)
-                    .wait_for_text("Press 'C' to continue in a new session.", 3000)
-                    .press_key("C")
+                    .wait_for_text("c: continue", 5000)
+                    .wait_for_text("Press 'c' to continue in a new session.", 3000)
+                    .viewing_pause_ms(1500)
+                    .capture_labeled(
+                        "done_session_actions",
+                        "Linked done session offers continuation without review comments",
+                    )
+                    .press_key("c")
                     .wait_for_text("Confirm Continue", 3000)
                     .viewing_pause_ms(1500)
                     .capture_labeled(
@@ -4501,7 +4523,17 @@ fn terminal_session_continue_opens_seeded_prompt() -> E2eResult {
                     )
             },
             |frame, report| {
-                let confirmation_frame = common::frame_from_capture(&report.captures[0]);
+                let done_session_frame = common::frame_from_capture(&report.captures[0]);
+                let done_session_full =
+                    Region::full(done_session_frame.cols(), done_session_frame.rows());
+                assertion::assert_text_in_region(
+                    &done_session_frame,
+                    "c: continue",
+                    &done_session_full,
+                );
+                assertion::assert_not_visible(&done_session_frame, "comments");
+
+                let confirmation_frame = common::frame_from_capture(&report.captures[1]);
                 let confirmation_full =
                     Region::full(confirmation_frame.cols(), confirmation_frame.rows());
                 assertion::assert_text_in_region(

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -189,13 +189,14 @@ State-specific differences:
   while the stack is idle.
 - Sessions with a linked pull request or merge request use `c` to open its comments page
   and hide `m`; merge the linked request through its forge instead of Agentty's local
-  merge queue. Linked terminal sessions keep continuation available on `C`.
+  merge queue.
 - **Merged** sessions remain in Active and expose only read-only navigation, linked
   review comments, and `d` for the diff until list-mode `s` successfully syncs their
   local target branch.
-- **Done** sessions offer `C` to start a continuation draft (confirmation popup).
+- **Done** sessions offer `c` to start a continuation draft (confirmation popup) and
+  hide linked review comments.
 - **Canceled**, **Queued**, and **Merging** sessions are otherwise read-only (`q`,
-  scroll, help). Linked review requests remain available from any session state with
+  scroll, help). Linked review requests remain available from other session states with
   `c`.
 
 `o` runs the configured `Launch Configurations` entry, or opens a selector popup when

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -59,11 +59,11 @@ on the left, while the selected entry's metadata, attached current-diff context,
 conversation appear on the right. In **Review**, **AgentReview**, or **Question**, press
 `a` to send the selected actionable inline thread to the active session agent or `A` to
 send every actionable inline thread. Standalone comments are read-only because they do
-not have forge thread IDs. The timer ticks only while the session is actively working. A
-linked terminal session keeps `C` available for starting a continuation draft.
-File-level comments show an explicit no-line-context message instead of a synthetic code
-anchor. Each session stores the project reasoning default when it is created, so later
-default changes affect new sessions without relabeling existing ones.
+not have forge thread IDs. The timer ticks only while the session is actively working.
+`Done` sessions use `c` to start a continuation draft and no longer expose review
+comments. File-level comments show an explicit no-line-context message instead of a
+synthetic code anchor. Each session stores the project reasoning default when it is
+created, so later default changes affect new sessions without relabeling existing ones.
 
 The top status bar shows the current version and update status, and rotates short
 page-scoped `FYI:` messages once per minute in the **Sessions** list and session chat


### PR DESCRIPTION
- Routes unmodified lowercase `c` to continuation and removes shifted `C` support.
- Hides linked review comments from `Done` sessions so continuation remains unambiguous.
- Updates help text, rendered hints, E2E coverage, and usage docs.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)