### PR TITLE
Support continuing canceled sessions

### DIFF
--- a/crates/ag-session/src/model.rs
+++ b/crates/ag-session/src/model.rs
@@ -206,7 +206,7 @@ impl SessionStatus {
 
     /// Returns whether this status can seed a follow-on continuation session.
     pub fn allows_terminal_continuation(self) -> bool {
-        matches!(self, SessionStatus::Done)
+        matches!(self, SessionStatus::Done | SessionStatus::Canceled)
     }
 
     /// Returns whether this lifecycle state permits only local inspection.
@@ -456,6 +456,24 @@ mod tests {
         assert!(status.can_transition_to(SessionStatus::Merged));
         assert!(status.can_transition_to(SessionStatus::Done));
         assert!(!status.can_transition_to(SessionStatus::Review));
+    }
+
+    #[test]
+    fn terminal_continuation_is_available_for_done_and_canceled_sessions() {
+        // Arrange
+        let statuses = SessionStatus::ALL;
+
+        // Act
+        let continuation_statuses = statuses
+            .into_iter()
+            .filter(|status| status.allows_terminal_continuation())
+            .collect::<Vec<_>>();
+
+        // Assert
+        assert_eq!(
+            continuation_statuses,
+            vec![SessionStatus::Done, SessionStatus::Canceled]
+        );
     }
 
     #[test]

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -1043,7 +1043,7 @@ impl App {
             .ok_or_else(|| AppError::Workflow("Session not found".to_string()))?;
         if !source_session.allows_terminal_continuation() {
             return Err(AppError::Workflow(
-                "Only `Done` sessions can be continued".to_string(),
+                "Only `Done` or `Canceled` sessions can be continued".to_string(),
             ));
         }
 
@@ -1060,12 +1060,14 @@ impl App {
                         .to_string(),
                 )
             })?;
-        let prompt_seed = if let Some(merged_commit_hash) = self
+        let merged_commit_hash = self
             .services
             .db()
             .sessions()
             .load_session_merged_commit_hash(source_session_id)
-            .await?
+            .await?;
+        let prompt_seed = if source_session.status == Status::Done
+            && let Some(merged_commit_hash) = merged_commit_hash
         {
             Self::merged_commit_continuation_prompt(source_session, &merged_commit_hash)
         } else {

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -5082,32 +5082,101 @@ async fn test_continue_terminal_session_rejects_non_terminal_source_session() {
     assert!(matches!(
         result,
         Err(AppError::Workflow(message))
-            if message == "Only `Done` sessions can be continued"
+            if message == "Only `Done` or `Canceled` sessions can be continued"
     ));
 }
 
 #[tokio::test]
-async fn test_continue_terminal_session_rejects_canceled_source_session() {
+async fn test_continue_terminal_session_uses_persisted_context_for_canceled_source_session() {
     // Arrange
-    let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
-        Arc::new(MockTmuxClient::new()),
+    let base_dir = tempdir().expect("failed to create temp dir");
+    let base_path = base_dir.path().to_path_buf();
+    let database = AppRepositories::in_memory().await;
+    let clients = crate::test_support::test_app_clients()
+        .with_app_server_client_override(crate::test_support::mock_app_server())
+        .with_tmux_client(Arc::new(MockTmuxClient::new()));
+    let mut app = App::new_with_clients(
+        base_path.clone(),
+        base_path,
+        Some("main".to_string()),
+        database,
+        clients,
     )
-    .await;
+    .await
+    .expect("failed to build test app");
+    let project_id = app.active_project_id();
+    app.services
+        .db()
+        .sessions()
+        .insert_session(
+            "canceled-source",
+            "gpt-5.6-sol",
+            "main",
+            "Canceled",
+            project_id,
+        )
+        .await
+        .expect("failed to insert source session row");
+    app.services
+        .db()
+        .sessions()
+        .update_session_merged_commit_hash("canceled-source", Some("stale-merged-hash".to_string()))
+        .await
+        .expect("failed to persist stale merged commit hash");
     let source_session = crate::test_support::SessionFixtureBuilder::new()
         .id("canceled-source")
         .status(Status::Canceled)
-        .summary(Some("summary".to_string()))
+        .summary(Some("# Summary\n\nResume the remaining work.".to_string()))
+        .title(Some("Canceled source".to_string()))
         .build();
     app.sessions.push_session(source_session);
+    let mut mock_git_client = ag_git::MockGitClient::new();
+    mock_git_client
+        .expect_find_git_repo_root()
+        .times(1..)
+        .returning(|path| Box::pin(async move { Some(path) }));
+    mock_git_client
+        .expect_fetch_remote()
+        .times(0..)
+        .returning(|_| Box::pin(async { Ok(()) }));
+    mock_git_client
+        .expect_branch_tracking_statuses()
+        .times(0..)
+        .returning(|_| Box::pin(async { Ok(HashMap::new()) }));
+    mock_git_client
+        .expect_get_ref_ahead_behind()
+        .times(0..)
+        .returning(|_, _, _| Box::pin(async { Ok((0, 0)) }));
+    install_mock_git_client(&mut app, mock_git_client);
 
     // Act
-    let result = app.continue_terminal_session("canceled-source").await;
+    let continued_session_id = app
+        .continue_terminal_session("canceled-source")
+        .await
+        .expect("expected canceled continuation to succeed");
 
     // Assert
+    let continued_session = app
+        .sessions
+        .sessions()
+        .iter()
+        .find(|session| session.id == continued_session_id)
+        .expect("expected created continuation draft");
+    assert_eq!(continued_session.status, Status::Draft);
+    assert_eq!(
+        continued_session.prompt,
+        "Continue the work from this previous Agentty session.\n\nPrevious session: Canceled \
+         source\nProject: project\nStatus: Canceled\n\nPrevious session summary:\n# \
+         Summary\n\nResume the remaining work.\n"
+    );
+    assert!(!continued_session.prompt.contains("stale-merged-hash"));
     assert!(matches!(
-        result,
-        Err(AppError::Workflow(message))
-            if message == "Only `Done` sessions can be continued"
+        app.mode,
+        AppMode::Prompt {
+            ref input,
+            ref session_id,
+            ..
+        } if session_id.as_str() == continued_session_id && input.text().is_empty()
     ));
 }
 

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -1598,7 +1598,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_status_allows_terminal_continuation_only_for_done() {
+    fn test_status_allows_terminal_continuation_for_terminal_session_outcomes() {
         // Arrange
         let done_status = Status::Done;
         let canceled_status = Status::Canceled;
@@ -1611,7 +1611,7 @@ pub(crate) mod tests {
 
         // Assert
         assert!(done_allows_continuation);
-        assert!(!canceled_allows_continuation);
+        assert!(canceled_allows_continuation);
         assert!(!review_allows_continuation);
     }
 
@@ -1771,18 +1771,31 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
     }
 
     #[test]
-    fn test_session_continuation_prompt_seed_disabled_for_canceled_session() {
+    fn test_session_continuation_prompt_seed_uses_summary_for_canceled_session() {
         // Arrange
         let session = SessionFixtureBuilder::new()
             .status(Status::Canceled)
             .project_name("project-beta")
+            .summary(Some("# Summary\n\nResume the remaining work.".to_string()))
+            .transcript("assistant transcript")
+            .title(Some("Canceled session".to_string()))
             .build();
 
         // Act
-        let continuation_prompt_seed = session.continuation_prompt_seed();
+        let continuation_prompt_seed = session
+            .continuation_prompt_seed()
+            .expect("expected canceled continuation prompt seed");
 
         // Assert
-        assert_eq!(continuation_prompt_seed, None);
+        assert!(continuation_prompt_seed.contains(TERMINAL_CONTINUATION_PROMPT_INTRO));
+        assert!(continuation_prompt_seed.contains("Previous session: Canceled session"));
+        assert!(continuation_prompt_seed.contains("Project: project-beta"));
+        assert!(continuation_prompt_seed.contains("Status: Canceled"));
+        assert!(
+            continuation_prompt_seed
+                .contains("Previous session summary:\n# Summary\n\nResume the remaining work.")
+        );
+        assert!(!continuation_prompt_seed.contains("assistant transcript"));
     }
 
     #[test]

--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -197,7 +197,7 @@ impl ViewActionSet {
         Self {
             continue_terminal_session: ViewActionAvailability::from_bool(matches!(
                 state.session_state,
-                ViewSessionState::Done
+                ViewSessionState::Done | ViewSessionState::Canceled
             )),
             fork_session: ViewActionAvailability::from_bool(
                 state.can_fork_session.is_enabled() && can_show_review,
@@ -433,7 +433,7 @@ pub(crate) fn view_actions(state: ViewHelpState) -> Vec<HelpAction> {
 }
 
 /// Returns full session-view help actions with linked review comments when
-/// available outside terminal `Done` sessions.
+/// available outside sessions that support terminal continuation.
 pub(crate) fn view_actions_with_review_comments(
     state: ViewHelpState,
     can_view_review_comments: bool,
@@ -441,7 +441,7 @@ pub(crate) fn view_actions_with_review_comments(
     let mut actions = view_actions(state);
     append_review_comment_action(
         &mut actions,
-        can_view_review_comments && state.session_state != ViewSessionState::Done,
+        can_append_review_comments(state.session_state, can_view_review_comments),
     );
 
     actions
@@ -474,7 +474,7 @@ pub(crate) fn view_footer_actions(state: ViewHelpState) -> Vec<HelpAction> {
 }
 
 /// Returns compact session-view footer actions with linked review comments
-/// when available outside terminal `Done` sessions.
+/// when available outside sessions that support terminal continuation.
 pub(crate) fn view_footer_actions_with_review_comments(
     state: ViewHelpState,
     can_view_review_comments: bool,
@@ -482,10 +482,22 @@ pub(crate) fn view_footer_actions_with_review_comments(
     let mut actions = view_footer_actions(state);
     append_review_comment_action(
         &mut actions,
-        can_view_review_comments && state.session_state != ViewSessionState::Done,
+        can_append_review_comments(state.session_state, can_view_review_comments),
     );
 
     actions
+}
+
+/// Returns whether linked review comments should be added to session-view
+/// actions without competing with terminal continuation on `c`.
+fn can_append_review_comments(
+    session_state: ViewSessionState,
+    can_view_review_comments: bool,
+) -> bool {
+    match session_state {
+        ViewSessionState::Done | ViewSessionState::Canceled => false,
+        _ => can_view_review_comments,
+    }
 }
 
 /// Adds the comments shortcut before trailing navigation actions.
@@ -1629,7 +1641,7 @@ mod tests {
     }
 
     #[test]
-    fn test_view_actions_canceled_without_branch_publish_action() {
+    fn test_view_actions_canceled_shows_continue_without_edit_actions() {
         // Arrange
         let state = ViewHelpState {
             can_fork_session: ViewActionAvailability::Enabled,
@@ -1647,7 +1659,11 @@ mod tests {
         let actions = view_actions(state);
 
         // Assert
-        assert!(!actions.iter().any(|action| action.key == "c"));
+        assert!(actions.iter().any(|action| {
+            action.key == "c"
+                && action.footer_label == "continue"
+                && action.popup_label == "Continue in new session"
+        }));
         assert!(!actions.iter().any(|action| action.key == "p"));
         assert!(!actions.iter().any(|action| action.key == "Enter"));
         assert!(!actions.iter().any(|action| action.key == "o"));
@@ -1678,7 +1694,44 @@ mod tests {
     }
 
     #[test]
-    fn test_view_actions_done_hide_linked_review_comments() {
+    fn test_view_actions_terminal_sessions_hide_linked_review_comments() {
+        // Arrange
+        let terminal_states = [ViewSessionState::Done, ViewSessionState::Canceled];
+
+        for session_state in terminal_states {
+            let state = ViewHelpState {
+                can_fork_session: ViewActionAvailability::Enabled,
+                can_merge_session_branch: ViewActionAvailability::Enabled,
+                can_mutate_session_branch: ViewActionAvailability::Enabled,
+                can_rebase_session_branch: ViewActionAvailability::Enabled,
+                can_open_worktree: ViewActionAvailability::Enabled,
+                reply_to_session: ViewActionAvailability::Enabled,
+                can_start_staged_session: ViewActionAvailability::Disabled,
+                publish_pull_request_action: None,
+                session_state,
+            };
+
+            // Act
+            let full_actions = view_actions_with_review_comments(state, true);
+            let footer_actions = view_footer_actions_with_review_comments(state, true);
+
+            // Assert
+            for actions in [&full_actions, &footer_actions] {
+                assert_eq!(actions.iter().filter(|action| action.key == "c").count(), 1);
+                assert!(actions.iter().any(|action| {
+                    action.key == "c" && action.popup_label == "Continue in new session"
+                }));
+                assert!(
+                    !actions
+                        .iter()
+                        .any(|action| action.popup_label == "Show review comments")
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_view_actions_non_terminal_review_comments_follow_availability() {
         // Arrange
         let state = ViewHelpState {
             can_fork_session: ViewActionAvailability::Enabled,
@@ -1689,19 +1742,24 @@ mod tests {
             reply_to_session: ViewActionAvailability::Enabled,
             can_start_staged_session: ViewActionAvailability::Disabled,
             publish_pull_request_action: None,
-            session_state: ViewSessionState::Done,
+            session_state: ViewSessionState::Review,
         };
 
         // Act
-        let full_actions = view_actions_with_review_comments(state, true);
-        let footer_actions = view_footer_actions_with_review_comments(state, true);
+        let available_actions = view_actions_with_review_comments(state, true);
+        let available_footer_actions = view_footer_actions_with_review_comments(state, true);
+        let unavailable_actions = view_actions_with_review_comments(state, false);
+        let unavailable_footer_actions = view_footer_actions_with_review_comments(state, false);
 
         // Assert
-        for actions in [&full_actions, &footer_actions] {
-            assert_eq!(actions.iter().filter(|action| action.key == "c").count(), 1);
-            assert!(actions.iter().any(|action| {
-                action.key == "c" && action.popup_label == "Continue in new session"
-            }));
+        for actions in [&available_actions, &available_footer_actions] {
+            assert!(
+                actions
+                    .iter()
+                    .any(|action| action.popup_label == "Show review comments")
+            );
+        }
+        for actions in [&unavailable_actions, &unavailable_footer_actions] {
             assert!(
                 !actions
                     .iter()
@@ -1711,7 +1769,7 @@ mod tests {
     }
 
     #[test]
-    fn test_view_footer_actions_canceled_hides_continue() {
+    fn test_view_footer_actions_canceled_shows_continue_before_scroll() {
         // Arrange
         let state = ViewHelpState {
             can_fork_session: ViewActionAvailability::Enabled,
@@ -1730,7 +1788,7 @@ mod tests {
         let ordered_keys = actions.iter().map(|action| action.key).collect::<Vec<_>>();
 
         // Assert
-        assert_eq!(&ordered_keys[..3], ["q", "j/k", "?"]);
+        assert_eq!(&ordered_keys[..4], ["q", "c", "j/k", "?"]);
     }
 
     #[test]

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -611,7 +611,7 @@ fn view_session_snapshot(app: &App, view_context: &ViewContext) -> Option<ViewSe
                 .can_reply_to_session_in_stack(view_context.session_id.as_str()),
         ),
         review_comments: ViewActionState::from_bool(
-            session.has_review_request() && session_status != Status::Done,
+            session.has_review_request() && !session.allows_terminal_continuation(),
         ),
         session_state: help_action::session_view_state(session),
         session_status,
@@ -1166,6 +1166,23 @@ mod tests {
         new_test_app_with_session_and_tmux_client(Arc::new(MockTmuxClient::new())).await
     }
 
+    /// Attaches one open GitHub review request to a session fixture.
+    fn attach_open_review_request(session: &mut crate::domain::session::Session) {
+        session.review_request = Some(ReviewRequest {
+            last_refreshed_at: 0,
+            summary: ReviewRequestSummary {
+                display_id: "#42".to_string(),
+                forge_kind: ForgeKind::GitHub,
+                source_branch: "wt/linked-terminal".to_string(),
+                state: ReviewRequestState::Open,
+                status_summary: None,
+                target_branch: "main".to_string(),
+                title: "Linked terminal session".to_string(),
+                web_url: "https://github.com/agentty-xyz/agentty/pull/42".to_string(),
+            },
+        });
+    }
+
     /// Builds one reply-enabled review snapshot for primary-key routing tests.
     fn reply_enabled_review_snapshot() -> ViewSessionSnapshot {
         ViewSessionSnapshot {
@@ -1328,7 +1345,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_view_session_snapshot_disables_continue_for_canceled_session() {
+    async fn test_view_session_snapshot_enables_continue_for_canceled_session() {
         // Arrange
         let (mut app, _base_dir, session_id) = new_test_app_with_session().await;
         app.sessions.sessions_mut()[0].status = Status::Canceled;
@@ -1342,7 +1359,7 @@ mod tests {
         let snapshot = view_session_snapshot(&app, &context).expect("expected view snapshot");
 
         // Assert
-        assert!(!snapshot.can_continue_terminal_session());
+        assert!(snapshot.can_continue_terminal_session());
         assert!(!snapshot.can_open_worktree());
         assert_eq!(snapshot.session_state, ViewSessionState::Canceled);
         assert_eq!(snapshot.session_status, Status::Canceled);
@@ -2678,19 +2695,7 @@ mod tests {
             .iter_mut()
             .find(|session| session.id == session_id)
             .expect("session should exist");
-        session.review_request = Some(ReviewRequest {
-            last_refreshed_at: 0,
-            summary: ReviewRequestSummary {
-                display_id: "#42".to_string(),
-                forge_kind: ForgeKind::GitHub,
-                source_branch: "wt/linked-terminal".to_string(),
-                state: ReviewRequestState::Open,
-                status_summary: None,
-                target_branch: "main".to_string(),
-                title: "Linked terminal session".to_string(),
-                web_url: "https://github.com/agentty-xyz/agentty/pull/42".to_string(),
-            },
-        });
+        attach_open_review_request(session);
         session.status = Status::Done;
         app.mode = AppMode::View {
             session_id: session_id.clone().into(),
@@ -2738,7 +2743,50 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_continue_key_does_not_open_confirmation_for_canceled_session() {
+    async fn test_linked_canceled_session_routes_c_to_continue_without_comments() {
+        // Arrange
+        let (mut app, _base_dir, session_id) = new_test_app_with_session().await;
+        let session = app
+            .sessions
+            .sessions_mut()
+            .iter_mut()
+            .find(|session| session.id == session_id)
+            .expect("session should exist");
+        attach_open_review_request(session);
+        session.status = Status::Canceled;
+        app.mode = AppMode::View {
+            session_id: session_id.clone().into(),
+            scroll_offset: Some(0),
+        };
+        let view_context = view_context(&mut app).expect("expected view context");
+        let pending_update = ViewPendingUpdate::from_context(&view_context);
+        let view_session_snapshot =
+            view_session_snapshot(&app, &view_context).expect("expected session snapshot");
+
+        // Act
+        let continue_result = handle_primary_view_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE),
+            &view_context,
+            &view_session_snapshot,
+            &pending_update,
+        )
+        .await;
+
+        // Assert
+        assert!(!view_session_snapshot.can_open_review_comments());
+        assert_eq!(continue_result, Some(false));
+        assert!(matches!(
+            app.mode,
+            AppMode::Confirmation {
+                confirmation_intent: ConfirmationIntent::ContinueSession,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_continue_key_opens_confirmation_for_canceled_session() {
         // Arrange
         let (mut app, _base_dir, source_session_id) = new_test_app_with_session().await;
         app.sessions
@@ -2767,10 +2815,11 @@ mod tests {
         assert!(matches!(result, EventResult::Continue));
         assert!(matches!(
             app.mode,
-            AppMode::View {
+            AppMode::Confirmation {
+                confirmation_intent: ConfirmationIntent::ContinueSession,
                 ref session_id,
                 ..
-            } if session_id.as_str() == source_session_id
+            } if matches!(session_id, Some(session_id) if session_id.as_str() == source_session_id)
         ));
     }
 

--- a/crates/agentty/src/ui/page/session_chat.rs
+++ b/crates/agentty/src/ui/page/session_chat.rs
@@ -780,7 +780,7 @@ mod tests {
             .collect()
     }
 
-    /// Verifies the chat footer advertises continuation only for completed
+    /// Verifies the chat footer advertises continuation for completed
     /// sessions.
     #[test]
     fn test_render_done_session_shows_continue_footer_action() {
@@ -809,10 +809,10 @@ mod tests {
         assert!(!text.contains("comments"));
     }
 
-    /// Verifies canceled terminal sessions render without a continuation
-    /// shortcut in the chat footer.
+    /// Verifies canceled terminal sessions advertise continuation in the chat
+    /// footer.
     #[test]
-    fn test_render_canceled_session_hides_continue_footer_action() {
+    fn test_render_canceled_session_shows_continue_footer_action() {
         // Arrange
         let mut session = session_fixture();
         session.status = Status::Canceled;
@@ -834,7 +834,8 @@ mod tests {
 
         // Assert
         let text = buffer_text(terminal.backend().buffer());
-        assert!(!text.contains("c: continue"));
+        assert!(text.contains("c: continue"));
+        assert!(!text.contains("comments"));
     }
 
     /// Verifies running sessions advertise sync as a queued action while

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -2134,6 +2134,35 @@ fn seed_done_session_for_continuation(env: &BuilderEnv) -> Result<(), Box<dyn st
     Ok(())
 }
 
+/// Seeds one canceled session whose saved summary can drive the continuation
+/// draft flow.
+fn seed_canceled_session_for_continuation(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    common::seed_session(
+        env,
+        SessionSeed::regular("canceled-continue-0001", "gpt-5.6-sol", "main", "Canceled")
+            .with_title("Continue canceled session"),
+    )?;
+
+    let runtime = common::seed_runtime()?;
+
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        database
+            .sessions()
+            .update_session_summary(
+                "canceled-continue-0001",
+                "# Summary\n\nResume the remaining work.",
+            )
+            .await?;
+
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })?;
+
+    Ok(())
+}
+
 /// Seeds one in-progress session so the session view can show the active
 /// Tachyonfx loader without launching a live agent backend.
 fn seed_active_loader_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
@@ -4691,6 +4720,69 @@ fn terminal_session_continue_opens_seeded_prompt() -> E2eResult {
                 assertion::assert_text_in_region(frame, "Use 704de31d0f4b5a12", &full);
                 assertion::assert_text_in_region(frame, "704de31d0f4b5a12", &full);
                 assertion::assert_text_in_region(frame, "commit as an initial context", &full);
+                assertion::assert_text_in_region(frame, "Type your message", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that pressing `c` in a canceled session opens a confirmation and,
+/// after acceptance, stages its saved context in a new draft composer.
+#[test]
+fn canceled_session_continue_opens_seeded_prompt() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("canceled_session_continue")
+        .with_git()
+        .setup(seed_canceled_session_for_continuation)
+        .zola(
+            "Continue canceled session",
+            "Continue a canceled session in a new draft with its saved summary staged as context.",
+            46,
+        )
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("Enter")
+                    .wait_for_text("c: continue", 5000)
+                    .press_key("c")
+                    .wait_for_text("Confirm Continue", 3000)
+                    .viewing_pause_ms(1500)
+                    .capture_labeled(
+                        "continue_confirmation",
+                        "Continuation confirmation for the canceled session",
+                    )
+                    .press_key("y")
+                    .wait_for_text("Resume the remaining work.", 15000)
+                    .wait_for_stable_frame(500, 15000)
+                    .viewing_pause_ms(1500)
+                    .capture_labeled(
+                        "canceled_session_continue",
+                        "New draft composer with canceled-session context staged",
+                    )
+            },
+            |frame, report| {
+                let confirmation_frame = common::frame_from_capture(&report.captures[0]);
+                let confirmation_full =
+                    Region::full(confirmation_frame.cols(), confirmation_frame.rows());
+                assertion::assert_text_in_region(
+                    &confirmation_frame,
+                    "Confirm Continue",
+                    &confirmation_full,
+                );
+                assertion::assert_text_in_region(
+                    &confirmation_frame,
+                    "Create a new draft sess...",
+                    &confirmation_full,
+                );
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Enter: stage draft", &full);
+                assertion::assert_text_in_region(frame, "Status: Canceled", &full);
+                assertion::assert_text_in_region(frame, "Previous session summary:", &full);
+                assertion::assert_text_in_region(frame, "Resume the remaining work.", &full);
                 assertion::assert_text_in_region(frame, "Type your message", &full);
             },
         )?;

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -193,11 +193,12 @@ State-specific differences:
 - **Merged** sessions remain in Active and expose only read-only navigation, linked
   review comments, and `d` for the diff until list-mode `s` successfully syncs their
   local target branch.
-- **Done** sessions offer `c` to start a continuation draft (confirmation popup) and
-  hide linked review comments.
-- **Canceled**, **Queued**, and **Merging** sessions are otherwise read-only (`q`,
-  scroll, help). Linked review requests remain available from other session states with
-  `c`.
+- **Done** and **Canceled** sessions offer `c` to start a continuation draft
+  (confirmation popup). Done-session drafts use the merged commit hash when available;
+  canceled-session drafts use the saved summary, transcript, or original prompt. Both
+  terminal states hide linked review comments so continuation remains unambiguous.
+- **Queued** and **Merging** sessions are otherwise read-only (`q`, scroll, help).
+  Linked review requests remain available from other session states with `c`.
 
 `o` runs the configured `Launch Configurations` entry, or opens a selector popup when
 several are configured. Run Agentty inside `tmux` when you rely on

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -345,12 +345,13 @@ and unchanged pre-existing tracked changes do not emit this warning. Projects ba
 a bare repository have no main working checkout, so this main-checkout dirty-state guard
 is skipped there.
 
-### Continuing a Done Session
+### Continuing a Terminal Session
 
-Pressing `C` on a **Done** session opens a confirmation, then creates a brand-new draft
-session with a continuation message staged from the merged commit hash (or the saved
-summary when the hash is unavailable). **Canceled** sessions remain terminal and
-read-only.
+Pressing `c` on a **Done** or **Canceled** session opens a confirmation, then creates a
+brand-new draft session. **Done** sessions stage a continuation message from the merged
+commit hash, or from saved context when the hash is unavailable. **Canceled** sessions
+stage the saved summary, transcript, or original prompt. The source session remains
+terminal and unchanged.
 
 ## Draft and Stacked Sessions
 


### PR DESCRIPTION
- Allow `Done` and `Canceled` sessions to start terminal continuation drafts through `c` and hide linked review comments.
- Seed `Done` continuations from merged commits and `Canceled` continuations from saved context.
- Add model, UI, E2E, and documentation coverage for canceled-session continuation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)