### PR TITLE
Focused reviews use valid terminal Codex answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   recover only interrupted review generation with bounded persistence backoff, while
   persisting diff-preparation failures so storage or Git failures cannot strand
   orchestrated workers.
+- agentty: keep intermediate Codex commentary and blank completion fallbacks out of
+  completed focused reviews, using the latest valid terminal answer instead.
 
 ## [v0.14.2] - 2026-08-05
 

--- a/crates/ag-agent/src/agent/app_server/codex/client.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/client.rs
@@ -515,6 +515,138 @@ mod tests {
         assert_eq!(result.expect("turn should complete"), (String::new(), 0, 0));
     }
 
+    #[tokio::test]
+    async fn execute_turn_event_loop_prefers_completed_final_message_over_commentary() {
+        // Arrange
+        let folder = tempdir().expect("temporary folder should be created");
+        let turn_start_id = Arc::new(Mutex::new(None));
+        let mut transport = MockCodexRuntimeTransport::new();
+        let mut sequence = Sequence::new();
+        let (stream_tx, _stream_rx) = mpsc::unbounded_channel();
+        let final_response = r#"{"answer":"Final focused review.","questions":[],"summary":null}"#;
+
+        expect_commentary_then_completed_final_turn(
+            &mut transport,
+            &mut sequence,
+            turn_start_id,
+            final_response,
+        );
+
+        // Act
+        let result = lifecycle::execute_turn_event_loop(
+            &mut transport,
+            lifecycle::CodexTurnEventLoopInput {
+                folder: folder.path(),
+                model: AgentModel::Gpt56Sol.as_str(),
+                prompt: "Review the current diff".into(),
+                reasoning_level: ReasoningLevel::default(),
+                speed_mode: SpeedMode::default(),
+                stream_tx,
+                thread_id: "thread-1",
+                turn_timeout: app_server_transport::TURN_TIMEOUT,
+            },
+        )
+        .await;
+
+        // Assert
+        assert_eq!(
+            result.expect("turn should return its final answer"),
+            (final_response.to_string(), 0, 0)
+        );
+    }
+
+    /// Expects one turn to emit commentary before carrying its structured
+    /// final answer in `turn/completed`.
+    fn expect_commentary_then_completed_final_turn(
+        transport: &mut MockCodexRuntimeTransport,
+        sequence: &mut Sequence,
+        turn_start_id: Arc<Mutex<Option<String>>>,
+        final_response: &'static str,
+    ) {
+        transport
+            .expect_write_json_line()
+            .times(1)
+            .in_sequence(sequence)
+            .withf(|payload| payload.get("method").and_then(Value::as_str) == Some("turn/start"))
+            .returning({
+                let turn_start_id = Arc::clone(&turn_start_id);
+
+                move |payload| {
+                    remember_request_id(&turn_start_id, &payload);
+
+                    Box::pin(async { Ok(()) })
+                }
+            });
+        transport
+            .expect_next_stdout()
+            .times(1)
+            .in_sequence(sequence)
+            .return_once(move || {
+                let response_id = turn_start_id
+                    .lock()
+                    .expect("turn/start mutex should lock")
+                    .clone()
+                    .expect("turn/start id should be recorded");
+
+                Box::pin(async move {
+                    Ok(Some(
+                        serde_json::json!({
+                            "id": response_id,
+                            "result": {"turn": {"id": "turn-123"}}
+                        })
+                        .to_string(),
+                    ))
+                })
+            });
+        transport
+            .expect_next_stdout()
+            .times(1)
+            .in_sequence(sequence)
+            .return_once(|| {
+                Box::pin(async {
+                    Ok(Some(
+                        serde_json::json!({
+                            "method": "item/completed",
+                            "params": {
+                                "turnId": "turn-123",
+                                "item": {
+                                    "type": "agentMessage",
+                                    "phase": "commentary",
+                                    "text": "I'll inspect the current code."
+                                }
+                            }
+                        })
+                        .to_string(),
+                    ))
+                })
+            });
+        transport
+            .expect_next_stdout()
+            .times(1)
+            .in_sequence(sequence)
+            .return_once(move || {
+                Box::pin(async move {
+                    Ok(Some(
+                        serde_json::json!({
+                            "method": "turn/completed",
+                            "params": {
+                                "turnId": "turn-123",
+                                "turn": {
+                                    "status": "completed",
+                                    "items": [{
+                                        "type": "agentMessage",
+                                        "phase": "final_answer",
+                                        "text": final_response
+                                    }]
+                                }
+                            }
+                        })
+                        .to_string(),
+                    ))
+                })
+            });
+    }
+
     /// Expects a user-input request to receive an empty response before turn
     /// completion.
     fn expect_user_input_request_turn(

--- a/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
@@ -642,11 +642,16 @@ impl CodexTurnEventLoopState {
         else {
             return Ok(None);
         };
+        let completed_assistant_message = stream_parser::extract_turn_completed_agent_message(
+            response_value,
+            self.active_turn_id.as_deref(),
+        );
         let (input_tokens, output_tokens) =
             usage::resolve_turn_usage(self.completed_turn_usage, self.latest_stream_usage);
 
         finalize_turn_completion(
             turn_result,
+            completed_assistant_message.as_ref(),
             &self.assistant_messages,
             &self.stream_tx,
             input_tokens,
@@ -865,6 +870,7 @@ fn emit_phase_progress_update(
 /// response tuple.
 fn finalize_turn_completion(
     turn_result: Result<(), String>,
+    completed_assistant_message: Option<&stream_parser::ExtractedAgentMessage>,
     assistant_messages: &[String],
     stream_tx: &mpsc::UnboundedSender<AppServerStreamEvent>,
     input_tokens: u64,
@@ -872,8 +878,10 @@ fn finalize_turn_completion(
 ) -> Result<(String, u64, u64), AppServerError> {
     match turn_result {
         Ok(()) => {
-            let assistant_message =
-                stream_parser::preferred_completed_assistant_message(assistant_messages);
+            let assistant_message = completed_assistant_message.map_or_else(
+                || stream_parser::preferred_completed_assistant_message(assistant_messages),
+                |message| message.message.clone(),
+            );
 
             Ok((assistant_message, input_tokens, output_tokens))
         }

--- a/crates/ag-agent/src/agent/app_server/codex/stream_parser.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/stream_parser.rs
@@ -221,6 +221,41 @@ pub(super) fn extract_agent_message(response_value: &Value) -> Option<ExtractedA
     }
 
     let item = response_value.get("params")?.get("item")?;
+    extract_completed_assistant_item(item)
+}
+
+/// Extracts the final assistant message carried by a matching
+/// `turn/completed` notification.
+///
+/// Current Codex app-server versions include the terminal agent message in
+/// `params.turn.items` as a completion fallback. Reading that canonical item
+/// prevents an earlier `commentary` item from becoming the completed turn
+/// response when no separate final `item/completed` notification was sent.
+/// Turn matching accepts the same nested and flat id aliases as completion
+/// parsing.
+pub(super) fn extract_turn_completed_agent_message(
+    response_value: &Value,
+    expected_turn_id: Option<&str>,
+) -> Option<ExtractedAgentMessage> {
+    if response_value.get("method").and_then(Value::as_str) != Some("turn/completed") {
+        return None;
+    }
+    let expected_turn_id = expected_turn_id?;
+    let turn_id = extract_turn_id_from_turn_completed_notification(response_value)?;
+    if turn_id != expected_turn_id {
+        return None;
+    }
+    let turn = response_value.get("params")?.get("turn")?;
+
+    turn.get("items")?
+        .as_array()?
+        .iter()
+        .rev()
+        .find_map(extract_completed_assistant_item)
+}
+
+/// Extracts terminal assistant text from one Codex thread item.
+fn extract_completed_assistant_item(item: &Value) -> Option<ExtractedAgentMessage> {
     let phase = item
         .get("phase")
         .and_then(Value::as_str)
@@ -229,12 +264,12 @@ pub(super) fn extract_agent_message(response_value: &Value) -> Option<ExtractedA
     if !is_completed_assistant_message_item_type(&item_type) {
         return None;
     }
-    if is_codex_thought_phase(phase.as_deref()) {
+    if is_codex_intermediate_phase(phase.as_deref()) {
         return None;
     }
 
     if let Some(item_text) = item.get("text").and_then(Value::as_str) {
-        if agent::is_codex_completion_status_message(item_text) {
+        if item_text.trim().is_empty() || agent::is_codex_completion_status_message(item_text) {
             return None;
         }
 
@@ -247,7 +282,11 @@ pub(super) fn extract_agent_message(response_value: &Value) -> Option<ExtractedA
     let content = item.get("content")?.as_array()?;
     let mut parts = Vec::new();
     for content_item in content {
-        if let Some(text) = content_item.get("text").and_then(Value::as_str) {
+        if let Some(text) = content_item
+            .get("text")
+            .and_then(Value::as_str)
+            .filter(|text| !text.trim().is_empty())
+        {
             parts.push(text.to_string());
         }
     }
@@ -273,16 +312,17 @@ pub(super) fn is_completed_assistant_message_item_type(item_type: &str) -> bool 
     )
 }
 
-/// Returns whether one Codex assistant item `phase` denotes thought/planning
-/// text instead of final assistant output.
-pub(super) fn is_codex_thought_phase(phase: Option<&str>) -> bool {
+/// Returns whether one Codex assistant item `phase` denotes intermediate text
+/// instead of final assistant output.
+pub(super) fn is_codex_intermediate_phase(phase: Option<&str>) -> bool {
     let Some(phase_value) = phase else {
         return false;
     };
 
     let normalized_phase = phase_value.trim();
 
-    normalized_phase.eq_ignore_ascii_case("thinking")
+    normalized_phase.eq_ignore_ascii_case("commentary")
+        || normalized_phase.eq_ignore_ascii_case("thinking")
         || normalized_phase.eq_ignore_ascii_case("plan")
         || normalized_phase.eq_ignore_ascii_case("reasoning")
         || normalized_phase.eq_ignore_ascii_case("thought")
@@ -714,7 +754,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_agent_message_ignores_thought_phase_status_and_unsupported_items() {
+    fn extract_agent_message_ignores_intermediate_blank_status_and_unsupported_items() {
         // Arrange
         let thought_response = serde_json::json!({
             "method": "item/completed",
@@ -723,6 +763,39 @@ mod tests {
                     "type": "assistant_message",
                     "phase": "Thinking",
                     "text": "private thought"
+                }
+            }
+        });
+        let commentary_response = serde_json::json!({
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "type": "agentMessage",
+                    "phase": "commentary",
+                    "text": "I'll inspect the current code."
+                }
+            }
+        });
+        let blank_text_response = serde_json::json!({
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "type": "agentMessage",
+                    "phase": "final_answer",
+                    "text": "  \n "
+                }
+            }
+        });
+        let blank_content_response = serde_json::json!({
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "type": "agentMessage",
+                    "phase": "final_answer",
+                    "content": [
+                        {"text": "   "},
+                        {"type": "output_text"}
+                    ]
                 }
             }
         });
@@ -747,11 +820,17 @@ mod tests {
 
         // Act
         let thought_message = extract_agent_message(&thought_response);
+        let commentary_message = extract_agent_message(&commentary_response);
+        let blank_text_message = extract_agent_message(&blank_text_response);
+        let blank_content_message = extract_agent_message(&blank_content_response);
         let status_message = extract_agent_message(&status_response);
         let unsupported_message = extract_agent_message(&unsupported_response);
 
         // Assert
         assert_eq!(thought_message, None);
+        assert_eq!(commentary_message, None);
+        assert_eq!(blank_text_message, None);
+        assert_eq!(blank_content_message, None);
         assert_eq!(status_message, None);
         assert_eq!(unsupported_message, None);
     }
@@ -763,17 +842,93 @@ mod tests {
         let assistant_message_supported =
             is_completed_assistant_message_item_type("assistantmessage");
         let command_unsupported = is_completed_assistant_message_item_type("command_execution");
-        let thought_phase = is_codex_thought_phase(Some(" reasoning "));
-        let final_phase = is_codex_thought_phase(Some("final"));
-        let missing_phase = is_codex_thought_phase(None);
+        let commentary_phase = is_codex_intermediate_phase(Some(" commentary "));
+        let thought_phase = is_codex_intermediate_phase(Some(" reasoning "));
+        let final_phase = is_codex_intermediate_phase(Some("final_answer"));
+        let missing_phase = is_codex_intermediate_phase(None);
 
         // Assert
         assert!(agent_message_supported);
         assert!(assistant_message_supported);
         assert!(!command_unsupported);
+        assert!(commentary_phase);
         assert!(thought_phase);
         assert!(!final_phase);
         assert!(!missing_phase);
+    }
+
+    #[test]
+    fn extract_turn_completed_agent_message_uses_matching_terminal_item() {
+        // Arrange
+        let response_value = serde_json::json!({
+            "method": "turn/completed",
+            "params": {
+                "turnId": "turn-123",
+                "turn": {
+                    "status": "completed",
+                    "items": [
+                        {
+                            "type": "agentMessage",
+                            "phase": "commentary",
+                            "text": "I'll inspect the current code."
+                        },
+                        {
+                            "type": "agentMessage",
+                            "phase": "final_answer",
+                            "text": "Final review result."
+                        }
+                    ]
+                }
+            }
+        });
+
+        // Act
+        let matching_message =
+            extract_turn_completed_agent_message(&response_value, Some("turn-123"));
+        let other_turn_message =
+            extract_turn_completed_agent_message(&response_value, Some("turn-other"));
+        let missing_turn_message = extract_turn_completed_agent_message(&response_value, None);
+        let non_completion_message = extract_turn_completed_agent_message(
+            &serde_json::json!({"method": "turn/started"}),
+            Some("turn-123"),
+        );
+
+        // Assert
+        assert_eq!(
+            matching_message,
+            Some(ExtractedAgentMessage {
+                message: "Final review result.".to_string(),
+                phase: Some("final_answer".to_string()),
+            })
+        );
+        assert_eq!(other_turn_message, None);
+        assert_eq!(missing_turn_message, None);
+        assert_eq!(non_completion_message, None);
+    }
+
+    #[test]
+    fn extract_turn_completed_agent_message_rejects_commentary_only_turn() {
+        // Arrange
+        let response_value = serde_json::json!({
+            "method": "turn/completed",
+            "params": {
+                "turn": {
+                    "id": "turn-123",
+                    "status": "completed",
+                    "items": [{
+                        "type": "agentMessage",
+                        "phase": "commentary",
+                        "text": "I'll inspect the current code."
+                    }]
+                }
+            }
+        });
+
+        // Act
+        let message = extract_turn_completed_agent_message(&response_value, Some("turn-123"));
+
+        // Assert
+        assert_eq!(message, None);
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -612,6 +612,57 @@ printf '{{"type":"result","subtype":"success","result":"{{\\"answer\\":\\"## Rev
     )
 }
 
+/// Seeds a Codex focused review with commentary, a valid final item, and a
+/// blank duplicate final item in `turn/completed`.
+fn seed_codex_review_with_blank_completed_fallback(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    seed_review_ready_session(env)?;
+    seed_review_worktree_with_diff(env)?;
+
+    let codex_path = env.stub_bin.join("codex");
+    let script = r###"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'codex-cli 0.146.0\n'; exit 0; fi
+
+extract_id() {
+    printf '%s\n' "$1" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p'
+}
+
+while IFS= read -r request; do
+    case "$request" in
+        *'"method":"initialize"'*)
+            request_id=$(extract_id "$request")
+            printf '{"id":"%s","result":{}}\n' "$request_id"
+            ;;
+        *'"method":"thread/start"'*)
+            request_id=$(extract_id "$request")
+            printf '{"id":"%s","result":{"thread":{"id":"review-thread"}}}\n' "$request_id"
+            ;;
+        *'"method":"turn/start"'*)
+            request_id=$(extract_id "$request")
+            printf '{"id":"%s","result":{"turn":{"id":"review-turn"}}}\n' "$request_id"
+            printf '%s\n' '{"method":"turn/started","params":{"turn":{"id":"review-turn"}}}'
+            printf '%s\n' '{"method":"item/completed","params":{"threadId":"review-thread","turnId":"review-turn","item":{"type":"agentMessage","id":"commentary-item","text":"I will inspect the current code.","phase":"commentary"}}}'
+            printf '%s\n' '{"method":"item/completed","params":{"threadId":"review-thread","turnId":"review-turn","item":{"type":"agentMessage","id":"final-item","text":"{\"answer\":\"## Review\\n\\n### Project Impact\\n\\n- Final focused review result.\\n\\n### Suggestions\\n\\n- None.\",\"questions\":[],\"summary\":null}","phase":"final_answer"}}}'
+            printf '%s\n' '{"method":"turn/completed","params":{"threadId":"review-thread","turn":{"id":"review-turn","status":"completed","items":[{"type":"agentMessage","id":"blank-final-item","text":"   ","phase":"final_answer"}]}}}'
+            ;;
+    esac
+done
+"###;
+    std::fs::write(&codex_path, script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&codex_path, std::fs::Permissions::from_mode(0o755))?;
+
+    seed_project_settings(
+        env,
+        &[
+            ("DefaultReviewAgent", "codex"),
+            ("DefaultReviewModel", "gpt-5.6-sol"),
+        ],
+    )
+}
+
 /// Seeds one review-ready session plus its default source branch and
 /// propagates setup errors to the caller.
 fn seed_review_ready_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
@@ -6412,6 +6463,40 @@ fn focused_review_honors_resolved_session_decisions() -> E2eResult {
                 assertion::assert_text_in_region(frame, "- None", &full);
                 assertion::assert_not_visible(frame, MISSING_DECISION_CONTEXT_POLICY_TEXT);
                 assertion::assert_not_visible(frame, MISSING_RESOLVED_DECISION_HISTORY_TEXT);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify a blank Codex completion fallback cannot replace an earlier final
+/// focused-review item.
+#[test]
+fn focused_review_ignores_blank_completed_fallback() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("focused_review_ignores_blank_completed_fallback")
+        .with_git()
+        .setup(seed_codex_review_with_blank_completed_fallback)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("Enter")
+                    .press_key("f")
+                    .wait_for_text("Final focused review result.", 30000)
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled(
+                        "final_review",
+                        "Focused review preserves the nonblank final answer",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Final focused review result.", &full);
+                assertion::assert_text_in_region(frame, "Suggestions", &full);
+                assertion::assert_not_visible(frame, "I will inspect the current code.");
+                assertion::assert_not_visible(frame, "Reviewing changes with");
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -678,7 +678,10 @@ Title generation, focused review, commit-message generation, and conflict assist
 submit owned `OneShotRequest` values through `OneShotClient`. Its production
 implementation owns provider routing, CLI/app-server selection, protocol repair, runtime
 cleanup, and usage aggregation; app workflow tests inject `MockOneShotClient` without
-constructing provider commands.
+constructing provider commands. Codex app-server turns ignore `commentary` assistant
+items when selecting completed output and prefer a nonblank terminal agent message
+carried by the matching `turn/completed` payload. A blank completion fallback cannot
+replace valid final output received earlier in the turn.
 
 ## Sync, Merge, and Rebase Flows
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -115,7 +115,8 @@ The shortcuts available in each state are listed in
 When a session enters **Review**, Agentty starts focused review in the background. While
 it is running, **AgentReview** keeps the review-oriented shortcuts available; pressing
 `r` starts session sync immediately and cancels pending focused-review output so stale
-review text cannot reappear after the rebase begins.
+review text cannot reappear after the rebase begins. Provider progress and commentary
+remain transient; only the terminal focused-review answer is stored and rendered.
 
 ### Typical Transitions
 


### PR DESCRIPTION
- Completed turns ignore intermediate commentary and blank terminal items.
- Completed turns also reject status and unsupported assistant items.
- Matching `turn/completed` payloads provide a fallback only when they contain a nonblank final agent message, preserving earlier valid output.
- Completion matching accepts all supported turn-ID shapes.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)