### PR TITLE
Keep post-sync workflow statuses chronological

### DIFF
--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -1271,8 +1271,9 @@ impl App {
             },
         );
         if let Some(session) = self.sessions.state_mut().session_mut_for_id(session_id) {
+            let anchor = app::review::focused_review_result_anchor(session);
             session.transient_messages.upsert(TransientMessage {
-                anchor: TransientMessageAnchor::AfterCompletedTurn,
+                anchor,
                 body: TransientMessageBody::Markdown(text),
                 lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
                 slot: TransientMessageSlot::Review,

--- a/crates/agentty/src/app/review.rs
+++ b/crates/agentty/src/app/review.rs
@@ -184,6 +184,17 @@ pub(crate) fn prune_review_cache(
     });
 }
 
+/// Keeps a completed focused review at the position established by its
+/// loading row, falling back to completed-turn placement for restored output.
+pub(crate) fn focused_review_result_anchor(session: &Session) -> TransientMessageAnchor {
+    session
+        .transient_messages
+        .get(TransientMessageSlot::Review)
+        .map_or(TransientMessageAnchor::AfterCompletedTurn, |message| {
+            message.anchor
+        })
+}
+
 /// Synchronizes one session's focused-review display slot from the canonical
 /// cache state.
 fn hydrate_session_review_transient(
@@ -214,11 +225,11 @@ fn hydrate_session_review_transient(
             TransientMessageBody::Loading(review_loading_message(review_model)),
         ),
         ReviewCacheEntry::Ready { text, .. } => (
-            TransientMessageAnchor::AfterCompletedTurn,
+            focused_review_result_anchor(session),
             TransientMessageBody::Markdown(text.clone()),
         ),
         ReviewCacheEntry::Failed { error, .. } => (
-            TransientMessageAnchor::AfterCompletedTurn,
+            focused_review_result_anchor(session),
             TransientMessageBody::Plain(review_failure_message(error)),
         ),
         ReviewCacheEntry::Suppressed => {
@@ -459,12 +470,13 @@ fn apply_review_update(
         .iter_mut()
         .find(|session| session.id == session_id)
     {
+        let anchor = focused_review_result_anchor(session);
         let body = match &result {
             Ok(review_text) => TransientMessageBody::Markdown(review_text.clone()),
             Err(error) => TransientMessageBody::Plain(review_failure_message(error)),
         };
         session.transient_messages.upsert(TransientMessage {
-            anchor: TransientMessageAnchor::AfterCompletedTurn,
+            anchor,
             body,
             lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
             slot: TransientMessageSlot::Review,
@@ -905,6 +917,49 @@ mod tests {
             review_cache.get(session_id.as_str()),
             Some(ReviewCacheEntry::Ready { text, .. }) if text == review_text
         ));
+    }
+
+    #[test]
+    fn apply_review_updates_preserves_loading_row_tail_position() {
+        // Arrange
+        let session_id = SessionId::from("session-tail-review");
+        let diff_hash = 17;
+        let review_text = "## Review\nChronological finding.";
+        let mut review_cache = loading_review_cache(&session_id, diff_hash);
+        let mut session = SessionFixtureBuilder::new()
+            .id(session_id.as_str())
+            .status(Status::AgentReview)
+            .build();
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading("Reviewing changes".to_string()),
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::Review,
+            turn_position: None,
+        });
+        let mut session_state = SessionState::new(
+            HashMap::new(),
+            vec![session],
+            SelectionState::default(),
+            Arc::new(RealClock),
+            0,
+            0,
+        );
+        let review_updates = successful_review_update(&session_id, diff_hash, review_text);
+
+        // Act
+        apply_review_updates(&mut review_cache, &mut session_state, review_updates);
+
+        // Assert
+        let review_message = session_state.sessions()[0]
+            .transient_messages
+            .get(TransientMessageSlot::Review)
+            .expect("completed review should remain visible");
+        assert_eq!(review_message.anchor, TransientMessageAnchor::Tail);
+        assert_eq!(
+            review_message.body,
+            TransientMessageBody::Markdown(review_text.to_string())
+        );
     }
 
     #[test]

--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -573,7 +573,7 @@ impl SessionManager {
             .find(|session| session.id == session_id)
         {
             session.transient_messages.upsert(TransientMessage {
-                anchor: TransientMessageAnchor::AfterCompletedTurn,
+                anchor: TransientMessageAnchor::Tail,
                 body: TransientMessageBody::Loading(
                     "Auto-pushing published branch after completed turn...".to_string(),
                 ),

--- a/crates/agentty/src/domain/transient_message.rs
+++ b/crates/agentty/src/domain/transient_message.rs
@@ -30,6 +30,17 @@ pub(crate) enum TransientMessageAnchor {
     Tail,
 }
 
+/// Order in which anchored transient blocks appear in session output.
+///
+/// Keep aligned with the anchored blocks in `SESSION_OUTPUT_BLOCK_ORDER`
+/// (`ui/session_output_assembly.rs`); the fingerprint stays stable only while
+/// this order matches the rendered block order.
+const TRANSIENT_MESSAGE_ANCHOR_ORDER: [TransientMessageAnchor; 3] = [
+    TransientMessageAnchor::AfterCompletedTurn,
+    TransientMessageAnchor::AfterActiveTurn,
+    TransientMessageAnchor::Tail,
+];
+
 /// Removal policy for one transient message.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum TransientMessageLifecycle {
@@ -75,8 +86,8 @@ pub(crate) struct TransientMessage {
 /// `version` changes only when observable slot content changes. `fingerprint`
 /// gives render caches a content identity that remains valid when refreshes
 /// reconstruct an equivalent store with a new local version sequence. Slots
-/// use canonical enum order rather than async event arrival order, so status
-/// replacement does not move surrounding output.
+/// retain insertion order so concurrently visible workflow rows follow their
+/// start chronology; replacing a slot does not move it.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct TransientMessageStore {
     fingerprint: u64,
@@ -124,7 +135,6 @@ impl TransientMessageStore {
         }
 
         self.messages.push(message);
-        self.messages.sort_by_key(|message| message.slot);
         self.bump_version();
     }
 
@@ -160,9 +170,17 @@ impl TransientMessageStore {
         self.fingerprint = Self::calculate_fingerprint(&self.messages);
     }
 
+    /// Hashes messages grouped by anchor in rendered block order so that
+    /// display-invisible cross-anchor insertion permutations keep one identity
+    /// while order changes within an anchor still invalidate render caches.
     fn calculate_fingerprint(messages: &[TransientMessage]) -> u64 {
         let mut hasher = FxHasher::default();
-        messages.hash(&mut hasher);
+        for anchor in TRANSIENT_MESSAGE_ANCHOR_ORDER {
+            anchor.hash(&mut hasher);
+            for message in messages.iter().filter(|message| message.anchor == anchor) {
+                message.hash(&mut hasher);
+            }
+        }
 
         hasher.finish()
     }
@@ -199,15 +217,15 @@ mod tests {
     fn upsert_replaces_slot_without_moving_it() {
         // Arrange
         let mut store = TransientMessageStore::default();
-        store.upsert(message(TransientMessageSlot::Summary, "summary", 1));
         store.upsert(message(TransientMessageSlot::Review, "review", 1));
+        store.upsert(message(TransientMessageSlot::Summary, "summary", 1));
 
         // Act
-        store.upsert(message(TransientMessageSlot::Summary, "new summary", 1));
+        store.upsert(message(TransientMessageSlot::Review, "new review", 1));
 
         // Assert
-        assert_eq!(store.messages[0].body.text(), "new summary");
-        assert_eq!(store.messages[1].slot, TransientMessageSlot::Review);
+        assert_eq!(store.messages[0].body.text(), "new review");
+        assert_eq!(store.messages[1].slot, TransientMessageSlot::Summary);
         assert_eq!(store.version(), 3);
     }
 
@@ -267,6 +285,55 @@ mod tests {
         // Assert
         assert_eq!(loading_store.version(), ready_store.version());
         assert_ne!(loading_fingerprint, ready_fingerprint);
+    }
+
+    #[test]
+    fn fingerprint_ignores_cross_anchor_insertion_order() {
+        // Arrange
+        let tail_message = TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading("Pushing...".to_string()),
+            lifecycle: TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::PublishedBranchSync,
+            turn_position: Some(1),
+        };
+        let completed_turn_message = message(TransientMessageSlot::WorkflowNotice, "commit", 1);
+
+        let mut notice_first_store = TransientMessageStore::default();
+        notice_first_store.upsert(completed_turn_message.clone());
+        notice_first_store.upsert(tail_message.clone());
+        let mut push_first_store = TransientMessageStore::default();
+        push_first_store.upsert(tail_message);
+        push_first_store.upsert(completed_turn_message);
+
+        // Act
+        let notice_first_fingerprint = notice_first_store.fingerprint();
+        let push_first_fingerprint = push_first_store.fingerprint();
+
+        // Assert
+        assert_ne!(notice_first_store.messages(), push_first_store.messages());
+        assert_eq!(notice_first_fingerprint, push_first_fingerprint);
+    }
+
+    #[test]
+    fn fingerprint_distinguishes_order_within_one_anchor() {
+        // Arrange
+        let notice = message(TransientMessageSlot::WorkflowNotice, "commit", 1);
+        let review = message(TransientMessageSlot::Review, "review", 1);
+
+        let mut notice_first_store = TransientMessageStore::default();
+        notice_first_store.upsert(notice.clone());
+        notice_first_store.upsert(review.clone());
+        let mut review_first_store = TransientMessageStore::default();
+        review_first_store.upsert(review);
+        review_first_store.upsert(notice);
+
+        // Act
+        let notice_first_fingerprint = notice_first_store.fingerprint();
+        let review_first_fingerprint = review_first_store.fingerprint();
+
+        // Assert
+        assert_ne!(notice_first_fingerprint, review_first_fingerprint);
     }
 
     #[test]

--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -817,7 +817,8 @@ mod tests {
     use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
     use crate::domain::theme::ColorTheme;
     use crate::domain::transient_message::{
-        TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageSlot,
+        TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
+        TransientMessageSlot,
     };
     use crate::ui::prompt_block::{self, USER_PROMPT_PREFIX};
 
@@ -835,7 +836,7 @@ mod tests {
         session.transient_messages.upsert(TransientMessage {
             anchor: TransientMessageAnchor::AfterCompletedTurn,
             body,
-            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::ClearOnNewTurn,
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
             slot: TransientMessageSlot::Review,
             turn_position: session.latest_user_prompt_position(),
         });
@@ -1085,7 +1086,7 @@ mod tests {
         session.transient_messages.upsert(TransientMessage {
             anchor: TransientMessageAnchor::Tail,
             body: TransientMessageBody::Loading("Publishing review request...".to_string()),
-            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::UntilResolved,
+            lifecycle: TransientMessageLifecycle::UntilResolved,
             slot: TransientMessageSlot::BranchPublish,
             turn_position: None,
         });
@@ -1361,7 +1362,7 @@ mod tests {
         session.transient_messages.upsert(TransientMessage {
             anchor: TransientMessageAnchor::AfterCompletedTurn,
             body: TransientMessageBody::Markdown("[Commit] No changes to commit.".to_string()),
-            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::ClearOnNewTurn,
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
             slot: TransientMessageSlot::WorkflowNotice,
             turn_position: None,
         });
@@ -1409,7 +1410,7 @@ mod tests {
         session.transient_messages.upsert(TransientMessage {
             anchor: TransientMessageAnchor::AfterCompletedTurn,
             body: TransientMessageBody::Markdown("## Review\n\n- Cached finding".to_string()),
-            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::ClearOnNewTurn,
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
             slot: TransientMessageSlot::Review,
             turn_position: None,
         });
@@ -1433,7 +1434,7 @@ mod tests {
         loading_session.transient_messages.upsert(TransientMessage {
             anchor: TransientMessageAnchor::Tail,
             body: TransientMessageBody::Loading("Reviewing changes".to_string()),
-            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::ClearOnNewTurn,
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
             slot: TransientMessageSlot::Review,
             turn_position: None,
         });
@@ -2079,6 +2080,77 @@ mod tests {
         assert!(!text.contains("type \"/apply\" to verify and apply"));
     }
 
+    /// Verifies post-sync work remains below the durable sync result that
+    /// caused it, even while focused review starts in parallel.
+    #[test]
+    fn test_output_lines_orders_post_sync_statuses_chronologically() {
+        // Arrange
+        let mut session = session_fixture();
+        set_conversation_transcript(
+            &mut session,
+            vec![
+                (
+                    SessionMessageKind::AssistantAnswer,
+                    "implemented the change",
+                ),
+                (
+                    SessionMessageKind::WorkflowNotice,
+                    "\n[Sync] Successfully synced wt/session onto origin/main\n",
+                ),
+            ],
+        );
+        session.status = Status::Review;
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::AfterCompletedTurn,
+            body: TransientMessageBody::Markdown("[Commit] No changes to commit.".to_string()),
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::WorkflowNotice,
+            turn_position: session.latest_user_prompt_position(),
+        });
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading(
+                "Auto-pushing published branch after completed turn...".to_string(),
+            ),
+            lifecycle: TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::PublishedBranchSync,
+            turn_position: session.latest_user_prompt_position(),
+        });
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Markdown(
+                "## Review\n\nChronological review result.".to_string(),
+            ),
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::Review,
+            turn_position: session.latest_user_prompt_position(),
+        });
+
+        // Act
+        let text = output_lines(&session, Rect::new(0, 0, 120, 12), line_context(), None)
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let commit_index = text
+            .find("[Commit] No changes to commit.")
+            .expect("commit notice should render");
+        let sync_index = text
+            .find("[Sync] Successfully synced")
+            .expect("sync result should render");
+        let auto_push_index = text
+            .find("Auto-pushing published branch")
+            .expect("auto-push status should render");
+        let review_index = text
+            .find("Chronological review result.")
+            .expect("focused-review status should render");
+
+        // Assert
+        assert!(commit_index < sync_index);
+        assert!(sync_index < auto_push_index);
+        assert!(auto_push_index < review_index);
+    }
+
     /// Verifies focused-review failures remain visible after the transient
     /// loading status returns to `Review`.
     #[test]
@@ -2114,7 +2186,7 @@ mod tests {
         session.transient_messages.upsert(TransientMessage {
             anchor: TransientMessageAnchor::Tail,
             body: TransientMessageBody::Loading("Publishing review request...".to_string()),
-            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::UntilResolved,
+            lifecycle: TransientMessageLifecycle::UntilResolved,
             slot: TransientMessageSlot::BranchPublish,
             turn_position: None,
         });
@@ -2552,7 +2624,7 @@ mod tests {
             body: TransientMessageBody::Markdown(
                 "[Sync] Queued until the current turn finishes.".to_string(),
             ),
-            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::ClearOnNewTurn,
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
             slot: TransientMessageSlot::WorkflowNotice,
             turn_position: session.latest_user_prompt_position(),
         });

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -5,11 +5,13 @@
 //! basics (typing, multiline via Alt+Enter and CSI-u Shift+Enter, cancel via
 //! Esc), and returning to the session list from session view.
 
+use std::io::Read;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
-use std::process::Command;
-use std::time::Duration;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use agentty::db::{DB_DIR, DB_FILE, Database};
 use agentty::domain::agent::ReasoningLevel;
@@ -82,6 +84,12 @@ const MISSING_DECISION_CONTEXT_POLICY_TEXT: &str =
 /// Diagnostic emitted when the focused-review prompt omits saved chat context.
 const MISSING_RESOLVED_DECISION_HISTORY_TEXT: &str =
     "Focused review prompt omitted the resolved session decision.";
+
+/// Wall-clock budget for one seeded git invocation before it is killed.
+const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Poll interval used while waiting for a seeded git invocation to exit.
+const GIT_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
 /// Returns every scrollbar row and the subset occupied by its thumb in the
 /// session output's rightmost column.
@@ -692,6 +700,94 @@ fn seed_rebase_transcript_session(env: &BuilderEnv) -> Result<(), Box<dyn std::e
     std::fs::write(&pre_rebase_hook, "#!/bin/sh\nsleep 5\n")?;
     #[cfg(unix)]
     std::fs::set_permissions(&pre_rebase_hook, std::fs::Permissions::from_mode(0o755))?;
+
+    Ok(())
+}
+
+/// Seeds one synced published session whose next completed turn appends a
+/// durable commit notice and then starts a delayed auto-push, leaving the
+/// earlier sync result, the turn commit notice, and the auto-push progress row
+/// visible in one frame.
+fn seed_published_session_output_chronology(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    seed_session_title_candidate_project(env)?;
+
+    let session_id = "review-shortcut-0001";
+    common::seed_session(
+        env,
+        SessionSeed::regular(session_id, "claude-haiku-4-5-20251001", "main", "Review")
+            .with_title("Chronological session output"),
+    )?;
+
+    // The session worktree must stay a linked worktree of the project
+    // checkout; a standalone repository trips the session isolation guard and
+    // the turn never starts.
+    let remote_path = env.agentty_root.join("chronology-remote.git");
+    let remote_path_text = remote_path.to_string_lossy().into_owned();
+    run_git(&env.workdir, &["init", "--bare", remote_path_text.as_str()])?;
+    run_git(
+        &env.workdir,
+        &["remote", "add", "origin", remote_path_text.as_str()],
+    )?;
+    run_git(&env.workdir, &["push", "--set-upstream", "origin", "main"])?;
+
+    let session_worktree = test_support::session_folder(&env.agentty_root.join("wt"), session_id);
+    let session_worktree_text = session_worktree.to_string_lossy().into_owned();
+    run_git(
+        &env.workdir,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "wt/review-s",
+            session_worktree_text.as_str(),
+        ],
+    )?;
+    run_git(
+        &session_worktree,
+        &["push", "--set-upstream", "origin", "wt/review-s"],
+    )?;
+
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        database
+            .sessions()
+            .update_session_published_upstream_ref(
+                session_id,
+                Some("origin/wt/review-s".to_string()),
+            )
+            .await?;
+        database
+            .sessions()
+            .append_session_message(
+                session_id,
+                SessionMessageKind::WorkflowNotice,
+                "\n[Sync] Successfully synced wt/review-s onto origin/main\n",
+            )
+            .await
+    })?;
+
+    let real_git = std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
+        .map(|path| path.join("git"))
+        .find(|path| path.is_file())
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "git not found"))?;
+    let git_path = env.stub_bin.join("git");
+    let script = format!(
+        r#"#!/bin/sh
+case "$1" in
+  push)
+    sleep 8
+    ;;
+esac
+exec '{}' "$@"
+"#,
+        real_git.display()
+    );
+    std::fs::write(&git_path, script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&git_path, std::fs::Permissions::from_mode(0o755))?;
 
     Ok(())
 }
@@ -1848,43 +1944,83 @@ fn seed_binary_diff_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::
 }
 
 /// Runs one git command in `working_directory`, returning an error with stderr
-/// detail when git fails.
+/// detail when git fails and discarding its stdout.
 fn run_git(working_directory: &Path, args: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(working_directory)
-        .output()?;
-    if !output.status.success() {
-        return Err(std::io::Error::other(format!(
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        ))
-        .into());
-    }
+    run_git_stdout(working_directory, args)?;
 
     Ok(())
 }
 
 /// Runs one git command in `working_directory` and returns trimmed stdout.
+///
+/// The child is killed and reported as an error once `GIT_COMMAND_TIMEOUT`
+/// elapses so a stalled git process fails the test instead of hanging CI.
 fn run_git_stdout(
     working_directory: &Path,
     args: &[&str],
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let output = Command::new("git")
+    let mut child = Command::new("git")
         .args(args)
         .current_dir(working_directory)
-        .output()?;
-    if !output.status.success() {
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    // Drain both pipes from reader threads so a chatty git command cannot fill
+    // a pipe buffer and block while the timeout loop polls for exit.
+    let mut child_stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| std::io::Error::other("git stdout pipe missing"))?;
+    let mut child_stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| std::io::Error::other("git stderr pipe missing"))?;
+    let stdout_reader = thread::spawn(move || {
+        let mut stdout = Vec::new();
+        child_stdout.read_to_end(&mut stdout).map(|_| stdout)
+    });
+    let stderr_reader = thread::spawn(move || {
+        let mut stderr = Vec::new();
+        child_stderr.read_to_end(&mut stderr).map(|_| stderr)
+    });
+
+    let deadline = Instant::now() + GIT_COMMAND_TIMEOUT;
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+
+        if Instant::now() >= deadline {
+            child.kill()?;
+            child.wait()?;
+
+            return Err(std::io::Error::other(format!(
+                "git {} timed out after {GIT_COMMAND_TIMEOUT:?}",
+                args.join(" ")
+            ))
+            .into());
+        }
+
+        thread::sleep(GIT_COMMAND_POLL_INTERVAL);
+    };
+
+    let stdout = stdout_reader
+        .join()
+        .map_err(|_| std::io::Error::other("git stdout reader panicked"))??;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| std::io::Error::other("git stderr reader panicked"))??;
+    if !status.success() {
         return Err(std::io::Error::other(format!(
             "git {} failed: {}",
             args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
+            String::from_utf8_lossy(&stderr)
         ))
         .into());
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    Ok(String::from_utf8_lossy(&stdout).trim().to_string())
 }
 
 /// Installs a deterministic `gh` stub that returns review-request status.
@@ -3374,6 +3510,73 @@ fn session_rebase_keeps_completed_transcript_before_summary() -> E2eResult {
                     .rect
                     .row;
                 assert!(answer_row < summary_row);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify post-turn auto-push progress renders below every durable notice that
+/// preceded it — the earlier sync result and the completed turn's commit
+/// notice — preserving workflow chronology in session output.
+#[test]
+fn test_session_output_chronology() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_output_chronology")
+        .with_git()
+        .with_terminal_size(120, 30)
+        .setup(seed_published_session_output_chronology)
+        .zola(
+            "Chronological session output",
+            "Follow sync, commit, and auto-push progress in execution order.",
+            44,
+        )
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("Enter")
+                    .wait_for_text("Enter: reply", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Type your message", 5000)
+                    .write_text("Continue after the sync")
+                    .press_key("Enter")
+                    .wait_for_text("Got it. What would you like me to do?", 30000)
+                    .wait_for_text("Auto-pushing", 10000)
+                    .viewing_pause_ms(1000)
+                    .capture_labeled(
+                        "session_output_chronology",
+                        "Earlier sync and commit results remain above later auto-push progress",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                let view_text = frame.text_in_region(&full);
+                // Row lookup goes through the rendered lines instead of
+                // `find_text` because unpainted terminal cells drop the spaces
+                // inside multi-word notices.
+                let notice_row =
+                    |needle: &str| view_text.lines().position(|line| line.contains(needle));
+                for needle in [
+                    "[Sync] Successfully synced",
+                    "[Commit] No changes to commit.",
+                    "Auto-pushing published branch",
+                ] {
+                    assert!(
+                        notice_row(needle).is_some(),
+                        "missing `{needle}` in frame:\n{view_text}"
+                    );
+                }
+
+                let sync_row = notice_row("[Sync] Successfully synced").expect("sync result row");
+                let commit_row =
+                    notice_row("[Commit] No changes to commit.").expect("turn commit notice row");
+                let auto_push_row =
+                    notice_row("Auto-pushing published branch").expect("auto-push status row");
+
+                assert!(sync_row < commit_row);
+                assert!(commit_row < auto_push_row);
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -179,10 +179,12 @@ Published-branch auto-push completion sends one terminal reducer event carrying 
 `WorkflowNotice`. After accepting the current operation identifier, the reducer persists
 the notice, retracts the matching loading slot, and projects the durable transcript
 message in the same batch. Stale completions therefore cannot write a notice, and no
-frame can contain both the progress row and completed notice. The output-layout cache
-keys the transient-store version rather than maintaining a separate fingerprint for
-every temporary channel. Structured clarification questions render in the bottom
-question panel (`AppMode::Question`), not inside the output component.
+frame can contain both the progress row and completed notice. The in-progress auto-push
+slot uses the session-output tail so a durable sync result that started the push remains
+above it in chronological order; focused-review progress follows in the status tail. The
+output-layout cache keys the transient-store version rather than maintaining a separate
+fingerprint for every temporary channel. Structured clarification questions render in
+the bottom question panel (`AppMode::Question`), not inside the output component.
 
 Runtime owns one shared `RenderCacheStore` for markdown, diff, and session-output layout
 caches. The session-output cache keeps a bounded stable-body layer keyed by the typed

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -223,6 +223,10 @@ branch-publish ownership before it queues or starts, and retains that ownership 
 its post-rebase push. A completed turn or subsequent sync therefore cannot start a
 competing published-branch auto-push.
 
+Session output keeps workflow feedback in execution order. Commit feedback appears
+before its sync result, post-sync auto-push progress appears after that result, and
+focused-review progress remains at the tail while those branch operations finish.
+
 ### Focused Review
 
 When a session enters **Review**, Agentty starts generating a focused review in the


### PR DESCRIPTION
- Preserve transient status insertion order and focused-review placement.
- Anchor published-branch auto-push progress at the session-output tail.
- Add unit and E2E coverage for workflow status ordering.
- Document chronological workflow feedback in runtime and workflow guides.
- Anchor-group the transient-store fingerprint so display-invisible ordering differences reuse the cached layout.
- Enforce a subprocess timeout in the E2E git helper.
- Feature GIF and Zola feature page remain ungenerated because VHS recording needs the pinned container or an unsandboxed run.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)