### PR TITLE
Preserve focused review order around review requests

### DIFF
--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -24,6 +24,10 @@ use crate::domain::session::{
 };
 use crate::domain::session_message::{SessionMessageKind, SessionTranscript};
 use crate::domain::setting::SettingName;
+use crate::domain::transient_message::{
+    TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
+    TransientMessageSlot,
+};
 use crate::infra::db::AppRepositories;
 use crate::infra::project_discovery::{HOME_PROJECT_SCAN_MAX_RESULTS, RealProjectDiscoveryClient};
 use crate::infra::tmux::{MockTmuxClient, TmuxClient};
@@ -2154,6 +2158,7 @@ async fn apply_branch_publish_action_update_persists_pull_request_notice() {
     app.sessions
         .session_handles_mut()
         .insert("session-1".into(), SessionHandles::new(Status::Review));
+    seed_completed_review_transient_message(&mut app);
     app.mode = AppMode::List;
     let review_request = crate::domain::session::ReviewRequest {
         last_refreshed_at: 55,
@@ -2176,12 +2181,7 @@ async fn apply_branch_publish_action_update_persists_pull_request_notice() {
 
     // Assert
     assert!(matches!(app.mode, AppMode::List));
-    assert!(
-        app.sessions.state().sessions()[0]
-            .transient_messages
-            .get(crate::domain::transient_message::TransientMessageSlot::BranchPublish)
-            .is_none()
-    );
+    assert_review_message_reanchored_after_publish(&app);
     let transcript = app.sessions.state().sessions()[0]
         .transcript
         .as_ref()
@@ -2244,6 +2244,37 @@ async fn apply_branch_publish_action_update_persists_pull_request_notice() {
             .first()
             .and_then(|session| session.review_request.clone()),
         Some(review_request)
+    );
+}
+
+fn seed_completed_review_transient_message(app: &mut App) {
+    app.sessions.state_mut().sessions_mut()[0]
+        .transient_messages
+        .upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Markdown(
+                "## Review\n\nReview completed before publishing.".to_string(),
+            ),
+            lifecycle: TransientMessageLifecycle::ClearOnNewTurn,
+            slot: TransientMessageSlot::Review,
+            turn_position: None,
+        });
+}
+
+fn assert_review_message_reanchored_after_publish(app: &App) {
+    let transient_messages = &app.sessions.state().sessions()[0].transient_messages;
+
+    assert!(
+        transient_messages
+            .get(TransientMessageSlot::BranchPublish)
+            .is_none()
+    );
+    assert_eq!(
+        transient_messages
+            .get(TransientMessageSlot::Review)
+            .expect("completed review should remain visible")
+            .anchor,
+        TransientMessageAnchor::AfterCompletedTurn
     );
 }
 

--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -601,11 +601,32 @@ impl SessionManager {
                 .get_or_insert_default()
                 .append_message(SessionMessageKind::WorkflowNotice, persistent_notice);
         }
+        Self::place_completed_review_before_new_workflow_notice(session);
         session
             .transient_messages
             .retract(TransientMessageSlot::BranchPublish);
 
         true
+    }
+
+    /// Moves an already-completed focused review ahead of a newer durable
+    /// workflow notice while leaving an in-flight review at the output tail.
+    fn place_completed_review_before_new_workflow_notice(session: &mut Session) {
+        let Some(mut review_message) = session
+            .transient_messages
+            .get(TransientMessageSlot::Review)
+            .filter(|message| {
+                matches!(
+                    &message.body,
+                    TransientMessageBody::Markdown(_) | TransientMessageBody::Plain(_)
+                )
+            })
+            .cloned()
+        else {
+            return;
+        };
+        review_message.anchor = TransientMessageAnchor::AfterCompletedTurn;
+        session.transient_messages.upsert(review_message);
     }
 
     /// Marks one session branch as currently auto-syncing to its published

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -37,7 +37,8 @@ use crate::domain::session::{
 use crate::domain::session_message::SessionTranscript;
 use crate::domain::setting::SettingName;
 use crate::domain::transient_message::{
-    TransientMessageAnchor, TransientMessageBody, TransientMessageSlot, TransientMessageStore,
+    TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
+    TransientMessageSlot, TransientMessageStore,
 };
 use crate::infra::clock::{Clock, RealClock};
 use crate::infra::db::AppRepositories;
@@ -869,6 +870,44 @@ fn test_append_workflow_notice_anchors_active_status_notices_after_active_turn()
             "unexpected anchor for {status}"
         );
     }
+}
+
+#[test]
+fn test_finish_review_request_publish_keeps_loading_review_at_tail() {
+    // Arrange
+    let mut session_manager = test_session_manager("session-id", None);
+    session_manager.sessions_mut()[0]
+        .transient_messages
+        .upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading("Reviewing changes...".to_string()),
+            lifecycle: TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::Review,
+            turn_position: None,
+        });
+    session_manager.start_branch_publish("session-id", "Publishing review request...".to_string());
+
+    // Act
+    let finished = session_manager.finish_review_request_publish(
+        "session-id",
+        "[Review Request] Created PR https://example.test/pull/42",
+    );
+
+    // Assert
+    assert!(finished);
+    let transient_messages = &session_manager.sessions()[0].transient_messages;
+    assert_eq!(
+        transient_messages
+            .get(TransientMessageSlot::Review)
+            .expect("loading review should remain visible")
+            .anchor,
+        TransientMessageAnchor::Tail
+    );
+    assert!(
+        transient_messages
+            .get(TransientMessageSlot::BranchPublish)
+            .is_none()
+    );
 }
 
 #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -67,6 +67,10 @@ const PROMPT_FOCUS_DRAFT_TEXT: &str = "Draft kept while reading chat";
 /// decision and the instruction to honor it.
 const RESOLVED_DECISION_REVIEW_TEXT: &str = "Resolved session decision honored.";
 
+/// Review-request notice body used by the timeline-order regression.
+const REVIEW_REQUEST_TIMELINE_NOTICE_TEXT: &str =
+    "Created PR https://github.com/agentty-xyz/agentty/pull/42";
+
 /// Stable policy phrase the focused-review stub expects in the prompt.
 ///
 /// This intentionally matches only the durable concept instead of one full
@@ -852,8 +856,28 @@ fn seed_slow_successful_review_request_publish(
 ) -> Result<(), Box<dyn std::error::Error>> {
     seed_review_ready_session(env)?;
     seed_review_worktree_with_diff(env)?;
+
+    seed_successful_review_request_publish(env, 3, 15)
+}
+
+/// Seeds a live focused review that completes before a delayed review-request
+/// publish, reproducing the cross-source transcript ordering boundary.
+fn seed_review_request_timeline(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    seed_review_with_resolved_decision(env)?;
+
+    seed_successful_review_request_publish(env, 0, 0)
+}
+
+/// Configures the review-ready worktree and forge stubs for one successful
+/// review-request publish with deterministic command delays.
+fn seed_successful_review_request_publish(
+    env: &BuilderEnv,
+    push_delay_seconds: u64,
+    create_delay_seconds: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
     let session_worktree = env.agentty_root.join("wt").join("review-s");
     run_git(&session_worktree, &["branch", "-m", "wt/review-s"])?;
+    run_git(&session_worktree, &["branch", "main", "HEAD"])?;
 
     let real_git = std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
         .map(|path| path.join("git"))
@@ -863,7 +887,7 @@ fn seed_slow_successful_review_request_publish(
     let script = format!(
         r#"#!/bin/sh
 if [ "$1" = "push" ]; then
-  sleep 3
+  sleep {push_delay_seconds}
   exit 0
 fi
 exec '{}' "$@"
@@ -875,9 +899,7 @@ exec '{}' "$@"
     std::fs::set_permissions(&git_path, std::fs::Permissions::from_mode(0o755))?;
 
     let gh_path = env.stub_bin.join("gh");
-    std::fs::write(
-        &gh_path,
-        r#"#!/bin/sh
+    let gh_script = r#"#!/bin/sh
 marker_path="${0}.created"
 case "$*" in
   *"auth status"*)
@@ -891,8 +913,7 @@ case "$*" in
     fi
     ;;
   *"pr create"*)
-    # Exceeds both 3 s scenario wait budgets plus the 5.5 s mid-flight pause.
-    sleep 15
+    sleep __CREATE_DELAY_SECONDS__
     touch "$marker_path"
     ;;
   *"pr view"*)
@@ -903,8 +924,12 @@ case "$*" in
     exit 1
     ;;
 esac
-"#,
-    )?;
+"#
+    .replace(
+        "__CREATE_DELAY_SECONDS__",
+        &create_delay_seconds.to_string(),
+    );
+    std::fs::write(&gh_path, gh_script)?;
     #[cfg(unix)]
     std::fs::set_permissions(&gh_path, std::fs::Permissions::from_mode(0o755))?;
 
@@ -5732,6 +5757,55 @@ fn review_request_publish_runs_in_background() -> E2eResult {
                     &full,
                 );
                 assertion::assert_text_in_region(frame, "q: back", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify a review-request notice created after focused review completion is
+/// rendered below that review instead of being regrouped above it.
+#[test]
+fn review_request_notice_follows_completed_review() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("review_request_timeline_order")
+        .with_git()
+        .with_terminal_size(120, 40)
+        .setup(seed_review_request_timeline)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .compose(&common::open_selected_session_view())
+                    .press_key("f")
+                    .wait_for_text(RESOLVED_DECISION_REVIEW_TEXT, 30000)
+                    .press_key("p")
+                    .wait_for_text("Publish Review Request", 3000)
+                    .press_key("Enter")
+                    .wait_for_text(REVIEW_REQUEST_TIMELINE_NOTICE_TEXT, 10000)
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled(
+                        "review_request_timeline_order",
+                        "Review-request result follows the earlier focused review",
+                    )
+            },
+            |frame, _report| {
+                let review_finding = frame
+                    .find_text(RESOLVED_DECISION_REVIEW_TEXT)
+                    .into_iter()
+                    .next()
+                    .expect("completed focused review should render");
+                let review_request_notice = frame
+                    .find_text(REVIEW_REQUEST_TIMELINE_NOTICE_TEXT)
+                    .into_iter()
+                    .next()
+                    .expect("review-request notice should render");
+
+                assert!(
+                    review_finding.rect.row < review_request_notice.rect.row,
+                    "review-request notice should follow the earlier focused review"
+                );
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -177,10 +177,13 @@ queued chat. A worker-start event replaces that row with animated publish progre
 terminal reducer event then replaces it with inline success or failure output without
 changing whichever app mode is active at completion. Successful review-request creation
 retracts the transient row and appends its single-line URL result as a durable
-`WorkflowNotice` at the current transcript position. Later turns therefore leave the
-result in its original history position instead of reconstructing a transient between
-turns. The manual task holds the same per-session branch-operation lock as
-completed-turn auto-push for its full push and forge-metadata workflow. Queued
+`WorkflowNotice` at the current transcript position. If focused review already completed
+at the output tail, the reducer first moves that result into completed-turn placement so
+the newer review-request notice remains below it. An in-flight focused review stays at
+the tail and therefore appears after the notice when it completes later. Later turns
+leave the durable result in its original history position instead of reconstructing a
+transient between turns. The manual task holds the same per-session branch-operation
+lock as completed-turn auto-push for its full push and forge-metadata workflow. Queued
 review-request creation also registers as unfinished branch work before the current turn
 can start automatic publishing. Its UI and API handlers only attempt a non-blocking lock
 reservation while persisting the command; when another branch action already owns the

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -244,7 +244,10 @@ creation behind the operation in progress.
 
 Session output keeps workflow feedback in execution order. Commit feedback appears
 before its sync result, post-sync auto-push progress appears after that result, and
-focused-review progress remains at the tail while those branch operations finish.
+focused-review progress remains at the tail while those branch operations finish. If a
+focused review completes before a review request is published, the completed review
+stays above the later `[Review Request]` notice; a review that completes afterward stays
+below that notice.
 
 ### Focused Review
 


### PR DESCRIPTION
- Completed focused reviews appear before durable review-request notices while in-flight reviews remain at the output tail.
- Reducer state and end-to-end transcript ordering include regression coverage.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)