### PR TITLE
Generate intent-aware session commit messages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,21 @@
+<!--
+Write for a reviewer who has not seen the implementation. Keep each section to the
+information that changes how the work is understood, reviewed, or used. Omit file
+inventories, routine tests, formatting, and mechanical refactors.
+-->
+
 ## Why?
 
-Describe the problem, motivation, or context for this change.
+<!-- One short paragraph: the problem, motivation, or context. -->
 
 ## What?
 
-Summarize the implementation and the key changes in this pull request.
+<!-- Two to four outcome-level bullets. Do not restate the title or walk through files. -->
 
 ## Project impact
 
-Explain the user-facing, operational, or maintenance impact of this change.
+<!--
+Material user-facing, operational, or maintenance consequences: migration,
+compatibility, configuration, performance, or breaking changes. Delete this whole
+section when the change has none; do not write "N/A".
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -475,7 +475,11 @@ Always wrap these code elements in backticks when referenced in prose:
 
 ## Git Conventions
 
-- For all commit preparation and commit message work, use `skills/git-commit/SKILL.md`.
+- For all commit preparation, commit message, and pull-request description work, use
+  `skills/git-commit/SKILL.md`.
+- Write commits and pull-request descriptions for a reviewer who has not seen the
+  implementation: state the outcome, not the activity, and keep only content that
+  changes how the work is understood, reviewed, or used.
 - Never bypass `prek`-managed hooks (see MANDATORY).
 
 ## Release Automation

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -4,7 +4,8 @@ Reusable skills available to agents in this repository.
 
 ## Available Skills
 
-- `git-commit` covers commit-message and commit-preparation workflow.
+- `git-commit` covers commit-message, commit-preparation, and pull-request description
+  workflow.
 - `bump-version` covers version bump selection, package metadata updates, and baseline
   release-preparation validation.
 - `review` covers structured code-review workflow.

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -1,27 +1,50 @@
 ---
 name: git-commit
-description: Guide for preparing git commits in this repository, including context gathering and repository-specific commit message conventions.
+description: Guide for preparing git commits and pull-request descriptions in this repository, including context gathering and repository-specific commit message conventions.
 ---
 
 # Git Commit Workflow
 
-Use this skill when preparing or creating commits.
+Use this skill when preparing commits or authoring pull-request descriptions.
 
 ## Workflow
 
 1. **Gather commit context in one tool call**
 
-   - Run: `git status && git diff && git log -n 3 --format="---%n%B"`.
+   - Run:
+     `git status --short && git diff && git diff --staged && git log -n 3 --format="---%n%B"`.
+   - `git diff` alone hides staged and untracked work, so a message written from it can
+     silently omit part of the commit. Read the staged diff too.
+   - Neither diff shows the contents of untracked files, only their names in
+     `git status --short`. Read the contents of every untracked file the commit will
+     include; otherwise a whole new file is invisible to the message.
 
-1. **Write commit title and description**
+1. **Write for a reviewer who has not seen the implementation**
 
-   - Use a concise summary on the first line (the title) in present simple tense
-     (example: `Fix cursor offset`).
-   - Leave one blank line between the title and the body.
-   - Add a body only when it improves clarity.
-   - Explain *why* and *how* in present simple tense.
-   - If there are multiple points, format them as `-` bullet lines with one point per
-     line.
+   - Assume the reader has the title, the body, and no appetite for the diff.
+
+1. **Write the commit title**
+
+   - Use one concise line in imperative mood (example: `Fix cursor offset`), with no
+     trailing period.
+   - State the outcome the change achieves, not the activity performed. Prefer
+     `Prevent duplicate session commits` over `Update session commit handling`.
+
+1. **Write the body only when it adds information**
+
+   - Leave one blank line between the title and the body, and write bullets as concise
+     declarative statements. Imperative mood belongs to the title; motivation and impact
+     are facts, so forcing them into commands distorts them.
+   - Admit a bullet only when it states why the change exists, a distinct behavior or
+     design decision a reviewer must know, or migration, compatibility, configuration,
+     or operational impact.
+   - Omit file inventories, line counts, routine tests, formatting, documentation
+     updates, and mechanical refactors unless they change how the result is used or
+     reviewed.
+   - Default to at most three `-` bullets, one point per line. Merge bullets that serve
+     the same outcome, never restate the title, and drop near-duplicate wording.
+   - Never infer rationale the change context does not support. Omit motivation rather
+     than guess it.
 
 1. **Avoid Conventional Commit prefixes**
 
@@ -31,3 +54,17 @@ Use this skill when preparing or creating commits.
 
    - Never use `--no-verify` with git commands to bypass `prek`-managed hooks.
    - Do not add `Co-Authored-By` trailers or AI attribution to commit messages.
+
+## Pull Request Descriptions
+
+Apply this section only when you author a pull-request description yourself. Publishing
+a session sends the commit title and body straight to the forge as the review-request
+body, which bypasses the template, so never reshape a commit body into these sections to
+compensate — hold the commit message to the rules above.
+
+When you do author a description, fill `.github/pull_request_template.md` as:
+
+- `Why?`: one short paragraph of problem or motivation.
+- `What?`: two to four outcome-level bullets, not a file-by-file walkthrough.
+- `Project impact`: material user-facing, operational, or maintenance consequences only.
+  Delete the section when the change has none rather than writing `N/A`.


### PR DESCRIPTION
- Include bounded cumulative session summaries as intent context while letting the diff determine the shipped result.
- Keep generated messages and pull-request descriptions focused on reviewer-relevant outcomes, motivation, distinct behavior, and material impact.
- Reuse structured commit-generation inputs across session and merge workflows with safe handling for missing, legacy, and oversized summaries.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)