### PR TITLE
Git, forge review, and clipboard flows handle failures more safely

### DIFF
--- a/crates/ag-clipboard/src/backend.rs
+++ b/crates/ag-clipboard/src/backend.rs
@@ -1,5 +1,5 @@
 mod contract;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 mod linux;
 #[cfg(target_os = "macos")]
 mod macos;

--- a/crates/ag-clipboard/src/backend/linux.rs
+++ b/crates/ag-clipboard/src/backend/linux.rs
@@ -1,16 +1,18 @@
+#[cfg(target_os = "linux")]
 use std::env;
 
-use super::{ClipboardBackend, wayland, x11};
+use super::ClipboardBackend;
+#[cfg(target_os = "linux")]
+use super::{wayland, x11};
 use crate::ClipboardError;
 
+#[cfg(target_os = "linux")]
 pub(crate) fn new_backend() -> Result<Box<dyn ClipboardBackend>, ClipboardError> {
-    match select_backend(&LinuxClipboardEnvironment::from_env()) {
-        LinuxBackendSelection::Wayland => Ok(Box::new(wayland::WaylandClipboard::new()?)),
-        LinuxBackendSelection::X11 => Ok(Box::new(x11::X11Clipboard::new()?)),
-        LinuxBackendSelection::Unavailable => Err(ClipboardError::Unavailable {
-            reason: "no supported Linux clipboard display was detected".to_string(),
-        }),
-    }
+    new_backend_with_factories(
+        &LinuxClipboardEnvironment::from_env(),
+        WaylandClipboardFactory,
+        X11ClipboardFactory,
+    )
 }
 
 #[derive(Debug, Default, Eq, PartialEq)]
@@ -20,6 +22,7 @@ struct LinuxClipboardEnvironment {
 }
 
 impl LinuxClipboardEnvironment {
+    #[cfg(target_os = "linux")]
     fn from_env() -> Self {
         Self {
             display: env::var("DISPLAY").ok(),
@@ -28,39 +31,228 @@ impl LinuxClipboardEnvironment {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
-enum LinuxBackendSelection {
-    Unavailable,
-    Wayland,
-    X11,
+trait ClipboardBackendFactory {
+    fn create(&mut self) -> Result<Box<dyn ClipboardBackend>, ClipboardError>;
 }
 
-fn select_backend(environment: &LinuxClipboardEnvironment) -> LinuxBackendSelection {
-    if environment
+#[cfg(target_os = "linux")]
+struct WaylandClipboardFactory;
+
+#[cfg(target_os = "linux")]
+impl ClipboardBackendFactory for WaylandClipboardFactory {
+    fn create(&mut self) -> Result<Box<dyn ClipboardBackend>, ClipboardError> {
+        Ok(Box::new(wayland::WaylandClipboard::new()?))
+    }
+}
+
+#[cfg(target_os = "linux")]
+struct X11ClipboardFactory;
+
+#[cfg(target_os = "linux")]
+impl ClipboardBackendFactory for X11ClipboardFactory {
+    fn create(&mut self) -> Result<Box<dyn ClipboardBackend>, ClipboardError> {
+        Ok(Box::new(x11::X11Clipboard::new()?))
+    }
+}
+
+fn new_backend_with_factories<WaylandFactory, X11Factory>(
+    environment: &LinuxClipboardEnvironment,
+    mut wayland_factory: WaylandFactory,
+    mut x11_factory: X11Factory,
+) -> Result<Box<dyn ClipboardBackend>, ClipboardError>
+where
+    WaylandFactory: ClipboardBackendFactory,
+    X11Factory: ClipboardBackendFactory,
+{
+    let has_wayland_display = environment
         .wayland_display
         .as_deref()
-        .is_some_and(|value| !value.is_empty())
-    {
-        return LinuxBackendSelection::Wayland;
-    }
-
-    if environment
+        .is_some_and(|value| !value.is_empty());
+    let has_x11_display = environment
         .display
         .as_deref()
-        .is_some_and(|value| !value.is_empty())
-    {
-        return LinuxBackendSelection::X11;
+        .is_some_and(|value| !value.is_empty());
+
+    if has_wayland_display {
+        match wayland_factory.create() {
+            Ok(backend) => return Ok(backend),
+            Err(wayland_error) if has_x11_display => {
+                return x11_factory
+                    .create()
+                    .map_err(|x11_error| ClipboardError::Unavailable {
+                        reason: format!(
+                            "Wayland clipboard backend failed: {wayland_error}; X11 clipboard \
+                             backend failed: {x11_error}"
+                        ),
+                    });
+            }
+            Err(error) => return Err(error),
+        }
     }
 
-    LinuxBackendSelection::Unavailable
+    if has_x11_display {
+        return x11_factory.create();
+    }
+
+    Err(ClipboardError::Unavailable {
+        reason: "no supported Linux clipboard display was detected".to_string(),
+    })
 }
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_os = "linux")]
+    use std::ffi::OsString;
+    #[cfg(target_os = "linux")]
+    use std::fs;
+    #[cfg(target_os = "linux")]
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+    #[cfg(target_os = "linux")]
+    use std::process::Command;
+    #[cfg(target_os = "linux")]
+    use std::time::{SystemTime, UNIX_EPOCH};
+
     use super::*;
 
+    struct TestClipboardBackend;
+
+    struct TestClipboardBackendFactory {
+        error: Option<ClipboardError>,
+    }
+
+    impl TestClipboardBackendFactory {
+        fn successful() -> Self {
+            Self { error: None }
+        }
+
+        fn unavailable(reason: &str) -> Self {
+            Self {
+                error: Some(ClipboardError::Unavailable {
+                    reason: reason.to_string(),
+                }),
+            }
+        }
+
+        fn backend_error(reason: &str) -> Self {
+            Self {
+                error: Some(ClipboardError::Backend {
+                    reason: reason.to_string(),
+                }),
+            }
+        }
+    }
+
+    impl ClipboardBackendFactory for TestClipboardBackendFactory {
+        fn create(&mut self) -> Result<Box<dyn ClipboardBackend>, ClipboardError> {
+            if let Some(error) = self.error.take() {
+                return Err(error);
+            }
+
+            Ok(Box::new(TestClipboardBackend))
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    struct TestExecutableDirectory {
+        path: PathBuf,
+    }
+
+    #[cfg(target_os = "linux")]
+    impl TestExecutableDirectory {
+        fn new() -> Self {
+            let unique_suffix = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should follow the Unix epoch")
+                .as_nanos();
+            let workspace_target = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .ancestors()
+                .nth(2)
+                .expect("clipboard crate should belong to the workspace")
+                .join("target");
+            let path = workspace_target.join(format!(
+                "agentty-clipboard-{}-{unique_suffix}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).expect("clipboard executable directory should be created");
+
+            Self { path }
+        }
+
+        fn path(&self) -> &std::path::Path {
+            &self.path
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    impl Drop for TestExecutableDirectory {
+        fn drop(&mut self) {
+            fs::remove_dir_all(&self.path)
+                .expect("clipboard executable directory should be removed");
+        }
+    }
+
+    impl ClipboardBackend for TestClipboardBackend {
+        fn read_text(&mut self) -> Result<String, ClipboardError> {
+            Ok(String::new())
+        }
+
+        fn read_file_list(&mut self) -> Result<Vec<PathBuf>, ClipboardError> {
+            Ok(Vec::new())
+        }
+
+        fn read_image_rgba(&mut self) -> Result<crate::RgbaImageData, ClipboardError> {
+            Ok(crate::RgbaImageData {
+                height: 0,
+                rgba_bytes: Vec::new(),
+                width: 0,
+            })
+        }
+    }
+
     #[test]
-    fn test_select_backend_prefers_wayland_over_x11() {
+    fn test_clipboard_backend_returns_empty_fixture_content() {
+        // Arrange
+        let mut backend = TestClipboardBackend;
+
+        // Act
+        let text = backend.read_text();
+        let files = backend.read_file_list();
+        let image = backend.read_image_rgba();
+
+        // Assert
+        assert_eq!(text.expect("fixture text should load"), "");
+        assert!(files.expect("fixture files should load").is_empty());
+        assert_eq!(
+            image.expect("fixture image should load"),
+            crate::RgbaImageData {
+                height: 0,
+                rgba_bytes: Vec::new(),
+                width: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn new_backend_prefers_successful_wayland_without_opening_x11() {
+        // Arrange
+        let environment = LinuxClipboardEnvironment {
+            display: Some(":0".to_string()),
+            wayland_display: Some("wayland-0".to_string()),
+        };
+        // Act
+        let result = new_backend_with_factories(
+            &environment,
+            TestClipboardBackendFactory::successful(),
+            TestClipboardBackendFactory::unavailable("X11 should not be opened"),
+        );
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn new_backend_falls_back_to_x11_when_wayland_initialization_fails() {
         // Arrange
         let environment = LinuxClipboardEnvironment {
             display: Some(":0".to_string()),
@@ -68,14 +260,67 @@ mod tests {
         };
 
         // Act
-        let backend_selection = select_backend(&environment);
+        let result = new_backend_with_factories(
+            &environment,
+            TestClipboardBackendFactory::unavailable("wl-paste is unavailable"),
+            TestClipboardBackendFactory::successful(),
+        );
 
         // Assert
-        assert_eq!(backend_selection, LinuxBackendSelection::Wayland);
+        assert!(result.is_ok());
     }
 
     #[test]
-    fn test_select_backend_uses_x11_when_only_display_is_set() {
+    fn new_backend_reports_both_initialization_failures() {
+        // Arrange
+        let environment = LinuxClipboardEnvironment {
+            display: Some(":0".to_string()),
+            wayland_display: Some("wayland-0".to_string()),
+        };
+
+        // Act
+        let result = new_backend_with_factories(
+            &environment,
+            TestClipboardBackendFactory::unavailable("wl-paste is unavailable"),
+            TestClipboardBackendFactory::unavailable("X11 connection failed"),
+        );
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(ClipboardError::Unavailable { reason })
+                if reason.contains("wl-paste is unavailable")
+                    && reason.contains("X11 connection failed")
+        ));
+    }
+
+    #[test]
+    fn new_backend_preserves_wayland_error_without_x11_display() {
+        // Arrange
+        let environment = LinuxClipboardEnvironment {
+            display: None,
+            wayland_display: Some("wayland-0".to_string()),
+        };
+
+        // Act
+        let result = new_backend_with_factories(
+            &environment,
+            TestClipboardBackendFactory::backend_error(
+                "Wayland compositor rejected the connection",
+            ),
+            TestClipboardBackendFactory::successful(),
+        );
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(ClipboardError::Backend { reason })
+                if reason == "Wayland compositor rejected the connection"
+        ));
+    }
+
+    #[test]
+    fn new_backend_uses_x11_when_only_x11_display_is_set() {
         // Arrange
         let environment = LinuxClipboardEnvironment {
             display: Some(":0".to_string()),
@@ -83,14 +328,18 @@ mod tests {
         };
 
         // Act
-        let backend_selection = select_backend(&environment);
+        let result = new_backend_with_factories(
+            &environment,
+            TestClipboardBackendFactory::unavailable("Wayland should not be opened"),
+            TestClipboardBackendFactory::successful(),
+        );
 
         // Assert
-        assert_eq!(backend_selection, LinuxBackendSelection::X11);
+        assert!(result.is_ok());
     }
 
     #[test]
-    fn test_select_backend_reports_unavailable_without_display_variables() {
+    fn new_backend_reports_unavailable_without_display_variables() {
         // Arrange
         let environment = LinuxClipboardEnvironment {
             display: None,
@@ -98,9 +347,135 @@ mod tests {
         };
 
         // Act
-        let backend_selection = select_backend(&environment);
+        let result = new_backend_with_factories(
+            &environment,
+            TestClipboardBackendFactory::successful(),
+            TestClipboardBackendFactory::successful(),
+        );
 
         // Assert
-        assert_eq!(backend_selection, LinuxBackendSelection::Unavailable);
+        assert!(matches!(
+            result,
+            Err(ClipboardError::Unavailable { reason })
+                if reason == "no supported Linux clipboard display was detected"
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn new_backend_uses_detected_linux_platform_backends() {
+        const CHILD_MODE_ENVIRONMENT: &str = "AGENTTY_CLIPBOARD_TEST_CHILD_MODE";
+
+        // Arrange
+        if let Ok(mode) = env::var(CHILD_MODE_ENVIRONMENT) {
+            // Act
+            let result = new_backend();
+
+            // Assert
+            if mode == "no-display" {
+                assert!(matches!(
+                    result,
+                    Err(ClipboardError::Unavailable { reason })
+                        if reason == "no supported Linux clipboard display was detected"
+                ));
+            } else if mode == "wayland" {
+                assert!(result.is_ok());
+            } else {
+                assert_eq!(mode, "wayland-x11-failure");
+                assert!(matches!(
+                    result,
+                    Err(ClipboardError::Unavailable { reason })
+                        if reason.contains("Wayland clipboard backend failed")
+                            && reason.contains("X11 clipboard backend failed")
+                ));
+            }
+
+            return;
+        }
+
+        let temp_dir = TestExecutableDirectory::new();
+        let wl_paste_path = temp_dir.path().join("wl-paste");
+        fs::write(
+            &wl_paste_path,
+            "#!/bin/sh\nexit \"${AGENTTY_WL_PASTE_EXIT_CODE:-0}\"\n",
+        )
+        .expect("wl-paste test executable should be written");
+        fs::set_permissions(&wl_paste_path, fs::Permissions::from_mode(0o755))
+            .expect("wl-paste test executable should be executable");
+        let executable_search_path = executable_search_path(temp_dir.path());
+
+        // Act
+        let no_display = run_backend_child(
+            CHILD_MODE_ENVIRONMENT,
+            "no-display",
+            &executable_search_path,
+            None,
+            None,
+            "0",
+        );
+        let wayland = run_backend_child(
+            CHILD_MODE_ENVIRONMENT,
+            "wayland",
+            &executable_search_path,
+            None,
+            Some("wayland-0"),
+            "0",
+        );
+        let wayland_x11_failure = run_backend_child(
+            CHILD_MODE_ENVIRONMENT,
+            "wayland-x11-failure",
+            &executable_search_path,
+            Some("invalid-display"),
+            Some("wayland-0"),
+            "1",
+        );
+
+        // Assert
+        assert!(no_display.success());
+        assert!(wayland.success());
+        assert!(wayland_x11_failure.success());
+    }
+
+    #[cfg(target_os = "linux")]
+    fn executable_search_path(test_executable_directory: &std::path::Path) -> OsString {
+        let system_paths = env::var_os("PATH")
+            .map(|path| env::split_paths(&path).collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        env::join_paths(
+            std::iter::once(test_executable_directory.to_path_buf()).chain(system_paths),
+        )
+        .expect("clipboard executable search path should be valid")
+    }
+
+    #[cfg(target_os = "linux")]
+    fn run_backend_child(
+        child_mode_environment: &str,
+        child_mode: &str,
+        executable_search_path: &OsString,
+        display: Option<&str>,
+        wayland_display: Option<&str>,
+        wl_paste_exit_code: &str,
+    ) -> std::process::ExitStatus {
+        let mut command = Command::new(env::current_exe().expect("test executable should resolve"));
+        command
+            .args([
+                "--exact",
+                "backend::linux::tests::new_backend_uses_detected_linux_platform_backends",
+                "--nocapture",
+            ])
+            .env(child_mode_environment, child_mode)
+            .env("AGENTTY_WL_PASTE_EXIT_CODE", wl_paste_exit_code)
+            .env("PATH", executable_search_path)
+            .env_remove("DISPLAY")
+            .env_remove("WAYLAND_DISPLAY");
+        if let Some(display) = display {
+            command.env("DISPLAY", display);
+        }
+        if let Some(wayland_display) = wayland_display {
+            command.env("WAYLAND_DISPLAY", wayland_display);
+        }
+
+        command.status().expect("clipboard child test should run")
     }
 }

--- a/crates/ag-forge/src/github.rs
+++ b/crates/ag-forge/src/github.rs
@@ -19,15 +19,24 @@ use super::{
 const REQUESTED_REVIEW_LIMIT: usize = 100;
 /// Maximum assigned-issue rows loaded from `gh` for one refresh.
 const ASSIGNED_ISSUE_LIMIT: usize = 100;
-/// GraphQL query text used to fetch review threads and review-request-wide
-/// conversation comments for one pull request.
-///
-/// Capped at 100 threads per request and 100 comments per thread/PR.
+/// Paginated GraphQL query used to fetch review threads for one pull request.
 const REVIEW_THREADS_QUERY: &str =
-    "query($owner: String!, $repo: String!, $number: Int!) { repository(owner: $owner, name: \
-     $repo) { pullRequest(number: $number) { comments(first: 100) { nodes { author { login } body \
-     } } reviewThreads(first: 100) { nodes { id diffSide isOutdated isResolved line path \
-     startLine subjectType comments(first: 100) { nodes { author { login } body } } } } } } }";
+    "query($owner: String!, $repo: String!, $number: Int!, $endCursor: String) { \
+     repository(owner: $owner, name: $repo) { pullRequest(number: $number) { reviewThreads(first: \
+     100, after: $endCursor) { nodes { id diffSide isOutdated isResolved line path startLine \
+     subjectType comments(first: 100) { nodes { author { login } body } pageInfo { hasNextPage \
+     endCursor } } } pageInfo { hasNextPage endCursor } } } } }";
+/// Paginated GraphQL query used to fetch pull-request conversation comments.
+const PULL_REQUEST_COMMENTS_QUERY: &str =
+    "query($owner: String!, $repo: String!, $number: Int!, $endCursor: String) { \
+     repository(owner: $owner, name: $repo) { pullRequest(number: $number) { comments(first: 100, \
+     after: $endCursor) { nodes { author { login } body } pageInfo { hasNextPage endCursor } } } \
+     } }";
+/// Paginated GraphQL query used when one review thread exceeds 100 comments.
+const THREAD_COMMENTS_QUERY: &str = "query($threadId: ID!, $endCursor: String) { node(id: \
+                                     $threadId) { ... on PullRequestReviewThread { \
+                                     comments(first: 100, after: $endCursor) { nodes { author { \
+                                     login } body } pageInfo { hasNextPage endCursor } } } } }";
 /// GraphQL mutation used to add one reply to a pull-request review thread.
 const REPLY_TO_THREAD_MUTATION: &str =
     "mutation($threadId: ID!, $body: String!) { addPullRequestReviewThreadReply(input: { \
@@ -227,14 +236,59 @@ impl ReviewRequestAdapter for GitHubReviewRequestAdapter {
         remote: ForgeRemote,
         display_id: String,
     ) -> ForgeFuture<Result<ReviewCommentSnapshot, ReviewRequestError>> {
-        self.operations.fetch_review_comment_snapshot_future(
-            remote,
-            display_id,
-            parse_display_id,
-            review_threads_command,
-            "fetch review comments",
-            parse_review_comment_snapshot_response,
-        )
+        let operations = self.operations.clone();
+
+        Box::pin(async move {
+            let pull_request_number = parse_display_id(&display_id)?;
+            let threads_output = operations
+                .run_review_command(
+                    &remote,
+                    review_threads_command(&remote, &pull_request_number),
+                    "fetch pull-request review threads",
+                )
+                .await?;
+            let mut thread_nodes = map_parse_error(
+                ForgeKind::GitHub,
+                parse_review_thread_pages(&threads_output.stdout),
+            )?;
+            let comments_output = operations
+                .run_review_command(
+                    &remote,
+                    pull_request_comments_command(&remote, &pull_request_number),
+                    "fetch pull-request conversation comments",
+                )
+                .await?;
+            let pr_level_comments = map_parse_error(
+                ForgeKind::GitHub,
+                parse_pull_request_comment_pages(&comments_output.stdout),
+            )?;
+
+            for thread_node in &mut thread_nodes {
+                if !thread_node.comments.page_info.has_next_page {
+                    continue;
+                }
+
+                let comments_output = operations
+                    .run_review_command(
+                        &remote,
+                        thread_comments_command(&remote, &thread_node.id),
+                        "fetch review-thread comments",
+                    )
+                    .await?;
+                thread_node.comments.nodes = map_parse_error(
+                    ForgeKind::GitHub,
+                    parse_thread_comment_pages(&comments_output.stdout),
+                )?;
+            }
+
+            Ok(ReviewCommentSnapshot {
+                pr_level_comments,
+                threads: thread_nodes
+                    .into_iter()
+                    .map(review_comment_thread_from_node)
+                    .collect(),
+            })
+        })
     }
 
     fn reply_to_authenticated_thread(
@@ -586,26 +640,62 @@ fn edit_metadata_command(
     github_command(remote, arguments)
 }
 
-/// Builds one `gh api graphql` command that fetches review threads and
-/// comments for `pull_request_number`.
+/// Builds one paginated `gh api graphql` command that fetches review threads.
 fn review_threads_command(remote: &ForgeRemote, pull_request_number: &str) -> ForgeCommand {
-    github_command(
+    paginated_graphql_command(
         remote,
+        REVIEW_THREADS_QUERY,
         vec![
-            "api".to_string(),
-            "--hostname".to_string(),
-            remote.host.clone(),
-            "graphql".to_string(),
-            "-f".to_string(),
-            format!("query={REVIEW_THREADS_QUERY}"),
-            "-F".to_string(),
             format!("owner={}", remote.namespace),
-            "-F".to_string(),
             format!("repo={}", remote.project),
-            "-F".to_string(),
             format!("number={pull_request_number}"),
         ],
     )
+}
+
+/// Builds one paginated GraphQL command for pull-request conversation comments.
+fn pull_request_comments_command(remote: &ForgeRemote, pull_request_number: &str) -> ForgeCommand {
+    paginated_graphql_command(
+        remote,
+        PULL_REQUEST_COMMENTS_QUERY,
+        vec![
+            format!("owner={}", remote.namespace),
+            format!("repo={}", remote.project),
+            format!("number={pull_request_number}"),
+        ],
+    )
+}
+
+/// Builds one paginated GraphQL command for all comments in one review thread.
+fn thread_comments_command(remote: &ForgeRemote, thread_id: &str) -> ForgeCommand {
+    paginated_graphql_command(
+        remote,
+        THREAD_COMMENTS_QUERY,
+        vec![format!("threadId={thread_id}")],
+    )
+}
+
+/// Builds one `gh api graphql --paginate --slurp` command.
+fn paginated_graphql_command(
+    remote: &ForgeRemote,
+    query: &str,
+    variables: Vec<String>,
+) -> ForgeCommand {
+    let mut arguments = vec![
+        "api".to_string(),
+        "--hostname".to_string(),
+        remote.host.clone(),
+        "graphql".to_string(),
+        "--paginate".to_string(),
+        "--slurp".to_string(),
+        "-f".to_string(),
+        format!("query={query}"),
+    ];
+    for variable in variables {
+        arguments.extend(["-F".to_string(), variable]);
+    }
+
+    github_command(remote, arguments)
 }
 
 /// Builds one `gh api graphql` mutation that replies to a review thread.
@@ -644,46 +734,79 @@ fn resolve_thread_command(remote: &ForgeRemote, thread_id: &str) -> ForgeCommand
     )
 }
 
-/// Parses the full review-comment snapshot from a GraphQL response.
-///
-/// Threads are returned in the forge-reported order; callers sort by
-/// `(path, line)` before rendering in the UI. PR-level conversation comments
-/// preserve GitHub's chronological order.
-fn parse_review_comment_snapshot_response(stdout: &str) -> Result<ReviewCommentSnapshot, String> {
-    let response: GitHubReviewThreadsEnvelope = serde_json::from_str(stdout)
+/// Parses and combines all `--slurp` pages from a review-threads query.
+fn parse_review_thread_pages(stdout: &str) -> Result<Vec<GitHubReviewThreadNode>, String> {
+    let responses: Vec<GitHubReviewThreadsEnvelope> = serde_json::from_str(stdout)
         .map_err(|error| format!("invalid GitHub review-threads response: {error}"))?;
+    let mut thread_nodes = Vec::new();
+    for response in responses {
+        let Some(data) = response.data else {
+            return Err("GitHub review-threads response is missing a data payload".to_string());
+        };
+        let Some(pull_request) = data
+            .repository
+            .and_then(|repository| repository.pull_request)
+        else {
+            return Err("GitHub review-threads response is missing a pull request".to_string());
+        };
 
-    let Some(data) = response.data else {
-        return Err("GitHub review-threads response is missing a data payload".to_string());
-    };
-    let Some(pull_request) = data
-        .repository
-        .and_then(|repository| repository.pull_request)
-    else {
-        return Err("GitHub review-threads response is missing a pull request".to_string());
-    };
+        thread_nodes.extend(pull_request.review_threads.nodes);
+    }
 
-    let threads = pull_request
-        .review_threads
-        .nodes
-        .into_iter()
-        .map(review_comment_thread_from_node)
-        .collect();
-    let pr_level_comments = pull_request
-        .comments
-        .map(|connection| {
-            connection
+    Ok(thread_nodes)
+}
+
+/// Parses and combines all pull-request conversation-comment pages.
+fn parse_pull_request_comment_pages(stdout: &str) -> Result<Vec<ReviewComment>, String> {
+    let responses: Vec<GitHubPullRequestCommentsEnvelope> = serde_json::from_str(stdout)
+        .map_err(|error| format!("invalid GitHub pull-request comments response: {error}"))?;
+    let mut comments = Vec::new();
+    for response in responses {
+        let Some(data) = response.data else {
+            return Err(
+                "GitHub pull-request comments response is missing a data payload".to_string(),
+            );
+        };
+        let Some(pull_request) = data
+            .repository
+            .and_then(|repository| repository.pull_request)
+        else {
+            return Err(
+                "GitHub pull-request comments response is missing a pull request".to_string(),
+            );
+        };
+
+        comments.extend(
+            pull_request
+                .comments
                 .nodes
                 .into_iter()
-                .map(review_comment_from_node)
-                .collect()
-        })
-        .unwrap_or_default();
+                .map(review_comment_from_node),
+        );
+    }
 
-    Ok(ReviewCommentSnapshot {
-        pr_level_comments,
-        threads,
-    })
+    Ok(comments)
+}
+
+/// Parses and combines all comments pages for one oversized review thread.
+fn parse_thread_comment_pages(stdout: &str) -> Result<Vec<GitHubReviewCommentNode>, String> {
+    let responses: Vec<GitHubThreadCommentsEnvelope> = serde_json::from_str(stdout)
+        .map_err(|error| format!("invalid GitHub review-thread comments response: {error}"))?;
+    let mut comments = Vec::new();
+    for response in responses {
+        let Some(data) = response.data else {
+            return Err(
+                "GitHub review-thread comments response is missing a data payload".to_string(),
+            );
+        };
+        let Some(thread) = data.node else {
+            return Err("GitHub review-thread comments response is missing a thread".to_string());
+        };
+
+        comments.extend(thread.comments.nodes);
+    }
+
+    Ok(comments)
 }
 
 /// Converts one GraphQL thread node into the forge-neutral representation.
@@ -954,11 +1077,9 @@ struct GitHubReviewThreadsRepository {
     pull_request: Option<GitHubReviewThreadsPullRequest>,
 }
 
-/// GraphQL pull-request node carrying the review-threads connection and the
-/// review-request-wide conversation comments.
+/// GraphQL pull-request node carrying the review-threads connection.
 #[derive(Deserialize)]
 struct GitHubReviewThreadsPullRequest {
-    comments: Option<GitHubReviewCommentsConnection>,
     #[serde(rename = "reviewThreads")]
     review_threads: GitHubReviewThreadsConnection,
 }
@@ -992,6 +1113,58 @@ struct GitHubReviewThreadNode {
 #[derive(Deserialize)]
 struct GitHubReviewCommentsConnection {
     nodes: Vec<GitHubReviewCommentNode>,
+    #[serde(rename = "pageInfo")]
+    page_info: GitHubPageInfo,
+}
+
+/// GraphQL pagination state used to identify oversized nested connections.
+#[derive(Deserialize)]
+struct GitHubPageInfo {
+    #[serde(rename = "hasNextPage")]
+    has_next_page: bool,
+}
+
+/// GraphQL response envelope for pull-request conversation comments.
+#[derive(Deserialize)]
+struct GitHubPullRequestCommentsEnvelope {
+    data: Option<GitHubPullRequestCommentsData>,
+}
+
+/// GraphQL `data` payload for pull-request conversation comments.
+#[derive(Deserialize)]
+struct GitHubPullRequestCommentsData {
+    repository: Option<GitHubPullRequestCommentsRepository>,
+}
+
+/// GraphQL repository node carrying pull-request conversation comments.
+#[derive(Deserialize)]
+struct GitHubPullRequestCommentsRepository {
+    #[serde(rename = "pullRequest")]
+    pull_request: Option<GitHubPullRequestCommentsPullRequest>,
+}
+
+/// GraphQL pull-request node carrying its conversation-comment connection.
+#[derive(Deserialize)]
+struct GitHubPullRequestCommentsPullRequest {
+    comments: GitHubReviewCommentsConnection,
+}
+
+/// GraphQL response envelope for one review thread's comments.
+#[derive(Deserialize)]
+struct GitHubThreadCommentsEnvelope {
+    data: Option<GitHubThreadCommentsData>,
+}
+
+/// GraphQL `data` payload for one review thread's comments.
+#[derive(Deserialize)]
+struct GitHubThreadCommentsData {
+    node: Option<GitHubThreadCommentsNode>,
+}
+
+/// GraphQL review-thread node carrying its complete comments connection.
+#[derive(Deserialize)]
+struct GitHubThreadCommentsNode {
+    comments: GitHubReviewCommentsConnection,
 }
 
 /// One GraphQL review-comment node.
@@ -1710,6 +1883,18 @@ mod tests {
                 move |command| command == &review_threads_command(&remote, "42")
             })
             .returning(|_| Box::pin(async { Ok(success_output(github_review_threads_json())) }));
+        command_runner
+            .expect_run()
+            .once()
+            .in_sequence(&mut sequence)
+            .withf({
+                let remote = remote.clone();
+
+                move |command| command == &pull_request_comments_command(&remote, "42")
+            })
+            .returning(|_| {
+                Box::pin(async { Ok(success_output(github_pull_request_comments_json())) })
+            });
         let adapter = GitHubReviewRequestAdapter::new(Arc::new(command_runner));
 
         // Act
@@ -1747,6 +1932,190 @@ mod tests {
         assert_eq!(snapshot.pr_level_comments[0].author, "carol");
         assert_eq!(snapshot.pr_level_comments[0].body, "Overall looks good.");
         assert_eq!(snapshot.pr_level_comments[1].author, "ghost");
+    }
+
+    #[tokio::test]
+    async fn fetch_authenticated_review_comment_snapshot_loads_oversized_thread_comments() {
+        // Arrange
+        let remote = github_remote();
+        let mut sequence = Sequence::new();
+        let mut command_runner = MockForgeCommandRunner::new();
+        command_runner
+            .expect_run()
+            .once()
+            .in_sequence(&mut sequence)
+            .withf({
+                let remote = remote.clone();
+
+                move |command| command == &review_threads_command(&remote, "42")
+            })
+            .returning(|_| Box::pin(async { Ok(success_output(github_oversized_thread_json())) }));
+        command_runner
+            .expect_run()
+            .once()
+            .in_sequence(&mut sequence)
+            .withf({
+                let remote = remote.clone();
+
+                move |command| command == &pull_request_comments_command(&remote, "42")
+            })
+            .returning(|_| {
+                Box::pin(async { Ok(success_output(github_empty_pull_request_comments_json())) })
+            });
+        command_runner
+            .expect_run()
+            .once()
+            .in_sequence(&mut sequence)
+            .withf({
+                let remote = remote.clone();
+
+                move |command| command == &thread_comments_command(&remote, "thread-large")
+            })
+            .returning(|_| {
+                Box::pin(async { Ok(success_output(github_thread_comment_pages_json())) })
+            });
+        let adapter = GitHubReviewRequestAdapter::new(Arc::new(command_runner));
+
+        // Act
+        let snapshot = adapter
+            .fetch_authenticated_review_comment_snapshot(remote, "#42".to_string())
+            .await
+            .expect("oversized review thread should load all comments");
+
+        // Assert
+        assert_eq!(snapshot.threads.len(), 1);
+        assert_eq!(snapshot.threads[0].comments.len(), 2);
+        assert_eq!(snapshot.threads[0].comments[0].body, "First page");
+        assert_eq!(snapshot.threads[0].comments[1].body, "Second page");
+    }
+
+    #[tokio::test]
+    async fn fetch_authenticated_review_comment_snapshot_preserves_thread_parse_failure() {
+        // Arrange
+        let remote = github_remote();
+        let mut command_runner = MockForgeCommandRunner::new();
+        command_runner
+            .expect_run()
+            .once()
+            .withf({
+                let remote = remote.clone();
+
+                move |command| command == &review_threads_command(&remote, "42")
+            })
+            .returning(|_| Box::pin(async { Ok(success_output("not-json".to_string())) }));
+        let adapter = GitHubReviewRequestAdapter::new(Arc::new(command_runner));
+
+        // Act
+        let error = adapter
+            .fetch_authenticated_review_comment_snapshot(remote, "#42".to_string())
+            .await
+            .expect_err("invalid review threads should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            ReviewRequestError::OperationFailed { forge_kind, message }
+                if forge_kind == ForgeKind::GitHub
+                    && message.contains("invalid GitHub review-threads response")
+        ));
+    }
+
+    #[tokio::test]
+    async fn fetch_authenticated_review_comment_snapshot_preserves_pr_comment_parse_failure() {
+        // Arrange
+        let remote = github_remote();
+        let mut sequence = Sequence::new();
+        let mut command_runner = MockForgeCommandRunner::new();
+        command_runner
+            .expect_run()
+            .once()
+            .in_sequence(&mut sequence)
+            .withf({
+                let remote = remote.clone();
+
+                move |command| command == &review_threads_command(&remote, "42")
+            })
+            .returning(|_| Box::pin(async { Ok(success_output(github_review_threads_json())) }));
+        command_runner
+            .expect_run()
+            .once()
+            .in_sequence(&mut sequence)
+            .withf({
+                let remote = remote.clone();
+
+                move |command| command == &pull_request_comments_command(&remote, "42")
+            })
+            .returning(|_| Box::pin(async { Ok(success_output("not-json".to_string())) }));
+        let adapter = GitHubReviewRequestAdapter::new(Arc::new(command_runner));
+
+        // Act
+        let error = adapter
+            .fetch_authenticated_review_comment_snapshot(remote, "#42".to_string())
+            .await
+            .expect_err("invalid pull-request comments should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            ReviewRequestError::OperationFailed { forge_kind, message }
+                if forge_kind == ForgeKind::GitHub
+                    && message.contains("invalid GitHub pull-request comments response")
+        ));
+    }
+
+    #[tokio::test]
+    async fn fetch_authenticated_review_comment_snapshot_preserves_thread_comment_parse_failure() {
+        // Arrange
+        let remote = github_remote();
+        let mut sequence = Sequence::new();
+        let mut command_runner = MockForgeCommandRunner::new();
+        command_runner
+            .expect_run()
+            .once()
+            .in_sequence(&mut sequence)
+            .withf({
+                let remote = remote.clone();
+
+                move |command| command == &review_threads_command(&remote, "42")
+            })
+            .returning(|_| Box::pin(async { Ok(success_output(github_oversized_thread_json())) }));
+        command_runner
+            .expect_run()
+            .once()
+            .in_sequence(&mut sequence)
+            .withf({
+                let remote = remote.clone();
+
+                move |command| command == &pull_request_comments_command(&remote, "42")
+            })
+            .returning(|_| {
+                Box::pin(async { Ok(success_output(github_empty_pull_request_comments_json())) })
+            });
+        command_runner
+            .expect_run()
+            .once()
+            .in_sequence(&mut sequence)
+            .withf({
+                let remote = remote.clone();
+
+                move |command| command == &thread_comments_command(&remote, "thread-large")
+            })
+            .returning(|_| Box::pin(async { Ok(success_output("not-json".to_string())) }));
+        let adapter = GitHubReviewRequestAdapter::new(Arc::new(command_runner));
+
+        // Act
+        let error = adapter
+            .fetch_authenticated_review_comment_snapshot(remote, "#42".to_string())
+            .await
+            .expect_err("invalid review-thread comments should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            ReviewRequestError::OperationFailed { forge_kind, message }
+                if forge_kind == ForgeKind::GitHub
+                    && message.contains("invalid GitHub review-thread comments response")
+        ));
     }
 
     #[tokio::test]
@@ -1798,13 +2167,14 @@ mod tests {
     }
 
     #[test]
-    fn parse_review_comment_snapshot_response_rejects_missing_data() {
+    fn parse_review_thread_pages_rejects_missing_data() {
         // Arrange
-        let stdout = "{\"data\": null}";
+        let stdout = "[{\"data\": null}]";
 
         // Act
-        let error = parse_review_comment_snapshot_response(stdout)
-            .expect_err("null data payload should be rejected");
+        let error = parse_review_thread_pages(stdout)
+            .err()
+            .expect("null data payload should be rejected");
 
         // Assert
         assert!(
@@ -1814,13 +2184,14 @@ mod tests {
     }
 
     #[test]
-    fn parse_review_comment_snapshot_response_rejects_missing_pull_request() {
+    fn parse_review_thread_pages_rejects_missing_pull_request() {
         // Arrange
-        let stdout = "{\"data\": {\"repository\": {\"pullRequest\": null}}}";
+        let stdout = "[{\"data\": {\"repository\": {\"pullRequest\": null}}}]";
 
         // Act
-        let error = parse_review_comment_snapshot_response(stdout)
-            .expect_err("null pull request should be rejected");
+        let error = parse_review_thread_pages(stdout)
+            .err()
+            .expect("null pull request should be rejected");
 
         // Assert
         assert!(
@@ -1830,19 +2201,99 @@ mod tests {
     }
 
     #[test]
-    fn parse_review_comment_snapshot_response_returns_empty_snapshot_on_empty_threads() {
+    fn paginated_snapshot_parsers_return_empty_collections_for_empty_connections() {
         // Arrange
-        let stdout = r#"{"data": {"repository": {"pullRequest": {
-            "reviewThreads": { "nodes": [] }
-        }}}}"#;
+        let thread_stdout = r#"[{"data": {"repository": {"pullRequest": {
+            "reviewThreads": {"nodes": [], "pageInfo": {"hasNextPage": false, "endCursor": null}}
+        }}}}]"#;
+        let comment_stdout = github_empty_pull_request_comments_json();
 
         // Act
-        let snapshot = parse_review_comment_snapshot_response(stdout)
+        let threads = parse_review_thread_pages(thread_stdout)
             .expect("empty review thread list should parse");
+        let comments = parse_pull_request_comment_pages(&comment_stdout)
+            .expect("empty pull-request comments should parse");
 
         // Assert
-        assert!(snapshot.threads.is_empty());
-        assert!(snapshot.pr_level_comments.is_empty());
+        assert!(threads.is_empty());
+        assert!(comments.is_empty());
+    }
+
+    #[test]
+    fn paginated_comment_parsers_reject_missing_graphql_nodes() {
+        // Arrange
+        let missing_data = "[{\"data\": null}]";
+        let missing_pull_request = "[{\"data\": {\"repository\": {\"pullRequest\": null}}}]";
+        let missing_thread = "[{\"data\": {\"node\": null}}]";
+
+        // Act
+        let pull_request_data_error = parse_pull_request_comment_pages(missing_data)
+            .expect_err("missing pull-request data should fail");
+        let pull_request_error = parse_pull_request_comment_pages(missing_pull_request)
+            .expect_err("missing pull request should fail");
+        let thread_data_error = parse_thread_comment_pages(missing_data)
+            .err()
+            .expect("missing thread data should fail");
+        let thread_error = parse_thread_comment_pages(missing_thread)
+            .err()
+            .expect("missing thread should fail");
+
+        // Assert
+        assert!(pull_request_data_error.contains("missing a data payload"));
+        assert!(pull_request_error.contains("missing a pull request"));
+        assert!(thread_data_error.contains("missing a data payload"));
+        assert!(thread_error.contains("missing a thread"));
+    }
+
+    #[test]
+    fn paginated_snapshot_parsers_preserve_invalid_json_context() {
+        // Arrange
+        let invalid_json = "not-json";
+
+        // Act
+        let thread_error = parse_review_thread_pages(invalid_json)
+            .err()
+            .expect("invalid review-thread JSON should fail");
+        let pull_request_error = parse_pull_request_comment_pages(invalid_json)
+            .expect_err("invalid pull-request comment JSON should fail");
+        let thread_comment_error = parse_thread_comment_pages(invalid_json)
+            .err()
+            .expect("invalid thread-comment JSON should fail");
+
+        // Assert
+        assert!(thread_error.contains("invalid GitHub review-threads response"));
+        assert!(pull_request_error.contains("invalid GitHub pull-request comments response"));
+        assert!(thread_comment_error.contains("invalid GitHub review-thread comments response"));
+    }
+
+    #[test]
+    fn snapshot_graphql_commands_request_pagination_and_slurped_pages() {
+        // Arrange
+        let remote = github_remote();
+        let commands = [
+            review_threads_command(&remote, "42"),
+            pull_request_comments_command(&remote, "42"),
+            thread_comments_command(&remote, "thread-1"),
+        ];
+
+        // Act
+        let all_request_pagination = commands.iter().all(|command| {
+            command
+                .arguments
+                .iter()
+                .any(|argument| argument == "--paginate")
+                && command
+                    .arguments
+                    .iter()
+                    .any(|argument| argument == "--slurp")
+                && command
+                    .arguments
+                    .iter()
+                    .any(|argument| argument.contains("$endCursor"))
+        });
+
+        // Assert
+        assert!(all_request_pagination);
     }
 
     #[tokio::test]
@@ -1936,99 +2387,179 @@ mod tests {
     }
 
     fn github_review_threads_json() -> String {
-        r#"{
+        serde_json::json!([
+            review_threads_page(vec![review_thread_node(ReviewThreadFixture {
+                comments: vec![
+                    review_comment_node(Some("alice"), "Why aren't we handling None?"),
+                    review_comment_node(Some("bob"), "Good catch. Will fix."),
+                ],
+                diff_side: "RIGHT",
+                has_next_comment_page: false,
+                id: "thread-1",
+                is_resolved: false,
+                line: Some(42),
+                path: "src/foo.rs",
+                subject_type: "LINE",
+            })]),
+            review_threads_page(vec![
+                review_thread_node(ReviewThreadFixture {
+                    comments: vec![review_comment_node(None, "Resolved thread.")],
+                    diff_side: "LEFT",
+                    has_next_comment_page: false,
+                    id: "thread-2",
+                    is_resolved: true,
+                    line: Some(15),
+                    path: "src/bar.rs",
+                    subject_type: "LINE",
+                }),
+                review_thread_node(ReviewThreadFixture {
+                    comments: Vec::new(),
+                    diff_side: "RIGHT",
+                    has_next_comment_page: false,
+                    id: "thread-3",
+                    is_resolved: false,
+                    line: None,
+                    path: "Cargo.toml",
+                    subject_type: "FILE",
+                }),
+            ]),
+        ])
+        .to_string()
+    }
+
+    fn github_pull_request_comments_json() -> String {
+        serde_json::json!([
+            pull_request_comments_page(vec![review_comment_node(
+                Some("carol"),
+                "Overall looks good.",
+            )]),
+            pull_request_comments_page(vec![review_comment_node(
+                None,
+                "Ghost conversation comment.",
+            )]),
+        ])
+        .to_string()
+    }
+
+    fn github_empty_pull_request_comments_json() -> String {
+        serde_json::json!([pull_request_comments_page(Vec::new())]).to_string()
+    }
+
+    fn github_oversized_thread_json() -> String {
+        serde_json::json!([review_threads_page(vec![review_thread_node(
+            ReviewThreadFixture {
+                comments: vec![review_comment_node(Some("alice"), "First page")],
+                diff_side: "RIGHT",
+                has_next_comment_page: true,
+                id: "thread-large",
+                is_resolved: false,
+                line: Some(7),
+                path: "src/large.rs",
+                subject_type: "LINE",
+            }
+        )])])
+        .to_string()
+    }
+
+    fn github_thread_comment_pages_json() -> String {
+        serde_json::json!([
+            thread_comments_page(vec![review_comment_node(Some("alice"), "First page")]),
+            thread_comments_page(vec![review_comment_node(Some("bob"), "Second page")]),
+        ])
+        .to_string()
+    }
+
+    fn review_threads_page(nodes: Vec<serde_json::Value>) -> serde_json::Value {
+        let nodes = serde_json::Value::Array(nodes);
+
+        serde_json::json!({
             "data": {
                 "repository": {
                     "pullRequest": {
-                        "comments": {
-                            "nodes": [
-                                {
-                                    "author": {"login": "carol"},
-                                    "body": "Overall looks good."
-                                },
-                                {
-                                    "author": null,
-                                    "body": "Ghost conversation comment."
-                                }
-                            ]
-                        },
                         "reviewThreads": {
-                            "nodes": [
-                                {
-                                    "id": "thread-1",
-                                    "isResolved": false,
-                                    "isOutdated": false,
-                                    "path": "src/foo.rs",
-                                    "line": 42,
-                                    "startLine": null,
-                                    "diffSide": "RIGHT",
-                                    "subjectType": "LINE",
-                                    "comments": {
-                                        "nodes": [
-                                            {
-                                                "id": "comment-1",
-                                                "author": {"login": "alice"},
-                                                "body": "Why aren't we handling None?",
-                                                "diffHunk": "@@ -40,3 +40,6 @@\n fn parse(input) {\n+    if raw.is_empty() {",
-                                                "createdAt": "2026-04-19T10:00:00Z",
-                                                "updatedAt": "2026-04-19T10:00:00Z",
-                                                "url": "https://github.com/agentty-xyz/agentty/pull/42#discussion_r1"
-                                            },
-                                            {
-                                                "id": "comment-2",
-                                                "author": {"login": "bob"},
-                                                "body": "Good catch. Will fix.",
-                                                "diffHunk": "@@ -40,3 +40,6 @@\n fn parse(input) {\n+    if raw.is_empty() {",
-                                                "createdAt": "2026-04-19T11:00:00Z",
-                                                "updatedAt": "2026-04-19T11:00:00Z",
-                                                "url": "https://github.com/agentty-xyz/agentty/pull/42#discussion_r2"
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "id": "thread-2",
-                                    "isResolved": true,
-                                    "isOutdated": false,
-                                    "path": "src/bar.rs",
-                                    "line": 15,
-                                    "startLine": null,
-                                    "diffSide": "LEFT",
-                                    "subjectType": "LINE",
-                                    "comments": {
-                                        "nodes": [
-                                            {
-                                                "id": "comment-3",
-                                                "author": null,
-                                                "body": "Resolved thread.",
-                                                "diffHunk": "@@ -15 +15 @@\n-old\n+new",
-                                                "createdAt": "2026-04-18T09:00:00Z",
-                                                "updatedAt": "2026-04-18T09:00:00Z",
-                                                "url": "https://github.com/agentty-xyz/agentty/pull/42#discussion_r3"
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "id": "thread-3",
-                                    "isResolved": false,
-                                    "isOutdated": false,
-                                    "path": "Cargo.toml",
-                                    "line": null,
-                                    "startLine": null,
-                                    "diffSide": "RIGHT",
-                                    "subjectType": "FILE",
-                                    "comments": {
-                                        "nodes": []
-                                    }
-                                }
-                            ]
+                            "nodes": nodes,
+                            "pageInfo": {"hasNextPage": false, "endCursor": null}
                         }
                     }
                 }
             }
-        }"#
-        .to_string()
+        })
+    }
+
+    struct ReviewThreadFixture<'a> {
+        comments: Vec<serde_json::Value>,
+        diff_side: &'a str,
+        has_next_comment_page: bool,
+        id: &'a str,
+        is_resolved: bool,
+        line: Option<u32>,
+        path: &'a str,
+        subject_type: &'a str,
+    }
+
+    fn review_thread_node(fixture: ReviewThreadFixture<'_>) -> serde_json::Value {
+        let comments = serde_json::Value::Array(fixture.comments);
+
+        serde_json::json!({
+            "id": fixture.id,
+            "isResolved": fixture.is_resolved,
+            "isOutdated": false,
+            "path": fixture.path,
+            "line": fixture.line,
+            "startLine": null,
+            "diffSide": fixture.diff_side,
+            "subjectType": fixture.subject_type,
+            "comments": {
+                "nodes": comments,
+                "pageInfo": {
+                    "hasNextPage": fixture.has_next_comment_page,
+                    "endCursor": if fixture.has_next_comment_page {
+                        Some("cursor-1")
+                    } else {
+                        None
+                    }
+                }
+            }
+        })
+    }
+
+    fn pull_request_comments_page(nodes: Vec<serde_json::Value>) -> serde_json::Value {
+        let nodes = serde_json::Value::Array(nodes);
+
+        serde_json::json!({
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "comments": {
+                            "nodes": nodes,
+                            "pageInfo": {"hasNextPage": false, "endCursor": null}
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    fn thread_comments_page(nodes: Vec<serde_json::Value>) -> serde_json::Value {
+        let nodes = serde_json::Value::Array(nodes);
+
+        serde_json::json!({
+            "data": {
+                "node": {
+                    "comments": {
+                        "nodes": nodes,
+                        "pageInfo": {"hasNextPage": false, "endCursor": null}
+                    }
+                }
+            }
+        })
+    }
+
+    fn review_comment_node(author: Option<&str>, body: &str) -> serde_json::Value {
+        serde_json::json!({
+            "author": author.map(|login| serde_json::json!({"login": login})),
+            "body": body
+        })
     }
 
     fn github_view_json() -> String {

--- a/crates/ag-forge/src/model.rs
+++ b/crates/ag-forge/src/model.rs
@@ -271,7 +271,7 @@ pub struct ForgeRemote {
     pub namespace: String,
     /// Repository name without a trailing `.git` suffix.
     pub project: String,
-    /// Original remote URL returned by git.
+    /// Credential-free remote URL suitable for display and diagnostics.
     pub repo_url: String,
     /// Browser-openable repository URL derived from the remote.
     pub web_url: String,

--- a/crates/ag-forge/src/remote.rs
+++ b/crates/ag-forge/src/remote.rs
@@ -17,7 +17,7 @@ pub(crate) struct ParsedRemote {
     pub(crate) namespace: String,
     /// Repository name without a trailing `.git` suffix.
     pub(crate) project: String,
-    /// Original remote URL returned by git.
+    /// Credential-free remote URL suitable for display and diagnostics.
     pub(crate) repo_url: String,
     /// Browser-openable repository URL derived from the remote.
     pub(crate) web_url: String,
@@ -53,22 +53,24 @@ pub fn detect_remote(repo_url: &str) -> Result<ForgeRemote, ReviewRequestError> 
     }
 
     Err(ReviewRequestError::UnsupportedRemote {
-        repo_url: repo_url.to_string(),
+        repo_url: display_safe_remote_url(repo_url),
     })
 }
 
 /// Parses a git remote URL into normalized hostname and repository components.
 ///
-/// HTTPS remotes may include `username[:password]@` userinfo, which is ignored
-/// when deriving the forge host and browser-openable repository URL.
+/// URL remotes may include `username[:password]@` userinfo, which is removed
+/// before the remote is retained or used for diagnostics.
 pub(crate) fn parse_remote_url(repo_url: &str) -> Option<ParsedRemote> {
     let trimmed_url = repo_url.trim().trim_end_matches('/');
     if trimmed_url.is_empty() {
         return None;
     }
 
-    if let Some(ssh_remote) = trimmed_url.strip_prefix("git@") {
-        let (host, path) = ssh_remote.split_once(':')?;
+    if let Some((authority, path)) = trimmed_url.split_once(':')
+        && authority.contains('@')
+    {
+        let host = strip_userinfo(authority);
 
         return parsed_remote_from_parts(trimmed_url, host, path, true);
     }
@@ -117,9 +119,32 @@ fn parsed_remote_from_parts(
         host: host.clone(),
         namespace: namespace.to_string(),
         project: project.to_string(),
-        repo_url: repo_url.to_string(),
+        repo_url: display_safe_remote_url(repo_url),
         web_url: format!("https://{host}/{path}"),
     })
+}
+
+/// Removes URL userinfo so repository remotes are safe to retain or display.
+fn display_safe_remote_url(repo_url: &str) -> String {
+    let trimmed_url = repo_url.trim();
+    let Some((scheme, scheme_rest)) = trimmed_url.split_once("://") else {
+        if let Some((authority, suffix)) = trimmed_url.split_once(':')
+            && authority.contains('@')
+        {
+            return format!("{}:{suffix}", strip_userinfo(authority));
+        }
+
+        return trimmed_url.to_string();
+    };
+    let (authority, suffix) = scheme_rest
+        .split_once('/')
+        .map_or((scheme_rest, ""), |(authority, path)| (authority, path));
+    let authority = strip_userinfo(authority);
+    if suffix.is_empty() {
+        return format!("{scheme}://{authority}");
+    }
+
+    format!("{scheme}://{authority}/{suffix}")
 }
 
 /// Removes any `username[:password]@` prefix from one URL authority segment.
@@ -159,7 +184,7 @@ mod tests {
     #[test]
     fn detect_remote_ignores_https_userinfo_for_github_origin() {
         // Arrange
-        let repo_url = "https://build-bot:token123@github.com/agentty-xyz/agentty.git";
+        let repo_url = "https://test-user:placeholder@github.com/agentty-xyz/agentty.git";
 
         // Act
         let remote =
@@ -170,8 +195,72 @@ mod tests {
         assert_eq!(remote.host, "github.com");
         assert_eq!(remote.namespace, "agentty-xyz");
         assert_eq!(remote.project, "agentty");
-        assert_eq!(remote.repo_url, repo_url);
+        assert_eq!(
+            remote.repo_url,
+            "https://github.com/agentty-xyz/agentty.git"
+        );
         assert_eq!(remote.web_url, "https://github.com/agentty-xyz/agentty");
+    }
+
+    #[test]
+    fn detect_remote_redacts_https_userinfo_from_unsupported_remote_error() {
+        // Arrange
+        let repo_url = "https://test-user:placeholder@example.com/team/project.git";
+
+        // Act
+        let error = detect_remote(repo_url).expect_err("unsupported remote should fail");
+        let detail = error.detail_message();
+
+        // Assert
+        assert_eq!(
+            error,
+            ReviewRequestError::UnsupportedRemote {
+                repo_url: "https://example.com/team/project.git".to_string(),
+            }
+        );
+        assert!(!detail.contains("test-user"));
+        assert!(!detail.contains("placeholder"));
+    }
+
+    #[test]
+    fn display_safe_remote_url_redacts_userinfo_without_a_path() {
+        // Arrange
+        let repo_url = "https://test-user:placeholder@example.com";
+
+        // Act
+        let sanitized = display_safe_remote_url(repo_url);
+
+        // Assert
+        assert_eq!(sanitized, "https://example.com");
+    }
+
+    #[test]
+    fn display_safe_remote_url_preserves_scp_style_remote_without_userinfo() {
+        // Arrange
+        let repo_url = "github.com:agentty-xyz/agentty.git";
+
+        // Act
+        let sanitized = display_safe_remote_url(repo_url);
+
+        // Assert
+        assert_eq!(sanitized, repo_url);
+    }
+
+    #[test]
+    fn detect_remote_redacts_scp_style_ssh_userinfo() {
+        // Arrange
+        let repo_url = "test-user@gitlab.com:agentty-xyz/agentty.git";
+
+        // Act
+        let remote = detect_remote(repo_url).expect("GitLab SSH remote should be supported");
+
+        // Assert
+        assert_eq!(remote.forge_kind, ForgeKind::GitLab);
+        assert_eq!(
+            remote.repo_url,
+            "gitlab.com:agentty-xyz/agentty.git".to_string()
+        );
+        assert!(!remote.repo_url.contains("test-user"));
     }
 
     #[test]

--- a/crates/ag-git/src/client.rs
+++ b/crates/ag-git/src/client.rs
@@ -1235,24 +1235,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_abort_rebase_cleans_stale_rebase_merge_metadata() {
-        // Arrange
-        let dir = tempdir().expect("failed to create temp dir");
-        setup_test_git_repo(dir.path());
-        let stale_rebase_dir = dir.path().join(".git/rebase-merge");
-        fs::create_dir_all(&stale_rebase_dir).expect("failed to create stale rebase metadata");
-        fs::write(stale_rebase_dir.join("head-name"), "refs/heads/main")
-            .expect("failed to write stale rebase metadata");
-
-        // Act
-        let result = abort_rebase(dir.path().to_path_buf()).await;
-
-        // Assert
-        assert!(result.is_ok(), "abort_rebase should succeed: {result:?}");
-        assert!(!stale_rebase_dir.exists());
-    }
-
-    #[tokio::test]
     async fn test_abort_rebase_returns_error_without_rebase_state_or_stale_metadata() {
         // Arrange
         let dir = tempdir().expect("failed to create temp dir");

--- a/crates/ag-git/src/merge.rs
+++ b/crates/ag-git/src/merge.rs
@@ -53,7 +53,7 @@ pub(crate) async fn squash_merge_diff(
 /// This function:
 /// 1. Verifies the repository is already on the target branch
 /// 2. Performs `git merge --squash` from the source branch
-/// 3. Commits the squashed changes (skipping configured commit hooks)
+/// 3. Commits the squashed changes, running configured commit hooks
 ///
 /// The caller is responsible for ensuring `repo_path` is already checked out
 /// on `target_branch`. Switching branches here would disrupt the user's
@@ -70,7 +70,7 @@ pub(crate) async fn squash_merge_diff(
 ///
 /// # Errors
 /// Returns an error if the repository is on the wrong branch, the merge
-/// fails, or the commit fails.
+/// fails, or the commit or a configured commit hook fails.
 pub(crate) async fn squash_merge(
     repo_path: PathBuf,
     source_branch: String,
@@ -119,10 +119,9 @@ pub(crate) async fn squash_merge(
             });
         }
 
-        // Skip hooks here because the session worktree already ran them.
         run_git_command_sync(
             &repo_path,
-            &["commit", "--no-verify", "-m", commit_message.as_str()],
+            &["commit", "-m", commit_message.as_str()],
             "Failed to commit squash merge",
         )?;
 
@@ -134,6 +133,8 @@ pub(crate) async fn squash_merge(
 #[cfg(test)]
 mod tests {
     use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::path::Path;
     use std::process::Command;
 
@@ -236,6 +237,44 @@ mod tests {
             SquashMergeOutcome::Committed,
         );
         assert_eq!(head_message, commit_message);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn squash_merge_runs_pre_commit_hook() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        setup_test_git_repo(temp_dir.path());
+        run_git_command(temp_dir.path(), &["checkout", "-b", "feature-branch"]);
+        fs::write(temp_dir.path().join("feature.txt"), "feature content")
+            .expect("failed to write feature file");
+        run_git_command(temp_dir.path(), &["add", "feature.txt"]);
+        run_git_command(temp_dir.path(), &["commit", "-m", "Add feature"]);
+        run_git_command(temp_dir.path(), &["checkout", "main"]);
+        let hooks_dir = temp_dir.path().join("test-hooks");
+        fs::create_dir(&hooks_dir).expect("failed to create hooks directory");
+        let hook_path = hooks_dir.join("pre-commit");
+        fs::write(&hook_path, "#!/bin/sh\necho hook-blocked >&2\nexit 1\n")
+            .expect("failed to write pre-commit hook");
+        let mut permissions = fs::metadata(&hook_path)
+            .expect("failed to read hook metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&hook_path, permissions).expect("failed to make hook executable");
+        run_git_command(temp_dir.path(), &["config", "core.hooksPath", "test-hooks"]);
+
+        // Act
+        let error = squash_merge(
+            temp_dir.path().to_path_buf(),
+            "feature-branch".to_string(),
+            "main".to_string(),
+            "Squash merge feature".to_string(),
+        )
+        .await
+        .expect_err("pre-commit hook should block the squash commit");
+
+        // Assert
+        assert!(error.to_string().contains("hook-blocked"));
     }
 
     #[tokio::test]

--- a/crates/ag-git/src/rebase.rs
+++ b/crates/ag-git/src/rebase.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Output;
 use std::time::Duration;
@@ -12,8 +13,8 @@ use super::repo::{
 };
 use crate::{Sleeper, ThreadSleeper};
 
-const GIT_INDEX_LOCK_RETRY_ATTEMPTS: usize = 5;
-const GIT_INDEX_LOCK_RETRY_DELAY: Duration = Duration::from_millis(100);
+pub(super) const GIT_INDEX_LOCK_RETRY_ATTEMPTS: usize = 5;
+pub(super) const GIT_INDEX_LOCK_RETRY_DELAY: Duration = Duration::from_millis(100);
 
 /// Executes git commands for rebase operations.
 #[cfg_attr(test, mockall::automock)]
@@ -25,6 +26,22 @@ trait GitCommandRunner: Send + Sync {
         args: &[String],
         environment: &[(String, String)],
     ) -> Result<Output, GitError>;
+}
+
+/// Removes stale rebase metadata through an injectable filesystem boundary.
+#[cfg_attr(test, mockall::automock)]
+trait RebaseMetadataCleaner: Send + Sync {
+    /// Removes exact rebase metadata entries under the resolved git directory.
+    fn clean_stale_metadata(&self, repo_path: &Path) -> Result<bool, GitError>;
+}
+
+/// Rebase metadata cleaner backed by the local filesystem.
+struct FilesystemRebaseMetadataCleaner;
+
+impl RebaseMetadataCleaner for FilesystemRebaseMetadataCleaner {
+    fn clean_stale_metadata(&self, repo_path: &Path) -> Result<bool, GitError> {
+        clean_stale_rebase_metadata(repo_path)
+    }
 }
 
 /// Git command runner backed by process execution.
@@ -222,9 +239,9 @@ pub(crate) async fn rebase_continue(repo_path: PathBuf) -> Result<RebaseStepResu
 
 /// Aborts an in-progress rebase.
 ///
-/// When git reports stale or inconsistent rebase metadata and abort cannot
-/// complete normally, this helper removes stale `rebase-merge`/`rebase-apply`
-/// paths as a recovery fallback.
+/// When Git reports a known stale or inactive rebase state, this removes only
+/// `rebase-merge` and `rebase-apply` under the resolved git directory. Other
+/// failures are returned unchanged with their command output.
 ///
 /// # Arguments
 /// * `repo_path` - Path to the git repository or worktree
@@ -236,30 +253,11 @@ pub(crate) async fn rebase_continue(repo_path: PathBuf) -> Result<RebaseStepResu
 /// Returns a [`GitError`] when `git rebase --abort` cannot be executed.
 pub(crate) async fn abort_rebase(repo_path: PathBuf) -> Result<(), GitError> {
     spawn_blocking(move || {
-        let output =
-            run_git_command_with_index_lock_retry(&repo_path, &["rebase", "--abort"], &[])?;
+        let command_runner = ProcessGitCommandRunner;
+        let metadata_cleaner = FilesystemRebaseMetadataCleaner;
+        let sleeper = ThreadSleeper;
 
-        if !output.status.success() {
-            let detail = command_output_detail(&output.stdout, &output.stderr);
-            if !is_stale_or_inactive_rebase_error(&detail) {
-                return Err(GitError::CommandFailed {
-                    command: "git rebase --abort".to_string(),
-                    stderr: format!("Failed to abort rebase: {detail}."),
-                });
-            }
-
-            let cleaned_stale_metadata = clean_stale_rebase_metadata(&repo_path)?;
-            if cleaned_stale_metadata {
-                return Ok(());
-            }
-
-            return Err(GitError::CommandFailed {
-                command: "git rebase --abort".to_string(),
-                stderr: format!("Failed to abort rebase: {detail}."),
-            });
-        }
-
-        Ok(())
+        abort_rebase_with_dependencies(&repo_path, &command_runner, &sleeper, &metadata_cleaner)
     })
     .await?
 }
@@ -460,6 +458,84 @@ fn run_rebase_step(
     })
 }
 
+/// Aborts one rebase through injected process and retry boundaries.
+fn abort_rebase_with_dependencies(
+    repo_path: &Path,
+    command_runner: &dyn GitCommandRunner,
+    sleeper: &dyn Sleeper,
+    metadata_cleaner: &dyn RebaseMetadataCleaner,
+) -> Result<(), GitError> {
+    let output = run_git_command_with_index_lock_retry_with_dependencies(
+        repo_path,
+        &["rebase", "--abort"],
+        &[],
+        command_runner,
+        sleeper,
+    )?;
+    if !output.status.success() {
+        let detail = command_output_detail(&output.stdout, &output.stderr);
+        if is_stale_or_inactive_rebase_error(&detail) {
+            match metadata_cleaner.clean_stale_metadata(repo_path) {
+                Ok(true) => return Ok(()),
+                Ok(false) => {}
+                Err(cleanup_error) => {
+                    return Err(GitError::CommandFailed {
+                        command: "git rebase --abort".to_string(),
+                        stderr: format!(
+                            "Failed to abort rebase: {detail}. Stale rebase metadata cleanup \
+                             failed: {cleanup_error}."
+                        ),
+                    });
+                }
+            }
+        }
+
+        return Err(GitError::CommandFailed {
+            command: "git rebase --abort".to_string(),
+            stderr: format!("Failed to abort rebase: {detail}."),
+        });
+    }
+
+    Ok(())
+}
+
+/// Returns whether abort output identifies a known stale or inactive rebase.
+fn is_stale_or_inactive_rebase_error(detail: &str) -> bool {
+    let normalized_detail = detail.to_ascii_lowercase();
+
+    normalized_detail.contains("no rebase in progress")
+        || normalized_detail.contains("already a rebase-merge directory")
+        || normalized_detail.contains("already a rebase-apply directory")
+        || normalized_detail.contains("middle of another rebase")
+}
+
+/// Removes exact stale rebase metadata entries from the resolved git directory.
+fn clean_stale_rebase_metadata(repo_path: &Path) -> Result<bool, GitError> {
+    let git_dir = resolve_git_dir(repo_path)
+        .ok_or_else(|| GitError::OutputParse("Failed to resolve git directory".to_string()))?;
+    let removed_rebase_merge = remove_stale_rebase_metadata_path(&git_dir.join("rebase-merge"))?;
+    let removed_rebase_apply = remove_stale_rebase_metadata_path(&git_dir.join("rebase-apply"))?;
+
+    Ok(removed_rebase_merge || removed_rebase_apply)
+}
+
+/// Removes one exact metadata path without following directory symlinks.
+fn remove_stale_rebase_metadata_path(path: &Path) -> Result<bool, GitError> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+
+    if metadata.file_type().is_dir() {
+        fs::remove_dir_all(path)?;
+    } else {
+        fs::remove_file(path)?;
+    }
+
+    Ok(true)
+}
+
 /// Runs a git command and retries when `index.lock` contention occurs.
 pub(super) fn run_git_command_with_index_lock_retry(
     repo_path: &Path,
@@ -529,59 +605,8 @@ pub(super) fn is_rebase_conflict(detail: &str) -> bool {
         || detail.contains("Committing is not possible")
 }
 
-/// Returns whether abort output indicates stale or inactive rebase metadata.
-fn is_stale_or_inactive_rebase_error(detail: &str) -> bool {
-    let normalized_detail = detail.to_ascii_lowercase();
-
-    normalized_detail.contains("already a rebase-merge directory")
-        || normalized_detail.contains("already a rebase-apply directory")
-        || normalized_detail.contains("middle of another rebase")
-        || normalized_detail.contains("no rebase in progress")
-        || normalized_detail.contains("rebase-merge")
-        || normalized_detail.contains("rebase-apply")
-}
-
-/// Removes stale rebase metadata directories/files from the git directory.
-///
-/// Returns `true` when at least one stale metadata path was removed.
-///
-/// # Errors
-/// Returns a [`GitError`] when the git directory cannot be resolved or
-/// metadata cleanup fails.
-fn clean_stale_rebase_metadata(repo_path: &Path) -> Result<bool, GitError> {
-    let git_dir = resolve_git_dir(repo_path)
-        .ok_or_else(|| GitError::OutputParse("Failed to resolve git directory".to_string()))?;
-    let rebase_merge = git_dir.join("rebase-merge");
-    let rebase_apply = git_dir.join("rebase-apply");
-    let removed_rebase_merge = remove_stale_rebase_metadata_path(&rebase_merge)?;
-    let removed_rebase_apply = remove_stale_rebase_metadata_path(&rebase_apply)?;
-
-    Ok(removed_rebase_merge || removed_rebase_apply)
-}
-
-/// Removes one stale rebase metadata path and returns whether anything changed.
-///
-/// # Errors
-/// Returns a [`GitError`] when a stale metadata path exists but cannot be
-/// removed.
-fn remove_stale_rebase_metadata_path(path: &Path) -> Result<bool, GitError> {
-    if !path.exists() {
-        return Ok(false);
-    }
-
-    if path.is_dir() {
-        fs::remove_dir_all(path)?;
-
-        return Ok(true);
-    }
-
-    fs::remove_file(path)?;
-
-    Ok(true)
-}
-
 /// Returns whether git output indicates transient index lock contention.
-fn is_git_index_lock_error(detail: &str) -> bool {
+pub(super) fn is_git_index_lock_error(detail: &str) -> bool {
     let normalized_detail = detail.to_ascii_lowercase();
 
     normalized_detail.contains("index.lock")
@@ -593,6 +618,8 @@ fn is_git_index_lock_error(detail: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs as unix_fs;
     use std::process::{Command, Output};
 
     use mockall::predicate::eq;
@@ -791,15 +818,327 @@ mod tests {
     }
 
     #[test]
-    fn test_is_stale_or_inactive_rebase_error_matches_no_rebase_message() {
+    fn abort_rebase_succeeds_through_injected_boundaries() {
         // Arrange
-        let detail = "fatal: No rebase in progress?";
+        let mut command_runner = MockGitCommandRunner::new();
+        let metadata_cleaner = MockRebaseMetadataCleaner::new();
+        let mut sleeper = MockSleeper::new();
+        command_runner
+            .expect_run_git_command_output_with_env()
+            .withf(|repo_path, args, environment| {
+                repo_path == Path::new("session-worktree")
+                    && args == ["rebase", "--abort"]
+                    && environment.is_empty()
+            })
+            .once()
+            .returning(|_, _, _| Ok(success_output()));
+        sleeper.expect_sleep().times(0);
 
         // Act
-        let is_stale_metadata_error = is_stale_or_inactive_rebase_error(detail);
+        let result = abort_rebase_with_dependencies(
+            Path::new("session-worktree"),
+            &command_runner,
+            &sleeper,
+            &metadata_cleaner,
+        );
 
         // Assert
-        assert!(is_stale_metadata_error);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn abort_rebase_preserves_command_runner_error() {
+        // Arrange
+        let mut command_runner = MockGitCommandRunner::new();
+        let metadata_cleaner = MockRebaseMetadataCleaner::new();
+        let mut sleeper = MockSleeper::new();
+        command_runner
+            .expect_run_git_command_output_with_env()
+            .once()
+            .return_once(|_, _, _| {
+                Err(GitError::CommandFailed {
+                    command: "git rebase --abort".to_string(),
+                    stderr: "failed to spawn git".to_string(),
+                })
+            });
+        sleeper.expect_sleep().times(0);
+
+        // Act
+        let error = abort_rebase_with_dependencies(
+            Path::new("session-worktree"),
+            &command_runner,
+            &sleeper,
+            &metadata_cleaner,
+        )
+        .expect_err("command runner failure should be preserved");
+
+        // Assert
+        assert!(matches!(
+            error,
+            GitError::CommandFailed { command, stderr }
+                if command == "git rebase --abort" && stderr == "failed to spawn git"
+        ));
+    }
+
+    #[test]
+    fn abort_rebase_preserves_actionable_command_failure() {
+        // Arrange
+        let mut command_runner = MockGitCommandRunner::new();
+        let metadata_cleaner = MockRebaseMetadataCleaner::new();
+        let mut sleeper = MockSleeper::new();
+        command_runner
+            .expect_run_git_command_output_with_env()
+            .once()
+            .returning(|_, _, _| {
+                let mut output = non_lock_failure_output();
+                output.stderr = b"fatal: cannot open .git/rebase-merge/head-name".to_vec();
+
+                Ok(output)
+            });
+        sleeper.expect_sleep().times(0);
+
+        // Act
+        let error = abort_rebase_with_dependencies(
+            Path::new("session-worktree"),
+            &command_runner,
+            &sleeper,
+            &metadata_cleaner,
+        )
+        .expect_err("failed abort should preserve the git error");
+
+        // Assert
+        assert!(matches!(
+            error,
+            GitError::CommandFailed { command, stderr }
+                if command == "git rebase --abort"
+                    && stderr.contains(".git/rebase-merge/head-name")
+        ));
+    }
+
+    #[test]
+    fn abort_rebase_recovers_when_stale_metadata_is_removed() {
+        // Arrange
+        let temp_dir = tempdir().expect("tempdir should be created");
+        let git_dir = temp_dir.path().join(".git");
+        let stale_metadata = git_dir.join("rebase-merge");
+        fs::create_dir(&git_dir).expect("git dir should be created");
+        fs::create_dir(&stale_metadata).expect("stale metadata should be created");
+        let mut command_runner = MockGitCommandRunner::new();
+        let metadata_cleaner = FilesystemRebaseMetadataCleaner;
+        let mut sleeper = MockSleeper::new();
+        command_runner
+            .expect_run_git_command_output_with_env()
+            .once()
+            .returning(|_, _, _| Ok(stale_rebase_failure_output()));
+        sleeper.expect_sleep().times(0);
+
+        // Act
+        let result = abort_rebase_with_dependencies(
+            temp_dir.path(),
+            &command_runner,
+            &sleeper,
+            &metadata_cleaner,
+        );
+
+        // Assert
+        assert!(result.is_ok());
+        assert!(!stale_metadata.exists());
+    }
+
+    #[test]
+    fn abort_rebase_preserves_stale_error_when_no_metadata_is_removed() {
+        // Arrange
+        let mut command_runner = MockGitCommandRunner::new();
+        let mut metadata_cleaner = MockRebaseMetadataCleaner::new();
+        let mut sleeper = MockSleeper::new();
+        command_runner
+            .expect_run_git_command_output_with_env()
+            .once()
+            .returning(|_, _, _| Ok(stale_rebase_failure_output()));
+        metadata_cleaner
+            .expect_clean_stale_metadata()
+            .once()
+            .returning(|_| Ok(false));
+        sleeper.expect_sleep().times(0);
+
+        // Act
+        let error = abort_rebase_with_dependencies(
+            Path::new("session-worktree"),
+            &command_runner,
+            &sleeper,
+            &metadata_cleaner,
+        )
+        .expect_err("missing stale metadata should preserve the abort failure");
+
+        // Assert
+        assert!(matches!(
+            error,
+            GitError::CommandFailed { command, stderr }
+                if command == "git rebase --abort" && stderr.contains("No rebase in progress")
+        ));
+    }
+
+    #[test]
+    fn abort_rebase_appends_stale_metadata_cleanup_failure() {
+        // Arrange
+        let mut command_runner = MockGitCommandRunner::new();
+        let mut metadata_cleaner = MockRebaseMetadataCleaner::new();
+        let mut sleeper = MockSleeper::new();
+        command_runner
+            .expect_run_git_command_output_with_env()
+            .once()
+            .returning(|_, _, _| Ok(stale_rebase_failure_output()));
+        metadata_cleaner
+            .expect_clean_stale_metadata()
+            .once()
+            .returning(|_| {
+                Err(GitError::Io(std::io::Error::new(
+                    ErrorKind::PermissionDenied,
+                    "metadata is read-only",
+                )))
+            });
+        sleeper.expect_sleep().times(0);
+
+        // Act
+        let error = abort_rebase_with_dependencies(
+            Path::new("session-worktree"),
+            &command_runner,
+            &sleeper,
+            &metadata_cleaner,
+        )
+        .expect_err("cleanup failure should preserve both error contexts");
+
+        // Assert
+        assert!(matches!(
+            error,
+            GitError::CommandFailed { command, stderr }
+                if command == "git rebase --abort"
+                    && stderr.contains("No rebase in progress")
+                    && stderr.contains("metadata is read-only")
+        ));
+    }
+
+    #[test]
+    fn stale_rebase_error_detection_matches_only_known_diagnostics() {
+        // Arrange
+        let stale_diagnostics = [
+            "fatal: No rebase in progress?",
+            "fatal: It seems that there is already a rebase-merge directory",
+            "fatal: It seems that there is already a rebase-apply directory",
+            "fatal: It seems that I cannot tell whether you are in the middle of another rebase",
+        ];
+
+        // Act
+        let stale_results = stale_diagnostics.map(is_stale_or_inactive_rebase_error);
+        let unrelated_result =
+            is_stale_or_inactive_rebase_error("fatal: cannot read rebase-merge/head-name");
+
+        // Assert
+        assert!(stale_results.into_iter().all(|is_stale| is_stale));
+        assert!(!unrelated_result);
+    }
+
+    #[test]
+    fn filesystem_metadata_cleaner_removes_exact_rebase_entries() {
+        // Arrange
+        let temp_dir = tempdir().expect("tempdir should be created");
+        let git_dir = temp_dir.path().join(".git");
+        let rebase_merge = git_dir.join("rebase-merge");
+        let rebase_apply = git_dir.join("rebase-apply");
+        let unrelated_metadata = git_dir.join("MERGE_HEAD");
+        fs::create_dir(&git_dir).expect("git dir should be created");
+        fs::create_dir(&rebase_merge).expect("rebase-merge should be created");
+        fs::write(rebase_merge.join("head-name"), "refs/heads/main")
+            .expect("rebase-merge metadata should be written");
+        fs::write(&rebase_apply, "apply state").expect("rebase-apply should be written");
+        fs::write(&unrelated_metadata, "merge state").expect("merge metadata should be written");
+        let metadata_cleaner = FilesystemRebaseMetadataCleaner;
+
+        // Act
+        let removed = metadata_cleaner
+            .clean_stale_metadata(temp_dir.path())
+            .expect("stale metadata cleanup should succeed");
+
+        // Assert
+        assert!(removed);
+        assert!(!rebase_merge.exists());
+        assert!(!rebase_apply.exists());
+        assert!(unrelated_metadata.exists());
+    }
+
+    #[test]
+    fn filesystem_metadata_cleaner_reports_no_change_without_rebase_entries() {
+        // Arrange
+        let temp_dir = tempdir().expect("tempdir should be created");
+        fs::create_dir(temp_dir.path().join(".git")).expect("git dir should be created");
+        let metadata_cleaner = FilesystemRebaseMetadataCleaner;
+
+        // Act
+        let removed = metadata_cleaner
+            .clean_stale_metadata(temp_dir.path())
+            .expect("empty metadata cleanup should succeed");
+
+        // Assert
+        assert!(!removed);
+    }
+
+    #[test]
+    fn filesystem_metadata_cleaner_rejects_missing_git_directory() {
+        // Arrange
+        let temp_dir = tempdir().expect("tempdir should be created");
+        let metadata_cleaner = FilesystemRebaseMetadataCleaner;
+
+        // Act
+        let error = metadata_cleaner
+            .clean_stale_metadata(temp_dir.path())
+            .expect_err("repository without git metadata should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            GitError::OutputParse(message) if message == "Failed to resolve git directory"
+        ));
+    }
+
+    #[test]
+    fn remove_stale_metadata_preserves_non_not_found_io_error() {
+        // Arrange
+        let temp_dir = tempdir().expect("tempdir should be created");
+        let parent_file = temp_dir.path().join("parent-file");
+        fs::write(&parent_file, "not a directory").expect("parent file should be written");
+
+        // Act
+        let error = remove_stale_rebase_metadata_path(&parent_file.join("rebase-merge"))
+            .expect_err("non-directory parent should remain an I/O error");
+
+        // Assert
+        assert!(matches!(error, GitError::Io(_)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn filesystem_metadata_cleaner_does_not_follow_directory_symlink() {
+        // Arrange
+        let temp_dir = tempdir().expect("tempdir should be created");
+        let git_dir = temp_dir.path().join(".git");
+        let external_dir = temp_dir.path().join("external-rebase-data");
+        let external_marker = external_dir.join("marker");
+        fs::create_dir(&git_dir).expect("git dir should be created");
+        fs::create_dir(&external_dir).expect("external directory should be created");
+        fs::write(&external_marker, "preserve").expect("external marker should be written");
+        unix_fs::symlink(&external_dir, git_dir.join("rebase-merge"))
+            .expect("metadata symlink should be created");
+        let metadata_cleaner = FilesystemRebaseMetadataCleaner;
+
+        // Act
+        let removed = metadata_cleaner
+            .clean_stale_metadata(temp_dir.path())
+            .expect("symlink cleanup should succeed");
+
+        // Assert
+        assert!(removed);
+        assert!(!git_dir.join("rebase-merge").exists());
+        assert!(external_marker.exists());
     }
 
     #[test]
@@ -882,28 +1221,6 @@ mod tests {
         assert_eq!(operation, None);
     }
 
-    #[test]
-    fn test_clean_stale_rebase_metadata_removes_existing_paths() {
-        // Arrange
-        let temp_dir = tempdir().expect("tempdir should be created");
-        let git_dir = temp_dir.path().join(".git");
-        let rebase_merge = git_dir.join("rebase-merge");
-        let rebase_apply = git_dir.join("rebase-apply");
-
-        fs::create_dir(&git_dir).expect("git dir should be created");
-        fs::create_dir(&rebase_merge).expect("rebase-merge dir should be created");
-        fs::write(&rebase_apply, "apply state").expect("rebase-apply file should be created");
-
-        // Act
-        let cleaned = clean_stale_rebase_metadata(temp_dir.path())
-            .expect("stale metadata cleanup should succeed");
-
-        // Assert
-        assert!(cleaned);
-        assert!(!rebase_merge.exists());
-        assert!(!rebase_apply.exists());
-    }
-
     /// Returns a successful git command output.
     fn success_output() -> Output {
         Command::new("git")
@@ -932,6 +1249,14 @@ mod tests {
             .expect("failed to run git invalid command");
         output.stdout = vec![];
         output.stderr = b"fatal: not a git repository".to_vec();
+
+        output
+    }
+
+    /// Returns a failing git command output for known stale rebase metadata.
+    fn stale_rebase_failure_output() -> Output {
+        let mut output = non_lock_failure_output();
+        output.stderr = b"fatal: No rebase in progress?".to_vec();
 
         output
     }

--- a/crates/ag-git/src/repo.rs
+++ b/crates/ag-git/src/repo.rs
@@ -1,5 +1,7 @@
 use std::fs;
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::process::{Command, Output, Stdio};
 use std::time::Duration;
 
@@ -11,6 +13,75 @@ use super::error::GitError;
 
 /// Maximum time one asynchronous git subprocess may run.
 const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// One asynchronous git invocation with owned process inputs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct AsyncGitCommand {
+    /// Git arguments excluding the executable name.
+    pub(super) arguments: Vec<String>,
+    /// Environment overrides applied after noninteractive defaults.
+    pub(super) environment: Vec<(String, String)>,
+    /// Repository or worktree used as the process working directory.
+    pub(super) repo_path: PathBuf,
+}
+
+impl AsyncGitCommand {
+    /// Builds one git command without environment overrides.
+    pub(super) fn new(repo_path: PathBuf, arguments: Vec<String>) -> Self {
+        Self {
+            arguments,
+            environment: Vec::new(),
+            repo_path,
+        }
+    }
+
+    /// Applies environment overrides to this command.
+    pub(super) fn with_environment(mut self, environment: Vec<(String, String)>) -> Self {
+        self.environment = environment;
+
+        self
+    }
+}
+
+/// Captured output from one asynchronous git subprocess.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct AsyncGitCommandOutput {
+    /// Process exit code, or `None` when terminated by a signal.
+    pub(super) exit_code: Option<i32>,
+    /// Captured standard error bytes.
+    pub(super) stderr: Vec<u8>,
+    /// Captured standard output bytes.
+    pub(super) stdout: Vec<u8>,
+}
+
+impl AsyncGitCommandOutput {
+    /// Returns whether the process exited successfully.
+    pub(super) fn success(&self) -> bool {
+        self.exit_code == Some(0)
+    }
+}
+
+/// Mockable boundary for cancellable asynchronous git subprocesses.
+#[cfg_attr(test, mockall::automock)]
+pub(super) trait AsyncGitCommandRunner: Send + Sync {
+    /// Runs one owned git command and captures its output.
+    fn run(
+        &self,
+        command: AsyncGitCommand,
+    ) -> Pin<Box<dyn Future<Output = Result<AsyncGitCommandOutput, GitError>> + Send>>;
+}
+
+/// Production asynchronous git runner backed by `tokio::process`.
+pub(super) struct ProcessAsyncGitCommandRunner;
+
+impl AsyncGitCommandRunner for ProcessAsyncGitCommandRunner {
+    fn run(
+        &self,
+        command: AsyncGitCommand,
+    ) -> Pin<Box<dyn Future<Output = Result<AsyncGitCommandOutput, GitError>> + Send>> {
+        Box::pin(async move { run_git_command_with_timeout(command, GIT_COMMAND_TIMEOUT).await })
+    }
+}
 
 /// Returns the origin repository URL normalized to HTTPS form when possible.
 ///
@@ -165,7 +236,7 @@ pub(super) fn resolve_git_dir(repo_dir: &Path) -> Option<PathBuf> {
     None
 }
 
-/// Runs a git command in a blocking task and returns stdout text.
+/// Runs a cancellable git command and returns stdout text.
 ///
 /// # Arguments
 /// * `repo_path` - Path to the git repository or worktree
@@ -176,59 +247,33 @@ pub(super) fn resolve_git_dir(repo_dir: &Path) -> Option<PathBuf> {
 /// The command stdout on success.
 ///
 /// # Errors
-/// Returns [`GitError::Join`] if the blocking task panics, or
-/// [`GitError::CommandFailed`] if spawning fails or the command exits with
-/// a non-zero status.
+/// Returns [`GitError::CommandTimedOut`] if the command exceeds its runtime
+/// bound, or [`GitError::CommandFailed`] if spawning fails or the command
+/// exits with a non-zero status.
 pub(super) async fn run_git_command(
     repo_path: PathBuf,
     args: Vec<String>,
     error_context: String,
 ) -> Result<String, GitError> {
-    spawn_blocking(move || {
-        let argument_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let command_runner = ProcessAsyncGitCommandRunner;
 
-        run_git_command_sync(&repo_path, &argument_refs, &error_context)
-    })
-    .await?
+    run_git_command_with_runner(
+        AsyncGitCommand::new(repo_path, args),
+        &error_context,
+        &command_runner,
+    )
+    .await
 }
 
-/// Runs a cancellable git subprocess with the cleanup-safe runtime bound.
-pub(super) async fn run_git_command_cancellable(
-    repo_path: PathBuf,
-    args: Vec<String>,
-    error_context: String,
+/// Runs one asynchronous git command through an injected runner.
+pub(super) async fn run_git_command_with_runner(
+    command: AsyncGitCommand,
+    error_context: &str,
+    command_runner: &dyn AsyncGitCommandRunner,
 ) -> Result<String, GitError> {
-    run_git_command_with_timeout(repo_path, args, error_context, GIT_COMMAND_TIMEOUT).await
-}
-
-/// Runs a cancellable git subprocess with an explicit runtime bound.
-async fn run_git_command_with_timeout(
-    repo_path: PathBuf,
-    args: Vec<String>,
-    error_context: String,
-    timeout: Duration,
-) -> Result<String, GitError> {
-    let argument_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
-    let git_invocation = format_git_invocation(&argument_refs);
-    let mut command = AsyncCommand::new("git");
-    command
-        .args(&args)
-        .current_dir(repo_path)
-        .stdin(Stdio::null())
-        .kill_on_drop(true);
-    apply_non_interactive_environment_async(&mut command);
-
-    let output = time::timeout(timeout, command.output())
-        .await
-        .map_err(|_| GitError::CommandTimedOut {
-            command: git_invocation.clone(),
-            timeout,
-        })?
-        .map_err(|error| GitError::CommandFailed {
-            command: git_invocation.clone(),
-            stderr: error.to_string(),
-        })?;
-    if !output.status.success() {
+    let git_invocation = format_git_invocation_from_strings(&command.arguments);
+    let output = command_runner.run(command).await?;
+    if !output.success() {
         let detail = command_output_detail(&output.stdout, &output.stderr);
 
         return Err(GitError::CommandFailed {
@@ -238,6 +283,41 @@ async fn run_git_command_with_timeout(
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Runs a cancellable git subprocess with an explicit runtime bound.
+async fn run_git_command_with_timeout(
+    command: AsyncGitCommand,
+    timeout: Duration,
+) -> Result<AsyncGitCommandOutput, GitError> {
+    let git_invocation = format_git_invocation_from_strings(&command.arguments);
+    let mut process = AsyncCommand::new("git");
+    process
+        .args(&command.arguments)
+        .current_dir(&command.repo_path)
+        .stdin(Stdio::null())
+        .kill_on_drop(true);
+    apply_non_interactive_environment_async(&mut process);
+    for (key, value) in &command.environment {
+        process.env(key, value);
+    }
+
+    let output = time::timeout(timeout, process.output())
+        .await
+        .map_err(|_| GitError::CommandTimedOut {
+            command: git_invocation.clone(),
+            timeout,
+        })?
+        .map_err(|error| GitError::CommandFailed {
+            command: git_invocation.clone(),
+            stderr: error.to_string(),
+        })?;
+
+    Ok(AsyncGitCommandOutput {
+        exit_code: output.status.code(),
+        stderr: output.stderr,
+        stdout: output.stdout,
+    })
 }
 
 /// Runs a git command in `repo_path` and returns stdout text.
@@ -280,6 +360,13 @@ fn format_git_invocation(args: &[&str]) -> String {
     }
 
     format!("git {}", args.join(" "))
+}
+
+/// Formats a git invocation from owned command arguments.
+pub(super) fn format_git_invocation_from_strings(args: &[String]) -> String {
+    let argument_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+
+    format_git_invocation(&argument_refs)
 }
 
 /// Runs a git command in `repo_path` and returns raw process output.
@@ -390,7 +477,7 @@ pub(super) fn command_output_detail(stdout: &[u8], stderr: &[u8]) -> String {
 /// Resolves the shared repository through cancellable async git commands.
 async fn resolve_shared_repo(repo_path: &Path) -> Result<SharedRepo, GitError> {
     let (git_dir, git_common_dir) = git_directory_paths_async(repo_path).await?;
-    let is_bare = run_git_command_cancellable(
+    let is_bare = run_git_command(
         git_common_dir.clone(),
         vec!["rev-parse".to_string(), "--is-bare-repository".to_string()],
         "Git rev-parse --is-bare-repository failed".to_string(),
@@ -426,7 +513,7 @@ fn normalize_repo_url(remote: &str) -> String {
 
 /// Reads absolute git and common git directory paths for `repo_path`.
 async fn git_directory_paths_async(repo_path: &Path) -> Result<(PathBuf, PathBuf), GitError> {
-    let stdout = run_git_command_cancellable(
+    let stdout = run_git_command(
         repo_path.to_path_buf(),
         vec![
             "rev-parse".to_string(),
@@ -482,7 +569,7 @@ async fn repo_root_from_git_dir_async(
         return Ok(repo_root);
     }
 
-    let root = run_git_command_cancellable(
+    let root = run_git_command(
         repo_path.to_path_buf(),
         vec!["rev-parse".to_string(), "--show-toplevel".to_string()],
         "Git rev-parse --show-toplevel failed".to_string(),
@@ -607,20 +694,19 @@ mod tests {
             .expect("failed to initialize temporary repository");
         assert!(init_output.status.success());
         let timeout = Duration::from_millis(25);
-
-        // Act
-        let error = run_git_command_with_timeout(
+        let command = AsyncGitCommand::new(
             temp_dir.path().to_path_buf(),
             vec![
                 "-c".to_string(),
                 "alias.agentty-hang=!exec sleep 1".to_string(),
                 "agentty-hang".to_string(),
             ],
-            "Git timeout test failed".to_string(),
-            timeout,
-        )
-        .await
-        .expect_err("long-running git command should time out");
+        );
+
+        // Act
+        let error = run_git_command_with_timeout(command, timeout)
+            .await
+            .expect_err("long-running git command should time out");
 
         // Assert
         assert!(matches!(
@@ -723,6 +809,25 @@ mod tests {
                 if command == "git definitely-not-a-git-subcommand"
                     && stderr.contains("Git command failed")),
             "unexpected error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn repo_root_from_git_dir_async_falls_back_to_git_toplevel() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        run_setup_git(temp_dir.path(), &["init", "--quiet"]);
+        let nonstandard_git_dir = temp_dir.path().join("custom-admin");
+
+        // Act
+        let repo_root = repo_root_from_git_dir_async(temp_dir.path(), &nonstandard_git_dir)
+            .await
+            .expect("repository root fallback should succeed");
+
+        // Assert
+        assert_eq!(
+            repo_root,
+            fs::canonicalize(temp_dir.path()).expect("repository root should canonicalize")
         );
     }
 

--- a/crates/ag-git/src/sync.rs
+++ b/crates/ag-git/src/sync.rs
@@ -2,16 +2,22 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 use std::process::Output;
+use std::time::Duration;
 
 #[cfg(unix)]
 use rustix::fs::{self as rustix_fs, Access};
 use tokio::task::spawn_blocking;
+use tokio::time;
 
 use super::error::GitError;
-use super::rebase::{is_rebase_conflict, run_git_command_with_index_lock_retry};
+use super::rebase::{
+    GIT_INDEX_LOCK_RETRY_ATTEMPTS, GIT_INDEX_LOCK_RETRY_DELAY, is_git_index_lock_error,
+    is_rebase_conflict, run_git_command_with_index_lock_retry,
+};
 use super::repo::{
-    command_output_detail, run_git_command, run_git_command_cancellable,
-    run_git_command_output_sync, run_git_command_output_with_env_sync, run_git_command_sync,
+    AsyncGitCommand, AsyncGitCommandOutput, AsyncGitCommandRunner, ProcessAsyncGitCommandRunner,
+    command_output_detail, run_git_command, run_git_command_output_sync,
+    run_git_command_output_with_env_sync, run_git_command_sync, run_git_command_with_runner,
 };
 
 /// Map of local branch names to their ahead/behind counts relative to their
@@ -262,7 +268,7 @@ pub(crate) async fn head_commit_message(repo_path: PathBuf) -> Result<Option<Str
 /// Returns a [`GitError`] if the branch delete command fails or exceeds its
 /// runtime bound.
 pub(crate) async fn delete_branch(repo_path: PathBuf, branch_name: String) -> Result<(), GitError> {
-    run_git_command_cancellable(
+    run_git_command(
         repo_path,
         vec!["branch".to_string(), "-D".to_string(), branch_name],
         "Git branch deletion failed".to_string(),
@@ -564,39 +570,49 @@ pub(crate) async fn tracked_worktree_status(repo_path: PathBuf) -> Result<String
 /// # Errors
 /// Returns a [`GitError`] for non-conflict pull/rebase failures.
 pub(crate) async fn pull_rebase(repo_path: PathBuf) -> Result<PullRebaseResult, GitError> {
-    spawn_blocking(move || {
-        let pull_arguments = pull_rebase_arguments(&repo_path)
-            .unwrap_or_else(|_| vec!["pull".to_string(), "--rebase".to_string()]);
-        let pull_argument_refs: Vec<&str> = pull_arguments.iter().map(String::as_str).collect();
-        let output = run_git_command_with_index_lock_retry(
-            &repo_path,
-            &pull_argument_refs,
-            &[("GIT_EDITOR", ":"), ("GIT_SEQUENCE_EDITOR", ":")],
-        )?;
+    let command_runner = ProcessAsyncGitCommandRunner;
 
-        if output.status.success() {
-            return Ok(PullRebaseResult::Completed);
-        }
+    pull_rebase_with_runner(repo_path, &command_runner, GIT_INDEX_LOCK_RETRY_DELAY).await
+}
 
-        let detail = command_output_detail(&output.stdout, &output.stderr);
-        if is_rebase_conflict(&detail) {
-            return Ok(PullRebaseResult::Conflict { detail });
-        }
+/// Runs pull/rebase through an injected asynchronous command boundary.
+async fn pull_rebase_with_runner(
+    repo_path: PathBuf,
+    command_runner: &dyn AsyncGitCommandRunner,
+    retry_delay: Duration,
+) -> Result<PullRebaseResult, GitError> {
+    let pull_arguments = pull_rebase_arguments(&repo_path, command_runner).await?;
+    let command = AsyncGitCommand::new(repo_path, pull_arguments).with_environment(vec![
+        ("GIT_EDITOR".to_string(), ":".to_string()),
+        ("GIT_SEQUENCE_EDITOR".to_string(), ":".to_string()),
+    ]);
+    let output =
+        run_async_git_command_with_index_lock_retry(command, command_runner, retry_delay).await?;
 
-        Err(GitError::CommandFailed {
-            command: "git pull --rebase".to_string(),
-            stderr: detail,
-        })
+    if output.success() {
+        return Ok(PullRebaseResult::Completed);
+    }
+
+    let detail = command_output_detail(&output.stdout, &output.stderr);
+    if is_rebase_conflict(&detail) {
+        return Ok(PullRebaseResult::Conflict { detail });
+    }
+
+    Err(GitError::CommandFailed {
+        command: "git pull --rebase".to_string(),
+        stderr: detail,
     })
-    .await?
 }
 
 /// Builds pull arguments that target a single upstream branch when available.
 ///
 /// Resolves an explicit `<remote> <branch>` pull target for both remote and
 /// local upstreams so git does not need to infer one from branch config.
-fn pull_rebase_arguments(repo_path: &Path) -> Result<Vec<String>, GitError> {
-    let upstream_reference = primary_upstream_reference(repo_path)?;
+async fn pull_rebase_arguments(
+    repo_path: &Path,
+    command_runner: &dyn AsyncGitCommandRunner,
+) -> Result<Vec<String>, GitError> {
+    let upstream_reference = primary_upstream_reference(repo_path, command_runner).await?;
 
     if let Some((remote_name, branch_name)) = upstream_reference.split_once('/') {
         return Ok(vec![
@@ -607,7 +623,13 @@ fn pull_rebase_arguments(repo_path: &Path) -> Result<Vec<String>, GitError> {
         ]);
     }
 
-    let remote_name = current_branch_remote_name(repo_path)?;
+    let remote_name = current_branch_remote_name(repo_path, command_runner)
+        .await?
+        .ok_or_else(|| {
+            GitError::OutputParse(
+                "Failed to resolve current branch remote: not configured".to_string(),
+            )
+        })?;
 
     Ok(vec![
         "pull".to_string(),
@@ -622,8 +644,11 @@ fn pull_rebase_arguments(repo_path: &Path) -> Result<Vec<String>, GitError> {
 /// Git can return multiple lines when multiple merge targets are configured.
 /// Pulling with rebase needs one concrete target, so this selects the first
 /// non-empty line.
-fn primary_upstream_reference(repo_path: &Path) -> Result<String, GitError> {
-    let upstream_reference = upstream_reference_name(repo_path)?;
+async fn primary_upstream_reference(
+    repo_path: &Path,
+    command_runner: &dyn AsyncGitCommandRunner,
+) -> Result<String, GitError> {
+    let upstream_reference = upstream_reference_name(repo_path, command_runner).await?;
     let Some(primary_reference) = upstream_reference
         .lines()
         .map(str::trim)
@@ -638,12 +663,24 @@ fn primary_upstream_reference(repo_path: &Path) -> Result<String, GitError> {
 }
 
 /// Returns the full upstream reference for `HEAD` (for example, `origin/main`).
-fn upstream_reference_name(repo_path: &Path) -> Result<String, GitError> {
-    let upstream_reference = run_git_command_sync(
-        repo_path,
-        &["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+async fn upstream_reference_name(
+    repo_path: &Path,
+    command_runner: &dyn AsyncGitCommandRunner,
+) -> Result<String, GitError> {
+    let upstream_reference = run_git_command_with_runner(
+        AsyncGitCommand::new(
+            repo_path.to_path_buf(),
+            vec![
+                "rev-parse".to_string(),
+                "--abbrev-ref".to_string(),
+                "--symbolic-full-name".to_string(),
+                "@{u}".to_string(),
+            ],
+        ),
         "Failed to resolve upstream branch",
-    )?;
+        command_runner,
+    )
+    .await?;
     let upstream_reference = upstream_reference.trim().to_string();
     if upstream_reference.is_empty() {
         return Err(GitError::OutputParse(
@@ -658,31 +695,73 @@ fn upstream_reference_name(repo_path: &Path) -> Result<String, GitError> {
 ///
 /// This is used when the upstream short name omits a remote prefix (for
 /// example, `main` with `branch.<name>.remote=.`).
-fn current_branch_remote_name(repo_path: &Path) -> Result<String, GitError> {
-    let current_branch_name = current_branch_name(repo_path)?;
+async fn current_branch_remote_name(
+    repo_path: &Path,
+    command_runner: &dyn AsyncGitCommandRunner,
+) -> Result<Option<String>, GitError> {
+    let current_branch_name = current_branch_name(repo_path, command_runner).await?;
     let remote_config_key = format!("branch.{current_branch_name}.remote");
-    let remote_name = run_git_command_sync(
-        repo_path,
-        &["config", "--get", &remote_config_key],
-        &format!("Failed to resolve current branch remote `{remote_config_key}`"),
-    )?;
-    let remote_name = remote_name.trim().to_string();
+    let output = command_runner
+        .run(AsyncGitCommand::new(
+            repo_path.to_path_buf(),
+            vec![
+                "config".to_string(),
+                "--get".to_string(),
+                remote_config_key.clone(),
+            ],
+        ))
+        .await?;
+
+    parse_current_branch_remote_output(&output, &remote_config_key)
+}
+
+/// Parses `git config --get` output for one current-branch remote.
+fn parse_current_branch_remote_output(
+    output: &AsyncGitCommandOutput,
+    remote_config_key: &str,
+) -> Result<Option<String>, GitError> {
+    if output.exit_code == Some(1) {
+        return Ok(None);
+    }
+    if !output.success() {
+        let detail = command_output_detail(&output.stdout, &output.stderr);
+
+        return Err(GitError::CommandFailed {
+            command: format!("git config --get {remote_config_key}"),
+            stderr: format!(
+                "Failed to resolve current branch remote `{remote_config_key}`: {detail}"
+            ),
+        });
+    }
+
+    let remote_name = String::from_utf8_lossy(&output.stdout).trim().to_string();
     if remote_name.is_empty() {
         return Err(GitError::OutputParse(format!(
             "Failed to resolve current branch remote `{remote_config_key}`: empty output"
         )));
     }
 
-    Ok(remote_name)
+    Ok(Some(remote_name))
 }
 
 /// Returns the current local branch name for `HEAD`.
-fn current_branch_name(repo_path: &Path) -> Result<String, GitError> {
-    let branch_name = run_git_command_sync(
-        repo_path,
-        &["rev-parse", "--abbrev-ref", "HEAD"],
+async fn current_branch_name(
+    repo_path: &Path,
+    command_runner: &dyn AsyncGitCommandRunner,
+) -> Result<String, GitError> {
+    let branch_name = run_git_command_with_runner(
+        AsyncGitCommand::new(
+            repo_path.to_path_buf(),
+            vec![
+                "rev-parse".to_string(),
+                "--abbrev-ref".to_string(),
+                "HEAD".to_string(),
+            ],
+        ),
         "Failed to resolve current branch name",
-    )?;
+        command_runner,
+    )
+    .await?;
     let branch_name = branch_name.trim().to_string();
     if branch_name.is_empty() {
         return Err(GitError::OutputParse(
@@ -697,6 +776,31 @@ fn current_branch_name(repo_path: &Path) -> Result<String, GitError> {
     }
 
     Ok(branch_name)
+}
+
+/// Runs one asynchronous git command and retries transient index lock
+/// contention without blocking a Tokio worker.
+async fn run_async_git_command_with_index_lock_retry(
+    command: AsyncGitCommand,
+    command_runner: &dyn AsyncGitCommandRunner,
+    retry_delay: Duration,
+) -> Result<AsyncGitCommandOutput, GitError> {
+    let mut attempt_count = 0;
+    loop {
+        attempt_count += 1;
+        let output = command_runner.run(command.clone()).await?;
+        if output.success() {
+            return Ok(output);
+        }
+
+        let detail = command_output_detail(&output.stdout, &output.stderr);
+        let is_last_attempt = attempt_count == GIT_INDEX_LOCK_RETRY_ATTEMPTS;
+        if !is_git_index_lock_error(&detail) || is_last_attempt {
+            return Ok(output);
+        }
+
+        time::sleep(retry_delay).await;
+    }
 }
 
 /// Pushes the current branch to its upstream remote with
@@ -716,36 +820,55 @@ fn current_branch_name(repo_path: &Path) -> Result<String, GitError> {
 /// Returns a [`GitError`] if `git push` fails or upstream tracking cannot be
 /// resolved afterwards.
 pub(crate) async fn push_current_branch(repo_path: PathBuf) -> Result<String, GitError> {
-    spawn_blocking(move || -> Result<String, GitError> {
-        let push_output = run_git_command_output_sync(&repo_path, &["push", "--force-with-lease"])?;
+    let command_runner = ProcessAsyncGitCommandRunner;
 
-        if push_output.status.success() {
-            return primary_upstream_reference(&repo_path);
-        }
+    push_current_branch_with_runner(repo_path, &command_runner).await
+}
 
-        let push_detail = command_output_detail(&push_output.stdout, &push_output.stderr);
-        if !is_no_upstream_error(&push_detail) {
-            return Err(GitError::CommandFailed {
-                command: "git push".to_string(),
-                stderr: push_detail,
-            });
-        }
+/// Pushes the current branch through an injected asynchronous command
+/// boundary.
+async fn push_current_branch_with_runner(
+    repo_path: PathBuf,
+    command_runner: &dyn AsyncGitCommandRunner,
+) -> Result<String, GitError> {
+    let push_command = AsyncGitCommand::new(
+        repo_path.clone(),
+        vec!["push".to_string(), "--force-with-lease".to_string()],
+    );
+    let push_output = command_runner.run(push_command).await?;
 
-        run_git_command_sync(
-            &repo_path,
-            &[
-                "push",
-                "--force-with-lease",
-                "--set-upstream",
-                "origin",
-                "HEAD",
+    if push_output.success() {
+        return primary_upstream_reference(&repo_path, command_runner).await;
+    }
+
+    let push_detail = command_output_detail(&push_output.stdout, &push_output.stderr);
+    if !is_no_upstream_error(&push_detail) {
+        return Err(GitError::CommandFailed {
+            command: "git push --force-with-lease".to_string(),
+            stderr: push_detail,
+        });
+    }
+
+    let remote_name = current_branch_remote_name(&repo_path, command_runner)
+        .await?
+        .unwrap_or_else(|| "origin".to_string());
+    run_git_command_with_runner(
+        AsyncGitCommand::new(
+            repo_path.clone(),
+            vec![
+                "push".to_string(),
+                "--force-with-lease".to_string(),
+                "--set-upstream".to_string(),
+                remote_name,
+                "HEAD".to_string(),
             ],
-            "Git push failed",
-        )?;
+        ),
+        "Git push failed",
+        command_runner,
+    )
+    .await?;
 
-        primary_upstream_reference(&repo_path)
-    })
-    .await?
+    primary_upstream_reference(&repo_path, command_runner).await
 }
 
 /// Checks whether a branch already exists on the remote.
@@ -764,28 +887,34 @@ pub(crate) async fn remote_branch_exists(
     repo_path: PathBuf,
     remote_branch_name: String,
 ) -> Result<bool, GitError> {
-    spawn_blocking(move || -> Result<bool, GitError> {
-        let remote_name =
-            current_branch_remote_name(&repo_path).unwrap_or_else(|_| "origin".to_string());
-        let output = run_git_command_output_sync(
-            &repo_path,
-            &["ls-remote", "--heads", &remote_name, &remote_branch_name],
-        )?;
+    let command_runner = ProcessAsyncGitCommandRunner;
 
-        if !output.status.success() {
-            let detail = command_output_detail(&output.stdout, &output.stderr);
+    remote_branch_exists_with_runner(repo_path, remote_branch_name, &command_runner).await
+}
 
-            return Err(GitError::CommandFailed {
-                command: "git ls-remote".to_string(),
-                stderr: detail,
-            });
-        }
+/// Checks a remote branch through an injected asynchronous command boundary.
+async fn remote_branch_exists_with_runner(
+    repo_path: PathBuf,
+    remote_branch_name: String,
+    command_runner: &dyn AsyncGitCommandRunner,
+) -> Result<bool, GitError> {
+    let remote_name = current_branch_remote_name(&repo_path, command_runner)
+        .await?
+        .unwrap_or_else(|| "origin".to_string());
+    let arguments = vec![
+        "ls-remote".to_string(),
+        "--heads".to_string(),
+        remote_name,
+        remote_branch_name,
+    ];
+    let stdout = run_git_command_with_runner(
+        AsyncGitCommand::new(repo_path, arguments),
+        "Git ls-remote failed",
+        command_runner,
+    )
+    .await?;
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-
-        Ok(!stdout.trim().is_empty())
-    })
-    .await?
+    Ok(!stdout.trim().is_empty())
 }
 
 /// Pushes the current branch to one explicit remote branch name with
@@ -808,26 +937,38 @@ pub(crate) async fn push_current_branch_to_remote_branch(
     repo_path: PathBuf,
     remote_branch_name: String,
 ) -> Result<String, GitError> {
-    spawn_blocking(move || -> Result<String, GitError> {
-        let remote_name =
-            current_branch_remote_name(&repo_path).unwrap_or_else(|_| "origin".to_string());
-        let push_refspec = format!("HEAD:{remote_branch_name}");
+    let command_runner = ProcessAsyncGitCommandRunner;
 
-        run_git_command_sync(
-            &repo_path,
-            &[
-                "push",
-                "--force-with-lease",
-                "--set-upstream",
-                &remote_name,
-                &push_refspec,
-            ],
-            "Git push failed",
-        )?;
+    push_current_branch_to_remote_branch_with_runner(repo_path, remote_branch_name, &command_runner)
+        .await
+}
 
-        Ok(format!("{remote_name}/{remote_branch_name}"))
-    })
-    .await?
+/// Pushes one explicit branch through an injected asynchronous command
+/// boundary.
+async fn push_current_branch_to_remote_branch_with_runner(
+    repo_path: PathBuf,
+    remote_branch_name: String,
+    command_runner: &dyn AsyncGitCommandRunner,
+) -> Result<String, GitError> {
+    let remote_name = current_branch_remote_name(&repo_path, command_runner)
+        .await?
+        .unwrap_or_else(|| "origin".to_string());
+    let push_refspec = format!("HEAD:{remote_branch_name}");
+    let arguments = vec![
+        "push".to_string(),
+        "--force-with-lease".to_string(),
+        "--set-upstream".to_string(),
+        remote_name.clone(),
+        push_refspec,
+    ];
+    run_git_command_with_runner(
+        AsyncGitCommand::new(repo_path, arguments),
+        "Git push failed",
+        command_runner,
+    )
+    .await?;
+
+    Ok(format!("{remote_name}/{remote_branch_name}"))
 }
 
 /// Returns the current upstream reference for `HEAD`.
@@ -842,7 +983,9 @@ pub(crate) async fn push_current_branch_to_remote_branch(
 /// Returns a [`GitError`] when upstream tracking information cannot be
 /// resolved.
 pub(crate) async fn current_upstream_reference(repo_path: PathBuf) -> Result<String, GitError> {
-    spawn_blocking(move || primary_upstream_reference(&repo_path)).await?
+    let command_runner = ProcessAsyncGitCommandRunner;
+
+    primary_upstream_reference(&repo_path, &command_runner).await
 }
 
 /// Fetches from the configured remote.
@@ -1438,9 +1581,25 @@ mod tests {
     use std::path::Path;
     use std::process::{Command, Output};
 
+    use mockall::Sequence;
+    use mockall::predicate::function;
     use tempfile::tempdir;
 
     use super::*;
+    use crate::repo::MockAsyncGitCommandRunner;
+
+    /// Builds captured asynchronous git output for command-runner tests.
+    fn async_git_output(
+        exit_code: i32,
+        stdout: impl Into<Vec<u8>>,
+        stderr: impl Into<Vec<u8>>,
+    ) -> AsyncGitCommandOutput {
+        AsyncGitCommandOutput {
+            exit_code: Some(exit_code),
+            stderr: stderr.into(),
+            stdout: stdout.into(),
+        }
+    }
 
     /// Runs `git` in `repo_path` and asserts the command succeeds.
     fn run_git_command(repo_path: &Path, args: &[&str]) {
@@ -1488,6 +1647,26 @@ mod tests {
         fs::write(repo_path.join("README.md"), "base\n").expect("failed to write base file");
         run_git_command(repo_path, &["add", "README.md"]);
         run_git_command(repo_path, &["commit", "-m", "Initial commit"]);
+    }
+
+    #[tokio::test]
+    async fn delete_branch_removes_branch_from_isolated_repository() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        setup_test_git_repo(temp_dir.path());
+        run_git_command(temp_dir.path(), &["branch", "review/topic"]);
+
+        // Act
+        delete_branch(temp_dir.path().to_path_buf(), "review/topic".to_string())
+            .await
+            .expect("branch deletion should succeed");
+
+        // Assert
+        let branch_lookup = git_command_output(
+            temp_dir.path(),
+            &["show-ref", "--verify", "--quiet", "refs/heads/review/topic"],
+        );
+        assert!(!branch_lookup.status.success());
     }
 
     #[tokio::test]
@@ -1868,23 +2047,82 @@ mod tests {
         );
     }
 
-    #[test]
-    fn current_branch_name_returns_error_for_detached_head() {
+    #[tokio::test]
+    async fn current_branch_name_returns_error_for_detached_head() {
         // Arrange
         let temp_dir = tempdir().expect("failed to create temp dir");
         setup_test_git_repo(temp_dir.path());
         run_git_command(temp_dir.path(), &["checkout", "--detach"]);
+        let command_runner = ProcessAsyncGitCommandRunner;
 
         // Act
-        let result = current_branch_name(temp_dir.path());
+        let result = current_branch_name(temp_dir.path(), &command_runner).await;
 
         // Assert
         let error = result.expect_err("detached HEAD should fail");
         assert!(error.to_string().contains("detached HEAD"));
     }
 
+    #[tokio::test]
+    async fn current_branch_remote_name_returns_none_when_remote_is_not_configured() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        setup_test_git_repo(temp_dir.path());
+        let command_runner = ProcessAsyncGitCommandRunner;
+
+        // Act
+        let remote_name = current_branch_remote_name(temp_dir.path(), &command_runner)
+            .await
+            .expect("missing branch remote should not be a command failure");
+
+        // Assert
+        assert_eq!(remote_name, None);
+    }
+
+    #[tokio::test]
+    async fn current_branch_remote_name_returns_configured_non_origin_remote() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        setup_test_git_repo(temp_dir.path());
+        run_git_command(
+            temp_dir.path(),
+            &["config", "branch.main.remote", "review-remote"],
+        );
+        let command_runner = ProcessAsyncGitCommandRunner;
+
+        // Act
+        let remote_name = current_branch_remote_name(temp_dir.path(), &command_runner)
+            .await
+            .expect("configured branch remote should resolve");
+
+        // Assert
+        assert_eq!(remote_name, Some("review-remote".to_string()));
+    }
+
     #[test]
-    fn primary_upstream_reference_uses_first_non_empty_line() {
+    fn parse_current_branch_remote_output_preserves_fatal_config_error() {
+        // Arrange
+        let output = AsyncGitCommandOutput {
+            exit_code: Some(128),
+            stderr: b"fatal: bad config line".to_vec(),
+            stdout: Vec::new(),
+        };
+
+        // Act
+        let error = parse_current_branch_remote_output(&output, "branch.main.remote")
+            .expect_err("malformed config should remain an error");
+
+        // Assert
+        assert!(matches!(
+            error,
+            GitError::CommandFailed { command, stderr }
+                if command == "git config --get branch.main.remote"
+                    && stderr.contains("Failed to resolve current branch remote")
+        ));
+    }
+
+    #[tokio::test]
+    async fn primary_upstream_reference_uses_first_non_empty_line() {
         // Arrange
         let temp_dir = tempdir().expect("failed to create temp dir");
         let remote_dir = tempdir().expect("failed to create remote temp dir");
@@ -1906,13 +2144,370 @@ mod tests {
             temp_dir.path(),
             &["config", "--add", "branch.main.merge", "refs/heads/feature"],
         );
+        let command_runner = ProcessAsyncGitCommandRunner;
 
         // Act
-        let upstream_reference =
-            primary_upstream_reference(temp_dir.path()).expect("failed to resolve upstream");
+        let upstream_reference = primary_upstream_reference(temp_dir.path(), &command_runner)
+            .await
+            .expect("failed to resolve upstream");
 
         // Assert
         assert_eq!(upstream_reference, "origin/main");
+    }
+
+    #[tokio::test]
+    async fn pull_rebase_retries_index_lock_through_async_runner() {
+        // Arrange
+        let repo_path = PathBuf::from("test-repo");
+        let mut command_runner = MockAsyncGitCommandRunner::new();
+        let mut sequence = Sequence::new();
+        command_runner
+            .expect_run()
+            .with(function(|command: &AsyncGitCommand| {
+                command.arguments == ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]
+            }))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(|_| {
+                Box::pin(async { Ok(async_git_output(0, "origin/main\n", Vec::new())) })
+            });
+        for output in [
+            async_git_output(
+                128,
+                Vec::new(),
+                "fatal: Unable to create '.git/index.lock': File exists.",
+            ),
+            async_git_output(0, Vec::new(), Vec::new()),
+        ] {
+            command_runner
+                .expect_run()
+                .with(function(|command: &AsyncGitCommand| {
+                    command.arguments == ["pull", "--rebase", "origin", "main"]
+                        && command.environment
+                            == [
+                                ("GIT_EDITOR".to_string(), ":".to_string()),
+                                ("GIT_SEQUENCE_EDITOR".to_string(), ":".to_string()),
+                            ]
+                }))
+                .times(1)
+                .in_sequence(&mut sequence)
+                .return_once(move |_| Box::pin(async move { Ok(output) }));
+        }
+
+        // Act
+        let result = pull_rebase_with_runner(repo_path, &command_runner, Duration::ZERO).await;
+
+        // Assert
+        assert!(matches!(result, Ok(PullRebaseResult::Completed)));
+    }
+
+    #[tokio::test]
+    async fn pull_rebase_preserves_non_conflict_command_failure() {
+        // Arrange
+        let repo_path = PathBuf::from("test-repo");
+        let mut command_runner = MockAsyncGitCommandRunner::new();
+        let mut sequence = Sequence::new();
+        command_runner
+            .expect_run()
+            .with(function(|command: &AsyncGitCommand| {
+                command.arguments == ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]
+            }))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(|_| {
+                Box::pin(async { Ok(async_git_output(0, "origin/main\n", Vec::new())) })
+            });
+        command_runner
+            .expect_run()
+            .with(function(|command: &AsyncGitCommand| {
+                command.arguments == ["pull", "--rebase", "origin", "main"]
+            }))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(|_| {
+                Box::pin(async { Ok(async_git_output(128, Vec::new(), "fatal: transport failed")) })
+            });
+
+        // Act
+        let error = pull_rebase_with_runner(repo_path, &command_runner, Duration::ZERO)
+            .await
+            .expect_err("non-conflict pull failure should remain an error");
+
+        // Assert
+        assert!(matches!(
+            error,
+            GitError::CommandFailed { command, stderr }
+                if command == "git pull --rebase" && stderr == "fatal: transport failed"
+        ));
+    }
+
+    #[tokio::test]
+    async fn pull_rebase_rejects_local_upstream_without_configured_remote() {
+        // Arrange
+        let repo_path = PathBuf::from("test-repo");
+        let mut command_runner = MockAsyncGitCommandRunner::new();
+        let mut sequence = Sequence::new();
+        let expectations = [
+            (
+                vec!["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+                async_git_output(0, "main\n", Vec::new()),
+            ),
+            (
+                vec!["rev-parse", "--abbrev-ref", "HEAD"],
+                async_git_output(0, "main\n", Vec::new()),
+            ),
+            (
+                vec!["config", "--get", "branch.main.remote"],
+                async_git_output(1, Vec::new(), Vec::new()),
+            ),
+        ];
+        for (arguments, output) in expectations {
+            let arguments = arguments
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            command_runner
+                .expect_run()
+                .with(function(move |command: &AsyncGitCommand| {
+                    command.arguments == arguments
+                }))
+                .times(1)
+                .in_sequence(&mut sequence)
+                .return_once(move |_| Box::pin(async move { Ok(output) }));
+        }
+
+        // Act
+        let error = pull_rebase_with_runner(repo_path, &command_runner, Duration::ZERO)
+            .await
+            .expect_err("local upstream without a remote should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            GitError::OutputParse(message)
+                if message == "Failed to resolve current branch remote: not configured"
+        ));
+    }
+
+    #[tokio::test]
+    async fn pull_rebase_returns_last_index_lock_failure_after_retry_exhaustion() {
+        // Arrange
+        let repo_path = PathBuf::from("test-repo");
+        let mut command_runner = MockAsyncGitCommandRunner::new();
+        let mut sequence = Sequence::new();
+        command_runner
+            .expect_run()
+            .with(function(|command: &AsyncGitCommand| {
+                command.arguments == ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]
+            }))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(|_| {
+                Box::pin(async { Ok(async_git_output(0, "origin/main\n", Vec::new())) })
+            });
+        command_runner
+            .expect_run()
+            .with(function(|command: &AsyncGitCommand| {
+                command.arguments == ["pull", "--rebase", "origin", "main"]
+            }))
+            .times(GIT_INDEX_LOCK_RETRY_ATTEMPTS)
+            .in_sequence(&mut sequence)
+            .returning(|_| {
+                Box::pin(async {
+                    Ok(async_git_output(
+                        128,
+                        Vec::new(),
+                        "fatal: Unable to create '.git/index.lock': File exists.",
+                    ))
+                })
+            });
+
+        // Act
+        let error = pull_rebase_with_runner(repo_path, &command_runner, Duration::ZERO)
+            .await
+            .expect_err("exhausted index-lock retries should return the last failure");
+
+        // Assert
+        assert!(matches!(
+            error,
+            GitError::CommandFailed { command, stderr }
+                if command == "git pull --rebase" && stderr.contains("index.lock")
+        ));
+    }
+
+    #[tokio::test]
+    async fn remote_branch_lookup_uses_origin_fallback_through_async_runner() {
+        // Arrange
+        let repo_path = PathBuf::from("test-repo");
+        let mut command_runner = MockAsyncGitCommandRunner::new();
+        let mut sequence = Sequence::new();
+        let expectations = [
+            (
+                vec!["rev-parse", "--abbrev-ref", "HEAD"],
+                async_git_output(0, "main\n", Vec::new()),
+            ),
+            (
+                vec!["config", "--get", "branch.main.remote"],
+                async_git_output(1, Vec::new(), Vec::new()),
+            ),
+            (
+                vec!["ls-remote", "--heads", "origin", "review/topic"],
+                async_git_output(0, "abc123\trefs/heads/review/topic\n", Vec::new()),
+            ),
+        ];
+        for (arguments, output) in expectations {
+            let arguments = arguments
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            command_runner
+                .expect_run()
+                .with(function(move |command: &AsyncGitCommand| {
+                    command.arguments == arguments
+                }))
+                .times(1)
+                .in_sequence(&mut sequence)
+                .return_once(move |_| Box::pin(async move { Ok(output) }));
+        }
+
+        // Act
+        let exists = remote_branch_exists_with_runner(
+            repo_path,
+            "review/topic".to_string(),
+            &command_runner,
+        )
+        .await
+        .expect("remote branch lookup should succeed");
+
+        // Assert
+        assert!(exists);
+    }
+
+    #[tokio::test]
+    async fn remote_branch_lookup_checks_isolated_local_remote() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let remote_dir = tempdir().expect("failed to create remote temp dir");
+        setup_test_git_repo(temp_dir.path());
+        run_git_command(remote_dir.path(), &["init", "--bare"]);
+        let remote_path = remote_dir.path().to_string_lossy().to_string();
+        run_git_command(temp_dir.path(), &["remote", "add", "origin", &remote_path]);
+        run_git_command(temp_dir.path(), &["push", "-u", "origin", "main"]);
+
+        // Act
+        let exists = remote_branch_exists(temp_dir.path().to_path_buf(), "main".to_string())
+            .await
+            .expect("local remote branch lookup should succeed");
+
+        // Assert
+        assert!(exists);
+    }
+
+    #[tokio::test]
+    async fn remote_branch_lookup_preserves_remote_config_failure() {
+        // Arrange
+        let repo_path = PathBuf::from("test-repo");
+        let mut command_runner = MockAsyncGitCommandRunner::new();
+        let mut sequence = Sequence::new();
+        command_runner
+            .expect_run()
+            .with(function(|command: &AsyncGitCommand| {
+                command.arguments == ["rev-parse", "--abbrev-ref", "HEAD"]
+            }))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(|_| Box::pin(async { Ok(async_git_output(0, "main\n", Vec::new())) }));
+        command_runner
+            .expect_run()
+            .with(function(|command: &AsyncGitCommand| {
+                command.arguments == ["config", "--get", "branch.main.remote"]
+            }))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(|_| {
+                Box::pin(async {
+                    Ok(async_git_output(
+                        128,
+                        Vec::new(),
+                        "fatal: malformed branch config",
+                    ))
+                })
+            });
+
+        // Act
+        let error = remote_branch_exists_with_runner(
+            repo_path,
+            "review/topic".to_string(),
+            &command_runner,
+        )
+        .await
+        .expect_err("remote config failure should not fall back to origin");
+
+        // Assert
+        assert!(matches!(
+            error,
+            GitError::CommandFailed { command, stderr }
+                if command == "git config --get branch.main.remote"
+                    && stderr.contains("malformed branch config")
+        ));
+    }
+
+    #[tokio::test]
+    async fn push_without_upstream_reuses_configured_remote() {
+        // Arrange
+        let repo_path = PathBuf::from("test-repo");
+        let mut command_runner = MockAsyncGitCommandRunner::new();
+        let mut sequence = Sequence::new();
+        let expectations = [
+            (
+                vec!["push", "--force-with-lease"],
+                async_git_output(128, Vec::new(), "fatal: no upstream branch"),
+            ),
+            (
+                vec!["rev-parse", "--abbrev-ref", "HEAD"],
+                async_git_output(0, "main\n", Vec::new()),
+            ),
+            (
+                vec!["config", "--get", "branch.main.remote"],
+                async_git_output(0, "review-remote\n", Vec::new()),
+            ),
+            (
+                vec![
+                    "push",
+                    "--force-with-lease",
+                    "--set-upstream",
+                    "review-remote",
+                    "HEAD",
+                ],
+                async_git_output(0, Vec::new(), Vec::new()),
+            ),
+            (
+                vec!["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+                async_git_output(0, "review-remote/main\n", Vec::new()),
+            ),
+        ];
+        for (arguments, output) in expectations {
+            let arguments = arguments
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            command_runner
+                .expect_run()
+                .with(function(move |command: &AsyncGitCommand| {
+                    command.arguments == arguments
+                }))
+                .times(1)
+                .in_sequence(&mut sequence)
+                .return_once(move |_| Box::pin(async move { Ok(output) }));
+        }
+
+        // Act
+        let upstream_reference = push_current_branch_with_runner(repo_path, &command_runner)
+            .await
+            .expect("configured remote push should succeed");
+
+        // Assert
+        assert_eq!(upstream_reference, "review-remote/main");
     }
 
     #[test]

--- a/crates/ag-git/src/worktree.rs
+++ b/crates/ag-git/src/worktree.rs
@@ -4,9 +4,7 @@ use std::path::{Path, PathBuf};
 use tokio::task::spawn_blocking;
 
 use super::error::GitError;
-use super::repo::{
-    main_repo_root, resolve_git_dir, run_git_command_cancellable, run_git_command_sync,
-};
+use super::repo::{main_repo_root, resolve_git_dir, run_git_command, run_git_command_sync};
 
 /// Detects git repository information for the given directory.
 /// Returns the current branch name if in a git repository, None otherwise.
@@ -85,7 +83,7 @@ pub(crate) async fn create_worktree(
 pub(crate) async fn remove_worktree(worktree_path: PathBuf) -> Result<(), GitError> {
     let repo_root = main_repo_root(worktree_path.clone()).await?;
     let worktree_path = worktree_path.to_string_lossy().to_string();
-    run_git_command_cancellable(
+    run_git_command(
         repo_root,
         vec![
             "worktree".to_string(),

--- a/crates/agentty/tests/e2e/navigation.rs
+++ b/crates/agentty/tests/e2e/navigation.rs
@@ -85,16 +85,28 @@ fi
 
 if [ "$1" = "api" ] && [ "$2" = "--hostname" ] && [ "$4" = "graphql" ]; then
   case "$*" in
-    *"number=42"*)
+    *"reviewThreads(first:"*"number=42"*)
       sleep 3
       cat <<'JSON'
-{"data":{"repository":{"pullRequest":{"comments":{"nodes":[{"author":{"login":"alice"},"body":"General **review** comment."}]},"reviewThreads":{"nodes":[{"id":"thread-navigation","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":7,"path":"crates/agentty/src/ui/page/review_detail.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"bob"},"body":"Please show this selected review comment."}]}}]}}}}}
+[{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-navigation","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":7,"path":"crates/agentty/src/ui/page/review_detail.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"bob"},"body":"Please show this selected review comment."}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]
 JSON
       exit 0
       ;;
-    *"number=43"*)
+    *"reviewThreads(first:"*"number=43"*)
       cat <<'JSON'
-{"data":{"repository":{"pullRequest":{"comments":{"nodes":[]},"reviewThreads":{"nodes":[]}}}}}
+[{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]
+JSON
+      exit 0
+      ;;
+    *"comments(first:"*"number=42"*)
+      cat <<'JSON'
+[{"data":{"repository":{"pullRequest":{"comments":{"nodes":[{"author":{"login":"alice"},"body":"General **review** comment."}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]
+JSON
+      exit 0
+      ;;
+    *"comments(first:"*"number=43"*)
+      cat <<'JSON'
+[{"data":{"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]
 JSON
       exit 0
       ;;

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -2085,8 +2085,21 @@ case "$*" in
   *"auth status"*)
     exit 0
     ;;
-  *"api --hostname github.com graphql"*)
-    printf '%s\n' '{"data":{"repository":{"pullRequest":{"comments":{"nodes":[{"author":{"login":"carol"},"body":"Thanks for documenting the behavior."}]},"reviewThreads":{"nodes":[{"id":"thread-inline","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":2,"path":"src/main.rs","startLine":1,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"alice"},"body":"<!-- hidden reviewer note --><p>Please <strong>explain</strong> why this review output is needed.<br>Use <code>stdout</code> context.</p>"}]}},{"id":"thread-file","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":null,"path":"src/main.rs","startLine":null,"subjectType":"FILE","comments":{"nodes":[{"author":{"login":"bob"},"body":"Please review the whole file."}]}},{"id":"thread-outdated","diffSide":"RIGHT","isOutdated":true,"isResolved":false,"line":2,"path":"old.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"erin"},"body":"This comment refers to an earlier diff."}]}},{"id":"thread-resolved","diffSide":"RIGHT","isOutdated":false,"isResolved":true,"line":3,"path":"src/main.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"dana"},"body":"This thread is complete."}]}},{"id":"thread-resolved-outdated","diffSide":"LEFT","isOutdated":true,"isResolved":true,"line":4,"path":"ro.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"frank"},"body":"This resolved thread refers to an earlier diff."}]}}]}}}}}'
+  *"addPullRequestReviewThreadReply"*)
+    printf '%s\n' '{"data":{"addPullRequestReviewThreadReply":{"comment":{"id":"reply-1"}}}}'
+    ;;
+  *"resolveReviewThread"*)
+    printf '%s\n' '{"data":{"resolveReviewThread":{"thread":{"id":"thread-inline","isResolved":true}}}}'
+    ;;
+  *"reviewThreads(first:"*)
+    cat <<'JSON'
+[{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-inline","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":2,"path":"src/main.rs","startLine":1,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"alice"},"body":"<!-- hidden reviewer note --><p>Please <strong>explain</strong> why this review output is needed.<br>Use <code>stdout</code> context.</p>"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}},{"id":"thread-file","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":null,"path":"src/main.rs","startLine":null,"subjectType":"FILE","comments":{"nodes":[{"author":{"login":"bob"},"body":"Please review the whole file."}],"pageInfo":{"hasNextPage":false,"endCursor":null}}},{"id":"thread-outdated","diffSide":"RIGHT","isOutdated":true,"isResolved":false,"line":2,"path":"old.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"erin"},"body":"This comment refers to an earlier diff."}],"pageInfo":{"hasNextPage":false,"endCursor":null}}},{"id":"thread-resolved","diffSide":"RIGHT","isOutdated":false,"isResolved":true,"line":3,"path":"src/main.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"dana"},"body":"This thread is complete."}],"pageInfo":{"hasNextPage":false,"endCursor":null}}},{"id":"thread-resolved-outdated","diffSide":"LEFT","isOutdated":true,"isResolved":true,"line":4,"path":"ro.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"frank"},"body":"This resolved thread refers to an earlier diff."}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]
+JSON
+    ;;
+  *"comments(first:"*)
+    cat <<'JSON'
+[{"data":{"repository":{"pullRequest":{"comments":{"nodes":[{"author":{"login":"carol"},"body":"Thanks for documenting the behavior."}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]
+JSON
     ;;
   *"pr view"*)
     printf '%s\n' '{"number":42,"title":"Review-ready session shortcuts","state":"OPEN","url":"https://github.com/agentty-xyz/agentty/pull/42","baseRefName":"main","headRefName":"wt/review-s","isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"REVIEW_REQUIRED","mergedAt":null}'


### PR DESCRIPTION
- Git commands use cancellable async boundaries, timeouts, nonblocking index-lock retries, configured remotes, and hook-enabled squash merges.
- GitHub review snapshots paginate pull-request and oversized thread comments, while remote URLs redact embedded credentials.
- Linux clipboard setup falls back from Wayland to X11, and rebase aborts preserve actionable git errors.
- Targeted stale-rebase restart recovery is bounded, remote fixtures are safe, and squash-merge documentation is accurate.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)