### PR TITLE
Centralizes settings input and terminal lifecycle handling

### DIFF
--- a/crates/agentty/src/presentation/settings.rs
+++ b/crates/agentty/src/presentation/settings.rs
@@ -1,4 +1,4 @@
-//! Frontend-neutral settings screen state and actions.
+//! Presentation-owned settings screen state and input translation.
 
 use crate::domain::agent::{AgentSelection, ReasoningLevel};
 use crate::domain::input::{InputCommand, InputState};
@@ -60,6 +60,17 @@ pub(crate) enum SettingsAction {
     Next,
     Previous,
     StartAddingLaunchConfiguration,
+}
+
+/// One frontend-neutral input received while a settings overlay is active.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum SettingsInput {
+    Cancel,
+    Character(char),
+    Confirm,
+    Edit(InputCommand),
+    MoveDown,
+    MoveUp,
 }
 
 /// Render-ready option for an open settings selector dropdown.
@@ -167,6 +178,84 @@ impl SettingsPresentationState {
                 None
             }
         }
+    }
+
+    /// Reduces one frontend-neutral input into the semantic action accepted by
+    /// the active settings overlay.
+    pub(crate) fn action_for_input(&self, input: SettingsInput) -> Option<SettingsAction> {
+        if self.is_selector_dropdown_open() {
+            return match input {
+                SettingsInput::Cancel => Some(SettingsAction::Cancel),
+                SettingsInput::Character(character) if character.eq_ignore_ascii_case(&'q') => {
+                    Some(SettingsAction::Cancel)
+                }
+                SettingsInput::Character('j') | SettingsInput::MoveDown => {
+                    Some(SettingsAction::Next)
+                }
+                SettingsInput::Character('k') | SettingsInput::MoveUp => {
+                    Some(SettingsAction::Previous)
+                }
+                SettingsInput::Confirm => Some(SettingsAction::Confirm),
+                _ => None,
+            };
+        }
+
+        if self.is_launch_configuration_list_editor_input_active() {
+            return match input {
+                SettingsInput::Cancel => Some(SettingsAction::Cancel),
+                SettingsInput::Character(character) => {
+                    Some(SettingsAction::Input(InputCommand::Insert(character)))
+                }
+                SettingsInput::Confirm => Some(SettingsAction::Confirm),
+                SettingsInput::Edit(command) => Some(SettingsAction::Input(command)),
+                SettingsInput::MoveDown => Some(SettingsAction::Input(InputCommand::MoveDown)),
+                SettingsInput::MoveUp => Some(SettingsAction::Input(InputCommand::MoveUp)),
+            };
+        }
+
+        if self.is_launch_configuration_list_editor_open() {
+            return match input {
+                SettingsInput::Cancel => Some(SettingsAction::Cancel),
+                SettingsInput::Character(character) if character.eq_ignore_ascii_case(&'q') => {
+                    Some(SettingsAction::Cancel)
+                }
+                SettingsInput::Character('j') | SettingsInput::MoveDown => {
+                    Some(SettingsAction::Next)
+                }
+                SettingsInput::Character('k') | SettingsInput::MoveUp => {
+                    Some(SettingsAction::Previous)
+                }
+                SettingsInput::Character('J') => Some(SettingsAction::MoveLaunchConfigurationDown),
+                SettingsInput::Character('K') => Some(SettingsAction::MoveLaunchConfigurationUp),
+                SettingsInput::Character('a') => {
+                    Some(SettingsAction::StartAddingLaunchConfiguration)
+                }
+                SettingsInput::Character('e') | SettingsInput::Confirm => {
+                    Some(SettingsAction::EditLaunchConfiguration)
+                }
+                SettingsInput::Character('d') => Some(SettingsAction::DeleteLaunchConfiguration),
+                _ => None,
+            };
+        }
+
+        None
+    }
+
+    /// Translates pasted text into a single-line input action when the launch
+    /// configuration editor currently accepts text.
+    pub(crate) fn action_for_paste(&self, pasted_text: &str) -> Option<SettingsAction> {
+        if !self.is_launch_configuration_list_editor_input_active() {
+            return None;
+        }
+
+        let normalized_text = pasted_text.replace("\r\n", "\n").replace('\r', "\n");
+        let first_line = normalized_text
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .to_string();
+
+        Some(SettingsAction::Input(InputCommand::InsertText(first_line)))
     }
 
     /// Returns whether the launch-configuration editor is open.
@@ -1049,6 +1138,164 @@ mod tests {
             let operation = state.apply(view, SettingsAction::Next);
             assert_eq!(operation, None);
         }
+    }
+
+    /// Opens the launch-configuration editor in browse mode.
+    fn launch_configuration_editor_state(view: &SettingsView) -> SettingsPresentationState {
+        let mut state = SettingsPresentationState::default();
+        select_row(
+            &mut state,
+            view,
+            SettingRow::LaunchConfiguration.table_index(),
+        );
+        let _ = state.apply(view, SettingsAction::Activate);
+
+        state
+    }
+
+    #[test]
+    fn action_for_input_maps_selector_inputs() {
+        // Arrange
+        let view = test_settings_view("");
+        let mut state = SettingsPresentationState::default();
+        let _ = state.apply(&view, SettingsAction::Activate);
+        let mappings = [
+            (SettingsInput::Cancel, Some(SettingsAction::Cancel)),
+            (SettingsInput::Character('q'), Some(SettingsAction::Cancel)),
+            (SettingsInput::Character('Q'), Some(SettingsAction::Cancel)),
+            (SettingsInput::Character('j'), Some(SettingsAction::Next)),
+            (SettingsInput::MoveDown, Some(SettingsAction::Next)),
+            (
+                SettingsInput::Character('k'),
+                Some(SettingsAction::Previous),
+            ),
+            (SettingsInput::MoveUp, Some(SettingsAction::Previous)),
+            (SettingsInput::Confirm, Some(SettingsAction::Confirm)),
+            (SettingsInput::Character('x'), None),
+            (SettingsInput::Edit(InputCommand::MoveLeft), None),
+        ];
+
+        // Act / Assert
+        for (input, expected_action) in mappings {
+            assert_eq!(state.action_for_input(input), expected_action);
+        }
+    }
+
+    #[test]
+    fn action_for_input_maps_launch_configuration_browse_inputs() {
+        // Arrange
+        let view = test_settings_view("cargo test\ncargo check");
+        let state = launch_configuration_editor_state(&view);
+        let mappings = [
+            (SettingsInput::Cancel, Some(SettingsAction::Cancel)),
+            (SettingsInput::Character('q'), Some(SettingsAction::Cancel)),
+            (SettingsInput::Character('Q'), Some(SettingsAction::Cancel)),
+            (SettingsInput::Character('j'), Some(SettingsAction::Next)),
+            (SettingsInput::MoveDown, Some(SettingsAction::Next)),
+            (
+                SettingsInput::Character('k'),
+                Some(SettingsAction::Previous),
+            ),
+            (SettingsInput::MoveUp, Some(SettingsAction::Previous)),
+            (
+                SettingsInput::Character('J'),
+                Some(SettingsAction::MoveLaunchConfigurationDown),
+            ),
+            (
+                SettingsInput::Character('K'),
+                Some(SettingsAction::MoveLaunchConfigurationUp),
+            ),
+            (
+                SettingsInput::Character('a'),
+                Some(SettingsAction::StartAddingLaunchConfiguration),
+            ),
+            (
+                SettingsInput::Character('e'),
+                Some(SettingsAction::EditLaunchConfiguration),
+            ),
+            (
+                SettingsInput::Confirm,
+                Some(SettingsAction::EditLaunchConfiguration),
+            ),
+            (
+                SettingsInput::Character('d'),
+                Some(SettingsAction::DeleteLaunchConfiguration),
+            ),
+            (SettingsInput::Character('x'), None),
+            (SettingsInput::Edit(InputCommand::MoveLeft), None),
+        ];
+
+        // Act / Assert
+        for (input, expected_action) in mappings {
+            assert_eq!(state.action_for_input(input), expected_action);
+        }
+    }
+
+    #[test]
+    fn action_for_input_maps_launch_configuration_text_input() {
+        // Arrange
+        let view = test_settings_view("");
+        let mut state = launch_configuration_editor_state(&view);
+        let _ = state.apply(&view, SettingsAction::StartAddingLaunchConfiguration);
+
+        // Act
+        let confirm = state.action_for_input(SettingsInput::Confirm);
+        let cancel = state.action_for_input(SettingsInput::Cancel);
+        let character = state.action_for_input(SettingsInput::Character('x'));
+        let edit = state.action_for_input(SettingsInput::Edit(InputCommand::DeleteBackward));
+        let move_down = state.action_for_input(SettingsInput::MoveDown);
+        let move_up = state.action_for_input(SettingsInput::MoveUp);
+
+        // Assert
+        assert_eq!(confirm, Some(SettingsAction::Confirm));
+        assert_eq!(cancel, Some(SettingsAction::Cancel));
+        assert_eq!(
+            character,
+            Some(SettingsAction::Input(InputCommand::Insert('x')))
+        );
+        assert_eq!(
+            edit,
+            Some(SettingsAction::Input(InputCommand::DeleteBackward))
+        );
+        assert_eq!(
+            move_down,
+            Some(SettingsAction::Input(InputCommand::MoveDown))
+        );
+        assert_eq!(move_up, Some(SettingsAction::Input(InputCommand::MoveUp)));
+    }
+
+    #[test]
+    fn action_for_input_ignores_input_without_open_overlay() {
+        // Arrange
+        let state = SettingsPresentationState::default();
+
+        // Act
+        let action = state.action_for_input(SettingsInput::Confirm);
+
+        // Assert
+        assert_eq!(action, None);
+    }
+
+    #[test]
+    fn action_for_paste_normalizes_active_single_line_input() {
+        // Arrange
+        let view = test_settings_view("");
+        let mut active_state = launch_configuration_editor_state(&view);
+        let _ = active_state.apply(&view, SettingsAction::StartAddingLaunchConfiguration);
+        let inactive_state = SettingsPresentationState::default();
+
+        // Act
+        let active_action = active_state.action_for_paste("cargo test\r\nignored");
+        let inactive_action = inactive_state.action_for_paste("cargo test");
+
+        // Assert
+        assert_eq!(
+            active_action,
+            Some(SettingsAction::Input(InputCommand::InsertText(
+                "cargo test".to_string()
+            )))
+        );
+        assert_eq!(inactive_action, None);
     }
 
     #[test]

--- a/crates/agentty/src/runtime/core.rs
+++ b/crates/agentty/src/runtime/core.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -64,6 +64,45 @@ pub(crate) enum EventResult {
     Quit,
 }
 
+/// Owns the blocking terminal-reader thread and its shutdown signal.
+struct EventReaderTask {
+    join_handle: std::thread::JoinHandle<()>,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl EventReaderTask {
+    /// Starts the production terminal reader for `event_tx`.
+    fn spawn(event_tx: mpsc::UnboundedSender<io::Result<crossterm::event::Event>>) -> Self {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let join_handle = event::spawn_event_reader(event_tx, Arc::clone(&shutdown));
+
+        Self {
+            join_handle,
+            shutdown,
+        }
+    }
+
+    /// Requests reader shutdown and waits for the blocking thread to finish.
+    async fn shutdown(self) -> io::Result<()> {
+        self.shutdown.store(true, Ordering::Relaxed);
+        let join_result = tokio::task::spawn_blocking(move || self.join_handle.join()).await;
+
+        Self::map_join_result(join_result)
+    }
+
+    /// Maps the blocking join task and reader thread outcomes into one runtime
+    /// error surface.
+    fn map_join_result(
+        join_result: Result<std::thread::Result<()>, tokio::task::JoinError>,
+    ) -> io::Result<()> {
+        let reader_result = join_result.map_err(|error| {
+            io::Error::other(format!("failed to join event reader task: {error}"))
+        })?;
+
+        reader_result.map_err(|_| io::Error::other("terminal event reader panicked"))
+    }
+}
+
 /// Runs the TUI event/render loop until the user exits.
 ///
 /// # Errors
@@ -75,18 +114,17 @@ pub async fn run(app: &mut App) -> io::Result<()> {
     // Spawn a dedicated thread for crossterm event reading so the main async
     // loop can yield to tokio between iterations.
     let (event_tx, mut event_rx) = mpsc::unbounded_channel();
-    let shutdown = Arc::new(AtomicBool::new(false));
-    event::spawn_event_reader(event_tx, shutdown.clone());
+    let event_reader_task = EventReaderTask::spawn(event_tx);
 
     let mut tick = tokio::time::interval(FRAME_INTERVAL);
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     let run_result = run_main_loop(app, &mut terminal, &mut event_rx, &mut tick).await;
-    shutdown.store(true, std::sync::atomic::Ordering::Relaxed);
+    let reader_shutdown_result = event_reader_task.shutdown().await;
     app.wait_for_background_cleanup_tasks().await;
-    terminal.show_cursor()?;
+    let cursor_result = terminal.show_cursor().map_err(backend_err);
 
-    run_result
+    run_result.and(reader_shutdown_result).and(cursor_result)
 }
 
 /// Runs the TUI event/render loop with an externally provided backend and
@@ -120,10 +158,10 @@ where
 /// Reads the runtime clock from `app.services.clock()` so render-throttle
 /// timing is sourced through the same `Clock` trait used by session refresh
 /// logic, keeping `runtime` free of direct `Instant::now()` calls.
-async fn run_main_loop<B: Backend>(
+async fn run_main_loop<B: Backend, Message: event::TerminalEventMessage>(
     app: &mut App,
     terminal: &mut Terminal<B>,
-    event_rx: &mut mpsc::UnboundedReceiver<crossterm::event::Event>,
+    event_rx: &mut mpsc::UnboundedReceiver<Message>,
     tick: &mut tokio::time::Interval,
 ) -> io::Result<()>
 where
@@ -150,23 +188,38 @@ where
     };
 
     let result = run_until_quit(&mut main_loop_state, |state| Box::pin(state.run_cycle())).await;
+    let orchestration_shutdown_result = stop_orchestration_task(orchestration_task).await;
+
+    result.and(orchestration_shutdown_result)
+}
+
+/// Cancels the coordinator and observes its final task result.
+async fn stop_orchestration_task(
+    orchestration_task: tokio::task::JoinHandle<()>,
+) -> io::Result<()> {
     orchestration_task.abort();
 
-    result
+    match orchestration_task.await {
+        Ok(()) => Ok(()),
+        Err(error) if error.is_cancelled() => Ok(()),
+        Err(error) => Err(io::Error::other(format!(
+            "orchestration coordinator task failed: {error}"
+        ))),
+    }
 }
 
 /// Borrowed runtime state required to process one main-loop cycle.
-struct MainLoopState<'a, B: Backend> {
+struct MainLoopState<'a, B: Backend, Message> {
     app: &'a mut App,
     clock: Arc<dyn Clock>,
-    event_rx: &'a mut mpsc::UnboundedReceiver<crossterm::event::Event>,
+    event_rx: &'a mut mpsc::UnboundedReceiver<Message>,
     last_draw_at: Instant,
     presentation: Rc<PresentationState>,
     terminal: &'a mut Terminal<B>,
     tick: &'a mut tokio::time::Interval,
 }
 
-impl<B: Backend> MainLoopState<'_, B>
+impl<B: Backend, Message: event::TerminalEventMessage> MainLoopState<'_, B, Message>
 where
     B::Error: std::error::Error + Send + Sync + 'static,
 {
@@ -239,22 +292,10 @@ where
         return Ok(());
     }
 
-    let mut assigned_issue_table_state = presentation.assigned_issue_table_state();
-    let mut project_table_state = presentation.project_table_state();
-    let mut requested_review_table_state = presentation.requested_review_table_state();
-    let mut session_table_state = presentation.session_table_state();
     let snapshot = app.view_snapshot();
     terminal
         .draw(|frame| {
-            crate::ui::render_app(
-                &snapshot,
-                frame,
-                &mut assigned_issue_table_state,
-                &mut project_table_state,
-                presentation.render_cache_store(),
-                &mut requested_review_table_state,
-                &mut session_table_state,
-            );
+            presentation.render(&snapshot, frame);
         })
         .map_err(backend_err)?;
     app.clear_redraw();
@@ -281,6 +322,7 @@ mod tests {
     use ratatui::backend::{Backend, ClearType, TestBackend, WindowSize};
     use ratatui::buffer::Cell;
     use ratatui::layout::{Position, Size};
+    use testty::session::PtySessionBuilder;
 
     use super::*;
     use crate::app::AppEvent;
@@ -288,6 +330,12 @@ mod tests {
     use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
     use crate::presentation::app_mode::AppMode;
     use crate::test_support::SessionFixtureBuilder;
+
+    /// Environment marker used to distinguish the nested PTY test process.
+    const PRODUCTION_RUN_CHILD_ENV: &str = "AGENTTY_TEST_PRODUCTION_RUN_CHILD";
+    /// Fully-qualified libtest name invoked inside the nested PTY.
+    const PRODUCTION_RUN_CHILD_TEST: &str =
+        "runtime::core::tests::production_run_exits_cleanly_in_pty_child";
 
     /// Test-only loop state that records call counts and scripted outcomes.
     struct TestLoopState {
@@ -347,6 +395,184 @@ mod tests {
         let error = loop_result.expect_err("loop should return the cycle error");
         assert_eq!(error.to_string(), "cycle failed");
         assert_eq!(state.cycle_count, 1);
+    }
+
+    /// Drives the concrete terminal entrypoint in a PTY so its setup, event
+    /// reader, and ordered cleanup path remain covered by source tests.
+    #[test]
+    fn production_run_exits_cleanly_in_pty() {
+        // Arrange
+        let test_binary = std::env::current_exe().expect("test binary path should be available");
+        let mut session = PtySessionBuilder::new(test_binary)
+            .args(["--exact", PRODUCTION_RUN_CHILD_TEST, "--nocapture"])
+            .env(PRODUCTION_RUN_CHILD_ENV, "1")
+            .spawn()
+            .expect("failed to spawn production runtime test in a PTY");
+        session
+            .wait_for_text("Sessions", Duration::from_secs(10))
+            .expect("production runtime should render its initial list view");
+
+        // Act
+        session
+            .press_key("q")
+            .expect("failed to open quit confirmation");
+        session
+            .wait_for_text("Confirm Quit", Duration::from_secs(5))
+            .expect("quit confirmation should be rendered");
+        session
+            .press_key("y")
+            .expect("failed to confirm runtime exit");
+        let exited_successfully = session
+            .wait_for_exit(Duration::from_secs(5))
+            .expect("production runtime should exit before the timeout");
+
+        // Assert
+        assert!(exited_successfully);
+    }
+
+    /// Runs only when re-invoked by `production_run_exits_cleanly_in_pty`.
+    #[tokio::test]
+    async fn production_run_exits_cleanly_in_pty_child() {
+        // Arrange
+        if std::env::var_os(PRODUCTION_RUN_CHILD_ENV).is_none() {
+            return;
+        }
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+
+        // Act
+        let result = tokio::time::timeout(Duration::from_secs(10), run(&mut app))
+            .await
+            .expect("production runtime should not hang");
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn event_reader_task_spawn_starts_a_shutdown_capable_reader() {
+        // Arrange
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+
+        // Act
+        let result = EventReaderTask::spawn(event_tx).shutdown().await;
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn event_reader_task_shutdown_signals_and_joins_reader() {
+        // Arrange
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let reader_shutdown = Arc::clone(&shutdown);
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let join_handle = std::thread::spawn(move || {
+            started_tx
+                .send(())
+                .expect("reader should signal that it started");
+            while !reader_shutdown.load(Ordering::Relaxed) {
+                std::thread::yield_now();
+            }
+        });
+        started_rx
+            .recv()
+            .expect("reader should start before shutdown is requested");
+        let task = EventReaderTask {
+            join_handle,
+            shutdown,
+        };
+
+        // Act
+        let result = task.shutdown().await;
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn event_reader_task_shutdown_reports_reader_panic() {
+        // Arrange
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let join_handle = std::thread::spawn(|| {
+            std::panic::resume_unwind(Box::new("reader panic"));
+        });
+        let task = EventReaderTask {
+            join_handle,
+            shutdown,
+        };
+
+        // Act
+        let result = task.shutdown().await;
+
+        // Assert
+        let error = result.expect_err("reader panic should be reported");
+        assert_eq!(error.to_string(), "terminal event reader panicked");
+    }
+
+    #[tokio::test]
+    async fn event_reader_task_maps_blocking_join_failure() {
+        // Arrange
+        let join_error = tokio::spawn(async {
+            std::panic::resume_unwind(Box::new("blocking join panic"));
+        })
+        .await
+        .expect_err("panicked task should return a join error");
+
+        // Act
+        let result = EventReaderTask::map_join_result(Err(join_error));
+
+        // Assert
+        let error = result.expect_err("blocking join failure should be reported");
+        assert!(
+            error
+                .to_string()
+                .starts_with("failed to join event reader task:")
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_orchestration_task_accepts_completed_task() {
+        // Arrange
+        let task = tokio::spawn(async {});
+        tokio::task::yield_now().await;
+
+        // Act
+        let result = stop_orchestration_task(task).await;
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn stop_orchestration_task_accepts_cancelled_task() {
+        // Arrange
+        let task = tokio::spawn(std::future::pending::<()>());
+
+        // Act
+        let result = stop_orchestration_task(task).await;
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn stop_orchestration_task_reports_panicked_task() {
+        // Arrange
+        let task = tokio::spawn(async {
+            std::panic::resume_unwind(Box::new("coordinator panic"));
+        });
+        tokio::task::yield_now().await;
+
+        // Act
+        let result = stop_orchestration_task(task).await;
+
+        // Assert
+        let error = result.expect_err("coordinator panic should be reported");
+        assert!(
+            error
+                .to_string()
+                .starts_with("orchestration coordinator task failed:")
+        );
     }
 
     /// Flattens a test terminal buffer into one searchable string.
@@ -468,6 +694,31 @@ mod tests {
         );
     }
 
+    /// Verifies a dropped injected event sender exits the full runtime loop
+    /// instead of repeatedly producing empty input cycles.
+    #[tokio::test]
+    async fn run_with_backend_returns_error_when_event_channel_closes() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).expect("failed to create test terminal");
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        drop(event_tx);
+
+        // Act
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            run_with_backend(&mut app, &mut terminal, &mut event_rx),
+        )
+        .await
+        .expect("runtime should exit when its event channel closes");
+
+        // Assert
+        let error = result.expect_err("closed event channel should fail the runtime");
+        assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
+        assert_eq!(error.to_string(), "terminal event reader stopped");
+    }
+
     #[tokio::test]
     async fn run_with_backend_waits_for_cleanup_tasks_after_quit() {
         // Arrange
@@ -570,7 +821,7 @@ mod tests {
         // Arrange
         let (mut app, base_dir) = crate::test_support::new_test_app().await;
         let session_id = "session-1".to_string();
-        let mut event_rx = mpsc::unbounded_channel().1;
+        let (_event_tx, mut event_rx) = mpsc::unbounded_channel::<Event>();
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).expect("failed to create test terminal");
         let mut tick = tokio::time::interval(Duration::from_millis(1));

--- a/crates/agentty/src/runtime/event.rs
+++ b/crates/agentty/src/runtime/event.rs
@@ -15,7 +15,6 @@ use tracing::debug;
 use crate::app::{App, AppRuntimeEvent};
 use crate::domain::input::InputCommand;
 use crate::presentation::app_mode::AppMode;
-use crate::presentation::settings::SettingsAction;
 use crate::runtime::{EventResult, FRAME_INTERVAL, PresentationState, key_handler, mode};
 
 /// Maximum terminal input events processed in one foreground cycle.
@@ -49,16 +48,42 @@ impl EventSource for CrosstermEventSource {
 /// Represents the next runtime wake-up source while awaiting input or redraw.
 enum LoopSignal {
     /// One terminal input event from the foreground reader thread.
-    Event(Option<Event>),
+    Event(Option<io::Result<Event>>),
     /// One foreground-owned app event or session actor command.
     Runtime(AppRuntimeEvent),
     /// One redraw tick with no immediate input payload.
     Tick,
 }
 
+/// Converts injected terminal messages into the fallible production event
+/// transport used by the runtime loop.
+pub(crate) trait TerminalEventMessage {
+    fn into_event_result(self) -> io::Result<Event>;
+}
+
+impl TerminalEventMessage for Event {
+    fn into_event_result(self) -> io::Result<Event> {
+        Ok(self)
+    }
+}
+
+impl TerminalEventMessage for io::Result<Event> {
+    fn into_event_result(self) -> io::Result<Event> {
+        self
+    }
+}
+
+/// Returns the terminal-reader failure used when any event sender disappears.
+fn terminal_event_channel_closed_error() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::UnexpectedEof,
+        "terminal event reader stopped",
+    )
+}
+
 /// Spawns the terminal event reader thread with production dependencies.
 pub(crate) fn spawn_event_reader(
-    event_tx: mpsc::UnboundedSender<Event>,
+    event_tx: mpsc::UnboundedSender<io::Result<Event>>,
     shutdown: Arc<AtomicBool>,
 ) -> std::thread::JoinHandle<()> {
     let event_source: Arc<dyn EventSource> = Arc::new(CrosstermEventSource);
@@ -69,7 +94,7 @@ pub(crate) fn spawn_event_reader(
 /// Spawns the terminal event reader with injected dependencies.
 fn spawn_event_reader_with_source(
     event_source: Arc<dyn EventSource>,
-    event_tx: mpsc::UnboundedSender<Event>,
+    event_tx: mpsc::UnboundedSender<io::Result<Event>>,
     shutdown: Arc<AtomicBool>,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
@@ -79,15 +104,26 @@ fn spawn_event_reader_with_source(
             }
 
             match event_source.poll(FRAME_INTERVAL) {
-                Ok(true) => {
-                    if let Ok(event) = event_source.read()
-                        && event_tx.send(event).is_err()
-                    {
+                Ok(true) => match event_source.read() {
+                    Ok(event) => {
+                        if event_tx.send(Ok(event)).is_err() {
+                            break;
+                        }
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+                    Err(error) => {
+                        let _ = event_tx.send(Err(error));
+
                         break;
                     }
-                }
+                },
                 Ok(false) => {}
-                Err(_) => break,
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+                Err(error) => {
+                    let _ = event_tx.send(Err(error));
+
+                    break;
+                }
             }
         }
     })
@@ -95,11 +131,11 @@ fn spawn_event_reader_with_source(
 
 /// Waits for the next terminal/app event or tick and dispatches one runtime
 /// processing cycle.
-pub(crate) async fn process_events<B: Backend>(
+pub(crate) async fn process_events<B: Backend, Message: TerminalEventMessage>(
     app: &mut App,
     presentation: Rc<PresentationState>,
     terminal: &mut Terminal<B>,
-    event_rx: &mut mpsc::UnboundedReceiver<Event>,
+    event_rx: &mut mpsc::UnboundedReceiver<Message>,
     tick: &mut tokio::time::Interval,
 ) -> io::Result<EventResult>
 where
@@ -115,14 +151,15 @@ where
 
 /// Processes one event/tick cycle with an injected event handler so loop exit
 /// branches can be tested without a real terminal.
-async fn process_events_with_handler<Terminal, EventHandler>(
+async fn process_events_with_handler<Terminal, Message, EventHandler>(
     app: &mut App,
     terminal: &mut Terminal,
-    event_rx: &mut mpsc::UnboundedReceiver<Event>,
+    event_rx: &mut mpsc::UnboundedReceiver<Message>,
     tick: &mut tokio::time::Interval,
     mut handle_event: EventHandler,
 ) -> io::Result<EventResult>
 where
+    Message: TerminalEventMessage,
     EventHandler: for<'handler> FnMut(
         &'handler mut App,
         &'handler mut Terminal,
@@ -135,7 +172,9 @@ where
     // This yields to tokio so spawned tasks (agent output, git status) can
     // make progress on this worker thread.
     let signal = tokio::select! {
-        event = event_rx.recv() => LoopSignal::Event(event),
+        event = event_rx.recv() => {
+            LoopSignal::Event(event.map(TerminalEventMessage::into_event_result))
+        },
         runtime_event = app.next_runtime_event() => LoopSignal::Runtime(runtime_event),
         _ = tick.tick() => LoopSignal::Tick,
     };
@@ -153,13 +192,13 @@ where
 
             None
         }
-        LoopSignal::Event(event) => {
-            if event.is_some() {
-                handled_terminal_events += 1;
-            }
+        LoopSignal::Event(Some(Ok(event))) => {
+            handled_terminal_events += 1;
 
-            event
+            Some(event)
         }
+        LoopSignal::Event(Some(Err(error))) => return Err(error),
+        LoopSignal::Event(None) => return Err(terminal_event_channel_closed_error()),
         LoopSignal::Tick => {
             if app.refresh_sessions_if_needed().await {
                 app.mark_dirty();
@@ -181,8 +220,12 @@ where
     let remaining_terminal_event_budget =
         TERMINAL_EVENT_DRAIN_BUDGET.saturating_sub(handled_terminal_events);
     for _ in 0..remaining_terminal_event_budget {
-        let Ok(event) = event_rx.try_recv() else {
-            break;
+        let event = match event_rx.try_recv() {
+            Ok(message) => message.into_event_result()?,
+            Err(mpsc::error::TryRecvError::Empty) => break,
+            Err(mpsc::error::TryRecvError::Disconnected) => {
+                return Err(terminal_event_channel_closed_error());
+            }
         };
 
         handled_terminal_events += 1;
@@ -293,15 +336,10 @@ async fn process_paste_event(app: &mut App, pasted_text: &str) {
     }
 
     if matches!(&app.mode, AppMode::List)
-        && app
-            .settings_presentation
-            .is_launch_configuration_list_editor_input_active()
+        && let Some(action) = app.settings_presentation.action_for_paste(pasted_text)
     {
-        let text = mode::input_key::normalize_single_line_pasted_text(pasted_text);
         let view = app.settings.view();
-        let _ = app
-            .settings_presentation
-            .apply(&view, SettingsAction::Input(InputCommand::InsertText(text)));
+        let _ = app.settings_presentation.apply(&view, action);
     }
 }
 
@@ -324,6 +362,38 @@ mod tests {
     use crate::presentation::prompt::{
         PromptAttachmentState, PromptHistoryState, PromptSlashState,
     };
+    use crate::presentation::settings::SettingsAction;
+
+    /// Continues a test cycle while asserting no terminal event was produced.
+    fn continue_without_terminal_event<'handler>(
+        _app: &'handler mut App,
+        _terminal: &'handler mut (),
+        event: Option<Event>,
+    ) -> Pin<Box<dyn Future<Output = io::Result<EventResult>> + 'handler>> {
+        assert_eq!(
+            event.into_iter().count(),
+            0,
+            "reader failures must not become events"
+        );
+
+        Box::pin(std::future::ready(Ok(EventResult::Continue)))
+    }
+
+    /// Verifies the production reader wiring honors a pre-requested shutdown
+    /// without polling the concrete terminal source.
+    #[test]
+    fn test_spawn_event_reader_exits_when_shutdown_is_already_requested() {
+        // Arrange
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let shutdown = Arc::new(AtomicBool::new(true));
+
+        // Act
+        let join_result = spawn_event_reader(event_tx, shutdown).join();
+
+        // Assert
+        assert!(join_result.is_ok());
+        assert!(event_rx.try_recv().is_err());
+    }
 
     /// Verifies the event reader forwards one queued event before stopping on
     /// a poll error.
@@ -353,7 +423,7 @@ mod tests {
             .with(eq(FRAME_INTERVAL))
             .times(1)
             .in_sequence(&mut sequence)
-            .returning(|_| Err(io::Error::new(ErrorKind::Interrupted, "stop")));
+            .returning(|_| Err(io::Error::new(ErrorKind::BrokenPipe, "stop")));
         let event_source: Arc<dyn EventSource> = Arc::new(mock_source);
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
         let shutdown = Arc::new(AtomicBool::new(false));
@@ -363,7 +433,8 @@ mod tests {
         let received_event = tokio::time::timeout(Duration::from_secs(1), event_rx.recv())
             .await
             .expect("timed out waiting for event")
-            .expect("failed to receive event");
+            .expect("failed to receive event")
+            .expect("event reader returned an error");
         join_handle
             .join()
             .expect("failed to join event reader thread");
@@ -402,9 +473,49 @@ mod tests {
         assert!(join_result.is_ok());
     }
 
-    /// Verifies a false poll result skips reads and leaves the channel empty.
+    /// Verifies an interrupted poll is retried before a later fatal failure is
+    /// forwarded.
     #[test]
-    fn test_spawn_event_reader_with_source_skips_read_when_poll_returns_false() {
+    fn test_spawn_event_reader_with_source_retries_interrupted_poll() {
+        // Arrange
+        let mut mock_source = MockEventSource::new();
+        let mut sequence = Sequence::new();
+        mock_source
+            .expect_poll()
+            .with(eq(FRAME_INTERVAL))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(|_| Err(io::Error::new(ErrorKind::Interrupted, "retry")));
+        mock_source
+            .expect_poll()
+            .with(eq(FRAME_INTERVAL))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(|_| Err(io::Error::new(ErrorKind::BrokenPipe, "stop")));
+        mock_source.expect_read().times(0);
+        let event_source: Arc<dyn EventSource> = Arc::new(mock_source);
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        // Act
+        let join_handle = spawn_event_reader_with_source(event_source, event_tx, shutdown);
+        let join_result = join_handle.join();
+        let queued_error = event_rx
+            .try_recv()
+            .expect("fatal poll failure should be forwarded after retry")
+            .expect_err("reader should forward the fatal poll error");
+
+        // Assert
+        assert!(join_result.is_ok());
+        assert_eq!(queued_error.kind(), ErrorKind::BrokenPipe);
+        assert_eq!(queued_error.to_string(), "stop");
+        assert!(event_rx.try_recv().is_err());
+    }
+
+    /// Verifies a false poll result skips reads before forwarding the next
+    /// fatal poll failure.
+    #[test]
+    fn test_spawn_event_reader_with_source_forwards_poll_error_after_empty_poll() {
         // Arrange
         let mut mock_source = MockEventSource::new();
         let mut sequence = Sequence::new();
@@ -419,7 +530,7 @@ mod tests {
             .with(eq(FRAME_INTERVAL))
             .times(1)
             .in_sequence(&mut sequence)
-            .returning(|_| Err(io::Error::new(ErrorKind::Interrupted, "stop")));
+            .returning(|_| Err(io::Error::new(ErrorKind::BrokenPipe, "stop")));
         mock_source.expect_read().times(0);
         let event_source: Arc<dyn EventSource> = Arc::new(mock_source);
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
@@ -428,11 +539,90 @@ mod tests {
         // Act
         let join_handle = spawn_event_reader_with_source(event_source, event_tx, shutdown);
         let join_result = join_handle.join();
-        let queued_event = event_rx.try_recv();
+        let queued_error = event_rx
+            .try_recv()
+            .expect("poll failure should be forwarded")
+            .expect_err("reader should forward the poll error");
 
         // Assert
         assert!(join_result.is_ok());
-        assert!(queued_event.is_err());
+        assert_eq!(queued_error.kind(), ErrorKind::BrokenPipe);
+        assert_eq!(queued_error.to_string(), "stop");
+    }
+
+    /// Verifies an interrupted read is retried from polling instead of being
+    /// forwarded to the runtime.
+    #[test]
+    fn test_spawn_event_reader_with_source_retries_interrupted_read() {
+        // Arrange
+        let mut mock_source = MockEventSource::new();
+        let mut sequence = Sequence::new();
+        mock_source
+            .expect_poll()
+            .with(eq(FRAME_INTERVAL))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(|_| Ok(true));
+        mock_source
+            .expect_read()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(|| Err(io::Error::new(ErrorKind::Interrupted, "retry")));
+        mock_source
+            .expect_poll()
+            .with(eq(FRAME_INTERVAL))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(|_| Err(io::Error::new(ErrorKind::BrokenPipe, "stop")));
+        let event_source: Arc<dyn EventSource> = Arc::new(mock_source);
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        // Act
+        let join_handle = spawn_event_reader_with_source(event_source, event_tx, shutdown);
+        let join_result = join_handle.join();
+        let queued_error = event_rx
+            .try_recv()
+            .expect("fatal poll failure should be forwarded after read retry")
+            .expect_err("reader should forward the fatal poll error");
+
+        // Assert
+        assert!(join_result.is_ok());
+        assert_eq!(queued_error.kind(), ErrorKind::BrokenPipe);
+        assert_eq!(queued_error.to_string(), "stop");
+        assert!(event_rx.try_recv().is_err());
+    }
+
+    /// Verifies terminal read failures are forwarded before the reader exits.
+    #[test]
+    fn test_spawn_event_reader_with_source_forwards_read_error() {
+        // Arrange
+        let mut mock_source = MockEventSource::new();
+        mock_source
+            .expect_poll()
+            .with(eq(FRAME_INTERVAL))
+            .once()
+            .returning(|_| Ok(true));
+        mock_source
+            .expect_read()
+            .once()
+            .returning(|| Err(io::Error::new(ErrorKind::BrokenPipe, "read failed")));
+        let event_source: Arc<dyn EventSource> = Arc::new(mock_source);
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        // Act
+        let join_handle = spawn_event_reader_with_source(event_source, event_tx, shutdown);
+        let join_result = join_handle.join();
+        let queued_error = event_rx
+            .try_recv()
+            .expect("read failure should be forwarded")
+            .expect_err("reader should forward the read error");
+
+        // Assert
+        assert!(join_result.is_ok());
+        assert_eq!(queued_error.kind(), ErrorKind::BrokenPipe);
+        assert_eq!(queued_error.to_string(), "read failed");
     }
 
     /// Verifies a pre-set shutdown flag exits the reader without touching the
@@ -684,10 +874,10 @@ mod tests {
         let mut terminal = ();
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
         event_tx
-            .send(Event::Key(KeyEvent::new(
+            .send(Ok(Event::Key(KeyEvent::new(
                 KeyCode::Char('x'),
                 KeyModifiers::NONE,
-            )))
+            ))))
             .expect("failed to queue event");
         let mut tick = tokio::time::interval(Duration::from_mins(1));
 
@@ -709,12 +899,90 @@ mod tests {
         assert_eq!(error.to_string(), "handler failed");
     }
 
+    /// Verifies a terminal reader failure exits the event cycle without being
+    /// converted into a terminal event.
+    #[tokio::test]
+    async fn test_process_events_with_handler_returns_reader_error() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let mut terminal = ();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let mut tick = tokio::time::interval(Duration::from_mins(1));
+        let initial_result = process_events_with_handler(
+            &mut app,
+            &mut terminal,
+            &mut event_rx,
+            &mut tick,
+            continue_without_terminal_event,
+        )
+        .await;
+        event_tx
+            .send(Err(io::Error::new(ErrorKind::BrokenPipe, "reader failed")))
+            .expect("failed to queue reader error");
+
+        // Act
+        let result = process_events_with_handler(
+            &mut app,
+            &mut terminal,
+            &mut event_rx,
+            &mut tick,
+            continue_without_terminal_event,
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(initial_result, Ok(EventResult::Continue)));
+        let error = result
+            .err()
+            .expect("reader failure should exit the event cycle");
+        assert_eq!(error.kind(), ErrorKind::BrokenPipe);
+        assert_eq!(error.to_string(), "reader failed");
+    }
+
+    /// Verifies a closed terminal channel exits instead of spinning through
+    /// no-input cycles.
+    #[tokio::test]
+    async fn test_process_events_with_handler_returns_error_when_reader_channel_closes() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let mut terminal = ();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel::<io::Result<Event>>();
+        let mut tick = tokio::time::interval(Duration::from_mins(1));
+        let initial_result = process_events_with_handler(
+            &mut app,
+            &mut terminal,
+            &mut event_rx,
+            &mut tick,
+            continue_without_terminal_event,
+        )
+        .await;
+        drop(event_tx);
+
+        // Act
+        let result = process_events_with_handler(
+            &mut app,
+            &mut terminal,
+            &mut event_rx,
+            &mut tick,
+            continue_without_terminal_event,
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(initial_result, Ok(EventResult::Continue)));
+        let error = result
+            .err()
+            .expect("closed reader channel should exit the event cycle");
+        assert_eq!(error.kind(), ErrorKind::UnexpectedEof);
+        assert_eq!(error.to_string(), "terminal event reader stopped");
+    }
+
     #[tokio::test]
     async fn test_process_events_with_handler_drives_session_runtime_commands() {
         // Arrange
         let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
         let mut terminal = ();
-        let (_event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let (_event_tx, mut event_rx) = mpsc::unbounded_channel::<Event>();
         let mut tick = tokio::time::interval(Duration::from_mins(1));
         tick.tick().await;
         let _session_runtime_consumer = app.sessions.foreground_consumer();
@@ -766,7 +1034,7 @@ mod tests {
         let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
         app.services.emit_app_event(AppEvent::RefreshSessions);
         let mut terminal = ();
-        let (_event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let (_event_tx, mut event_rx) = mpsc::unbounded_channel::<Event>();
         let mut tick = tokio::time::interval(Duration::from_mins(1));
         tick.tick().await;
 
@@ -798,10 +1066,10 @@ mod tests {
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
         for _ in 0..(TERMINAL_EVENT_DRAIN_BUDGET + 2) {
             event_tx
-                .send(Event::Key(KeyEvent::new(
+                .send(Ok(Event::Key(KeyEvent::new(
                     KeyCode::Char('x'),
                     KeyModifiers::NONE,
-                )))
+                ))))
                 .expect("failed to queue event");
         }
         let handled_events = Arc::new(AtomicUsize::new(0));
@@ -829,5 +1097,47 @@ mod tests {
             TERMINAL_EVENT_DRAIN_BUDGET
         );
         assert_eq!(event_rx.len(), 2);
+    }
+
+    /// Verifies channel closure noticed while draining queued input exits the
+    /// event cycle after handling the final event.
+    #[tokio::test]
+    async fn test_process_events_with_handler_returns_error_when_channel_closes_during_drain() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let mut terminal = ();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        event_tx
+            .send(Ok(Event::Key(KeyEvent::new(
+                KeyCode::Char('x'),
+                KeyModifiers::NONE,
+            ))))
+            .expect("failed to queue event");
+        drop(event_tx);
+        let handled_events = Arc::new(AtomicUsize::new(0));
+        let mut tick = tokio::time::interval(Duration::from_mins(1));
+        tick.tick().await;
+
+        // Act
+        let result =
+            process_events_with_handler(&mut app, &mut terminal, &mut event_rx, &mut tick, {
+                let handled_events = Arc::clone(&handled_events);
+
+                move |_, (), event| {
+                    if event.is_some() {
+                        handled_events.fetch_add(1, Ordering::Relaxed);
+                    }
+
+                    Box::pin(async { Ok(EventResult::Continue) })
+                }
+            })
+            .await;
+
+        // Assert
+        let error = result
+            .err()
+            .expect("closed reader channel should exit during drain");
+        assert_eq!(error.kind(), ErrorKind::UnexpectedEof);
+        assert_eq!(handled_events.load(Ordering::Relaxed), 1);
     }
 }

--- a/crates/agentty/src/runtime/mode/list.rs
+++ b/crates/agentty/src/runtime/mode/list.rs
@@ -4,14 +4,14 @@ use ag_tui_text::text_util::inline_text;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::app::{App, Tab};
-use crate::domain::input::InputState;
+use crate::domain::input::{InputCommand, InputState};
 use crate::domain::session::{Session, Status};
 use crate::presentation::app_mode::{AppMode, ChatFocus, ConfirmationIntent, HelpContext};
 use crate::presentation::help_action::{
     HelpAction, project_list_actions, session_list_actions, settings_actions,
 };
 use crate::presentation::prompt::{PromptAttachmentState, PromptHistoryState};
-use crate::presentation::settings::SettingsAction;
+use crate::presentation::settings::{SettingsAction, SettingsInput};
 use crate::runtime::EventResult;
 use crate::runtime::mode::confirmation::DEFAULT_OPTION_INDEX;
 use crate::runtime::mode::input_key;
@@ -26,16 +26,18 @@ use crate::runtime::mode::input_key;
 /// `Shift+Tab` cycles backward.
 pub(crate) async fn handle(app: &mut App, key: KeyEvent) -> io::Result<EventResult> {
     if app.tabs.current() == Tab::Settings
-        && app
+        && (app
             .settings_presentation
             .is_launch_configuration_list_editor_open()
+            || app.settings_presentation.is_selector_dropdown_open())
     {
-        return handle_settings_launch_configuration_list_editor(app, key).await;
-    }
+        if let Some(input) = settings_input_for_key(key)
+            && let Some(action) = app.settings_presentation.action_for_input(input)
+        {
+            apply_settings_action(app, action).await;
+        }
 
-    if app.tabs.current() == Tab::Settings && app.settings_presentation.is_selector_dropdown_open()
-    {
-        return handle_settings_selector_dropdown(app, key).await;
+        return Ok(EventResult::Continue);
     }
 
     match key.code {
@@ -116,6 +118,23 @@ pub(crate) async fn handle(app: &mut App, key: KeyEvent) -> io::Result<EventResu
     Ok(EventResult::Continue)
 }
 
+/// Translates terminal-specific keys into frontend-neutral settings input.
+fn settings_input_for_key(key: KeyEvent) -> Option<SettingsInput> {
+    let input_command = input_key::command_for_key(key, input_key::InputCapabilities::SINGLE_LINE);
+
+    match (key.code, input_command) {
+        (KeyCode::Esc, _) => Some(SettingsInput::Cancel),
+        (KeyCode::Enter, _) => Some(SettingsInput::Confirm),
+        (KeyCode::Down, _) => Some(SettingsInput::MoveDown),
+        (KeyCode::Up, _) => Some(SettingsInput::MoveUp),
+        (KeyCode::Char(character), Some(InputCommand::Insert(_))) => {
+            Some(SettingsInput::Character(character))
+        }
+        (_, Some(command)) => Some(SettingsInput::Edit(command)),
+        (_, None) => None,
+    }
+}
+
 fn cancel_confirmation_message(session_title: &str, running_child_count: usize) -> String {
     if running_child_count > 0 {
         return format!("Cancel orchestration and its {running_child_count} running children?");
@@ -191,103 +210,6 @@ async fn handle_enter_key(app: &mut App) -> io::Result<EventResult> {
         }
         Tab::Issues => {
             app.open_selected_assigned_issue();
-        }
-    }
-
-    Ok(EventResult::Continue)
-}
-
-/// Handles key input while a settings selector dropdown is open.
-async fn handle_settings_selector_dropdown(
-    app: &mut App,
-    key: KeyEvent,
-) -> io::Result<EventResult> {
-    match key.code {
-        KeyCode::Esc => {
-            apply_settings_action(app, SettingsAction::Cancel).await;
-        }
-        KeyCode::Char(character) if character.eq_ignore_ascii_case(&'q') => {
-            apply_settings_action(app, SettingsAction::Cancel).await;
-        }
-        KeyCode::Char('j') | KeyCode::Down => {
-            apply_settings_action(app, SettingsAction::Next).await;
-        }
-        KeyCode::Char('k') | KeyCode::Up => {
-            apply_settings_action(app, SettingsAction::Previous).await;
-        }
-        KeyCode::Enter => {
-            apply_settings_action(app, SettingsAction::Confirm).await;
-        }
-        _ => {}
-    }
-
-    Ok(EventResult::Continue)
-}
-
-/// Handles key input while the `Launch Configurations` list editor is open.
-async fn handle_settings_launch_configuration_list_editor(
-    app: &mut App,
-    key: KeyEvent,
-) -> io::Result<EventResult> {
-    if app
-        .settings_presentation
-        .is_launch_configuration_list_editor_input_active()
-    {
-        return handle_settings_launch_configuration_input(app, key).await;
-    }
-
-    match key.code {
-        KeyCode::Esc => {
-            apply_settings_action(app, SettingsAction::Cancel).await;
-        }
-        KeyCode::Char(character) if character.eq_ignore_ascii_case(&'q') => {
-            apply_settings_action(app, SettingsAction::Cancel).await;
-        }
-        KeyCode::Char('j') | KeyCode::Down => {
-            apply_settings_action(app, SettingsAction::Next).await;
-        }
-        KeyCode::Char('k') | KeyCode::Up => {
-            apply_settings_action(app, SettingsAction::Previous).await;
-        }
-        KeyCode::Char('J') => {
-            apply_settings_action(app, SettingsAction::MoveLaunchConfigurationDown).await;
-        }
-        KeyCode::Char('K') => {
-            apply_settings_action(app, SettingsAction::MoveLaunchConfigurationUp).await;
-        }
-        KeyCode::Char('a') => {
-            apply_settings_action(app, SettingsAction::StartAddingLaunchConfiguration).await;
-        }
-        KeyCode::Char('e') | KeyCode::Enter => {
-            apply_settings_action(app, SettingsAction::EditLaunchConfiguration).await;
-        }
-        KeyCode::Char('d') => {
-            apply_settings_action(app, SettingsAction::DeleteLaunchConfiguration).await;
-        }
-        _ => {}
-    }
-
-    Ok(EventResult::Continue)
-}
-
-/// Handles key input while adding or editing one launch configuration.
-async fn handle_settings_launch_configuration_input(
-    app: &mut App,
-    key: KeyEvent,
-) -> io::Result<EventResult> {
-    match key.code {
-        KeyCode::Enter => {
-            apply_settings_action(app, SettingsAction::Confirm).await;
-        }
-        KeyCode::Esc => {
-            apply_settings_action(app, SettingsAction::Cancel).await;
-        }
-        _ => {
-            if let Some(command) =
-                input_key::command_for_key(key, input_key::InputCapabilities::SINGLE_LINE)
-            {
-                apply_settings_action(app, SettingsAction::Input(command)).await;
-            }
         }
     }
 
@@ -454,6 +376,43 @@ mod tests {
             scroll_offset: Some(3),
             session_id: session_id.into(),
             slash_state: PromptSlashState::default(),
+        }
+    }
+
+    #[test]
+    fn settings_input_for_key_maps_terminal_keys() {
+        // Arrange
+        let mappings = [
+            (
+                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+                Some(SettingsInput::Cancel),
+            ),
+            (
+                KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+                Some(SettingsInput::Confirm),
+            ),
+            (
+                KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+                Some(SettingsInput::MoveDown),
+            ),
+            (
+                KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+                Some(SettingsInput::MoveUp),
+            ),
+            (
+                KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+                Some(SettingsInput::Character('x')),
+            ),
+            (
+                KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL),
+                Some(SettingsInput::Edit(InputCommand::DeleteWordBackward)),
+            ),
+            (KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE), None),
+        ];
+
+        // Act / Assert
+        for (key, expected_input) in mappings {
+            assert_eq!(settings_input_for_key(key), expected_input);
         }
     }
 
@@ -1141,6 +1100,30 @@ mod tests {
         assert_eq!(selector_dropdown.row_index, 0);
         assert_eq!(selector_dropdown.selected_index, 0);
         assert_eq!(selector_dropdown.options[0].label, "Agentty Default");
+    }
+
+    #[tokio::test]
+    async fn test_settings_selector_dropdown_ignores_unmapped_key() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+        app.tabs.set(Tab::Settings);
+        handle(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .await
+            .expect("failed to open settings selector dropdown");
+
+        // Act
+        let event_result = handle(&mut app, KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE))
+            .await
+            .expect("failed to ignore unmapped settings key");
+        let selector_dropdown = app
+            .settings_presentation
+            .snapshot(&app.settings.view())
+            .selector_dropdown
+            .expect("settings selector dropdown should remain open");
+
+        // Assert
+        assert!(matches!(event_result, EventResult::Continue));
+        assert_eq!(selector_dropdown.selected_index, 0);
     }
 
     #[tokio::test]

--- a/crates/agentty/src/runtime/presentation.rs
+++ b/crates/agentty/src/runtime/presentation.rs
@@ -1,8 +1,10 @@
-use std::cell::{RefCell, RefMut};
+use std::cell::RefCell;
 
+use ratatui::Frame;
 use ratatui::widgets::TableState;
 
-use crate::ui::RenderCacheStore;
+use crate::app::AppViewSnapshot;
+use crate::ui::{self, RenderCacheStore};
 
 /// Runtime-owned state used to measure and render the terminal presentation.
 ///
@@ -19,28 +21,27 @@ pub(crate) struct PresentationState {
 }
 
 impl PresentationState {
-    /// Borrows the assigned-issue table viewport for one render pass.
-    pub(crate) fn assigned_issue_table_state(&self) -> RefMut<'_, TableState> {
-        self.assigned_issue_table_state.borrow_mut()
-    }
+    /// Renders one immutable application snapshot through the single runtime
+    /// presentation boundary.
+    pub(crate) fn render(&self, snapshot: &AppViewSnapshot<'_>, frame: &mut Frame) {
+        let mut assigned_issue_table_state = self.assigned_issue_table_state.borrow_mut();
+        let mut project_table_state = self.project_table_state.borrow_mut();
+        let mut requested_review_table_state = self.requested_review_table_state.borrow_mut();
+        let mut session_table_state = self.session_table_state.borrow_mut();
 
-    /// Borrows the project-list table viewport for one render pass.
-    pub(crate) fn project_table_state(&self) -> RefMut<'_, TableState> {
-        self.project_table_state.borrow_mut()
+        ui::render_app(
+            snapshot,
+            frame,
+            &mut assigned_issue_table_state,
+            &mut project_table_state,
+            &self.render_cache_store,
+            &mut requested_review_table_state,
+            &mut session_table_state,
+        );
     }
 
     /// Returns the UI cache collection shared by input metrics and rendering.
     pub(crate) fn render_cache_store(&self) -> &RenderCacheStore {
         &self.render_cache_store
-    }
-
-    /// Borrows the requested-review table viewport for one render pass.
-    pub(crate) fn requested_review_table_state(&self) -> RefMut<'_, TableState> {
-        self.requested_review_table_state.borrow_mut()
-    }
-
-    /// Borrows the session-list table viewport for one render pass.
-    pub(crate) fn session_table_state(&self) -> RefMut<'_, TableState> {
-        self.session_table_state.borrow_mut()
     }
 }


### PR DESCRIPTION
- Move settings key and paste translation into presentation state.
- Forward terminal reader failures and observe task shutdown results.
- Route rendering through the presentation boundary and expand runtime coverage.
- Forward terminal reader failures, retry interrupted operations, and observe task shutdown results.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)