### PR TITLE
Hydrate lazy session transcripts from persisted history

### DIFF
--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -514,7 +514,7 @@ fn insert_loaded_session_handle(
     let session_handle = if let Some(transcript) = session_transcript.clone() {
         SessionHandles::new_with_transcript(persisted_status, transcript)
     } else {
-        SessionHandles::new(persisted_status)
+        SessionHandles::new_unloaded(persisted_status)
     };
     handles.insert(session_id, session_handle);
 
@@ -531,25 +531,13 @@ async fn load_session_transcript(
     Ok(SessionTranscript::new(session_messages_from_rows(messages)))
 }
 
-/// Synchronizes a handle transcript from loaded rows when the handle does not
-/// already have live transcript messages.
+/// Synchronizes a handle from loaded rows while preserving complete live
+/// transcripts and replacing partial unhydrated snapshots.
 fn sync_handle_transcript_with_loaded(
     handles: &SessionHandles,
     loaded_transcript: Option<&SessionTranscript>,
 ) -> Option<SessionTranscript> {
-    let Ok(mut handle_transcript) = handles.transcript.lock() else {
-        return None;
-    };
-    if handle_transcript.is_empty()
-        && let Some(loaded_transcript) = loaded_transcript
-    {
-        handle_transcript.clone_from(loaded_transcript);
-    }
-    if handle_transcript.is_empty() {
-        return None;
-    }
-
-    Some(handle_transcript.clone())
+    handles.transcript_snapshot_with_loaded(loaded_transcript)
 }
 
 /// Converts database message rows into domain messages, skipping unknown
@@ -1178,7 +1166,7 @@ mod tests {
         let mut handles: HashMap<SessionId, SessionHandles> = HashMap::new();
         handles.insert(
             session_id.to_string().into(),
-            SessionHandles::new(Status::Review),
+            SessionHandles::new_unloaded(Status::Review),
         );
 
         // Act
@@ -1714,6 +1702,99 @@ WHERE id = ?
         assert_eq!(
             handles.transcript.lock().ok().as_deref(),
             Some(&live_transcript)
+        );
+    }
+
+    #[test]
+    /// Verifies persisted history merges with a partial workflow notice
+    /// appended before a lazy transcript was hydrated.
+    fn sync_handle_transcript_with_loaded_merges_partial_unloaded_transcript() {
+        // Arrange
+        let handles = SessionHandles::new_unloaded(Status::Review);
+        handles
+            .transcript
+            .lock()
+            .expect("transcript lock should not be poisoned")
+            .clone_from(&SessionTranscript::new(vec![SessionMessage::new(
+                2,
+                SessionMessageKind::WorkflowNotice,
+                "\n[Sync] Successfully synced onto main\n",
+            )]));
+        let loaded_transcript = SessionTranscript::new(vec![
+            SessionMessage::conversation(0, SessionMessageKind::UserPrompt, "original prompt"),
+            SessionMessage::conversation(1, SessionMessageKind::AssistantAnswer, "original answer"),
+        ]);
+        let expected_transcript = SessionTranscript::new(vec![
+            SessionMessage::conversation(0, SessionMessageKind::UserPrompt, "original prompt"),
+            SessionMessage::conversation(1, SessionMessageKind::AssistantAnswer, "original answer"),
+            SessionMessage::new(
+                2,
+                SessionMessageKind::WorkflowNotice,
+                "\n[Sync] Successfully synced onto main\n",
+            ),
+        ]);
+
+        // Act
+        let transcript = sync_handle_transcript_with_loaded(&handles, Some(&loaded_transcript));
+
+        // Assert
+        assert_eq!(transcript, Some(expected_transcript.clone()));
+        assert_eq!(
+            handles.transcript.lock().ok().as_deref(),
+            Some(&expected_transcript)
+        );
+    }
+
+    #[test]
+    /// Verifies hydration deduplicates a persisted live append while retaining
+    /// an unpersisted message whose temporary position conflicts.
+    fn sync_handle_transcript_with_loaded_merges_matching_and_conflicting_messages() {
+        // Arrange
+        let handles = SessionHandles::new_unloaded(Status::Review);
+        let persisted_notice = SessionMessage::new(
+            2,
+            SessionMessageKind::WorkflowNotice,
+            "\n[Sync] Successfully synced onto main\n",
+        );
+        handles
+            .transcript
+            .lock()
+            .expect("transcript lock should not be poisoned")
+            .clone_from(&SessionTranscript::new(vec![
+                SessionMessage::new(
+                    0,
+                    SessionMessageKind::WorkflowNotice,
+                    "\n[Sync Error] persistence failed\n",
+                ),
+                persisted_notice.clone(),
+            ]));
+        let loaded_transcript = SessionTranscript::new(vec![
+            SessionMessage::conversation(0, SessionMessageKind::UserPrompt, "original prompt"),
+            SessionMessage::conversation(1, SessionMessageKind::AssistantAnswer, "original answer"),
+            persisted_notice.clone(),
+        ]);
+
+        // Act
+        let transcript = sync_handle_transcript_with_loaded(&handles, Some(&loaded_transcript))
+            .expect("merged transcript should be available");
+
+        // Assert
+        assert_eq!(
+            transcript.messages(),
+            &[
+                SessionMessage::conversation(0, SessionMessageKind::UserPrompt, "original prompt"),
+                SessionMessage::conversation(
+                    1,
+                    SessionMessageKind::AssistantAnswer,
+                    "original answer"
+                ),
+                persisted_notice,
+                SessionMessage::new(
+                    3,
+                    SessionMessageKind::WorkflowNotice,
+                    "\n[Sync Error] persistence failed\n"
+                ),
+            ]
         );
     }
 

--- a/crates/agentty/src/app/session/workflow/task.rs
+++ b/crates/agentty/src/app/session/workflow/task.rs
@@ -1,6 +1,7 @@
 //! Session task execution helpers for process running, output capture, and
 //! status persistence.
 
+use std::future::Future;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -28,7 +29,7 @@ use crate::domain::session::{
 use crate::domain::session_message::{SessionMessageKind, SessionTranscript};
 use crate::domain::setting::SettingName;
 use crate::domain::transcript_notice::TranscriptNotice;
-use crate::infra::db::AppRepositories;
+use crate::infra::db::{AppRepositories, DbError};
 use crate::infra::fs::FsClient;
 
 const AUTO_COMMIT_ASSIST_POLICY: AssistPolicy = AssistPolicy {
@@ -1135,23 +1136,16 @@ impl SessionTaskService {
         id: &str,
         message: &str,
     ) {
-        Self::append_live_transcript_message(
+        Self::append_live_and_persist_transcript_message(
             transcript,
             id,
             SessionMessageKind::WorkflowNotice,
             message,
-        );
-        if let Err(error) = db
-            .sessions()
-            .append_session_message(id, SessionMessageKind::WorkflowNotice, message)
-            .await
-        {
-            warn!(
-                session_id = id,
-                error = %error,
-                "failed to persist workflow notice"
-            );
-        }
+            db.sessions()
+                .append_session_message(id, SessionMessageKind::WorkflowNotice, message),
+            "failed to persist workflow notice",
+        )
+        .await;
         Self::emit_session_updated(app_event_tx, session_update_versions, id);
     }
 
@@ -1183,27 +1177,28 @@ impl SessionTaskService {
         id: &str,
         message: SessionTranscriptMessageAppend<'_>,
     ) {
-        Self::append_live_transcript_message(transcript, id, message.kind, message.raw_content);
-        if let Err(error) = db
-            .sessions()
-            .append_session_message(id, message.kind, message.raw_content)
-            .await
-        {
-            warn!(
-                session_id = id,
-                error = %error,
-                "failed to persist session transcript message"
-            );
-        }
+        Self::append_live_and_persist_transcript_message(
+            transcript,
+            id,
+            message.kind,
+            message.raw_content,
+            db.sessions()
+                .append_session_message(id, message.kind, message.raw_content),
+            "failed to persist session transcript message",
+        )
+        .await;
         Self::emit_session_updated(app_event_tx, session_update_versions, id);
     }
 
-    /// Appends one typed message to the live transcript snapshot.
-    fn append_live_transcript_message(
+    /// Appends one live message before awaiting persistence so the render
+    /// snapshot remains current while durable storage is in flight.
+    async fn append_live_and_persist_transcript_message(
         transcript: &Arc<Mutex<SessionTranscript>>,
         id: &str,
         kind: SessionMessageKind,
         content: &str,
+        persistence: impl Future<Output = Result<(), DbError>>,
+        persistence_error_message: &'static str,
     ) {
         match transcript.lock() {
             Ok(mut transcript) => transcript.append_message(kind, content),
@@ -1214,6 +1209,14 @@ impl SessionTaskService {
                     "failed to lock session transcript buffer"
                 );
             }
+        }
+
+        if let Err(error) = persistence.await {
+            warn!(
+                session_id = id,
+                error = %error,
+                "{persistence_error_message}"
+            );
         }
     }
 
@@ -1444,6 +1447,7 @@ mod tests {
 
     use ag_agent::MockOneShotClient;
     use ag_git::{GitError, MockGitClient};
+    use tokio::sync::oneshot;
 
     use super::*;
     use crate::app::service::AppServiceDeps;
@@ -1617,6 +1621,113 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].kind, "workflow_notice");
         assert_eq!(messages[0].content, "\n[Commit] No changes to commit.\n");
+    }
+
+    #[tokio::test]
+    async fn test_workflow_notice_append_survives_hydration_during_persistence() {
+        // Arrange
+        let handles = SessionHandles::new_unloaded(Status::Review);
+        let loaded_transcript = SessionTranscript::new(vec![
+            SessionMessage::conversation(0, SessionMessageKind::UserPrompt, "original prompt"),
+            SessionMessage::conversation(1, SessionMessageKind::AssistantAnswer, "original answer"),
+        ]);
+        let (persistence_started_tx, persistence_started_rx) = oneshot::channel();
+        let (release_persistence_tx, release_persistence_rx) = oneshot::channel();
+        let transcript = Arc::clone(&handles.transcript);
+        let append_task = tokio::spawn(async move {
+            SessionTaskService::append_live_and_persist_transcript_message(
+                &transcript,
+                "session-id",
+                SessionMessageKind::WorkflowNotice,
+                "\n[Sync] Successfully synced onto main\n",
+                async move {
+                    let _ = persistence_started_tx.send(());
+                    let _ = release_persistence_rx.await;
+
+                    Ok(())
+                },
+                "failed to persist workflow notice",
+            )
+            .await;
+        });
+        persistence_started_rx
+            .await
+            .expect("persistence should start");
+
+        // Act
+        let hydrated_transcript = handles.transcript_snapshot_with_loaded(Some(&loaded_transcript));
+        release_persistence_tx
+            .send(())
+            .expect("persistence should still be waiting");
+        append_task.await.expect("append task should finish");
+
+        // Assert
+        assert_eq!(
+            hydrated_transcript,
+            Some(SessionTranscript::new(vec![
+                SessionMessage::conversation(0, SessionMessageKind::UserPrompt, "original prompt"),
+                SessionMessage::conversation(
+                    1,
+                    SessionMessageKind::AssistantAnswer,
+                    "original answer"
+                ),
+                SessionMessage::new(
+                    2,
+                    SessionMessageKind::WorkflowNotice,
+                    "\n[Sync] Successfully synced onto main\n"
+                ),
+            ]))
+        );
+        assert_eq!(
+            handles
+                .transcript
+                .lock()
+                .expect("transcript lock should not be poisoned")
+                .messages(),
+            &[
+                SessionMessage::conversation(0, SessionMessageKind::UserPrompt, "original prompt"),
+                SessionMessage::conversation(
+                    1,
+                    SessionMessageKind::AssistantAnswer,
+                    "original answer"
+                ),
+                SessionMessage::new(
+                    2,
+                    SessionMessageKind::WorkflowNotice,
+                    "\n[Sync] Successfully synced onto main\n"
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_workflow_notice_append_remains_live_after_persistence_error() {
+        // Arrange
+        let transcript = Arc::new(Mutex::new(SessionTranscript::default()));
+
+        // Act
+        SessionTaskService::append_live_and_persist_transcript_message(
+            &transcript,
+            "session-id",
+            SessionMessageKind::WorkflowNotice,
+            "\n[Sync Error] persistence failed\n",
+            async { Err(DbError::Query(sqlx::Error::RowNotFound)) },
+            "failed to persist workflow notice",
+        )
+        .await;
+
+        // Assert
+        assert_eq!(
+            transcript
+                .lock()
+                .expect("transcript lock should not be poisoned")
+                .messages(),
+            &[SessionMessage::new(
+                0,
+                SessionMessageKind::WorkflowNotice,
+                "\n[Sync Error] persistence failed\n"
+            )]
+        );
     }
 
     #[tokio::test]

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 pub use ag_agent::{SessionDiffState, SessionStats};
@@ -793,10 +794,15 @@ pub struct SessionHandles {
     pub status: Arc<Mutex<Status>>,
     /// Shared typed transcript snapshot mirrored to the render layer.
     pub transcript: Arc<Mutex<SessionTranscript>>,
+    /// Whether [`Self::transcript`] contains the complete persisted history.
+    ///
+    /// Lazy session-list handles start unhydrated so background workflow
+    /// notices cannot make a partial transcript look authoritative.
+    transcript_is_hydrated: AtomicBool,
 }
 
 impl SessionHandles {
-    /// Creates handles initialized with the given status.
+    /// Creates handles with a loaded, empty transcript.
     pub fn new(status: Status) -> Self {
         Self {
             branch_operation_lock: Arc::new(AsyncMutex::new(())),
@@ -805,6 +811,20 @@ impl SessionHandles {
             queued_messages: Arc::new(Mutex::new(VecDeque::new())),
             status: Arc::new(Mutex::new(status)),
             transcript: Arc::new(Mutex::new(SessionTranscript::default())),
+            transcript_is_hydrated: AtomicBool::new(true),
+        }
+    }
+
+    /// Creates handles whose persisted transcript has not been loaded yet.
+    pub(crate) fn new_unloaded(status: Status) -> Self {
+        Self {
+            branch_operation_lock: Arc::new(AsyncMutex::new(())),
+            cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
+            child_pid: Arc::new(Mutex::new(None)),
+            queued_messages: Arc::new(Mutex::new(VecDeque::new())),
+            status: Arc::new(Mutex::new(status)),
+            transcript: Arc::new(Mutex::new(SessionTranscript::default())),
+            transcript_is_hydrated: AtomicBool::new(false),
         }
     }
 
@@ -817,7 +837,30 @@ impl SessionHandles {
             queued_messages: Arc::new(Mutex::new(VecDeque::new())),
             status: Arc::new(Mutex::new(status)),
             transcript: Arc::new(Mutex::new(transcript)),
+            transcript_is_hydrated: AtomicBool::new(true),
         }
+    }
+
+    /// Returns the live transcript, hydrating an unloaded handle from the
+    /// persisted snapshot even when background notices made it non-empty.
+    pub(crate) fn transcript_snapshot_with_loaded(
+        &self,
+        loaded_transcript: Option<&SessionTranscript>,
+    ) -> Option<SessionTranscript> {
+        let Ok(mut transcript) = self.transcript.lock() else {
+            return None;
+        };
+        if !self.transcript_is_hydrated.load(Ordering::Acquire)
+            && let Some(loaded_transcript) = loaded_transcript
+        {
+            *transcript = Self::merge_unloaded_transcript(loaded_transcript, &transcript);
+            self.transcript_is_hydrated.store(true, Ordering::Release);
+        }
+        if transcript.is_empty() {
+            return None;
+        }
+
+        Some(transcript.clone())
     }
 
     /// Returns the transcript text for each queued message in submission
@@ -835,6 +878,36 @@ impl SessionHandles {
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default()
+    }
+
+    /// Merges messages appended while persistence was in flight into a
+    /// database snapshot, deduplicating exact matches and retaining conflicts.
+    fn merge_unloaded_transcript(
+        loaded_transcript: &SessionTranscript,
+        live_transcript: &SessionTranscript,
+    ) -> SessionTranscript {
+        let mut messages = loaded_transcript.messages().to_vec();
+        for live_message in live_transcript.messages() {
+            if let Some(loaded_message) = messages
+                .iter()
+                .find(|message| message.position == live_message.position)
+            {
+                if loaded_message == live_message {
+                    continue;
+                }
+
+                let next_position = messages
+                    .last()
+                    .map_or(0, |message| message.position.saturating_add(1));
+                let mut appended_message = live_message.clone();
+                appended_message.position = next_position;
+                messages.push(appended_message);
+            } else {
+                messages.push(live_message.clone());
+            }
+        }
+
+        SessionTranscript::new(messages)
     }
 }
 
@@ -859,6 +932,29 @@ pub(crate) mod tests {
         // Assert
         assert_eq!(positive_offset_day_key, 1);
         assert_eq!(negative_offset_day_key, 0);
+    }
+
+    #[test]
+    fn test_transcript_snapshot_with_loaded_returns_none_for_poisoned_transcript_lock() {
+        // Arrange
+        let handles = SessionHandles::new_unloaded(Status::Review);
+        let transcript = Arc::clone(&handles.transcript);
+        let poison_transcript = |transcript: Arc<Mutex<SessionTranscript>>, should_poison: bool| {
+            let _transcript = transcript
+                .lock()
+                .expect("transcript lock should initially be available");
+
+            assert!(!should_poison, "poison transcript lock");
+        };
+        poison_transcript(Arc::clone(&transcript), false);
+        let poison_result = std::thread::spawn(move || poison_transcript(transcript, true)).join();
+        assert!(poison_result.is_err());
+
+        // Act
+        let snapshot = handles.transcript_snapshot_with_loaded(None);
+
+        // Assert
+        assert_eq!(snapshot, None);
     }
 
     #[test]


### PR DESCRIPTION
- Track whether session handles contain complete transcript history.
- Merge live notices added during persistence with loaded transcripts while deduplicating matches.
- Append transcript messages before awaiting persistence so hydration retains them after database errors.
- Cover lazy transcript replacement and persistence races with regression tests.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)