### PR TITLE
Complete merged stacked reviews after manual sync

### DIFF
--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -39,6 +39,7 @@ use crate::domain::session::{
 };
 use crate::domain::transcript_notice::TranscriptNotice;
 use crate::domain::transient_message::TransientMessageBody;
+use crate::infra::db::DbError;
 use crate::presentation::app_mode::{
     AppMode, ChatFocus, ConfirmationViewMode, DiffPreview, DiffPreviewUnavailableReason,
     HelpContext,
@@ -2003,33 +2004,49 @@ impl App {
         (!warnings.is_empty()).then(|| warnings.join("\n"))
     }
 
-    /// Finalizes read-only merged sessions targeting the branch updated by a
-    /// successful user-triggered main sync.
+    /// Finalizes read-only merged sessions that reached the branch updated by
+    /// a successful user-triggered main sync.
+    ///
+    /// A merged stacked child also reached that branch when its merged parent
+    /// targeted the branch directly, even if the child's persisted review
+    /// target still names the parent review branch.
     async fn finalize_merged_sessions_after_main_sync(
         &mut self,
         default_branch: &str,
     ) -> Vec<SessionId> {
         let mut deferred_session_ids = Vec::new();
-        let session_ids = self
+        let merged_session_ids = self
             .sessions
             .sessions()
             .iter()
             .filter(|session| {
-                session
-                    .review_request
-                    .as_ref()
-                    .is_some_and(|review_request| {
-                        review_request.summary.target_branch == default_branch
-                    })
-                    && self
-                        .sessions
-                        .session_handles_or_err(&session.id)
-                        .ok()
-                        .and_then(|handles| handles.status.lock().ok().map(|status| *status))
-                        == Some(Status::Merged)
+                self.sessions
+                    .session_handles_or_err(&session.id)
+                    .ok()
+                    .and_then(|handles| handles.status.lock().ok().map(|status| *status))
+                    == Some(Status::Merged)
             })
             .map(|session| session.id.clone())
             .collect::<Vec<_>>();
+        let mut session_ids = Vec::new();
+        for session_id in merged_session_ids {
+            match self
+                .merged_session_reached_synced_branch(&session_id, default_branch)
+                .await
+            {
+                Ok(true) => session_ids.push(session_id),
+                Ok(false) => {}
+                Err(error) => {
+                    self.append_output_for_session(
+                        &session_id,
+                        &TranscriptNotice::ReviewRequestSyncWarning
+                            .format(format!("Durable restack marker load failed: {error}")),
+                    )
+                    .await;
+                    deferred_session_ids.push(session_id);
+                }
+            }
+        }
 
         for session_id in session_ids {
             let session_head_hash = match self
@@ -2075,6 +2092,62 @@ impl App {
         }
 
         deferred_session_ids
+    }
+
+    /// Returns whether one merged review is now present on the manually
+    /// synchronized branch, directly, through its merged stack parent, or by
+    /// the durable restack marker left after that parent was archived.
+    ///
+    /// Returns an error when the durable marker cannot be loaded.
+    async fn merged_session_reached_synced_branch(
+        &self,
+        session_id: &SessionId,
+        default_branch: &str,
+    ) -> Result<bool, DbError> {
+        let Ok(session) = self.sessions.session_or_err(session_id) else {
+            return Ok(false);
+        };
+        let Some(review_request) = session.review_request.as_ref() else {
+            return Ok(false);
+        };
+        if review_request.summary.target_branch == default_branch {
+            return Ok(true);
+        }
+        if let Some(parent_session_id) = session.parent_session_id.as_ref() {
+            let Some(parent_session) = self
+                .sessions
+                .sessions()
+                .iter()
+                .find(|candidate| candidate.id == *parent_session_id)
+            else {
+                return Ok(false);
+            };
+            let Some(parent_review_request) = parent_session.review_request.as_ref() else {
+                return Ok(false);
+            };
+
+            return Ok(review_request.summary.target_branch
+                == parent_review_request.summary.source_branch
+                && parent_review_request.summary.target_branch == default_branch
+                && self
+                    .sessions
+                    .session_handles_or_err(parent_session_id)
+                    .ok()
+                    .and_then(|handles| handles.status.lock().ok().map(|status| *status))
+                    == Some(Status::Merged));
+        }
+        if session.base_branch != default_branch {
+            return Ok(false);
+        }
+
+        let stack_base_commit_hash = self
+            .services
+            .db()
+            .sessions()
+            .get_session_stack_base_commit_hash(session_id)
+            .await?;
+
+        Ok(stack_base_commit_hash.is_some())
     }
 
     /// Marks one externally merged session `Done` after manual target sync,
@@ -2409,6 +2482,76 @@ mod tests {
     };
 
     use super::*;
+    use crate::domain::session::{
+        ForgeKind, ReviewRequest, ReviewRequestState, ReviewRequestSummary,
+    };
+
+    #[tokio::test]
+    async fn merged_branch_eligibility_rejects_incomplete_session_context() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let review_request = ReviewRequest {
+            last_refreshed_at: 0,
+            summary: ReviewRequestSummary {
+                display_id: "#23".to_string(),
+                forge_kind: ForgeKind::GitHub,
+                source_branch: "wt/child".to_string(),
+                state: ReviewRequestState::Merged,
+                status_summary: None,
+                target_branch: "wt/parent".to_string(),
+                title: "Merged child".to_string(),
+                web_url: "https://example.test/pull/23".to_string(),
+            },
+        };
+        app.sessions.push_session(
+            crate::test_support::SessionFixtureBuilder::new()
+                .id("session-without-review")
+                .build(),
+        );
+        app.sessions.push_session(
+            crate::test_support::SessionFixtureBuilder::new()
+                .id("child-with-missing-parent")
+                .parent_session_id(Some("missing-parent".into()))
+                .review_request(Some(review_request.clone()))
+                .build(),
+        );
+        app.sessions.push_session(
+            crate::test_support::SessionFixtureBuilder::new()
+                .id("parent-without-review")
+                .build(),
+        );
+        app.sessions.push_session(
+            crate::test_support::SessionFixtureBuilder::new()
+                .id("child-with-unlinked-parent")
+                .parent_session_id(Some("parent-without-review".into()))
+                .review_request(Some(review_request))
+                .build(),
+        );
+
+        // Act
+        let missing_session = app
+            .merged_session_reached_synced_branch(&"missing-session".into(), "main")
+            .await
+            .expect("missing session eligibility should not fail");
+        let session_without_review = app
+            .merged_session_reached_synced_branch(&"session-without-review".into(), "main")
+            .await
+            .expect("unlinked session eligibility should not fail");
+        let child_with_missing_parent = app
+            .merged_session_reached_synced_branch(&"child-with-missing-parent".into(), "main")
+            .await
+            .expect("missing parent eligibility should not fail");
+        let child_with_unlinked_parent = app
+            .merged_session_reached_synced_branch(&"child-with-unlinked-parent".into(), "main")
+            .await
+            .expect("unlinked parent eligibility should not fail");
+
+        // Assert
+        assert!(!missing_session);
+        assert!(!session_without_review);
+        assert!(!child_with_missing_parent);
+        assert!(!child_with_unlinked_parent);
+    }
 
     #[tokio::test]
     async fn test_issue_detail_success_preserves_action_error() {

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -5693,7 +5693,11 @@ fn merged_review_request_status_update(
     session_id: &str,
     display_id: &str,
     session_head_hash: &str,
+    target_branch: &str,
 ) -> ReviewRequestStatusUpdate {
+    let mut summary = test_review_request_summary(display_id, ReviewRequestState::Merged);
+    summary.target_branch = target_branch.to_string();
+
     ReviewRequestStatusUpdate {
         generation: 0,
         result: Ok(SyncReviewRequestTaskResult {
@@ -5701,10 +5705,7 @@ fn merged_review_request_status_update(
                 display_id: display_id.to_string(),
                 session_head_hash: Some(session_head_hash.to_string()),
             },
-            summary: Some(test_review_request_summary(
-                display_id,
-                ReviewRequestState::Merged,
-            )),
+            summary: Some(summary),
         }),
         session_id: session_id.into(),
     }
@@ -5800,7 +5801,7 @@ async fn manual_sync_defers_merged_session_when_commit_hash_cannot_load() {
     let session_id = "session-load-failure";
     insert_review_session_with_data_dir(&app, session_id).await;
     app.refresh_sessions_now().await;
-    let update = merged_review_request_status_update(session_id, "#12", "abc1234");
+    let update = merged_review_request_status_update(session_id, "#12", "abc1234", "main");
     app.apply_review_request_status_update(update).await;
     app.process_pending_app_events().await;
     pool.close().await;
@@ -5846,7 +5847,7 @@ async fn manual_sync_surfaces_restack_failure_and_keeps_parent_merged() {
         .await
         .expect("failed to insert child session");
     app.refresh_sessions_now().await;
-    let update = merged_review_request_status_update(session_id, "#13", "abc1234");
+    let update = merged_review_request_status_update(session_id, "#13", "abc1234", "main");
     app.apply_review_request_status_update(update).await;
     app.process_pending_app_events().await;
     sqlx::query!(
@@ -6162,7 +6163,7 @@ async fn merged_review_waits_for_successful_manual_sync_before_cleanup() {
         .returning(|_, _| Box::pin(async { Ok(()) }));
     install_mock_git_client(&mut app, mock_git_client);
 
-    let merged_update = merged_review_request_status_update(session_id, "#9", "abc1234");
+    let merged_update = merged_review_request_status_update(session_id, "#9", "abc1234", "main");
 
     // Act
     tokio::time::timeout(
@@ -6223,7 +6224,7 @@ async fn failed_or_unrelated_manual_sync_keeps_session_merged() {
     let session_id = "session-waiting";
     insert_review_session_with_data_dir(&app, session_id).await;
     app.refresh_sessions_now().await;
-    let update = merged_review_request_status_update(session_id, "#11", "def5678");
+    let update = merged_review_request_status_update(session_id, "#11", "def5678", "main");
     app.apply_review_request_status_update(update).await;
     app.process_pending_app_events().await;
 
@@ -6292,7 +6293,7 @@ async fn test_apply_review_request_status_update_merged_restacks_stacked_child()
         .returning(|_| Box::pin(async { Ok(()) }));
     install_mock_git_client(&mut app, mock_git_client);
 
-    let update = merged_review_request_status_update(session_id, "#9", "abc1234");
+    let update = merged_review_request_status_update(session_id, "#9", "abc1234", "main");
 
     // Act
     app.apply_review_request_status_update(update).await;
@@ -6340,4 +6341,181 @@ async fn test_apply_review_request_status_update_merged_restacks_stacked_child()
     assert_eq!(db_child_session.parent_session_id, None);
     assert_eq!(db_child_session.base_branch, "main");
     app.services.wait_for_cleanup_tasks().await;
+}
+
+#[tokio::test]
+async fn manual_sync_archives_merged_parent_and_merged_stacked_child() {
+    // Arrange
+    let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    let project_id = app.active_project_id();
+    let parent_session_id = "merged-parent";
+    let child_session_id = "merged-child";
+    insert_review_session_with_data_dir(&app, parent_session_id).await;
+    app.services
+        .db()
+        .sessions()
+        .insert_stacked_draft_session(
+            child_session_id,
+            "gemini-3.6-flash",
+            "wt/session-id",
+            &Status::Review.to_string(),
+            parent_session_id,
+            project_id,
+        )
+        .await
+        .expect("failed to insert stacked child session");
+    fs::create_dir_all(
+        app.services
+            .base_path()
+            .join(child_session_id.chars().take(8).collect::<String>())
+            .join(SESSION_DATA_DIR),
+    )
+    .expect("failed to create child session data dir");
+    app.refresh_sessions_now().await;
+    let mut mock_git_client = ag_git::MockGitClient::new();
+    mock_git_client
+        .expect_main_repo_root()
+        .times(2)
+        .returning(|_| Box::pin(async { Ok(PathBuf::from("/tmp/repo")) }));
+    mock_git_client
+        .expect_remove_worktree()
+        .times(2)
+        .returning(|_| Box::pin(async { Ok(()) }));
+    mock_git_client
+        .expect_delete_branch()
+        .times(2)
+        .returning(|_, _| Box::pin(async { Ok(()) }));
+    install_mock_git_client(&mut app, mock_git_client);
+    let parent_update =
+        merged_review_request_status_update(parent_session_id, "#20", "parent-tip", "main");
+    let child_update =
+        merged_review_request_status_update(child_session_id, "#21", "child-tip", "wt/session-id");
+    app.apply_review_request_status_update(parent_update).await;
+    app.apply_review_request_status_update(child_update).await;
+    app.process_pending_app_events().await;
+
+    // Act
+    app.apply_app_events(successful_manual_sync("main", 1))
+        .await;
+    app.process_pending_app_events().await;
+
+    // Assert
+    let parent_session = app
+        .sessions
+        .session_or_err(parent_session_id)
+        .expect("expected merged parent session");
+    let child_session = app
+        .sessions
+        .session_or_err(child_session_id)
+        .expect("expected merged child session");
+    assert_eq!(parent_session.status, Status::Done);
+    assert_eq!(child_session.status, Status::Done);
+    app.services.wait_for_cleanup_tasks().await;
+}
+
+#[tokio::test]
+async fn manual_sync_recovers_merged_child_after_parent_was_already_archived() {
+    // Arrange
+    let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    let child_session_id = "stuck-child";
+    insert_review_session_with_data_dir(&app, child_session_id).await;
+    app.services
+        .db()
+        .sessions()
+        .update_session_stack_base_commit_hash(child_session_id, Some("parent-tip".to_string()))
+        .await
+        .expect("failed to persist completed parent restack marker");
+    app.refresh_sessions_now().await;
+    let mut mock_git_client = ag_git::MockGitClient::new();
+    mock_git_client
+        .expect_main_repo_root()
+        .once()
+        .returning(|_| Box::pin(async { Ok(PathBuf::from("/tmp/repo")) }));
+    mock_git_client
+        .expect_remove_worktree()
+        .once()
+        .returning(|_| Box::pin(async { Ok(()) }));
+    mock_git_client
+        .expect_delete_branch()
+        .once()
+        .returning(|_, _| Box::pin(async { Ok(()) }));
+    install_mock_git_client(&mut app, mock_git_client);
+    let child_update = merged_review_request_status_update(
+        child_session_id,
+        "#21",
+        "child-tip",
+        "wt/archived-parent",
+    );
+    app.apply_review_request_status_update(child_update).await;
+    app.process_pending_app_events().await;
+
+    // Act
+    app.apply_app_events(successful_manual_sync("main", 1))
+        .await;
+    app.process_pending_app_events().await;
+
+    // Assert
+    let child_session = app
+        .sessions
+        .session_or_err(child_session_id)
+        .expect("expected recovered child session");
+    assert_eq!(child_session.status, Status::Done);
+    app.services.wait_for_cleanup_tasks().await;
+}
+
+#[tokio::test]
+async fn manual_sync_defers_stranded_child_when_restack_marker_cannot_load() {
+    // Arrange
+    let (mut app, pool, _base_dir) = new_test_app_with_database_pool().await;
+    let child_session_id = "stranded-child";
+    insert_review_session_with_data_dir(&app, child_session_id).await;
+    app.services
+        .db()
+        .sessions()
+        .update_session_stack_base_commit_hash(child_session_id, Some("parent-tip".to_string()))
+        .await
+        .expect("failed to persist completed parent restack marker");
+    app.refresh_sessions_now().await;
+    let child_update = merged_review_request_status_update(
+        child_session_id,
+        "#22",
+        "child-tip",
+        "wt/archived-parent",
+    );
+    app.apply_review_request_status_update(child_update).await;
+    app.process_pending_app_events().await;
+    pool.close().await;
+
+    // Act
+    app.apply_app_events(successful_manual_sync("main", 1))
+        .await;
+
+    // Assert
+    let child_session = app
+        .sessions
+        .session_or_err(child_session_id)
+        .expect("expected stranded child session");
+    assert_eq!(child_session.status, Status::Merged);
+    assert!(matches!(
+        app.mode,
+        AppMode::SyncBlockedPopup { ref message, .. }
+            if message.contains("Merged sessions still waiting")
+                && message.contains(child_session_id)
+    ));
+    let workflow_output = app
+        .sessions
+        .session_handles_or_err(child_session_id)
+        .expect("expected stranded child handles")
+        .transcript
+        .lock()
+        .expect("transcript lock poisoned")
+        .replay_text()
+        .expect("expected durable marker warning");
+    assert!(workflow_output.contains("Durable restack marker load failed"));
 }

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1975,6 +1975,81 @@ esac
     install_delayed_worktree_remove_stub(env, 4)
 }
 
+/// Seeds a merged parent and merged stacked child whose review target still
+/// names the parent branch, plus a remote for the manual main sync.
+fn seed_merged_stacked_review_requests(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    common::seed_session(
+        env,
+        SessionSeed::regular("stack-parent-0001", "gpt-5.6-sol", "main", "Merged")
+            .with_title("Merged stack parent"),
+    )?;
+    common::seed_session(
+        env,
+        SessionSeed::stacked_draft(
+            "stack-child-0001",
+            "gpt-5.6-sol",
+            "wt/stack-pa",
+            "Merged",
+            "stack-parent-0001",
+        )
+        .with_title("Merged stack child"),
+    )?;
+
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        let parent_review_request = ReviewRequest {
+            last_refreshed_at: 55,
+            summary: ReviewRequestSummary {
+                display_id: "#42".to_string(),
+                forge_kind: ForgeKind::GitHub,
+                source_branch: "wt/stack-pa".to_string(),
+                state: ReviewRequestState::Merged,
+                status_summary: None,
+                target_branch: "main".to_string(),
+                title: "Merged stack parent".to_string(),
+                web_url: "https://github.com/example/project/pull/42".to_string(),
+            },
+        };
+        let child_review_request = ReviewRequest {
+            last_refreshed_at: 55,
+            summary: ReviewRequestSummary {
+                display_id: "#43".to_string(),
+                forge_kind: ForgeKind::GitHub,
+                source_branch: "wt/stack-ch".to_string(),
+                state: ReviewRequestState::Merged,
+                status_summary: None,
+                target_branch: "wt/stack-pa".to_string(),
+                title: "Merged stack child".to_string(),
+                web_url: "https://github.com/example/project/pull/43".to_string(),
+            },
+        };
+
+        database
+            .reviews()
+            .update_session_review_request("stack-parent-0001", Some(parent_review_request))
+            .await?;
+        database
+            .reviews()
+            .update_session_review_request("stack-child-0001", Some(child_review_request))
+            .await
+    })?;
+
+    std::fs::create_dir_all(env.agentty_root.join("wt").join("stack-pa"))?;
+    std::fs::create_dir_all(env.agentty_root.join("wt").join("stack-ch"))?;
+    let sync_origin = env.agentty_root.join("sync-origin.git");
+    std::fs::create_dir_all(&sync_origin)?;
+    run_git(&sync_origin, &["init", "--bare", "."])?;
+    let sync_origin_path = sync_origin.to_string_lossy().into_owned();
+    run_git(
+        &env.workdir,
+        &["remote", "add", "origin", sync_origin_path.as_str()],
+    )?;
+    run_git(&env.workdir, &["push", "--set-upstream", "origin", "main"])?;
+
+    install_delayed_worktree_remove_stub(env, 1)
+}
+
 /// Installs a git wrapper that delays worktree removal while forwarding all
 /// other commands to the real executable.
 fn install_delayed_worktree_remove_stub(
@@ -4916,6 +4991,45 @@ fn test_merged_review_request_waits_for_manual_sync() -> E2eResult {
 
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "Done", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify one successful manual main sync archives both reviews in a fully
+/// merged stack, including the child that still targets the parent branch.
+#[test]
+fn merged_stacked_reviews_complete_together_after_manual_sync() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("merged_stacked_reviews_complete_together_after_manual_sync")
+        .with_git()
+        .setup(seed_merged_stacked_review_requests)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .wait_for_text("Merged stack child", 5000)
+                    .press_key("s")
+                    .wait_for_text("Sync complete", 10_000)
+                    .press_key("Enter")
+                    .wait_for_text("Done", 10_000)
+                    .capture_labeled(
+                        "merged_stack_done",
+                        "Manual main sync archives both merged stack sessions",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                let session_list_text = frame.text_in_region(&full);
+
+                assertion::assert_text_in_region(frame, "Merged stack parent", &full);
+                assertion::assert_text_in_region(frame, "Merged stack child", &full);
+                assert!(
+                    session_list_text.matches("Done").count() >= 2,
+                    "expected both merged stack rows to be Done:\n{session_list_text}"
+                );
             },
         )?;
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -462,6 +462,13 @@ after restart. If restack intent or archival cannot be persisted, the sync popup
 the session that remains in **Merged** so the user can inspect its workflow warning and
 retry safely. A closed request still moves an editable session to **Canceled**.
 
+When both a stacked parent and child review request have already merged, syncing the
+parent's local target branch moves both sessions to **Done**. This also applies while
+the child's stored review target still names the parent review branch, because the
+merged parent has carried the child's changes into the synchronized target. Retrying
+that sync also recovers a child left in **Merged** by an earlier Agentty run that
+already archived its parent.
+
 ## Clarification Interaction Loop
 
 <a id="usage-clarification-loop"></a> If an agent emits structured clarification


### PR DESCRIPTION
- Detect merged stacked children through their merged parent or persisted restack marker.
- Defer cleanup when the durable restack marker cannot load.
- Add unit and end-to-end coverage for stacked completion and recovery.
- Document merged stack synchronization behavior.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)