### PR TITLE
Require successful startup recovery

### DIFF
--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -29,8 +29,9 @@ impl App {
     /// runs automatically after detecting a newer version.
     ///
     /// # Errors
-    /// Returns an error if startup project metadata cannot be persisted or
-    /// required startup state cannot be loaded from the database.
+    /// Returns an error if startup project metadata cannot be persisted,
+    /// required startup state cannot be loaded from the database, or restart
+    /// recovery cannot complete.
     pub async fn new(
         auto_update: bool,
         base_path: PathBuf,
@@ -60,8 +61,9 @@ impl App {
     /// `auto_update` flag for production startup.
     ///
     /// # Errors
-    /// Returns an error if startup project metadata cannot be persisted or
-    /// required startup state cannot be loaded from the database.
+    /// Returns an error if startup project metadata cannot be persisted,
+    /// required startup state cannot be loaded from the database, or restart
+    /// recovery cannot complete.
     #[cfg(test)]
     pub(crate) async fn new_with_clients(
         base_path: PathBuf,
@@ -84,8 +86,9 @@ impl App {
     /// Core constructor with all options explicit.
     ///
     /// # Errors
-    /// Returns an error if startup project metadata cannot be persisted or
-    /// required startup state cannot be loaded from the database.
+    /// Returns an error if startup project metadata cannot be persisted,
+    /// required startup state cannot be loaded from the database, or restart
+    /// recovery cannot complete.
     async fn new_with_options(
         auto_update: bool,
         base_path: PathBuf,
@@ -121,13 +124,13 @@ impl App {
             &clients,
         )
         .await?;
-        SessionManager::fail_unfinished_operations_from_previous_run(
+        Self::recover_startup_operations(
             repositories.clone(),
-            base_path.clone(),
+            base_path,
             services.git_client(),
-            Arc::clone(&clock),
+            clock,
         )
-        .await;
+        .await?;
         let projects = crate::app::project::ProjectManager::new(
             active_project_id,
             active_project_name,
@@ -351,6 +354,34 @@ impl App {
         ))
     }
 
+    /// Completes durable operation recovery before startup admits sessions.
+    ///
+    /// # Errors
+    /// Returns an actionable error when recovery cannot complete.
+    async fn recover_startup_operations(
+        repositories: AppRepositories,
+        base_path: PathBuf,
+        git_client: Arc<dyn GitClient>,
+        clock: Arc<dyn Clock>,
+    ) -> Result<(), AppError> {
+        SessionManager::fail_unfinished_operations_from_previous_run(
+            repositories,
+            base_path,
+            git_client,
+            clock,
+        )
+        .await
+        .map_err(Self::startup_recovery_error)
+    }
+
+    /// Converts a failed startup recovery into an actionable application error.
+    fn startup_recovery_error(error: impl std::fmt::Display) -> AppError {
+        AppError::Workflow(format!(
+            "Startup recovery did not complete. Resolve the underlying storage or Git error and \
+             restart Agentty: {error}"
+        ))
+    }
+
     /// Resolves the configured upstream reference for one project branch.
     pub(super) async fn load_git_upstream_ref(
         git_client: &dyn GitClient,
@@ -462,5 +493,182 @@ impl App {
     /// Converts a project row into domain project model.
     pub(super) fn project_from_row(project_row: db::ProjectRow) -> crate::domain::project::Project {
         AppStartup::project_from_row(project_row)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::domain::session::Status;
+    use crate::infra::db::{AppRepositories, Database};
+
+    const PUBLIC_CONSTRUCTOR_COVERAGE_ENV: &str = "AGENTTY_PUBLIC_CONSTRUCTOR_COVERAGE";
+
+    #[tokio::test]
+    /// Verifies the public constructor starts with its production client
+    /// bundle in an isolated environment.
+    async fn test_new_uses_production_client_bundle() {
+        if std::env::var_os(PUBLIC_CONSTRUCTOR_COVERAGE_ENV).is_some() {
+            // Arrange
+            let base_dir = tempdir().expect("failed to create temp dir");
+            let base_path = base_dir.path().to_path_buf();
+            let database = Database::open_in_memory()
+                .await
+                .expect("failed to open in-memory database");
+
+            // Act
+            let app = App::new(false, base_path.clone(), base_path, None, database)
+                .await
+                .expect("public constructor should build app");
+
+            // Assert
+            assert!(app.selected_session().is_none());
+
+            return;
+        }
+
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let stub_bin = base_dir.path().join("stub-bin");
+        fs::create_dir_all(&stub_bin).expect("failed to create stub bin directory");
+        let codex_stub = stub_bin.join("codex");
+        fs::write(&codex_stub, "#!/bin/sh\nexit 0\n").expect("failed to write codex stub");
+        fs::set_permissions(&codex_stub, fs::Permissions::from_mode(0o755))
+            .expect("failed to mark codex stub executable");
+        let test_binary = std::env::current_exe().expect("failed to locate test binary");
+        let child_path = format!("{}:/usr/bin:/bin", stub_bin.display());
+        let child_coverage_profile = std::env::var_os("LLVM_PROFILE_FILE").map(|profile| {
+            profile
+                .to_string_lossy()
+                .replace(".profraw", "-child.profraw")
+        });
+
+        // Act
+        let mut child = Command::new(test_binary);
+        child
+            .arg("--exact")
+            .arg("app::core::new::tests::test_new_uses_production_client_bundle")
+            .arg("--nocapture")
+            .env(PUBLIC_CONSTRUCTOR_COVERAGE_ENV, "1")
+            .env("HOME", base_dir.path())
+            .env("PATH", child_path);
+        if let Some(profile) = child_coverage_profile {
+            child.env("LLVM_PROFILE_FILE", profile);
+        }
+        let child_status = child
+            .status()
+            .expect("failed to run isolated constructor test");
+
+        // Assert
+        assert!(child_status.success());
+    }
+
+    #[tokio::test]
+    /// Verifies incomplete recovery prevents startup from admitting sessions.
+    async fn test_new_with_clients_returns_actionable_error_when_recovery_fails() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let base_path = base_dir.path().to_path_buf();
+        let (database, pool) = AppRepositories::in_memory_with_pool().await;
+        sqlx::query("DROP TABLE session_operation")
+            .execute(&pool)
+            .await
+            .expect("failed to remove session operation table");
+
+        // Act
+        let error = App::new_with_clients(
+            base_path.clone(),
+            base_path,
+            None,
+            database,
+            crate::test_support::test_app_clients(),
+        )
+        .await
+        .err();
+
+        // Assert
+        assert!(
+            error.is_some(),
+            "incomplete recovery should prevent app startup"
+        );
+        if let Some(error) = error {
+            assert!(matches!(error, AppError::Workflow(_)));
+            assert!(
+                error
+                    .to_string()
+                    .contains("Startup recovery did not complete")
+            );
+            assert!(error.to_string().contains("restart Agentty"));
+        }
+    }
+
+    #[tokio::test]
+    /// Verifies a subsequent startup admits sessions after recovery is
+    /// retried following a transient operation-update failure.
+    async fn test_new_with_clients_retries_recovery_after_operation_update_failure() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let base_path = base_dir.path().to_path_buf();
+        let (database, pool) = AppRepositories::in_memory_with_pool().await;
+        let project_id = database
+            .projects()
+            .upsert_project(&base_path.to_string_lossy(), None)
+            .await
+            .expect("failed to upsert project");
+        database
+            .sessions()
+            .insert_session(
+                "sess1",
+                "gemini-3.6-flash",
+                "main",
+                &Status::InProgress.to_string(),
+                project_id,
+            )
+            .await
+            .expect("failed to insert session");
+        database
+            .operations()
+            .insert_session_operation("op-1", "sess1", "reply")
+            .await
+            .expect("failed to insert session operation");
+        sqlx::query(
+            "CREATE TRIGGER fail_startup_recovery BEFORE UPDATE OF status ON session_operation \
+             BEGIN SELECT RAISE(FAIL, 'operation update failed'); END",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to create recovery trigger");
+
+        // Act
+        let failed_startup = App::new_with_clients(
+            base_path.clone(),
+            base_path.clone(),
+            None,
+            database.clone(),
+            crate::test_support::test_app_clients(),
+        )
+        .await;
+        sqlx::query("DROP TRIGGER fail_startup_recovery")
+            .execute(&pool)
+            .await
+            .expect("failed to remove recovery trigger");
+        let retried_startup = App::new_with_clients(
+            base_path.clone(),
+            base_path,
+            None,
+            database,
+            crate::test_support::test_app_clients(),
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(failed_startup, Err(AppError::Workflow(_))));
+        assert!(retried_startup.is_ok());
     }
 }

--- a/crates/agentty/src/app/orchestration.rs
+++ b/crates/agentty/src/app/orchestration.rs
@@ -1,7 +1,7 @@
 //! Multi-session orchestration planning, reconciliation, and fan-in.
 //!
 //! Controller turns persist validated plans before approval. A background
-//! coordinator reads child state directly from SQLite and uses the foreground
+//! coordinator reads child state directly from `SQLite` and uses the foreground
 //! session runtime only for mutations, keeping polling off the bounded actor
 //! mailbox used by interactive commands.
 

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -5194,7 +5194,21 @@ async fn test_rebase_session_cancels_pending_focused_review() {
     // Assert
     assert!(!app.review_cache.contains_key(session_id.as_str()));
     assert!(matches!(app.mode, AppMode::View { .. }));
-    let restarted_app = new_test_app_with_git_and_db(dir.path(), db).await;
+    let clients = crate::test_support::test_app_clients()
+        .with_app_server_client_override(crate::test_support::mock_app_server())
+        .with_git_client(Arc::new(create_default_mock_git_client(
+            dir.path().to_path_buf(),
+        )));
+    let restarted_app = App::new_with_clients(
+        dir.path().to_path_buf(),
+        dir.path().to_path_buf(),
+        Some("main".to_string()),
+        db,
+        clients,
+    )
+    .await
+    .expect("failed to build app after recovery");
+
     assert!(!restarted_app.review_cache.contains_key(session_id.as_str()));
 }
 

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -525,23 +525,23 @@ impl SessionWorkerService {
 
     /// Marks unfinished operations from previous process runs as failed and
     /// closes any open active-work timing window at `timestamp_seconds`.
+    ///
+    /// # Errors
+    /// Returns an error when loading operations, cleaning interrupted rebases,
+    /// reconciling session status, or recording interrupted operations fails.
     pub(super) async fn fail_unfinished_operations_from_previous_run_at(
         db: &AppRepositories,
         base_path: &Path,
         git_client: Arc<dyn GitClient>,
         timestamp_seconds: i64,
-    ) {
-        let unfinished_operations = db
-            .operations()
-            .load_unfinished_session_operations()
-            .await
-            .unwrap_or_default();
+    ) -> Result<(), SessionError> {
+        let unfinished_operations = db.operations().load_unfinished_session_operations().await?;
         Self::abort_rebase_operations_from_previous_run(
             base_path,
             git_client.as_ref(),
             &unfinished_operations,
         )
-        .await;
+        .await?;
 
         let interrupted_session_ids: HashSet<String> = unfinished_operations
             .into_iter()
@@ -549,33 +549,35 @@ impl SessionWorkerService {
             .collect();
 
         for session_id in interrupted_session_ids {
-            // Best-effort: status persistence failure is non-critical.
-            let _ = db
-                .sessions()
+            db.sessions()
                 .update_session_status_with_timing_at(
                     &session_id,
                     &Status::Review.to_string(),
                     timestamp_seconds,
                 )
-                .await;
+                .await?;
         }
 
-        // Best-effort: operation tracking metadata is non-critical.
-        let _ = db
-            .operations()
+        db.operations()
             .fail_unfinished_session_operations(RESTART_FAILURE_REASON)
-            .await;
+            .await?;
+
+        Ok(())
     }
 
     /// Aborts stale git rebase state left by interrupted worker operations.
     ///
     /// Only worker-backed rebase operations are handled here because merge
     /// tasks are not yet persisted in `session_operation`.
+    ///
+    /// # Errors
+    /// Returns an error when Git cannot inspect or abort interrupted rebase
+    /// state.
     async fn abort_rebase_operations_from_previous_run(
         base_path: &Path,
         git_client: &dyn GitClient,
         unfinished_operations: &[SessionOperationRow],
-    ) {
+    ) -> Result<(), SessionError> {
         let mut rebase_session_ids = unfinished_operations
             .iter()
             .filter(|operation| operation.kind == REBASE_OPERATION_KIND)
@@ -586,14 +588,13 @@ impl SessionWorkerService {
 
         for session_id in rebase_session_ids {
             let folder = session_folder(base_path, session_id);
-            let Ok(is_rebase_in_progress) = git_client.is_rebase_in_progress(folder.clone()).await
-            else {
-                continue;
-            };
+            let is_rebase_in_progress = git_client.is_rebase_in_progress(folder.clone()).await?;
             if is_rebase_in_progress {
-                let _ = git_client.abort_rebase(folder).await;
+                git_client.abort_rebase(folder).await?;
             }
         }
+
+        Ok(())
     }
 
     /// Persists and enqueues a command on the per-session worker queue.
@@ -1067,12 +1068,16 @@ impl SessionWorkerService {
 
 impl SessionManager {
     /// Marks unfinished operations from previous process runs as failed.
+    ///
+    /// # Errors
+    /// Returns an error when startup recovery cannot finish, leaving the
+    /// unfinished operations available for a later retry.
     pub(crate) async fn fail_unfinished_operations_from_previous_run(
         db: AppRepositories,
         base_path: PathBuf,
         git_client: Arc<dyn GitClient>,
         clock: Arc<dyn Clock>,
-    ) {
+    ) -> Result<(), SessionError> {
         let timestamp_seconds = unix_timestamp_from_system_time(clock.now_system_time());
 
         SessionWorkerService::fail_unfinished_operations_from_previous_run_at(
@@ -1081,7 +1086,7 @@ impl SessionManager {
             git_client,
             timestamp_seconds,
         )
-        .await;
+        .await
     }
 
     /// Persists and enqueues a command on the per-session worker queue.
@@ -1284,6 +1289,34 @@ mod tests {
             .expect("failed to insert session");
 
         project_id
+    }
+
+    /// Seeds one unfinished operation and its owning session for recovery
+    /// tests.
+    async fn seed_recovery_test_operation(
+        db: &AppRepositories,
+        status: Status,
+        operation_kind: &str,
+    ) {
+        let project_id = db
+            .projects()
+            .upsert_project("/tmp/project", Some("main".to_string()))
+            .await
+            .expect("failed to upsert project");
+        db.sessions()
+            .insert_session(
+                "sess1",
+                "gemini-3.6-flash",
+                "main",
+                &status.to_string(),
+                project_id,
+            )
+            .await
+            .expect("failed to insert session");
+        db.operations()
+            .insert_session_operation("op-1", "sess1", operation_kind)
+            .await
+            .expect("failed to insert session operation");
     }
 
     fn empty_transcript() -> Arc<Mutex<SessionTranscript>> {
@@ -4519,6 +4552,211 @@ mod tests {
     }
 
     #[tokio::test]
+    /// Verifies recovery stops immediately when unfinished operations cannot
+    /// be loaded from storage.
+    async fn test_fail_unfinished_operations_from_previous_run_returns_load_error() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let (db, pool) = AppRepositories::in_memory_with_pool().await;
+        pool.close().await;
+        let mut mock_git_client = MockGitClient::new();
+        mock_git_client.expect_is_rebase_in_progress().times(0);
+        mock_git_client.expect_abort_rebase().times(0);
+
+        // Act
+        let result = SessionWorkerService::fail_unfinished_operations_from_previous_run_at(
+            &db,
+            base_dir.path(),
+            Arc::new(mock_git_client),
+            300,
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(result, Err(SessionError::Db(_))));
+    }
+
+    #[tokio::test]
+    /// Verifies recovery leaves the operation unfinished when stale rebase
+    /// cleanup fails.
+    async fn test_fail_unfinished_operations_from_previous_run_returns_rebase_cleanup_error() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let db = AppRepositories::in_memory().await;
+        seed_recovery_test_operation(&db, Status::Rebasing, REBASE_OPERATION_KIND).await;
+        let mut mock_git_client = MockGitClient::new();
+        mock_git_client
+            .expect_is_rebase_in_progress()
+            .once()
+            .returning(|_| Box::pin(async { Ok(true) }));
+        mock_git_client.expect_abort_rebase().once().returning(|_| {
+            Box::pin(async { Err(ag_git::GitError::OutputParse("abort failed".to_string())) })
+        });
+
+        // Act
+        let result = SessionWorkerService::fail_unfinished_operations_from_previous_run_at(
+            &db,
+            base_dir.path(),
+            Arc::new(mock_git_client),
+            300,
+        )
+        .await;
+        let operation_is_unfinished = db
+            .operations()
+            .is_session_operation_unfinished("op-1")
+            .await
+            .expect("failed to check operation status");
+
+        // Assert
+        assert!(matches!(result, Err(SessionError::Git(_))));
+        assert!(operation_is_unfinished);
+    }
+
+    #[tokio::test]
+    /// Verifies recovery stops before interrupting operations when session
+    /// status reconciliation fails.
+    async fn test_fail_unfinished_operations_from_previous_run_returns_session_reconciliation_error()
+     {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let (db, pool) = AppRepositories::in_memory_with_pool().await;
+        seed_recovery_test_operation(&db, Status::InProgress, "reply").await;
+        sqlx::query(
+            "CREATE TRIGGER fail_recovery_session_status BEFORE UPDATE OF status ON session BEGIN \
+             SELECT RAISE(FAIL, 'session status failed'); END",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to create session status trigger");
+        let mut mock_git_client = MockGitClient::new();
+        mock_git_client.expect_is_rebase_in_progress().times(0);
+        mock_git_client.expect_abort_rebase().times(0);
+
+        // Act
+        let result = SessionWorkerService::fail_unfinished_operations_from_previous_run_at(
+            &db,
+            base_dir.path(),
+            Arc::new(mock_git_client),
+            300,
+        )
+        .await;
+        let operation_is_unfinished = db
+            .operations()
+            .is_session_operation_unfinished("op-1")
+            .await
+            .expect("failed to check operation status");
+
+        // Assert
+        assert!(matches!(result, Err(SessionError::Db(_))));
+        assert!(operation_is_unfinished);
+    }
+
+    #[tokio::test]
+    /// Verifies recovery returns an operation-interruption failure after
+    /// session reconciliation rather than admitting normal work.
+    async fn test_fail_unfinished_operations_from_previous_run_returns_operation_update_error() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let (db, pool) = AppRepositories::in_memory_with_pool().await;
+        seed_recovery_test_operation(&db, Status::InProgress, "reply").await;
+        sqlx::query(
+            "CREATE TRIGGER fail_recovery_operation_update BEFORE UPDATE OF status ON \
+             session_operation BEGIN SELECT RAISE(FAIL, 'operation update failed'); END",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to create operation update trigger");
+        let mut mock_git_client = MockGitClient::new();
+        mock_git_client.expect_is_rebase_in_progress().times(0);
+        mock_git_client.expect_abort_rebase().times(0);
+
+        // Act
+        let result = SessionWorkerService::fail_unfinished_operations_from_previous_run_at(
+            &db,
+            base_dir.path(),
+            Arc::new(mock_git_client),
+            300,
+        )
+        .await;
+        let sessions = db
+            .sessions()
+            .load_sessions()
+            .await
+            .expect("failed to load sessions");
+        let operation_is_unfinished = db
+            .operations()
+            .is_session_operation_unfinished("op-1")
+            .await
+            .expect("failed to check operation status");
+
+        // Assert
+        assert!(matches!(result, Err(SessionError::Db(_))));
+        assert_eq!(sessions[0].status, "Review");
+        assert!(operation_is_unfinished);
+    }
+
+    #[tokio::test]
+    /// Verifies a later startup successfully retries recovery after an
+    /// earlier operation-interruption failure.
+    async fn test_fail_unfinished_operations_from_previous_run_retries_after_failure() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let (db, pool) = AppRepositories::in_memory_with_pool().await;
+        seed_recovery_test_operation(&db, Status::InProgress, "reply").await;
+        sqlx::query(
+            "CREATE TRIGGER fail_recovery_retry BEFORE UPDATE OF status ON session_operation \
+             BEGIN SELECT RAISE(FAIL, 'operation update failed'); END",
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to create retry trigger");
+        let mut failed_recovery_git_client = MockGitClient::new();
+        failed_recovery_git_client
+            .expect_is_rebase_in_progress()
+            .times(0);
+        failed_recovery_git_client.expect_abort_rebase().times(0);
+
+        // Act
+        let failed_recovery =
+            SessionWorkerService::fail_unfinished_operations_from_previous_run_at(
+                &db,
+                base_dir.path(),
+                Arc::new(failed_recovery_git_client),
+                300,
+            )
+            .await;
+        sqlx::query("DROP TRIGGER fail_recovery_retry")
+            .execute(&pool)
+            .await
+            .expect("failed to remove retry trigger");
+        let mut successful_recovery_git_client = MockGitClient::new();
+        successful_recovery_git_client
+            .expect_is_rebase_in_progress()
+            .times(0);
+        successful_recovery_git_client
+            .expect_abort_rebase()
+            .times(0);
+        let successful_recovery =
+            SessionWorkerService::fail_unfinished_operations_from_previous_run_at(
+                &db,
+                base_dir.path(),
+                Arc::new(successful_recovery_git_client),
+                301,
+            )
+            .await;
+        let operation_is_unfinished = db
+            .operations()
+            .is_session_operation_unfinished("op-1")
+            .await
+            .expect("failed to check operation status");
+
+        // Assert
+        assert!(matches!(failed_recovery, Err(SessionError::Db(_))));
+        assert!(successful_recovery.is_ok());
+        assert!(!operation_is_unfinished);
+    }
+
+    #[tokio::test]
     /// Verifies restart recovery marks unfinished operations failed and
     /// restores affected sessions to `Review`.
     async fn test_fail_unfinished_operations_from_previous_run_restores_session_review_status() {
@@ -4559,7 +4797,8 @@ mod tests {
             Arc::new(mock_git_client),
             300,
         )
-        .await;
+        .await
+        .expect("restart recovery should complete");
         let sessions = db
             .sessions()
             .load_sessions()
@@ -4618,7 +4857,8 @@ mod tests {
             Arc::new(mock_git_client),
             300,
         )
-        .await;
+        .await
+        .expect("restart recovery should complete");
         let sessions = db
             .sessions()
             .load_sessions()

--- a/crates/agentty/src/infra/db/repository.rs
+++ b/crates/agentty/src/infra/db/repository.rs
@@ -200,7 +200,7 @@ mod tests {
         }
     }
 
-    /// Clock fixture used to expose accidental fallbacks to SQLite wall time.
+    /// Clock fixture used to expose accidental fallbacks to `SQLite` wall time.
     struct FixedPersistenceClock;
 
     impl Clock for FixedPersistenceClock {

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -86,7 +86,7 @@ const MISSING_RESOLVED_DECISION_HISTORY_TEXT: &str =
     "Focused review prompt omitted the resolved session decision.";
 
 /// Wall-clock budget for one seeded git invocation before it is killed.
-const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
+const GIT_COMMAND_TIMEOUT: Duration = Duration::from_mins(1);
 
 /// Poll interval used while waiting for a seeded git invocation to exit.
 const GIT_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(25);

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -363,10 +363,12 @@ restart-safe:
 - Cancel requests are persisted and checked before command execution.
 - On startup, active sessions across every saved project are migrated from retired model
   ids to their current provider/model replacements before project-scoped snapshots load.
-- On startup, unfinished operations are failed with reason `Interrupted by app restart`,
-  interrupted rebase operations abort stale in-progress git rebase metadata, and
-  impacted sessions are reset to `Review`. Pending post-merge stacked-child syncs are
-  requeued.
+- On startup, recovery loads unfinished operations, aborts stale interrupted-rebase
+  metadata, resets impacted sessions to `Review`, then fails the operations with reason
+  `Interrupted by app restart`. Each step must succeed before the next begins. A storage
+  or Git failure stops startup before any sessions are admitted, preserving unfinished
+  operation rows so the next startup can retry recovery. Pending post-merge
+  stacked-child syncs are requeued only after this recovery completes.
 
 ### Status Transition Rules
 


### PR DESCRIPTION
- Propagate storage and Git errors instead of silently discarding recovery failures.
- Preserve unfinished operations for retry on a later startup.
- Document fail-closed recovery behavior and cover failure and retry paths with tests.