### PR TITLE
Wrap slash command selection

### DIFF
--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -570,9 +570,7 @@ where
     B::Error: std::error::Error + Send + Sync + 'static,
 {
     if prompt_context.is_slash_command() {
-        if let AppMode::Prompt { slash_state, .. } = &mut app.mode {
-            slash_state.selected_index = slash_state.selected_index.saturating_sub(1);
-        }
+        move_prompt_slash_selection(app, false);
 
         return Ok(());
     }
@@ -603,7 +601,7 @@ where
     B::Error: std::error::Error + Send + Sync + 'static,
 {
     if prompt_context.is_slash_command() {
-        advance_prompt_slash_selection(app);
+        move_prompt_slash_selection(app, true);
 
         return Ok(());
     }
@@ -686,7 +684,7 @@ fn navigate_prompt_history_down(app: &mut App) {
     }
 }
 
-fn advance_prompt_slash_selection(app: &mut App) {
+fn move_prompt_slash_selection(app: &mut App, is_next: bool) {
     let (
         available_agent_kinds,
         input_text,
@@ -732,8 +730,12 @@ fn advance_prompt_slash_selection(app: &mut App) {
     }
 
     if let AppMode::Prompt { slash_state, .. } = &mut app.mode {
-        let max_index = option_count.saturating_sub(1);
-        slash_state.selected_index = (selected_index + 1).min(max_index);
+        let selected_index = selected_index.min(option_count - 1);
+        slash_state.selected_index = if is_next {
+            (selected_index + 1) % option_count
+        } else {
+            selected_index.checked_sub(1).unwrap_or(option_count - 1)
+        };
     }
 }
 
@@ -2525,16 +2527,41 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_advance_prompt_slash_selection_stays_on_last_agent() {
+    async fn test_next_prompt_slash_selection_wraps_to_first_agent() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("/model", None).await;
         if let AppMode::Prompt { slash_state, .. } = &mut app.mode {
             slash_state.stage = PromptSlashStage::Agent;
             slash_state.selected_index = AgentKind::ALL.len().saturating_sub(1);
         }
+        let terminal = test_terminal();
+        let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act
-        advance_prompt_slash_selection(&mut app);
+        handle_prompt_down_key(&mut app, &terminal, &prompt_context)
+            .expect("slash selection should move down");
+
+        // Assert
+        if let AppMode::Prompt { slash_state, .. } = &app.mode {
+            assert_eq!(slash_state.stage, PromptSlashStage::Agent);
+            assert_eq!(slash_state.selected_index, 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_previous_prompt_slash_selection_wraps_to_last_agent() {
+        // Arrange
+        let (mut app, _base_dir) = new_test_prompt_app("/model", None).await;
+        if let AppMode::Prompt { slash_state, .. } = &mut app.mode {
+            slash_state.stage = PromptSlashStage::Agent;
+            slash_state.selected_index = 0;
+        }
+        let terminal = test_terminal();
+        let prompt_context = prompt_context(&mut app).expect("expected prompt context");
+
+        // Act
+        handle_prompt_up_key(&mut app, &terminal, &prompt_context)
+            .expect("slash selection should move up");
 
         // Assert
         if let AppMode::Prompt { slash_state, .. } = &app.mode {
@@ -2549,7 +2576,7 @@ mod tests {
     /// Verifies slash navigation leaves selection unchanged when the current
     /// command text matches no slash-command options.
     #[tokio::test]
-    async fn test_advance_prompt_slash_selection_ignores_empty_command_matches() {
+    async fn test_move_prompt_slash_selection_ignores_empty_command_matches() {
         // Arrange
         let (mut app, _base_dir) = new_test_prompt_app("/x", None).await;
         if let AppMode::Prompt { slash_state, .. } = &mut app.mode {
@@ -2557,7 +2584,7 @@ mod tests {
         }
 
         // Act
-        advance_prompt_slash_selection(&mut app);
+        move_prompt_slash_selection(&mut app, true);
 
         // Assert
         if let AppMode::Prompt { slash_state, .. } = &app.mode {

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -6563,6 +6563,60 @@ fn model_slash_command_contains_match_is_visible() -> E2eResult {
     Ok(())
 }
 
+/// Verify that moving up from the first slash-command option wraps selection
+/// to the final visible option.
+#[test]
+fn slash_command_selection_wraps_from_first_to_last() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("slash_command_selection_wraps")
+        .with_git()
+        .setup(seed_review_ready_session)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .compose(&common::open_selected_session_view())
+                    .press_key("Enter")
+                    .wait_for_text("Type your message", 5000)
+                    .press_key("/")
+                    .wait_for_text("Slash Command", 3000)
+                    .press_key("Up")
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled(
+                        "slash_selection_wrapped",
+                        "Up wraps slash selection from the first option to the last",
+                    )
+            },
+            |frame, _report| {
+                let slash_menu_title = frame
+                    .find_text("Slash Command")
+                    .into_iter()
+                    .next()
+                    .expect("slash-command menu title should render");
+                let slash_menu_left_col = (0..=slash_menu_title.rect.col)
+                    .rev()
+                    .find(|column| frame.cell_text(slash_menu_title.rect.row, *column) == "╭")
+                    .expect("slash-command menu should have a left border");
+                let option_rows = (slash_menu_title.rect.row + 1..frame.rows())
+                    .take_while(|row| frame.cell_text(*row, slash_menu_left_col) == "│")
+                    .collect::<Vec<_>>();
+                let last_option_row = option_rows
+                    .last()
+                    .copied()
+                    .expect("slash-command menu should render at least one option");
+
+                assert_eq!(
+                    frame.cell_text(last_option_row, slash_menu_left_col + 1),
+                    ">",
+                    "expected the final visible slash command to be selected after wrapping up"
+                );
+            },
+        )?;
+
+    Ok(())
+}
+
 /// Verify `/speed` exposes normal and fast modes, reflects the selection, and
 /// drops both fast mode and its speed display when `/model` switches to a
 /// provider without a speed control.

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -301,6 +301,7 @@ short availability notice. Press `p` again to return to raw diff lines.
 | `Tab`                               | Focus chat output for scrolling     |
 | `@`                                 | Open file picker                    |
 | `/`                                 | Open slash commands                 |
+| `j` / `k` / `Up` / `Down`           | Navigate and wrap slash menu        |
 
 While the chat output is focused, the `d` diff-preview hint is hidden only when the
 latest successful refresh found an empty diff against the session's base branch. The

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -597,8 +597,9 @@ actions. From an editable session view, press `/` to open a new composer with th
 leading slash already inserted. This replaces any prompt draft previously saved by
 returning to the sessions list:
 
-The command picker filters as you type and accepts contains or fuzzy abbreviations such
-as `/o` for `/model`.
+The command picker filters as you type, accepts contains or fuzzy abbreviations such as
+`/o` for `/model`, and wraps between its first and last options when you navigate with
+`j` / `k` or `Up` / `Down`.
 
 | Command        | Description                                                   |
 | -------------- | ------------------------------------------------------------- |


### PR DESCRIPTION
- Wrap slash-command navigation in both directions.
- Add E2E coverage and document slash-menu navigation keys.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)