### PR TITLE
Keep review-request campaigns active until merge

### DIFF
--- a/crates/agentty/.sqlx/query-02f4c9e54e5a0008f94d6ac5d22f116718019bb38d7b178c6c70f4fe0827033e.json
+++ b/crates/agentty/.sqlx/query-02f4c9e54e5a0008f94d6ac5d22f116718019bb38d7b178c6c70f4fe0827033e.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE session SET status = 'Review' WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "02f4c9e54e5a0008f94d6ac5d22f116718019bb38d7b178c6c70f4fe0827033e"
+}

--- a/crates/agentty/.sqlx/query-48982db6339535f038342fe3c15dd8d734e887e1cbe1fb54b66fdaa6d3dd40c3.json
+++ b/crates/agentty/.sqlx/query-48982db6339535f038342fe3c15dd8d734e887e1cbe1fb54b66fdaa6d3dd40c3.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE session_orchestration SET status = 'Integrating', integration_approach = 'ReviewRequest'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": []
+  },
+  "hash": "48982db6339535f038342fe3c15dd8d734e887e1cbe1fb54b66fdaa6d3dd40c3"
+}

--- a/crates/agentty/.sqlx/query-8e497fd139db0f21837f300e0c15b9251deaeaa67ee175ae8af167cb6c951ec0.json
+++ b/crates/agentty/.sqlx/query-8e497fd139db0f21837f300e0c15b9251deaeaa67ee175ae8af167cb6c951ec0.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE session SET status = 'Canceled' WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "8e497fd139db0f21837f300e0c15b9251deaeaa67ee175ae8af167cb6c951ec0"
+}

--- a/crates/agentty/.sqlx/query-a96981c21efa61153e0006938061c1de49cefec0e95c6cb26ba7f2b0bf41f708.json
+++ b/crates/agentty/.sqlx/query-a96981c21efa61153e0006938061c1de49cefec0e95c6cb26ba7f2b0bf41f708.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE session_orchestration_task SET status = CASE task_key WHEN 'protocol' THEN 'ReviewRequested' ELSE 'Integrated' END",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": []
+  },
+  "hash": "a96981c21efa61153e0006938061c1de49cefec0e95c6cb26ba7f2b0bf41f708"
+}

--- a/crates/agentty/src/app/orchestration.rs
+++ b/crates/agentty/src/app/orchestration.rs
@@ -1011,6 +1011,7 @@ impl OrchestrationCoordinator {
             .await
             .map_err(|error| error.to_string())?;
         for task in &mut tasks {
+            self.reconcile_review_requested_task(task).await?;
             self.reconcile_merging_task(task, integration_approach)
                 .await?;
         }
@@ -1039,6 +1040,37 @@ impl OrchestrationCoordinator {
             self.complete_campaign(orchestration).await?;
         } else {
             self.emit_live_status(orchestration, &tasks);
+        }
+
+        Ok(())
+    }
+
+    async fn reconcile_review_requested_task(
+        &self,
+        task: &mut SessionOrchestrationTaskRow,
+    ) -> Result<(), String> {
+        if task_status(task) != Some(OrchestrationTaskStatus::ReviewRequested) {
+            return Ok(());
+        }
+
+        let child_status = task
+            .child_status
+            .as_deref()
+            .and_then(|status| status.parse::<SessionStatus>().ok());
+        match child_status {
+            Some(SessionStatus::Merged | SessionStatus::Done) => {
+                self.update_task_status(task, OrchestrationTaskStatus::Integrated, None)
+                    .await?;
+            }
+            Some(SessionStatus::Canceled) => {
+                self.update_task_status(
+                    task,
+                    OrchestrationTaskStatus::IntegrationFailed,
+                    Some("Review request closed without merge".to_string()),
+                )
+                .await?;
+            }
+            _ => {}
         }
 
         Ok(())
@@ -3130,10 +3162,6 @@ mod tests {
             .times(2)
             .returning(|_, _, _| Ok(()));
         repository
-            .expect_complete_orchestration_campaign()
-            .times(2)
-            .returning(|_| Ok(true));
-        repository
             .expect_load_orchestration_integration_approach()
             .times(3)
             .returning(|_| Ok(IntegrationApproach::ReviewRequest.to_string()));
@@ -3157,6 +3185,105 @@ mod tests {
                 .calls()
                 .contains(&"review:child-interrupted".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn review_request_campaign_waits_for_open_children_and_completes_after_merge() {
+        // Arrange
+        let backend = TestSessionBackend::default();
+        let mut repository = MockOrchestrationRepository::new();
+        let open = task(
+            1,
+            "open-review",
+            OrchestrationTaskStatus::ReviewRequested,
+            Some("child-review"),
+        );
+        let merged = with_child_observation(
+            task(
+                1,
+                "merged-review",
+                OrchestrationTaskStatus::ReviewRequested,
+                Some("child-review"),
+            ),
+            SessionStatus::Merged,
+            None,
+        );
+        mock_task_snapshots(&mut repository, vec![vec![open], vec![merged]]);
+        repository
+            .expect_update_orchestration_task_status()
+            .once()
+            .withf(|_, status, error| status == "Integrated" && error.as_ref().is_none())
+            .returning(|_, _, _| Ok(()));
+        repository
+            .expect_complete_orchestration_campaign()
+            .once()
+            .returning(|_| Ok(true));
+        repository
+            .expect_load_orchestration_integration_approach()
+            .times(2)
+            .returning(|_| Ok(IntegrationApproach::ReviewRequest.to_string()));
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        let coordinator =
+            OrchestrationCoordinator::new(event_tx, Arc::new(repository), backend.service());
+        let mut campaign = orchestration(2);
+        campaign.status = OrchestrationStatus::Integrating.to_string();
+
+        // Act
+        coordinator
+            .reconcile_integration(&campaign)
+            .await
+            .expect("open review request should remain active");
+        coordinator
+            .reconcile_integration(&campaign)
+            .await
+            .expect("merged review request should complete");
+
+        // Assert
+        assert!(backend.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn closed_review_request_records_integration_failure() {
+        // Arrange
+        let backend = TestSessionBackend::default();
+        let mut repository = MockOrchestrationRepository::new();
+        let canceled = with_child_observation(
+            task(
+                1,
+                "closed-review",
+                OrchestrationTaskStatus::ReviewRequested,
+                Some("child-review"),
+            ),
+            SessionStatus::Canceled,
+            None,
+        );
+        mock_task_snapshots(&mut repository, vec![vec![canceled]]);
+        repository
+            .expect_update_orchestration_task_status()
+            .once()
+            .withf(|_, status, error| {
+                status == "IntegrationFailed"
+                    && error.as_deref() == Some("Review request closed without merge")
+            })
+            .returning(|_, _, _| Ok(()));
+        repository
+            .expect_load_orchestration_integration_approach()
+            .once()
+            .returning(|_| Ok(IntegrationApproach::ReviewRequest.to_string()));
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        let coordinator =
+            OrchestrationCoordinator::new(event_tx, Arc::new(repository), backend.service());
+        let mut campaign = orchestration(2);
+        campaign.status = OrchestrationStatus::Integrating.to_string();
+
+        // Act
+        coordinator
+            .reconcile_integration(&campaign)
+            .await
+            .expect("closed review request should record a failure");
+
+        // Assert
+        assert!(backend.calls().is_empty());
     }
 
     #[tokio::test]

--- a/crates/agentty/src/domain/orchestration.rs
+++ b/crates/agentty/src/domain/orchestration.rs
@@ -140,7 +140,8 @@ pub enum OrchestrationTaskStatus {
     Merging,
     /// Branch work was merged locally successfully.
     Integrated,
-    /// The child branch was published as a forge review request.
+    /// The child branch was published and is waiting for its forge review
+    /// request to merge.
     ReviewRequested,
     /// Integration failed and requires attention.
     IntegrationFailed,
@@ -263,6 +264,9 @@ impl OrchestrationTaskStatus {
                     | OrchestrationTaskStatus::ReviewRequested
                     | OrchestrationTaskStatus::IntegrationFailed
             ) | (
+                OrchestrationTaskStatus::ReviewRequested,
+                OrchestrationTaskStatus::Integrated | OrchestrationTaskStatus::IntegrationFailed
+            ) | (
                 OrchestrationTaskStatus::Planned
                     | OrchestrationTaskStatus::Creating
                     | OrchestrationTaskStatus::Running
@@ -277,7 +281,6 @@ impl OrchestrationTaskStatus {
         matches!(
             self,
             OrchestrationTaskStatus::Integrated
-                | OrchestrationTaskStatus::ReviewRequested
                 | OrchestrationTaskStatus::Detached
                 | OrchestrationTaskStatus::Canceled
                 | OrchestrationTaskStatus::Failed
@@ -655,11 +658,10 @@ mod tests {
     }
 
     #[test]
-    fn integration_terminal_states_are_settled() {
+    fn integration_settlement_waits_for_review_request_merge() {
         // Arrange
         let settled = [
             OrchestrationTaskStatus::Integrated,
-            OrchestrationTaskStatus::ReviewRequested,
             OrchestrationTaskStatus::Detached,
             OrchestrationTaskStatus::Canceled,
             OrchestrationTaskStatus::Failed,
@@ -671,9 +673,18 @@ mod tests {
                 .all(OrchestrationTaskStatus::is_integration_settled)
         );
         assert!(!OrchestrationTaskStatus::AwaitingIntegration.is_integration_settled());
+        assert!(!OrchestrationTaskStatus::ReviewRequested.is_integration_settled());
         assert!(
             OrchestrationTaskStatus::Merging
                 .can_transition_to(OrchestrationTaskStatus::ReviewRequested)
+        );
+        assert!(
+            OrchestrationTaskStatus::ReviewRequested
+                .can_transition_to(OrchestrationTaskStatus::Integrated)
+        );
+        assert!(
+            OrchestrationTaskStatus::ReviewRequested
+                .can_transition_to(OrchestrationTaskStatus::IntegrationFailed)
         );
     }
 

--- a/crates/agentty/tests/e2e/orchestration.rs
+++ b/crates/agentty/tests/e2e/orchestration.rs
@@ -154,6 +154,56 @@ fn seed_review_ready_managed_worker(env: &BuilderEnv) -> E2eResult {
     })
 }
 
+/// Seeds a review-request campaign with one worker still awaiting its forge
+/// merge and one already integrated sibling.
+fn seed_review_request_campaign_awaiting_merge(env: &BuilderEnv) -> E2eResult {
+    seed_orchestration_campaign(env)?;
+
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        sqlx::query!(
+            "UPDATE session_orchestration SET status = 'Integrating', integration_approach = \
+             'ReviewRequest'",
+        )
+        .execute(database.pool())
+        .await?;
+        sqlx::query!(
+            "UPDATE session_orchestration_task SET status = CASE task_key WHEN 'protocol' THEN \
+             'ReviewRequested' ELSE 'Integrated' END",
+        )
+        .execute(database.pool())
+        .await?;
+        sqlx::query!(
+            "UPDATE session SET status = 'Review' WHERE id = ?",
+            WORKER_ID
+        )
+        .execute(database.pool())
+        .await?;
+
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })
+}
+
+/// Seeds a review-request campaign whose forge review was closed without a
+/// merge so reconciliation must surface an integration failure.
+fn seed_review_request_campaign_with_closed_worker(env: &BuilderEnv) -> E2eResult {
+    seed_review_request_campaign_awaiting_merge(env)?;
+
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        sqlx::query!(
+            "UPDATE session SET status = 'Canceled' WHERE id = ?",
+            WORKER_ID
+        )
+        .execute(database.pool())
+        .await?;
+
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })
+}
+
 /// Returns the numbered transcript rows visible in one captured frame.
 fn visible_transcript_line_indexes(frame: &TerminalFrame) -> Vec<u16> {
     let full = Region::full(frame.cols(), frame.rows());
@@ -234,6 +284,90 @@ fn test_orchestration_campaign_board() -> E2eResult {
                     &full,
                 );
                 assertion::assert_text_in_region(frame, "a approve  Enter discuss/revise", &full);
+            },
+        )
+}
+
+#[test]
+fn test_review_request_campaign_waits_for_worker_merge() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("review_request_campaign_waits_for_worker_merge")
+        .with_git()
+        .setup(seed_review_request_campaign_awaiting_merge)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .compose(&common::open_selected_session_view())
+                    .wait_for_text("Phase: Integrating", 5000)
+                    .capture_labeled(
+                        "controller_waiting",
+                        "Controller remains active while review request is open",
+                    )
+                    .press_key("q")
+                    .press_key("j")
+                    .press_key("Enter")
+                    .wait_for_text("Managed by controller-0001", 5000)
+                    .press_key("?")
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled(
+                        "worker_attached",
+                        "Review-request worker remains attached to controller",
+                    )
+            },
+            |frame, report| {
+                let controller_frame = common::frame_from_capture(&report.captures[0]);
+                let controller_full =
+                    Region::full(controller_frame.cols(), controller_frame.rows());
+                assertion::assert_text_in_region(
+                    &controller_frame,
+                    "Phase: Integrating",
+                    &controller_full,
+                );
+                assertion::assert_text_in_region(
+                    &controller_frame,
+                    "Protocol contract [protocol]: review requested",
+                    &controller_full,
+                );
+                let controller_text = controller_frame.text_in_region(&controller_full);
+                assert!(!controller_text.contains("Campaign complete"));
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Managed by controller-0001", &full);
+                assertion::assert_text_in_region(frame, "Detach managed", &full);
+            },
+        )
+}
+
+#[test]
+fn test_review_request_campaign_reports_closed_worker() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("review_request_campaign_reports_closed_worker")
+        .with_git()
+        .setup(seed_review_request_campaign_with_closed_worker)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .compose(&common::open_selected_session_view())
+                    .wait_for_text("integration failed", 5000)
+                    .capture_labeled(
+                        "closed_worker_failure",
+                        "Closed review request remains visible as integration failure",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Phase: Integrating", &full);
+                assertion::assert_text_in_region(
+                    frame,
+                    "Protocol contract [protocol]: integration failed",
+                    &full,
+                );
+                let text = frame.text_in_region(&full);
+                assert!(!text.contains("Campaign complete"));
             },
         )
 }

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -323,12 +323,16 @@ flowchart LR
    so restart recovery cannot switch destinations. `Integrating` then serializes local
    merges or review-request publication through the coordinator session service.
    Successful managed merges persist the final patch as `session.archived_diff` before
-   cleanup removes the worker worktree and local branch; published tasks become
-   `ReviewRequested` and retain the forge-linked branch. Failures remain durable and
-   visible. Once every task is integration-settled, one transaction marks both the
-   campaign and disposable controller `Done`; no second controller report turn is
-   needed. A one-way detach transaction instead clears both task links and changes the
-   worker role back to `Worker`.
+   cleanup removes the worker worktree and local branch. Published tasks become
+   `ReviewRequested`, retain the forge-linked branch, and keep the orchestration active
+   until review sync moves the child session to `Merged`; reconciliation then advances
+   the task to `Integrated`. A child moved to `Canceled` by closed-review sync advances
+   to `IntegrationFailed` with a durable explanation, keeping the campaign active for
+   follow-up. Other failures also remain durable and visible. Once every task is
+   integration-settled, one transaction marks both the campaign and disposable
+   controller `Done`; no second controller report turn is needed. A one-way detach
+   transaction instead clears both task links and changes the worker role back to
+   `Worker`.
 1. When `a` requests the session-type selector, the app asks `GitClient` to verify the
    effective pre-commit hook whenever the project contains `.pre-commit-config.yaml` or
    `.pre-commit-config.yml`. A missing executable hook opens a warning overlay with

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -443,11 +443,15 @@ Use an orchestrator when a goal contains at least two independent pieces of work
    the same live child when a correction is required.
 1. At **AwaitingIntegration**, press `a`, then choose **Local merges** or **Review
    requests**. Agentty applies local merges or creates forge review requests in plan
-   order and records failures on the campaign monitor. When all integrations settle, the
+   order and records failures on the campaign monitor. A published review-request task
+   remains **Review requested**, and the controller stays active, until review sync
+   observes that worker's request as merged. When every integration has settled, the
    campaign and controller become **Done** without another model turn. Local merge
    integration archives an immutable copy of each worker diff before removing its
    worktree and local branch. Review-request workers retain their published branch and
-   remain browsable under the controller. Detached workers remain ordinary sessions.
+   remain browsable under the controller. A review request closed without merging is
+   recorded as an **Integration failed** task, leaving the controller active for
+   follow-up. Detached workers remain ordinary sessions.
 
 Multi-turn feedback is routed by scope. Reusing a settled task's exact key and touched
 areas continues its existing worker, branch, and conversation and returns it to


### PR DESCRIPTION
- Review-request tasks remain unsettled until their child reaches `Merged` or `Done`.
- Merged review-request children transition to `Integrated`, allowing the campaign to complete.
- Closed review requests transition to `IntegrationFailed` with a durable explanation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)