### PR TITLE
Separate orchestration policy from application runtime

### DIFF
--- a/crates/agentty/src/app/AGENTS.md
+++ b/crates/agentty/src/app/AGENTS.md
@@ -17,15 +17,17 @@ Application-layer workflows and orchestration.
   - `SessionRuntimeHandle` implements the frontend-neutral `ag-session` `SessionBackend`
     port; `session_api.rs` executes accepted commands against the foreground-owned
     runtime and host services.
-  - `SessionManager` inside the runtime owns session snapshots, runtime handles, and
-    session worker queues.
+  - `SessionManager` inside the runtime coordinates session snapshots, workflow state,
+    and session worker queues.
   - `ProjectManager` owns project list, active project context, and git status tracking
     state.
   - `AppServices` holds shared dependencies (`Database`, base path, app-event sender).
 - Session state model:
   - `Session` is a render-friendly data snapshot.
-  - `SessionHandles` stores shared runtime channels used by background tasks.
-  - `SessionState` performs handle-to-snapshot sync before render.
+  - `SessionRuntimeState` owns `SessionHandles`, which store shared runtime channels
+    used by background tasks.
+  - `SessionState` owns persisted/render-friendly projections and performs
+    handle-to-snapshot sync before render.
 - Event model:
   - `AppEvent` is the internal bus between background workflows and the runtime loop.
   - `SessionRuntimeCommand` carries programmatic session requests through a bounded
@@ -33,7 +35,8 @@ Application-layer workflows and orchestration.
   - Runtime handles observe a reference-counted foreground-consumer signal, rejecting
     requests while no command consumer is registered and abandoning pending waits when
     the final consumer exits.
-  - `apply_app_events()` is the reducer for app-side async mutations.
+  - `apply_app_events()` coalesces app-side async mutations; each batch first produces a
+    deterministic state/effect plan, then the app executes the ordered effects.
   - The foreground event loop selects between `AppEvent` values and session-runtime
     commands so both mutate reducer-owned state on the same task.
   - Programmatic creation reloads the active-project session snapshot before

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -312,6 +312,23 @@ pub(super) struct AppEventBatch {
     pub(super) update_status: Option<UpdateStatus>,
 }
 
+/// Ordered external effects planned before an app-event batch mutates state.
+#[derive(Debug, Eq, PartialEq)]
+enum AppEventEffect {
+    ReloadSessions,
+    ReloadProjects,
+    RefreshGitStatus,
+    ApplyReviewUpdates(HashMap<SessionId, ReviewUpdate>),
+}
+
+/// Deterministic state/effect plan derived from one coalesced event batch.
+#[derive(Debug, Eq, PartialEq)]
+struct AppEventReductionPlan {
+    after_snapshot_effects: Vec<AppEventEffect>,
+    before_snapshot_effects: Vec<AppEventEffect>,
+    changes_observable_state: bool,
+}
+
 /// Completed selected issue-detail load ready for reducer application.
 pub(super) struct IssueDetailUpdate {
     pub(super) display_id: String,
@@ -373,6 +390,66 @@ pub(super) struct RequestedReviewCommentSnapshotUpdate {
 }
 
 impl AppEventBatch {
+    /// Drains payload-bearing updates into an ordered effect plan without
+    /// mutating application state or performing I/O.
+    ///
+    /// The batch remains available for later reducer phases, but updates
+    /// moved into the returned plan must not be read from the batch again.
+    fn drain_reduction_plan(&mut self) -> AppEventReductionPlan {
+        let mut before_snapshot_effects = Vec::new();
+        if self.should_reload_sessions {
+            before_snapshot_effects.push(AppEventEffect::ReloadSessions);
+        }
+        if self.should_reload_projects {
+            before_snapshot_effects.push(AppEventEffect::ReloadProjects);
+        }
+        if self.should_refresh_git_status {
+            before_snapshot_effects.push(AppEventEffect::RefreshGitStatus);
+        }
+        let changes_observable_state = self.should_reload_sessions
+            || self.should_reload_projects
+            || self.agent_cli_updates.is_some()
+            || self.assigned_issues.is_some()
+            || self.git_status_update.is_some()
+            || !self.issue_details.is_empty()
+            || self.latest_available_version_update.is_some()
+            || self.update_status.is_some()
+            || !self.applied_turns.is_empty()
+            || !self.at_mention_entries_updates.is_empty()
+            || !self.branch_publish_action_updates.is_empty()
+            || !self.diff_preview_updates.is_empty()
+            || !self.published_branch_sync_updates.is_empty()
+            || !self.review_request_status_updates.is_empty()
+            || self.requested_reviews.is_some()
+            || !self.requested_review_comment_snapshots.is_empty()
+            || !self.review_updates.is_empty()
+            || !self.session_model_updates.is_empty()
+            || !self.session_orchestration_progress_updates.is_empty()
+            || !self.session_personality_updates.is_empty()
+            || !self.session_progress_updates.is_empty()
+            || !self.session_review_comment_snapshots.is_empty()
+            || !self.session_reasoning_level_updates.is_empty()
+            || !self.session_speed_mode_updates.is_empty()
+            || !self.session_diff_stats_updates.is_empty()
+            || !self.session_title_generation_finished.is_empty()
+            || !self.session_workflow_notice_updates.is_empty()
+            || !self.stacked_parent_merge_child_rebases.is_empty()
+            || !self.stacked_parent_syncs_completed.is_empty()
+            || !self.stacked_parent_turns_completed.is_empty()
+            || self.sync_main_conflicted_files.is_some()
+            || self.sync_main_result.is_some();
+        let after_snapshot_effects = (!self.review_updates.is_empty())
+            .then(|| AppEventEffect::ApplyReviewUpdates(std::mem::take(&mut self.review_updates)))
+            .into_iter()
+            .collect();
+
+        AppEventReductionPlan {
+            after_snapshot_effects,
+            before_snapshot_effects,
+            changes_observable_state,
+        }
+    }
+
     /// Collects one app event into the coalesced batch state.
     ///
     /// Most per-session projections use latest-wins semantics, but queued
@@ -941,23 +1018,22 @@ impl App {
     /// so background workers can shut down provider runtimes.
     async fn apply_app_event_batch(&mut self, mut event_batch: AppEventBatch) {
         let sync_generation_for_review_updates = self.sync_handle.current_generation();
-        let mut should_mark_dirty = Self::app_event_batch_changes_observable_state(&event_batch);
+        let AppEventReductionPlan {
+            after_snapshot_effects,
+            before_snapshot_effects,
+            changes_observable_state,
+        } = event_batch.drain_reduction_plan();
+        let mut should_mark_dirty = changes_observable_state;
         let previous_session_states = self.previous_session_states(&event_batch.session_ids);
 
         should_mark_dirty |=
             self.update_session_redraw_versions(&event_batch.session_update_versions);
 
-        self.apply_batch_runtime_updates(&mut event_batch).await;
+        self.apply_app_event_effects(before_snapshot_effects).await;
+        self.apply_batch_runtime_updates(&mut event_batch);
 
         self.apply_batch_session_snapshot_updates(&mut event_batch);
-
-        let focused_review_persistence = apply_review_updates(
-            &mut self.review_cache,
-            self.sessions.state_mut(),
-            std::mem::take(&mut event_batch.review_updates),
-        );
-        self.persist_focused_review_updates(focused_review_persistence)
-            .await;
+        self.apply_app_event_effects(after_snapshot_effects).await;
 
         for branch_publish_action_update in
             std::mem::take(&mut event_batch.branch_publish_action_updates)
@@ -1164,21 +1240,28 @@ impl App {
         );
     }
 
-    /// Applies reducer-batch updates that affect global app runtime state
-    /// before session-local projections are synchronized.
-    async fn apply_batch_runtime_updates(&mut self, event_batch: &mut AppEventBatch) {
-        if event_batch.should_reload_sessions {
-            self.refresh_sessions_now().await;
+    /// Executes the ordered external effects from a pure reduction plan.
+    async fn apply_app_event_effects(&mut self, effects: Vec<AppEventEffect>) {
+        for effect in effects {
+            match effect {
+                AppEventEffect::ReloadSessions => self.refresh_sessions_now().await,
+                AppEventEffect::ReloadProjects => self.reload_projects().await,
+                AppEventEffect::RefreshGitStatus => self.restart_git_status_task(),
+                AppEventEffect::ApplyReviewUpdates(review_updates) => {
+                    let focused_review_persistence = apply_review_updates(
+                        &mut self.review_cache,
+                        self.sessions.state_mut(),
+                        review_updates,
+                    );
+                    self.persist_focused_review_updates(focused_review_persistence)
+                        .await;
+                }
+            }
         }
+    }
 
-        if event_batch.should_reload_projects {
-            self.reload_projects().await;
-        }
-
-        if event_batch.should_refresh_git_status {
-            self.restart_git_status_task();
-        }
-
+    /// Applies reducer-batch payloads that mutate global app runtime state.
+    fn apply_batch_runtime_updates(&mut self, event_batch: &mut AppEventBatch) {
         if let Some(agent_clis) = event_batch.agent_cli_updates.take() {
             self.services.replace_available_agent_clis(agent_clis);
         }
@@ -1495,45 +1578,6 @@ impl App {
                     .map(|session| (session_id.clone(), session.status))
             })
             .collect()
-    }
-
-    /// Returns whether one reduced event batch changes any render-visible
-    /// application state before `SessionUpdated` version deduplication.
-    fn app_event_batch_changes_observable_state(event_batch: &AppEventBatch) -> bool {
-        event_batch.should_reload_sessions
-            || event_batch.should_reload_projects
-            || event_batch.agent_cli_updates.is_some()
-            || event_batch.assigned_issues.is_some()
-            || event_batch.git_status_update.is_some()
-            || !event_batch.issue_details.is_empty()
-            || event_batch.latest_available_version_update.is_some()
-            || event_batch.update_status.is_some()
-            || !event_batch.applied_turns.is_empty()
-            || !event_batch.at_mention_entries_updates.is_empty()
-            || !event_batch.branch_publish_action_updates.is_empty()
-            || !event_batch.diff_preview_updates.is_empty()
-            || !event_batch.published_branch_sync_updates.is_empty()
-            || !event_batch.review_request_status_updates.is_empty()
-            || event_batch.requested_reviews.is_some()
-            || !event_batch.requested_review_comment_snapshots.is_empty()
-            || !event_batch.review_updates.is_empty()
-            || !event_batch.session_model_updates.is_empty()
-            || !event_batch
-                .session_orchestration_progress_updates
-                .is_empty()
-            || !event_batch.session_personality_updates.is_empty()
-            || !event_batch.session_progress_updates.is_empty()
-            || !event_batch.session_review_comment_snapshots.is_empty()
-            || !event_batch.session_reasoning_level_updates.is_empty()
-            || !event_batch.session_speed_mode_updates.is_empty()
-            || !event_batch.session_diff_stats_updates.is_empty()
-            || !event_batch.session_title_generation_finished.is_empty()
-            || !event_batch.session_workflow_notice_updates.is_empty()
-            || !event_batch.stacked_parent_merge_child_rebases.is_empty()
-            || !event_batch.stacked_parent_syncs_completed.is_empty()
-            || !event_batch.stacked_parent_turns_completed.is_empty()
-            || event_batch.sync_main_conflicted_files.is_some()
-            || event_batch.sync_main_result.is_some()
     }
 
     /// Updates the loading sync popup with the current conflict-resolution
@@ -2913,7 +2957,7 @@ mod tests {
         });
 
         // Assert
-        assert!(App::app_event_batch_changes_observable_state(&event_batch));
+        assert!(event_batch.drain_reduction_plan().changes_observable_state);
     }
 
     #[test]
@@ -2930,7 +2974,82 @@ mod tests {
         });
 
         // Assert
-        assert!(App::app_event_batch_changes_observable_state(&event_batch));
+        assert!(event_batch.drain_reduction_plan().changes_observable_state);
+    }
+
+    #[test]
+    fn reduction_plan_orders_external_effects_without_running_them() {
+        // Arrange
+        let mut event_batch = AppEventBatch {
+            should_refresh_git_status: true,
+            should_reload_projects: true,
+            should_reload_sessions: true,
+            ..AppEventBatch::default()
+        };
+
+        // Act
+        let reduction_plan = event_batch.drain_reduction_plan();
+
+        // Assert
+        assert_eq!(
+            reduction_plan,
+            AppEventReductionPlan {
+                after_snapshot_effects: Vec::new(),
+                before_snapshot_effects: vec![
+                    AppEventEffect::ReloadSessions,
+                    AppEventEffect::ReloadProjects,
+                    AppEventEffect::RefreshGitStatus,
+                ],
+                changes_observable_state: true,
+            }
+        );
+    }
+
+    #[test]
+    fn reduction_plan_keeps_an_empty_batch_pure_and_invisible() {
+        // Arrange
+        let mut event_batch = AppEventBatch::default();
+
+        // Act
+        let reduction_plan = event_batch.drain_reduction_plan();
+
+        // Assert
+        assert_eq!(
+            reduction_plan,
+            AppEventReductionPlan {
+                after_snapshot_effects: Vec::new(),
+                before_snapshot_effects: Vec::new(),
+                changes_observable_state: false,
+            }
+        );
+    }
+
+    #[test]
+    fn reduction_plan_orders_review_persistence_after_snapshot_updates() {
+        // Arrange
+        let mut event_batch = AppEventBatch::default();
+        event_batch.collect_event(AppEvent::ReviewPrepared {
+            diff_hash: 42,
+            review_text: "review output".to_string(),
+            session_id: "session-1".into(),
+        });
+
+        // Act
+        let reduction_plan = event_batch.drain_reduction_plan();
+
+        // Assert
+        assert_eq!(
+            reduction_plan.after_snapshot_effects,
+            vec![AppEventEffect::ApplyReviewUpdates(HashMap::from([(
+                "session-1".into(),
+                ReviewUpdate {
+                    diff_hash: 42,
+                    result: Ok("review output".to_string()),
+                },
+            )]))]
+        );
+        assert!(reduction_plan.before_snapshot_effects.is_empty());
+        assert!(reduction_plan.changes_observable_state);
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/orchestration.rs
+++ b/crates/agentty/src/app/orchestration.rs
@@ -20,7 +20,10 @@ use tracing::warn;
 
 use crate::app::AppEvent;
 use crate::app::session::session_branch;
-use crate::domain::orchestration::{OrchestrationStatus, OrchestrationTaskStatus};
+use crate::domain::orchestration::{
+    OrchestrationPlanTask, OrchestrationPolicy, OrchestrationStatus, OrchestrationTaskStatus,
+    validate_subtasks as validate_orchestration_plan,
+};
 use crate::domain::setting::{
     DEFAULT_ORCHESTRATION_PARALLELISM, MAX_ORCHESTRATION_PARALLELISM, SettingName,
 };
@@ -420,19 +423,15 @@ impl OrchestrationCoordinator {
             self.reconcile_task(task).await?;
         }
 
-        let occupied_slots = tasks
-            .iter()
-            .filter(|task| {
-                task_status(task).is_some_and(OrchestrationTaskStatus::occupies_parallelism_slot)
-            })
-            .count();
-        let available_slots = usize::try_from(orchestration.max_parallelism)
-            .unwrap_or_default()
-            .saturating_sub(occupied_slots);
+        let task_statuses = tasks.iter().map(task_status).collect::<Vec<_>>();
+        let decision = OrchestrationPolicy::schedule(
+            usize::try_from(orchestration.max_parallelism).unwrap_or_default(),
+            &task_statuses,
+        );
         for task in tasks
             .iter_mut()
             .filter(|task| task_status(task) == Some(OrchestrationTaskStatus::Planned))
-            .take(available_slots)
+            .take(decision.spawn_count)
         {
             self.spawn_task(orchestration, task).await?;
         }
@@ -442,11 +441,12 @@ impl OrchestrationCoordinator {
             .load_orchestration_tasks(orchestration.id)
             .await
             .map_err(|error| error.to_string())?;
-        if !refreshed.is_empty()
-            && refreshed
-                .iter()
-                .all(|task| task_status(task).is_some_and(OrchestrationTaskStatus::is_settled))
-        {
+        let refreshed_statuses = refreshed.iter().map(task_status).collect::<Vec<_>>();
+        let refreshed_decision = OrchestrationPolicy::schedule(
+            usize::try_from(orchestration.max_parallelism).unwrap_or_default(),
+            &refreshed_statuses,
+        );
+        if refreshed_decision.should_submit {
             self.clear_live_status(orchestration);
             let claimed = self
                 .repository
@@ -537,7 +537,7 @@ impl OrchestrationCoordinator {
             .as_deref()
             .and_then(|status| status.parse::<SessionStatus>().ok())
             .unwrap_or(SessionStatus::Canceled);
-        let next = task_status_from_child(child_status);
+        let next = OrchestrationTaskStatus::from_child_status(child_status);
         self.update_task_status(task, next, None).await?;
         if next == OrchestrationTaskStatus::Ready {
             let summary = bounded_summary(task.child_summary.as_deref().unwrap_or("Completed"));
@@ -714,81 +714,17 @@ impl OrchestrationCoordinator {
 }
 
 fn validate_subtasks(subtasks: &[SubtaskItem], is_retry: bool) -> Result<(), String> {
-    if subtasks.len() < 2 && !is_retry {
-        return Err("a meaningful orchestration requires at least two subtasks.".to_string());
-    }
-    let mut task_keys = HashSet::new();
-    let mut scopes = Vec::<(&str, String)>::new();
-    for subtask in subtasks {
-        if !is_kebab_case_task_key(&subtask.task_key)
-            || !task_keys.insert(subtask.task_key.as_str())
-        {
-            return Err("every subtask needs a unique kebab-case task key.".to_string());
-        }
-        if subtask.prompt.trim().is_empty()
-            || subtask.title.trim().is_empty()
-            || subtask.touched_areas.is_empty()
-        {
-            return Err(format!(
-                "subtask `{}` needs a title, standalone prompt, and touched areas.",
-                subtask.task_key
-            ));
-        }
-        for area in &subtask.touched_areas {
-            let scope = normalized_scope(area).map_err(|reason| {
-                format!(
-                    "subtask `{}` has invalid touched area `{area}`: {reason}.",
-                    subtask.task_key
-                )
-            })?;
-            if let Some((other_key, _)) = scopes.iter().find(|(other_key, other_scope)| {
-                *other_key != subtask.task_key && scopes_overlap(other_scope, &scope)
-            }) {
-                return Err(format!(
-                    "subtasks `{other_key}` and `{}` overlap at `{area}`.",
-                    subtask.task_key
-                ));
-            }
-            scopes.push((subtask.task_key.as_str(), scope));
-        }
-    }
-
-    Ok(())
-}
-
-fn is_kebab_case_task_key(task_key: &str) -> bool {
-    !task_key.is_empty()
-        && task_key.split('-').all(|segment| {
-            !segment.is_empty()
-                && segment
-                    .bytes()
-                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+    let plan = subtasks
+        .iter()
+        .map(|subtask| OrchestrationPlanTask {
+            prompt: subtask.prompt.clone(),
+            task_key: subtask.task_key.clone(),
+            title: subtask.title.clone(),
+            touched_areas: subtask.touched_areas.clone(),
         })
-}
+        .collect::<Vec<_>>();
 
-fn normalized_scope(area: &str) -> Result<String, &'static str> {
-    let normalized = area.trim().trim_start_matches("./").trim_end_matches('/');
-    if normalized.is_empty()
-        || normalized.starts_with('/')
-        || normalized.split('/').any(|part| part == "..")
-    {
-        return Err("use a non-empty repository-relative path");
-    }
-    if normalized.contains(['*', '?', '[', ']', '{', '}']) {
-        return Err("use a literal file or directory path; wildcard patterns are not supported");
-    }
-
-    Ok(normalized.to_string())
-}
-
-fn scopes_overlap(left: &str, right: &str) -> bool {
-    left == right
-        || left
-            .strip_prefix(right)
-            .is_some_and(|suffix| suffix.starts_with('/'))
-        || right
-            .strip_prefix(left)
-            .is_some_and(|suffix| suffix.starts_with('/'))
+    validate_orchestration_plan(&plan, is_retry)
 }
 
 async fn reusable_retry_orchestration_id(
@@ -868,22 +804,6 @@ pub(crate) fn child_session_is_stopped(status: Option<&str>) -> bool {
                 SessionStatus::Merged | SessionStatus::Done | SessionStatus::Canceled
             )
         })
-}
-
-fn task_status_from_child(status: SessionStatus) -> OrchestrationTaskStatus {
-    match status {
-        SessionStatus::Draft
-        | SessionStatus::InProgress
-        | SessionStatus::Queued
-        | SessionStatus::Rebasing
-        | SessionStatus::Merging => OrchestrationTaskStatus::Running,
-        SessionStatus::Question => OrchestrationTaskStatus::WaitingForInput,
-        SessionStatus::Review
-        | SessionStatus::AgentReview
-        | SessionStatus::Merged
-        | SessionStatus::Done => OrchestrationTaskStatus::Ready,
-        SessionStatus::Canceled => OrchestrationTaskStatus::Failed,
-    }
 }
 
 fn child_prompt(task: &SessionOrchestrationTaskRow) -> String {
@@ -1531,7 +1451,10 @@ mod tests {
 
         // Act / Assert
         for (status, task_status) in expected {
-            assert_eq!(task_status_from_child(status), task_status);
+            assert_eq!(
+                OrchestrationTaskStatus::from_child_status(status),
+                task_status
+            );
         }
     }
 

--- a/crates/agentty/src/app/review.rs
+++ b/crates/agentty/src/app/review.rs
@@ -513,21 +513,7 @@ fn update_transient_review_status(
     current_status: Status,
     next_status: Status,
 ) {
-    if let Some(session) = session_state
-        .sessions_mut()
-        .iter_mut()
-        .find(|session| session.id == session_id)
-        && session.status == current_status
-    {
-        session.status = next_status;
-    }
-
-    if let Some(handles) = session_state.handles().get(session_id)
-        && let Ok(mut handle_status) = handles.status.lock()
-        && *handle_status == current_status
-    {
-        *handle_status = next_status;
-    }
+    session_state.transition_status_if_current(session_id, current_status, next_status);
 }
 
 #[cfg(test)]

--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -160,12 +160,17 @@ pub struct SessionManager {
     pub(super) default_session_model: AgentModel,
     pub(super) git_client: Arc<dyn git::GitClient>,
     pub(super) merge_service: SessionMergeService,
-    pub(super) pending_history_replay: HashSet<SessionId>,
-    pub(super) published_branch_sync_operations: HashMap<SessionId, String>,
     pub(super) state: SessionState,
     pub(super) stats_activity: Vec<DailyActivity>,
-    pub(super) title_generation_tasks: HashMap<SessionId, TitleGenerationTask>,
+    pub(super) workflow_state: SessionWorkflowState,
     pub(super) worker_service: SessionWorkerService,
+}
+
+/// Live bookkeeping shared by session lifecycle workflows.
+pub(super) struct SessionWorkflowState {
+    pub(super) pending_history_replay: HashSet<SessionId>,
+    pub(super) published_branch_sync_operations: HashMap<SessionId, String>,
+    pub(super) title_generation_tasks: HashMap<SessionId, TitleGenerationTask>,
 }
 
 /// Tracks one draft-title generation task plus the generation used to identify
@@ -201,11 +206,13 @@ impl SessionManager {
             default_session_model: defaults.model,
             git_client,
             merge_service: SessionMergeService,
-            pending_history_replay,
-            published_branch_sync_operations: HashMap::new(),
             state,
             stats_activity,
-            title_generation_tasks: HashMap::new(),
+            workflow_state: SessionWorkflowState {
+                pending_history_replay,
+                published_branch_sync_operations: HashMap::new(),
+                title_generation_tasks: HashMap::new(),
+            },
             worker_service: SessionWorkerService::new(),
         }
     }
@@ -220,13 +227,16 @@ impl SessionManager {
         generation: u64,
         title_generation_task: JoinHandle<()>,
     ) {
-        if let Some(existing_task) = self.title_generation_tasks.remove(session_id)
+        if let Some(existing_task) = self
+            .workflow_state
+            .title_generation_tasks
+            .remove(session_id)
             && !existing_task.join_handle.is_finished()
         {
             existing_task.join_handle.abort();
         }
 
-        self.title_generation_tasks.insert(
+        self.workflow_state.title_generation_tasks.insert(
             SessionId::from(session_id),
             TitleGenerationTask {
                 generation,
@@ -238,7 +248,10 @@ impl SessionManager {
     /// Aborts and forgets any tracked staged title-generation task for one
     /// session.
     pub(crate) fn abort_title_generation_task(&mut self, session_id: &str) {
-        if let Some(existing_task) = self.title_generation_tasks.remove(session_id)
+        if let Some(existing_task) = self
+            .workflow_state
+            .title_generation_tasks
+            .remove(session_id)
             && !existing_task.join_handle.is_finished()
         {
             existing_task.join_handle.abort();
@@ -248,7 +261,8 @@ impl SessionManager {
     /// Returns the next tracked generation number for one session's draft
     /// title-generation task.
     pub(crate) fn next_title_generation_task_generation(&self, session_id: &str) -> u64 {
-        self.title_generation_tasks
+        self.workflow_state
+            .title_generation_tasks
             .get(session_id)
             .map_or(1, |tracked_task| tracked_task.generation.saturating_add(1))
     }
@@ -261,12 +275,15 @@ impl SessionManager {
         generation: u64,
     ) {
         let should_clear = self
+            .workflow_state
             .title_generation_tasks
             .get(session_id)
             .is_some_and(|tracked_task| tracked_task.generation == generation);
 
         if should_clear {
-            self.title_generation_tasks.remove(session_id);
+            self.workflow_state
+                .title_generation_tasks
+                .remove(session_id);
         }
     }
 
@@ -391,7 +408,7 @@ impl SessionManager {
     pub(crate) fn session_handles(
         &self,
     ) -> &HashMap<SessionId, crate::domain::session::SessionHandles> {
-        &self.state.handles
+        self.state.handles()
     }
 
     /// Returns mutable runtime handles keyed by stable session id.
@@ -399,7 +416,7 @@ impl SessionManager {
     pub(crate) fn session_handles_mut(
         &mut self,
     ) -> &mut HashMap<SessionId, crate::domain::session::SessionHandles> {
-        &mut self.state.handles
+        self.state.handles_mut()
     }
 
     /// Returns the active prompt transcript block cached for sessions that are
@@ -597,7 +614,8 @@ impl SessionManager {
         session_id: &str,
         sync_operation_id: String,
     ) {
-        self.published_branch_sync_operations
+        self.workflow_state
+            .published_branch_sync_operations
             .insert(SessionId::from(session_id), sync_operation_id);
 
         if let Some(session) = self
@@ -626,7 +644,10 @@ impl SessionManager {
         sync_operation_id: &str,
         persistent_notice: Option<&str>,
     ) -> bool {
-        let Some(current_operation_id) = self.published_branch_sync_operations.get(session_id)
+        let Some(current_operation_id) = self
+            .workflow_state
+            .published_branch_sync_operations
+            .get(session_id)
         else {
             return false;
         };
@@ -634,7 +655,9 @@ impl SessionManager {
             return false;
         }
 
-        self.published_branch_sync_operations.remove(session_id);
+        self.workflow_state
+            .published_branch_sync_operations
+            .remove(session_id);
 
         let appended_to_handle = persistent_notice.is_some_and(|persistent_notice| {
             self.append_workflow_notice_to_handle(session_id, persistent_notice)
@@ -1018,7 +1041,7 @@ impl SessionManager {
     /// Appends one workflow notice to a live transcript handle when the
     /// session currently owns one.
     fn append_workflow_notice_to_handle(&self, session_id: &str, persistent_notice: &str) -> bool {
-        let Some(handles) = self.state.handles.get(session_id) else {
+        let Some(handles) = self.state.handle(session_id) else {
             return false;
         };
         let Ok(mut transcript) = handles.transcript.lock() else {

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -2159,9 +2159,13 @@ async fn test_replace_title_generation_task_aborts_superseded_task() {
     .expect("superseded task should abort promptly");
 
     // Assert
-    assert_eq!(session_manager.title_generation_tasks.len(), 1);
+    assert_eq!(
+        session_manager.workflow_state.title_generation_tasks.len(),
+        1
+    );
     assert!(
         session_manager
+            .workflow_state
             .title_generation_tasks
             .contains_key(session_id.as_str())
     );
@@ -2194,9 +2198,13 @@ async fn test_clear_title_generation_task_if_matches_ignores_stale_generation() 
     session_manager.clear_title_generation_task_if_matches(&session_id, 1);
 
     // Assert
-    assert_eq!(session_manager.title_generation_tasks.len(), 1);
+    assert_eq!(
+        session_manager.workflow_state.title_generation_tasks.len(),
+        1
+    );
     assert!(
         session_manager
+            .workflow_state
             .title_generation_tasks
             .contains_key(session_id.as_str())
     );
@@ -2229,7 +2237,12 @@ async fn test_clear_title_generation_task_if_matches_removes_matching_generation
     session_manager.clear_title_generation_task_if_matches(&session_id, 2);
 
     // Assert
-    assert!(session_manager.title_generation_tasks.is_empty());
+    assert!(
+        session_manager
+            .workflow_state
+            .title_generation_tasks
+            .is_empty()
+    );
 }
 
 #[tokio::test]

--- a/crates/agentty/src/app/session/state.rs
+++ b/crates/agentty/src/app/session/state.rs
@@ -6,7 +6,7 @@ use crate::app::session::{Clock, SESSION_REFRESH_INTERVAL};
 use crate::domain::selection::SelectionState;
 #[cfg(test)]
 use crate::domain::session::SessionRole;
-use crate::domain::session::{Session, SessionDiffStats, SessionHandles, SessionId};
+use crate::domain::session::{Session, SessionDiffStats, SessionHandles, SessionId, Status};
 
 /// Cached ahead/behind snapshots for one session branch.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -17,24 +17,51 @@ pub struct SessionGitStatus {
     pub remote_status: Option<(u32, u32)>,
 }
 
+/// Application-owned live state for active session workers.
+///
+/// Keeping synchronization handles behind this boundary distinguishes
+/// worker-owned mutable state from the persisted/render-friendly snapshots in
+/// [`SessionState::sessions`].
+struct SessionRuntimeState {
+    handles: HashMap<SessionId, SessionHandles>,
+}
+
+impl SessionRuntimeState {
+    fn handle(&self, session_id: &str) -> Option<&SessionHandles> {
+        self.handles.get(session_id)
+    }
+
+    fn handles(&self) -> &HashMap<SessionId, SessionHandles> {
+        &self.handles
+    }
+
+    fn handles_mut(&mut self) -> &mut HashMap<SessionId, SessionHandles> {
+        &mut self.handles
+    }
+
+    fn remove_handle(&mut self, session_id: &str) {
+        self.handles.remove(session_id);
+    }
+}
+
 /// Holds all in-memory state related to session listing and refresh tracking.
 pub struct SessionState {
+    pub(super) clock: Arc<dyn Clock>,
     /// Selected follow-up-task positions keyed by session id for session-view
     /// affordances.
     pub(super) follow_up_task_positions: HashMap<SessionId, usize>,
-    pub(super) handles: HashMap<SessionId, SessionHandles>,
-    /// Cached detected branch names keyed by session id.
-    pub(super) session_branch_names: HashMap<SessionId, String>,
-    /// Cached worktree-directory availability keyed by session id.
-    pub(super) session_worktree_availability: HashMap<SessionId, bool>,
-    /// Cached session list positions keyed by stable session id.
-    pub(super) session_index_by_id: HashMap<SessionId, usize>,
-    pub(super) sessions: Vec<Session>,
-    pub(super) table_state: SelectionState,
-    pub(super) clock: Arc<dyn Clock>,
     pub(super) refresh_deadline: Instant,
     pub(super) row_count: i64,
+    runtime: SessionRuntimeState,
+    /// Cached detected branch names keyed by session id.
+    pub(super) session_branch_names: HashMap<SessionId, String>,
     pub(super) session_git_statuses: HashMap<SessionId, SessionGitStatus>,
+    /// Cached session list positions keyed by stable session id.
+    pub(super) session_index_by_id: HashMap<SessionId, usize>,
+    /// Cached worktree-directory availability keyed by session id.
+    pub(super) session_worktree_availability: HashMap<SessionId, bool>,
+    pub(super) sessions: Vec<Session>,
+    pub(super) table_state: SelectionState,
     pub(super) updated_at_max: i64,
 }
 
@@ -54,17 +81,17 @@ impl SessionState {
         let _state_created_at = clock.now_system_time();
         let refresh_deadline = clock.now_instant() + SESSION_REFRESH_INTERVAL;
         let mut state = Self {
-            follow_up_task_positions: HashMap::new(),
-            handles,
-            session_branch_names: HashMap::new(),
-            session_worktree_availability: HashMap::new(),
-            session_index_by_id: HashMap::new(),
-            sessions: Vec::new(),
-            table_state,
             clock,
+            follow_up_task_positions: HashMap::new(),
             refresh_deadline,
             row_count,
+            runtime: SessionRuntimeState { handles },
+            session_branch_names: HashMap::new(),
             session_git_statuses: HashMap::new(),
+            session_index_by_id: HashMap::new(),
+            session_worktree_availability: HashMap::new(),
+            sessions: Vec::new(),
+            table_state,
             updated_at_max,
         };
 
@@ -92,8 +119,47 @@ impl SessionState {
     }
 
     /// Returns runtime handles keyed by stable session id.
-    pub(crate) fn handles(&self) -> &HashMap<SessionId, SessionHandles> {
-        &self.handles
+    pub(in crate::app::session) fn handles(&self) -> &HashMap<SessionId, SessionHandles> {
+        self.runtime.handles()
+    }
+
+    /// Returns mutable runtime handles for workflow loading and test setup.
+    pub(in crate::app::session) fn handles_mut(
+        &mut self,
+    ) -> &mut HashMap<SessionId, SessionHandles> {
+        self.runtime.handles_mut()
+    }
+
+    /// Returns one active session's live runtime handles.
+    pub(in crate::app::session) fn handle(&self, session_id: &str) -> Option<&SessionHandles> {
+        self.runtime.handle(session_id)
+    }
+
+    /// Removes live runtime state for one session that left the snapshot.
+    pub(in crate::app::session) fn remove_handle(&mut self, session_id: &str) {
+        self.runtime.remove_handle(session_id);
+    }
+
+    /// Applies one optimistic status transition to both the render snapshot
+    /// and live runtime handle when each still matches `current_status`.
+    pub(crate) fn transition_status_if_current(
+        &mut self,
+        session_id: &str,
+        current_status: Status,
+        next_status: Status,
+    ) {
+        if let Some(session) = self.session_mut_for_id(session_id)
+            && session.status == current_status
+        {
+            session.status = next_status;
+        }
+
+        if let Some(handles) = self.runtime.handle(session_id)
+            && let Ok(mut handle_status) = handles.status.lock()
+            && *handle_status == current_status
+        {
+            *handle_status = next_status;
+        }
     }
 
     /// Returns the current wall-clock value from the injected clock.
@@ -159,7 +225,7 @@ impl SessionState {
         let Some(session_index) = self.session_index_for_id(session_id) else {
             return;
         };
-        let Some(session_handles) = self.handles.get(session_id) else {
+        let Some(session_handles) = self.runtime.handle(session_id) else {
             return;
         };
         let Some(session) = self.sessions.get_mut(session_index) else {
@@ -176,7 +242,7 @@ impl SessionState {
     /// queued `SessionUpdated` events. This full sweep remains for explicit
     /// catch-up paths and focused tests.
     pub fn sync_from_handles(&mut self) {
-        let handles = &self.handles;
+        let handles = self.runtime.handles();
 
         for session in &mut self.sessions {
             let Some(session_handles) = handles.get(&session.id) else {
@@ -539,6 +605,46 @@ mod tests {
         // Assert
         assert_eq!(session_replay_text(&state.sessions[0]), "new\n\n");
         assert_eq!(state.sessions[0].status, Status::Review);
+    }
+
+    #[test]
+    /// Applies optimistic status transitions through the runtime-state
+    /// boundary without exposing the handle map.
+    fn transition_status_if_current_updates_snapshot_and_live_handle() {
+        // Arrange
+        let session_id = SessionId::from("session-status-transition");
+        let session = SessionFixtureBuilder::new()
+            .id(session_id.as_str())
+            .status(Status::Review)
+            .build();
+        let handles = HashMap::from([(session_id.clone(), SessionHandles::new(Status::Review))]);
+        let mut state = SessionState::new(
+            handles,
+            vec![session],
+            SelectionState::default(),
+            Arc::new(FixedClock::new()),
+            0,
+            0,
+        );
+
+        // Act
+        state.transition_status_if_current(
+            session_id.as_str(),
+            Status::Review,
+            Status::AgentReview,
+        );
+        state.transition_status_if_current(session_id.as_str(), Status::Question, Status::Done);
+
+        // Assert
+        assert_eq!(state.sessions()[0].status, Status::AgentReview);
+        assert_eq!(
+            state.handle(session_id.as_str()).and_then(|handles| handles
+                .status
+                .lock()
+                .ok()
+                .map(|status| *status)),
+            Some(Status::AgentReview)
+        );
     }
 
     #[test]

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -1911,7 +1911,7 @@ impl SessionManager {
         }
 
         let session = self.remove_session_at(selected_index)?;
-        self.state.handles.remove(&session.id);
+        self.state.remove_handle(&session.id);
         self.remove_session_worktree_availability(&session.id);
         self.remove_at_mention_index_for_root(&session.folder);
         self.abort_title_generation_task(&session.id);
@@ -4675,7 +4675,12 @@ mod tests {
         session_manager.track_draft_title_generation_task("session-id", 2, None);
 
         // Assert
-        assert!(session_manager.title_generation_tasks.is_empty());
+        assert!(
+            session_manager
+                .workflow_state
+                .title_generation_tasks
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -468,8 +468,7 @@ impl SessionManager {
     ) {
         let session_transcript = self
             .state
-            .handles
-            .get(session_id)
+            .handle(session_id)
             .and_then(|handles| sync_handle_transcript_with_loaded(handles, Some(&transcript)))
             .or_else(|| Some(transcript).filter(|transcript| !transcript.is_empty()));
 

--- a/crates/agentty/src/app/session/workflow/refresh.rs
+++ b/crates/agentty/src/app/session/workflow/refresh.rs
@@ -122,7 +122,7 @@ impl SessionManager {
                     fs_client: fs_client.as_ref(),
                     working_dir: projects.working_dir(),
                 },
-                &mut self.state.handles,
+                self.state.handles_mut(),
             )
             .await;
         self.state.replace_sessions(sessions);

--- a/crates/agentty/src/app/session/workflow/review.rs
+++ b/crates/agentty/src/app/session/workflow/review.rs
@@ -20,19 +20,24 @@ impl SessionManager {
 
     /// Marks a session id for one-time transcript replay on next reply.
     pub(super) fn mark_history_replay_pending(&mut self, session_id: &str) {
-        self.pending_history_replay
+        self.workflow_state
+            .pending_history_replay
             .insert(SessionId::from(session_id));
     }
 
     /// Clears one-time transcript replay tracking for a session id.
     pub(super) fn clear_history_replay_pending(&mut self, session_id: &str) {
-        self.pending_history_replay.remove(session_id);
+        self.workflow_state
+            .pending_history_replay
+            .remove(session_id);
     }
 
     /// Returns whether a session should replay transcript output on next
     /// reply.
     pub(super) fn should_replay_history(&self, session_id: &str) -> bool {
-        self.pending_history_replay.contains(session_id)
+        self.workflow_state
+            .pending_history_replay
+            .contains(session_id)
     }
 }
 

--- a/crates/agentty/src/domain/AGENTS.md
+++ b/crates/agentty/src/domain/AGENTS.md
@@ -9,6 +9,8 @@ Pure business logic and domain entities, decoupled from UI and infrastructure.
 - `agent.rs` defines provider kinds, models, and model metadata.
 - `session.rs` defines Agentty render/runtime session entities and sizing logic while
   re-exporting shared identity, status, and review-link models from `ag-session`.
+- `orchestration.rs` owns pure plan validation, child-status mapping, parallelism, and
+  roll-up readiness policy; persistence and session-runtime adapters remain in `app/`.
 - `session_message.rs` re-exports durable transcript models from `ag-session`.
 - `project.rs`, `setting.rs`, `permission.rs`, and `input.rs` define shared application
   concepts.

--- a/crates/agentty/src/domain/orchestration.rs
+++ b/crates/agentty/src/domain/orchestration.rs
@@ -5,8 +5,11 @@
 //! user's approval, actively fanning out, or settled; each task row tracks one
 //! child session through creation, execution, and settlement.
 
+use std::collections::HashSet;
 use std::fmt;
 use std::str::FromStr;
+
+use super::session::Status as SessionStatus;
 
 /// Lifecycle state for one controller-owned orchestration.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -92,6 +95,24 @@ pub enum OrchestrationTaskStatus {
 }
 
 impl OrchestrationTaskStatus {
+    /// Maps one observed child-session status into the task state owned by
+    /// orchestration.
+    pub fn from_child_status(status: SessionStatus) -> Self {
+        match status {
+            SessionStatus::Draft
+            | SessionStatus::InProgress
+            | SessionStatus::Queued
+            | SessionStatus::Rebasing
+            | SessionStatus::Merging => Self::Running,
+            SessionStatus::Question => Self::WaitingForInput,
+            SessionStatus::Review
+            | SessionStatus::AgentReview
+            | SessionStatus::Merged
+            | SessionStatus::Done => Self::Ready,
+            SessionStatus::Canceled => Self::Failed,
+        }
+    }
+
     /// Returns whether the task reached a state that fan-in treats as settled.
     ///
     /// A canceled straggler counts as settled so out-of-band cancellation
@@ -154,6 +175,145 @@ impl OrchestrationTaskStatus {
             )
         )
     }
+}
+
+/// Pure scheduling decision derived from one orchestration task snapshot.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct OrchestrationScheduleDecision {
+    /// Number of planned tasks that may claim a parallelism slot.
+    pub spawn_count: usize,
+    /// Whether every non-empty task has settled and roll-up can be claimed.
+    pub should_submit: bool,
+}
+
+/// Pure orchestration policy over typed task observations.
+pub struct OrchestrationPolicy;
+
+impl OrchestrationPolicy {
+    /// Decides fan-out capacity and roll-up readiness without persistence or
+    /// runtime dependencies.
+    pub fn schedule(
+        max_parallelism: usize,
+        task_statuses: &[Option<OrchestrationTaskStatus>],
+    ) -> OrchestrationScheduleDecision {
+        let occupied_slots = task_statuses
+            .iter()
+            .filter(|status| status.is_some_and(OrchestrationTaskStatus::occupies_parallelism_slot))
+            .count();
+        let planned_tasks = task_statuses
+            .iter()
+            .filter(|status| **status == Some(OrchestrationTaskStatus::Planned))
+            .count();
+        let spawn_count = max_parallelism
+            .saturating_sub(occupied_slots)
+            .min(planned_tasks);
+        let should_submit = !task_statuses.is_empty()
+            && task_statuses
+                .iter()
+                .all(|status| status.is_some_and(OrchestrationTaskStatus::is_settled));
+
+        OrchestrationScheduleDecision {
+            spawn_count,
+            should_submit,
+        }
+    }
+}
+
+/// Protocol-independent snapshot of one task proposed by an orchestration
+/// controller.
+pub struct OrchestrationPlanTask {
+    /// Standalone task prompt delivered to the child session.
+    pub prompt: String,
+    /// Stable kebab-case identity used for retries.
+    pub task_key: String,
+    /// Short user-facing task title.
+    pub title: String,
+    /// Literal repository-relative files or directories owned by the task.
+    pub touched_areas: Vec<String>,
+}
+
+/// Validates one proposed subtask set before application code persists it.
+///
+/// # Errors
+///
+/// Returns a user-facing reason when the plan is too small, incomplete, uses
+/// invalid task keys or paths, or gives different tasks overlapping scopes.
+pub fn validate_subtasks(subtasks: &[OrchestrationPlanTask], is_retry: bool) -> Result<(), String> {
+    if subtasks.len() < 2 && !is_retry {
+        return Err("a meaningful orchestration requires at least two subtasks.".to_string());
+    }
+    let mut task_keys = HashSet::new();
+    let mut scopes = Vec::<(&str, String)>::new();
+    for subtask in subtasks {
+        if !is_kebab_case_task_key(&subtask.task_key)
+            || !task_keys.insert(subtask.task_key.as_str())
+        {
+            return Err("every subtask needs a unique kebab-case task key.".to_string());
+        }
+        if subtask.prompt.trim().is_empty()
+            || subtask.title.trim().is_empty()
+            || subtask.touched_areas.is_empty()
+        {
+            return Err(format!(
+                "subtask `{}` needs a title, standalone prompt, and touched areas.",
+                subtask.task_key
+            ));
+        }
+        for area in &subtask.touched_areas {
+            let scope = normalized_scope(area).map_err(|reason| {
+                format!(
+                    "subtask `{}` has invalid touched area `{area}`: {reason}.",
+                    subtask.task_key
+                )
+            })?;
+            if let Some((other_key, _)) = scopes.iter().find(|(other_key, other_scope)| {
+                *other_key != subtask.task_key && scopes_overlap(other_scope, &scope)
+            }) {
+                return Err(format!(
+                    "subtasks `{other_key}` and `{}` overlap at `{area}`.",
+                    subtask.task_key
+                ));
+            }
+            scopes.push((subtask.task_key.as_str(), scope));
+        }
+    }
+
+    Ok(())
+}
+
+fn is_kebab_case_task_key(task_key: &str) -> bool {
+    !task_key.is_empty()
+        && task_key.split('-').all(|segment| {
+            !segment.is_empty()
+                && segment
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        })
+}
+
+fn normalized_scope(area: &str) -> Result<String, &'static str> {
+    let normalized = area.trim().trim_start_matches("./").trim_end_matches('/');
+    if normalized.is_empty()
+        || normalized.starts_with('/')
+        || normalized.split('/').any(|part| part == "..")
+    {
+        return Err("use a non-empty repository-relative path");
+    }
+    if normalized.contains(['*', '?', '[', ']', '{', '}']) {
+        return Err("use a literal file or directory path; wildcard patterns are not supported");
+    }
+
+    Ok(normalized.to_string())
+}
+
+fn scopes_overlap(left: &str, right: &str) -> bool {
+    left == right
+        || left
+            .strip_prefix(right)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+        || right
+            .strip_prefix(left)
+            .is_some_and(|suffix| suffix.starts_with('/'))
 }
 
 impl fmt::Display for OrchestrationTaskStatus {
@@ -319,5 +479,83 @@ mod tests {
         assert!(
             !OrchestrationTaskStatus::Canceled.can_transition_to(OrchestrationTaskStatus::Ready)
         );
+    }
+
+    #[test]
+    /// Derives fan-out capacity and roll-up readiness from typed task states.
+    fn test_orchestration_policy_schedules_available_slots_and_settlement() {
+        // Arrange
+        let active_statuses = [
+            Some(OrchestrationTaskStatus::Running),
+            Some(OrchestrationTaskStatus::WaitingForInput),
+            Some(OrchestrationTaskStatus::Planned),
+            Some(OrchestrationTaskStatus::Planned),
+        ];
+        let settled_statuses = [
+            Some(OrchestrationTaskStatus::Ready),
+            Some(OrchestrationTaskStatus::Failed),
+            Some(OrchestrationTaskStatus::Canceled),
+        ];
+        let invalid_statuses = [Some(OrchestrationTaskStatus::Ready), None];
+
+        // Act
+        let active_decision = OrchestrationPolicy::schedule(3, &active_statuses);
+        let settled_decision = OrchestrationPolicy::schedule(3, &settled_statuses);
+        let empty_decision = OrchestrationPolicy::schedule(3, &[]);
+        let invalid_decision = OrchestrationPolicy::schedule(3, &invalid_statuses);
+
+        // Assert
+        assert_eq!(
+            active_decision,
+            OrchestrationScheduleDecision {
+                spawn_count: 1,
+                should_submit: false,
+            }
+        );
+        assert_eq!(
+            settled_decision,
+            OrchestrationScheduleDecision {
+                spawn_count: 0,
+                should_submit: true,
+            }
+        );
+        assert_eq!(
+            empty_decision,
+            OrchestrationScheduleDecision {
+                spawn_count: 0,
+                should_submit: false,
+            }
+        );
+        assert!(!invalid_decision.should_submit);
+    }
+
+    #[test]
+    /// Maps every child-session lifecycle family into orchestration policy.
+    fn test_task_status_from_child_status_covers_session_lifecycle() {
+        // Arrange
+        let cases = [
+            (SessionStatus::Draft, OrchestrationTaskStatus::Running),
+            (SessionStatus::InProgress, OrchestrationTaskStatus::Running),
+            (SessionStatus::Queued, OrchestrationTaskStatus::Running),
+            (SessionStatus::Rebasing, OrchestrationTaskStatus::Running),
+            (SessionStatus::Merging, OrchestrationTaskStatus::Running),
+            (
+                SessionStatus::Question,
+                OrchestrationTaskStatus::WaitingForInput,
+            ),
+            (SessionStatus::Review, OrchestrationTaskStatus::Ready),
+            (SessionStatus::AgentReview, OrchestrationTaskStatus::Ready),
+            (SessionStatus::Merged, OrchestrationTaskStatus::Ready),
+            (SessionStatus::Done, OrchestrationTaskStatus::Ready),
+            (SessionStatus::Canceled, OrchestrationTaskStatus::Failed),
+        ];
+
+        // Act / Assert
+        for (session_status, expected_task_status) in cases {
+            assert_eq!(
+                OrchestrationTaskStatus::from_child_status(session_status),
+                expected_task_status
+            );
+        }
     }
 }

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -102,7 +102,10 @@ instead of returning an ambiguous error that could prompt duplicate creation.
 <a id="architecture-runtime-flow-notes"></a> Foreground loop details:
 
 - `run_main_loop()` drains one bounded batch of queued app events before draw so touched
-  sessions sync from their live handles without a full list-wide sweep every frame.
+  sessions sync from their live handles without a full list-wide sweep every frame. The
+  batch then drains payload-bearing work into an `AppEventReductionPlan`: effects that
+  must precede snapshot mutation run first, cached snapshot updates run next, and
+  post-snapshot effects run last.
 - `run_main_loop()` owns `PresentationState`; input measurement and `ui::render_app()`
   share its bounded `RenderCacheStore`. `App` neither constructs Ratatui frames nor owns
   render caches.
@@ -137,7 +140,10 @@ channels:
 <a id="architecture-runtime-flow-app-events"></a> `App::apply_app_events()` is the
 single reducer path for async app events. Each cycle drains queued events up to a
 bounded budget, coalesces them into one `AppEventBatch` (refresh, git status, model, and
-loader updates), and applies side effects in stable order. Key behaviors:
+loader updates), then drains an explicit `AppEventReductionPlan`. The plan separates
+ordered effects that must run before cached snapshot updates from effects that consume
+the resulting snapshot afterward. Reload effects currently run before snapshot updates;
+focused-review state application and persistence run afterward. Key behaviors:
 
 - Refresh events set reload flags instead of reloading inline; the expensive
   home-directory project discovery runs only during `App::new()`.


### PR DESCRIPTION
- Keeps subtask validation, child-session status mapping, and scheduling decisions in pure domain logic.
- Plans coalesced app-event state changes before executing ordered external effects.
- Encapsulates live session handles and workflow bookkeeping behind dedicated runtime state.
- Exposes an explicit payload-draining reducer contract aligned with the documented pre-snapshot/update/post-snapshot execution flow.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)