### PR TITLE
Draft orchestrators remain cancelable

### DIFF
--- a/crates/agentty/.sqlx/query-0e4a7f5440ae93a128188606b5dd3905d07cb8a5921ec91786fc09ab9284612b.json
+++ b/crates/agentty/.sqlx/query-0e4a7f5440ae93a128188606b5dd3905d07cb8a5921ec91786fc09ab9284612b.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE session SET role = 'Orchestrator' WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "0e4a7f5440ae93a128188606b5dd3905d07cb8a5921ec91786fc09ab9284612b"
+}

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -5963,7 +5963,7 @@ async fn test_cancel_session_requires_cancelable_status() {
         result
             .expect_err("should be error")
             .to_string()
-            .contains("must be running, in review")
+            .contains("not cancelable in its current state")
     );
 }
 

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -2987,7 +2987,8 @@ impl SessionManager {
         .await;
     }
 
-    /// Cancels a review, running, or unstarted draft session.
+    /// Cancels a review, running, unstarted draft, or draft orchestrator
+    /// session.
     ///
     /// Persisted transcript metadata remains available after the worktree
     /// checkout and session branch are removed. Draft sessions that never
@@ -3049,8 +3050,7 @@ impl SessionManager {
                 || session.status.allows_review_actions());
         if !session.allows_cancel_action() && !managed_cancel_allowed {
             return Err(SessionError::Workflow(
-                "Session must be running, in review, or be an unstarted draft to be canceled"
-                    .to_string(),
+                "Session is not cancelable in its current state".to_string(),
             ));
         }
 

--- a/crates/agentty/src/app/session_api.rs
+++ b/crates/agentty/src/app/session_api.rs
@@ -2281,7 +2281,7 @@ mod tests {
         assert!(
             cancel_error
                 .to_string()
-                .contains("must be running, in review, or be an unstarted draft")
+                .contains("not cancelable in its current state")
         );
         assert_eq!(controller.status, controller_before.status);
         assert_eq!(

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -465,12 +465,14 @@ impl Session {
     /// Running sessions can be canceled from the list after their active turn
     /// is signaled to stop. Review-oriented sessions remain cancelable, and
     /// unstarted draft sessions can also be canceled before they materialize a
-    /// worktree.
+    /// worktree. Draft orchestrators remain cancelable after their controller
+    /// worktree is materialized but before their first goal is submitted.
     pub fn allows_cancel_action(&self) -> bool {
         self.accepts_user_turns()
             && (self.status == Status::InProgress
                 || self.status.allows_review_actions()
-                || (self.status == Status::Draft && self.is_draft_session()))
+                || (self.status == Status::Draft
+                    && (self.is_draft_session() || self.role == SessionRole::Orchestrator)))
     }
 
     /// Returns whether this terminal session can launch a seeded follow-on
@@ -2517,6 +2519,20 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
         let mut session = test_session(None);
         session.status = Status::Draft;
         session.is_draft = true;
+
+        // Act
+        let allows_cancel_action = session.allows_cancel_action();
+
+        // Assert
+        assert!(allows_cancel_action);
+    }
+
+    #[test]
+    fn test_session_allows_cancel_action_for_draft_orchestrator() {
+        // Arrange
+        let mut session = test_session(None);
+        session.status = Status::Draft;
+        session.role = SessionRole::Orchestrator;
 
         // Act
         let allows_cancel_action = session.allows_cancel_action();

--- a/crates/agentty/src/runtime/mode/list.rs
+++ b/crates/agentty/src/runtime/mode/list.rs
@@ -22,8 +22,8 @@ use crate::runtime::mode::input_key;
 /// with `No` selected by default. Pressing `Enter` on the `Projects` tab
 /// selects the active project and then moves focus to `Tab::Sessions`.
 /// `c` opens a cancel confirmation overlay for running sessions, review
-/// sessions, and unstarted draft sessions, and `Tab` cycles tabs forward while
-/// `Shift+Tab` cycles backward.
+/// sessions, unstarted draft sessions, and draft orchestrators, and `Tab`
+/// cycles tabs forward while `Shift+Tab` cycles backward.
 pub(crate) async fn handle(app: &mut App, key: KeyEvent) -> io::Result<EventResult> {
     if app.tabs.current() == Tab::Settings
         && (app

--- a/crates/agentty/tests/e2e/confirmation.rs
+++ b/crates/agentty/tests/e2e/confirmation.rs
@@ -3,6 +3,7 @@
 
 use std::time::Duration;
 
+use agentty::test_support;
 use testty::assertion;
 use testty::region::Region;
 use testty::scenario::Scenario;
@@ -19,6 +20,37 @@ fn seed_cancelable_draft_session(env: &BuilderEnv) -> E2eResult {
         SessionSeed::draft("draft-cancel-0001", "gpt-5.6-sol", "main", "Draft")
             .with_title("Cancel staged draft from list"),
     )
+}
+
+/// Seeds one draft orchestrator with its materialized controller worktree.
+fn seed_cancelable_draft_orchestrator(env: &BuilderEnv) -> E2eResult {
+    let session_id = "orchdraft-0001";
+
+    common::seed_session(
+        env,
+        SessionSeed::regular(session_id, "gpt-5.6-sol", "main", "Draft")
+            .with_title("Cancel draft orchestrator"),
+    )?;
+
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        sqlx::query!(
+            "UPDATE session SET role = 'Orchestrator' WHERE id = ?",
+            session_id
+        )
+        .execute(database.pool())
+        .await?;
+
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })?;
+
+    std::fs::create_dir_all(test_support::session_folder(
+        &env.agentty_root.join("wt"),
+        session_id,
+    ))?;
+
+    Ok(())
 }
 
 /// Seeds one running session for list-mode cancel confirmation.
@@ -207,6 +239,66 @@ fn draft_session_cancel_confirmation() -> E2eResult {
                 assertion::assert_text_in_region(
                     &list_frame,
                     "Cancel staged draft from list",
+                    &list_full,
+                );
+                assertion::assert_text_in_region(&list_frame, "Draft", &list_full);
+                assertion::assert_text_in_region(&list_frame, "c: cancel", &list_full);
+
+                let confirmation_frame = common::frame_from_capture(&report.captures[1]);
+                let confirmation_full =
+                    Region::full(confirmation_frame.cols(), confirmation_frame.rows());
+                assertion::assert_text_in_region(
+                    &confirmation_frame,
+                    "Confirm Cancel",
+                    &confirmation_full,
+                );
+
+                let final_full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Archive", &final_full);
+                assertion::assert_text_in_region(frame, "Canceled", &final_full);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that a draft orchestrator can be canceled directly from the session
+/// list before its first goal is submitted.
+#[test]
+fn test_draft_orchestrator_cancel() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("draft_orchestrator_cancel")
+        .with_git()
+        .setup(seed_cancelable_draft_orchestrator)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .wait_for_text("Cancel draft orchestrator", 5000)
+                    .capture_labeled(
+                        "draft_orchestrator",
+                        "Draft orchestrator visible with cancel available",
+                    )
+                    .press_key("c")
+                    .wait_for_text("Confirm Cancel", 3000)
+                    .capture_labeled(
+                        "confirm_cancel",
+                        "Cancel confirmation for the draft orchestrator",
+                    )
+                    .press_key("y")
+                    .wait_for_text("Canceled", 5000)
+                    .capture_labeled(
+                        "canceled_orchestrator",
+                        "Canceled draft orchestrator moved into the archive group",
+                    )
+            },
+            |frame, report| {
+                let list_frame = common::frame_from_capture(&report.captures[0]);
+                let list_full = Region::full(list_frame.cols(), list_frame.rows());
+                assertion::assert_text_in_region(
+                    &list_frame,
+                    "Cancel draft orchestrator",
                     &list_full,
                 );
                 assertion::assert_text_in_region(&list_frame, "Draft", &list_full);

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -61,8 +61,9 @@ option are marked `[Preview]`.
 
 In the `a` selector, `Stacked` is enabled only when the selected session is a root
 session with an active branch. `c` appears only for cancelable rows: running sessions,
-review-ready sessions, and unstarted draft sessions. Canceling a running orchestrator
-opens a confirmation that names its running-child count and cascades to those children.
+review-ready sessions, unstarted draft sessions, and draft orchestrators. Canceling a
+running orchestrator opens a confirmation that names its running-child count and
+cascades to those children.
 
 <a id="usage-session-list-project-switcher"></a> The `p` popup lists registered projects
 in most-recently-opened order with the active project marked by a `* ` prefix. Each row

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -459,11 +459,12 @@ as new scope and parks the campaign on the approval board before that worker sta
 Once the controller is `Done`, a new goal or further feedback starts a new orchestrator
 campaign.
 
-Press `c` on a running controller to cancel the orchestration. The confirmation names
-the number of running children. Approval first blocks new worker fan-out, then cancels
-the controller and its active children idempotently. If any child cannot be canceled,
-Agentty reports the error and leaves the orchestration in **Canceling** so `c` can retry
-without reporting a false terminal cancellation.
+Press `c` on a draft or running controller to cancel it. Draft controllers can be
+canceled before their first goal is submitted. For running controllers, the confirmation
+names the number of running children. Approval first blocks new worker fan-out, then
+cancels the controller and its active children idempotently. If any child cannot be
+canceled, Agentty reports the error and leaves the orchestration in **Canceling** so `c`
+can retry without reporting a false terminal cancellation.
 
 ## Branch Publish Flow
 


### PR DESCRIPTION
- Draft controllers can be canceled after worktree creation and before their first goal submission.
- Session-list confirmation, E2E coverage, and user documentation reflect the new cancellation behavior.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)