### PR TITLE
Release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,27 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.14.1] - 2026-08-04
+
 ### Added
 
 - agentty: add standalone orchestration campaign boards with acceptance-criteria
   planning, read-only managed workers, question relay, verification-gated integration,
   follow-up continuations, detach ownership transfer, and approval-gated merges.
+
+### Changed
+
+- agentty: render embedded forge HTML in issue descriptions and review conversations
+  with bounded normalization, comment filtering, entity decoding, malformed-tag
+  preservation, and numeric control-character rejection.
+- agentty: use the `gemini-3.1-pro-preview` identifier for Gemini 3.1 Pro across Gemini
+  and Antigravity, migrate stored selections, and reject the retired identifier.
+- workflow: use bounded cumulative session summaries as intent context for diff-grounded
+  commit messages and pull-request descriptions.
+- ci: provide checksum-verified, architecture-specific E2E tool bundles for `amd64` and
+  `arm64`.
+- deps: update `schemars` from `1.2.1` to `1.2.2`.
+- release: bump workspace crate metadata and lockfile package versions to `0.14.1`.
 
 ### Fixed
 
@@ -32,6 +48,18 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   carries a multiline campaign-board snapshot.
 - agentty: hide the unavailable `p: PR` action from orchestrator sessions.
 - agentty: remove the misleading child-diff action from orchestrator campaign boards.
+- agentty: route review follow-ups for settled campaign workers through their original
+  branches and re-run verification after the additional work.
+- agentty: align orchestrator scroll bounds with the transcript pane below the campaign
+  board for line-by-line and half-page navigation.
+- agentty: fail startup recovery on storage or Git errors while preserving unfinished
+  operations for retry on a later launch.
+
+### Contributors
+
+- @andagaev
+- @dependabot
+- @minev-dev
 
 ## [v0.14.0] - 2026-08-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "image",
  "mockall",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "mockall",
  "serde",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "mockall",
  "rustix",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "ag-harness"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "jsonschema",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "askama",
  "schemars 1.2.2",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "ag-session"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "ag-agent",
  "ag-forge",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "clap",
  "tempfile",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -4281,7 +4281,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "base64 0.23.0",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -16,14 +16,14 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.14.0" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.14.0" }
-ag-forge = { path = "crates/ag-forge", version = "0.14.0" }
-ag-git = { path = "crates/ag-git", version = "0.14.0" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.14.0" }
-ag-session = { path = "crates/ag-session", version = "0.14.0" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.14.0" }
-testty = { path = "crates/testty", version = "0.14.0" }
+ag-agent = { path = "crates/ag-agent", version = "0.14.1" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.14.1" }
+ag-forge = { path = "crates/ag-forge", version = "0.14.1" }
+ag-git = { path = "crates/ag-git", version = "0.14.1" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.14.1" }
+ag-session = { path = "crates/ag-session", version = "0.14.1" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.14.1" }
+testty = { path = "crates/testty", version = "0.14.1" }
 async-trait = "0.1"
 agent-client-protocol = "2.0.0"
 assert_cmd = "2"


### PR DESCRIPTION
- Document orchestration campaign boards, workflow improvements, forge rendering, model migrations, CI updates, and fixes.
- Bump workspace crate metadata and lockfile package versions to `0.14.1`.
- Record release contributors.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)