### PR TITLE
Render embedded forge HTML in terminal views

### DIFF
--- a/crates/ag-tui-text/src/html.rs
+++ b/crates/ag-tui-text/src/html.rs
@@ -1,0 +1,654 @@
+use ratatui::text::Line;
+
+use crate::{TextRenderSettings, markdown};
+
+/// Maximum forge-authored HTML input normalized for one render.
+const MAX_HTML_INPUT_BYTE_COUNT: usize = 1024 * 1024;
+/// Notice appended after forge-authored HTML input is truncated.
+const HTML_INPUT_TRUNCATION_NOTICE: &str = "\n\n[Forge content truncated at 1 MiB.]";
+/// Maximum HTML tag size inspected while normalizing untrusted forge text.
+const MAX_HTML_TAG_BYTE_COUNT: usize = 4_096;
+/// Maximum HTML entity size inspected while normalizing untrusted forge text.
+const MAX_HTML_ENTITY_BYTE_COUNT: usize = 10;
+
+/// Converts HTML embedded in forge-authored Markdown into styled,
+/// word-wrapped terminal lines.
+pub fn render_html(text: &str, width: usize) -> Vec<Line<'static>> {
+    render_html_with_settings(text, width, TextRenderSettings::default())
+}
+
+/// Converts HTML embedded in forge-authored Markdown into styled,
+/// word-wrapped terminal lines using caller-provided theme settings. Inputs
+/// larger than 1 MiB are truncated before normalization.
+pub fn render_html_with_settings(
+    text: &str,
+    width: usize,
+    settings: TextRenderSettings,
+) -> Vec<Line<'static>> {
+    let normalized = html_to_markdown(text);
+
+    markdown::render_markdown_with_settings(&normalized, width, settings)
+}
+
+/// Converts common HTML snippets embedded in forge-authored Markdown to
+/// Markdown-like text before terminal rendering.
+fn html_to_markdown(html: &str) -> String {
+    let (html, was_truncated) = bounded_html_input(html);
+    let mut rendered = String::new();
+    let mut index = 0;
+    let mut is_fenced_code = false;
+    let mut is_inline_code = false;
+
+    while index < html.len() {
+        let character = html[index..].chars().next().unwrap_or_default();
+        if normalize_markdown_code(
+            html,
+            character,
+            &mut rendered,
+            &mut index,
+            &mut is_fenced_code,
+            &mut is_inline_code,
+        ) {
+            continue;
+        }
+
+        if let Some(end_index) = html_comment_end_index(html, index) {
+            index = end_index;
+
+            continue;
+        }
+
+        if let Some(tag) = parse_html_tag(html, index) {
+            append_html_tag_replacement(&mut rendered, &tag);
+            index = tag.end_index;
+
+            continue;
+        }
+
+        if let Some((decoded, consumed)) = decode_html_entity(&html[index..]) {
+            rendered.push(decoded);
+            index += consumed;
+
+            continue;
+        }
+
+        rendered.push(character);
+        index += character.len_utf8();
+    }
+
+    let mut normalized = compact_blank_lines(&rendered);
+    if was_truncated {
+        normalized.push_str(HTML_INPUT_TRUNCATION_NOTICE);
+    }
+
+    normalized
+}
+
+/// Bounds untrusted forge HTML at a valid UTF-8 boundary before parsing.
+fn bounded_html_input(html: &str) -> (&str, bool) {
+    if html.len() <= MAX_HTML_INPUT_BYTE_COUNT {
+        return (html, false);
+    }
+
+    let mut end_index = MAX_HTML_INPUT_BYTE_COUNT;
+    while !html.is_char_boundary(end_index) {
+        end_index -= 1;
+    }
+
+    (&html[..end_index], true)
+}
+
+/// Preserves a Markdown code token that must bypass HTML normalization,
+/// returning whether the current input position was consumed.
+fn normalize_markdown_code(
+    markdown: &str,
+    character: char,
+    rendered: &mut String,
+    index: &mut usize,
+    is_fenced_code: &mut bool,
+    is_inline_code: &mut bool,
+) -> bool {
+    if let Some((line_end_index, is_fence_delimiter)) =
+        preserved_code_line(markdown, *index, *is_fenced_code)
+    {
+        rendered.push_str(&markdown[*index..line_end_index]);
+        *index = line_end_index;
+        if is_fence_delimiter {
+            *is_fenced_code = !*is_fenced_code;
+        }
+
+        return true;
+    }
+
+    if character == '`' {
+        rendered.push(character);
+        *index += character.len_utf8();
+        if *is_inline_code {
+            *is_inline_code = false;
+        } else {
+            *is_inline_code = has_inline_code_closer(&markdown[*index..]);
+        }
+
+        return true;
+    }
+
+    if *is_inline_code {
+        rendered.push(character);
+        *index += character.len_utf8();
+
+        return true;
+    }
+
+    false
+}
+
+/// Returns a Markdown fence or fenced-content line that must bypass HTML
+/// normalization, together with whether the line toggles the fence state.
+fn preserved_code_line(
+    markdown: &str,
+    index: usize,
+    is_fenced_code: bool,
+) -> Option<(usize, bool)> {
+    if index != 0 && markdown.as_bytes().get(index - 1) != Some(&b'\n') {
+        return None;
+    }
+
+    let line_end_index = markdown[index..]
+        .find('\n')
+        .map_or(markdown.len(), |offset| index + offset + 1);
+    let is_fence_delimiter = markdown[index..line_end_index].trim().starts_with("```");
+    if !is_fenced_code && !is_fence_delimiter {
+        return None;
+    }
+
+    Some((line_end_index, is_fence_delimiter))
+}
+
+/// Whether the remainder of the current Markdown line closes an inline-code
+/// span containing at least one character.
+fn has_inline_code_closer(markdown: &str) -> bool {
+    let current_line = markdown.split_once('\n').map_or(markdown, |(line, _)| line);
+
+    current_line.find('`').is_some_and(|offset| offset > 0)
+}
+
+/// Returns the byte index following an HTML comment at `index`.
+///
+/// Unterminated comments consume the remainder of the body so hidden issue
+/// template instructions are never painted as visible text.
+fn html_comment_end_index(html: &str, index: usize) -> Option<usize> {
+    let suffix = html.get(index..)?;
+    if !suffix.starts_with("<!--") {
+        return None;
+    }
+
+    Some(
+        suffix
+            .find("-->")
+            .map_or(html.len(), |offset| index + offset + 3),
+    )
+}
+
+/// Parsed representation of one HTML tag embedded in a forge body.
+struct HtmlTag<'a> {
+    /// Byte index immediately after the closing `>` in the source string.
+    end_index: usize,
+    /// Whether the tag starts with `/`.
+    is_closing: bool,
+    /// Lowercase-insensitive tag name without attributes.
+    name: &'a str,
+}
+
+/// Parses one bounded ASCII HTML tag at `index`, returning `None` for literal
+/// `<` characters, oversized tags, or malformed tags.
+fn parse_html_tag(html: &str, index: usize) -> Option<HtmlTag<'_>> {
+    let suffix = html.get(index..)?;
+    if !suffix.starts_with('<') {
+        return None;
+    }
+
+    let close_offset = html_tag_close_offset(suffix)?;
+    let raw_tag = &suffix[1..close_offset];
+    let (is_closing, tag_content) = raw_tag
+        .strip_prefix('/')
+        .map_or((false, raw_tag), |content| (true, content));
+    if tag_content.starts_with(char::is_whitespace) {
+        return None;
+    }
+    let name_end = tag_content
+        .char_indices()
+        .take_while(|(_, character)| character.is_ascii_alphanumeric())
+        .map(|(offset, character)| offset + character.len_utf8())
+        .last()?;
+    let name = &tag_content[..name_end];
+    if !name
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_ascii_alphabetic())
+    {
+        return None;
+    }
+    let tag_suffix = &tag_content[name_end..];
+    if tag_suffix
+        .chars()
+        .next()
+        .is_some_and(|character| !character.is_ascii_whitespace() && character != '/')
+    {
+        return None;
+    }
+
+    Some(HtmlTag {
+        end_index: index + close_offset + 1,
+        is_closing,
+        name,
+    })
+}
+
+/// Finds the closing `>` for a bounded HTML tag while ignoring delimiters in
+/// single- or double-quoted attribute values.
+fn html_tag_close_offset(tag: &str) -> Option<usize> {
+    let mut attribute_quote = None;
+
+    for (offset, byte) in tag
+        .bytes()
+        .take(MAX_HTML_TAG_BYTE_COUNT.saturating_add(1))
+        .enumerate()
+    {
+        match (byte, attribute_quote) {
+            (b'\'' | b'"', None) => attribute_quote = Some(byte),
+            (quote, Some(active_quote)) if quote == active_quote => {
+                attribute_quote = None;
+            }
+            (b'>', None) => return Some(offset),
+            _ => {}
+        }
+    }
+
+    None
+}
+
+/// Appends Markdown punctuation or spacing for one recognized HTML tag.
+fn append_html_tag_replacement(output: &mut String, tag: &HtmlTag<'_>) {
+    match (tag.name.to_ascii_lowercase().as_str(), tag.is_closing) {
+        ("h1", false) => append_line_prefix(output, "# "),
+        ("h2", false) => append_line_prefix(output, "## "),
+        ("h3" | "summary", false) => append_line_prefix(output, "### "),
+        ("h4" | "h5" | "h6", false) => append_line_prefix(output, "#### "),
+        ("li", false) => append_line_prefix(output, "- "),
+        ("blockquote", false) => append_line_prefix(output, "> "),
+        ("hr", false) => {
+            append_line_prefix(output, "---");
+            append_line_break(output);
+        }
+        ("code" | "kbd", _) => output.push('`'),
+        ("strong" | "b", _) => output.push_str("**"),
+        ("em" | "i", _) => output.push('*'),
+        (
+            "br" | "p" | "div" | "details" | "summary" | "blockquote" | "h1" | "h2" | "h3" | "h4"
+            | "h5" | "h6" | "li" | "section" | "article",
+            true,
+        )
+        | ("br" | "p" | "div" | "ul" | "ol" | "details" | "section" | "article", false) => {
+            append_line_break(output);
+        }
+        _ => {}
+    }
+}
+
+/// Appends `prefix` at the beginning of a logical Markdown line.
+fn append_line_prefix(output: &mut String, prefix: &str) {
+    if !output.is_empty() && !output.ends_with('\n') {
+        output.push('\n');
+    }
+
+    output.push_str(prefix);
+}
+
+/// Appends a single line break while avoiding duplicate blank lines from
+/// adjacent HTML block tags.
+fn append_line_break(output: &mut String) {
+    if !output.ends_with('\n') {
+        output.push('\n');
+    }
+}
+
+/// Decodes named and numeric HTML entities common in forge bodies.
+fn decode_html_entity(input: &str) -> Option<(char, usize)> {
+    if !input.starts_with('&') {
+        return None;
+    }
+
+    let semicolon_index = input
+        .bytes()
+        .take(MAX_HTML_ENTITY_BYTE_COUNT)
+        .position(|byte| byte == b';')?;
+    let entity = &input[1..semicolon_index];
+    let decoded = match entity {
+        "amp" => '&',
+        "lt" => '<',
+        "gt" => '>',
+        "quot" => '"',
+        "apos" | "#39" => '\'',
+        "nbsp" => ' ',
+        _ => decode_numeric_html_entity(entity)?,
+    };
+
+    Some((decoded, semicolon_index + 1))
+}
+
+/// Decodes decimal and hexadecimal numeric HTML entities.
+fn decode_numeric_html_entity(entity: &str) -> Option<char> {
+    let codepoint = if let Some(hexadecimal) = entity
+        .strip_prefix("#x")
+        .or_else(|| entity.strip_prefix("#X"))
+    {
+        u32::from_str_radix(hexadecimal, 16).ok()?
+    } else {
+        let decimal = entity.strip_prefix('#')?;
+        decimal.parse::<u32>().ok()?
+    };
+
+    let decoded = char::from_u32(codepoint)?;
+
+    (!decoded.is_control() || matches!(decoded, '\n' | '\t')).then_some(decoded)
+}
+
+/// Collapses runs of blank lines produced by neighboring HTML block tags while
+/// preserving meaningful leading indentation inside content lines.
+fn compact_blank_lines(markdown: &str) -> String {
+    let mut compacted = Vec::new();
+    let mut is_fenced_code = false;
+    let mut previous_blank = false;
+
+    for raw_line in markdown.lines() {
+        let is_fence_delimiter = raw_line.trim().starts_with("```");
+        let preserve_line = is_fenced_code || is_fence_delimiter;
+        let line = if preserve_line {
+            raw_line
+        } else {
+            raw_line.trim_end()
+        };
+        let is_blank = line.trim().is_empty();
+        if !preserve_line && is_blank && previous_blank {
+            continue;
+        }
+
+        compacted.push(line);
+        if is_fence_delimiter {
+            is_fenced_code = !is_fenced_code;
+        }
+        previous_blank = !preserve_line && is_blank;
+    }
+
+    compacted.join("\n").trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::style::Modifier;
+
+    use super::*;
+
+    #[test]
+    fn test_render_html_normalizes_block_and_inline_markup() {
+        // Arrange
+        let input = concat!(
+            "<details><summary>Release notes</summary>",
+            "<h1>One</h1><h2>Two</h2><h3>Three</h3><h4>Four</h4>",
+            "<h5>Five</h5><h6>Six</h6>",
+            "<ul><li><strong>Fix</strong> <em>parser</em> ",
+            "with <code>fast</code> and <kbd>Enter</kbd>.</li></ul>",
+            "<blockquote>Quoted</blockquote><hr></details>",
+        );
+
+        // Act
+        let lines = render_html(input, 80);
+        let text = lines.iter().map(Line::to_string).collect::<Vec<_>>();
+
+        // Assert
+        assert!(text.contains(&"Release notes".to_string()));
+        assert!(text.contains(&"One".to_string()));
+        assert!(text.contains(&"Two".to_string()));
+        assert!(text.contains(&"Three".to_string()));
+        assert!(text.contains(&"Four".to_string()));
+        assert!(text.contains(&"Five".to_string()));
+        assert!(text.contains(&"Six".to_string()));
+        assert!(text.contains(&"- Fix parser with fast and Enter.".to_string()));
+        assert!(text.contains(&"│ Quoted".to_string()));
+        assert!(lines.iter().any(|line| line.spans.iter().any(|span| {
+            span.content.as_ref() == "Fix" && span.style.add_modifier.contains(Modifier::BOLD)
+        })));
+        assert!(!text.join("\n").contains('<'));
+    }
+
+    #[test]
+    fn test_render_html_handles_layout_tags_comments_and_entities() {
+        // Arrange
+        let input = concat!(
+            "<!-- hidden issue template -->",
+            "<article><section><div><p>A&amp;B&lt;C&gt;D &quot;Q&quot; ",
+            "&apos;x&apos; &#39;y&#39; &nbsp; &#65; &#x42; &#X43;</p>",
+            "line<br>next</div></section></article>",
+        );
+
+        // Act
+        let lines = render_html_with_settings(input, 80, TextRenderSettings::default());
+        let text = lines
+            .iter()
+            .map(Line::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Assert
+        assert_eq!(text, "A&B<C>D \"Q\" 'x' 'y' A B C\nline\nnext");
+        assert!(!text.contains("hidden issue template"));
+    }
+
+    #[test]
+    fn test_html_to_markdown_preserves_literal_and_malformed_markup() {
+        // Arrange
+        let input = "Keep 2 < 3 and 5 > 4, &unknown;, <1>, <broken, and <x>tag</x>.";
+
+        // Act
+        let rendered = html_to_markdown(input);
+
+        // Assert
+        assert_eq!(
+            rendered,
+            "Keep 2 < 3 and 5 > 4, &unknown;, <1>, <broken, and tag."
+        );
+    }
+
+    #[test]
+    fn test_html_to_markdown_preserves_whitespace_prefixed_tags() {
+        // Arrange
+        let input = "a < b > c and d </ b > e";
+
+        // Act
+        let rendered = html_to_markdown(input);
+
+        // Assert
+        assert_eq!(rendered, input);
+    }
+
+    #[test]
+    fn test_html_to_markdown_ignores_tag_delimiters_inside_quoted_attributes() {
+        // Arrange
+        let input = concat!(
+            r#"<a title="x ' > y">double quoted</a> and "#,
+            r#"<span data-note='a " > b'>single quoted</span>"#,
+        );
+
+        // Act
+        let rendered = html_to_markdown(input);
+
+        // Assert
+        assert_eq!(rendered, "double quoted and single quoted");
+    }
+
+    #[test]
+    fn test_html_to_markdown_preserves_fenced_markdown_code() {
+        // Arrange
+        let input = concat!(
+            "Before <strong>bold</strong>\n",
+            "```html\n",
+            "<div>&amp;</div>  \n",
+            "\n",
+            "```\n",
+            "After <em>text</em>",
+        );
+
+        // Act
+        let rendered = html_to_markdown(input);
+
+        // Assert
+        assert_eq!(
+            rendered,
+            concat!(
+                "Before **bold**\n",
+                "```html\n",
+                "<div>&amp;</div>  \n",
+                "\n",
+                "```\n",
+                "After *text*",
+            )
+        );
+    }
+
+    #[test]
+    fn test_html_to_markdown_preserves_inline_markdown_code() {
+        // Arrange
+        let input = concat!(
+            "Use `<div>&amp;</div>` with <strong>care</strong>. ",
+            "An unmatched ` leaves <em>markup</em> active.",
+        );
+
+        // Act
+        let rendered = html_to_markdown(input);
+
+        // Assert
+        assert_eq!(
+            rendered,
+            concat!(
+                "Use `<div>&amp;</div>` with **care**. ",
+                "An unmatched ` leaves *markup* active.",
+            )
+        );
+    }
+
+    #[test]
+    fn test_html_to_markdown_discards_unterminated_comment_and_invalid_entities() {
+        // Arrange
+        let input = "Visible &; &#; &#x; &#99999999;<!-- hidden forever";
+
+        // Act
+        let rendered = html_to_markdown(input);
+
+        // Assert
+        assert_eq!(rendered, "Visible &; &#; &#x; &#99999999;");
+    }
+
+    #[test]
+    fn test_html_to_markdown_preserves_oversized_tag_text() {
+        // Arrange
+        let input = format!(
+            "<div {}>visible",
+            "x".repeat(MAX_HTML_TAG_BYTE_COUNT.saturating_add(1))
+        );
+
+        // Act
+        let rendered = html_to_markdown(&input);
+
+        // Assert
+        assert_eq!(rendered, input);
+    }
+
+    #[test]
+    fn test_html_to_markdown_bounds_input_at_utf8_boundary() {
+        // Arrange
+        let mut input = "x".repeat(MAX_HTML_INPUT_BYTE_COUNT - 1);
+        input.push('é');
+        input.push_str("<strong>hidden overflow</strong>");
+
+        // Act
+        let rendered = html_to_markdown(&input);
+
+        // Assert
+        assert_eq!(
+            rendered.len(),
+            MAX_HTML_INPUT_BYTE_COUNT - 1 + HTML_INPUT_TRUNCATION_NOTICE.len()
+        );
+        assert!(rendered.ends_with(HTML_INPUT_TRUNCATION_NOTICE));
+        assert!(!rendered.contains("hidden overflow"));
+    }
+
+    #[test]
+    fn test_html_to_markdown_bounds_malformed_entity_scanning() {
+        // Arrange
+        let input = format!("{};", "&".repeat(100_000));
+
+        // Act
+        let rendered = html_to_markdown(&input);
+
+        // Assert
+        assert_eq!(rendered, input);
+    }
+
+    #[test]
+    fn test_decode_html_entity_accepts_maximum_supported_length() {
+        // Arrange
+        let input = "&#1114111;";
+
+        // Act
+        let decoded = decode_html_entity(input);
+
+        // Assert
+        assert_eq!(decoded, Some(('\u{10ffff}', MAX_HTML_ENTITY_BYTE_COUNT)));
+    }
+
+    #[test]
+    fn test_html_to_markdown_rejects_control_character_entities() {
+        // Arrange
+        let input = concat!(
+            "Keep &#x1b;[2J, &#27;[H, &#127;, and &#159;; ",
+            "allow &#10;line and &#9;tab.",
+        );
+
+        // Act
+        let rendered = html_to_markdown(input);
+
+        // Assert
+        assert_eq!(
+            rendered,
+            concat!(
+                "Keep &#x1b;[2J, &#27;[H, &#127;, and &#159;; allow\n",
+                "line and \ttab.",
+            )
+        );
+        assert!(!rendered.contains('\u{1b}'));
+    }
+
+    #[test]
+    fn test_html_to_markdown_compacts_adjacent_block_spacing() {
+        // Arrange
+        let input = "<p>First</p>\n\n<div>Second</div><ol><li>Third</li></ol>";
+
+        // Act
+        let rendered = html_to_markdown(input);
+
+        // Assert
+        assert_eq!(rendered, "First\n\nSecond\n- Third");
+    }
+
+    #[test]
+    fn test_append_line_prefix_starts_a_new_logical_line() {
+        // Arrange
+        let mut output = "Existing".to_string();
+
+        // Act
+        append_line_prefix(&mut output, "# ");
+
+        // Assert
+        assert_eq!(output, "Existing\n# ");
+    }
+}

--- a/crates/ag-tui-text/src/lib.rs
+++ b/crates/ag-tui-text/src/lib.rs
@@ -1,5 +1,7 @@
 //! Shared terminal text rendering helpers for Agentty frontends.
 
+/// HTML normalization and terminal rendering for forge-authored Markdown.
+pub mod html;
 /// Markdown parsing, terminal styling, wrapping, and rendered-line caching.
 pub mod markdown;
 /// Bounded Mermaid parsing and terminal diagram rendering.

--- a/crates/agentty/src/ui/markdown.rs
+++ b/crates/agentty/src/ui/markdown.rs
@@ -22,9 +22,15 @@ struct PromptBlock {
     next_line_index: usize,
 }
 
-/// Theme-aware cache for rendered markdown transcript lines.
+/// Theme-aware cache for rendered Markdown and forge HTML lines.
+///
+/// Markdown and HTML use separate bounded entry sets because identical source
+/// text can require different renderers. Both sets key entries by source text,
+/// width, and theme version, and [`Self::bump_version()`] invalidates them
+/// together.
 #[derive(Default)]
 pub struct MarkdownRenderCache {
+    html_inner: ag_tui_text::markdown::MarkdownRenderCache,
     inner: ag_tui_text::markdown::MarkdownRenderCache,
 }
 
@@ -45,8 +51,22 @@ impl MarkdownRenderCache {
         self.inner.render_with_settings(text, width, settings)
     }
 
+    /// Returns cached rendered lines after normalizing HTML embedded in a
+    /// forge-authored Markdown body.
+    pub fn render_html(&self, text: &str, width: usize) -> Arc<[Line<'static>]> {
+        let settings = style::text_render_settings();
+
+        self.html_inner.render_with_settings_and_renderer(
+            text,
+            width,
+            settings,
+            move |text, width| ag_tui_text::html::render_html_with_settings(text, width, settings),
+        )
+    }
+
     /// Bumps the cache version and drops all rendered entries.
     pub fn bump_version(&self) {
+        self.html_inner.bump_version();
         self.inner.bump_version();
     }
 
@@ -385,6 +405,31 @@ mod tests {
                         .contains(ratatui::style::Modifier::BOLD)
             })
         }));
+    }
+
+    #[test]
+    fn test_markdown_render_cache_keeps_html_entries_separate_and_invalidates_them() {
+        // Arrange
+        let cache = MarkdownRenderCache::default();
+        let input = "Use <strong>shared</strong> rendering.";
+        let initial_version = cache.version();
+
+        // Act
+        let markdown_lines = cache.render(input, 80);
+        let html_lines = cache.render_html(input, 80);
+        let cached_html_lines = cache.render_html(input, 80);
+        cache.bump_version();
+        let refreshed_markdown_lines = cache.render(input, 80);
+        let refreshed_html_lines = cache.render_html(input, 80);
+
+        // Assert
+        assert_eq!(markdown_lines[0].to_string(), input);
+        assert_eq!(html_lines[0].to_string(), "Use shared rendering.");
+        assert!(!Arc::ptr_eq(&markdown_lines, &html_lines));
+        assert!(Arc::ptr_eq(&html_lines, &cached_html_lines));
+        assert!(!Arc::ptr_eq(&markdown_lines, &refreshed_markdown_lines));
+        assert!(!Arc::ptr_eq(&html_lines, &refreshed_html_lines));
+        assert_eq!(cache.version(), initial_version + 1);
     }
 
     #[test]

--- a/crates/agentty/src/ui/page/issue_detail.rs
+++ b/crates/agentty/src/ui/page/issue_detail.rs
@@ -144,7 +144,7 @@ fn issue_detail_lines(
     ]);
     lines.extend(
         markdown_render_cache
-            .render(description, width)
+            .render_html(description, width)
             .iter()
             .cloned(),
     );
@@ -282,6 +282,41 @@ mod tests {
         assert!(rendered_text.contains("Failed to start issue session: worktree unavailable"));
         assert!(rendered_text.contains("Title: Keep issue details reachable"));
         assert!(rendered_text.contains("One description line."));
+    }
+
+    #[test]
+    fn test_issue_detail_lines_renders_embedded_html() {
+        // Arrange
+        let issue = assigned_issue();
+        let mut detail = issue_detail();
+        detail.body = Some(
+            "<!-- hidden template --><h2>Details</h2><ul><li>Use <code>shared</code> \
+             rendering.</li></ul>"
+                .to_string(),
+        );
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+
+        // Act
+        let lines = issue_detail_lines(
+            &issue,
+            Some(&detail),
+            None,
+            None,
+            &markdown_render_cache,
+            80,
+        );
+        let rendered_text = lines
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Assert
+        assert!(rendered_text.contains("Details"));
+        assert!(rendered_text.contains("- Use shared rendering."));
+        assert!(!rendered_text.contains("hidden template"));
+        assert!(!rendered_text.contains("<h2>"));
+        assert!(!rendered_text.contains("<code>"));
     }
 
     #[test]

--- a/crates/agentty/src/ui/page/review_comment.rs
+++ b/crates/agentty/src/ui/page/review_comment.rs
@@ -45,7 +45,7 @@ pub struct ReviewCommentPageInput<'a> {
     pub diff: &'a str,
     /// Whether the forge comment request is still running.
     pub is_loading_comments: bool,
-    /// Shared cache used for styled Markdown comment bodies.
+    /// Shared cache used for styled Markdown and embedded HTML comment bodies.
     pub markdown_render_cache: &'a markdown::MarkdownRenderCache,
     /// Vertical offset inside the selected comment detail panel.
     pub scroll_offset: u16,

--- a/crates/agentty/src/ui/page/review_detail.rs
+++ b/crates/agentty/src/ui/page/review_detail.rs
@@ -16,7 +16,7 @@ pub struct ReviewDetailPage<'a> {
     comment_error: Option<&'a str>,
     /// Whether comments are currently being fetched in the background.
     is_loading_comments: bool,
-    /// Shared cache used for styled markdown body rendering.
+    /// Shared cache used for styled Markdown and embedded HTML body rendering.
     markdown_render_cache: &'a markdown::MarkdownRenderCache,
     /// Requested review opened from the review list.
     review: &'a RequestedReview,
@@ -119,7 +119,6 @@ fn detail_lines(
         .map(str::trim)
         .filter(|body| !body.is_empty())
         .unwrap_or("No description provided.");
-    let description = review_description_markdown(description);
     let mut lines = vec![
         section_label("Title"),
         Line::from(review.title.clone()),
@@ -132,7 +131,7 @@ fn detail_lines(
 
     lines.extend(
         markdown_render_cache
-            .render(&description, width)
+            .render_html(description, width)
             .iter()
             .cloned(),
     );
@@ -254,175 +253,6 @@ fn error_line(text: impl Into<String>) -> Line<'static> {
         text.into(),
         Style::default().fg(style::palette::danger()),
     ))
-}
-
-/// Converts common HTML snippets embedded in forge markdown bodies to
-/// markdown-like text before terminal markdown rendering.
-fn review_description_markdown(description: &str) -> String {
-    let mut rendered = String::new();
-    let mut index = 0;
-
-    while index < description.len() {
-        if let Some(tag) = parse_html_tag(description, index) {
-            append_html_tag_replacement(&mut rendered, &tag);
-            index = tag.end_index;
-
-            continue;
-        }
-
-        if let Some((decoded, consumed)) = decode_html_entity(&description[index..]) {
-            rendered.push(decoded);
-            index += consumed;
-
-            continue;
-        }
-
-        let Some(character) = description[index..].chars().next() else {
-            break;
-        };
-        rendered.push(character);
-        index += character.len_utf8();
-    }
-
-    compact_blank_lines(&rendered)
-}
-
-/// Parsed representation of one HTML tag embedded in a forge description.
-struct HtmlTag<'a> {
-    /// Byte index immediately after the closing `>` in the source string.
-    end_index: usize,
-    /// Whether the tag starts with `/`.
-    is_closing: bool,
-    /// Lowercase-insensitive tag name without attributes.
-    name: &'a str,
-}
-
-/// Parses one ASCII HTML tag at `index`, returning `None` for literal `<`
-/// characters or malformed tags.
-fn parse_html_tag(description: &str, index: usize) -> Option<HtmlTag<'_>> {
-    let suffix = description.get(index..)?;
-    if !suffix.starts_with('<') {
-        return None;
-    }
-
-    let close_offset = suffix.find('>')?;
-    let raw_tag = suffix[1..close_offset].trim();
-    let (is_closing, tag_content) = raw_tag
-        .strip_prefix('/')
-        .map_or((false, raw_tag), |content| (true, content.trim_start()));
-    let name_end = tag_content
-        .char_indices()
-        .take_while(|(_, character)| character.is_ascii_alphanumeric())
-        .map(|(offset, character)| offset + character.len_utf8())
-        .last()?;
-    let name = &tag_content[..name_end];
-    if !name
-        .chars()
-        .next()
-        .is_some_and(|character| character.is_ascii_alphabetic())
-    {
-        return None;
-    }
-
-    Some(HtmlTag {
-        end_index: index + close_offset + 1,
-        is_closing,
-        name,
-    })
-}
-
-/// Appends markdown punctuation or spacing for one recognized HTML tag.
-fn append_html_tag_replacement(output: &mut String, tag: &HtmlTag<'_>) {
-    match (tag.name.to_ascii_lowercase().as_str(), tag.is_closing) {
-        ("h1", false) => append_line_prefix(output, "# "),
-        ("h2", false) => append_line_prefix(output, "## "),
-        ("h3" | "summary", false) => append_line_prefix(output, "### "),
-        ("h4", false) => append_line_prefix(output, "#### "),
-        ("li", false) => append_line_prefix(output, "- "),
-        ("blockquote", false) => append_line_prefix(output, "> "),
-        ("code", _) => output.push('`'),
-        ("strong" | "b", _) => output.push_str("**"),
-        ("em" | "i", _) => output.push('*'),
-        (
-            "br" | "p" | "details" | "summary" | "blockquote" | "h1" | "h2" | "h3" | "h4" | "li",
-            true,
-        )
-        | ("br" | "p" | "ul" | "ol" | "details", false) => append_line_break(output),
-        _ => {}
-    }
-}
-
-/// Appends `prefix` at the beginning of a logical markdown line.
-fn append_line_prefix(output: &mut String, prefix: &str) {
-    if !output.is_empty() && !output.ends_with('\n') {
-        output.push('\n');
-    }
-
-    output.push_str(prefix);
-}
-
-/// Appends a single line break while avoiding duplicate blank lines from
-/// adjacent HTML block tags.
-fn append_line_break(output: &mut String) {
-    if !output.ends_with('\n') {
-        output.push('\n');
-    }
-}
-
-/// Decodes a small set of named and numeric HTML entities common in forge
-/// review descriptions.
-fn decode_html_entity(input: &str) -> Option<(char, usize)> {
-    if !input.starts_with('&') {
-        return None;
-    }
-
-    let semicolon_index = input.find(';')?;
-    let entity = &input[1..semicolon_index];
-    let decoded = match entity {
-        "amp" => '&',
-        "lt" => '<',
-        "gt" => '>',
-        "quot" => '"',
-        "apos" | "#39" => '\'',
-        "nbsp" => ' ',
-        _ => decode_numeric_html_entity(entity)?,
-    };
-
-    Some((decoded, semicolon_index + 1))
-}
-
-/// Decodes decimal and hexadecimal numeric HTML entities.
-fn decode_numeric_html_entity(entity: &str) -> Option<char> {
-    let codepoint = if let Some(hexadecimal) = entity
-        .strip_prefix("#x")
-        .or_else(|| entity.strip_prefix("#X"))
-    {
-        u32::from_str_radix(hexadecimal, 16).ok()?
-    } else {
-        let decimal = entity.strip_prefix('#')?;
-        decimal.parse::<u32>().ok()?
-    };
-
-    char::from_u32(codepoint)
-}
-
-/// Collapses runs of blank lines produced by neighboring HTML block tags while
-/// preserving meaningful leading indentation inside content lines.
-fn compact_blank_lines(markdown: &str) -> String {
-    let mut compacted = Vec::new();
-    let mut previous_blank = false;
-
-    for line in markdown.lines().map(str::trim_end) {
-        let is_blank = line.trim().is_empty();
-        if is_blank && previous_blank {
-            continue;
-        }
-
-        compacted.push(line);
-        previous_blank = is_blank;
-    }
-
-    compacted.join("\n").trim().to_string()
 }
 
 /// Returns the width used to wrap rendered review description markdown.
@@ -726,18 +556,6 @@ mod tests {
 
         // Assert
         assert_eq!(max_scroll_offset, 12);
-    }
-
-    #[test]
-    fn test_review_description_markdown_preserves_literal_angle_brackets() {
-        // Arrange
-        let description = "Keep 2 < 3 and 5 > 4 visible.";
-
-        // Act
-        let rendered = review_description_markdown(description);
-
-        // Assert
-        assert_eq!(rendered, "Keep 2 < 3 and 5 > 4 visible.");
     }
 
     /// Builds one requested-review fixture for detail render tests.

--- a/crates/agentty/src/ui/review_comment_format.rs
+++ b/crates/agentty/src/ui/review_comment_format.rs
@@ -4,7 +4,8 @@ use ratatui::text::{Line, Span};
 
 use crate::ui::{markdown, style};
 
-/// Appends comment author rows and two-space-indented markdown bodies.
+/// Appends comment author rows and two-space-indented Markdown bodies after
+/// normalizing embedded HTML.
 pub(crate) fn append_comment_bodies(
     lines: &mut Vec<Line<'static>>,
     comments: &[ReviewComment],
@@ -73,7 +74,7 @@ pub(crate) fn thread_anchor_line_range(thread: &ReviewCommentThread) -> Option<(
     Some((start_line.min(end_line), start_line.max(end_line)))
 }
 
-/// Appends one comment's author header followed by the markdown-rendered body.
+/// Appends one comment's author header followed by its rendered body.
 fn append_comment_body(
     lines: &mut Vec<Line<'static>>,
     comment: &ReviewComment,
@@ -88,7 +89,7 @@ fn append_comment_body(
     )));
 
     let body_width = width.saturating_sub(2).max(1);
-    let rendered = markdown_render_cache.render(&comment.body, body_width);
+    let rendered = markdown_render_cache.render_html(&comment.body, body_width);
     for rendered_line in rendered.iter() {
         let mut spans = Vec::with_capacity(rendered_line.spans.len() + 1);
         spans.push(Span::raw("  "));
@@ -185,6 +186,37 @@ mod tests {
             .join("\n");
         assert!(text.contains("alice"));
         assert!(text.contains("  Looks good."));
+    }
+
+    #[test]
+    fn test_append_comment_bodies_renders_embedded_html() {
+        // Arrange
+        let mut lines = Vec::new();
+        let comments = vec![ReviewComment {
+            author: "alice".to_string(),
+            body: concat!(
+                "<!-- hidden reviewer note -->",
+                "<p><strong>Explain</strong> this output.<br>",
+                "Use <code>stdout</code>.</p>",
+            )
+            .to_string(),
+        }];
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+
+        // Act
+        append_comment_bodies(&mut lines, &comments, &markdown_render_cache, 40);
+        let text = lines
+            .iter()
+            .map(Line::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Assert
+        assert!(text.contains("  Explain this output."));
+        assert!(text.contains("  Use stdout."));
+        assert!(!text.contains("hidden reviewer note"));
+        assert!(!text.contains("<strong>"));
+        assert!(!text.contains("<br>"));
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/navigation.rs
+++ b/crates/agentty/tests/e2e/navigation.rs
@@ -160,7 +160,7 @@ if [ "$1" = "issue" ] && [ "$2" = "view" ] && [ "$3" = "124" ]; then
 {
   "assignees": [{"login": "octocat"}],
   "author": {"login": "hubot"},
-  "body": "Show the selected issue's base information without loading comments.",
+  "body": "<!-- hidden issue template --><h2>Implementation notes</h2><ul><li>Show the selected issue's base information without loading comments.</li><li>Use <code>shared</code> rendering.</li></ul><p><a title=\"x > y\">Quoted attribute link</a></p><p>Literal relation: a < b > c.</p><p>Control sample: &#x1b;[2J stays visible.</p>\n\nInline sample: `<span>literal inline HTML</span>`.\n\n```html\n<div>literal fenced HTML</div>\n```",
   "createdAt": "2026-07-01T10:00:00Z",
   "labels": [{"name": "enhancement"}, {"name": "ui"}],
   "number": 124,
@@ -460,6 +460,13 @@ fn test_assigned_github_issues() -> E2eResult {
                     .capture_labeled("issues", "Assigned GitHub issue list")
                     .press_key("Enter")
                     .wait_for_text("Description", 5000)
+                    .wait_for_text("Implementation notes", 5000)
+                    .wait_for_text("Use shared rendering.", 5000)
+                    .wait_for_text("Quoted attribute link", 5000)
+                    .wait_for_text("Literal relation: a < b > c.", 5000)
+                    .wait_for_text("Control sample: &#x1b;[2J stays visible.", 5000)
+                    .wait_for_text("<span>literal inline HTML</span>", 5000)
+                    .wait_for_text("<div>literal fenced HTML</div>", 5000)
                     .viewing_pause_ms(1500)
                     .capture_labeled("issue_detail", "Selected GitHub issue details")
             },
@@ -486,6 +493,21 @@ fn test_assigned_github_issues() -> E2eResult {
                     "Show the selected issue's base information",
                     &full,
                 );
+                assertion::assert_text_in_region(frame, "Implementation notes", &full);
+                assertion::assert_text_in_region(frame, "Use shared rendering.", &full);
+                assertion::assert_text_in_region(frame, "Quoted attribute link", &full);
+                assertion::assert_text_in_region(frame, "Literal relation: a < b > c.", &full);
+                assertion::assert_text_in_region(
+                    frame,
+                    "Control sample: &#x1b;[2J stays visible.",
+                    &full,
+                );
+                assertion::assert_text_in_region(frame, "<span>literal inline HTML</span>", &full);
+                assertion::assert_text_in_region(frame, "<div>literal fenced HTML</div>", &full);
+                assertion::assert_not_visible(frame, "hidden issue template");
+                assertion::assert_not_visible(frame, "<h2>");
+                assertion::assert_not_visible(frame, "y\">Quoted attribute link");
+                assertion::assert_not_visible(frame, "```html");
             },
         )?;
 

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -2078,7 +2078,7 @@ case "$*" in
     exit 0
     ;;
   *"api --hostname github.com graphql"*)
-    printf '%s\n' '{"data":{"repository":{"pullRequest":{"comments":{"nodes":[{"author":{"login":"carol"},"body":"Thanks for documenting the behavior."}]},"reviewThreads":{"nodes":[{"id":"thread-inline","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":2,"path":"src/main.rs","startLine":1,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"alice"},"body":"Please explain why this review output is needed."}]}},{"id":"thread-file","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":null,"path":"src/main.rs","startLine":null,"subjectType":"FILE","comments":{"nodes":[{"author":{"login":"bob"},"body":"Please review the whole file."}]}},{"id":"thread-outdated","diffSide":"RIGHT","isOutdated":true,"isResolved":false,"line":2,"path":"old.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"erin"},"body":"This comment refers to an earlier diff."}]}},{"id":"thread-resolved","diffSide":"RIGHT","isOutdated":false,"isResolved":true,"line":3,"path":"src/main.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"dana"},"body":"This thread is complete."}]}},{"id":"thread-resolved-outdated","diffSide":"LEFT","isOutdated":true,"isResolved":true,"line":4,"path":"ro.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"frank"},"body":"This resolved thread refers to an earlier diff."}]}}]}}}}}'
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"comments":{"nodes":[{"author":{"login":"carol"},"body":"Thanks for documenting the behavior."}]},"reviewThreads":{"nodes":[{"id":"thread-inline","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":2,"path":"src/main.rs","startLine":1,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"alice"},"body":"<!-- hidden reviewer note --><p>Please <strong>explain</strong> why this review output is needed.<br>Use <code>stdout</code> context.</p>"}]}},{"id":"thread-file","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":null,"path":"src/main.rs","startLine":null,"subjectType":"FILE","comments":{"nodes":[{"author":{"login":"bob"},"body":"Please review the whole file."}]}},{"id":"thread-outdated","diffSide":"RIGHT","isOutdated":true,"isResolved":false,"line":2,"path":"old.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"erin"},"body":"This comment refers to an earlier diff."}]}},{"id":"thread-resolved","diffSide":"RIGHT","isOutdated":false,"isResolved":true,"line":3,"path":"src/main.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"dana"},"body":"This thread is complete."}]}},{"id":"thread-resolved-outdated","diffSide":"LEFT","isOutdated":true,"isResolved":true,"line":4,"path":"ro.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"frank"},"body":"This resolved thread refers to an earlier diff."}]}}]}}}}}'
     ;;
   *"pr view"*)
     printf '%s\n' '{"number":42,"title":"Review-ready session shortcuts","state":"OPEN","url":"https://github.com/agentty-xyz/agentty/pull/42","baseRefName":"main","headRefName":"wt/review-s","isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"REVIEW_REQUIRED","mergedAt":null}'
@@ -5725,6 +5725,7 @@ fn test_session_review_comments() -> E2eResult {
                     .wait_for_text("c: comments", 5000)
                     .press_key("c")
                     .wait_for_text("Please explain why this review output is needed.", 5000)
+                    .wait_for_text("Use stdout context.", 5000)
                     .wait_for_stable_frame(300, 5000)
                     .viewing_pause_ms(1500)
                     .capture_labeled(
@@ -5795,6 +5796,9 @@ fn assert_inline_review_comment(frame: &TerminalFrame) {
         "Please explain why this review output is needed.",
         &full,
     );
+    assertion::assert_text_in_region(frame, "Use stdout context.", &full);
+    assertion::assert_not_visible(frame, "hidden reviewer note");
+    assertion::assert_not_visible(frame, "<strong>");
     assertion::assert_text_in_region(frame, "Code context", &full);
     assertion::assert_text_in_region(frame, "println!(\"review\")", &full);
     assert!(

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -42,10 +42,10 @@ For file-level detail, read the module docstrings directly.
   object-safe `SessionBackend` port exposed through the owned, cloneable
   `SessionService` for creation, lookup, messaging, structured question answers, durable
   coordinator submissions, cancellation, merge, and review-request workflows.
-- `crates/ag-tui-text/`: Shared Ratatui text-rendering library crate with markdown
-  parsing/styling, bounded mermaid-to-terminal diagram rendering, and terminal-width
-  wrapping/truncation helpers. Host applications inject semantic palette and cache
-  version settings at the render boundary.
+- `crates/ag-tui-text/`: Shared Ratatui text-rendering library crate with Markdown
+  parsing/styling, forge HTML normalization, bounded mermaid-to-terminal diagram
+  rendering, and terminal-width wrapping/truncation helpers. Host applications inject
+  semantic palette and cache version settings at the render boundary.
 - `crates/agentty/`: Main TUI application crate with composition root, application,
   domain, infrastructure, runtime, and UI layers.
 - `crates/testty/`: Rust-native TUI end-to-end testing framework with PTY-driven

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -33,7 +33,7 @@ these constraints:
 | `crates/ag-agent/`        | Shared agent provider models plus channel and transport boundaries.  |
 | `crates/ag-protocol/`     | Shared structured response protocol and turn prompt payload library. |
 | `crates/ag-session/`      | Shared session models and frontend-neutral lifecycle API.            |
-| `crates/ag-tui-text/`     | Shared markdown, mermaid, wrapping, and truncation text helpers.     |
+| `crates/ag-tui-text/`     | Shared Markdown, HTML, mermaid, wrapping, and truncation helpers.    |
 | `crates/agentty/`         | Main TUI application crate.                                          |
 | `crates/testty/`          | TUI end-to-end testing framework.                                    |
 | `crates/ag-xtask/`        | Workspace maintenance and automation commands.                       |

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -221,7 +221,8 @@ separate groups. The Outdated group contains unresolved threads with stale ancho
 resolved threads stay in the Resolved group even when their anchors are outdated. The
 right panel shows the selected comment's author, resolution state, outdated-anchor
 metadata when applicable, current diff context for its attached line or range, and then
-the conversation. Outdated threads explicitly report that their original context is
+the conversation. Comment bodies render Markdown and common embedded HTML without
+showing HTML comments. Outdated threads explicitly report that their original context is
 unavailable instead of mapping the stale anchor onto the current diff. File-level
 comments similarly show that they have no attached code line instead of highlighting an
 arbitrary diff row. Current inline snippets use the same gutters and added/removed line

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -30,17 +30,20 @@ tabs. Press `Tab` to move forward or `Shift+Tab` to move backward:
 - **Inbox**: Read-only list of open GitHub pull requests or GitLab merge requests that
   request your review in the active project, including drafts. Press `s` to refresh and
   `Enter` to open a read-only detail page with the description and comment threads.
+  Description and comment bodies render Markdown plus common embedded HTML, while HTML
+  comments remain hidden.
 - **Issues**: Open GitHub issues assigned to the user authenticated with `gh` in the
   active project repository. The table labels the non-empty result group **Assigned to
   you**. Press `s` to refresh, use `j` / `k` to move through the first `100` results,
   and press `Enter` to load a read-only detail page with base metadata and the
-  description. From issue details, press `a` to create and start a regular session whose
-  first prompt instructs the agent to address the issue and includes its URL. If session
-  creation fails, the issue details remain open and show the failure inline, even when
-  the detail fetch finishes later. If prompt submission fails after creation, Agentty
-  opens the recoverable session with the error in its transcript. Comments are not
-  loaded in this iteration. Install the GitHub CLI and run `gh auth login` to enable
-  this tab.
+  description. Issue descriptions render Markdown plus common embedded HTML, while HTML
+  comments from issue templates remain hidden. From issue details, press `a` to create
+  and start a regular session whose first prompt instructs the agent to address the
+  issue and includes its URL. If session creation fails, the issue details remain open
+  and show the failure inline, even when the detail fetch finishes later. If prompt
+  submission fails after creation, Agentty opens the recoverable session with the error
+  in its transcript. Comments are not loaded in this iteration. Install the GitHub CLI
+  and run `gh auth login` to enable this tab.
 - **Settings**: Configure the color theme, orchestrator parallelism, per-role
   smart/fast/review model and reasoning defaults, the optional
   `Last used model as default` mode, the session commit coauthor trailer, and
@@ -60,12 +63,15 @@ on the left, while the selected entry's metadata, attached current-diff context,
 conversation appear on the right. In **Review**, **AgentReview**, or **Question**, press
 `a` to send the selected actionable inline thread to the active session agent or `A` to
 send every actionable inline thread. Standalone comments are read-only because they do
-not have forge thread IDs. The timer ticks only while the session is actively working.
-`Done` sessions use `c` to start a continuation draft and no longer expose review
-comments. File-level comments show an explicit no-line-context message instead of a
-synthetic code anchor. Each session stores the project's Smart reasoning default when it
-is created, so later default changes affect new sessions without relabeling existing
-ones.
+not have forge thread IDs. Conversation bodies render Markdown and common embedded HTML
+through the same shared text-rendering path used by issue and review-request details.
+Forge-authored description and comment input is capped at `1 MiB` before normalization;
+truncated bodies end with `[Forge content truncated at 1 MiB.]`. The timer ticks only
+while the session is actively working. `Done` sessions use `c` to start a continuation
+draft and no longer expose review comments. File-level comments show an explicit
+no-line-context message instead of a synthetic code anchor. Each session stores the
+project's Smart reasoning default when it is created, so later default changes affect
+new sessions without relabeling existing ones.
 
 The top status bar shows the current version and update status, and rotates short
 page-scoped `FYI:` messages once per minute in the **Sessions** list and session chat


### PR DESCRIPTION
- Add bounded HTML normalization, comment filtering, and entity decoding to shared text rendering.
- Use HTML-aware rendering for issue descriptions and review conversations.
- Extend unit, E2E, architecture, and workflow documentation coverage.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)
- Preserve malformed literal tags and prevent numeric control-character injection.