### PR TITLE
Centralizes model request lifecycle

### DIFF
--- a/crates/ag-harness/AGENTS.md
+++ b/crates/ag-harness/AGENTS.md
@@ -36,8 +36,10 @@ agentty/
 ```
 
 The current foundation lives entirely in `ag-harness`: the provider-neutral `Model`
-contract accepts a text `ModelRequest` and returns a text `ModelResponse`. `Qwen` is its
-first adapter and uses the OpenAI-compatible Chat Completions API.
+contract owns the shared request lifecycle, including telemetry and structured-output
+validation. Provider adapters implement `ModelBackend` to supply model identity and raw
+generation. `Qwen` is the first adapter and uses the OpenAI-compatible Chat Completions
+API.
 
 ## Session management
 
@@ -115,8 +117,9 @@ The next model-contract iteration evolves the current text-only response into
 provider-neutral structured output:
 
 - The caller supplies the expected JSON shape as a provider-independent schema.
-- Each adapter uses the strongest structured-output mechanism its provider supports,
-  then the harness parses and validates the returned JSON against the caller's schema.
+- Each adapter uses the strongest structured-output mechanism its provider supports and
+  returns raw assistant text. The shared `Model` lifecycle parses and validates the
+  returned JSON against the caller's schema.
 - Provider-specific request fields remain inside the adapter. For Qwen, the adapter uses
   JSON Object mode and performs schema validation in the harness because Qwen guarantees
   valid JSON, not schema conformance.
@@ -132,6 +135,8 @@ unstructured text.
 - External OTLP metrics export is enabled when `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
 - The harness records only `gen_ai.client.operation.duration`, labeled by provider and
   model.
+- The shared `Model` lifecycle records the metric for every `ModelBackend`, including
+  failed and cancelled requests.
 - Application binaries configure the metric exporter and flush it on exit.
 - Histogram state is cumulative and process-local; the one-shot example verifies export
   rather than cross-run totals.

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -8,6 +8,6 @@ mod qwen;
 mod schema_contract;
 mod telemetry;
 
-pub use model::{Model, ModelError, ModelRequest, ModelResponse};
+pub use model::{Model, ModelBackend, ModelError, ModelMetadata, ModelRequest, ModelResponse};
 pub use qwen::{Qwen, QwenConfig};
 pub use schema_contract::{OutputSchema, OutputSchemaError};

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -5,10 +5,21 @@ use serde_json::Value;
 use thiserror::Error;
 
 use crate::schema_contract::{OutputSchema, OutputValidationError};
+use crate::telemetry;
 
-/// A model backend that completes provider-neutral requests.
+mod private {
+    pub trait Sealed {}
+
+    impl<T> Sealed for T where T: super::ModelBackend + ?Sized {}
+}
+
+/// Provider-neutral model behavior available to applications.
+///
+/// Implement [`ModelBackend`] to receive this behavior automatically. The
+/// shared implementation records telemetry and validates structured output for
+/// every provider.
 #[async_trait]
-pub trait Model: Send + Sync {
+pub trait Model: private::Sealed + Send + Sync {
     /// Completes one model request.
     ///
     /// # Errors
@@ -16,6 +27,62 @@ pub trait Model: Send + Sync {
     /// Returns [`ModelError`] when the provider request fails or its response
     /// cannot be converted to the provider-neutral response.
     async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError>;
+}
+
+#[async_trait]
+impl<T> Model for T
+where
+    T: ModelBackend + ?Sized,
+{
+    async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
+        let _duration = telemetry::RequestDuration::start(self.metadata());
+        let output = self.generate(&request).await?;
+
+        request
+            .schema()
+            .parse_and_validate(&output)
+            .map(ModelResponse::new)
+            .map_err(ModelError::from)
+    }
+}
+
+/// Provider strategy used by the shared [`Model`] request lifecycle.
+#[async_trait]
+pub trait ModelBackend: Send + Sync {
+    /// Returns stable identity attributes for model telemetry.
+    fn metadata(&self) -> ModelMetadata<'_>;
+
+    /// Generates raw structured-output text for one provider-neutral request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] when the provider cannot satisfy the request or
+    /// its response cannot be converted to assistant text.
+    async fn generate(&self, request: &ModelRequest) -> Result<String, ModelError>;
+}
+
+/// Stable provider and model identity used by shared model behavior.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ModelMetadata<'a> {
+    model: &'a str,
+    provider: &'static str,
+}
+
+impl<'a> ModelMetadata<'a> {
+    /// Creates metadata for one provider model.
+    pub fn new(provider: &'static str, model: &'a str) -> Self {
+        Self { model, provider }
+    }
+
+    /// Returns the model identifier sent to the provider.
+    pub fn model(&self) -> &'a str {
+        self.model
+    }
+
+    /// Returns the provider identifier used by telemetry.
+    pub fn provider(&self) -> &'static str {
+        self.provider
+    }
 }
 
 /// Provider-neutral input for one model request.
@@ -52,14 +119,13 @@ pub struct ModelResponse {
 }
 
 impl ModelResponse {
-    /// Creates a response from parsed JSON that passed the caller's schema.
-    pub fn new(output: Value) -> Self {
-        Self { output }
-    }
-
     /// Returns the parsed, schema-validated output.
     pub fn output(&self) -> &Value {
         &self.output
+    }
+
+    fn new(output: Value) -> Self {
+        Self { output }
     }
 }
 
@@ -108,7 +174,8 @@ pub enum ModelError {
 }
 
 impl ModelError {
-    pub(crate) fn request(error: impl Error + Send + Sync + 'static) -> Self {
+    /// Wraps a provider transport or response-decoding failure.
+    pub fn request(error: impl Error + Send + Sync + 'static) -> Self {
         Self::Request(Box::new(error))
     }
 }
@@ -132,6 +199,130 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    enum StubOutcome {
+        Failure,
+        Output(&'static str),
+    }
+
+    struct StubBackend {
+        model: &'static str,
+        outcome: StubOutcome,
+        provider: &'static str,
+    }
+
+    #[async_trait]
+    impl ModelBackend for StubBackend {
+        fn metadata(&self) -> ModelMetadata<'_> {
+            ModelMetadata::new(self.provider, self.model)
+        }
+
+        async fn generate(&self, request: &ModelRequest) -> Result<String, ModelError> {
+            assert_eq!(request.prompt(), "hello");
+
+            match self.outcome {
+                StubOutcome::Failure => Err(ModelError::request(io::Error::other("offline"))),
+                StubOutcome::Output(output) => Ok(output.to_string()),
+            }
+        }
+    }
+
+    fn object_schema() -> OutputSchema {
+        OutputSchema::new(json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        }))
+        .expect("schema should be valid")
+    }
+
+    fn backend(outcome: StubOutcome) -> StubBackend {
+        StubBackend {
+            model: "stub-large",
+            outcome,
+            provider: "stub_provider",
+        }
+    }
+
+    #[tokio::test]
+    async fn completes_request_through_shared_model_flow() {
+        // Arrange
+        let model = backend(StubOutcome::Output(r#"{"name":"Ada"}"#));
+
+        // Act
+        let response = model
+            .complete(ModelRequest::new("hello", object_schema()))
+            .await
+            .expect("valid backend output should succeed");
+
+        // Assert
+        assert_eq!(response.output(), &json!({ "name": "Ada" }));
+    }
+
+    #[test]
+    fn metadata_exposes_provider_and_model() {
+        // Arrange
+        let model = backend(StubOutcome::Output(r#"{"name":"Ada"}"#));
+
+        // Act
+        let metadata = model.metadata();
+
+        // Assert
+        assert_eq!(metadata.provider(), "stub_provider");
+        assert_eq!(metadata.model(), "stub-large");
+        assert_eq!(metadata, ModelMetadata::new("stub_provider", "stub-large"));
+    }
+
+    #[tokio::test]
+    async fn shared_model_flow_returns_provider_failure() {
+        // Arrange
+        let model = backend(StubOutcome::Failure);
+
+        // Act
+        let error = model
+            .complete(ModelRequest::new("hello", object_schema()))
+            .await
+            .expect_err("provider failure should be returned");
+
+        // Assert
+        assert_eq!(error.to_string(), "model request failed: offline");
+    }
+
+    #[tokio::test]
+    async fn shared_model_flow_rejects_invalid_json() {
+        // Arrange
+        let model = backend(StubOutcome::Output("not JSON"));
+
+        // Act
+        let error = model
+            .complete(ModelRequest::new("hello", object_schema()))
+            .await
+            .expect_err("invalid JSON should fail");
+
+        // Assert
+        assert!(matches!(error, ModelError::InvalidJson { .. }));
+    }
+
+    #[tokio::test]
+    async fn shared_model_flow_rejects_schema_violation() {
+        // Arrange
+        let model = backend(StubOutcome::Output(r#"{"name":42}"#));
+
+        // Act
+        let error = model
+            .complete(ModelRequest::new("hello", object_schema()))
+            .await
+            .expect_err("schema violation should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            ModelError::SchemaViolation { path, .. } if path == "/name"
+        ));
+    }
 
     #[test]
     fn request_contains_prompt_and_schema() {

--- a/crates/ag-harness/src/qwen.rs
+++ b/crates/ag-harness/src/qwen.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{model, schema_contract, telemetry};
+use crate::{model, schema_contract};
 
 const ERROR_BODY_LIMIT_BYTES: usize = 4 * 1024;
 const JSON_STRING_MAX_EXPANSION: usize = 6;
@@ -32,9 +32,8 @@ pub struct QwenConfig {
     pub model: String,
 }
 
-/// Qwen implementation of the provider-neutral [`model::Model`] contract.
-///
-/// Calls record a duration metric without prompt or response content.
+/// Qwen implementation of the provider-neutral [`model::ModelBackend`]
+/// strategy.
 pub struct Qwen {
     client: reqwest::Client,
     config: QwenConfig,
@@ -116,13 +115,12 @@ impl Qwen {
 }
 
 #[async_trait]
-impl model::Model for Qwen {
-    async fn complete(
-        &self,
-        request: model::ModelRequest,
-    ) -> Result<model::ModelResponse, model::ModelError> {
-        let _duration = telemetry::RequestDuration::start(PROVIDER_NAME, &self.config.model);
+impl model::ModelBackend for Qwen {
+    fn metadata(&self) -> model::ModelMetadata<'_> {
+        model::ModelMetadata::new(PROVIDER_NAME, &self.config.model)
+    }
 
+    async fn generate(&self, request: &model::ModelRequest) -> Result<String, model::ModelError> {
         if !request.schema().has_object_root() {
             return Err(model::ModelError::UnsupportedOutputSchema {
                 reason: UNSUPPORTED_SCHEMA_REASON.to_string(),
@@ -191,11 +189,7 @@ impl model::Model for Qwen {
             .content
             .ok_or(model::ModelError::InvalidResponse)?;
 
-        request
-            .schema()
-            .parse_and_validate(&text)
-            .map(model::ModelResponse::new)
-            .map_err(model::ModelError::from)
+        Ok(text)
     }
 }
 

--- a/crates/ag-harness/src/telemetry.rs
+++ b/crates/ag-harness/src/telemetry.rs
@@ -3,6 +3,8 @@ use std::time::Instant;
 use opentelemetry::metrics::Histogram;
 use opentelemetry::{KeyValue, global};
 
+use crate::model::ModelMetadata;
+
 const DURATION_BOUNDARIES_SECONDS: [f64; 14] = [
     0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
 ];
@@ -17,7 +19,7 @@ pub(crate) struct RequestDuration<'a> {
 
 impl<'a> RequestDuration<'a> {
     /// Starts timing one model request.
-    pub(crate) fn start(provider: &'static str, model: &'a str) -> Self {
+    pub(crate) fn start(metadata: ModelMetadata<'a>) -> Self {
         let metric = global::meter("ag-harness")
             .f64_histogram("gen_ai.client.operation.duration")
             .with_description("GenAI operation duration.")
@@ -27,8 +29,8 @@ impl<'a> RequestDuration<'a> {
 
         Self {
             metric,
-            model,
-            provider,
+            model: metadata.model(),
+            provider: metadata.provider(),
             started_at: Instant::now(),
         }
     }

--- a/crates/ag-harness/tests/telemetry.rs
+++ b/crates/ag-harness/tests/telemetry.rs
@@ -1,13 +1,41 @@
 //! Integration coverage for the `ag-harness` request-duration metric.
 #![cfg(test)]
 
-use ag_harness::{Model, ModelRequest, OutputSchema, Qwen, QwenConfig};
+use std::{future, io};
+
+use ag_harness::{Model, ModelBackend, ModelError, ModelMetadata, ModelRequest, OutputSchema};
+use async_trait::async_trait;
 use opentelemetry::global;
 use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
 use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
 use serde_json::json;
-use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[derive(Clone, Copy)]
+enum StubOutcome {
+    Failure,
+    Pending,
+    Success,
+}
+
+struct StubBackend {
+    model: &'static str,
+    outcome: StubOutcome,
+}
+
+#[async_trait]
+impl ModelBackend for StubBackend {
+    fn metadata(&self) -> ModelMetadata<'_> {
+        ModelMetadata::new("stub_provider", self.model)
+    }
+
+    async fn generate(&self, _request: &ModelRequest) -> Result<String, ModelError> {
+        match self.outcome {
+            StubOutcome::Failure => Err(ModelError::request(io::Error::other("offline"))),
+            StubOutcome::Pending => future::pending().await,
+            StubOutcome::Success => Ok(r#"{"name":"Ada"}"#.to_string()),
+        }
+    }
+}
 
 fn schema() -> OutputSchema {
     OutputSchema::new(json!({
@@ -36,27 +64,13 @@ fn metric_attributes(
 #[tokio::test(flavor = "current_thread")]
 async fn records_only_request_duration_after_provider_installation() {
     // Arrange
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/chat/completions"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "choices": [{
-                "finish_reason": "stop",
-                "message": {"content": r#"{"name":"Ada"}"#}
-            }]
-        })))
-        .expect(2)
-        .mount(&server)
-        .await;
-    let model = Qwen::new(QwenConfig {
-        api_key: "test-key".to_string(),
-        base_url: server.uri(),
-        model: "qwen-plus".to_string(),
-    });
-    model
-        .complete(ModelRequest::new("before provider installation", schema()))
-        .await
-        .expect("request before provider installation should succeed");
+    StubBackend {
+        model: "before-installation",
+        outcome: StubOutcome::Success,
+    }
+    .complete(ModelRequest::new("before provider installation", schema()))
+    .await
+    .expect("request before provider installation should succeed");
     let exporter = InMemoryMetricExporter::default();
     let meter_provider = SdkMeterProvider::builder()
         .with_periodic_exporter(exporter.clone())
@@ -64,15 +78,39 @@ async fn records_only_request_duration_after_provider_installation() {
     global::set_meter_provider(meter_provider.clone());
 
     // Act
-    model
-        .complete(ModelRequest::new("after provider installation", schema()))
+    StubBackend {
+        model: "successful",
+        outcome: StubOutcome::Success,
+    }
+    .complete(ModelRequest::new("after provider installation", schema()))
+    .await
+    .expect("instrumented request should succeed");
+    let failure = StubBackend {
+        model: "failed",
+        outcome: StubOutcome::Failure,
+    }
+    .complete(ModelRequest::new("failing request", schema()))
+    .await
+    .expect_err("instrumented provider failure should be returned");
+    let pending_request = tokio::spawn(
+        StubBackend {
+            model: "cancelled",
+            outcome: StubOutcome::Pending,
+        }
+        .complete(ModelRequest::new("cancelled request", schema())),
+    );
+    tokio::task::yield_now().await;
+    pending_request.abort();
+    let cancellation = pending_request
         .await
-        .expect("instrumented request should succeed");
+        .expect_err("aborted request should be cancelled");
     meter_provider
         .force_flush()
         .expect("duration metric should flush");
 
     // Assert
+    assert!(matches!(failure, ModelError::Request(_)));
+    assert!(cancellation.is_cancelled());
     let resource_metrics = exporter
         .get_finished_metrics()
         .expect("duration metric should be exported");
@@ -88,13 +126,28 @@ async fn records_only_request_duration_after_provider_installation() {
         metric.data(),
         AggregatedMetrics::F64(MetricData::Histogram(histogram)) if {
             let points = histogram.data_points().collect::<Vec<_>>();
-            assert_eq!(points.len(), 1);
-            assert_eq!(points[0].count(), 1);
+            assert_eq!(points.len(), 3);
+            assert!(points.iter().all(|point| point.count() == 1));
+            let mut attributes = points
+                .iter()
+                .map(|point| metric_attributes(point))
+                .collect::<Vec<_>>();
+            attributes.sort_unstable();
             assert_eq!(
-                metric_attributes(points[0]),
+                attributes,
                 [
-                    ("gen_ai.provider.name", "alibaba_cloud".to_string()),
-                    ("gen_ai.request.model", "qwen-plus".to_string()),
+                    vec![
+                        ("gen_ai.provider.name", "stub_provider".to_string()),
+                        ("gen_ai.request.model", "cancelled".to_string()),
+                    ],
+                    vec![
+                        ("gen_ai.provider.name", "stub_provider".to_string()),
+                        ("gen_ai.request.model", "failed".to_string()),
+                    ],
+                    vec![
+                        ("gen_ai.provider.name", "stub_provider".to_string()),
+                        ("gen_ai.request.model", "successful".to_string()),
+                    ],
                 ]
             );
 

--- a/crates/agentty/src/app/task.rs
+++ b/crates/agentty/src/app/task.rs
@@ -1167,8 +1167,8 @@ mod tests {
             [
                 Duration::from_millis(250),
                 Duration::from_millis(500),
-                Duration::from_millis(1_000),
-                Duration::from_millis(1_000),
+                Duration::from_secs(1),
+                Duration::from_secs(1),
             ]
         );
     }

--- a/crates/agentty/tests/e2e/orchestration.rs
+++ b/crates/agentty/tests/e2e/orchestration.rs
@@ -351,9 +351,10 @@ fn test_review_request_campaign_waits_for_worker_merge() -> E2eResult {
                         "controller_waiting",
                         "Controller remains active while review request is open",
                     )
-                    .press_key("q")
+                    .compose(&common::return_to_session_list())
                     .press_key("j")
-                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 3000)
+                    .compose(&common::open_selected_session_view())
                     .wait_for_text("Managed by controller-0001", 5000)
                     .press_key("?")
                     .wait_for_stable_frame(300, 5000)

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -42,8 +42,9 @@ agentty/
 ```
 
 The current foundation lives entirely in `ag-harness`: the provider-neutral `Model`
-contract requires an `OutputSchema` on every `ModelRequest` and returns validated JSON
-in `ModelResponse`. `Qwen` is its first adapter.
+contract owns telemetry and structured-output validation for every request.
+Provider-specific adapters implement `ModelBackend` to supply model identity and raw
+assistant output. `Qwen` is the first adapter.
 
 ## Session management
 
@@ -120,8 +121,9 @@ sequenceDiagram
 The model contract requires provider-neutral structured output:
 
 - The caller supplies the expected JSON shape as a provider-independent schema.
-- Each adapter uses the strongest structured-output mechanism its provider supports,
-  then the harness parses and validates the returned JSON against the caller's schema.
+- Each adapter uses the strongest structured-output mechanism its provider supports and
+  returns raw assistant text. The shared `Model` lifecycle parses and validates the
+  returned JSON against the caller's schema.
 - Provider-specific request fields remain inside the adapter. For Qwen, the adapter uses
   JSON Object mode and performs schema validation in the harness because Qwen guarantees
   valid JSON, not schema conformance.
@@ -137,14 +139,15 @@ unstructured text.
 - **Metric** - records one duration observation per call, including Qwen/model
   breakdowns.
 - **Labels** - provider and model only.
-- **Ownership** - model adapters record duration; binaries configure and flush the OTLP
-  metrics exporter.
+- **Ownership** - the shared `Model` lifecycle records duration for every
+  `ModelBackend`, including failed and cancelled requests; binaries configure and flush
+  the OTLP metrics exporter.
 - **Lifecycle** - histogram state is cumulative and process-local; the one-shot example
   verifies export rather than cross-run totals.
 
 ```mermaid
 flowchart LR
-    C["Qwen model call"] --> M["Duration histogram"]
+    C["Model lifecycle"] --> M["Duration histogram"]
     M --> O["OTLP collector"]
     O --> P["Prometheus"]
     P --> G["Grafana"]


### PR DESCRIPTION
- `ModelBackend` supplies provider metadata and raw output while shared `Model` behavior validates structured responses.
- Duration telemetry covers every backend request, including failures and cancellations.
- Review-request E2E navigation reopens selected sessions through stable list transitions.