### PR TITLE
Allow review-ready managed workers to open worktrees

### DIFF
--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -433,6 +433,16 @@ impl Session {
             && (self.status.allows_review_actions() || self.status == Status::Question)
     }
 
+    /// Returns whether the session lifecycle and ownership role permit opening
+    /// its materialized worktree.
+    ///
+    /// Managed orchestration workers remain unavailable for direct user turns,
+    /// but a settled worker in `Review` may be opened for external inspection.
+    pub fn allows_worktree_open_action(&self) -> bool {
+        self.status.allows_session_actions()
+            && (self.accepts_user_turns() || (self.is_managed() && self.status == Status::Review))
+    }
+
     /// Returns whether this session exposes branch diff, merge, and publish
     /// affordances.
     pub fn owns_branch_changes(&self) -> bool {
@@ -1136,6 +1146,24 @@ pub(crate) mod tests {
         // Assert
         assert!(!allows_reply);
         assert!(!managed_allows_reply);
+    }
+
+    #[test]
+    fn test_allows_worktree_open_action_accepts_managed_worker_only_in_review() {
+        // Arrange
+        let statuses = [Status::InProgress, Status::Review, Status::AgentReview];
+
+        // Act
+        let open_permissions = statuses.map(|status| {
+            SessionFixtureBuilder::new()
+                .role(SessionRole::OrchestrationWorker)
+                .status(status)
+                .build()
+                .allows_worktree_open_action()
+        });
+
+        // Assert
+        assert_eq!(open_permissions, [false, true, false]);
     }
 
     #[test]

--- a/crates/agentty/src/presentation/app_mode.rs
+++ b/crates/agentty/src/presentation/app_mode.rs
@@ -55,6 +55,9 @@ pub enum ConfirmationIntent {
     RegenerateReview,
     /// Confirms permanently detaching a coordinator-owned worker.
     DetachManagedSession,
+    /// Acknowledges that a managed worker worktree opens with normal write
+    /// access.
+    OpenManagedWorktree,
     /// Chooses between local merges and forge review requests for a campaign.
     ChooseIntegrationApproach,
 }

--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -178,7 +178,8 @@ impl ViewActionSet {
         let can_open_worktree = state.can_open_worktree.is_enabled()
             && matches!(
                 state.session_state,
-                ViewSessionState::Interactive
+                ViewSessionState::Managed
+                    | ViewSessionState::Interactive
                     | ViewSessionState::NewSession
                     | ViewSessionState::StackedDraft
                     | ViewSessionState::Review
@@ -1961,10 +1962,38 @@ mod tests {
         // Assert
         assert!(managed_keys.contains(&"d"));
         assert!(managed_keys.contains(&"D"));
+        assert!(!managed_keys.contains(&"o"));
         assert!(!managed_keys.contains(&"Enter"));
         assert!(controller_keys.contains(&"a"));
         assert!(controller_keys.contains(&"Enter"));
         assert!(!controller_keys.contains(&"m"));
+    }
+
+    #[test]
+    fn managed_review_view_actions_expose_worktree_open_when_available() {
+        // Arrange
+        let state = ViewHelpState {
+            can_fork_session: ViewActionAvailability::Disabled,
+            can_merge_session_branch: ViewActionAvailability::Disabled,
+            can_mutate_session_branch: ViewActionAvailability::Disabled,
+            can_open_worktree: ViewActionAvailability::Enabled,
+            can_rebase_session_branch: ViewActionAvailability::Disabled,
+            reply_to_session: ViewActionAvailability::Disabled,
+            can_start_staged_session: ViewActionAvailability::Disabled,
+            publish_pull_request_action: None,
+            session_state: ViewSessionState::Managed,
+        };
+
+        // Act
+        let managed_keys = view_actions(state)
+            .iter()
+            .map(|action| action.key)
+            .collect::<Vec<_>>();
+
+        // Assert
+        assert!(managed_keys.contains(&"o"));
+        assert!(!managed_keys.contains(&"Enter"));
+        assert!(!managed_keys.contains(&"m"));
     }
 
     #[test]

--- a/crates/agentty/src/runtime/key_handler.rs
+++ b/crates/agentty/src/runtime/key_handler.rs
@@ -636,6 +636,7 @@ fn confirmation_cancel_mode(mode: &AppMode) -> AppMode {
             | ConfirmationIntent::MergeSession
             | ConfirmationIntent::RegenerateReview
             | ConfirmationIntent::DetachManagedSession
+            | ConfirmationIntent::OpenManagedWorktree
             | ConfirmationIntent::ChooseIntegrationApproach,
         restore_view: Some(restore_view),
         ..
@@ -689,6 +690,10 @@ async fn handle_confirmation_confirm(app: &mut App) -> io::Result<EventResult> {
             handle_detach_managed_session_confirmation(app, confirmation_session_id, restore_view)
                 .await
         }
+        ConfirmationIntent::OpenManagedWorktree => {
+            handle_open_managed_worktree_confirmation(app, confirmation_session_id, restore_view)
+                .await
+        }
         ConfirmationIntent::ChooseIntegrationApproach => {
             handle_integration_approach_confirmation(
                 app,
@@ -699,6 +704,28 @@ async fn handle_confirmation_confirm(app: &mut App) -> io::Result<EventResult> {
             .await
         }
     }
+}
+
+/// Opens a managed worker worktree after the user acknowledges write access.
+async fn handle_open_managed_worktree_confirmation(
+    app: &mut App,
+    confirmation_session_id: Option<SessionId>,
+    restore_view: Option<ConfirmationViewMode>,
+) -> io::Result<EventResult> {
+    let Some(restore_view) = restore_view else {
+        app.mode = AppMode::List;
+
+        return Ok(EventResult::Continue);
+    };
+    if confirmation_session_id.as_ref() != Some(&restore_view.session_id) {
+        app.mode = restore_view.into_view_mode();
+
+        return Ok(EventResult::Continue);
+    }
+
+    mode::session_view::open_worktree_for_view_session(app, restore_view).await;
+
+    Ok(EventResult::Continue)
 }
 
 /// Resolves the second binary choice, which only has distinct semantics for
@@ -1552,11 +1579,61 @@ mod tests {
         // Act
         let cancel_result = handle_cancel_session_confirmation(&mut app, None).await;
         let merge_result = handle_merge_confirmation(&mut app, None, None).await;
+        let open_result = handle_open_managed_worktree_confirmation(&mut app, None, None).await;
 
         // Assert
         assert!(matches!(cancel_result, Ok(EventResult::Continue)));
         assert!(matches!(merge_result, Ok(EventResult::Continue)));
+        assert!(matches!(open_result, Ok(EventResult::Continue)));
         assert!(matches!(app.mode, AppMode::List));
+    }
+
+    #[tokio::test]
+    async fn managed_worktree_confirmation_validates_target_then_opens_selector() {
+        // Arrange
+        let (mut app, _base_dir) =
+            crate::test_support::new_git_test_app_with_mock_tmux_client().await;
+        let session_id = app
+            .create_session()
+            .await
+            .expect("failed to create session");
+        app.settings.launch_configuration = "cargo test\nnpm run dev".to_string();
+        let restore_view = ConfirmationViewMode {
+            scroll_offset: Some(3),
+            session_id: session_id.clone().into(),
+        };
+
+        // Act
+        let mismatched_result = handle_open_managed_worktree_confirmation(
+            &mut app,
+            Some(SessionId::from("other-session")),
+            Some(restore_view.clone()),
+        )
+        .await;
+        app.mode = AppMode::Confirmation {
+            confirmation_intent: ConfirmationIntent::OpenManagedWorktree,
+            confirmation_message: "Open?".to_string(),
+            confirmation_title: "Open Managed Worktree".to_string(),
+            restore_view: Some(restore_view),
+            session_id: Some(session_id.clone().into()),
+            selected_confirmation_index: 0,
+        };
+        let confirmed_result =
+            handle_confirmation_decision(&mut app, ConfirmationDecision::Confirm).await;
+
+        // Assert
+        assert!(matches!(mismatched_result, Ok(EventResult::Continue)));
+        assert!(matches!(confirmed_result, Ok(EventResult::Continue)));
+        assert!(matches!(
+            app.mode,
+            AppMode::LaunchConfigurationSelector {
+                ref commands,
+                ref restore_view,
+                selected_command_index: 0,
+            } if commands == &["cargo test".to_string(), "npm run dev".to_string()]
+                && restore_view.session_id == session_id
+                && restore_view.scroll_offset == Some(3)
+        ));
     }
 
     #[tokio::test]

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -318,7 +318,7 @@ async fn handle_primary_view_key(
             app.mode = AppMode::List;
         }
         KeyCode::Char('o') if view_session_snapshot.can_open_worktree() => {
-            open_worktree_for_view_session(app, view_context).await;
+            return Some(handle_open_worktree_key(app, view_context, view_session_snapshot).await);
         }
         KeyCode::Char('l') if view_session_snapshot.follow_up_task_action.is_some() => {
             if let Err(error) = app
@@ -408,6 +408,23 @@ async fn handle_primary_view_key(
     }
 
     Some(true)
+}
+
+/// Opens a regular worktree immediately or warns for a managed worker.
+async fn handle_open_worktree_key(
+    app: &mut App,
+    view_context: &ViewContext,
+    view_session_snapshot: &ViewSessionSnapshot,
+) -> bool {
+    let restore_view = confirmation_view_mode(view_context);
+    if view_session_snapshot.is_managed {
+        open_managed_worktree_confirmation(app, restore_view);
+
+        return false;
+    }
+    open_worktree_for_view_session(app, restore_view).await;
+
+    true
 }
 
 /// Applies campaign-board controls owned by an orchestrator session.
@@ -578,14 +595,31 @@ fn open_continue_confirmation(app: &mut App, view_context: &ViewContext) {
     };
 }
 
+/// Warns before opening a controller-managed worker's writable worktree.
+fn open_managed_worktree_confirmation(app: &mut App, restore_view: ConfirmationViewMode) {
+    app.mode = AppMode::Confirmation {
+        confirmation_intent: ConfirmationIntent::OpenManagedWorktree,
+        confirmation_message: "This opens a writable shell in a controller-managed worktree. \
+                               Edits can invalidate orchestration verification. Open anyway?"
+            .to_string(),
+        confirmation_title: "Open Managed Worktree".to_string(),
+        session_id: Some(restore_view.session_id.clone()),
+        restore_view: Some(restore_view),
+        selected_confirmation_index: DEFAULT_OPTION_INDEX,
+    };
+}
+
 /// Opens the viewed session worktree directly or shows a command selector when
 /// multiple launch configurations are configured.
-async fn open_worktree_for_view_session(app: &mut App, view_context: &ViewContext) {
+pub(crate) async fn open_worktree_for_view_session(
+    app: &mut App,
+    restore_view: ConfirmationViewMode,
+) {
     let launch_configurations = app.configured_launch_configurations();
     if launch_configurations.len() > 1 {
         app.mode = AppMode::LaunchConfigurationSelector {
             commands: launch_configurations,
-            restore_view: confirmation_view_mode(view_context),
+            restore_view,
             selected_command_index: 0,
         };
 
@@ -593,6 +627,7 @@ async fn open_worktree_for_view_session(app: &mut App, view_context: &ViewContex
     }
 
     let selected_launch_configuration = launch_configurations.first().map(String::as_str);
+    app.mode = restore_view.into_view_mode();
 
     app.open_session_worktree_in_tmux_with_command(selected_launch_configuration)
         .await;
@@ -647,7 +682,7 @@ async fn open_or_regenerate_review(
 fn view_session_snapshot(app: &App, view_context: &ViewContext) -> Option<ViewSessionSnapshot> {
     let session = app.sessions.session_at(view_context.session_index)?;
     let session_status = session.status;
-    let can_open_worktree = session_status.allows_session_actions()
+    let can_open_worktree = session.allows_worktree_open_action()
         && *app
             .sessions
             .session_worktree_availability()
@@ -681,9 +716,7 @@ fn view_session_snapshot(app: &App, view_context: &ViewContext) -> Option<ViewSe
                     .sessions
                     .can_mutate_session_branch_in_stack(view_context.session_id.as_str()),
         ),
-        open_worktree: ViewActionState::from_bool(
-            can_open_worktree && session.accepts_user_turns(),
-        ),
+        open_worktree: ViewActionState::from_bool(can_open_worktree),
         publish_pull_request_action: session.publish_pull_request_action(),
         rebase_session_branch: ViewActionState::from_bool(
             session.owns_branch_changes()
@@ -1482,7 +1515,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn managed_session_snapshot_hides_review_comment_entry() {
+    async fn managed_review_session_snapshot_allows_open_but_hides_review_comments() {
         // Arrange
         let (mut app, _base_dir, session_id) = new_test_app_with_session().await;
         let session = &mut app.sessions.sessions_mut()[0];
@@ -1499,7 +1532,28 @@ mod tests {
         let snapshot = view_session_snapshot(&app, &context).expect("expected view snapshot");
 
         // Assert
+        assert!(snapshot.can_open_worktree());
         assert!(!snapshot.can_open_review_comments());
+    }
+
+    #[tokio::test]
+    async fn managed_running_session_snapshot_hides_worktree_open() {
+        // Arrange
+        let (mut app, _base_dir, session_id) = new_test_app_with_session().await;
+        let session = &mut app.sessions.sessions_mut()[0];
+        session.role = SessionRole::OrchestrationWorker;
+        session.status = Status::InProgress;
+        app.mode = AppMode::View {
+            session_id: session_id.into(),
+            scroll_offset: Some(1),
+        };
+        let context = view_context(&mut app).expect("expected view context");
+
+        // Act
+        let snapshot = view_session_snapshot(&app, &context).expect("expected view snapshot");
+
+        // Assert
+        assert!(!snapshot.can_open_worktree());
     }
 
     #[tokio::test]
@@ -2311,7 +2365,7 @@ mod tests {
         let context = view_context(&mut app).expect("expected view context");
 
         // Act
-        open_worktree_for_view_session(&mut app, &context).await;
+        open_worktree_for_view_session(&mut app, confirmation_view_mode(&context)).await;
 
         // Assert
         assert!(matches!(
@@ -2352,7 +2406,7 @@ mod tests {
         let context = view_context(&mut app).expect("expected view context");
 
         // Act
-        open_worktree_for_view_session(&mut app, &context).await;
+        open_worktree_for_view_session(&mut app, confirmation_view_mode(&context)).await;
 
         // Assert
         assert!(matches!(
@@ -3057,6 +3111,81 @@ mod tests {
                 confirmation_intent: ConfirmationIntent::DetachManagedSession,
                 ..
             }
+        ));
+    }
+
+    #[tokio::test]
+    async fn managed_worktree_open_requires_write_access_confirmation() {
+        // Arrange
+        let (mut app, _temp_dir) = crate::test_support::new_test_app().await;
+        let view_context = ViewContext {
+            scroll_offset: Some(2),
+            session_id: SessionId::from("managed-worker"),
+            session_index: 0,
+        };
+        let pending_update = ViewPendingUpdate::from_context(&view_context);
+        let mut snapshot = reply_enabled_review_snapshot();
+        snapshot.is_managed = true;
+
+        // Act
+        let result = handle_primary_view_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE),
+            &view_context,
+            &snapshot,
+            &pending_update,
+        )
+        .await;
+
+        // Assert
+        assert_eq!(result, Some(false));
+        assert!(matches!(
+            app.mode,
+            AppMode::Confirmation {
+                confirmation_intent: ConfirmationIntent::OpenManagedWorktree,
+                ref confirmation_message,
+                ref confirmation_title,
+                restore_view: Some(ConfirmationViewMode {
+                    scroll_offset: Some(2),
+                    ref session_id,
+                }),
+                selected_confirmation_index: DEFAULT_OPTION_INDEX,
+                ..
+            } if confirmation_title == "Open Managed Worktree"
+                && confirmation_message.contains("writable shell")
+                && session_id == "managed-worker"
+        ));
+    }
+
+    #[tokio::test]
+    async fn regular_worktree_open_skips_warning_and_opens_selector() {
+        // Arrange
+        let (mut app, _temp_dir) = crate::test_support::new_test_app().await;
+        app.settings.launch_configuration = "cargo test\nnpm run dev".to_string();
+        let view_context = ViewContext {
+            scroll_offset: Some(2),
+            session_id: SessionId::from("regular-worker"),
+            session_index: 0,
+        };
+        let snapshot = reply_enabled_review_snapshot();
+
+        // Act
+        let should_apply_pending_update =
+            handle_open_worktree_key(&mut app, &view_context, &snapshot).await;
+
+        // Assert
+        assert!(should_apply_pending_update);
+        assert!(matches!(
+            app.mode,
+            AppMode::LaunchConfigurationSelector {
+                ref commands,
+                restore_view: ConfirmationViewMode {
+                    scroll_offset: Some(2),
+                    ref session_id,
+                },
+                selected_command_index: 0,
+            } if commands == &["cargo test".to_string(), "npm run dev".to_string()]
+                && session_id == "regular-worker"
         ));
     }
 

--- a/crates/agentty/src/ui/page/session_chat.rs
+++ b/crates/agentty/src/ui/page/session_chat.rs
@@ -355,7 +355,9 @@ impl<'a> SessionChatPage<'a> {
             can_fork_session: ViewActionAvailability::from_bool(session.allows_fork_action()),
             can_merge_session_branch: ViewActionAvailability::from_bool(can_merge_session_branch),
             can_mutate_session_branch: ViewActionAvailability::from_bool(can_mutate_session_branch),
-            can_open_worktree: ViewActionAvailability::from_bool(self.can_open_worktree),
+            can_open_worktree: ViewActionAvailability::from_bool(
+                self.can_open_worktree && session.allows_worktree_open_action(),
+            ),
             can_rebase_session_branch: ViewActionAvailability::from_bool(can_rebase_session_branch),
             reply_to_session: ViewActionAvailability::from_bool(can_reply_to_session),
             can_start_staged_session: ViewActionAvailability::from_bool(can_start_staged_session),

--- a/crates/agentty/src/ui/router.rs
+++ b/crates/agentty/src/ui/router.rs
@@ -224,6 +224,7 @@ fn surface_for_mode(mode: &AppMode) -> Surface<'_> {
                 | ConfirmationIntent::MergeSession
                 | ConfirmationIntent::RegenerateReview
                 | ConfirmationIntent::DetachManagedSession
+                | ConfirmationIntent::OpenManagedWorktree
                 | ConfirmationIntent::ChooseIntegrationApproach,
             restore_view: Some(restore_view),
             ..

--- a/crates/agentty/src/ui/session_format.rs
+++ b/crates/agentty/src/ui/session_format.rs
@@ -54,7 +54,7 @@ pub fn session_header_lines(
             .as_ref()
             .map_or("orchestrator", SessionId::as_str);
         lines.push(Line::from(Span::styled(
-            format!("Managed by {controller} — read-only"),
+            format!("Managed by {controller} — actions restricted"),
             Style::default().fg(style::palette::warning()),
         )));
     }
@@ -503,7 +503,7 @@ mod tests {
         assert!(
             header_lines[1]
                 .to_string()
-                .contains("Managed by campaign-controller — read-only")
+                .contains("Managed by campaign-controller — actions restricted")
         );
     }
 

--- a/crates/agentty/tests/e2e/orchestration.rs
+++ b/crates/agentty/tests/e2e/orchestration.rs
@@ -93,6 +93,12 @@ fn seed_orchestration_campaign(env: &BuilderEnv) -> E2eResult {
                 }),
             )
             .await?;
+        // Keep the controller as the deterministic initial raw selection so
+        // one `j` press always reaches its grouped worker row.
+        database
+            .sessions()
+            .update_session_title(CONTROLLER_ID, "Managed feature delivery")
+            .await?;
 
         Ok::<(), Box<dyn std::error::Error>>(())
     });
@@ -124,6 +130,28 @@ fn seed_scrollable_orchestration_campaign(env: &BuilderEnv) -> E2eResult {
     })?;
 
     Ok(())
+}
+
+/// Seeds one parked campaign whose managed worker is ready for review.
+fn seed_review_ready_managed_worker(env: &BuilderEnv) -> E2eResult {
+    seed_orchestration_campaign(env)?;
+
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        database
+            .sessions()
+            .update_session_status_with_timing_at(WORKER_ID, "Review", 0)
+            .await?;
+        // The worker status update touches its row, so restore the same stable
+        // initial selection ordering used by the base campaign seed.
+        database
+            .sessions()
+            .update_session_title(CONTROLLER_ID, "Managed feature delivery")
+            .await?;
+
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })
 }
 
 /// Returns the numbered transcript rows visible in one captured frame.
@@ -253,9 +281,9 @@ fn test_orchestration_campaign_smooth_scroll() -> E2eResult {
 }
 
 #[test]
-fn test_managed_worker_read_only_view() -> E2eResult {
+fn test_managed_worker_restricted_view() -> E2eResult {
     // Arrange, Act, Assert
-    FeatureTest::new("managed_worker_read_only_view")
+    FeatureTest::new("managed_worker_restricted_view")
         .with_git()
         .setup(seed_orchestration_campaign)
         .run(
@@ -276,7 +304,7 @@ fn test_managed_worker_read_only_view() -> E2eResult {
                     .wait_for_stable_frame(300, 5000)
                     .press_key("?")
                     .wait_for_stable_frame(300, 5000)
-                    .capture_labeled("managed_worker", "Managed worker read-only actions")
+                    .capture_labeled("managed_worker", "Managed worker restricted actions")
             },
             |frame, report| {
                 let running_frame = common::frame_from_capture(&report.captures[0]);
@@ -290,13 +318,56 @@ fn test_managed_worker_read_only_view() -> E2eResult {
 
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "Managed by controller-0001", &full);
-                assertion::assert_text_in_region(frame, "read-only", &full);
+                assertion::assert_text_in_region(frame, "actions restricted", &full);
                 assertion::assert_text_in_region(frame, "d: Show diff", &full);
                 assertion::assert_text_in_region(frame, "Detach managed", &full);
                 let text = frame.text_in_region(&full);
                 assert!(!text.contains("Enter: Reply"));
                 assert!(!text.contains("p: Create or refresh"));
                 assert!(!text.contains("Review comments"));
+            },
+        )
+}
+
+#[test]
+fn test_managed_worker_review_open_action() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("managed_worker_review_open_action")
+        .with_git()
+        .setup(seed_review_ready_managed_worker)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("j")
+                    .press_key("Enter")
+                    .wait_for_text("Managed by controller-0001", 5000)
+                    .compose(&common::open_help_overlay())
+                    .capture_labeled(
+                        "managed_worker_review_help",
+                        "Review-ready managed worker exposes worktree open",
+                    )
+                    .press_key("q")
+                    .press_key("o")
+                    .wait_for_text("Open Managed Worktree", 5000)
+                    .capture_labeled(
+                        "managed_worker_open_warning",
+                        "Managed worktree write-access warning",
+                    )
+            },
+            |frame, report| {
+                let help_frame = common::frame_from_capture(&report.captures[0]);
+                let help_full = Region::full(help_frame.cols(), help_frame.rows());
+                assertion::assert_text_in_region(&help_frame, "o: Open worktree", &help_full);
+                let help_text = help_frame.text_in_region(&help_full);
+                assert!(!help_text.contains("Enter: Reply"));
+                assert!(!help_text.contains("m: Add to merge queue"));
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Managed by controller-0001", &full);
+                assertion::assert_text_in_region(frame, "Open Managed Worktree", &full);
+                assertion::assert_text_in_region(frame, "This opens a writable", &full);
             },
         )
 }

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -194,12 +194,14 @@ State-specific differences:
   approves the plan; after verification, `a` opens a choice between local merges and
   review requests. Worker parallelism comes from the global **Orchestrator Parallelism**
   setting. Controllers hide branch actions: `d`, `o`, `p`, `F`, `m`, and `r`.
-- Managed orchestration workers are read-only. `d` opens their diff and `D` confirms a
-  one-way detach into a regular user-owned session. Reply, slash-command, worktree,
-  publish, fork, merge, sync, cancel, linked review-comment, and direct question-answer
-  actions stay hidden; `Ctrl+c` is ignored while the worker remains managed. After a
-  managed merge removes the worktree, `d` reads the immutable diff archived during
-  integration.
+- Managed orchestration workers restrict direct Agentty actions. `d` opens their diff,
+  `D` confirms a one-way detach into a regular user-owned session, and a worker in
+  **Review** exposes `o` to open its materialized worktree. The confirmation warns that
+  the shell has normal write access and edits can invalidate orchestration verification.
+  Reply, slash-command, publish, fork, merge, sync, cancel, linked review-comment, and
+  direct question-answer actions stay hidden; `Ctrl+c` is ignored while the worker
+  remains managed. After a managed merge removes the worktree, `d` reads the immutable
+  diff archived during integration.
 - Review-ready stacked parents with a materialized child keep `Enter`, `/`, `m`, and `r`
   while the stack is idle.
 - Sessions with a linked pull request or merge request use `c` to open its comments page

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -415,13 +415,15 @@ Use an orchestrator when a goal contains at least two independent pieces of work
    the controller recommends a regular session instead of creating a ceremonial worker.
 1. Follow real-time task status on the campaign monitor. Status changes do not add
    transcript messages. Worker rows remain grouped with their controller in the
-   **Sessions** list. Workers are read-only: open one to inspect its transcript, press
-   `d` for its diff, or press `D` and confirm **Detach** to permanently transfer it into
-   an ordinary user-owned session. Direct reply, question-answer, cancel, merge,
-   publish, fork, worktree-open, review-comment addressing, `Ctrl+c` turn interruption,
-   and slash-command actions are unavailable while it is managed. The controller
-   conversation below the monitor uses the same line-by-line transcript scrolling as a
-   regular session.
+   **Sessions** list. Workers restrict direct Agentty actions: open one to inspect its
+   transcript, press `d` for its diff, or press `D` and confirm **Detach** to
+   permanently transfer it into an ordinary user-owned session. A worker in **Review**
+   also exposes `o` to open its materialized worktree. The confirmation warns that the
+   shell has normal write access and edits can invalidate orchestration verification.
+   Direct reply, question-answer, cancel, merge, publish, fork, review-comment
+   addressing, `Ctrl+c` turn interruption, and slash-command actions are unavailable
+   while it is managed. The controller conversation below the monitor uses the same
+   line-by-line transcript scrolling as a regular session.
 1. When a worker asks a blocking question, Agentty mirrors it into the controller's
    question panel only when the controller has no question of its own. The relay durably
    records the exact task that owns the mirrored question, so concurrent worker


### PR DESCRIPTION
- Expose `o` for managed orchestration workers in `Review` when a materialized worktree is available while keeping direct turns and branch actions unavailable.
- Document and cover the review-only inspection flow with unit and E2E tests.
- Requires confirmation before opening a managed worktree with normal write access, warning that edits can invalidate orchestration verification.
- The related E2E seed guarantees deterministic controller-first selection, fixing timestamp-dependent selection ordering.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)