### PR TITLE
Align orchestrator scrolling with the campaign board

### DIFF
--- a/crates/agentty/src/runtime/mode/chat_scroll.rs
+++ b/crates/agentty/src/runtime/mode/chat_scroll.rs
@@ -8,11 +8,11 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::Rect;
 
 use crate::app::App;
-use crate::domain::session::SessionId;
+use crate::domain::session::{SessionId, SessionRole};
 use crate::presentation::app_mode::ChatFocus;
 use crate::runtime::mode::session_output_metric;
 use crate::ui::page::session_chat::{self, SessionChatLayoutInput};
-use crate::ui::{RenderCacheStore, input_layout, layout, session_format};
+use crate::ui::{RenderCacheStore, input_layout, layout, page, session_format};
 
 /// Bottom-panel height of a chat page that only reserves a footer row.
 const FOOTER_ONLY_BOTTOM_HEIGHT: u16 = 1;
@@ -56,13 +56,24 @@ impl ChatScrollMetrics {
         terminal_size: Rect,
     ) -> Self {
         let page_area = layout::app_frame_areas(terminal_size).content_area;
-        let output_width = page_area.width.saturating_sub(2);
+        let session = app.sessions.session_at(session_index);
+        let chat_area = session.map_or(page_area, |session| {
+            if session.role != SessionRole::Orchestrator {
+                return page_area;
+            }
+
+            page::orchestration::campaign_page_areas(
+                page_area,
+                session.orchestration_progress.as_deref(),
+            )[1]
+        });
+        let output_width = chat_area.width.saturating_sub(2);
         let (_, review_text) = app.review_view_state(session_id);
-        let view_height = app.sessions.session_at(session_index).map_or_else(
-            || Self::footer_only_view_height(page_area),
+        let view_height = session.map_or_else(
+            || Self::footer_only_view_height(chat_area),
             |session| {
                 session_chat::transcript_view_height(SessionChatLayoutInput {
-                    area: page_area,
+                    area: chat_area,
                     default_reasoning_level: app.settings.default_smart_reasoning_level,
                     mode: &app.mode,
                     review_text,
@@ -272,6 +283,8 @@ fn half_page_step(metrics: ChatScrollMetrics) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::session::Status;
+    use crate::test_support::SessionFixtureBuilder;
 
     /// Builds a plain key press without modifiers.
     fn plain_key(code: KeyCode) -> KeyEvent {
@@ -372,6 +385,24 @@ mod tests {
     }
 
     #[test]
+    fn test_apply_scroll_key_steps_up_one_line() {
+        // Arrange
+        let metrics = ChatScrollMetrics {
+            total_lines: 30,
+            view_height: 10,
+        };
+        let mut scroll_offset = Some(5);
+
+        // Act
+        let is_consumed =
+            apply_scroll_key(&mut scroll_offset, metrics, plain_key(KeyCode::Char('k')));
+
+        // Assert
+        assert!(is_consumed);
+        assert_eq!(scroll_offset, Some(4));
+    }
+
+    #[test]
     fn test_apply_scroll_key_jumps_to_top_and_bottom() {
         // Arrange
         let metrics = ChatScrollMetrics {
@@ -409,6 +440,27 @@ mod tests {
         // Assert
         assert!(is_consumed);
         assert_eq!(scroll_offset, Some(15));
+    }
+
+    #[test]
+    fn test_apply_scroll_key_scrolls_half_page_down() {
+        // Arrange
+        let metrics = ChatScrollMetrics {
+            total_lines: 30,
+            view_height: 10,
+        };
+        let mut scroll_offset = Some(5);
+
+        // Act
+        let is_consumed = apply_scroll_key(
+            &mut scroll_offset,
+            metrics,
+            KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL),
+        );
+
+        // Assert
+        assert!(is_consumed);
+        assert_eq!(scroll_offset, Some(10));
     }
 
     #[test]
@@ -457,5 +509,76 @@ mod tests {
 
         // Assert
         assert_eq!(next_offset, 15);
+    }
+
+    #[tokio::test]
+    async fn test_metrics_use_footer_only_viewport_when_session_is_missing() {
+        // Arrange
+        let (app, _base_dir) = crate::test_support::new_test_app().await;
+        let missing_session_id = SessionId::from("missing-session");
+        let terminal_size = Rect::new(0, 0, 80, 24);
+
+        // Act
+        let metrics = ChatScrollMetrics::new(
+            &app,
+            &RenderCacheStore::default(),
+            &missing_session_id,
+            0,
+            terminal_size,
+        );
+
+        // Assert
+        let empty_metrics = ChatScrollMetrics::empty(terminal_size);
+        assert_eq!(metrics.total_lines, 0);
+        assert_eq!(metrics.view_height, empty_metrics.view_height);
+    }
+
+    #[tokio::test]
+    async fn test_orchestrator_metrics_reserve_campaign_board_height() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+        let mut session = SessionFixtureBuilder::new()
+            .role(SessionRole::Orchestrator)
+            .status(Status::Review)
+            .transcript(
+                (0..60)
+                    .map(|index| format!("line {index}"))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            )
+            .build();
+        session.orchestration_progress = Some(
+            "Phase: AwaitingApproval\nParallel workers: 3\n1. ui - awaiting approval".to_string(),
+        );
+        let session_id = session.id.clone();
+        app.sessions.push_session(session);
+        app.mode = crate::presentation::app_mode::AppMode::View {
+            scroll_offset: None,
+            session_id: session_id.clone(),
+        };
+        let terminal_size = Rect::new(0, 0, 80, 24);
+
+        // Act
+        let orchestrator_metrics = ChatScrollMetrics::new(
+            &app,
+            &RenderCacheStore::default(),
+            &session_id,
+            0,
+            terminal_size,
+        );
+        app.sessions.sessions_mut()[0].role = SessionRole::Worker;
+        let regular_metrics = ChatScrollMetrics::new(
+            &app,
+            &RenderCacheStore::default(),
+            &session_id,
+            0,
+            terminal_size,
+        );
+
+        // Assert
+        assert_eq!(
+            orchestrator_metrics.view_height + 7,
+            regular_metrics.view_height
+        );
     }
 }

--- a/crates/agentty/src/ui/page/orchestration.rs
+++ b/crates/agentty/src/ui/page/orchestration.rs
@@ -34,15 +34,6 @@ impl<'a> OrchestrationPage<'a> {
         self
     }
 
-    fn board_height(&self) -> u16 {
-        campaign_board_height(
-            self.chat_input
-                .sessions
-                .get(self.chat_input.session_index)
-                .and_then(|session| session.orchestration_progress.as_deref()),
-        )
-    }
-
     fn render_board(&self, frame: &mut Frame, area: Rect) {
         let session = self.chat_input.sessions.get(self.chat_input.session_index);
         let progress = session
@@ -88,6 +79,32 @@ impl<'a> OrchestrationPage<'a> {
     }
 }
 
+impl Page for OrchestrationPage<'_> {
+    fn render(&mut self, frame: &mut Frame, area: Rect) {
+        let progress = self
+            .chat_input
+            .sessions
+            .get(self.chat_input.session_index)
+            .and_then(|session| session.orchestration_progress.as_deref());
+        let [board_area, chat_area] = campaign_page_areas(area, progress);
+
+        self.render_board(frame, board_area);
+        SessionChatPage::new(self.chat_input)
+            .can_open_worktree(self.can_open_worktree)
+            .render(frame, chat_area);
+    }
+}
+
+/// Splits a controller page into its campaign board and chat areas.
+///
+/// Runtime scroll metrics use the same chat area so line-step bounds match
+/// the compact transcript viewport painted below the campaign board.
+pub(crate) fn campaign_page_areas(area: Rect, progress: Option<&str>) -> [Rect; 2] {
+    let board_height = campaign_board_height(progress);
+
+    Layout::vertical([Constraint::Length(board_height), Constraint::Min(8)]).areas(area)
+}
+
 /// Calculates the bounded campaign board height from the current snapshot.
 fn campaign_board_height(progress: Option<&str>) -> u16 {
     let progress_lines = progress.map_or(1, |progress| progress.lines().count());
@@ -95,18 +112,6 @@ fn campaign_board_height(progress: Option<&str>) -> u16 {
     u16::try_from(progress_lines.saturating_add(4))
         .unwrap_or(12)
         .clamp(6, 12)
-}
-
-impl Page for OrchestrationPage<'_> {
-    fn render(&mut self, frame: &mut Frame, area: Rect) {
-        let areas = Layout::vertical([Constraint::Length(self.board_height()), Constraint::Min(8)])
-            .split(area);
-
-        self.render_board(frame, areas[0]);
-        SessionChatPage::new(self.chat_input)
-            .can_open_worktree(self.can_open_worktree)
-            .render(frame, areas[1]);
-    }
 }
 
 #[cfg(test)]
@@ -191,6 +196,20 @@ mod tests {
 
         // Assert
         assert_eq!(height, 12);
+    }
+
+    #[test]
+    fn campaign_page_areas_reserve_the_board_above_chat() {
+        // Arrange
+        let page_area = Rect::new(2, 3, 80, 24);
+        let progress = "Phase: Running\n1. api\n2. ui\n3. docs";
+
+        // Act
+        let [board_area, chat_area] = campaign_page_areas(page_area, Some(progress));
+
+        // Assert
+        assert_eq!(board_area, Rect::new(2, 3, 80, 8));
+        assert_eq!(chat_area, Rect::new(2, 11, 80, 16));
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/orchestration.rs
+++ b/crates/agentty/tests/e2e/orchestration.rs
@@ -3,7 +3,9 @@
 use agentty::domain::session::{
     ForgeKind, ReviewRequest, ReviewRequestState, ReviewRequestSummary,
 };
+use agentty::domain::session_message::SessionMessageKind;
 use testty::assertion;
+use testty::frame::TerminalFrame;
 use testty::region::Region;
 
 use crate::common;
@@ -102,6 +104,43 @@ fn seed_orchestration_campaign(env: &BuilderEnv) -> E2eResult {
     Ok(())
 }
 
+/// Seeds enough controller transcript output to exercise line-by-line scroll
+/// bounds in the compact chat pane below the campaign board.
+fn seed_scrollable_orchestration_campaign(env: &BuilderEnv) -> E2eResult {
+    seed_orchestration_campaign(env)?;
+
+    let output = (0..60)
+        .map(|line_index| format!("Transcript line {line_index:02}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let output = format!("```text\n{output}\n```");
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        database
+            .sessions()
+            .append_session_message(CONTROLLER_ID, SessionMessageKind::AssistantAnswer, &output)
+            .await
+    })?;
+
+    Ok(())
+}
+
+/// Returns the numbered transcript rows visible in one captured frame.
+fn visible_transcript_line_indexes(frame: &TerminalFrame) -> Vec<u16> {
+    let full = Region::full(frame.cols(), frame.rows());
+
+    frame
+        .text_in_region(&full)
+        .lines()
+        .filter_map(|line| {
+            let suffix = line.split_once("Transcript line ")?.1;
+
+            suffix.get(..2)?.parse().ok()
+        })
+        .collect()
+}
+
 /// Seeds one completed managed worker whose worktree-independent review diff
 /// has already been archived by the merge workflow.
 fn seed_archived_managed_worker(env: &BuilderEnv) -> E2eResult {
@@ -167,6 +206,48 @@ fn test_orchestration_campaign_board() -> E2eResult {
                     &full,
                 );
                 assertion::assert_text_in_region(frame, "a approve  Enter discuss/revise", &full);
+            },
+        )
+}
+
+#[test]
+fn test_orchestration_campaign_smooth_scroll() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("orchestration_campaign_smooth_scroll")
+        .with_git()
+        .with_terminal_size(80, 24)
+        .setup(seed_scrollable_orchestration_campaign)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .compose(&common::open_selected_session_view())
+                    .wait_for_text("Transcript line 59", 5000)
+                    .capture_labeled("campaign_bottom", "Controller transcript at bottom")
+                    .press_key("k")
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled("campaign_one_line_up", "Controller transcript one line up")
+            },
+            |_frame, report| {
+                assert_eq!(report.captures.len(), 2);
+
+                let bottom_frame = common::frame_from_capture(&report.captures[0]);
+                let one_line_up_frame = common::frame_from_capture(&report.captures[1]);
+                let bottom_lines = visible_transcript_line_indexes(&bottom_frame);
+                let one_line_up_lines = visible_transcript_line_indexes(&one_line_up_frame);
+                assert!(!bottom_lines.is_empty(), "expected bottom transcript rows");
+                assert!(
+                    !one_line_up_lines.is_empty(),
+                    "expected scrolled transcript rows"
+                );
+                assert_eq!(
+                    one_line_up_lines
+                        .first()
+                        .copied()
+                        .map(|line_index| line_index + 1),
+                    bottom_lines.first().copied()
+                );
             },
         )
 }

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -419,7 +419,9 @@ Use an orchestrator when a goal contains at least two independent pieces of work
    `d` for its diff, or press `D` and confirm **Detach** to permanently transfer it into
    an ordinary user-owned session. Direct reply, question-answer, cancel, merge,
    publish, fork, worktree-open, review-comment addressing, `Ctrl+c` turn interruption,
-   and slash-command actions are unavailable while it is managed.
+   and slash-command actions are unavailable while it is managed. The controller
+   conversation below the monitor uses the same line-by-line transcript scrolling as a
+   regular session.
 1. When a worker asks a blocking question, Agentty mirrors it into the controller's
    question panel only when the controller has no question of its own. The relay durably
    records the exact task that owns the mirrored question, so concurrent worker


### PR DESCRIPTION
- Shared campaign page areas keep scroll bounds aligned with the rendered transcript pane below the board.
- Unit and E2E coverage verifies one-line scrolling, and the workflow guide documents the behavior.
- Unit and E2E coverage verifies line-by-line and half-page scrolling behavior.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)