### PR TITLE
Queues review-request publishing behind active turns

### DIFF
--- a/crates/ag-session/src/model.rs
+++ b/crates/ag-session/src/model.rs
@@ -435,7 +435,7 @@ pub struct Session {
     pub published_upstream_ref: Option<String>,
     /// Structured clarification questions waiting for answers.
     pub questions: Vec<QuestionItem>,
-    /// Chat messages waiting behind the active turn or rebase.
+    /// Chat messages waiting behind the active turn or queued branch action.
     pub queued_messages: Vec<String>,
     /// Persisted review-request linkage, when present.
     pub review_request: Option<ReviewRequest>,

--- a/crates/ag-session/src/service.rs
+++ b/crates/ag-session/src/service.rs
@@ -121,8 +121,8 @@ pub trait SessionBackend: Send + Sync {
     /// Requests merge processing for one review-ready session.
     async fn merge_session(&self, session_id: &SessionId) -> Result<(), SessionError>;
 
-    /// Publishes one session branch and creates or refreshes its review
-    /// request.
+    /// Queues publication of one session branch and creates or refreshes its
+    /// review request.
     async fn create_review_request(
         &self,
         session_id: &SessionId,
@@ -219,11 +219,12 @@ impl SessionService {
         self.backend.merge_session(session_id).await
     }
 
-    /// Publishes one session and creates or refreshes its review request.
+    /// Queues publication of one session and creates or refreshes its review
+    /// request.
     ///
     /// # Errors
-    /// Returns an error when branch publication, forge access, or persistence
-    /// fails.
+    /// Returns an error when queueing, branch publication, forge access, or
+    /// persistence fails.
     pub async fn create_review_request(
         &self,
         session_id: &SessionId,

--- a/crates/agentty/src/app/branch_publish.rs
+++ b/crates/agentty/src/app/branch_publish.rs
@@ -149,6 +149,25 @@ pub(crate) enum BranchPublishTaskSuccess {
 pub(crate) type BranchPublishTaskResult =
     Result<BranchPublishTaskSuccess, BranchPublishTaskFailure>;
 
+/// Extracts the review request created by a completed publish action.
+///
+/// # Errors
+/// Returns the user-facing publish failure, or an invariant error when a
+/// plain branch-push result is supplied for review-request creation.
+pub(crate) fn review_request_from_publish_result(
+    result: &BranchPublishTaskResult,
+) -> Result<ReviewRequest, String> {
+    match result {
+        Ok(BranchPublishTaskSuccess::PullRequestPublished { review_request, .. }) => {
+            Ok(review_request.clone())
+        }
+        Ok(BranchPublishTaskSuccess::Pushed { .. }) => {
+            Err("Review-request publishing completed without a review request".to_string())
+        }
+        Err(BranchPublishTaskFailure { message, .. }) => Err(message.clone()),
+    }
+}
+
 /// Forge-specific metadata used to describe one review-request creation path
 /// after a branch push.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -165,6 +184,12 @@ pub(crate) fn branch_publish_loading_label(publish_branch_action: PublishBranchA
         PublishBranchAction::Push => "Pushing branch...".to_string(),
         PublishBranchAction::PublishPullRequest => "Publishing review request...".to_string(),
     }
+}
+
+/// Returns the inline label shown while review-request creation waits behind
+/// an active session turn.
+pub(crate) fn review_request_queued_label() -> String {
+    "Review request queued; publishing after the current turn finishes...".to_string()
 }
 
 /// Returns the inline success title for a completed branch-publish action.

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -202,6 +202,9 @@ pub(crate) enum AppEvent {
         result: Box<BranchPublishTaskResult>,
         session_id: SessionId,
     },
+    /// Indicates a queued review-request action has begun executing on its
+    /// session worker.
+    BranchPublishActionStarted { session_id: SessionId },
     /// Indicates review assist output became available for a session.
     ReviewPrepared {
         diff_hash: u64,
@@ -278,6 +281,7 @@ pub(super) struct AppEventBatch {
     pub(super) agent_cli_updates: Option<Vec<AgentCliInfo>>,
     pub(super) at_mention_entries_updates: HashMap<SessionId, Vec<FileEntry>>,
     pub(super) branch_publish_action_updates: Vec<BranchPublishActionUpdate>,
+    pub(super) branch_publish_started_session_ids: HashSet<SessionId>,
     pub(super) diff_preview_updates: Vec<DiffPreviewUpdate>,
     pub(super) focused_review_persistence_retries: Vec<FocusedReviewPersistenceRetry>,
     pub(super) git_status_update: Option<GitStatusBatchUpdate>,
@@ -426,6 +430,7 @@ impl AppEventBatch {
             || !self.applied_turns.is_empty()
             || !self.at_mention_entries_updates.is_empty()
             || !self.branch_publish_action_updates.is_empty()
+            || !self.branch_publish_started_session_ids.is_empty()
             || !self.diff_preview_updates.is_empty()
             || !self.published_branch_sync_updates.is_empty()
             || !self.review_request_status_updates.is_empty()
@@ -564,8 +569,7 @@ impl AppEventBatch {
                 session_id,
             } => self.collect_session_progress_updated(session_id, progress_message),
             AppEvent::SessionReviewCommentSnapshotLoaded { result, session_id } => {
-                self.session_review_comment_snapshots
-                    .insert(session_id, result);
+                self.collect_session_review_comment_snapshot_loaded(session_id, result);
             }
             AppEvent::SyncMainCompleted { result } => self.collect_sync_main_completed(result),
             AppEvent::SyncMainConflictResolutionStarted { conflicted_files } => {
@@ -582,11 +586,13 @@ impl AppEventBatch {
                 generation,
                 session_id,
             } => {
-                self.session_title_generation_finished
-                    .insert(session_id, generation);
+                self.collect_session_title_generation_finished(session_id, generation);
             }
             AppEvent::BranchPublishActionCompleted { result, session_id } => {
                 self.collect_branch_publish_action_completed(*result, session_id);
+            }
+            AppEvent::BranchPublishActionStarted { session_id } => {
+                self.branch_publish_started_session_ids.insert(session_id);
             }
             AppEvent::ReviewPrepared {
                 diff_hash,
@@ -646,6 +652,26 @@ impl AppEventBatch {
             } => self.collect_review_request_status_updated(generation, result, session_id),
             _ => unreachable!("top-level app event should be collected before runtime events"),
         }
+    }
+
+    /// Keeps the latest loaded review-comment snapshot for one session.
+    fn collect_session_review_comment_snapshot_loaded(
+        &mut self,
+        session_id: SessionId,
+        result: Result<ag_forge::ReviewCommentSnapshot, String>,
+    ) {
+        self.session_review_comment_snapshots
+            .insert(session_id, result);
+    }
+
+    /// Keeps the latest completed title-generation task for one session.
+    fn collect_session_title_generation_finished(
+        &mut self,
+        session_id: SessionId,
+        generation: u64,
+    ) {
+        self.session_title_generation_finished
+            .insert(session_id, generation);
     }
 
     /// Keeps the freshest assigned-issue result when one batch contains
@@ -1052,6 +1078,10 @@ impl App {
         self.apply_batch_session_snapshot_updates(&mut event_batch);
         self.apply_app_event_effects(after_snapshot_effects).await;
 
+        self.apply_branch_publish_starts(std::mem::take(
+            &mut event_batch.branch_publish_started_session_ids,
+        ));
+
         for branch_publish_action_update in
             std::mem::take(&mut event_batch.branch_publish_action_updates)
         {
@@ -1139,6 +1169,16 @@ impl App {
 
         if should_mark_dirty {
             self.mark_dirty();
+        }
+    }
+
+    /// Replaces queued review-request labels when their worker actions start.
+    fn apply_branch_publish_starts(&mut self, session_ids: HashSet<SessionId>) {
+        for session_id in session_ids {
+            self.sessions.start_branch_publish(
+                &session_id,
+                Self::branch_publish_loading_label(PublishBranchAction::PublishPullRequest),
+            );
         }
     }
 

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -15,7 +15,8 @@ use ag_git::{GitClient, GitError, RealGitClient};
 #[cfg(test)]
 use app::branch_publish::detected_forge_kind_from_git_push_error;
 use app::branch_publish::{
-    BranchPublishTaskContext, BranchPublishTaskSession, run_branch_publish_action,
+    BranchPublishTaskContext, BranchPublishTaskSession, review_request_queued_label,
+    run_branch_publish_action,
 };
 #[cfg(test)]
 use app::branch_publish::{BranchPublishTaskFailure, branch_push_failure, push_session_branch};
@@ -1568,7 +1569,7 @@ impl App {
     }
 
     /// Starts the session-view branch-publish action flow for one session.
-    pub(crate) fn start_publish_branch_action(
+    pub(crate) async fn start_publish_branch_action(
         &mut self,
         restore_view: ConfirmationViewMode,
         session_id: &str,
@@ -1586,6 +1587,44 @@ impl App {
 
             return;
         };
+
+        if publish_branch_action == PublishBranchAction::PublishPullRequest {
+            let is_queued = branch_publish_context.session.status == Status::InProgress;
+            let branch_operation_lock = Arc::clone(&branch_publish_context.branch_operation_lock);
+            // Reserve an idle branch before persistence. An existing owner
+            // already serializes worker execution, so the UI never waits here.
+            let _branch_operation_guard = branch_operation_lock.try_lock_owned().ok();
+            let enqueue_result = self
+                .sessions
+                .enqueue_review_request_creation(
+                    &self.services,
+                    branch_publish_context.session,
+                    remote_branch_name,
+                    None,
+                )
+                .await;
+            let loading_label = if is_queued {
+                review_request_queued_label()
+            } else {
+                Self::branch_publish_loading_label(publish_branch_action)
+            };
+            if let Err(error) = enqueue_result {
+                self.sessions
+                    .start_branch_publish(session_id, loading_label);
+                self.sessions.finish_branch_publish(
+                    session_id,
+                    TransientMessageBody::Markdown(format!(
+                        "**Review request publish failed**\n\n{error}"
+                    )),
+                );
+            } else {
+                self.sessions
+                    .start_branch_publish(session_id, loading_label);
+            }
+            self.mode = restore_view.into_view_mode();
+
+            return;
+        }
 
         let loading_label = Self::branch_publish_loading_label(publish_branch_action);
         let clock = self.services.clock();

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -1717,6 +1717,168 @@ async fn manual_branch_publish_waits_for_existing_branch_operation() {
 }
 
 #[tokio::test]
+async fn review_request_enqueue_does_not_wait_for_existing_branch_operation() {
+    // Arrange
+    let (mut app, _temp_dir) = crate::test_support::new_git_test_app().await;
+    let session_id = app
+        .create_session()
+        .await
+        .expect("session should be created");
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::Done);
+    let branch_operation_lock = Arc::clone(
+        &app.sessions
+            .session_handles_or_err(&session_id)
+            .expect("expected session handles")
+            .branch_operation_lock,
+    );
+    let existing_operation_guard = Arc::clone(&branch_operation_lock).lock_owned().await;
+    let restore_view = ConfirmationViewMode {
+        scroll_offset: None,
+        session_id: session_id.clone().into(),
+    };
+
+    // Act
+    let enqueue_result = tokio::time::timeout(
+        Duration::from_secs(1),
+        app.start_publish_branch_action(
+            restore_view,
+            &session_id,
+            PublishBranchAction::PublishPullRequest,
+            None,
+        ),
+    )
+    .await;
+    let publish_label = app.sessions.state().sessions()[0]
+        .transient_messages
+        .get(crate::domain::transient_message::TransientMessageSlot::BranchPublish)
+        .map(|message| message.body.text().to_string());
+    drop(existing_operation_guard);
+
+    // Assert
+    assert!(
+        enqueue_result.is_ok(),
+        "queueing should not wait for the existing branch operation"
+    );
+    assert_eq!(
+        publish_label.as_deref(),
+        Some("Publishing review request...")
+    );
+}
+
+#[tokio::test]
+async fn review_request_enqueue_failure_replaces_queued_status_with_error() {
+    // Arrange
+    let (mut app, _temp_dir) = crate::test_support::new_git_test_app().await;
+    let session_id = app
+        .create_session()
+        .await
+        .expect("session should be created");
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::InProgress);
+    let restore_view = ConfirmationViewMode {
+        scroll_offset: Some(3),
+        session_id: session_id.clone().into(),
+    };
+
+    // Act
+    app.start_publish_branch_action(
+        restore_view,
+        &session_id,
+        PublishBranchAction::PublishPullRequest,
+        None,
+    )
+    .await;
+    let publish_body = app
+        .sessions
+        .state()
+        .sessions()
+        .iter()
+        .find(|session| session.id == session_id)
+        .and_then(|session| {
+            session
+                .transient_messages
+                .get(crate::domain::transient_message::TransientMessageSlot::BranchPublish)
+        })
+        .map(|message| message.body.text().to_string());
+
+    // Assert
+    assert!(matches!(
+        app.mode,
+        AppMode::View {
+            session_id: ref viewed_session_id,
+            scroll_offset: Some(3),
+        } if viewed_session_id == &session_id
+    ));
+    assert!(
+        publish_body
+            .as_deref()
+            .is_some_and(|body| body.contains("**Review request publish failed**"))
+    );
+    assert!(
+        publish_body
+            .as_deref()
+            .is_some_and(|body| body.contains("active session worker is unavailable"))
+    );
+}
+
+#[tokio::test]
+async fn push_action_still_dispatches_through_background_publish_path() {
+    // Arrange
+    let (mut app, _temp_dir) = crate::test_support::new_git_test_app().await;
+    let session_id = app
+        .create_session()
+        .await
+        .expect("session should be created");
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::InProgress);
+    let restore_view = ConfirmationViewMode {
+        scroll_offset: Some(5),
+        session_id: session_id.clone().into(),
+    };
+    let pending_git_status_event =
+        tokio::time::timeout(Duration::from_secs(1), app.next_app_event())
+            .await
+            .expect("pending git status event should arrive")
+            .expect("app event channel should remain open");
+    assert!(matches!(
+        pending_git_status_event,
+        AppEvent::GitStatusUpdated { .. }
+    ));
+
+    // Act
+    app.start_publish_branch_action(restore_view, &session_id, PublishBranchAction::Push, None)
+        .await;
+    let completion_event = tokio::time::timeout(Duration::from_secs(1), app.next_app_event())
+        .await
+        .expect("background branch publish should complete")
+        .expect("app event channel should remain open");
+    let publish_label = app.sessions.state().sessions()[0]
+        .transient_messages
+        .get(crate::domain::transient_message::TransientMessageSlot::BranchPublish)
+        .map(|message| message.body.text());
+
+    // Assert
+    assert!(matches!(
+        app.mode,
+        AppMode::View {
+            session_id: ref viewed_session_id,
+            scroll_offset: Some(5),
+        } if viewed_session_id == &session_id
+    ));
+    assert_eq!(publish_label, Some("Pushing branch..."));
+    assert!(matches!(
+        completion_event,
+        AppEvent::BranchPublishActionCompleted {
+            result,
+            session_id: completed_session_id,
+        } if completed_session_id == session_id
+            && matches!(
+                *result,
+                Err(BranchPublishTaskFailure { ref message, .. })
+                    if message == "Session must be in review to push the branch."
+            )
+    ));
+}
+
+#[tokio::test]
 async fn branch_publish_task_context_targets_stacked_parent_review_source_branch() {
     // Arrange
     let mut app = crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(
@@ -2079,6 +2241,37 @@ async fn apply_branch_publish_action_update_persists_pull_request_notice() {
             .first()
             .and_then(|session| session.review_request.clone()),
         Some(review_request)
+    );
+}
+
+#[tokio::test]
+async fn apply_branch_publish_started_replaces_queued_label() {
+    // Arrange
+    let session_folder = tempdir().expect("failed to create temp dir");
+    let mut app = new_test_app_with_selected_session(
+        session_folder.path().to_path_buf(),
+        "",
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    app.sessions.start_branch_publish(
+        "session-1",
+        "Review request queued; publishing after the current turn finishes...".to_string(),
+    );
+
+    // Act
+    app.apply_app_events(AppEvent::BranchPublishActionStarted {
+        session_id: "session-1".into(),
+    })
+    .await;
+
+    // Assert
+    assert_eq!(
+        app.sessions.state().sessions()[0]
+            .transient_messages
+            .get(crate::domain::transient_message::TransientMessageSlot::BranchPublish)
+            .map(|message| message.body.text()),
+        Some("Publishing review request...")
     );
 }
 
@@ -2883,6 +3076,9 @@ fn app_event_batch_collect_event_keeps_publish_results_and_latest_reviews() {
         result: Box::new(Ok(test_pushed_branch_result("feature/final"))),
         session_id: "session-b".into(),
     });
+    event_batch.collect_event(AppEvent::BranchPublishActionStarted {
+        session_id: "session-a".into(),
+    });
 
     // Assert
     assert_eq!(
@@ -2911,6 +3107,11 @@ fn app_event_batch_collect_event_keeps_publish_results_and_latest_reviews() {
                 session_id: "session-b".into(),
             },
         ]
+    );
+    assert!(
+        event_batch
+            .branch_publish_started_session_ids
+            .contains("session-a")
     );
     assert!(event_batch.should_refresh_git_status);
 }

--- a/crates/agentty/src/app/service.rs
+++ b/crates/agentty/src/app/service.rs
@@ -334,6 +334,7 @@ fn app_event_label(event: &AppEvent) -> &'static str {
         AppEvent::SessionDiffStatsUpdated { .. } => "SessionDiffStatsUpdated",
         AppEvent::SessionTitleGenerationFinished { .. } => "SessionTitleGenerationFinished",
         AppEvent::BranchPublishActionCompleted { .. } => "BranchPublishActionCompleted",
+        AppEvent::BranchPublishActionStarted { .. } => "BranchPublishActionStarted",
         AppEvent::ReviewPrepared { .. } => "ReviewPrepared",
         AppEvent::ReviewPreparationFailed { .. } => "ReviewPreparationFailed",
         AppEvent::FocusedReviewPersistenceRetry { .. } => "FocusedReviewPersistenceRetry",
@@ -439,6 +440,20 @@ mod tests {
 
         // Assert
         assert_eq!(label, "SessionOrchestrationProgressUpdated");
+    }
+
+    #[test]
+    fn app_event_label_names_branch_publish_starts() {
+        // Arrange
+        let event = AppEvent::BranchPublishActionStarted {
+            session_id: "session-id".into(),
+        };
+
+        // Act
+        let label = app_event_label(&event);
+
+        // Assert
+        assert_eq!(label, "BranchPublishActionStarted");
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/session/workflow/post_turn.rs
+++ b/crates/agentty/src/app/session/workflow/post_turn.rs
@@ -14,7 +14,7 @@ use tokio::sync::mpsc;
 use tracing::warn;
 
 use super::task::SessionTranscriptMessageAppend;
-use super::worker::{SessionWorkerContext, TurnMetadata, has_unfinished_rebase_operation};
+use super::worker::{SessionWorkerContext, TurnMetadata, has_unfinished_branch_operation};
 use super::{SessionTaskService, StatusTransition, published_branch};
 use crate::app::assist::AssistContext;
 use crate::app::service::SessionUpdateVersionMap;
@@ -108,7 +108,7 @@ impl PostTurnContext {
 
     /// Returns whether session sync is already queued or running on this
     /// worker, failing closed when persisted operation state cannot be read.
-    async fn has_unfinished_rebase_operation(&self) -> bool {
+    async fn has_unfinished_branch_operation(&self) -> bool {
         let unfinished_operations = match self
             .db
             .operations()
@@ -127,7 +127,7 @@ impl PostTurnContext {
             }
         };
 
-        has_unfinished_rebase_operation(&unfinished_operations, self.session_id.as_str())
+        has_unfinished_branch_operation(&unfinished_operations, self.session_id.as_str())
     }
 }
 
@@ -591,7 +591,7 @@ async fn start_published_branch_auto_push(
     let branch_operation_guard = Arc::clone(&context.branch_operation_lock)
         .lock_owned()
         .await;
-    if context.has_unfinished_rebase_operation().await {
+    if context.has_unfinished_branch_operation().await {
         return;
     }
 
@@ -799,7 +799,7 @@ mod tests {
         };
 
         // Act
-        let should_skip_auto_push = context.has_unfinished_rebase_operation().await;
+        let should_skip_auto_push = context.has_unfinished_branch_operation().await;
 
         // Assert
         assert!(

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -15,7 +15,7 @@ use ag_git::GitClient;
 use ag_protocol::AgentResponse;
 #[cfg(test)]
 use ag_protocol::AgentResponseSummary;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -24,11 +24,15 @@ use super::merge::{
 };
 use super::task::SessionTranscriptMessageAppend;
 use super::{SessionTaskService, isolation, session_folder, turn};
+use crate::app::branch_publish::{
+    BranchPublishTaskContext, BranchPublishTaskSession, review_request_from_publish_result,
+    run_branch_publish_action,
+};
 use crate::app::service::SessionUpdateVersionMap;
 use crate::app::session::{Clock, SessionError, unix_timestamp_from_system_time};
 use crate::app::{AppEvent, AppServices, SessionManager};
 use crate::domain::agent::AgentSelection;
-use crate::domain::session::{SessionId, SessionStats, Status};
+use crate::domain::session::{PublishBranchAction, ReviewRequest, SessionId, SessionStats, Status};
 use crate::domain::session_message::{SessionMessageKind, SessionTranscript};
 use crate::domain::turn_prompt::TurnPrompt;
 use crate::infra::db::{AppRepositories, OperationRepository, SessionOperationRow};
@@ -38,7 +42,18 @@ use crate::infra::process;
 
 const RESTART_FAILURE_REASON: &str = "Interrupted by app restart";
 const CANCEL_BEFORE_EXECUTION_REASON: &str = "Session canceled before execution";
+const CREATE_REVIEW_REQUEST_OPERATION_KIND: &str = "create_review_request";
 const REBASE_OPERATION_KIND: &str = "rebase";
+const SKIPPED_CREATE_REVIEW_REQUEST_REASON: &str =
+    "Review-request creation was canceled or already finished before execution";
+
+/// Shared completion slot used by programmatic review-request callers.
+///
+/// The runtime retains a clone while handing the command to the worker so an
+/// enqueue failure can still answer the caller instead of dropping the
+/// response channel with an ambiguous runtime-unavailable error.
+pub(super) type ReviewRequestResponse =
+    Arc<Mutex<Option<oneshot::Sender<Result<ReviewRequest, ag_session::SessionError>>>>>;
 
 /// Per-turn data captured at enqueue time that travels alongside the channel
 /// turn but is consumed only after turn completion.
@@ -65,6 +80,19 @@ pub(super) struct TurnMetadata {
 /// `StartPrompt`, `StartPromptAppServer`) with a single provider-agnostic
 /// variant. The underlying channel adapter handles transport-specific details.
 pub(super) enum SessionCommand {
+    /// Publishes the session branch and creates or refreshes its forge review
+    /// request after earlier work on this worker has completed.
+    CreateReviewRequest {
+        /// Session snapshot captured when the action was accepted.
+        branch_publish_session: BranchPublishTaskSession,
+        /// Persisted operation identifier.
+        operation_id: String,
+        /// Optional user-selected remote branch name.
+        remote_branch_name: Option<String>,
+        /// Optional programmatic caller waiting for the resulting review
+        /// request.
+        response: Option<ReviewRequestResponse>,
+    },
     /// Runs the session branch rebase workflow through this worker so
     /// conflict-resolution prompts reuse the active provider conversation.
     Rebase {
@@ -92,13 +120,16 @@ impl SessionCommand {
     /// Returns the persisted operation identifier for this command.
     fn operation_id(&self) -> &str {
         match self {
-            Self::Rebase { operation_id, .. } | Self::Run { operation_id, .. } => operation_id,
+            Self::CreateReviewRequest { operation_id, .. }
+            | Self::Rebase { operation_id, .. }
+            | Self::Run { operation_id, .. } => operation_id,
         }
     }
 
     /// Returns the operation kind persisted in the operations table.
     fn kind(&self) -> &'static str {
         match self {
+            Self::CreateReviewRequest { .. } => CREATE_REVIEW_REQUEST_OPERATION_KIND,
             Self::Rebase { .. } => REBASE_OPERATION_KIND,
             Self::Run {
                 request_kind: AgentRequestKind::SessionStart,
@@ -127,6 +158,21 @@ pub(super) fn has_unfinished_rebase_operation(
 ) -> bool {
     operations.iter().any(|operation| {
         operation.session_id == session_id && operation.kind == REBASE_OPERATION_KIND
+    })
+}
+
+/// Returns whether the session has a queued or running branch operation that
+/// must run before automatic post-turn publishing.
+pub(super) fn has_unfinished_branch_operation(
+    operations: &[SessionOperationRow],
+    session_id: &str,
+) -> bool {
+    operations.iter().any(|operation| {
+        operation.session_id == session_id
+            && matches!(
+                operation.kind.as_str(),
+                CREATE_REVIEW_REQUEST_OPERATION_KIND | REBASE_OPERATION_KIND
+            )
     })
 }
 
@@ -665,7 +711,7 @@ impl SessionWorkerService {
     ) -> Result<(), SessionError> {
         let sender = self.workers.get(session_id).cloned().ok_or_else(|| {
             SessionError::Workflow(
-                "Cannot queue session sync because the active session worker is unavailable"
+                "Cannot queue session action because the active session worker is unavailable"
                     .to_string(),
             )
         })?;
@@ -841,16 +887,21 @@ impl SessionWorkerService {
         command: SessionCommand,
     ) -> Option<Result<(), SessionError>> {
         let operation_id = command.operation_id().to_string();
-        if Self::should_skip_worker_command(context, &operation_id).await {
-            return None;
-        }
-        // Best-effort: operation tracking metadata is non-critical.
-        let _ = context
-            .db
-            .operations()
-            .mark_session_operation_running(&operation_id)
-            .await;
-        if Self::should_skip_worker_command(context, &operation_id).await {
+        let should_skip = if Self::should_skip_worker_command(context, &operation_id).await {
+            true
+        } else {
+            // Best-effort: operation tracking metadata is non-critical.
+            let _ = context
+                .db
+                .operations()
+                .mark_session_operation_running(&operation_id)
+                .await;
+
+            Self::should_skip_worker_command(context, &operation_id).await
+        };
+        if should_skip {
+            Self::complete_skipped_review_request_response(&command);
+
             return None;
         }
 
@@ -875,6 +926,22 @@ impl SessionWorkerService {
         }
 
         Some(result)
+    }
+
+    /// Answers a programmatic review-request caller when its queued command
+    /// is canceled or otherwise finished before worker execution begins.
+    fn complete_skipped_review_request_response(command: &SessionCommand) {
+        if let SessionCommand::CreateReviewRequest {
+            response: Some(response),
+            ..
+        } = command
+            && let Ok(mut response) = response.lock()
+            && let Some(response_tx) = response.take()
+        {
+            let _ = response_tx.send(Err(ag_session::SessionError::Operation(
+                SKIPPED_CREATE_REVIEW_REQUEST_REASON.to_string(),
+            )));
+        }
     }
 
     /// Pops queued prompts and dispatches them as follow-up `SessionResume`
@@ -960,6 +1027,20 @@ impl SessionWorkerService {
         command: SessionCommand,
     ) -> Result<(), SessionError> {
         match command {
+            SessionCommand::CreateReviewRequest {
+                branch_publish_session,
+                remote_branch_name,
+                response,
+                ..
+            } => {
+                Self::run_create_review_request_command(
+                    context,
+                    branch_publish_session,
+                    remote_branch_name,
+                    response,
+                )
+                .await
+            }
             SessionCommand::Rebase { base_branch, .. } => {
                 Self::run_rebase_command(context, Arc::clone(one_shot_client), base_branch).await
             }
@@ -981,6 +1062,57 @@ impl SessionWorkerService {
                 .await
             }
         }
+    }
+
+    /// Publishes one review request inside the serialized session worker.
+    ///
+    /// The live status is applied at execution time so an action accepted
+    /// during `InProgress` observes the completed turn's review-ready state
+    /// instead of the enqueue-time snapshot.
+    async fn run_create_review_request_command(
+        context: &SessionWorkerContext,
+        mut branch_publish_session: BranchPublishTaskSession,
+        remote_branch_name: Option<String>,
+        response: Option<ReviewRequestResponse>,
+    ) -> Result<(), SessionError> {
+        branch_publish_session.status = context.current_status();
+        let _ = context
+            .app_event_tx
+            .send(AppEvent::BranchPublishActionStarted {
+                session_id: context.session_id.clone(),
+            });
+        let result = run_branch_publish_action(
+            PublishBranchAction::PublishPullRequest,
+            BranchPublishTaskContext {
+                branch_operation_lock: Arc::clone(&context.branch_operation_lock),
+                session: branch_publish_session,
+            },
+            context.db.clone(),
+            Arc::clone(&context.clock),
+            Arc::clone(&context.git_client),
+            Arc::clone(&context.review_request_client),
+            remote_branch_name,
+        )
+        .await;
+        let response_result = review_request_from_publish_result(&result)
+            .map_err(ag_session::SessionError::Operation);
+        let command_result = review_request_from_publish_result(&result)
+            .map(|_| ())
+            .map_err(SessionError::Workflow);
+        let _ = context
+            .app_event_tx
+            .send(AppEvent::BranchPublishActionCompleted {
+                result: Box::new(result),
+                session_id: context.session_id.clone(),
+            });
+        if let Some(response) = response
+            && let Ok(mut response) = response.lock()
+            && let Some(response_tx) = response.take()
+        {
+            let _ = response_tx.send(response_result);
+        }
+
+        command_result
     }
 
     /// Runs the session rebase command inside this worker's serialized queue.
@@ -1123,6 +1255,49 @@ impl SessionManager {
         self.worker_service_mut()
             .enqueue_session_command_idempotently(services, runtime, command)
             .await
+    }
+
+    /// Persists and queues review-request creation on one session worker.
+    ///
+    /// Running sessions must already own a worker so stale status cannot
+    /// create a concurrent executor. Review-ready sessions lazily create a
+    /// worker and execute the action immediately.
+    ///
+    /// # Errors
+    /// Returns an error when operation persistence or worker delivery fails.
+    pub(crate) async fn enqueue_review_request_creation(
+        &mut self,
+        services: &AppServices,
+        branch_publish_session: BranchPublishTaskSession,
+        remote_branch_name: Option<String>,
+        response_tx: Option<oneshot::Sender<Result<ReviewRequest, ag_session::SessionError>>>,
+    ) -> Result<(), SessionError> {
+        let session_id = branch_publish_session.id.clone();
+        let status = branch_publish_session.status;
+        let response = response_tx.map(|response_tx| Arc::new(Mutex::new(Some(response_tx))));
+        let command = SessionCommand::CreateReviewRequest {
+            branch_publish_session,
+            operation_id: Uuid::new_v4().to_string(),
+            remote_branch_name,
+            response: response.clone(),
+        };
+        let result = if status == Status::InProgress {
+            self.worker_service_mut()
+                .enqueue_existing_session_command(services, &session_id, command)
+                .await
+        } else {
+            self.enqueue_session_command(services, &session_id, command)
+                .await
+        };
+        if let Err(error) = &result
+            && let Some(response) = response
+            && let Ok(mut response) = response.lock()
+            && let Some(response_tx) = response.take()
+        {
+            let _ = response_tx.send(Err(ag_session::SessionError::Operation(error.to_string())));
+        }
+
+        result
     }
 
     /// Drops the in-memory worker sender for a session.
@@ -1460,6 +1635,19 @@ mod tests {
     /// operation labels.
     fn test_session_command_kind_values() {
         // Arrange
+        let review_request_command = SessionCommand::CreateReviewRequest {
+            branch_publish_session: BranchPublishTaskSession {
+                base_branch: "main".to_string(),
+                folder: PathBuf::new(),
+                id: "sess1".into(),
+                published_upstream_ref: None,
+                review_request: None,
+                status: Status::Review,
+            },
+            operation_id: "op-review-request".to_string(),
+            remote_branch_name: None,
+            response: None,
+        };
         let start_command = SessionCommand::Run {
             operation_id: "op-start".to_string(),
             request_kind: AgentRequestKind::SessionStart,
@@ -1504,14 +1692,159 @@ mod tests {
         };
 
         // Act
+        let review_request_kind = review_request_command.kind();
         let start_kind = start_command.kind();
         let resume_kind = resume_command.kind();
         let account_read_kind = account_read_command.kind();
 
         // Assert
+        assert_eq!(review_request_kind, "create_review_request");
         assert_eq!(start_kind, "start_prompt");
         assert_eq!(resume_kind, "reply");
         assert_eq!(account_read_kind, "account_read");
+    }
+
+    #[test]
+    fn test_unfinished_branch_operation_includes_review_request_creation() {
+        // Arrange
+        let operations = vec![SessionOperationRow {
+            cancel_requested: false,
+            finished_at: None,
+            heartbeat_at: None,
+            id: "op-review-request".to_string(),
+            kind: CREATE_REVIEW_REQUEST_OPERATION_KIND.to_string(),
+            last_error: None,
+            queued_at: 0,
+            session_id: "sess1".to_string(),
+            started_at: None,
+            status: "queued".to_string(),
+        }];
+
+        // Act
+        let has_branch_operation = has_unfinished_branch_operation(&operations, "sess1");
+        let other_session_has_branch_operation =
+            has_unfinished_branch_operation(&operations, "sess2");
+
+        // Assert
+        assert!(has_branch_operation);
+        assert!(!other_session_has_branch_operation);
+    }
+
+    #[tokio::test]
+    async fn test_create_review_request_command_waits_for_live_review_status() {
+        // Arrange
+        let (mut context, _db, _queue, _base_dir) =
+            queue_test_context(MockAgentChannel::new(), VecDeque::new(), Status::Done).await;
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        context.app_event_tx = app_event_tx;
+        let (response_tx, response_rx) = oneshot::channel();
+        let command = SessionCommand::CreateReviewRequest {
+            branch_publish_session: BranchPublishTaskSession {
+                base_branch: "main".to_string(),
+                folder: context.folder.clone(),
+                id: context.session_id.clone(),
+                published_upstream_ref: None,
+                review_request: None,
+                status: Status::InProgress,
+            },
+            operation_id: "op-review-request".to_string(),
+            remote_branch_name: None,
+            response: Some(Arc::new(Mutex::new(Some(response_tx)))),
+        };
+
+        // Act
+        let result = SessionWorkerService::execute_session_command(
+            &context,
+            &auto_commit_one_shot_client(),
+            command,
+        )
+        .await;
+        let response = response_rx
+            .await
+            .expect("review-request response should be delivered");
+        let started_event = app_event_rx
+            .recv()
+            .await
+            .expect("publish-start event should be emitted");
+        let completed_event = app_event_rx
+            .recv()
+            .await
+            .expect("publish-complete event should be emitted");
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(SessionError::Workflow(message))
+                if message == "Session must be in review to publish the review request."
+        ));
+        assert_eq!(
+            response,
+            Err(ag_session::SessionError::Operation(
+                "Session must be in review to publish the review request.".to_string()
+            ))
+        );
+        assert!(matches!(
+            started_event,
+            AppEvent::BranchPublishActionStarted { session_id } if session_id == "sess1"
+        ));
+        assert!(matches!(
+            completed_event,
+            AppEvent::BranchPublishActionCompleted { result, session_id }
+                if result.is_err() && session_id == "sess1"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_skipped_review_request_command_answers_programmatic_caller() {
+        // Arrange
+        let (context, db, _queue, _base_dir) =
+            queue_test_context(MockAgentChannel::new(), VecDeque::new(), Status::Review).await;
+        db.operations()
+            .insert_session_operation(
+                "op-review-request",
+                &context.session_id,
+                CREATE_REVIEW_REQUEST_OPERATION_KIND,
+            )
+            .await
+            .expect("review-request operation should be inserted");
+        db.operations()
+            .request_cancel_for_session_operations(&context.session_id)
+            .await
+            .expect("review-request operation should be canceled");
+        let (response_tx, response_rx) = oneshot::channel();
+        let command = SessionCommand::CreateReviewRequest {
+            branch_publish_session: BranchPublishTaskSession {
+                base_branch: "main".to_string(),
+                folder: context.folder.clone(),
+                id: context.session_id.clone(),
+                published_upstream_ref: None,
+                review_request: None,
+                status: Status::Review,
+            },
+            operation_id: "op-review-request".to_string(),
+            remote_branch_name: None,
+            response: Some(Arc::new(Mutex::new(Some(response_tx)))),
+        };
+
+        // Act
+        let command_result = SessionWorkerService::process_session_command(
+            &context,
+            &auto_commit_one_shot_client(),
+            command,
+        )
+        .await;
+        let response = response_rx
+            .await
+            .expect("skipped review-request response should be delivered");
+
+        // Assert
+        assert!(command_result.is_none());
+        assert_eq!(
+            response,
+            Err(ag_session::SessionError::Operation(
+                SKIPPED_CREATE_REVIEW_REQUEST_REASON.to_string()
+            ))
+        );
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/session_api.rs
+++ b/crates/agentty/src/app/session_api.rs
@@ -13,12 +13,11 @@ use ag_session::{
     SessionRole, SessionService, SessionSettings, SessionStatus,
 };
 use async_trait::async_trait;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::oneshot;
 
-use crate::app::branch_publish::{
-    BranchPublishTaskFailure, BranchPublishTaskResult, BranchPublishTaskSuccess,
-    branch_publish_loading_label, run_branch_publish_action,
-};
+#[cfg(test)]
+use crate::app::branch_publish::{BranchPublishTaskSuccess, review_request_from_publish_result};
+use crate::app::branch_publish::{branch_publish_loading_label, review_request_queued_label};
 use crate::app::orchestration::{OrchestrationApprovalOutcome, child_session_is_stopped};
 use crate::app::session::{
     SessionCreationKind, SessionCreationSettings, migrate_session_off_retired_model,
@@ -227,14 +226,16 @@ impl App {
                 response_tx,
                 session_id,
             } => {
-                self.start_api_review_request_publish(session_id, access, response_tx);
+                self.start_api_review_request_publish(session_id, access, response_tx)
+                    .await;
             }
         }
     }
 
-    /// Starts review-request publishing on the detached branch-publish
-    /// workflow and leaves the foreground command loop available.
-    fn start_api_review_request_publish(
+    /// Queues review-request publishing on the session worker and leaves the
+    /// foreground command loop available while the API caller awaits the
+    /// worker result.
+    async fn start_api_review_request_publish(
         &mut self,
         session_id: SessionId,
         access: SessionRuntimeAccess,
@@ -262,26 +263,36 @@ impl App {
 
             return;
         };
-        let clock = self.services.clock();
-        let db = self.services.db().clone();
-        let event_sender = self.services.event_sender();
-        let git_client = self.services.git_client();
-        let review_request_client = self.services.review_request_client();
-        let publish_future = run_branch_publish_action(
-            PublishBranchAction::PublishPullRequest,
-            branch_publish_context,
-            db,
-            clock,
-            git_client,
-            review_request_client,
-            None,
-        );
-
-        self.sessions.start_branch_publish(
-            &session_id,
-            branch_publish_loading_label(PublishBranchAction::PublishPullRequest),
-        );
-        spawn_api_review_request_publish(publish_future, event_sender, response_tx, session_id);
+        let is_queued =
+            branch_publish_context.session.status == crate::domain::session::Status::InProgress;
+        let branch_operation_lock = Arc::clone(&branch_publish_context.branch_operation_lock);
+        // Reserve an idle branch before persistence. An existing owner
+        // already serializes worker execution, so the runtime actor never waits here.
+        let _branch_operation_guard = branch_operation_lock.try_lock_owned().ok();
+        let enqueue_result = self
+            .sessions
+            .enqueue_review_request_creation(
+                &self.services,
+                branch_publish_context.session,
+                None,
+                Some(response_tx),
+            )
+            .await;
+        let loading_label = if is_queued {
+            review_request_queued_label()
+        } else {
+            branch_publish_loading_label(PublishBranchAction::PublishPullRequest)
+        };
+        self.sessions
+            .start_branch_publish(&session_id, loading_label);
+        if let Err(error) = enqueue_result {
+            self.sessions.finish_branch_publish(
+                &session_id,
+                crate::domain::transient_message::TransientMessageBody::Markdown(format!(
+                    "**Review request publish failed**\n\n{error}"
+                )),
+            );
+        }
     }
 
     /// Creates one API-requested session, validating project relationships and
@@ -927,42 +938,6 @@ struct InheritedCreationSettings {
     settings: SessionCreationSettings,
 }
 
-/// Spawns one review-request publish future and routes its result to both the
-/// app reducer and the original API caller.
-fn spawn_api_review_request_publish(
-    publish_future: impl Future<Output = BranchPublishTaskResult> + Send + 'static,
-    event_sender: mpsc::UnboundedSender<AppEvent>,
-    response_tx: oneshot::Sender<Result<ReviewRequest, ApiSessionError>>,
-    session_id: SessionId,
-) {
-    tokio::spawn(async move {
-        let result = publish_future.await;
-        let response_result = api_review_request_result(&result);
-        let _ = event_sender.send(AppEvent::BranchPublishActionCompleted {
-            result: Box::new(result),
-            session_id,
-        });
-        let _ = response_tx.send(response_result);
-    });
-}
-
-/// Converts one branch-publish task result into the public API result.
-fn api_review_request_result(
-    result: &BranchPublishTaskResult,
-) -> Result<ReviewRequest, ApiSessionError> {
-    match result {
-        Ok(BranchPublishTaskSuccess::PullRequestPublished { review_request, .. }) => {
-            Ok(review_request.clone())
-        }
-        Ok(BranchPublishTaskSuccess::Pushed { .. }) => Err(ApiSessionError::Operation(
-            "Review-request publishing completed without a review request".to_string(),
-        )),
-        Err(BranchPublishTaskFailure { message, .. }) => {
-            Err(ApiSessionError::Operation(message.clone()))
-        }
-    }
-}
-
 /// Combines a rejected question answer with a subsequent persistence failure.
 fn question_restore_error(
     send_error: &ApiSessionError,
@@ -1542,84 +1517,16 @@ mod tests {
         });
 
         // Act
-        let published_review_request = api_review_request_result(&published_result);
-        let pushed_error = api_review_request_result(&pushed_result)
+        let published_review_request = review_request_from_publish_result(&published_result);
+        let pushed_error = review_request_from_publish_result(&pushed_result)
             .expect_err("a plain branch-push result should not satisfy the API request");
 
         // Assert
         assert_eq!(published_review_request, Ok(review_request));
         assert_eq!(
             pushed_error,
-            ApiSessionError::Operation(
-                "Review-request publishing completed without a review request".to_string()
-            )
+            "Review-request publishing completed without a review request".to_string()
         );
-    }
-
-    #[tokio::test]
-    async fn api_review_request_publish_runs_detached_from_its_caller() {
-        // Arrange
-        let publish_started = Arc::new(tokio::sync::Notify::new());
-        let publish_release = Arc::new(tokio::sync::Notify::new());
-        let publish_future = {
-            let publish_started = Arc::clone(&publish_started);
-            let publish_release = Arc::clone(&publish_release);
-
-            async move {
-                publish_started.notify_one();
-                publish_release.notified().await;
-
-                Err(BranchPublishTaskFailure::failed(
-                    PublishBranchAction::PublishPullRequest,
-                    "simulated publish failure".to_string(),
-                ))
-            }
-        };
-        let (event_sender, mut event_receiver) = mpsc::unbounded_channel();
-        let (response_tx, mut response_rx) = oneshot::channel();
-
-        // Act
-        spawn_api_review_request_publish(
-            publish_future,
-            event_sender,
-            response_tx,
-            SessionId::from("session-1"),
-        );
-        tokio::time::timeout(
-            std::time::Duration::from_secs(1),
-            publish_started.notified(),
-        )
-        .await
-        .expect("publish task should start");
-        let pending_response = response_rx.try_recv();
-        publish_release.notify_one();
-        let response = tokio::time::timeout(std::time::Duration::from_secs(1), response_rx)
-            .await
-            .expect("publish response should arrive")
-            .expect("publish response sender should stay available");
-        let event = tokio::time::timeout(std::time::Duration::from_secs(1), event_receiver.recv())
-            .await
-            .expect("publish event should arrive")
-            .expect("publish event sender should stay available");
-
-        // Assert
-        assert!(matches!(
-            pending_response,
-            Err(oneshot::error::TryRecvError::Empty)
-        ));
-        assert_eq!(
-            response,
-            Err(ApiSessionError::Operation(
-                "simulated publish failure".to_string()
-            ))
-        );
-        assert!(matches!(
-            event,
-            AppEvent::BranchPublishActionCompleted {
-                result,
-                session_id,
-            } if result.is_err() && session_id == "session-1"
-        ));
     }
 
     #[test]
@@ -1976,7 +1883,8 @@ mod tests {
             session_id.clone(),
             SessionRuntimeAccess::User,
             publish_tx,
-        );
+        )
+        .await;
         let publish_error = publish_rx
             .await
             .expect("publish result should be returned")
@@ -1996,6 +1904,96 @@ mod tests {
                     if message.contains("managed by an orchestration campaign")
             ));
         }
+    }
+
+    #[tokio::test]
+    async fn review_request_queue_rejects_stale_in_progress_session_without_worker() {
+        // Arrange
+        let (mut app, _temp_dir) = crate::test_support::new_git_test_app().await;
+        let project_id = app.active_project_id();
+        let session_id = request_session_creation(
+            &mut app,
+            CreateSessionRequest {
+                inherit_from_session_id: None,
+                mode: CreateSessionMode::Regular,
+                project_id,
+            },
+        )
+        .await
+        .expect("regular session should be created");
+        crate::test_support::set_session_status_for_test(
+            &mut app,
+            &session_id,
+            SessionStatus::InProgress,
+        );
+
+        // Act
+        let result = request_review_request(&mut app, session_id).await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(ApiSessionError::Operation(message))
+                if message.contains("active session worker is unavailable")
+        ));
+    }
+
+    #[tokio::test]
+    async fn review_request_runtime_handler_does_not_wait_for_branch_operation() {
+        // Arrange
+        let (mut app, _temp_dir) = crate::test_support::new_git_test_app().await;
+        let session_id = SessionId::from(
+            app.create_session()
+                .await
+                .expect("regular session should be created"),
+        );
+        crate::test_support::set_session_status_for_test(
+            &mut app,
+            &session_id,
+            SessionStatus::Done,
+        );
+        let branch_operation_lock = Arc::clone(
+            &app.sessions
+                .session_handles_or_err(&session_id)
+                .expect("expected session handles")
+                .branch_operation_lock,
+        );
+        let existing_operation_guard = Arc::clone(&branch_operation_lock).lock_owned().await;
+        let (response_tx, mut response_rx) = oneshot::channel();
+
+        // Act
+        let start_result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            app.start_api_review_request_publish(
+                session_id.clone(),
+                SessionRuntimeAccess::User,
+                response_tx,
+            ),
+        )
+        .await;
+        let response_before_unlock = response_rx.try_recv();
+        drop(existing_operation_guard);
+        let response_after_unlock = response_rx
+            .await
+            .expect("review-request result should be delivered after the lock is released");
+
+        // Assert
+        assert!(
+            start_result.is_ok(),
+            "runtime command handling should not wait for the branch operation"
+        );
+        assert!(matches!(
+            response_before_unlock,
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+        assert!(
+            matches!(
+                &response_after_unlock,
+                Err(ApiSessionError::Operation(message))
+                    if message == "Session must be in review to publish the review request."
+            ),
+            "unexpected review-request response: {response_after_unlock:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/session_runtime.rs
+++ b/crates/agentty/src/app/session_runtime.rs
@@ -70,8 +70,8 @@ pub(crate) enum SessionRuntimeCommand {
         response_tx: oneshot::Sender<Result<(), SessionError>>,
         session_id: SessionId,
     },
-    /// Publishes one session branch and creates or refreshes its review
-    /// request.
+    /// Queues publication of one session branch and creates or refreshes its
+    /// review request.
     CreateReviewRequest {
         access: SessionRuntimeAccess,
         response_tx: oneshot::Sender<Result<ReviewRequest, SessionError>>,
@@ -200,7 +200,8 @@ impl SessionRuntimeHandle {
         .await
     }
 
-    /// Creates or refreshes one review request through the runtime actor.
+    /// Queues creation or refresh of one review request through the runtime
+    /// actor.
     pub(crate) async fn create_review_request(
         &self,
         session_id: &SessionId,

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -574,7 +574,7 @@ impl Session {
     }
 
     /// Returns the review-request publish action currently available in session
-    /// view.
+    /// view, including queueing behind an active turn.
     pub fn publish_pull_request_action(&self) -> Option<PublishBranchAction> {
         let is_publish_active = self
             .transient_messages
@@ -583,7 +583,7 @@ impl Session {
 
         (self.accepts_user_turns()
             && self.owns_branch_changes()
-            && self.status.allows_review_actions()
+            && (self.status.allows_review_actions() || self.status == Status::InProgress)
             && !is_publish_active)
             .then_some(PublishBranchAction::PublishPullRequest)
     }
@@ -2119,7 +2119,7 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
     }
 
     #[test]
-    fn test_publish_pull_request_action_returns_none_for_in_progress_session() {
+    fn test_publish_pull_request_action_queues_for_in_progress_session() {
         // Arrange
         let session = Session {
             base_branch: "main".to_string(),
@@ -2162,7 +2162,7 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
         let action = session.publish_pull_request_action();
 
         // Assert
-        assert_eq!(action, None);
+        assert_eq!(action, Some(PublishBranchAction::PublishPullRequest));
     }
 
     #[test]

--- a/crates/agentty/src/runtime/key_handler.rs
+++ b/crates/agentty/src/runtime/key_handler.rs
@@ -46,7 +46,7 @@ where
     } else if matches!(app.mode, AppMode::LaunchConfigurationSelector { .. }) {
         handle_launch_configuration_selector_key(app, key).await
     } else if matches!(app.mode, AppMode::PublishBranchInput { .. }) {
-        Ok(handle_publish_branch_input_key(app, key))
+        Ok(handle_publish_branch_input_key(app, key).await)
     } else {
         match &app.mode {
             AppMode::List => mode::list::handle(app, key).await,
@@ -428,7 +428,7 @@ fn handle_view_info_popup_key(app: &mut App, key: KeyEvent) -> EventResult {
 /// Only `Esc` cancels the overlay. Plain character keys continue to edit the
 /// branch name so session-view shortcuts like `q` and `p` do not leak through
 /// while the text field has focus.
-fn handle_publish_branch_input_key(app: &mut App, key: KeyEvent) -> EventResult {
+async fn handle_publish_branch_input_key(app: &mut App, key: KeyEvent) -> EventResult {
     let publish_branch_input =
         PublishBranchInputModeState::from_mode(std::mem::replace(&mut app.mode, AppMode::List));
     let input_locked = publish_branch_input.locked_upstream_ref.is_some();
@@ -451,7 +451,8 @@ fn handle_publish_branch_input_key(app: &mut App, key: KeyEvent) -> EventResult 
                 &session_id,
                 publish_branch_input.publish_branch_action,
                 remote_branch_name,
-            );
+            )
+            .await;
         }
         _ if !input_locked => {
             app.mode = if let Some(command) = mode::input_key::command_for_key(
@@ -2061,6 +2062,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_handle_key_event_routes_publish_branch_input() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app_with_mock_tmux_client().await;
+        app.mode = AppMode::PublishBranchInput {
+            default_branch_name: "wt/session".to_string(),
+            input: crate::domain::input::InputState::with_text("review/custom".to_string()),
+            locked_upstream_ref: None,
+            publish_branch_action: crate::domain::session::PublishBranchAction::Push,
+            restore_view: ConfirmationViewMode {
+                scroll_offset: Some(7),
+                session_id: "session-id".into(),
+            },
+        };
+        let backend = ratatui::backend::TestBackend::new(120, 30);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+
+        // Act
+        let event_result = handle_key_event(
+            &mut app,
+            &PresentationState::default(),
+            &mut terminal,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(event_result, Ok(EventResult::Continue)));
+        assert!(matches!(
+            app.mode,
+            AppMode::View {
+                ref session_id,
+                scroll_offset: Some(7),
+            } if session_id == "session-id"
+        ));
+    }
+
+    #[tokio::test]
     async fn test_handle_publish_branch_input_key_escape_restores_view_mode() {
         // Arrange
         let (mut app, _base_dir) = crate::test_support::new_test_app_with_mock_tmux_client().await;
@@ -2079,7 +2117,8 @@ mod tests {
         let event_result = handle_publish_branch_input_key(
             &mut app,
             KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
-        );
+        )
+        .await;
 
         // Assert
         assert!(matches!(event_result, EventResult::Continue));
@@ -2121,7 +2160,8 @@ mod tests {
         let event_result = handle_publish_branch_input_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
-        );
+        )
+        .await;
 
         // Assert
         assert!(matches!(event_result, EventResult::Continue));
@@ -2164,7 +2204,8 @@ mod tests {
         let event_result = handle_publish_branch_input_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
-        );
+        )
+        .await;
 
         // Assert
         assert!(matches!(event_result, EventResult::Continue));
@@ -2208,7 +2249,8 @@ mod tests {
             let event_result = handle_publish_branch_input_key(
                 &mut app,
                 KeyEvent::new(KeyCode::Char(character), modifiers),
-            );
+            )
+            .await;
 
             // Assert
             assert!(matches!(event_result, EventResult::Continue));
@@ -2241,7 +2283,8 @@ mod tests {
         let event_result = handle_publish_branch_input_key(
             &mut app,
             KeyEvent::new(KeyCode::Left, KeyModifiers::NONE),
-        );
+        )
+        .await;
 
         // Assert
         assert!(matches!(event_result, EventResult::Continue));
@@ -2271,11 +2314,13 @@ mod tests {
         handle_publish_branch_input_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL),
-        );
+        )
+        .await;
         handle_publish_branch_input_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('z'), KeyModifiers::CONTROL),
-        );
+        )
+        .await;
         assert!(matches!(
             &app.mode,
             AppMode::PublishBranchInput { input, .. } if input.text() == "review custom"
@@ -2283,7 +2328,8 @@ mod tests {
         handle_publish_branch_input_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('y'), KeyModifiers::CONTROL),
-        );
+        )
+        .await;
 
         // Assert
         assert!(matches!(
@@ -2311,7 +2357,8 @@ mod tests {
         let result = handle_publish_branch_input_key(
             &mut app,
             KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE),
-        );
+        )
+        .await;
 
         // Assert
         assert!(matches!(result, EventResult::Continue));
@@ -2340,7 +2387,8 @@ mod tests {
         let event_result = handle_publish_branch_input_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
-        );
+        )
+        .await;
 
         // Assert
         assert!(matches!(event_result, EventResult::Continue));

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1739,6 +1739,10 @@ printf '{"type":"result","subtype":"success","result":"%s","usage":{"input_token
 /// Answer emitted before the queued session sync is allowed to start.
 const QUEUED_SYNC_TURN_ANSWER: &str = "Running turn completed before sync";
 
+/// Answer emitted before queued review-request creation begins.
+const QUEUED_REVIEW_REQUEST_TURN_ANSWER: &str =
+    "Running turn completed before review request creation";
+
 /// Installs a delayed Claude turn so the scenario can queue sync while the
 /// worker is still active, then observe the answer before the rebase result.
 fn install_delayed_sync_claude_stub(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
@@ -1758,6 +1762,89 @@ printf '%s\n' '{{"type":"result","subtype":"success","result":"{{\"answer\":\"{Q
     std::fs::write(&claude_path, script)?;
     #[cfg(unix)]
     std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o755))?;
+
+    seed_project_settings(env, &[("DefaultSmartModel", "claude-haiku-4-5-20251001")])
+}
+
+/// Installs delayed agent, Git, and GitHub stubs so review-request creation
+/// can be queued during a live turn and observed after that turn completes.
+fn install_queued_review_request_stubs(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    run_git(
+        &env.workdir,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/agentty-xyz/agentty.git",
+        ],
+    )?;
+
+    let claude_path = env.stub_bin.join("claude");
+    let claude_script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
+cat > /dev/null 2>&1
+sleep 8
+printf '%s\n' '{{"type":"system","subtype":"init"}}'
+printf '%s\n' '{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"{QUEUED_REVIEW_REQUEST_TURN_ANSWER}"}}]}}}}'
+printf '%s\n' '{{"type":"result","subtype":"success","result":"{{\"answer\":\"{QUEUED_REVIEW_REQUEST_TURN_ANSWER}\",\"questions\":[],\"summary\":null}}","usage":{{"input_tokens":5,"output_tokens":9}}}}'
+"#
+    );
+    std::fs::write(&claude_path, claude_script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o755))?;
+
+    let real_git = std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
+        .map(|path| path.join("git"))
+        .find(|path| path.is_file())
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "git not found"))?;
+    let git_path = env.stub_bin.join("git");
+    let git_script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "push" ]; then
+  sleep 2
+  exit 0
+fi
+exec '{}' "$@"
+"#,
+        real_git.display()
+    );
+    std::fs::write(&git_path, git_script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&git_path, std::fs::Permissions::from_mode(0o755))?;
+
+    let gh_path = env.stub_bin.join("gh");
+    std::fs::write(
+        &gh_path,
+        r#"#!/bin/sh
+marker_path="${0}.created"
+case "$*" in
+  *"auth status"*)
+    exit 0
+    ;;
+  *"api"*"/pulls"*)
+    if [ -f "$marker_path" ]; then
+      printf '%s\n' '[{"number":42}]'
+    else
+      printf '%s\n' '[]'
+    fi
+    ;;
+  *"pr create"*)
+    touch "$marker_path"
+    ;;
+  *"pr view"*)
+    printf '%s\n' '{"number":42,"title":"Queued review request","state":"OPEN","url":"https://github.com/agentty-xyz/agentty/pull/42","baseRefName":"main","headRefName":"wt/queued-review","isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"REVIEW_REQUIRED","mergedAt":null}'
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 1
+    ;;
+esac
+"#,
+    )?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&gh_path, std::fs::Permissions::from_mode(0o755))?;
 
     seed_project_settings(env, &[("DefaultSmartModel", "claude-haiku-4-5-20251001")])
 }
@@ -3531,6 +3618,96 @@ fn session_running_turn_shows_sync_shortcut() -> E2eResult {
                     .rect
                     .row;
                 assert!(answer_row < sync_row);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify review-request creation queues behind a running turn, begins only
+/// after the answer is complete, and records the created forge link.
+#[test]
+fn review_request_creation_queues_during_running_turn() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("review_request_queued_creation")
+        .with_git()
+        .setup(install_queued_review_request_stubs)
+        .zola(
+            "Queued review-request creation",
+            "Queue review-request creation behind a running session turn and publish it next.",
+            41,
+        )
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("Queue the review request")
+                    .wait_for_text("Queue the review request", 3000)
+                    .press_key("Enter")
+                    .wait_for_text("p: PR", 5000)
+                    .press_key("p")
+                    .wait_for_text("Publish Review Request", 5000)
+                    .press_key("Enter")
+                    .wait_for_text(
+                        "Review request queued; publishing after the current turn finishes...",
+                        5000,
+                    )
+                    .viewing_pause_ms(1200)
+                    .capture_labeled(
+                        "review_request_queued",
+                        "Review-request creation queued behind the active turn",
+                    )
+                    .wait_for_text(QUEUED_REVIEW_REQUEST_TURN_ANSWER, 30000)
+                    .wait_for_text("Publishing review request...", 5000)
+                    .capture_labeled(
+                        "review_request_started",
+                        "Queued review-request creation starts after the turn completes",
+                    )
+                    .wait_for_text("[Review Request] Created PR", 15000)
+                    .capture_labeled(
+                        "review_request_created",
+                        "Created review-request link recorded after the completed turn",
+                    )
+            },
+            |frame, report| {
+                let queued_frame = common::frame_from_capture(&report.captures[0]);
+                let queued_full = Region::full(queued_frame.cols(), queued_frame.rows());
+                assertion::assert_text_in_region(
+                    &queued_frame,
+                    "Review request queued; publishing after the current turn finishes...",
+                    &queued_full,
+                );
+                assertion::assert_text_in_region(
+                    &queued_frame,
+                    "Queue the review request",
+                    &queued_full,
+                );
+                assertion::assert_text_in_region(&queued_frame, "Ctrl+c: stop", &queued_full);
+
+                let started_frame = common::frame_from_capture(&report.captures[1]);
+                let started_full = Region::full(started_frame.cols(), started_frame.rows());
+                assertion::assert_text_in_region(
+                    &started_frame,
+                    QUEUED_REVIEW_REQUEST_TURN_ANSWER,
+                    &started_full,
+                );
+                assertion::assert_text_in_region(
+                    &started_frame,
+                    "Publishing review request...",
+                    &started_full,
+                );
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(
+                    frame,
+                    "[Review Request] Created PR https://github.com/agentty-xyz/agentty/pull/42",
+                    &full,
+                );
+                assertion::assert_not_visible(frame, "Review request queued;");
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -170,16 +170,22 @@ output anchor, and an explicit lifecycle. Reducer paths upsert or retract summar
 focused-review, workflow-feedback, manual-branch-publish, and published-branch-sync
 slots; starting a later turn clears older turn-scoped slots in one place.
 
-Manual branch and review-request publishing returns from its branch-name popup to
-`AppMode::View` before spawning the task. Its session-scoped transient slot renders the
-animated progress row, then the terminal reducer event replaces that row with inline
-success or failure output without changing whichever app mode is active at completion.
-Successful review-request creation retracts the transient row and appends its
-single-line URL result as a durable `WorkflowNotice` at the current transcript position.
-Later turns therefore leave the result in its original history position instead of
-reconstructing a transient between turns. The manual task holds the same per-session
-branch-operation lock as completed-turn auto-push for its full push and forge-metadata
-workflow.
+Manual branch publishing and review-request creation return from the branch-name popup
+to `AppMode::View`. Review-request creation is persisted on the per-session worker, so
+an action accepted during an active turn renders a queued row and executes before later
+queued chat. A worker-start event replaces that row with animated publish progress; the
+terminal reducer event then replaces it with inline success or failure output without
+changing whichever app mode is active at completion. Successful review-request creation
+retracts the transient row and appends its single-line URL result as a durable
+`WorkflowNotice` at the current transcript position. Later turns therefore leave the
+result in its original history position instead of reconstructing a transient between
+turns. The manual task holds the same per-session branch-operation lock as
+completed-turn auto-push for its full push and forge-metadata workflow. Queued
+review-request creation also registers as unfinished branch work before the current turn
+can start automatic publishing. Its UI and API handlers only attempt a non-blocking lock
+reservation while persisting the command; when another branch action already owns the
+lock, they return after queueing and let the worker wait without stalling the foreground
+event loop.
 
 Published-branch auto-push completion sends one terminal reducer event carrying its
 `WorkflowNotice`. After accepting the current operation identifier, the reducer persists
@@ -219,14 +225,14 @@ and review-request workflows without placing `App` behind an async mutex. User h
 and the coordinator handle carry distinct capabilities: the user path rejects every
 managed-worker mutation, while the coordinator can relay answers, continue work, cancel,
 merge, or publish through the same lifecycle workflows. Review-request commands snapshot
-the session's existing branch-publish context, spawn its push and forge work on the
-detached branch-publish task, and resolve the API response from that task's terminal
-result; the foreground mailbox remains available while publishing is in flight. Lookup
-joins persisted settings and ordered messages into one frontend-neutral aggregate.
-Creation is restricted to the active project while `SessionRuntime` owns a single
-active-project `SessionManager`, and can copy the agent, model, reasoning, personality,
-and base-branch snapshot from another session in that project without changing defaults
-for later ordinary sessions. The adapter deliberately contains no orchestrator policy.
+the session's existing branch-publish context, persist it on the per-session worker, and
+resolve the API response from that command's terminal result; the foreground mailbox
+remains available while publishing is queued or in flight. Lookup joins persisted
+settings and ordered messages into one frontend-neutral aggregate. Creation is
+restricted to the active project while `SessionRuntime` owns a single active-project
+`SessionManager`, and can copy the agent, model, reasoning, personality, and base-branch
+snapshot from another session in that project without changing defaults for later
+ordinary sessions. The adapter deliberately contains no orchestrator policy.
 `app/orchestration.rs` owns that sequencing: it persists proposed task rows before
 approval, reads child status, summary, and token totals in one SQLite task snapshot
 during reconciliation, and uses the session API mailbox only for child creation,
@@ -264,13 +270,13 @@ flowchart LR
 1. `start_session()` (first prompt) or `reply()` (follow-up) persists the command in
    `session_operation` and enqueues it on the per-session worker.
 1. The worker marks the operation `running`, checks cancel flags, verifies worktree
-   isolation, and delegates to `workflow/turn.rs` or the queued session-sync workflow.
-   An **InProgress** sync request can enqueue only through the sender already owned by
-   that worker; it cannot lazily create another worker. The same in-memory chat queue
-   accepts follow-up prompts while the worker is **InProgress** or **Rebasing**, and
-   drains them after the active operation. The receiver is checked between every pair of
-   retractable queued-chat turns, so a command received during one chat turn waits for
-   that turn and then runs before the remaining chat queue.
+   isolation, and delegates to `workflow/turn.rs`, queued session sync, or queued
+   review-request creation. An **InProgress** branch action can enqueue only through the
+   sender already owned by that worker; it cannot lazily create another worker. The same
+   in-memory chat queue accepts follow-up prompts while the worker is **InProgress** or
+   **Rebasing**, and drains them after the active operation. The receiver is checked
+   between every pair of retractable queued-chat turns, so a command received during one
+   chat turn waits for that turn and then runs before the remaining chat queue.
 1. Immediately before a chat turn, the worker resolves the persisted personality ID
    through `PersonalityCatalogClient`. The catalog scans only the session worktree's
    `.agents/agents` directory. The worker compares the resolved prompt fingerprint with

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -177,9 +177,10 @@ State-specific differences:
 - **AgentReview** keeps the review shortcuts, including `r`. Pressing `r` starts session
   sync immediately and cancels the pending focused review so stale review output cannot
   appear after the rebase begins.
-- **InProgress** sessions use `Enter` to queue a follow-up message and keep `r`
-  available to queue session sync behind the running turn. Each `Ctrl+c` retracts the
-  newest queued message; when the queue is empty, `Ctrl+c` stops the active turn.
+- **InProgress** sessions use `Enter` to queue a follow-up message, keep `r` available
+  to queue session sync, and keep `p` available to queue review-request creation behind
+  the running turn. Each `Ctrl+c` retracts the newest queued message; when the queue is
+  empty, `Ctrl+c` stops the active turn.
 - **Rebasing** sessions use `Enter` to queue a follow-up message behind the active
   session sync. Slash commands and branch actions remain unavailable until sync
   finishes.

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -98,7 +98,7 @@ to the assist agent.
 | Status          | Meaning                                                          |
 | --------------- | ---------------------------------------------------------------- |
 | **Draft**       | Created but not started; draft sessions can stage prompts first. |
-| **InProgress**  | Agent is working; `r` queues sync behind the running turn.       |
+| **InProgress**  | Agent is working; `r` and `p` queue branch actions.              |
 | **Review**      | Agent finished; changes are ready for review.                    |
 | **AgentReview** | Focused review is generating; `r` cancels it before syncing.     |
 | **Question**    | Agent requested clarification before continuing.                 |
@@ -230,6 +230,16 @@ the single queued rebase instead of adding duplicates. Session sync reserves
 branch-publish ownership before it queues or starts, and retains that ownership through
 its post-rebase push. A completed turn or subsequent sync therefore cannot start a
 competing published-branch auto-push.
+
+Pressing `p` during a running turn opens the usual branch-name popup and queues
+review-request creation on that same worker. The session remains **InProgress** and
+shows a queued review-request row until the active turn finishes. Publishing then runs
+before any remaining queued chat messages, and the row changes to
+`Publishing review request...`. Like queued sync, the queued publish reserves branch
+ownership before the current turn reaches auto-push, so the completed turn cannot race
+the requested review creation. If another branch operation already owns that lock, the
+handler queues immediately without waiting and the worker serializes review-request
+creation behind the operation in progress.
 
 Session output keeps workflow feedback in execution order. Commit feedback appears
 before its sync result, post-sync auto-push progress appears after that result, and
@@ -491,16 +501,17 @@ can retry without reporting a false terminal cancellation.
 
 ## Branch Publish Flow
 
-<a id="usage-review-request-flow"></a> In **Review** and **AgentReview**, `p` opens a
-publish popup for the linked forge review request:
+<a id="usage-review-request-flow"></a> In **Review**, **AgentReview**, and
+**InProgress**, `p` opens a publish popup for the linked forge review request:
 
 - Leave the field empty to keep the default branch target, or type a custom remote
   branch name. After the first publish, the popup is locked to that same remote branch.
 - Agentty publishes with `git push --force-with-lease`, then creates or refreshes the
   linked review request. After confirmation, the popup closes and publishing continues
-  in the background while session chat remains interactive. Inline progress is replaced
-  only after the forge URL is ready, including across intermediate session refreshes. It
-  becomes a one-line `[Review Request] Created PR URL` or
+  on the session worker while session chat remains interactive. During **InProgress**,
+  the action waits behind the active turn and ahead of remaining queued chat. Inline
+  progress is replaced only after the forge URL is ready, including across intermediate
+  session refreshes. It becomes a one-line `[Review Request] Created PR URL` or
   `[Review Request] Created MR URL` transcript notice recorded at that point in session
   history, or failure details when the task finishes; `p` stays hidden while that
   publish is active. Later turns do not move or reconstruct the creation notice. GitHub


### PR DESCRIPTION
- Persists manual and API review-request actions on the per-session worker so they run before queued chat.
- Shows queued and active publish progress while preserving branch-operation serialization.
- Covers queued review-request creation with unit and end-to-end tests.
- Returns cancellation responses through the affected UI and runtime paths.
- Review-request creation is available during `InProgress` sessions.
- Adds race handling and focused regression coverage across the session.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)