### PR TITLE
Use nightly Rust and allow generated Clippy attributes

### DIFF
--- a/.github/actions/setup-rust-prek/action.yml
+++ b/.github/actions/setup-rust-prek/action.yml
@@ -41,18 +41,29 @@ runs:
         uv tool install --no-build prek==0.4.3
         echo "/tmp/agentty-uv-tools/bin" >> "$GITHUB_PATH"
 
-    - name: Install Rust nightly toolchain
+    - name: Read pinned Rust toolchain
+      id: rust-toolchain
+      shell: bash
+      run: |
+        toolchain="$(python3 -c 'import tomllib; print(tomllib.load(open("rust-toolchain.toml", "rb"))["toolchain"]["channel"])')"
+        if [[ -z "$toolchain" ]]; then
+          echo "Missing toolchain channel in rust-toolchain.toml" >&2
+          exit 1
+        fi
+        echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
+
+    - name: Install pinned Rust nightly toolchain
       if: ${{ inputs['llvm-tools-preview'] != 'true' }}
       uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
       with:
-        toolchain: nightly
+        toolchain: ${{ steps.rust-toolchain.outputs.toolchain }}
         components: clippy, rustfmt
 
-    - name: Install Rust nightly toolchain with LLVM tools
+    - name: Install pinned Rust nightly toolchain with LLVM tools
       if: ${{ inputs['llvm-tools-preview'] == 'true' }}
       uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
       with:
-        toolchain: nightly
+        toolchain: ${{ steps.rust-toolchain.outputs.toolchain }}
         components: clippy, rustfmt, llvm-tools-preview
 
     - name: Install `cargo-llvm-cov`

--- a/.github/workflows/publish-crates-io.yml
+++ b/.github/workflows/publish-crates-io.yml
@@ -22,10 +22,21 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Rust nightly toolchain
+      - name: Read pinned Rust toolchain
+        id: rust-toolchain
+        shell: bash
+        run: |
+          toolchain="$(python3 -c 'import tomllib; print(tomllib.load(open("rust-toolchain.toml", "rb"))["toolchain"]["channel"])')"
+          if [[ -z "$toolchain" ]]; then
+            echo "Missing toolchain channel in rust-toolchain.toml" >&2
+            exit 1
+          fi
+          echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
+
+      - name: Install pinned Rust nightly toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: nightly
+          toolchain: ${{ steps.rust-toolchain.outputs.toolchain }}
 
       - name: Authenticate with crates.io
         id: auth

--- a/container/e2e.Containerfile
+++ b/container/e2e.Containerfile
@@ -117,10 +117,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && git config --system --add safe.directory /workspace
 
 # Pin the nightly toolchain to a date so image rebuilds keep the same
-# compiler. `RUSTUP_TOOLCHAIN` overrides the floating `nightly` channel from
-# `rust-toolchain.toml` inside the container, so rustup never downloads a
-# newer nightly at run time. Bump the date deliberately and re-verify the
-# committed GIF hash sidecars.
+# compiler. `RUSTUP_TOOLCHAIN` overrides the workspace toolchain selection
+# inside the container, so rustup never downloads a newer nightly at run time.
+# Bump the date deliberately and re-verify the committed GIF hash sidecars.
 ARG RUST_TOOLCHAIN=nightly-2026-07-15
 ENV RUSTUP_TOOLCHAIN=${RUST_TOOLCHAIN}
 

--- a/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
@@ -1018,7 +1018,7 @@ mod tests {
         assert_eq!(state.model, model);
         assert_eq!(state.latest_input_tokens, 0);
         assert!(!state.restored_context);
-        assert!(state.thread_id.is_empty());
+        assert_eq!(state.thread_id, "");
     }
 
     #[test]

--- a/crates/ag-agent/src/agent/availability.rs
+++ b/crates/ag-agent/src/agent/availability.rs
@@ -1081,6 +1081,9 @@ mod tests {
         let available_agent_kinds = available_agent_kinds_from_path(Some(path_value.as_os_str()));
 
         // Assert
-        assert!(available_agent_kinds.is_empty());
+        assert_eq!(
+            available_agent_kinds,
+            [] as [crate::model::agent::AgentKind; 0]
+        );
     }
 }

--- a/crates/ag-agent/src/channel/app_server.rs
+++ b/crates/ag-agent/src/channel/app_server.rs
@@ -348,7 +348,7 @@ mod tests {
         // Assert
         assert!(result.is_ok());
         let events = std::iter::from_fn(|| events_rx.try_recv().ok()).collect::<Vec<_>>();
-        assert!(!events.is_empty());
+        assert_ne!(events, [] as [crate::channel::contract::TurnEvent; 0]);
         assert!(
             events
                 .iter()
@@ -389,7 +389,7 @@ mod tests {
         // Assert
         assert!(result.is_ok());
         let events = std::iter::from_fn(|| events_rx.try_recv().ok()).collect::<Vec<_>>();
-        assert!(!events.is_empty());
+        assert_ne!(events, [] as [crate::channel::contract::TurnEvent; 0]);
         assert!(
             events
                 .iter()
@@ -430,7 +430,7 @@ mod tests {
         // Assert
         assert!(result.is_ok());
         let events = std::iter::from_fn(|| events_rx.try_recv().ok()).collect::<Vec<_>>();
-        assert!(!events.is_empty());
+        assert_ne!(events, [] as [crate::channel::contract::TurnEvent; 0]);
         assert!(
             events
                 .iter()

--- a/crates/ag-clipboard/src/backend/linux.rs
+++ b/crates/ag-clipboard/src/backend/linux.rs
@@ -222,7 +222,10 @@ mod tests {
 
         // Assert
         assert_eq!(text.expect("fixture text should load"), "");
-        assert!(files.expect("fixture files should load").is_empty());
+        assert_eq!(
+            files.expect("fixture files should load"),
+            [] as [std::path::PathBuf; 0]
+        );
         assert_eq!(
             image.expect("fixture image should load"),
             crate::RgbaImageData {

--- a/crates/ag-forge/src/github.rs
+++ b/crates/ag-forge/src/github.rs
@@ -2216,7 +2216,7 @@ mod tests {
 
         // Assert
         assert!(threads.is_empty());
-        assert!(comments.is_empty());
+        assert_eq!(comments, [] as [crate::model::ReviewComment; 0]);
     }
 
     #[test]

--- a/crates/ag-git/src/sync.rs
+++ b/crates/ag-git/src/sync.rs
@@ -2857,6 +2857,6 @@ main\torigin/main\tbehind 2\nwt/1234abcd\torigin/wt/1234abcd\tahead 3, behind \
         );
         assert_eq!(commit_count, "1");
         assert_eq!(head_message, "Initial commit");
-        assert!(status.is_empty());
+        assert_eq!(status, "");
     }
 }

--- a/crates/ag-protocol/src/model.rs
+++ b/crates/ag-protocol/src/model.rs
@@ -496,7 +496,10 @@ mod tests {
         // Assert
         assert_eq!(deserialized, response);
         assert!(serialized.contains(r#""task_key":"task-1""#));
-        assert!(AgentResponse::plain("no plan").subtask_items().is_empty());
+        assert_eq!(
+            AgentResponse::plain("no plan").subtask_items(),
+            [] as [crate::subtask::SubtaskItem; 0]
+        );
     }
 
     #[test]
@@ -543,7 +546,7 @@ mod tests {
             serde_json::from_str::<SubtaskItem>(raw).expect("subtask should parse without areas");
 
         // Assert
-        assert!(subtask.touched_areas.is_empty());
+        assert_eq!(subtask.touched_areas, [] as [std::string::String; 0]);
     }
 
     #[test]

--- a/crates/ag-session/src/message.rs
+++ b/crates/ag-session/src/message.rs
@@ -553,7 +553,7 @@ mod tests {
 
         // Assert
         assert!(transcript.is_empty());
-        assert!(replay_text.is_empty());
+        assert_eq!(replay_text, "");
     }
 
     #[test]

--- a/crates/ag-xtask/src/check_migration.rs
+++ b/crates/ag-xtask/src/check_migration.rs
@@ -162,6 +162,6 @@ mod tests {
         let dirs = find_migration_dirs(dir.path());
 
         // Assert
-        assert!(dirs.is_empty());
+        assert_eq!(dirs, Vec::<PathBuf>::new());
     }
 }

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -3175,7 +3175,10 @@ mod tests {
                 },
             )]))]
         );
-        assert!(reduction_plan.before_snapshot_effects.is_empty());
+        assert_eq!(
+            reduction_plan.before_snapshot_effects,
+            [] as [crate::app::core::events::AppEventEffect; 0]
+        );
         assert!(reduction_plan.changes_observable_state);
     }
 

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -382,7 +382,10 @@ async fn session_git_status_targets_skip_unmaterialized_drafts() {
     let targets_after_materialization = App::session_git_status_targets(&app.sessions);
 
     // Assert
-    assert!(targets_before_materialization.is_empty());
+    assert_eq!(
+        targets_before_materialization,
+        [] as [crate::app::sync::SessionGitStatusTarget; 0]
+    );
     assert_eq!(
         targets_after_materialization,
         vec![sync::SessionGitStatusTarget {
@@ -4215,7 +4218,10 @@ async fn apply_app_events_agent_response_updates_questions_and_token_usage() {
     .await;
 
     // Assert
-    assert!(app.sessions.sessions()[0].questions.is_empty());
+    assert_eq!(
+        app.sessions.sessions()[0].questions,
+        [] as [ag_protocol::QuestionItem; 0]
+    );
     assert_eq!(app.sessions.sessions()[0].stats.input_tokens, 18);
     assert_eq!(app.sessions.sessions()[0].stats.output_tokens, 29);
 }
@@ -4929,7 +4935,10 @@ async fn load_project_items_uses_persisted_rows_without_home_scan() {
     .await;
 
     // Assert
-    assert!(project_items.is_empty());
+    assert_eq!(
+        project_items,
+        [] as [crate::domain::project::ProjectListItem; 0]
+    );
     assert!(
         database
             .projects()
@@ -5645,12 +5654,7 @@ async fn auto_start_reviews_clears_cache_on_in_progress_transition() {
 
     // Assert
     assert!(!app.review_cache.contains_key(session_id));
-    assert!(
-        app.sessions.sessions()[0]
-            .transient_messages
-            .messages()
-            .is_empty()
-    );
+    assert_eq!(app.sessions.sessions()[0].transient_messages.messages(), []);
 }
 
 #[tokio::test]

--- a/crates/agentty/src/app/orchestration.rs
+++ b/crates/agentty/src/app/orchestration.rs
@@ -2916,7 +2916,7 @@ mod tests {
             .expect("follow-up routing should complete");
 
         // Assert
-        assert!(response.subtasks.is_empty());
+        assert_eq!(response.subtasks, [] as [ag_protocol::SubtaskItem; 0]);
         assert!(response.questions[0].text.contains("cannot be continued"));
         assert_eq!(
             response.questions[0].options,
@@ -3695,7 +3695,7 @@ mod tests {
             .expect("merged review request should complete");
 
         // Assert
-        assert!(backend.calls().is_empty());
+        assert_eq!(backend.calls(), [] as [std::string::String; 0]);
     }
 
     #[tokio::test]
@@ -3739,7 +3739,7 @@ mod tests {
             .expect("closed review request should record a failure");
 
         // Assert
-        assert!(backend.calls().is_empty());
+        assert_eq!(backend.calls(), [] as [std::string::String; 0]);
     }
 
     #[tokio::test]
@@ -3785,7 +3785,7 @@ mod tests {
             .expect("settled integration should complete");
 
         // Assert
-        assert!(backend.calls().is_empty());
+        assert_eq!(backend.calls(), [] as [std::string::String; 0]);
     }
 
     #[tokio::test]
@@ -3988,7 +3988,7 @@ mod tests {
             invalid_result,
             Err("Unknown focused review status: Unknown".to_string())
         );
-        assert!(backend.calls().is_empty());
+        assert_eq!(backend.calls(), [] as [std::string::String; 0]);
     }
 
     #[tokio::test]
@@ -4227,7 +4227,7 @@ mod tests {
             unknown,
             Err("Unknown review remediation operation status `unexpected` for task 7".to_string())
         );
-        assert!(backend.calls().is_empty());
+        assert_eq!(backend.calls(), [] as [std::string::String; 0]);
     }
 
     #[tokio::test]
@@ -4255,7 +4255,7 @@ mod tests {
             applying.status,
             OrchestrationTaskStatus::ReviewApplying.to_string()
         );
-        assert!(backend.calls().is_empty());
+        assert_eq!(backend.calls(), [] as [std::string::String; 0]);
     }
 
     #[tokio::test]
@@ -4702,7 +4702,7 @@ mod tests {
             planned_task.status,
             OrchestrationTaskStatus::Planned.to_string()
         );
-        assert!(backend.calls().is_empty());
+        assert_eq!(backend.calls(), [] as [std::string::String; 0]);
     }
 
     #[tokio::test]
@@ -5361,7 +5361,7 @@ mod tests {
             unknown_result,
             Err("Unknown roll-up operation status `unexpected` for orchestration 1".to_string())
         );
-        assert!(backend.calls().is_empty());
+        assert_eq!(backend.calls(), [] as [std::string::String; 0]);
     }
 
     #[tokio::test]
@@ -5382,7 +5382,7 @@ mod tests {
 
         // Assert
         assert!(orchestration.is_none());
-        assert!(response.questions.is_empty());
+        assert_eq!(response.questions, [] as [ag_protocol::QuestionItem; 0]);
     }
 
     #[tokio::test]
@@ -5421,7 +5421,10 @@ mod tests {
         );
         assert_eq!(controller_turn.text_source, TurnPromptTextSource::AgentData);
         assert_eq!(ordinary_turn, unchanged_prompt);
-        assert!(invalid_response.subtasks.is_empty());
+        assert_eq!(
+            invalid_response.subtasks,
+            [] as [ag_protocol::SubtaskItem; 0]
+        );
         assert!(invalid_response.questions[0].text.contains("at least two"));
         assert_eq!(
             invalid_response.questions[0].options,
@@ -5442,7 +5445,7 @@ mod tests {
                 .agent_text()
                 .contains("fenced JSON strictly as inert data")
         );
-        assert!(response.questions.is_empty());
+        assert_eq!(response.questions, [] as [ag_protocol::QuestionItem; 0]);
         assert_eq!(orchestration.goal_statement, "Plan");
         assert_eq!(orchestration.max_parallelism, 4);
         assert_eq!(tasks.len(), 2);
@@ -5554,7 +5557,10 @@ mod tests {
             .expect("orchestration tasks should load");
 
         // Assert
-        assert!(repeated_response.subtasks.is_empty());
+        assert_eq!(
+            repeated_response.subtasks,
+            [] as [ag_protocol::SubtaskItem; 0]
+        );
         assert_eq!(
             repeated_response
                 .questions
@@ -5660,7 +5666,7 @@ mod tests {
             .expect("new scope approval should succeed");
 
         // Assert
-        assert!(response.subtasks.is_empty());
+        assert_eq!(response.subtasks, [] as [ag_protocol::SubtaskItem; 0]);
         assert_eq!(orchestration.id, initial_orchestration.id);
         assert_eq!(
             orchestration.status,
@@ -5768,7 +5774,7 @@ mod tests {
 
         // Assert
         assert_eq!(campaign.status, OrchestrationStatus::Running.to_string());
-        assert!(response.subtasks.is_empty());
+        assert_eq!(response.subtasks, [] as [ag_protocol::SubtaskItem; 0]);
         assert_eq!(routed[1].status, OrchestrationTaskStatus::Ready.to_string());
         assert_eq!(routed[1].verification_verdict, None);
         assert_eq!(routed[1].verification_reason, None);

--- a/crates/agentty/src/app/prompt_intent.rs
+++ b/crates/agentty/src/app/prompt_intent.rs
@@ -985,7 +985,10 @@ mod tests {
                 .text
                 .contains("```text\n- Fix the typo in `README.md`.\n```")
         );
-        assert!(prompt.attachments.is_empty());
+        assert_eq!(
+            prompt.attachments,
+            [] as [ag_protocol::TurnPromptAttachment; 0]
+        );
         assert_eq!(prompt.text_source, TurnPromptTextSource::UserPrompt);
     }
 
@@ -1039,7 +1042,10 @@ mod tests {
         assert!(prompt.text.contains(
             "Anchor status: outdated; inspect the current file instead of trusting the line anchor"
         ));
-        assert!(prompt.attachments.is_empty());
+        assert_eq!(
+            prompt.attachments,
+            [] as [ag_protocol::TurnPromptAttachment; 0]
+        );
         assert_eq!(prompt.text_source, TurnPromptTextSource::UserPrompt);
     }
 
@@ -1183,7 +1189,10 @@ mod tests {
                 session_id: session_id.clone(),
             }
         );
-        assert!(app.sessions.sessions()[0].queued_messages.is_empty());
+        assert_eq!(
+            app.sessions.sessions()[0].queued_messages,
+            [] as [std::string::String; 0]
+        );
     }
 
     #[tokio::test]
@@ -1266,7 +1275,10 @@ mod tests {
             .await;
 
         // Assert
-        assert!(personalities.is_empty());
+        assert_eq!(
+            personalities,
+            [] as [crate::domain::personality::PersonalitySummary; 0]
+        );
         assert!(app.sessions.sessions().is_empty());
     }
 

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -1601,7 +1601,7 @@ async fn test_create_session() {
     // Assert — blank session
     assert_eq!(app.sessions.sessions().len(), 1);
     assert_eq!(app.sessions.sessions()[0].id, session_id);
-    assert!(app.sessions.sessions()[0].prompt.is_empty());
+    assert_eq!(app.sessions.sessions()[0].prompt, "");
     assert_eq!(app.sessions.sessions()[0].title, None);
     assert_eq!(app.sessions.sessions()[0].display_title(), "No title");
     assert!(!app.sessions.sessions()[0].is_draft_session());
@@ -2042,7 +2042,10 @@ async fn test_stage_draft_message_persists_bundle_without_starting_session() {
         app.sessions.sessions()[0].title,
         Some("First draft".to_string())
     );
-    assert!(app.sessions.sessions()[0].draft_attachments.is_empty());
+    assert_eq!(
+        app.sessions.sessions()[0].draft_attachments,
+        [] as [ag_protocol::TurnPromptAttachment; 0]
+    );
     let db_sessions = app
         .services
         .db()
@@ -2263,7 +2266,10 @@ async fn test_start_staged_session_launches_bundle_and_clears_staged_drafts() {
         app.sessions.sessions()[0].prompt,
         "First draft\n\nSecond draft"
     );
-    assert!(app.sessions.sessions()[0].draft_attachments.is_empty());
+    assert_eq!(
+        app.sessions.sessions()[0].draft_attachments,
+        [] as [ag_protocol::TurnPromptAttachment; 0]
+    );
     assert!(app.sessions.sessions()[0].folder.exists());
     assert!(
         app.sessions.sessions()[0]
@@ -2681,7 +2687,10 @@ async fn test_resolve_session_review_comments_enqueues_turn_and_clears_focused_r
         }
     );
     assert!(!app.review_cache.contains_key(&session_id));
-    assert!(focused_reviews.is_empty());
+    assert_eq!(
+        focused_reviews,
+        [] as [crate::infra::db::SessionFocusedReviewRow; 0]
+    );
 }
 
 /// Builds one actionable inline review thread for session-resolution tests.
@@ -2896,7 +2905,7 @@ async fn test_enqueue_message_rejects_empty_payload() {
         .iter()
         .find(|session| session.id == session_id)
         .expect("session present");
-    assert!(session.queued_messages.is_empty());
+    assert_eq!(session.queued_messages, [] as [std::string::String; 0]);
 }
 
 #[tokio::test]
@@ -5528,7 +5537,10 @@ async fn test_sync_main_pushes_local_commits_to_remote() {
     assert_eq!(outcome.pushed_commits, Some(0));
     assert_eq!(outcome.pulled_commit_titles, vec!["remote fix".to_string()]);
     assert_eq!(outcome.pushed_commit_titles, vec!["local work".to_string()]);
-    assert!(outcome.resolved_conflict_files.is_empty());
+    assert_eq!(
+        outcome.resolved_conflict_files,
+        [] as [std::string::String; 0]
+    );
 }
 
 #[tokio::test]

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -4032,9 +4032,12 @@ mod tests {
 
         // Assert
         assert!(matches!(error, SessionError::Fs(_)));
-        assert!(persisted_session.prompt.is_empty());
-        assert!(session_manager.sessions()[0].prompt.is_empty());
-        assert!(session_manager.sessions()[0].draft_attachments.is_empty());
+        assert_eq!(persisted_session.prompt, "");
+        assert_eq!(session_manager.sessions()[0].prompt, "");
+        assert_eq!(
+            session_manager.sessions()[0].draft_attachments,
+            [] as [ag_protocol::TurnPromptAttachment; 0]
+        );
     }
 
     #[tokio::test]
@@ -4569,7 +4572,7 @@ mod tests {
         // Assert
         assert!(!missing);
         assert!(accepted);
-        assert!(messages.is_empty());
+        assert_eq!(messages, [] as [db::SessionMessageRow; 0]);
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -1153,8 +1153,8 @@ mod tests {
             .find(|session| session.id == session_id)
             .expect("missing reloaded session");
         assert_eq!(session_replay_text(session), "");
-        assert!(session.prompt.is_empty());
-        assert!(session.questions.is_empty());
+        assert_eq!(session.prompt, "");
+        assert_eq!(session.questions, [] as [ag_protocol::QuestionItem; 0]);
         assert!(session.summary.is_none());
 
         let handle = handles.get(session_id).expect("missing runtime handle");
@@ -1984,9 +1984,9 @@ WHERE id = ?
         let items = result.expect("expected Some");
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].text, "Need target?");
-        assert!(items[0].options.is_empty());
+        assert_eq!(items[0].options, [] as [std::string::String; 0]);
         assert_eq!(items[1].text, "Need tests?");
-        assert!(items[1].options.is_empty());
+        assert_eq!(items[1].options, [] as [std::string::String; 0]);
     }
 
     #[test]

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -4764,7 +4764,7 @@ mod tests {
             .times(1)
             .in_sequence(&mut sequence)
             .returning(|_, paths| {
-                assert!(paths.is_empty());
+                assert_eq!(paths, [] as [std::string::String; 0]);
                 Box::pin(async { Ok(Vec::new()) })
             });
         mock_git_client

--- a/crates/agentty/src/app/session_api.rs
+++ b/crates/agentty/src/app/session_api.rs
@@ -2914,9 +2914,12 @@ mod tests {
             ApiSessionError::Operation("Session has no questions to answer".to_string())
         );
         assert_eq!(resumed_turn_kind, AgentRequestKind::SessionResume);
-        assert!(queued_messages_before_transition.is_empty());
-        assert!(session.questions.is_empty());
-        assert!(session.queued_messages.is_empty());
+        assert_eq!(
+            queued_messages_before_transition,
+            [] as [std::string::String; 0]
+        );
+        assert_eq!(session.questions, [] as [ag_protocol::QuestionItem; 0]);
+        assert_eq!(session.queued_messages, [] as [std::string::String; 0]);
         assert_eq!(clarification_answer_count(&session), 1);
     }
 
@@ -3008,7 +3011,7 @@ mod tests {
 
         // Assert
         assert_eq!(resumed_turn_kind, AgentRequestKind::SessionResume);
-        assert!(controller.questions.is_empty());
+        assert_eq!(controller.questions, [] as [ag_protocol::QuestionItem; 0]);
     }
 
     #[tokio::test]
@@ -3119,7 +3122,7 @@ mod tests {
             ))
         );
         assert_eq!(session.questions, [QuestionItem::new("Current question?")]);
-        assert!(session.messages.is_empty());
+        assert_eq!(session.messages, [] as [ag_session::SessionMessage; 0]);
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/setting.rs
+++ b/crates/agentty/src/app/setting.rs
@@ -2380,7 +2380,7 @@ mod tests {
         manager.move_selected_launch_configuration_up().await;
 
         // Assert
-        assert!(manager.settings().launch_configuration.is_empty());
+        assert_eq!(manager.settings().launch_configuration, "");
         assert!(!manager.is_selector_dropdown_open());
         assert_eq!(
             services

--- a/crates/agentty/src/app/task.rs
+++ b/crates/agentty/src/app/task.rs
@@ -762,7 +762,7 @@ mod tests {
         let entries = TaskService::join_at_mention_entries(load_handle, &"session-id".into()).await;
 
         // Assert
-        assert!(entries.is_empty());
+        assert_eq!(entries, [] as [crate::domain::file_entry::FileEntry; 0]);
     }
 
     #[test]

--- a/crates/agentty/src/domain/composer.rs
+++ b/crates/agentty/src/domain/composer.rs
@@ -1299,7 +1299,10 @@ mod tests {
         attachment_state.remember_current_revision(&input);
 
         // Assert
-        assert!(attachment_state.attachments[0].valid_locations.is_empty());
+        assert_eq!(
+            attachment_state.attachments[0].valid_locations,
+            [] as [crate::domain::composer::AttachmentRevision; 0]
+        );
     }
 
     #[test]
@@ -1334,7 +1337,10 @@ mod tests {
 
         // Assert
         assert_eq!(attachment_state.attachments.len(), 1);
-        assert!(attachment_state.archived_attachments.is_empty());
+        assert_eq!(
+            attachment_state.archived_attachments,
+            [] as [crate::domain::composer::PromptAttachment; 0]
+        );
         assert_eq!(attachment_state.next_attachment_number, 2);
     }
 
@@ -1358,10 +1364,16 @@ mod tests {
         attachment_state.sync_after_edit(&input, insert_start, insert_start, input.cursor);
 
         // Assert
-        assert!(attachment_state.attachments.is_empty());
+        assert_eq!(
+            attachment_state.attachments,
+            [] as [crate::domain::composer::PromptAttachment; 0]
+        );
         assert_eq!(attachment_state.archived_attachments.len(), 1);
         let submission = drain_prompt_submission(&mut attachment_state, &mut input);
-        assert!(submission.attachments.is_empty());
+        assert_eq!(
+            submission.attachments,
+            [] as [crate::domain::composer::PromptAttachment; 0]
+        );
         assert_eq!(submission.text, placeholder);
     }
 
@@ -1388,7 +1400,10 @@ mod tests {
         let unreachable = attachment_state.prune_unreachable(&input);
 
         // Assert
-        assert!(attachment_state.archived_attachments.is_empty());
+        assert_eq!(
+            attachment_state.archived_attachments,
+            [] as [crate::domain::composer::PromptAttachment; 0]
+        );
         assert_eq!(unreachable.len(), 1);
         assert_eq!(
             unreachable[0].local_image_path,
@@ -1754,7 +1769,10 @@ mod tests {
 
         // Assert
         assert_eq!(composer.input.text(), "Review  now");
-        assert!(composer.attachment_state.attachments.is_empty());
+        assert_eq!(
+            composer.attachment_state.attachments,
+            [] as [crate::domain::composer::PromptAttachment; 0]
+        );
         assert_eq!(composer.attachment_state.archived_attachments.len(), 1);
         assert_eq!(composer.attachment_state.next_attachment_number, 2);
     }
@@ -1824,7 +1842,10 @@ mod tests {
 
         // Assert
         assert_eq!(submission.text, "Notify user@example.com and @!");
-        assert!(submission.attachments.is_empty());
+        assert_eq!(
+            submission.attachments,
+            [] as [crate::domain::composer::PromptAttachment; 0]
+        );
     }
 
     #[test]

--- a/crates/agentty/src/domain/transient_message.rs
+++ b/crates/agentty/src/domain/transient_message.rs
@@ -350,7 +350,7 @@ mod tests {
 
         // Assert
         assert!(retracted_message.is_some());
-        assert!(emptied_store.messages().is_empty());
+        assert_eq!(emptied_store.messages(), []);
         assert_eq!(emptied_store.fingerprint(), fresh_store.fingerprint());
     }
 }

--- a/crates/agentty/src/infra/db/connection_test.rs
+++ b/crates/agentty/src/infra/db/connection_test.rs
@@ -385,7 +385,7 @@ async fn test_append_session_message_writes_message_rows() {
         .await
         .expect("failed to load session detail")
         .expect("session detail should exist");
-    assert!(detail.prompt.is_empty());
+    assert_eq!(detail.prompt, "");
     assert_eq!(messages.len(), 3);
     assert_eq!(messages[0].position, 0);
     assert_eq!(messages[0].kind, SessionMessageKind::UserPrompt.as_str());
@@ -2913,7 +2913,10 @@ async fn test_update_session_focused_review_clears_persisted_review() {
         .expect("failed to load focused reviews");
 
     // Assert
-    assert!(focused_reviews.is_empty());
+    assert_eq!(
+        focused_reviews,
+        [] as [crate::infra::db::session::SessionFocusedReviewRow; 0]
+    );
 }
 
 #[tokio::test]

--- a/crates/agentty/src/infra/db/orchestration.rs
+++ b/crates/agentty/src/infra/db/orchestration.rs
@@ -2761,7 +2761,10 @@ mod tests {
             Some("Verify then apply")
         );
         assert_eq!(task.review_iteration, 1);
-        assert!(review_cache.is_empty());
+        assert_eq!(
+            review_cache,
+            [] as [crate::infra::db::session::SessionFocusedReviewRow; 0]
+        );
         assert_eq!(task.child_focused_review_status, None);
         assert_eq!(task.child_focused_review_text, None);
     }

--- a/crates/agentty/src/infra/file_index.rs
+++ b/crates/agentty/src/infra/file_index.rs
@@ -157,7 +157,7 @@ mod tests {
         let entries = list_files(temp_dir.path());
 
         // Assert
-        assert!(entries.is_empty());
+        assert_eq!(entries, [] as [crate::domain::file_entry::FileEntry; 0]);
     }
 
     #[test]
@@ -449,7 +449,7 @@ mod tests {
         let filtered = filter_entries(&entries, "xyz");
 
         // Assert
-        assert!(filtered.is_empty());
+        assert_eq!(filtered, [] as [&crate::domain::file_entry::FileEntry; 0]);
     }
 
     #[test]
@@ -576,7 +576,7 @@ mod tests {
         let filtered = filter_entries(&entries, "cb");
 
         // Assert
-        assert!(filtered.is_empty());
+        assert_eq!(filtered, [] as [&crate::domain::file_entry::FileEntry; 0]);
     }
 
     #[test]

--- a/crates/agentty/src/infra/personality.rs
+++ b/crates/agentty/src/infra/personality.rs
@@ -657,7 +657,7 @@ mod tests {
             large,
             "---\nname: Reviewer\ndescription: Reviews code\n---\nprompt\n"
         );
-        assert!(empty.is_empty());
+        assert_eq!(empty, "");
         assert_eq!(invalid_start, "name: Reviewer\n");
         assert_eq!(
             missing_end,
@@ -849,8 +849,14 @@ mod tests {
             .await;
 
         // Assert
-        assert!(missing.is_empty());
-        assert!(malformed.is_empty());
+        assert_eq!(
+            missing,
+            [] as [crate::domain::personality::PersonalitySummary; 0]
+        );
+        assert_eq!(
+            malformed,
+            [] as [crate::domain::personality::PersonalitySummary; 0]
+        );
     }
 
     #[tokio::test]
@@ -882,8 +888,14 @@ mod tests {
             .await;
 
         // Assert
-        assert!(missing.is_empty());
-        assert!(unreadable.is_empty());
+        assert_eq!(
+            missing,
+            [] as [crate::domain::personality::PersonalitySummary; 0]
+        );
+        assert_eq!(
+            unreadable,
+            [] as [crate::domain::personality::PersonalitySummary; 0]
+        );
     }
 
     #[tokio::test]
@@ -945,7 +957,10 @@ mod tests {
         });
 
         // Assert
-        assert!(entries.is_empty());
+        assert_eq!(
+            entries,
+            [] as [crate::domain::personality::PersonalitySummary; 0]
+        );
         assert!(next_entry.is_none());
         assert!(!directory);
         assert!(!missing_directory);
@@ -987,8 +1002,14 @@ mod tests {
             .await;
 
         // Assert
-        assert!(outside_personalities.is_empty());
-        assert!(loop_personalities.is_empty());
+        assert_eq!(
+            outside_personalities,
+            [] as [crate::domain::personality::PersonalitySummary; 0]
+        );
+        assert_eq!(
+            loop_personalities,
+            [] as [crate::domain::personality::PersonalitySummary; 0]
+        );
     }
 
     #[cfg(unix)]
@@ -1024,6 +1045,9 @@ mod tests {
         let personalities = catalog.list_summaries(workspace.path().to_path_buf()).await;
 
         // Assert
-        assert!(personalities.is_empty());
+        assert_eq!(
+            personalities,
+            [] as [crate::domain::personality::PersonalitySummary; 0]
+        );
     }
 }

--- a/crates/agentty/src/presentation/review_comment.rs
+++ b/crates/agentty/src/presentation/review_comment.rs
@@ -362,7 +362,10 @@ mod tests {
                 thread_id: "thread".to_string(),
             }]
         );
-        assert!(selections.is_empty());
+        assert_eq!(
+            selections,
+            [] as [crate::presentation::app_mode::ReviewCommentActionSelection; 0]
+        );
     }
 
     #[test]

--- a/crates/agentty/src/presentation/settings.rs
+++ b/crates/agentty/src/presentation/settings.rs
@@ -1536,7 +1536,10 @@ mod tests {
             reasoning_selector_option_labels().len(),
             ReasoningLevel::ALL.len()
         );
-        assert!(launch_options.is_empty());
+        assert_eq!(
+            launch_options,
+            [] as [crate::presentation::settings::SettingSelectorOption; 0]
+        );
         assert_eq!(
             parallelism_options.len(),
             usize::from(MAX_ORCHESTRATION_PARALLELISM)

--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -2089,7 +2089,10 @@ mod tests {
         } = &app.mode
         {
             assert_eq!(input.text(), "Review ");
-            assert!(attachment_state.attachments.is_empty());
+            assert_eq!(
+                attachment_state.attachments,
+                [] as [crate::domain::composer::PromptAttachment; 0]
+            );
         }
     }
 
@@ -2109,10 +2112,19 @@ mod tests {
 
         // Assert
         assert!(matches!(app.mode, AppMode::List));
-        assert!(inserted_attachments.is_empty());
+        assert_eq!(
+            inserted_attachments,
+            [] as [crate::domain::composer::PromptAttachment; 0]
+        );
         assert!(prompt.is_empty());
-        assert!(archived_attachments.is_empty());
-        assert!(cleanup_attachments.is_empty());
+        assert_eq!(
+            archived_attachments,
+            [] as [crate::domain::composer::PromptAttachment; 0]
+        );
+        assert_eq!(
+            cleanup_attachments,
+            [] as [crate::domain::composer::PromptAttachment; 0]
+        );
     }
 
     /// Verifies unavailable clipboard backends surface as inline paste errors
@@ -2152,7 +2164,10 @@ mod tests {
         } = &app.mode
         {
             assert_eq!(input.text(), "Review ");
-            assert!(attachment_state.attachments.is_empty());
+            assert_eq!(
+                attachment_state.attachments,
+                [] as [crate::domain::composer::PromptAttachment; 0]
+            );
         }
     }
 
@@ -2179,8 +2194,11 @@ mod tests {
             ..
         } = &app.mode
         {
-            assert!(input.text().is_empty());
-            assert!(attachment_state.attachments.is_empty());
+            assert_eq!(input.text(), "");
+            assert_eq!(
+                attachment_state.attachments,
+                [] as [crate::domain::composer::PromptAttachment; 0]
+            );
             assert_eq!(attachment_state.next_attachment_number, 1);
         }
     }
@@ -2213,8 +2231,11 @@ mod tests {
             ..
         } = &app.mode
         {
-            assert!(input.text().is_empty());
-            assert!(attachment_state.attachments.is_empty());
+            assert_eq!(input.text(), "");
+            assert_eq!(
+                attachment_state.attachments,
+                [] as [crate::domain::composer::PromptAttachment; 0]
+            );
             assert_eq!(attachment_state.next_attachment_number, 1);
         }
     }
@@ -2232,7 +2253,10 @@ mod tests {
 
         // Assert
         assert_eq!(prompt.text, "Review ");
-        assert!(prompt.attachments.is_empty());
+        assert_eq!(
+            prompt.attachments,
+            [] as [ag_protocol::TurnPromptAttachment; 0]
+        );
         assert_eq!(archived_attachments.len(), 1);
         assert_eq!(archived_attachments[0].local_image_path, image_path);
         assert_eq!(archived_attachments[0].placeholder, "[Image #1]");
@@ -2717,7 +2741,10 @@ mod tests {
 
         // Assert
         assert_eq!(prompt.text, "normal prompt");
-        assert!(prompt.attachments.is_empty());
+        assert_eq!(
+            prompt.attachments,
+            [] as [ag_protocol::TurnPromptAttachment; 0]
+        );
     }
 
     #[tokio::test]
@@ -3080,7 +3107,10 @@ mod tests {
         } = &app.mode
         {
             assert_eq!(input.text(), "Review ");
-            assert!(attachment_state.attachments.is_empty());
+            assert_eq!(
+                attachment_state.attachments,
+                [] as [crate::domain::composer::PromptAttachment; 0]
+            );
             assert_eq!(attachment_state.next_attachment_number, 2);
             assert_eq!(history_state.selected_index, None);
             assert_eq!(history_state.draft_text, None);
@@ -3115,7 +3145,10 @@ mod tests {
         } = &app.mode
         {
             assert_eq!(input.text(), "Review ");
-            assert!(attachment_state.attachments.is_empty());
+            assert_eq!(
+                attachment_state.attachments,
+                [] as [crate::domain::composer::PromptAttachment; 0]
+            );
             assert_eq!(attachment_state.next_attachment_number, 2);
             assert_eq!(history_state.selected_index, None);
             assert_eq!(history_state.draft_text, None);
@@ -3186,7 +3219,10 @@ mod tests {
 
         // Assert
         assert_eq!(prompt.text, "[Image #1]");
-        assert!(prompt.attachments.is_empty());
+        assert_eq!(
+            prompt.attachments,
+            [] as [ag_protocol::TurnPromptAttachment; 0]
+        );
     }
 
     #[tokio::test]
@@ -3541,7 +3577,10 @@ mod tests {
 
         // Assert
         assert_eq!(prompt.text, completed_mention);
-        assert!(prompt.attachments.is_empty());
+        assert_eq!(
+            prompt.attachments,
+            [] as [ag_protocol::TurnPromptAttachment; 0]
+        );
     }
 
     /// Verifies stale at-mention selections are clamped to the filtered entry
@@ -3763,7 +3802,7 @@ mod tests {
             app.sessions.sessions()[0].status,
             crate::domain::session::Status::Draft
         );
-        assert!(app.sessions.sessions()[0].prompt.is_empty());
+        assert_eq!(app.sessions.sessions()[0].prompt, "");
     }
 
     #[tokio::test]
@@ -3813,7 +3852,10 @@ mod tests {
         // Assert
         assert!(matches!(app.mode, AppMode::View { .. }));
         assert_eq!(app.sessions.sessions()[0].prompt, "Review ");
-        assert!(app.sessions.sessions()[0].draft_attachments.is_empty());
+        assert_eq!(
+            app.sessions.sessions()[0].draft_attachments,
+            [] as [ag_protocol::TurnPromptAttachment; 0]
+        );
     }
 
     #[tokio::test]
@@ -3861,7 +3903,10 @@ mod tests {
             app.sessions.sessions()[0].title.as_deref(),
             Some("Review [Image #1]")
         );
-        assert!(app.sessions.sessions()[0].draft_attachments.is_empty());
+        assert_eq!(
+            app.sessions.sessions()[0].draft_attachments,
+            [] as [ag_protocol::TurnPromptAttachment; 0]
+        );
     }
 
     #[tokio::test]

--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -1684,7 +1684,7 @@ mod tests {
         // Assert
         let session = &app.sessions.sessions()[0];
         assert_eq!(session.status, Status::Review);
-        assert!(session.questions.is_empty());
+        assert_eq!(session.questions, [] as [ag_protocol::QuestionItem; 0]);
         assert_eq!(
             *app.sessions
                 .session_handles()

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -1937,7 +1937,7 @@ mod tests {
         let entries = prompt_history_entries(output);
 
         // Assert
-        assert!(entries.is_empty());
+        assert_eq!(entries, [] as [std::string::String; 0]);
     }
 
     #[tokio::test]
@@ -2239,7 +2239,7 @@ mod tests {
         let diff = load_view_session_diff(&app, &context).await;
 
         // Assert
-        assert!(diff.is_empty());
+        assert_eq!(diff, "");
     }
 
     #[tokio::test]
@@ -2275,7 +2275,7 @@ mod tests {
 
         // Assert
         assert_eq!(diff, archived_diff);
-        assert!(missing_diff.is_empty());
+        assert_eq!(missing_diff, "");
     }
 
     #[tokio::test]

--- a/crates/agentty/src/ui/activity_heatmap.rs
+++ b/crates/agentty/src/ui/activity_heatmap.rs
@@ -437,7 +437,7 @@ mod tests {
         // Assert
         assert_eq!(month_row.chars().count(), 26);
         assert!(month_row.contains("Dec"));
-        assert!(!month_row.trim().is_empty());
+        assert_ne!(month_row.trim(), "");
     }
 
     #[test]

--- a/crates/agentty/src/ui/component/file_explorer.rs
+++ b/crates/agentty/src/ui/component/file_explorer.rs
@@ -654,6 +654,6 @@ mod tests {
         let items = FileExplorer::file_tree_items(&parsed_lines);
 
         // Assert
-        assert!(items.is_empty());
+        assert_eq!(items, [] as [crate::ui::diff_util::FileTreeItem; 0]);
     }
 }

--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -2419,12 +2419,7 @@ mod tests {
         assert_eq!(prompt_line_index, 1);
         assert_eq!(context_line_index, prompt_line_index + 2);
         assert!(rendered_lines[prompt_line_index + 1].width() > 0);
-        assert!(
-            rendered_lines[prompt_line_index + 1]
-                .to_string()
-                .trim()
-                .is_empty()
-        );
+        assert_eq!(rendered_lines[prompt_line_index + 1].to_string().trim(), "");
         assert_eq!(response_line_index, context_line_index + 3);
         assert!(rendered_lines[context_line_index + 1].width() > 0);
         assert_eq!(rendered_lines[context_line_index + 2].width(), 0);

--- a/crates/agentty/src/ui/page/diff.rs
+++ b/crates/agentty/src/ui/page/diff.rs
@@ -1169,7 +1169,7 @@ mod tests {
         }
 
         // Assert
-        assert!(buffer_text(terminal.backend().buffer()).trim().is_empty());
+        assert_eq!(buffer_text(terminal.backend().buffer()).trim(), "");
     }
 
     #[test]

--- a/crates/agentty/src/ui/page/session_chat.rs
+++ b/crates/agentty/src/ui/page/session_chat.rs
@@ -1256,7 +1256,7 @@ mod tests {
         );
         let spacer_row = panel_areas.spacer_area.y;
         let spacer_text = buffer_row_text(terminal.backend().buffer(), spacer_row, width);
-        assert!(spacer_text.trim().is_empty());
+        assert_eq!(spacer_text.trim(), "");
     }
 
     #[test]

--- a/crates/agentty/src/ui/session_output_assembly.rs
+++ b/crates/agentty/src/ui/session_output_assembly.rs
@@ -911,7 +911,7 @@ mod tests {
         append_user_prompt(&mut lines, " \n\t", 80, None);
 
         // Assert
-        assert!(lines.is_empty());
+        assert_eq!(lines, [] as [ratatui::prelude::Line<'_>; 0]);
     }
 
     #[test]
@@ -947,7 +947,7 @@ mod tests {
         append_user_prompt(&mut lines, "\u{200b}", 80, None);
 
         // Assert
-        assert!(lines.is_empty());
+        assert_eq!(lines, [] as [ratatui::prelude::Line<'_>; 0]);
     }
 
     #[test]
@@ -959,7 +959,7 @@ mod tests {
         append_markdown_lines(&mut lines, "\u{200b}", 80, None);
 
         // Assert
-        assert!(lines.is_empty());
+        assert_eq!(lines, [] as [ratatui::prelude::Line<'_>; 0]);
     }
 
     #[test]

--- a/crates/testty/src/diff.rs
+++ b/crates/testty/src/diff.rs
@@ -232,7 +232,7 @@ mod tests {
         // Assert
         assert!(diff.is_identical());
         assert!(diff.changed_regions().is_empty());
-        assert!(diff.summary().is_empty());
+        assert_eq!(diff.summary(), [] as [std::string::String; 0]);
     }
 
     #[test]

--- a/crates/testty/src/proof/report.rs
+++ b/crates/testty/src/proof/report.rs
@@ -706,7 +706,7 @@ mod tests {
 
         // Assert — frame_bytes should contain ANSI escape sequences.
         let capture = &report.captures[0];
-        assert!(!capture.frame_bytes.is_empty());
+        assert_ne!(capture.frame_bytes, [] as [u8; 0]);
         assert!(capture.frame_bytes.len() > capture.frame_text.len());
     }
 }

--- a/crates/testty/src/vhs.rs
+++ b/crates/testty/src/vhs.rs
@@ -854,7 +854,7 @@ mod tests {
         assert_eq!(settings.width, 1200);
         assert_eq!(settings.height, 600);
         assert_eq!(settings.font_size, 14);
-        assert!(settings.theme.is_empty());
+        assert_eq!(settings.theme, "");
         assert_eq!(settings.framerate, 0);
         assert_eq!(settings.padding, 0);
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "nightly"
+# Keep local and CI lint and coverage behavior reproducible.
+channel = "nightly-2026-05-28"


### PR DESCRIPTION
- `async-trait` adds bare `#[must_use]` attributes to generated future methods, so Clippy permits the resulting `double_must_use` lint.
- Reuse a composite action that validates and installs the dated nightly from `rust-toolchain.toml`.
- Apply the pinned toolchain to prek and crates.io publishing workflows.
- Remove the `double_must_use` workspace lint allowance.
- Install `nightly` directly in the prek and crates.io publishing workflows.
- Remove custom validation for the dated toolchain in `rust-toolchain.toml`.
- Allow `double_must_use` for `async-trait`-generated future methods.
- Scope reasoned `double_must_use` exceptions to the 13 affected async traits.
- Async traits allow `double_must_use` for futures generated by `async-trait`.
- Empty-state tests use explicit length and value comparisons across the workspace.
- Local, CI, and E2E container toolchains use dated nightly releases for reproducible checks.
- Empty-state tests compare explicit empty values across the workspace.
- Preserve diagnostic empty-value assertions and remove production Clippy suppressions.
- Use `rust-toolchain.toml` as the workflow toolchain source of truth.