### PR TITLE
Instruments Qwen requests with OpenTelemetry metrics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -181,11 +181,12 @@ repos:
         stages: [manual]
       - id: coverage
         name: coverage
-        description: Verify source-test coverage meets workspace ratchet thresholds and write the CI LCOV report for SonarQube and Codecov.
+        description: Verify source and Qwen example coverage meets workspace ratchet thresholds and write the CI LCOV report for SonarQube and Codecov.
         entry: >-
-          cargo llvm-cov nextest --workspace --lib --bins --locked --profile ci
+          cargo llvm-cov nextest --workspace --lib --bins --example qwen --locked --profile ci
           --fail-under-lines 93 --fail-under-functions 91
-          --lcov --ignore-filename-regex '^crates/agentty/tests/'
+          --lcov --no-default-ignore-filename-regex
+          --ignore-filename-regex '(/rustc/|/(tests|benches)/|/(tests\.rs|[0-9a-zA-Z_-]+[_-]tests\.rs)$|/target/llvm-cov-target/|/\.cargo/(registry|git)/|/\.rustup/toolchains/)'
           --output-path coverage.lcov
         language: system
         types: [rust]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,9 @@ version = "0.14.3"
 dependencies = [
  "async-trait",
  "jsonschema",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "reqwest",
  "serde",
  "serde_json",
@@ -2746,6 +2749,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.5",
+ "thiserror 2.0.19",
+ "tokio",
+]
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3027,6 +3100,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3070,6 +3152,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3173,6 +3278,16 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
@@ -3183,10 +3298,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rand_core"
@@ -3376,7 +3510,9 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ mockall = "0.15"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", default-features = false }
 objc2-foundation = { version = "0.3", default-features = false }
+opentelemetry = { version = "0.32", default-features = false, features = ["metrics"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "metrics", "reqwest-blocking-client"] }
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["metrics"] }
 percent-encoding = "2"
 portable-pty = "0.9"
 ratatui = { version = "0.30.1", default-features = false, features = ["crossterm", "layout-cache", "std", "underline-color"] }

--- a/crates/ag-harness/AGENTS.md
+++ b/crates/ag-harness/AGENTS.md
@@ -127,6 +127,15 @@ Configurations that cannot satisfy the contract, such as Qwen thinking mode, ret
 explicit unsupported-configuration error rather than silently falling back to
 unstructured text.
 
+## Telemetry
+
+- External OTLP metrics export is enabled when `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+- The harness records only `gen_ai.client.operation.duration`, labeled by provider and
+  model.
+- Application binaries configure the metric exporter and flush it on exit.
+- Histogram state is cumulative and process-local; the one-shot example verifies export
+  rather than cross-run totals.
+
 ## Permissions
 
 All tools are denied by default. The session policy explicitly allows tools and, for

--- a/crates/ag-harness/Cargo.toml
+++ b/crates/ag-harness/Cargo.toml
@@ -11,12 +11,15 @@ homepage.workspace = true
 [dependencies]
 async-trait.workspace = true
 jsonschema.workspace = true
+opentelemetry.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+opentelemetry-otlp.workspace = true
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
 tokio.workspace = true
 wiremock.workspace = true
 

--- a/crates/ag-harness/examples/qwen.rs
+++ b/crates/ag-harness/examples/qwen.rs
@@ -1,14 +1,82 @@
 //! Requests structured output from a configured Qwen model and prints the
-//! validated JSON.
+//! validated JSON, with optional request-duration metrics over OTLP/HTTP.
 
 use std::error::Error;
 use std::io::{self, Write};
 
 use ag_harness::{Model, ModelRequest, OutputSchema, Qwen, QwenConfig};
+use opentelemetry::global;
+use opentelemetry_otlp::{Protocol, WithExportConfig};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
 use serde_json::json;
 
+type DynError = Box<dyn Error + Send + Sync>;
+
+/// Configures OTLP metrics when a collector endpoint is present.
+fn init_metrics(endpoint: Option<String>) -> Result<Option<SdkMeterProvider>, DynError> {
+    let Some(endpoint) = endpoint else {
+        return Ok(None);
+    };
+
+    let exporter = opentelemetry_otlp::MetricExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .with_endpoint(format!("{}/v1/metrics", endpoint.trim_end_matches('/')))
+        .build()?;
+    let provider = SdkMeterProvider::builder()
+        .with_periodic_exporter(exporter)
+        .with_resource(
+            Resource::builder()
+                .with_service_name("ag-harness-qwen")
+                .build(),
+        )
+        .build();
+    global::set_meter_provider(provider.clone());
+
+    Ok(Some(provider))
+}
+
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> Result<(), DynError> {
+    let meter_provider = init_metrics(std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok())?;
+    let result = run().await;
+    let shutdown_result = shutdown_metrics(meter_provider).await;
+
+    finish(result, shutdown_result)
+}
+
+/// Flushes configured metrics without blocking a Tokio worker thread.
+async fn shutdown_metrics(meter_provider: Option<SdkMeterProvider>) -> Result<(), DynError> {
+    let Some(meter_provider) = meter_provider else {
+        return Ok(());
+    };
+
+    tokio::task::spawn_blocking(move || meter_provider.shutdown()).await??;
+
+    Ok(())
+}
+
+/// Preserves an application failure when telemetry shutdown also fails.
+fn finish(
+    result: Result<(), DynError>,
+    shutdown_result: Result<(), DynError>,
+) -> Result<(), DynError> {
+    match (result, shutdown_result) {
+        (Err(error), Err(shutdown_error)) => {
+            drop(writeln!(
+                io::stderr().lock(),
+                "telemetry shutdown also failed: {shutdown_error}"
+            ));
+
+            Err(error)
+        }
+        (Err(error), Ok(())) => Err(error),
+        (Ok(()), shutdown_result) => shutdown_result,
+    }
+}
+
+async fn run() -> Result<(), DynError> {
     let model = Qwen::new(QwenConfig {
         api_key: std::env::var("DASHSCOPE_API_KEY")?,
         base_url: std::env::var("DASHSCOPE_BASE_URL")?,
@@ -35,4 +103,192 @@ async fn main() -> Result<(), Box<dyn Error>> {
     writeln!(io::stdout().lock(), "{}", response.output())?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::{ExitStatus, Stdio};
+    use std::time::Duration;
+
+    use tokio::process::{Child, Command};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    fn test_error(message: &'static str) -> DynError {
+        io::Error::other(message).into()
+    }
+
+    async fn wait_for_fixture(
+        child: &mut Child,
+        timeout_duration: Duration,
+    ) -> Result<ExitStatus, DynError> {
+        match tokio::time::timeout(timeout_duration, child.wait()).await {
+            Ok(status) => Ok(status?),
+            Err(error) => {
+                child.kill().await?;
+                child.wait().await?;
+
+                Err(error.into())
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn metrics_are_disabled_without_an_endpoint() {
+        // Arrange
+        let meter_provider = init_metrics(None).expect("disabled metrics setup should succeed");
+
+        // Act
+        let result = shutdown_metrics(meter_provider).await;
+
+        // Assert
+        result.expect("disabled metrics shutdown should succeed");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn process_exports_metrics_over_otlp_http_on_shutdown() {
+        // Arrange
+        let qwen_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": r#"{"message":"hello"}"#}
+                }]
+            })))
+            .expect(1)
+            .mount(&qwen_server)
+            .await;
+        let otlp_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/metrics"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&otlp_server)
+            .await;
+        let executable = std::env::current_exe().expect("test executable should be available");
+        let qwen_endpoint = qwen_server.uri();
+        let otlp_endpoint = otlp_server.uri();
+
+        // Act
+        let mut child = Command::new(executable)
+            .arg("tests::process_fixture_runs_main")
+            .arg("--exact")
+            .arg("--nocapture")
+            .env("AG_HARNESS_RUN_MAIN_FIXTURE", "1")
+            .env("DASHSCOPE_API_KEY", "test-key")
+            .env("DASHSCOPE_BASE_URL", qwen_endpoint)
+            .env("OTEL_EXPORTER_OTLP_ENDPOINT", otlp_endpoint)
+            .env_remove("OTEL_EXPORTER_OTLP_COMPRESSION")
+            .env_remove("OTEL_EXPORTER_OTLP_METRICS_COMPRESSION")
+            .env_remove("OTEL_EXPORTER_OTLP_METRICS_TIMEOUT")
+            .env_remove("OTEL_EXPORTER_OTLP_TIMEOUT")
+            .env_remove("OTEL_METRIC_EXPORT_INTERVAL")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("fixture process should start");
+        let status = wait_for_fixture(&mut child, Duration::from_secs(10))
+            .await
+            .expect("fixture process should finish before the timeout");
+
+        // Assert
+        assert!(status.success(), "fixture process should succeed");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn process_timeout_kills_and_reaps_fixture() {
+        // Arrange
+        let qwen_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(10)))
+            .mount(&qwen_server)
+            .await;
+        let executable = std::env::current_exe().expect("test executable should be available");
+        let mut child = Command::new(executable)
+            .arg("tests::process_fixture_runs_main")
+            .arg("--exact")
+            .arg("--nocapture")
+            .env("AG_HARNESS_RUN_MAIN_FIXTURE", "1")
+            .env("DASHSCOPE_API_KEY", "test-key")
+            .env("DASHSCOPE_BASE_URL", qwen_server.uri())
+            .env_remove("OTEL_EXPORTER_OTLP_ENDPOINT")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("fixture process should start");
+
+        // Act
+        let result = wait_for_fixture(&mut child, Duration::from_millis(100)).await;
+
+        // Assert
+        assert_eq!(
+            result
+                .expect_err("fixture should exceed the timeout")
+                .to_string(),
+            "deadline has elapsed"
+        );
+        assert!(
+            child
+                .try_wait()
+                .expect("reaped fixture status should be available")
+                .is_some(),
+            "timed-out fixture should be reaped"
+        );
+    }
+
+    #[test]
+    fn process_fixture_runs_main() {
+        // Arrange
+        let should_run = std::env::var_os("AG_HARNESS_RUN_MAIN_FIXTURE").is_some();
+        if !should_run {
+            return;
+        }
+
+        // Act
+        let result = main();
+
+        // Assert
+        result.expect("configured example should complete and flush metrics");
+    }
+
+    #[test]
+    fn finish_preserves_application_error_priority() {
+        // Arrange
+        let application_error = test_error("Qwen request failed");
+        let shutdown_error = test_error("metrics flush failed");
+
+        // Act
+        let combined_result = finish(Err(application_error), Err(shutdown_error));
+        let application_only_result = finish(Err(test_error("application only")), Ok(()));
+        let shutdown_only_result = finish(Ok(()), Err(test_error("shutdown only")));
+        let success_result = finish(Ok(()), Ok(()));
+
+        // Assert
+        assert_eq!(
+            combined_result
+                .expect_err("both failures should fail")
+                .to_string(),
+            "Qwen request failed"
+        );
+        assert_eq!(
+            application_only_result
+                .expect_err("the application failure should be returned")
+                .to_string(),
+            "application only"
+        );
+        assert_eq!(
+            shutdown_only_result
+                .expect_err("the shutdown failure should be returned")
+                .to_string(),
+            "shutdown only"
+        );
+        success_result.expect("successful run and shutdown should succeed");
+    }
 }

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -6,6 +6,7 @@
 mod model;
 mod qwen;
 mod schema_contract;
+mod telemetry;
 
 pub use model::{Model, ModelError, ModelRequest, ModelResponse};
 pub use qwen::{Qwen, QwenConfig};

--- a/crates/ag-harness/src/qwen.rs
+++ b/crates/ag-harness/src/qwen.rs
@@ -4,10 +4,11 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{model, schema_contract};
+use crate::{model, schema_contract, telemetry};
 
 const ERROR_BODY_LIMIT_BYTES: usize = 4 * 1024;
 const JSON_STRING_MAX_EXPANSION: usize = 6;
+const PROVIDER_NAME: &str = "alibaba_cloud";
 const RESPONSE_ENVELOPE_LIMIT_BYTES: usize = 64 * 1024;
 const REQUEST_TIMEOUT: Duration = Duration::from_mins(1);
 const SUCCESS_BODY_LIMIT_BYTES: usize = schema_contract::RESPONSE_CONTENT_LIMIT_BYTES
@@ -32,6 +33,8 @@ pub struct QwenConfig {
 }
 
 /// Qwen implementation of the provider-neutral [`model::Model`] contract.
+///
+/// Calls record a duration metric without prompt or response content.
 pub struct Qwen {
     client: reqwest::Client,
     config: QwenConfig,
@@ -118,6 +121,8 @@ impl model::Model for Qwen {
         &self,
         request: model::ModelRequest,
     ) -> Result<model::ModelResponse, model::ModelError> {
+        let _duration = telemetry::RequestDuration::start(PROVIDER_NAME, &self.config.model);
+
         if !request.schema().has_object_root() {
             return Err(model::ModelError::UnsupportedOutputSchema {
                 reason: UNSUPPORTED_SCHEMA_REASON.to_string(),

--- a/crates/ag-harness/src/telemetry.rs
+++ b/crates/ag-harness/src/telemetry.rs
@@ -1,0 +1,47 @@
+use std::time::Instant;
+
+use opentelemetry::metrics::Histogram;
+use opentelemetry::{KeyValue, global};
+
+const DURATION_BOUNDARIES_SECONDS: [f64; 14] = [
+    0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
+];
+
+/// Records one model request's duration when it leaves scope.
+pub(crate) struct RequestDuration<'a> {
+    metric: Histogram<f64>,
+    model: &'a str,
+    provider: &'static str,
+    started_at: Instant,
+}
+
+impl<'a> RequestDuration<'a> {
+    /// Starts timing one model request.
+    pub(crate) fn start(provider: &'static str, model: &'a str) -> Self {
+        let metric = global::meter("ag-harness")
+            .f64_histogram("gen_ai.client.operation.duration")
+            .with_description("GenAI operation duration.")
+            .with_unit("s")
+            .with_boundaries(DURATION_BOUNDARIES_SECONDS.to_vec())
+            .build();
+
+        Self {
+            metric,
+            model,
+            provider,
+            started_at: Instant::now(),
+        }
+    }
+}
+
+impl Drop for RequestDuration<'_> {
+    fn drop(&mut self) {
+        let attributes = [
+            KeyValue::new("gen_ai.provider.name", self.provider),
+            KeyValue::new("gen_ai.request.model", self.model.to_string()),
+        ];
+
+        self.metric
+            .record(self.started_at.elapsed().as_secs_f64(), &attributes);
+    }
+}

--- a/crates/ag-harness/tests/telemetry.rs
+++ b/crates/ag-harness/tests/telemetry.rs
@@ -1,0 +1,104 @@
+//! Integration coverage for the `ag-harness` request-duration metric.
+#![cfg(test)]
+
+use ag_harness::{Model, ModelRequest, OutputSchema, Qwen, QwenConfig};
+use opentelemetry::global;
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn schema() -> OutputSchema {
+    OutputSchema::new(json!({
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    }))
+    .expect("fixture schema should be valid")
+}
+
+fn metric_attributes(
+    point: &opentelemetry_sdk::metrics::data::HistogramDataPoint<f64>,
+) -> Vec<(&str, String)> {
+    let mut attributes = point
+        .attributes()
+        .map(|attribute| (attribute.key.as_str(), attribute.value.to_string()))
+        .collect::<Vec<_>>();
+    attributes.sort_unstable();
+
+    attributes
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn records_only_request_duration_after_provider_installation() {
+    // Arrange
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {"content": r#"{"name":"Ada"}"#}
+            }]
+        })))
+        .expect(2)
+        .mount(&server)
+        .await;
+    let model = Qwen::new(QwenConfig {
+        api_key: "test-key".to_string(),
+        base_url: server.uri(),
+        model: "qwen-plus".to_string(),
+    });
+    model
+        .complete(ModelRequest::new("before provider installation", schema()))
+        .await
+        .expect("request before provider installation should succeed");
+    let exporter = InMemoryMetricExporter::default();
+    let meter_provider = SdkMeterProvider::builder()
+        .with_periodic_exporter(exporter.clone())
+        .build();
+    global::set_meter_provider(meter_provider.clone());
+
+    // Act
+    model
+        .complete(ModelRequest::new("after provider installation", schema()))
+        .await
+        .expect("instrumented request should succeed");
+    meter_provider
+        .force_flush()
+        .expect("duration metric should flush");
+
+    // Assert
+    let resource_metrics = exporter
+        .get_finished_metrics()
+        .expect("duration metric should be exported");
+    let metrics = resource_metrics
+        .iter()
+        .flat_map(opentelemetry_sdk::metrics::data::ResourceMetrics::scope_metrics)
+        .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+        .collect::<Vec<_>>();
+    assert_eq!(metrics.len(), 1);
+    let metric = metrics.first().expect("one metric should be exported");
+    assert_eq!(metric.name(), "gen_ai.client.operation.duration");
+    assert!(matches!(
+        metric.data(),
+        AggregatedMetrics::F64(MetricData::Histogram(histogram)) if {
+            let points = histogram.data_points().collect::<Vec<_>>();
+            assert_eq!(points.len(), 1);
+            assert_eq!(points[0].count(), 1);
+            assert_eq!(
+                metric_attributes(points[0]),
+                [
+                    ("gen_ai.provider.name", "alibaba_cloud".to_string()),
+                    ("gen_ai.request.model", "qwen-plus".to_string()),
+                ]
+            );
+
+            true
+        }
+    ));
+}

--- a/docs/site/content/docs/architecture/_index.md
+++ b/docs/site/content/docs/architecture/_index.md
@@ -19,3 +19,5 @@ boundaries, and change paths.
   paths for common contribution scenarios.
 - [Testability Boundaries](@/docs/architecture/testability-boundaries.md) documents
   trait boundaries and deterministic testing guidance for external integrations.
+- [`ag-harness` Design](@/docs/architecture/ag-harness-design.md) documents the model
+  contract, request-duration metric, and local observability workflow.

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -132,6 +132,24 @@ Configurations that cannot satisfy the contract, such as Qwen thinking mode, ret
 explicit unsupported-configuration error rather than silently falling back to
 unstructured text.
 
+## Telemetry
+
+- **Metric** - records one duration observation per call, including Qwen/model
+  breakdowns.
+- **Labels** - provider and model only.
+- **Ownership** - model adapters record duration; binaries configure and flush the OTLP
+  metrics exporter.
+- **Lifecycle** - histogram state is cumulative and process-local; the one-shot example
+  verifies export rather than cross-run totals.
+
+```mermaid
+flowchart LR
+    C["Qwen model call"] --> M["Duration histogram"]
+    M --> O["OTLP collector"]
+    O --> P["Prometheus"]
+    P --> G["Grafana"]
+```
+
 ## Permissions
 
 All tools are denied by default. The session policy explicitly allows tools and, for

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -31,8 +31,10 @@ For file-level detail, read the module docstrings directly.
   metadata, commit/diff/push/pull sync, rebase/conflict handling, and squash-merge
   workflows behind the `GitClient` boundary.
 - `crates/ag-harness/`: Application-facing LLM harness crate with the provider-neutral
-  `Model` contract and its first Qwen adapter. Its local `AGENTS.md` records the
-  intended agent loop, tools, session, event, and permission boundaries.
+  `Model` contract, its first Qwen adapter, and a backend-neutral request-duration
+  metric. Application binaries own OpenTelemetry SDK and OTLP exporter setup. Its local
+  `AGENTS.md` records the intended agent loop, tools, session, event, and permission
+  boundaries.
 - `crates/ag-protocol/`: Shared structured response protocol library crate with
   transport-neutral response models, schema generation, parser diagnostics, protocol
   prompt envelopes, repair prompts, review-comment outcomes, and turn prompt payload


### PR DESCRIPTION
- Records request duration with provider and model attributes, including cancelled calls.
- Configures optional OTLP/HTTP metric export and graceful shutdown in the Qwen example.
- Adds telemetry integration tests and architecture documentation.
- Documents the local OTLP, Prometheus, and Grafana observability workflow.
- Collects one duration histogram used for total-call, duration, and model-specific dashboard views.
- Adds deterministic OTLP export, provider-safe metric initialization, and subprocess reliability coverage.