### PR TITLE
ModelClient owns the shared request lifecycle

### DIFF
--- a/crates/ag-harness/AGENTS.md
+++ b/crates/ag-harness/AGENTS.md
@@ -5,27 +5,28 @@ typed, and independent of Agentty UI or orchestration concerns.
 
 ## Boundaries
 
-- `Model` owns the shared request lifecycle, telemetry, and structured-output
-  validation.
-- Provider adapters implement `ModelBackend` and own authentication, capability checks,
-  payload translation, and raw generation.
-- API-family modules may share wire handling across providers, but their types remain
-  private.
+- `Model` is the object-safe application boundary; `ModelClient` implements it and owns
+  the shared request lifecycle, telemetry, and structured-output validation.
+- Private provider modules own public configuration and provider-specific capability
+  policy.
+- API-family modules own shared authentication, payload translation, wire handling, and
+  raw generation, but their runtime types remain private.
 - Network access stays behind an injectable client boundary.
 
 ## Invariants
 
 - Every request requires an output schema and every response is validated locally.
-- Unsupported provider capabilities return explicit errors; adapters must not silently
+- Unsupported provider capabilities return explicit errors; backends must not silently
   weaken the shared contract.
+- Provider metadata is validated and retained when a `ModelClient` is constructed.
 - Response bodies and diagnostics remain bounded.
-- Request-duration telemetry applies uniformly to every `ModelBackend`.
+- Request-duration telemetry applies uniformly to every `ModelClient` request.
 
 ## Change Routing
 
 - Put neutral lifecycle and contract changes in the model and schema modules.
 - Put reusable API-protocol behavior in its API-family module.
-- Keep provider-specific behavior under the provider module and in each adapter.
+- Keep provider-specific configuration and policy under the provider module.
 - Add focused tests for lifecycle, transport, schema, and provider behavior.
 
 ## Documentation

--- a/crates/ag-harness/examples/kimi.rs
+++ b/crates/ag-harness/examples/kimi.rs
@@ -3,7 +3,7 @@
 
 use std::io::{self, Write};
 
-use ag_harness::{Kimi, KimiConfig, Model, ModelRequest, OutputSchema};
+use ag_harness::{KimiConfig, ModelClient, ModelRequest, OutputSchema};
 
 #[path = "support/telemetry.rs"]
 mod telemetry;
@@ -28,11 +28,17 @@ async fn main() -> Result<(), DynError> {
 }
 
 async fn run() -> Result<(), DynError> {
-    let model = Kimi::new(KimiConfig {
+    let config = KimiConfig {
         api_key: std::env::var("KIMI_API_KEY")?,
         base_url: std::env::var("KIMI_BASE_URL")?,
         model: std::env::var("KIMI_MODEL")?,
-    });
+    };
+
+    request_greeting(config).await
+}
+
+async fn request_greeting(config: KimiConfig) -> Result<(), DynError> {
+    let model = ModelClient::kimi(config)?;
     let schema = OutputSchema::new(serde_json::from_str(GREETING_SCHEMA)?)?;
     let response = model
         .complete(ModelRequest::new(
@@ -71,6 +77,24 @@ mod tests {
                 Err(error.into())
             }
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn request_greeting_rejects_invalid_model() {
+        // Arrange
+        let config = KimiConfig {
+            api_key: "test-key".to_string(),
+            base_url: "https://example.com".to_string(),
+            model: "  ".to_string(),
+        };
+
+        // Act
+        let error = request_greeting(config)
+            .await
+            .expect_err("invalid model configuration should fail");
+
+        // Assert
+        assert_eq!(error.to_string(), "model identifier must not be empty");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/ag-harness/examples/qwen.rs
+++ b/crates/ag-harness/examples/qwen.rs
@@ -3,7 +3,7 @@
 
 use std::io::{self, Write};
 
-use ag_harness::{Model, ModelRequest, OutputSchema, Qwen, QwenConfig};
+use ag_harness::{ModelClient, ModelRequest, OutputSchema, QwenConfig};
 use serde_json::json;
 
 #[path = "support/telemetry.rs"]
@@ -17,12 +17,18 @@ async fn main() -> Result<(), DynError> {
 }
 
 async fn run() -> Result<(), DynError> {
-    let model = Qwen::new(QwenConfig {
+    let config = QwenConfig {
         api_key: std::env::var("DASHSCOPE_API_KEY")?,
         base_url: std::env::var("DASHSCOPE_BASE_URL")?,
         model: "qwen-plus".to_string(),
-    });
-    let schema = OutputSchema::new(json!({
+    };
+
+    request_greeting(config).await
+}
+
+async fn request_greeting(config: QwenConfig) -> Result<(), DynError> {
+    let client = ModelClient::qwen(config)?;
+    let schema = json!({
         "type": "object",
         "properties": {
             "message": {
@@ -32,8 +38,9 @@ async fn run() -> Result<(), DynError> {
         },
         "required": ["message"],
         "additionalProperties": false
-    }))?;
-    let response = model
+    });
+    let schema = OutputSchema::new(schema)?;
+    let response = client
         .complete(ModelRequest::new(
             "Return a JSON greeting with the message set to hello.",
             schema,
@@ -69,6 +76,24 @@ mod tests {
                 Err(error.into())
             }
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn request_greeting_rejects_invalid_model() {
+        // Arrange
+        let config = QwenConfig {
+            api_key: "test-key".to_string(),
+            base_url: "https://example.com".to_string(),
+            model: "  ".to_string(),
+        };
+
+        // Act
+        let error = request_greeting(config)
+            .await
+            .expect_err("invalid model configuration should fail");
+
+        // Assert
+        assert_eq!(error.to_string(), "model identifier must not be empty");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/ag-harness/src/chat_completion.rs
+++ b/crates/ag-harness/src/chat_completion.rs
@@ -4,11 +4,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 
-use crate::schema_contract;
+use crate::{model, schema_contract};
 
 pub(crate) const ERROR_BODY_LIMIT_BYTES: usize = 4 * 1024;
 const JSON_STRING_MAX_EXPANSION: usize = 6;
@@ -17,6 +17,130 @@ const REQUEST_TIMEOUT: Duration = Duration::from_mins(1);
 pub(crate) const SUCCESS_BODY_LIMIT_BYTES: usize = schema_contract::RESPONSE_CONTENT_LIMIT_BYTES
     * JSON_STRING_MAX_EXPANSION
     + RESPONSE_ENVELOPE_LIMIT_BYTES;
+pub(crate) const STRUCTURED_OUTPUT_INSTRUCTION: &str = concat!(
+    "Return only one JSON object. The object must validate against this JSON Schema. ",
+    "Do not include Markdown fences or any other text.\n\nJSON Schema:\n",
+);
+
+/// Provider policy applied by the shared JSON Object backend.
+#[derive(Clone, Copy)]
+pub(crate) struct JsonObjectProviderPolicy {
+    pub(crate) display_name: &'static str,
+    pub(crate) telemetry_name: &'static str,
+    pub(crate) unsupported_schema_reason: &'static str,
+}
+
+/// Shared JSON Object backend for OpenAI-compatible Chat Completions APIs.
+pub(crate) struct JsonObjectBackend {
+    api_key: String,
+    base_url: String,
+    client: Arc<dyn ChatCompletionClient>,
+    model: String,
+    policy: JsonObjectProviderPolicy,
+}
+
+impl JsonObjectBackend {
+    /// Creates a JSON Object backend with the production HTTP client.
+    pub(crate) fn new(
+        api_key: String,
+        base_url: String,
+        model: String,
+        policy: JsonObjectProviderPolicy,
+    ) -> Self {
+        Self::with_client(api_key, base_url, model, policy, default_client())
+    }
+
+    /// Returns the backend's telemetry identity.
+    pub(crate) fn identity(&self) -> (&'static str, &str) {
+        (self.policy.telemetry_name, &self.model)
+    }
+
+    /// Generates raw JSON Object output through the shared wire lifecycle.
+    pub(crate) async fn generate(
+        &self,
+        request: &model::ModelRequest,
+    ) -> Result<String, model::ModelError> {
+        if !request.schema().has_object_root() {
+            return Err(model::ModelError::UnsupportedOutputSchema {
+                reason: self.policy.unsupported_schema_reason.to_string(),
+            });
+        }
+        let messages = vec![
+            JsonObjectMessage {
+                content: format!(
+                    "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
+                    request.schema().value()
+                ),
+                role: "system",
+            },
+            JsonObjectMessage {
+                content: request.prompt().to_string(),
+                role: "user",
+            },
+        ];
+        let payload = JsonObjectRequest {
+            messages,
+            model: &self.model,
+            response_format: JsonObjectResponseFormat {
+                kind: "json_object",
+            },
+        };
+        let payload = serde_json::to_value(payload).map_err(model::ModelError::request)?;
+        let completion = self
+            .client
+            .complete(ChatCompletionRequest::new(
+                &self.api_key,
+                endpoint(&self.base_url),
+                payload,
+            ))
+            .await
+            .map_err(|error| self.map_completion_error(error))?
+            .ok_or(model::ModelError::InvalidResponse)?;
+        let (finish_reason, content) = completion.into_parts();
+        if finish_reason != "stop" {
+            return Err(model::ModelError::IncompleteResponse {
+                reason: schema_contract::bounded_diagnostic(finish_reason),
+            });
+        }
+        let text = content.ok_or(model::ModelError::InvalidResponse)?;
+
+        Ok(text)
+    }
+
+    /// Creates a JSON Object backend with an injected transport client.
+    pub(crate) fn with_client(
+        api_key: String,
+        base_url: String,
+        model: String,
+        policy: JsonObjectProviderPolicy,
+        client: Arc<dyn ChatCompletionClient>,
+    ) -> Self {
+        Self {
+            api_key,
+            base_url,
+            client,
+            model,
+            policy,
+        }
+    }
+
+    fn map_completion_error(&self, error: ChatCompletionError) -> model::ModelError {
+        match error {
+            ChatCompletionError::Http {
+                body,
+                source,
+                status,
+            } => model::ModelError::request(ProviderHttpError {
+                body,
+                provider: self.policy.display_name,
+                source,
+                status,
+            }),
+            ChatCompletionError::ResponseBodyTooLarge => model::ModelError::ResponseBodyTooLarge,
+            error => model::ModelError::request(error),
+        }
+    }
+}
 
 /// One provider-authenticated request using the Chat Completions wire API.
 pub(crate) struct ChatCompletionRequest<'a> {
@@ -221,6 +345,35 @@ impl ChatCompletionError {
     fn transport(error: impl Error + Send + Sync + 'static) -> Self {
         Self::Transport(Box::new(error))
     }
+}
+
+#[derive(Debug, Error)]
+#[error("{provider} returned HTTP {status}: {body}")]
+struct ProviderHttpError {
+    body: String,
+    provider: &'static str,
+    #[source]
+    source: reqwest::Error,
+    status: reqwest::StatusCode,
+}
+
+#[derive(Serialize)]
+struct JsonObjectRequest<'a> {
+    messages: Vec<JsonObjectMessage>,
+    model: &'a str,
+    response_format: JsonObjectResponseFormat,
+}
+
+#[derive(Serialize)]
+struct JsonObjectMessage {
+    content: String,
+    role: &'static str,
+}
+
+#[derive(Serialize)]
+struct JsonObjectResponseFormat {
+    #[serde(rename = "type")]
+    kind: &'static str,
 }
 
 #[derive(Deserialize)]

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -1,7 +1,7 @@
 //! Lightweight, Rust-native LLM harness for application-facing agent workflows.
 //!
-//! The crate provides a provider-neutral model contract, validated structured
-//! output, and model adapters.
+//! The crate provides a provider-neutral model client, validated structured
+//! output, and private provider backends.
 
 mod chat_completion;
 mod model;
@@ -9,6 +9,8 @@ mod provider;
 mod schema_contract;
 mod telemetry;
 
-pub use model::{Model, ModelBackend, ModelError, ModelMetadata, ModelRequest, ModelResponse};
-pub use provider::{Kimi, KimiConfig, Qwen, QwenConfig};
+pub use model::{
+    Model, ModelClient, ModelError, ModelMetadata, ModelMetadataError, ModelRequest, ModelResponse,
+};
+pub use provider::{KimiConfig, QwenConfig};
 pub use schema_contract::{OutputSchema, OutputSchemaError};

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -4,22 +4,16 @@ use async_trait::async_trait;
 use serde_json::Value;
 use thiserror::Error;
 
+use crate::provider::{self, KimiConfig, QwenConfig};
 use crate::schema_contract::{OutputSchema, OutputValidationError};
-use crate::telemetry;
+use crate::{chat_completion, telemetry};
 
-mod private {
-    pub trait Sealed {}
-
-    impl<T> Sealed for T where T: super::ModelBackend + ?Sized {}
-}
-
-/// Provider-neutral model behavior available to applications.
+/// Object-safe boundary for provider-neutral model requests.
 ///
-/// Implement [`ModelBackend`] to receive this behavior automatically. The
-/// shared implementation records telemetry and validates structured output for
-/// every provider.
+/// [`ModelClient`] implements this trait so applications can select supported
+/// providers dynamically without exposing provider backends or raw generation.
 #[async_trait]
-pub trait Model: private::Sealed + Send + Sync {
+pub trait Model: Send + Sync {
     /// Completes one model request.
     ///
     /// # Errors
@@ -29,14 +23,63 @@ pub trait Model: private::Sealed + Send + Sync {
     async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError>;
 }
 
-#[async_trait]
-impl<T> Model for T
-where
-    T: ModelBackend + ?Sized,
-{
-    async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
+/// Application-facing client for provider-neutral model requests.
+///
+/// Provider request execution remains private so every request passes through
+/// [`ModelClient::complete`], which owns telemetry and structured-output
+/// validation.
+pub struct ModelClient {
+    backend: chat_completion::JsonObjectBackend,
+    metadata: ModelMetadata,
+}
+
+impl ModelClient {
+    /// Creates a client backed by Moonshot AI's Kimi API.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelMetadataError`] when the configured model identifier is
+    /// empty or contains only whitespace.
+    pub fn kimi(config: KimiConfig) -> Result<Self, ModelMetadataError> {
+        Self::chat_completion(
+            config.api_key,
+            config.base_url,
+            config.model,
+            provider::KIMI_POLICY,
+        )
+    }
+
+    /// Creates a client backed by Alibaba Cloud Model Studio's Qwen API.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelMetadataError`] when the configured model identifier is
+    /// empty or contains only whitespace.
+    pub fn qwen(config: QwenConfig) -> Result<Self, ModelMetadataError> {
+        Self::chat_completion(
+            config.api_key,
+            config.base_url,
+            config.model,
+            provider::QWEN_POLICY,
+        )
+    }
+
+    /// Returns the validated provider and model identity retained by the
+    /// client.
+    pub fn metadata(&self) -> &ModelMetadata {
+        &self.metadata
+    }
+
+    /// Completes one model request through the shared telemetry and
+    /// structured-output lifecycle.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] when the provider request fails or its response
+    /// cannot be converted to the provider-neutral response.
+    pub async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
         let _duration = telemetry::RequestDuration::start(self.metadata());
-        let output = self.generate(&request).await?;
+        let output = self.backend.generate(&request).await?;
 
         request
             .schema()
@@ -44,45 +87,77 @@ where
             .map(ModelResponse::new)
             .map_err(ModelError::from)
     }
+
+    fn chat_completion(
+        api_key: String,
+        base_url: String,
+        model: String,
+        policy: chat_completion::JsonObjectProviderPolicy,
+    ) -> Result<Self, ModelMetadataError> {
+        let backend = chat_completion::JsonObjectBackend::new(api_key, base_url, model, policy);
+        let (provider, model) = backend.identity();
+        let metadata = ModelMetadata::new(provider, model)?;
+
+        Ok(Self { backend, metadata })
+    }
 }
 
-/// Provider strategy used by the shared [`Model`] request lifecycle.
 #[async_trait]
-pub trait ModelBackend: Send + Sync {
-    /// Returns stable identity attributes for model telemetry.
-    fn metadata(&self) -> ModelMetadata<'_>;
-
-    /// Generates raw structured-output text for one provider-neutral request.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ModelError`] when the provider cannot satisfy the request or
-    /// its response cannot be converted to assistant text.
-    async fn generate(&self, request: &ModelRequest) -> Result<String, ModelError>;
+impl Model for ModelClient {
+    async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
+        ModelClient::complete(self, request).await
+    }
 }
 
-/// Stable provider and model identity used by shared model behavior.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ModelMetadata<'a> {
-    model: &'a str,
+/// Validated provider and model identity used by the shared client lifecycle.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ModelMetadata {
+    model: String,
     provider: &'static str,
 }
 
-impl<'a> ModelMetadata<'a> {
+impl ModelMetadata {
     /// Creates metadata for one provider model.
-    pub fn new(provider: &'static str, model: &'a str) -> Self {
-        Self { model, provider }
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelMetadataError`] when `provider` or `model` is empty or
+    /// contains only whitespace.
+    pub fn new(
+        provider: &'static str,
+        model: impl Into<String>,
+    ) -> Result<Self, ModelMetadataError> {
+        if provider.trim().is_empty() {
+            return Err(ModelMetadataError::EmptyProvider);
+        }
+        let model = model.into();
+        if model.trim().is_empty() {
+            return Err(ModelMetadataError::EmptyModel);
+        }
+
+        Ok(Self { model, provider })
     }
 
     /// Returns the model identifier sent to the provider.
-    pub fn model(&self) -> &'a str {
-        self.model
+    pub fn model(&self) -> &str {
+        &self.model
     }
 
     /// Returns the provider identifier used by telemetry.
     pub fn provider(&self) -> &'static str {
         self.provider
     }
+}
+
+/// Invalid identity attributes supplied by a model provider.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ModelMetadataError {
+    /// The provider identifier is empty or contains only whitespace.
+    #[error("model provider must not be empty")]
+    EmptyProvider,
+    /// The model identifier is empty or contains only whitespace.
+    #[error("model identifier must not be empty")]
+    EmptyModel,
 }
 
 /// Provider-neutral input for one model request.
@@ -200,128 +275,71 @@ mod tests {
 
     use super::*;
 
-    enum StubOutcome {
-        Failure,
-        Output(&'static str),
-    }
+    #[test]
+    fn client_exposes_provider_and_model() {
+        // Arrange
+        let client = ModelClient::qwen(QwenConfig {
+            api_key: "test-key".to_string(),
+            base_url: "https://example.com".to_string(),
+            model: "qwen-plus".to_string(),
+        })
+        .expect("fixture configuration should be valid");
 
-    struct StubBackend {
-        model: &'static str,
-        outcome: StubOutcome,
-        provider: &'static str,
-    }
+        // Act
+        let metadata = client.metadata();
 
-    #[async_trait]
-    impl ModelBackend for StubBackend {
-        fn metadata(&self) -> ModelMetadata<'_> {
-            ModelMetadata::new(self.provider, self.model)
-        }
-
-        async fn generate(&self, request: &ModelRequest) -> Result<String, ModelError> {
-            assert_eq!(request.prompt(), "hello");
-
-            match self.outcome {
-                StubOutcome::Failure => Err(ModelError::request(io::Error::other("offline"))),
-                StubOutcome::Output(output) => Ok(output.to_string()),
-            }
-        }
-    }
-
-    fn object_schema() -> OutputSchema {
-        OutputSchema::new(json!({
-            "type": "object",
-            "properties": {
-                "name": { "type": "string" }
-            },
-            "required": ["name"],
-            "additionalProperties": false
-        }))
-        .expect("schema should be valid")
-    }
-
-    fn backend(outcome: StubOutcome) -> StubBackend {
-        StubBackend {
-            model: "stub-large",
-            outcome,
-            provider: "stub_provider",
-        }
+        // Assert
+        assert_eq!(metadata.provider(), "alibaba_cloud");
+        assert_eq!(metadata.model(), "qwen-plus");
+        assert_eq!(
+            metadata,
+            &ModelMetadata::new("alibaba_cloud", "qwen-plus").expect("metadata should be valid")
+        );
     }
 
     #[tokio::test]
-    async fn completes_request_through_shared_model_flow() {
+    async fn client_supports_dynamic_model_dispatch() {
         // Arrange
-        let model = backend(StubOutcome::Output(r#"{"name":"Ada"}"#));
+        let model: Box<dyn Model> = Box::new(
+            ModelClient::qwen(QwenConfig {
+                api_key: "test-key".to_string(),
+                base_url: "https://example.com".to_string(),
+                model: "qwen-plus".to_string(),
+            })
+            .expect("fixture configuration should be valid"),
+        );
+        let schema = OutputSchema::new(json!({ "type": "array" })).expect("schema should be valid");
 
         // Act
-        let response = model
-            .complete(ModelRequest::new("hello", object_schema()))
+        let error = model
+            .complete(ModelRequest::new("return a list", schema))
             .await
-            .expect("valid backend output should succeed");
+            .expect_err("Qwen should reject a non-object schema");
 
         // Assert
-        assert_eq!(response.output(), &json!({ "name": "Ada" }));
+        assert!(matches!(error, ModelError::UnsupportedOutputSchema { .. }));
     }
 
     #[test]
-    fn metadata_exposes_provider_and_model() {
-        // Arrange
-        let model = backend(StubOutcome::Output(r#"{"name":"Ada"}"#));
-
-        // Act
-        let metadata = model.metadata();
+    fn metadata_rejects_empty_provider() {
+        // Arrange and Act
+        let error =
+            ModelMetadata::new("  ", "stub-large").expect_err("empty provider should be rejected");
 
         // Assert
-        assert_eq!(metadata.provider(), "stub_provider");
-        assert_eq!(metadata.model(), "stub-large");
-        assert_eq!(metadata, ModelMetadata::new("stub_provider", "stub-large"));
+        assert_eq!(error, ModelMetadataError::EmptyProvider);
+        assert_eq!(error.to_string(), "model provider must not be empty");
     }
 
-    #[tokio::test]
-    async fn shared_model_flow_returns_provider_failure() {
-        // Arrange
-        let model = backend(StubOutcome::Failure);
-
-        // Act
-        let error = model
-            .complete(ModelRequest::new("hello", object_schema()))
-            .await
-            .expect_err("provider failure should be returned");
+    #[test]
+    fn metadata_rejects_empty_model() {
+        // Arrange and Act
+        let error =
+            ModelMetadata::new("stub_provider", "  ").expect_err("empty model should be rejected");
 
         // Assert
-        assert_eq!(error.to_string(), "model request failed: offline");
-    }
-
-    #[tokio::test]
-    async fn shared_model_flow_rejects_invalid_json() {
-        // Arrange
-        let model = backend(StubOutcome::Output("not JSON"));
-
-        // Act
-        let error = model
-            .complete(ModelRequest::new("hello", object_schema()))
-            .await
-            .expect_err("invalid JSON should fail");
-
-        // Assert
-        assert!(matches!(error, ModelError::InvalidJson { .. }));
-    }
-
-    #[tokio::test]
-    async fn shared_model_flow_rejects_schema_violation() {
-        // Arrange
-        let model = backend(StubOutcome::Output(r#"{"name":42}"#));
-
-        // Act
-        let error = model
-            .complete(ModelRequest::new("hello", object_schema()))
-            .await
-            .expect_err("schema violation should fail");
-
-        // Assert
-        assert!(matches!(
-            error,
-            ModelError::SchemaViolation { path, .. } if path == "/name"
-        ));
+        assert_eq!(error, ModelMetadataError::EmptyModel);
+        assert_eq!(error.to_string(), "model identifier must not be empty");
     }
 
     #[test]

--- a/crates/ag-harness/src/provider.rs
+++ b/crates/ag-harness/src/provider.rs
@@ -3,5 +3,7 @@
 mod kimi;
 mod qwen;
 
-pub use kimi::{Kimi, KimiConfig};
-pub use qwen::{Qwen, QwenConfig};
+pub use kimi::KimiConfig;
+pub(crate) use kimi::POLICY as KIMI_POLICY;
+pub(crate) use qwen::POLICY as QWEN_POLICY;
+pub use qwen::QwenConfig;

--- a/crates/ag-harness/src/provider/kimi.rs
+++ b/crates/ag-harness/src/provider/kimi.rs
@@ -1,18 +1,12 @@
-use std::sync::Arc;
+use crate::chat_completion;
 
-use async_trait::async_trait;
-use serde::Serialize;
-use thiserror::Error;
-
-use crate::{chat_completion, model, schema_contract};
-
-const PROVIDER_NAME: &str = "moonshot_ai";
-const STRUCTURED_OUTPUT_INSTRUCTION: &str = concat!(
-    "Return only one JSON object. The object must validate against this JSON Schema. ",
-    "Do not include Markdown fences or any other text.\n\nJSON Schema:\n",
-);
-const UNSUPPORTED_SCHEMA_REASON: &str =
-    "Kimi JSON Object mode requires an explicit object root schema";
+pub(crate) const PROVIDER_NAME: &str = "moonshot_ai";
+pub(crate) const POLICY: chat_completion::JsonObjectProviderPolicy =
+    chat_completion::JsonObjectProviderPolicy {
+        display_name: "Kimi",
+        telemetry_name: PROVIDER_NAME,
+        unsupported_schema_reason: "Kimi JSON Object mode requires an explicit object root schema",
+    };
 
 /// Configuration for a Kimi model served through Moonshot AI's
 /// OpenAI-compatible API.
@@ -25,128 +19,6 @@ pub struct KimiConfig {
     pub model: String,
 }
 
-/// Kimi implementation of the provider-neutral [`model::ModelBackend`]
-/// strategy.
-pub struct Kimi {
-    client: Arc<dyn chat_completion::ChatCompletionClient>,
-    config: KimiConfig,
-}
-
-impl Kimi {
-    /// Creates a Kimi model adapter.
-    pub fn new(config: KimiConfig) -> Self {
-        Self::with_client(config, chat_completion::default_client())
-    }
-
-    fn with_client(
-        config: KimiConfig,
-        client: Arc<dyn chat_completion::ChatCompletionClient>,
-    ) -> Self {
-        Self { client, config }
-    }
-
-    fn map_completion_error(error: chat_completion::ChatCompletionError) -> model::ModelError {
-        match error {
-            chat_completion::ChatCompletionError::Http {
-                body,
-                source,
-                status,
-            } => model::ModelError::request(KimiHttpError {
-                body,
-                source,
-                status,
-            }),
-            chat_completion::ChatCompletionError::ResponseBodyTooLarge => {
-                model::ModelError::ResponseBodyTooLarge
-            }
-            error => model::ModelError::request(error),
-        }
-    }
-}
-
-#[async_trait]
-impl model::ModelBackend for Kimi {
-    fn metadata(&self) -> model::ModelMetadata<'_> {
-        model::ModelMetadata::new(PROVIDER_NAME, &self.config.model)
-    }
-
-    async fn generate(&self, request: &model::ModelRequest) -> Result<String, model::ModelError> {
-        if !request.schema().has_object_root() {
-            return Err(model::ModelError::UnsupportedOutputSchema {
-                reason: UNSUPPORTED_SCHEMA_REASON.to_string(),
-            });
-        }
-        let messages = vec![
-            KimiMessage {
-                content: format!(
-                    "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
-                    request.schema().value()
-                ),
-                role: "system",
-            },
-            KimiMessage {
-                content: request.prompt().to_string(),
-                role: "user",
-            },
-        ];
-        let payload = KimiRequest {
-            messages,
-            model: &self.config.model,
-            response_format: KimiResponseFormat {
-                kind: "json_object",
-            },
-        };
-        let payload = serde_json::to_value(payload).map_err(model::ModelError::request)?;
-        let completion = self
-            .client
-            .complete(chat_completion::ChatCompletionRequest::new(
-                &self.config.api_key,
-                chat_completion::endpoint(&self.config.base_url),
-                payload,
-            ))
-            .await
-            .map_err(Self::map_completion_error)?
-            .ok_or(model::ModelError::InvalidResponse)?;
-        let (finish_reason, content) = completion.into_parts();
-        if finish_reason != "stop" {
-            return Err(model::ModelError::IncompleteResponse {
-                reason: schema_contract::bounded_diagnostic(finish_reason),
-            });
-        }
-        let text = content.ok_or(model::ModelError::InvalidResponse)?;
-
-        Ok(text)
-    }
-}
-
-#[derive(Debug, Error)]
-#[error("Kimi returned HTTP {status}: {body}")]
-struct KimiHttpError {
-    body: String,
-    #[source]
-    source: reqwest::Error,
-    status: reqwest::StatusCode,
-}
-
-#[derive(Serialize)]
-struct KimiRequest<'a> {
-    messages: Vec<KimiMessage>,
-    model: &'a str,
-    response_format: KimiResponseFormat,
-}
-
-#[derive(Serialize)]
-struct KimiMessage {
-    content: String,
-    role: &'static str,
-}
-
-#[derive(Serialize)]
-struct KimiResponseFormat {
-    #[serde(rename = "type")]
-    kind: &'static str,
-}
-
 #[cfg(test)]
 mod tests {
     use serde_json::{Value, json};
@@ -154,10 +26,11 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
-    use crate::Model;
     use crate::chat_completion::{
-        ERROR_BODY_LIMIT_BYTES, RESPONSE_ENVELOPE_LIMIT_BYTES, SUCCESS_BODY_LIMIT_BYTES,
+        ERROR_BODY_LIMIT_BYTES, RESPONSE_ENVELOPE_LIMIT_BYTES, STRUCTURED_OUTPUT_INSTRUCTION,
+        SUCCESS_BODY_LIMIT_BYTES,
     };
+    use crate::{model, schema_contract};
 
     fn person_schema_value() -> Value {
         json!({
@@ -190,29 +63,49 @@ mod tests {
         .expect("schema should be valid")
     }
 
-    fn kimi(server: &MockServer) -> Kimi {
-        Kimi::new(KimiConfig {
+    fn kimi(server: &MockServer) -> model::ModelClient {
+        model::ModelClient::kimi(KimiConfig {
             api_key: "test-key".to_string(),
             base_url: format!("{}/", server.uri()),
             model: "kimi-k2.6".to_string(),
         })
+        .expect("fixture configuration should be valid")
     }
 
     #[test]
     fn metadata_exposes_provider_and_model() {
         // Arrange
-        let model = Kimi::new(KimiConfig {
+        let model = model::ModelClient::kimi(KimiConfig {
             api_key: "test-key".to_string(),
             base_url: "https://api.moonshot.example/v1".to_string(),
             model: "kimi-k2.6".to_string(),
-        });
+        })
+        .expect("fixture configuration should be valid");
 
         // Act
-        let metadata = model::ModelBackend::metadata(&model);
+        let metadata = model.metadata();
 
         // Assert
         assert_eq!(metadata.provider(), "moonshot_ai");
         assert_eq!(metadata.model(), "kimi-k2.6");
+    }
+
+    #[test]
+    fn rejects_empty_model_during_construction() {
+        // Arrange
+        let config = KimiConfig {
+            api_key: "test-key".to_string(),
+            base_url: "https://api.moonshot.example/v1".to_string(),
+            model: "  ".to_string(),
+        };
+
+        // Act
+        let error = model::ModelClient::kimi(config)
+            .err()
+            .expect("empty model configuration should be rejected");
+
+        // Assert
+        assert_eq!(error, model::ModelMetadataError::EmptyModel);
     }
 
     async fn mount_structured_response(

--- a/crates/ag-harness/src/provider/qwen.rs
+++ b/crates/ag-harness/src/provider/qwen.rs
@@ -1,18 +1,12 @@
-use std::sync::Arc;
+use crate::chat_completion;
 
-use async_trait::async_trait;
-use serde::Serialize;
-use thiserror::Error;
-
-use crate::{chat_completion, model, schema_contract};
-
-const PROVIDER_NAME: &str = "alibaba_cloud";
-const STRUCTURED_OUTPUT_INSTRUCTION: &str = concat!(
-    "Return only one JSON object. The object must validate against this JSON Schema. ",
-    "Do not include Markdown fences or any other text.\n\nJSON Schema:\n",
-);
-const UNSUPPORTED_SCHEMA_REASON: &str =
-    "Qwen JSON Object mode requires an explicit object root schema";
+pub(crate) const PROVIDER_NAME: &str = "alibaba_cloud";
+pub(crate) const POLICY: chat_completion::JsonObjectProviderPolicy =
+    chat_completion::JsonObjectProviderPolicy {
+        display_name: "Qwen",
+        telemetry_name: PROVIDER_NAME,
+        unsupported_schema_reason: "Qwen JSON Object mode requires an explicit object root schema",
+    };
 
 /// Configuration for a Qwen model served through Alibaba Cloud Model Studio's
 /// OpenAI-compatible API.
@@ -25,140 +19,22 @@ pub struct QwenConfig {
     pub model: String,
 }
 
-/// Qwen implementation of the provider-neutral [`model::ModelBackend`]
-/// strategy.
-pub struct Qwen {
-    client: Arc<dyn chat_completion::ChatCompletionClient>,
-    config: QwenConfig,
-}
-
-impl Qwen {
-    /// Creates a Qwen model adapter.
-    pub fn new(config: QwenConfig) -> Self {
-        Self::with_client(config, chat_completion::default_client())
-    }
-
-    fn with_client(
-        config: QwenConfig,
-        client: Arc<dyn chat_completion::ChatCompletionClient>,
-    ) -> Self {
-        Self { client, config }
-    }
-
-    fn map_completion_error(error: chat_completion::ChatCompletionError) -> model::ModelError {
-        match error {
-            chat_completion::ChatCompletionError::Http {
-                body,
-                source,
-                status,
-            } => model::ModelError::request(QwenHttpError {
-                body,
-                source,
-                status,
-            }),
-            chat_completion::ChatCompletionError::ResponseBodyTooLarge => {
-                model::ModelError::ResponseBodyTooLarge
-            }
-            error => model::ModelError::request(error),
-        }
-    }
-}
-
-#[async_trait]
-impl model::ModelBackend for Qwen {
-    fn metadata(&self) -> model::ModelMetadata<'_> {
-        model::ModelMetadata::new(PROVIDER_NAME, &self.config.model)
-    }
-
-    async fn generate(&self, request: &model::ModelRequest) -> Result<String, model::ModelError> {
-        if !request.schema().has_object_root() {
-            return Err(model::ModelError::UnsupportedOutputSchema {
-                reason: UNSUPPORTED_SCHEMA_REASON.to_string(),
-            });
-        }
-        let messages = vec![
-            QwenMessage {
-                content: format!(
-                    "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
-                    request.schema().value()
-                ),
-                role: "system",
-            },
-            QwenMessage {
-                content: request.prompt().to_string(),
-                role: "user",
-            },
-        ];
-        let payload = QwenRequest {
-            messages,
-            model: &self.config.model,
-            response_format: QwenResponseFormat {
-                kind: "json_object",
-            },
-        };
-        let payload = serde_json::to_value(payload).map_err(model::ModelError::request)?;
-        let completion = self
-            .client
-            .complete(chat_completion::ChatCompletionRequest::new(
-                &self.config.api_key,
-                chat_completion::endpoint(&self.config.base_url),
-                payload,
-            ))
-            .await
-            .map_err(Self::map_completion_error)?
-            .ok_or(model::ModelError::InvalidResponse)?;
-        let (finish_reason, content) = completion.into_parts();
-        if finish_reason != "stop" {
-            return Err(model::ModelError::IncompleteResponse {
-                reason: schema_contract::bounded_diagnostic(finish_reason),
-            });
-        }
-        let text = content.ok_or(model::ModelError::InvalidResponse)?;
-
-        Ok(text)
-    }
-}
-
-#[derive(Debug, Error)]
-#[error("Qwen returned HTTP {status}: {body}")]
-struct QwenHttpError {
-    body: String,
-    #[source]
-    source: reqwest::Error,
-    status: reqwest::StatusCode,
-}
-
-#[derive(Serialize)]
-struct QwenRequest<'a> {
-    messages: Vec<QwenMessage>,
-    model: &'a str,
-    response_format: QwenResponseFormat,
-}
-
-#[derive(Serialize)]
-struct QwenMessage {
-    content: String,
-    role: &'static str,
-}
-
-#[derive(Serialize)]
-struct QwenResponseFormat {
-    #[serde(rename = "type")]
-    kind: &'static str,
-}
-
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
     use serde_json::json;
     use wiremock::matchers::{bearer_token, body_json, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
-    use crate::Model;
     use crate::chat_completion::{
         ChatCompletion, ChatCompletionClient, ChatCompletionError, ChatCompletionRequest,
-        ERROR_BODY_LIMIT_BYTES, RESPONSE_ENVELOPE_LIMIT_BYTES, SUCCESS_BODY_LIMIT_BYTES,
+        ERROR_BODY_LIMIT_BYTES, JsonObjectBackend, RESPONSE_ENVELOPE_LIMIT_BYTES,
+        STRUCTURED_OUTPUT_INSTRUCTION, SUCCESS_BODY_LIMIT_BYTES,
     };
+    use crate::{model, schema_contract};
 
     struct StubClient;
 
@@ -212,12 +88,31 @@ mod tests {
         .expect("schema should be valid")
     }
 
-    fn qwen(server: &MockServer) -> Qwen {
-        Qwen::new(QwenConfig {
+    fn qwen(server: &MockServer) -> model::ModelClient {
+        model::ModelClient::qwen(QwenConfig {
             api_key: "test-key".to_string(),
             base_url: format!("{}/", server.uri()),
             model: "qwen-plus".to_string(),
         })
+        .expect("fixture configuration should be valid")
+    }
+
+    #[test]
+    fn rejects_empty_model_during_construction() {
+        // Arrange
+        let config = QwenConfig {
+            api_key: "test-key".to_string(),
+            base_url: "https://example.com".to_string(),
+            model: "  ".to_string(),
+        };
+
+        // Act
+        let error = model::ModelClient::qwen(config)
+            .err()
+            .expect("empty model configuration should be rejected");
+
+        // Assert
+        assert_eq!(error, model::ModelMetadataError::EmptyModel);
     }
 
     async fn mount_structured_response(
@@ -276,23 +171,22 @@ mod tests {
     #[tokio::test]
     async fn completes_through_injected_client() {
         // Arrange
-        let model = Qwen::with_client(
-            QwenConfig {
-                api_key: "stub-key".to_string(),
-                base_url: "https://stub.example/v1/".to_string(),
-                model: "qwen-stub".to_string(),
-            },
+        let model = JsonObjectBackend::with_client(
+            "stub-key".to_string(),
+            "https://stub.example/v1/".to_string(),
+            "qwen-stub".to_string(),
+            POLICY,
             Arc::new(StubClient),
         );
 
         // Act
-        let response = model
-            .complete(request("extract the name"))
+        let output = model
+            .generate(&request("extract the name"))
             .await
             .expect("stubbed Qwen request should succeed");
 
         // Assert
-        assert_eq!(response.output(), &json!({ "name": "Ada" }));
+        assert_eq!(output, r#"{"name":"Ada"}"#);
     }
 
     #[tokio::test]
@@ -488,7 +382,7 @@ mod tests {
         assert!(errors.into_iter().all(|error| matches!(
             error,
             model::ModelError::UnsupportedOutputSchema { reason }
-                if reason == UNSUPPORTED_SCHEMA_REASON
+                if reason == "Qwen JSON Object mode requires an explicit object root schema"
         )));
         assert!(
             server

--- a/crates/ag-harness/src/telemetry.rs
+++ b/crates/ag-harness/src/telemetry.rs
@@ -19,20 +19,22 @@ pub(crate) struct RequestDuration<'a> {
 
 impl<'a> RequestDuration<'a> {
     /// Starts timing one model request.
-    pub(crate) fn start(metadata: ModelMetadata<'a>) -> Self {
-        let metric = global::meter("ag-harness")
-            .f64_histogram("gen_ai.client.operation.duration")
-            .with_description("GenAI operation duration.")
-            .with_unit("s")
-            .with_boundaries(DURATION_BOUNDARIES_SECONDS.to_vec())
-            .build();
-
+    pub(crate) fn start(metadata: &'a ModelMetadata) -> Self {
         Self {
-            metric,
+            metric: Self::duration_histogram(),
             model: metadata.model(),
             provider: metadata.provider(),
             started_at: Instant::now(),
         }
+    }
+
+    fn duration_histogram() -> Histogram<f64> {
+        global::meter("ag-harness")
+            .f64_histogram("gen_ai.client.operation.duration")
+            .with_description("GenAI operation duration.")
+            .with_unit("s")
+            .with_boundaries(DURATION_BOUNDARIES_SECONDS.to_vec())
+            .build()
     }
 }
 

--- a/crates/ag-harness/tests/telemetry.rs
+++ b/crates/ag-harness/tests/telemetry.rs
@@ -1,52 +1,72 @@
 //! Integration coverage for the `ag-harness` request-duration metric.
 #![cfg(test)]
 
-use std::{future, io};
+use std::sync::Arc;
+use std::time::Duration;
 
-use ag_harness::{Model, ModelBackend, ModelError, ModelMetadata, ModelRequest, OutputSchema};
-use async_trait::async_trait;
 use opentelemetry::global;
 use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
 use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
 use serde_json::json;
+use tokio::sync::Notify;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
 
-#[derive(Clone, Copy)]
-enum StubOutcome {
-    Failure,
-    Pending,
-    Success,
+struct PendingResponse {
+    started: Arc<Notify>,
 }
 
-struct StubBackend {
-    model: &'static str,
-    outcome: StubOutcome,
-}
+impl Respond for PendingResponse {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        self.started.notify_one();
 
-#[async_trait]
-impl ModelBackend for StubBackend {
-    fn metadata(&self) -> ModelMetadata<'_> {
-        ModelMetadata::new("stub_provider", self.model)
-    }
-
-    async fn generate(&self, _request: &ModelRequest) -> Result<String, ModelError> {
-        match self.outcome {
-            StubOutcome::Failure => Err(ModelError::request(io::Error::other("offline"))),
-            StubOutcome::Pending => future::pending().await,
-            StubOutcome::Success => Ok(r#"{"name":"Ada"}"#.to_string()),
-        }
+        ResponseTemplate::new(200)
+            .set_delay(Duration::from_secs(10))
+            .set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": r#"{"name":"Ada"}"#}
+                }]
+            }))
     }
 }
 
-fn schema() -> OutputSchema {
-    OutputSchema::new(json!({
-        "type": "object",
-        "properties": {
-            "name": { "type": "string" }
-        },
-        "required": ["name"],
-        "additionalProperties": false
-    }))
-    .expect("fixture schema should be valid")
+fn client(server: &MockServer, model: &str) -> ag_harness::ModelClient {
+    ag_harness::ModelClient::qwen(ag_harness::QwenConfig {
+        api_key: "test-key".to_string(),
+        base_url: server.uri(),
+        model: model.to_string(),
+    })
+    .expect("fixture configuration should be valid")
+}
+
+fn request(prompt: &str) -> ag_harness::ModelRequest {
+    ag_harness::ModelRequest::new(
+        prompt,
+        ag_harness::OutputSchema::new(json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        }))
+        .expect("fixture schema should be valid"),
+    )
+}
+
+async fn mount_success_response(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {"content": r#"{"name":"Ada"}"#}
+            }]
+        })))
+        .expect(1)
+        .mount(server)
+        .await;
 }
 
 fn metric_attributes(
@@ -61,45 +81,76 @@ fn metric_attributes(
     attributes
 }
 
-#[tokio::test(flavor = "current_thread")]
-async fn records_only_request_duration_after_provider_installation() {
-    // Arrange
-    StubBackend {
-        model: "before-installation",
-        outcome: StubOutcome::Success,
+async fn wait_for_provider(
+    started: &Notify,
+    request_task: &mut tokio::task::JoinHandle<
+        Result<ag_harness::ModelResponse, ag_harness::ModelError>,
+    >,
+) -> Result<(), String> {
+    tokio::select! {
+        () = started.notified() => Ok(()),
+        result = request_task => {
+            Err(format!("pending request completed before cancellation: {result:?}"))
+        }
+        () = tokio::time::sleep(Duration::from_secs(5)) => {
+            Err("pending request did not reach the provider before the timeout".to_string())
+        }
     }
-    .complete(ModelRequest::new("before provider installation", schema()))
-    .await
-    .expect("request before provider installation should succeed");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn records_request_duration_after_late_provider_installation_for_all_outcomes() {
+    // Arrange
+    let unconfigured_server = MockServer::start().await;
+    mount_success_response(&unconfigured_server).await;
+
+    // Act
+    client(&unconfigured_server, "before-installation")
+        .complete(request("request before telemetry installation"))
+        .await
+        .expect("request before telemetry installation should succeed");
+
+    // Arrange
     let exporter = InMemoryMetricExporter::default();
     let meter_provider = SdkMeterProvider::builder()
         .with_periodic_exporter(exporter.clone())
         .build();
     global::set_meter_provider(meter_provider.clone());
+    let success_server = MockServer::start().await;
+    mount_success_response(&success_server).await;
+    let failure_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("offline"))
+        .expect(1)
+        .mount(&failure_server)
+        .await;
+    let pending_server = MockServer::start().await;
+    let pending_started = Arc::new(Notify::new());
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(PendingResponse {
+            started: Arc::clone(&pending_started),
+        })
+        .expect(1)
+        .mount(&pending_server)
+        .await;
 
     // Act
-    StubBackend {
-        model: "successful",
-        outcome: StubOutcome::Success,
-    }
-    .complete(ModelRequest::new("after provider installation", schema()))
-    .await
-    .expect("instrumented request should succeed");
-    let failure = StubBackend {
-        model: "failed",
-        outcome: StubOutcome::Failure,
-    }
-    .complete(ModelRequest::new("failing request", schema()))
-    .await
-    .expect_err("instrumented provider failure should be returned");
-    let pending_request = tokio::spawn(
-        StubBackend {
-            model: "cancelled",
-            outcome: StubOutcome::Pending,
-        }
-        .complete(ModelRequest::new("cancelled request", schema())),
-    );
-    tokio::task::yield_now().await;
+    client(&success_server, "successful")
+        .complete(request("successful request"))
+        .await
+        .expect("instrumented request should succeed");
+    let failure = client(&failure_server, "failed")
+        .complete(request("failing request"))
+        .await
+        .expect_err("instrumented provider failure should be returned");
+    let pending_client = client(&pending_server, "cancelled");
+    let mut pending_request =
+        tokio::spawn(async move { pending_client.complete(request("cancelled request")).await });
+    wait_for_provider(&pending_started, &mut pending_request)
+        .await
+        .expect("pending request should reach the provider");
     pending_request.abort();
     let cancellation = pending_request
         .await
@@ -109,7 +160,7 @@ async fn records_only_request_duration_after_provider_installation() {
         .expect("duration metric should flush");
 
     // Assert
-    assert!(matches!(failure, ModelError::Request(_)));
+    assert!(matches!(failure, ag_harness::ModelError::Request(_)));
     assert!(cancellation.is_cancelled());
     let resource_metrics = exporter
         .get_finished_metrics()
@@ -137,15 +188,15 @@ async fn records_only_request_duration_after_provider_installation() {
                 attributes,
                 [
                     vec![
-                        ("gen_ai.provider.name", "stub_provider".to_string()),
+                        ("gen_ai.provider.name", "alibaba_cloud".to_string()),
                         ("gen_ai.request.model", "cancelled".to_string()),
                     ],
                     vec![
-                        ("gen_ai.provider.name", "stub_provider".to_string()),
+                        ("gen_ai.provider.name", "alibaba_cloud".to_string()),
                         ("gen_ai.request.model", "failed".to_string()),
                     ],
                     vec![
-                        ("gen_ai.provider.name", "stub_provider".to_string()),
+                        ("gen_ai.provider.name", "alibaba_cloud".to_string()),
                         ("gen_ai.request.model", "successful".to_string()),
                     ],
                 ]

--- a/crates/agentty/tests/e2e/orchestration.rs
+++ b/crates/agentty/tests/e2e/orchestration.rs
@@ -640,6 +640,7 @@ fn test_managed_worker_review_open_action() -> E2eResult {
                         "Review-ready managed worker exposes worktree open",
                     )
                     .press_key("q")
+                    .wait_for_stable_frame(300, 5000)
                     .press_key("o")
                     .wait_for_text("Open Managed Worktree", 5000)
                     .capture_labeled(

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -11,19 +11,23 @@ exposes provider-neutral model calls while preserving provider-specific capabili
 
 ```mermaid
 flowchart LR
-    A[Application] --> M[Model lifecycle]
-    M --> Q[Qwen backend]
-    M --> K[Kimi backend]
-    Q --> C[Chat Completions]
-    K --> C
+    A[Application] --> T[Model trait]
+    T --> M[ModelClient lifecycle]
+    M --> Q[Qwen policy]
+    M --> K[Kimi policy]
+    Q --> J[JSON Object backend]
+    K --> J
+    J --> C[Chat Completions]
 ```
 
 ## Model Boundary
 
-`Model` owns request-duration telemetry and validates every response against the
-request's `OutputSchema`. Provider adapters implement `ModelBackend` to supply stable
-identity and raw assistant output. Provider payloads, authentication, HTTP types, and
-capability rules remain private.
+The object-safe `Model` trait lets applications store supported clients behind
+`dyn Model`. `ModelClient` implements that boundary, owns request-duration telemetry,
+and validates every response against the request's `OutputSchema`. Provider request
+execution remains private so applications cannot bypass this lifecycle. `ModelClient`
+validates and retains the provider and model identity during construction, before any
+request starts.
 
 Provider-owned adapters and compatibility rules live under the private `provider`
 module. API-family clients remain separate so multiple providers can reuse a wire
@@ -32,14 +36,12 @@ protocol without sharing provider policy.
 Qwen and Kimi share Chat Completions request execution and bounded response decoding.
 Both providers request JSON Object output, include the requested `OutputSchema` in the
 system instruction, and rely on shared local schema validation before returning a
-successful response.
-
-Schemas without an explicit object root and unsupported configurations fail explicitly
-rather than falling back to unstructured output.
+successful response. Schemas without an explicit object root and unsupported
+configurations fail explicitly rather than falling back to unstructured output.
 
 ## Telemetry
 
-The shared `Model` lifecycle records `gen_ai.client.operation.duration` for every
+The shared `ModelClient` lifecycle records `gen_ai.client.operation.duration` for every
 backend request, including failures and cancellations. Application binaries own
 OpenTelemetry SDK setup, export, and shutdown. The Qwen and Kimi examples configure
 OTLP/HTTP metrics through the standard `OTEL_EXPORTER_OTLP_ENDPOINT` and

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -31,9 +31,9 @@ For file-level detail, read the module docstrings directly.
   metadata, commit/diff/push/pull sync, rebase/conflict handling, and squash-merge
   workflows behind the `GitClient` boundary.
 - `crates/ag-harness/`: Application-facing LLM harness crate with the provider-neutral
-  `Model` lifecycle, private provider adapters for Qwen and Kimi, shared Chat
-  Completions behavior, and backend-neutral request-duration telemetry. Application
-  binaries own telemetry setup.
+  object-safe `Model` boundary, its `ModelClient` implementation, private Qwen and Kimi
+  policies, a shared Chat Completions JSON Object backend, and backend-neutral
+  request-duration telemetry. Application binaries own telemetry setup.
 - `crates/ag-protocol/`: Shared structured response protocol library crate with
   transport-neutral response models, schema generation, parser diagnostics, protocol
   prompt envelopes, repair prompts, review-comment outcomes, and turn prompt payload


### PR DESCRIPTION
- Applications create validated provider clients and complete requests through the public `ModelClient`; provider backends and raw generation remain private.
- The client validates structured output and records successful, failed, and cancelled request durations.
- Provider adapters implement `Model` directly with validated identity metadata retained before requests begin and raw generation.
- The default `Model::complete()` lifecycle records successful, failed, and cancelled requests through the configured meter provider.
- The public `complete()` lifecycle validates structured output.
- Applications configure the meter provider before the first request so the shared histogram binds to it.
- The Qwen example covers constructor-error propagation.
- A capability token prevents direct raw-generation calls outside the shared lifecycle.
- The provider model API supports both concrete and dynamically dispatched adapters.
- The telemetry cancellation test is protected from indefinite waits.
- Request-duration instrumentation resolves the global meter for each request, so providers installed after an earlier request capture subsequent successful, failed, and cancelled outcomes.
- Kimi and Qwen share a private Chat Completions JSON Object backend while preserving provider-specific policies and configuration.
- Applications construct validated `ModelClient` instances that retain provider and model metadata while keeping provider backends and raw generation private.
- The client validates structured output and records request durations for successful, failed, and cancelled requests, including requests made after telemetry provider installation.