### PR TITLE
Kimi and Qwen share Chat Completions transport

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -181,10 +181,10 @@ repos:
         stages: [manual]
       - id: coverage
         name: coverage
-        description: Verify source and Qwen example coverage meets workspace ratchet thresholds and write the CI LCOV report for SonarQube and Codecov.
+        description: Verify source and example coverage meets workspace ratchet thresholds and write the CI LCOV report for SonarQube and Codecov.
         entry: >-
           env CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT=false CARGO_UNSTABLE_FINE_GRAIN_LOCKING=false
-          cargo llvm-cov nextest --workspace --lib --bins --example qwen --locked --profile ci
+          cargo llvm-cov nextest --workspace --lib --bins --examples --locked --profile ci
           --fail-under-lines 93 --fail-under-functions 91
           --lcov --no-default-ignore-filename-regex
           --ignore-filename-regex '(/rustc/|/(tests|benches)/|/(tests\.rs|[0-9a-zA-Z_-]+[_-]tests\.rs)$|/target/llvm-cov-target/|/\.cargo/(registry|git)/|/\.rustup/toolchains/)'

--- a/crates/ag-harness/AGENTS.md
+++ b/crates/ag-harness/AGENTS.md
@@ -1,198 +1,34 @@
-# `ag-harness` - a light LLM harness
+# `ag-harness`
 
-`ag-harness` is the base layer between an application and an LLM. Rust-native,
-app-facing and lightweight. It provides just the essentials: an agent loop, three core
-tools, session management, and a typed event stream, leaving the actual product
-decisions entirely to your app.
+Provider-neutral LLM harness for application-facing model calls. Keep the crate small,
+typed, and independent of Agentty UI or orchestration concerns.
 
-```mermaid
-flowchart LR
-    T["TUI"] --> H["ag-harness"]
-    C["CLI"] --> H
-    W["HTTP"] --> H
-    H --> A["Anthropic"]
-    H --> O["OpenAI"]
-    H --> Q["Qwen"]
-```
+## Boundaries
 
-## Core features
+- `Model` owns the shared request lifecycle, telemetry, and structured-output
+  validation.
+- Provider adapters implement `ModelBackend` and own authentication, capability checks,
+  payload translation, and raw generation.
+- API-family modules may share wire handling across providers, but their types remain
+  private.
+- Network access stays behind an injectable client boundary.
 
-- **Three built-in tools** - `read`, `write`, `bash`.
-- **Structured edits** - the `write` tool applies git-style diff patches and emits
-  clean, targeted diffs.
-- **Permission policy** - every tool call passes a policy check.
-- **Persisted sessions** - session state and required data are saved.
+## Invariants
 
-## Architecture
+- Every request requires an output schema and every response is validated locally.
+- Unsupported provider capabilities return explicit errors; adapters must not silently
+  weaken the shared contract.
+- Response bodies and diagnostics remain bounded.
+- Request-duration telemetry applies uniformly to every `ModelBackend`.
 
-### Crates
+## Change Routing
 
-```
-agentty/
-├── crates/
-│   ├── ag-harness            # facade
-│   ├── ag-harness-protocol   # Op, Event, Diff, Usage
-│   ├── ag-harness-core       # loop, tools, sessions, context, storage
-```
+- Put neutral lifecycle and contract changes in the model and schema modules.
+- Put reusable API-protocol behavior in its API-family module.
+- Keep provider-specific behavior under the provider module and in each adapter.
+- Add focused tests for lifecycle, transport, schema, and provider behavior.
 
-The current foundation lives entirely in `ag-harness`: the provider-neutral `Model`
-contract owns the shared request lifecycle, including telemetry and structured-output
-validation. Provider adapters implement `ModelBackend` to supply model identity and raw
-generation. `Qwen` is the first adapter and uses the OpenAI-compatible Chat Completions
-API.
+## Documentation
 
-## Session management
-
-- One host process manages multiple independent sessions.
-- An active session runs as an async task; sessions run in parallel.
-- Each session processes its prompts in sequence.
-- Session state is saved on disk and loaded when resumed.
-- The app coordinates work across sessions.
-- Closing the host process stops active turns; saved sessions remain resumable.
-
-```mermaid
-flowchart TB
-    H["Harness process"] --> S["Session management"]
-    S --> A["Session A"]
-    S --> B["Session B"]
-    S --> C["Session C"]
-    A --> AT["Async task"]
-    B --> BT["Async task"]
-    C --> CT["Async task"]
-```
-
-## Memory management
-
-- Active session state is kept in memory.
-- Session state is saved on disk.
-- Idle sessions reload from disk when resumed.
-
-## Agent loop
-
-A turn loops until the model responds without requesting a tool:
-
-```mermaid
-flowchart TD
-    A[user prompt] --> B[assemble context]
-    B --> C[call model, stream reply]
-    C --> D{tool requested?}
-    D -- yes --> E[policy check → run tool]
-    E --> B
-    D -- no --> F[turn complete]
-```
-
-### One tool call
-
-```mermaid
-sequenceDiagram
-    participant M as Model
-    participant H as Harness
-    participant App
-    M->>H: write(parser.rs, patch)
-    H->>H: policy → allowed?
-    H->>H: apply patch
-    H-->>App: Structured diff event
-    H->>M: tool result → loop continues
-```
-
-## Editing
-
-- **Write** - the model produces a git diff patch; the harness applies it. Alternative
-  edit methods (exact-match string replacement, etc.) are future experiments.
-- **Diff** - applied changes are streamed back as structured file-diff events,
-  renderable directly as git diffs.
-- **Output caps** - oversized tool output is truncated head+tail with a marker, so one
-  careless command can't flood the session's context. Per-tool limits; `read` supports
-  line ranges for precise re-reads.
-
-## Context
-
-- **Project discovery** - finds the project root and `AGENTS.md`; the model explores the
-  rest via `bash`.
-- **Base prompt** - one minimal system prompt.
-
-## Structured output
-
-The next model-contract iteration evolves the current text-only response into
-provider-neutral structured output:
-
-- The caller supplies the expected JSON shape as a provider-independent schema.
-- Each adapter uses the strongest structured-output mechanism its provider supports and
-  returns raw assistant text. The shared `Model` lifecycle parses and validates the
-  returned JSON against the caller's schema.
-- Provider-specific request fields remain inside the adapter. For Qwen, the adapter uses
-  JSON Object mode and performs schema validation in the harness because Qwen guarantees
-  valid JSON, not schema conformance.
-- Every new model adapter must implement these structured-output semantics before it is
-  added.
-
-Configurations that cannot satisfy the contract, such as Qwen thinking mode, return an
-explicit unsupported-configuration error rather than silently falling back to
-unstructured text.
-
-## Telemetry
-
-- External OTLP metrics export is enabled when `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
-- The harness records only `gen_ai.client.operation.duration`, labeled by provider and
-  model.
-- The shared `Model` lifecycle records the metric for every `ModelBackend`, including
-  failed and cancelled requests.
-- Application binaries configure the metric exporter and flush it on exit.
-- Histogram state is cumulative and process-local; the one-shot example verifies export
-  rather than cross-run totals.
-
-## Permissions
-
-All tools are denied by default. The session policy explicitly allows tools and, for
-`bash`, the permitted commands:
-
-```rust
-Policy {
-    read: Allow,
-    write: Deny,
-    bash: AllowCommands(["cargo test", "git status", "rg *"]),
-}
-```
-
-## Model tiers
-
-`ag-harness` will provide the ability to work with different AI model API tiers for the
-best cost and performance:
-
-- **Model variety** - frontier vs fast models: cheaper models for simpler tasks.
-- **Batch/Flex processing** - designed for latency-tolerant, non-critical workloads,
-  such as async jobs completed within 24 hours at 50% off.
-- **Priority processing** - faster responses at a premium for latency-critical turns.
-
-## Library API
-
-- **Harness** - creates and resumes sessions.
-- **Session** - holds model, policy, working directory, and state.
-- **Turn** - runs one prompt and streams text, diffs, completion, and failure events.
-- **App** - configures the session and renders its events.
-
-## Differences from existing harnesses
-
-- **User-facing products** (Claude Code, OpenCode, Aider): format output for humans;
-  `ag-harness` emits events for apps.
-- **Minimal harnesses** ([Pi](https://pi.dev/)): TypeScript-first, no permission layer;
-  `ag-harness` is Rust-native with an enforced policy hook.
-- **Vendor SDKs**: vendor-locked; `ag-harness` is model-agnostic.
-- **Rust model-API crates** (`rig`): abstract the model call only; `ag-harness` adds the
-  loop, persisted sessions, tools, permissions.
-- **Heavy harnesses**: bundle orchestration; `ag-harness` leaves it to the app.
-
-## Next iterations
-
-1. **Structured model output.** Add the provider-neutral schema contract, Qwen JSON
-   Object mode translation, parsing, validation, and typed errors described above.
-1. **Tool round trip.** Support one model-requested tool through execution to the final
-   response.
-1. **Second provider.** Integrate another model API through the structured-output
-   contract.
-
-## Roadmap
-
-1. **v1 - library.** `ag-harness` - unified crate integrated into agentty.
-1. **Service wrapper.** `ag-harness-service` (JSON-RPC 2.0 over Unix socket, WebSocket
-   for remote) + `ag-harness-client`.
+Update `docs/site/content/docs/architecture/ag-harness-design.md` when these boundaries
+or the planned runtime direction change.

--- a/crates/ag-harness/examples/kimi.rs
+++ b/crates/ag-harness/examples/kimi.rs
@@ -1,38 +1,39 @@
-//! Requests structured output from a configured Qwen model and prints the
+//! Requests structured output from a configured Kimi model and prints the
 //! validated JSON, with optional request-duration metrics over OTLP/HTTP.
 
 use std::io::{self, Write};
 
-use ag_harness::{Model, ModelRequest, OutputSchema, Qwen, QwenConfig};
-use serde_json::json;
+use ag_harness::{Kimi, KimiConfig, Model, ModelRequest, OutputSchema};
 
 #[path = "support/telemetry.rs"]
 mod telemetry;
 
 use telemetry::DynError;
 
+const GREETING_SCHEMA: &str = r#"{
+    "type": "object",
+    "properties": {
+        "message": {
+            "type": "string",
+            "enum": ["hello"]
+        }
+    },
+    "required": ["message"],
+    "additionalProperties": false
+}"#;
+
 #[tokio::main]
 async fn main() -> Result<(), DynError> {
-    telemetry::run_with_metrics("ag-harness-qwen", run()).await
+    telemetry::run_with_metrics("ag-harness-kimi", run()).await
 }
 
 async fn run() -> Result<(), DynError> {
-    let model = Qwen::new(QwenConfig {
-        api_key: std::env::var("DASHSCOPE_API_KEY")?,
-        base_url: std::env::var("DASHSCOPE_BASE_URL")?,
-        model: "qwen-plus".to_string(),
+    let model = Kimi::new(KimiConfig {
+        api_key: std::env::var("KIMI_API_KEY")?,
+        base_url: std::env::var("KIMI_BASE_URL")?,
+        model: std::env::var("KIMI_MODEL")?,
     });
-    let schema = OutputSchema::new(json!({
-        "type": "object",
-        "properties": {
-            "message": {
-                "type": "string",
-                "const": "hello"
-            }
-        },
-        "required": ["message"],
-        "additionalProperties": false
-    }))?;
+    let schema = OutputSchema::new(serde_json::from_str(GREETING_SCHEMA)?)?;
     let response = model
         .complete(ModelRequest::new(
             "Return a JSON greeting with the message set to hello.",
@@ -50,6 +51,7 @@ mod tests {
     use std::process::{ExitStatus, Stdio};
     use std::time::Duration;
 
+    use serde_json::json;
     use tokio::process::{Child, Command};
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -74,7 +76,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn process_exports_metrics_over_otlp_http_on_shutdown() {
         // Arrange
-        let qwen_server = MockServer::start().await;
+        let kimi_server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/chat/completions"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -84,7 +86,7 @@ mod tests {
                 }]
             })))
             .expect(1)
-            .mount(&qwen_server)
+            .mount(&kimi_server)
             .await;
         let otlp_server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -95,7 +97,7 @@ mod tests {
             .mount(&otlp_server)
             .await;
         let executable = std::env::current_exe().expect("test executable should be available");
-        let qwen_endpoint = qwen_server.uri();
+        let kimi_endpoint = kimi_server.uri();
         let otlp_endpoint = format!("{}/otlp", otlp_server.uri());
 
         // Act
@@ -104,8 +106,9 @@ mod tests {
             .arg("--exact")
             .arg("--nocapture")
             .env("AG_HARNESS_RUN_MAIN_FIXTURE", "1")
-            .env("DASHSCOPE_API_KEY", "test-key")
-            .env("DASHSCOPE_BASE_URL", qwen_endpoint)
+            .env("KIMI_API_KEY", "test-key")
+            .env("KIMI_BASE_URL", kimi_endpoint)
+            .env("KIMI_MODEL", "kimi-k2.6")
             .env("OTEL_EXPORTER_OTLP_ENDPOINT", otlp_endpoint)
             .env(
                 "OTEL_EXPORTER_OTLP_HEADERS",
@@ -134,11 +137,11 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn process_timeout_kills_and_reaps_fixture() {
         // Arrange
-        let qwen_server = MockServer::start().await;
+        let kimi_server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/chat/completions"))
             .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(10)))
-            .mount(&qwen_server)
+            .mount(&kimi_server)
             .await;
         let executable = std::env::current_exe().expect("test executable should be available");
         let mut child = Command::new(executable)
@@ -146,8 +149,9 @@ mod tests {
             .arg("--exact")
             .arg("--nocapture")
             .env("AG_HARNESS_RUN_MAIN_FIXTURE", "1")
-            .env("DASHSCOPE_API_KEY", "test-key")
-            .env("DASHSCOPE_BASE_URL", qwen_server.uri())
+            .env("KIMI_API_KEY", "test-key")
+            .env("KIMI_BASE_URL", kimi_server.uri())
+            .env("KIMI_MODEL", "kimi-k2.6")
             .env_remove("OTEL_EXPORTER_OTLP_ENDPOINT")
             .stdout(Stdio::null())
             .stderr(Stdio::null())

--- a/crates/ag-harness/examples/support/telemetry.rs
+++ b/crates/ag-harness/examples/support/telemetry.rs
@@ -1,0 +1,179 @@
+use std::env;
+use std::error::Error;
+use std::future::Future;
+use std::io::{self, Write};
+
+use opentelemetry::global;
+use opentelemetry_otlp::{Protocol, WithExportConfig};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+
+pub(crate) type DynError = Box<dyn Error + Send + Sync>;
+
+/// Runs an example with optional OTLP metrics configured from the environment.
+pub(crate) async fn run_with_metrics(
+    service_name: &'static str,
+    operation: impl Future<Output = Result<(), DynError>>,
+) -> Result<(), DynError> {
+    let meter_provider = init_metrics(service_name, metrics_endpoint_is_configured())?;
+    let operation_result = operation.await;
+    let shutdown_result = shutdown_metrics(meter_provider).await;
+
+    finish(operation_result, shutdown_result)
+}
+
+fn init_metrics(
+    service_name: &'static str,
+    endpoint_is_configured: bool,
+) -> Result<Option<SdkMeterProvider>, DynError> {
+    if !endpoint_is_configured {
+        return Ok(None);
+    }
+
+    let exporter = opentelemetry_otlp::MetricExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .build()?;
+    let provider = SdkMeterProvider::builder()
+        .with_periodic_exporter(exporter)
+        .with_resource(metrics_resource(
+            service_name,
+            env::var_os("OTEL_SERVICE_NAME").is_some(),
+        ))
+        .build();
+    global::set_meter_provider(provider.clone());
+
+    Ok(Some(provider))
+}
+
+fn metrics_endpoint_is_configured() -> bool {
+    env::var_os("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT").is_some()
+        || env::var_os("OTEL_EXPORTER_OTLP_ENDPOINT").is_some()
+}
+
+fn metrics_resource(service_name: &'static str, service_name_is_configured: bool) -> Resource {
+    let resource = Resource::builder();
+    if service_name_is_configured {
+        return resource.build();
+    }
+
+    resource.with_service_name(service_name).build()
+}
+
+async fn shutdown_metrics(meter_provider: Option<SdkMeterProvider>) -> Result<(), DynError> {
+    let Some(meter_provider) = meter_provider else {
+        return Ok(());
+    };
+
+    tokio::task::spawn_blocking(move || meter_provider.shutdown()).await??;
+
+    Ok(())
+}
+
+fn finish(
+    operation_result: Result<(), DynError>,
+    shutdown_result: Result<(), DynError>,
+) -> Result<(), DynError> {
+    match (operation_result, shutdown_result) {
+        (Err(error), Err(shutdown_error)) => {
+            drop(writeln!(
+                io::stderr().lock(),
+                "telemetry shutdown also failed: {shutdown_error}"
+            ));
+
+            Err(error)
+        }
+        (Err(error), Ok(())) => Err(error),
+        (Ok(()), shutdown_result) => shutdown_result,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry::Key;
+
+    use super::*;
+
+    fn test_error(message: &'static str) -> DynError {
+        io::Error::other(message).into()
+    }
+
+    #[test]
+    fn metrics_are_disabled_without_an_endpoint() {
+        // Arrange & Act
+        let meter_provider =
+            init_metrics("test-service", false).expect("disabled metrics setup should succeed");
+
+        // Assert
+        assert!(meter_provider.is_none());
+    }
+
+    #[test]
+    fn supplied_service_name_is_used_only_without_environment_configuration() {
+        // Arrange
+        let service_name_key = Key::from_static_str("service.name");
+
+        // Act
+        let supplied_resource = metrics_resource("test-service", false);
+        let configured_resource = metrics_resource("test-service", true);
+
+        // Assert
+        assert_eq!(
+            supplied_resource
+                .get(&service_name_key)
+                .expect("supplied service name should be present")
+                .as_str(),
+            "test-service"
+        );
+        assert_ne!(
+            configured_resource
+                .get(&service_name_key)
+                .expect("SDK service name should be present")
+                .as_str(),
+            "test-service"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_is_disabled_without_a_provider() {
+        // Arrange & Act
+        let result = shutdown_metrics(None).await;
+
+        // Assert
+        result.expect("disabled metrics shutdown should succeed");
+    }
+
+    #[test]
+    fn finish_preserves_operation_error_priority() {
+        // Arrange
+        let operation_error = test_error("model request failed");
+        let shutdown_error = test_error("metrics flush failed");
+
+        // Act
+        let combined_result = finish(Err(operation_error), Err(shutdown_error));
+        let operation_only_result = finish(Err(test_error("operation only")), Ok(()));
+        let shutdown_only_result = finish(Ok(()), Err(test_error("shutdown only")));
+        let success_result = finish(Ok(()), Ok(()));
+
+        // Assert
+        assert_eq!(
+            combined_result
+                .expect_err("both failures should fail")
+                .to_string(),
+            "model request failed"
+        );
+        assert_eq!(
+            operation_only_result
+                .expect_err("the operation failure should be returned")
+                .to_string(),
+            "operation only"
+        );
+        assert_eq!(
+            shutdown_only_result
+                .expect_err("the shutdown failure should be returned")
+                .to_string(),
+            "shutdown only"
+        );
+        success_result.expect("successful operation and shutdown should succeed");
+    }
+}

--- a/crates/ag-harness/src/chat_completion.rs
+++ b/crates/ag-harness/src/chat_completion.rs
@@ -1,0 +1,355 @@
+use std::error::Error;
+use std::fmt::Write as _;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::Value;
+use thiserror::Error;
+
+use crate::schema_contract;
+
+pub(crate) const ERROR_BODY_LIMIT_BYTES: usize = 4 * 1024;
+const JSON_STRING_MAX_EXPANSION: usize = 6;
+pub(crate) const RESPONSE_ENVELOPE_LIMIT_BYTES: usize = 64 * 1024;
+const REQUEST_TIMEOUT: Duration = Duration::from_mins(1);
+pub(crate) const SUCCESS_BODY_LIMIT_BYTES: usize = schema_contract::RESPONSE_CONTENT_LIMIT_BYTES
+    * JSON_STRING_MAX_EXPANSION
+    + RESPONSE_ENVELOPE_LIMIT_BYTES;
+
+/// One provider-authenticated request using the Chat Completions wire API.
+pub(crate) struct ChatCompletionRequest<'a> {
+    api_key: &'a str,
+    endpoint: String,
+    payload: Value,
+}
+
+impl<'a> ChatCompletionRequest<'a> {
+    /// Creates a request from provider-owned authentication and payload data.
+    pub(crate) fn new(api_key: &'a str, endpoint: String, payload: Value) -> Self {
+        Self {
+            api_key,
+            endpoint,
+            payload,
+        }
+    }
+
+    /// Consumes the request into values usable by a client implementation.
+    pub(crate) fn into_parts(self) -> (&'a str, String, Value) {
+        (self.api_key, self.endpoint, self.payload)
+    }
+}
+
+/// Provider-independent fields extracted from the first completion choice.
+pub(crate) struct ChatCompletion {
+    content: Option<String>,
+    finish_reason: String,
+}
+
+impl ChatCompletion {
+    /// Creates one normalized completion choice.
+    pub(crate) fn new(finish_reason: String, content: Option<String>) -> Self {
+        Self {
+            content,
+            finish_reason,
+        }
+    }
+
+    /// Consumes the choice into provider-interpreted completion fields.
+    pub(crate) fn into_parts(self) -> (String, Option<String>) {
+        (self.finish_reason, self.content)
+    }
+}
+
+/// Decoded client boundary between provider adapters and the Chat Completions
+/// API.
+#[async_trait]
+pub(crate) trait ChatCompletionClient: Send + Sync {
+    async fn complete(
+        &self,
+        request: ChatCompletionRequest<'_>,
+    ) -> Result<Option<ChatCompletion>, ChatCompletionError>;
+}
+
+/// Builds the Chat Completions endpoint for a provider base URL.
+pub(crate) fn endpoint(base_url: &str) -> String {
+    format!("{}/chat/completions", base_url.trim_end_matches('/'))
+}
+
+/// Creates the production Chat Completions client implementation.
+pub(crate) fn default_client() -> Arc<dyn ChatCompletionClient> {
+    Arc::new(ReqwestChatCompletionClient {
+        client: reqwest::Client::new(),
+    })
+}
+
+struct ReqwestChatCompletionClient {
+    client: reqwest::Client,
+}
+
+#[async_trait]
+impl ChatCompletionClient for ReqwestChatCompletionClient {
+    async fn complete(
+        &self,
+        request: ChatCompletionRequest<'_>,
+    ) -> Result<Option<ChatCompletion>, ChatCompletionError> {
+        let (api_key, endpoint, payload) = request.into_parts();
+        let mut response = self
+            .client
+            .post(endpoint)
+            .bearer_auth(api_key)
+            .timeout(REQUEST_TIMEOUT)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(ChatCompletionError::transport)?;
+
+        if let Err(source) = response.error_for_status_ref() {
+            let status = response.status();
+            let body = error_body_summary(&mut response).await;
+
+            return Err(ChatCompletionError::Http {
+                body,
+                source,
+                status,
+            });
+        }
+
+        let body = success_body(&mut response).await?;
+        let response = serde_json::from_slice::<ChatCompletionResponse>(&body)
+            .map_err(ChatCompletionError::InvalidResponse)?;
+
+        Ok(response
+            .choices
+            .into_iter()
+            .next()
+            .map(|choice| ChatCompletion::new(choice.finish_reason, choice.message.content)))
+    }
+}
+
+async fn error_body_summary(response: &mut reqwest::Response) -> String {
+    let mut body = Vec::new();
+    let mut is_truncated = false;
+    let read_error = loop {
+        let chunk = match response.chunk().await {
+            Ok(Some(chunk)) => chunk,
+            Ok(None) => break None,
+            Err(error) => break Some(error),
+        };
+
+        let remaining = ERROR_BODY_LIMIT_BYTES.saturating_sub(body.len());
+
+        if chunk.len() > remaining {
+            body.extend_from_slice(&chunk[..remaining]);
+            is_truncated = true;
+
+            break None;
+        }
+
+        body.extend_from_slice(&chunk);
+    };
+
+    let mut summary = String::from_utf8_lossy(&body)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if is_truncated {
+        summary.push_str(" ...");
+    }
+    if let Some(error) = read_error {
+        if !summary.is_empty() {
+            summary.push(' ');
+        }
+        let _ = write!(&mut summary, "[error body read failed: {error}]");
+    }
+
+    summary
+}
+
+async fn success_body(response: &mut reqwest::Response) -> Result<Vec<u8>, ChatCompletionError> {
+    let limit = u64::try_from(SUCCESS_BODY_LIMIT_BYTES).unwrap_or(u64::MAX);
+    if response
+        .content_length()
+        .is_some_and(|content_length| content_length > limit)
+    {
+        return Err(ChatCompletionError::ResponseBodyTooLarge);
+    }
+
+    let mut body = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(ChatCompletionError::transport)?
+    {
+        append_success_chunk(&mut body, &chunk)?;
+    }
+
+    Ok(body)
+}
+
+fn append_success_chunk(body: &mut Vec<u8>, chunk: &[u8]) -> Result<(), ChatCompletionError> {
+    let remaining = SUCCESS_BODY_LIMIT_BYTES.saturating_sub(body.len());
+    if chunk.len() > remaining {
+        return Err(ChatCompletionError::ResponseBodyTooLarge);
+    }
+
+    body.extend_from_slice(chunk);
+
+    Ok(())
+}
+
+/// Failure produced by a Chat Completions client implementation.
+#[derive(Debug, Error)]
+pub(crate) enum ChatCompletionError {
+    #[error("Chat Completions returned HTTP {status}: {body}")]
+    Http {
+        body: String,
+        #[source]
+        source: reqwest::Error,
+        status: reqwest::StatusCode,
+    },
+    #[error("Chat Completions returned an invalid response: {0}")]
+    InvalidResponse(#[source] serde_json::Error),
+    #[error("Chat Completions response body exceeds the size limit")]
+    ResponseBodyTooLarge,
+    #[error("Chat Completions transport failed: {0}")]
+    Transport(#[source] Box<dyn Error + Send + Sync>),
+}
+
+impl ChatCompletionError {
+    fn transport(error: impl Error + Send + Sync + 'static) -> Self {
+        Self::Transport(Box::new(error))
+    }
+}
+
+#[derive(Deserialize)]
+struct ChatCompletionResponse {
+    choices: Vec<ChatCompletionChoice>,
+}
+
+#[derive(Deserialize)]
+struct ChatCompletionChoice {
+    finish_reason: String,
+    message: ChatCompletionMessage,
+}
+
+#[derive(Deserialize)]
+struct ChatCompletionMessage {
+    content: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, Read, Write};
+    use std::net::TcpListener;
+
+    use super::*;
+
+    #[test]
+    fn builds_endpoint_from_base_url() {
+        // Arrange and Act
+        let endpoint = endpoint("https://example.com/v1///");
+
+        // Assert
+        assert_eq!(endpoint, "https://example.com/v1/chat/completions");
+    }
+
+    #[test]
+    fn rejects_success_chunk_that_exceeds_remaining_capacity() {
+        // Arrange
+        let mut body = vec![0; SUCCESS_BODY_LIMIT_BYTES - 1];
+
+        // Act
+        let error = append_success_chunk(&mut body, &[0, 1])
+            .expect_err("chunk exceeding the limit should fail");
+
+        // Assert
+        assert!(matches!(error, ChatCompletionError::ResponseBodyTooLarge));
+    }
+
+    #[test]
+    fn wraps_transport_error_with_its_source() {
+        // Arrange
+        let source = io::Error::other("connection reset");
+
+        // Act
+        let error = ChatCompletionError::transport(source);
+
+        // Assert
+        assert_eq!(
+            error.to_string(),
+            "Chat Completions transport failed: connection reset"
+        );
+        assert_eq!(
+            std::error::Error::source(&error)
+                .expect("transport failure should retain its source")
+                .to_string(),
+            "connection reset"
+        );
+    }
+
+    #[tokio::test]
+    async fn retains_http_status_when_error_body_read_fails() {
+        // Arrange
+        let listener =
+            TcpListener::bind("127.0.0.1:0").expect("truncated-response listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("truncated-response listener should have an address");
+        let server = tokio::task::spawn_blocking(move || {
+            let (mut stream, _) = listener
+                .accept()
+                .expect("truncated-response listener should accept a request");
+            let mut request = [0; 2_048];
+            let bytes_read = stream
+                .read(&mut request)
+                .expect("truncated-response server should read the request");
+            assert!(
+                bytes_read > 0,
+                "truncated-response request should not be empty"
+            );
+            stream
+                .write_all(
+                    b"HTTP/1.1 429 Too Many Requests\r\n\
+                      Content-Length: 64\r\n\
+                      Connection: close\r\n\r\n\
+                      partial error body",
+                )
+                .expect("truncated-response server should write the response");
+        });
+        let client = ReqwestChatCompletionClient {
+            client: reqwest::Client::new(),
+        };
+        let request = ChatCompletionRequest::new(
+            "test-key",
+            format!("http://{address}"),
+            serde_json::json!({}),
+        );
+
+        // Act
+        let result = client.complete(request).await;
+        server
+            .await
+            .expect("truncated-response server should finish");
+
+        // Assert
+        assert!(result.is_err(), "truncated HTTP error response should fail");
+        let error = result
+            .err()
+            .expect("truncated HTTP error response should contain an error");
+        assert!(matches!(
+            &error,
+            ChatCompletionError::Http { status, .. }
+                if *status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        ));
+        assert!(error.to_string().contains("error body read failed"));
+        let source = std::error::Error::source(&error)
+            .and_then(|source| source.downcast_ref::<reqwest::Error>())
+            .expect("HTTP failure should retain its status-bearing source");
+        assert_eq!(
+            source.status(),
+            Some(reqwest::StatusCode::TOO_MANY_REQUESTS)
+        );
+    }
+}

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -3,11 +3,12 @@
 //! The crate provides a provider-neutral model contract, validated structured
 //! output, and model adapters.
 
+mod chat_completion;
 mod model;
-mod qwen;
+mod provider;
 mod schema_contract;
 mod telemetry;
 
 pub use model::{Model, ModelBackend, ModelError, ModelMetadata, ModelRequest, ModelResponse};
-pub use qwen::{Qwen, QwenConfig};
+pub use provider::{Kimi, KimiConfig, Qwen, QwenConfig};
 pub use schema_contract::{OutputSchema, OutputSchemaError};

--- a/crates/ag-harness/src/provider.rs
+++ b/crates/ag-harness/src/provider.rs
@@ -1,0 +1,7 @@
+//! Provider-specific model adapters.
+
+mod kimi;
+mod qwen;
+
+pub use kimi::{Kimi, KimiConfig};
+pub use qwen::{Qwen, QwenConfig};

--- a/crates/ag-harness/src/provider/kimi.rs
+++ b/crates/ag-harness/src/provider/kimi.rs
@@ -1,0 +1,685 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::{chat_completion, model, schema_contract};
+
+const PROVIDER_NAME: &str = "moonshot_ai";
+const STRUCTURED_OUTPUT_INSTRUCTION: &str = concat!(
+    "Return only one JSON object. The object must validate against this JSON Schema. ",
+    "Do not include Markdown fences or any other text.\n\nJSON Schema:\n",
+);
+const UNSUPPORTED_SCHEMA_REASON: &str =
+    "Kimi JSON Object mode requires an explicit object root schema";
+
+/// Configuration for a Kimi model served through Moonshot AI's
+/// OpenAI-compatible API.
+pub struct KimiConfig {
+    /// API key sent as a bearer token.
+    pub api_key: String,
+    /// API base URL ending in the OpenAI-compatible version path.
+    pub base_url: String,
+    /// Kimi model identifier sent with each request.
+    pub model: String,
+}
+
+/// Kimi implementation of the provider-neutral [`model::ModelBackend`]
+/// strategy.
+pub struct Kimi {
+    client: Arc<dyn chat_completion::ChatCompletionClient>,
+    config: KimiConfig,
+}
+
+impl Kimi {
+    /// Creates a Kimi model adapter.
+    pub fn new(config: KimiConfig) -> Self {
+        Self::with_client(config, chat_completion::default_client())
+    }
+
+    fn with_client(
+        config: KimiConfig,
+        client: Arc<dyn chat_completion::ChatCompletionClient>,
+    ) -> Self {
+        Self { client, config }
+    }
+
+    fn map_completion_error(error: chat_completion::ChatCompletionError) -> model::ModelError {
+        match error {
+            chat_completion::ChatCompletionError::Http {
+                body,
+                source,
+                status,
+            } => model::ModelError::request(KimiHttpError {
+                body,
+                source,
+                status,
+            }),
+            chat_completion::ChatCompletionError::ResponseBodyTooLarge => {
+                model::ModelError::ResponseBodyTooLarge
+            }
+            error => model::ModelError::request(error),
+        }
+    }
+}
+
+#[async_trait]
+impl model::ModelBackend for Kimi {
+    fn metadata(&self) -> model::ModelMetadata<'_> {
+        model::ModelMetadata::new(PROVIDER_NAME, &self.config.model)
+    }
+
+    async fn generate(&self, request: &model::ModelRequest) -> Result<String, model::ModelError> {
+        if !request.schema().has_object_root() {
+            return Err(model::ModelError::UnsupportedOutputSchema {
+                reason: UNSUPPORTED_SCHEMA_REASON.to_string(),
+            });
+        }
+        let messages = vec![
+            KimiMessage {
+                content: format!(
+                    "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
+                    request.schema().value()
+                ),
+                role: "system",
+            },
+            KimiMessage {
+                content: request.prompt().to_string(),
+                role: "user",
+            },
+        ];
+        let payload = KimiRequest {
+            messages,
+            model: &self.config.model,
+            response_format: KimiResponseFormat {
+                kind: "json_object",
+            },
+        };
+        let payload = serde_json::to_value(payload).map_err(model::ModelError::request)?;
+        let completion = self
+            .client
+            .complete(chat_completion::ChatCompletionRequest::new(
+                &self.config.api_key,
+                chat_completion::endpoint(&self.config.base_url),
+                payload,
+            ))
+            .await
+            .map_err(Self::map_completion_error)?
+            .ok_or(model::ModelError::InvalidResponse)?;
+        let (finish_reason, content) = completion.into_parts();
+        if finish_reason != "stop" {
+            return Err(model::ModelError::IncompleteResponse {
+                reason: schema_contract::bounded_diagnostic(finish_reason),
+            });
+        }
+        let text = content.ok_or(model::ModelError::InvalidResponse)?;
+
+        Ok(text)
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Kimi returned HTTP {status}: {body}")]
+struct KimiHttpError {
+    body: String,
+    #[source]
+    source: reqwest::Error,
+    status: reqwest::StatusCode,
+}
+
+#[derive(Serialize)]
+struct KimiRequest<'a> {
+    messages: Vec<KimiMessage>,
+    model: &'a str,
+    response_format: KimiResponseFormat,
+}
+
+#[derive(Serialize)]
+struct KimiMessage {
+    content: String,
+    role: &'static str,
+}
+
+#[derive(Serialize)]
+struct KimiResponseFormat {
+    #[serde(rename = "type")]
+    kind: &'static str,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+    use wiremock::matchers::{bearer_token, body_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+    use crate::Model;
+    use crate::chat_completion::{
+        ERROR_BODY_LIMIT_BYTES, RESPONSE_ENVELOPE_LIMIT_BYTES, SUCCESS_BODY_LIMIT_BYTES,
+    };
+
+    fn person_schema_value() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        })
+    }
+
+    fn person_schema() -> crate::OutputSchema {
+        crate::OutputSchema::new(person_schema_value()).expect("schema should be valid")
+    }
+
+    fn request(prompt: &str) -> model::ModelRequest {
+        model::ModelRequest::new(prompt, person_schema())
+    }
+
+    fn escaped_value_schema() -> crate::OutputSchema {
+        crate::OutputSchema::new(json!({
+            "type": "object",
+            "properties": {
+                "value": { "type": "string" }
+            },
+            "required": ["value"],
+            "additionalProperties": false
+        }))
+        .expect("schema should be valid")
+    }
+
+    fn kimi(server: &MockServer) -> Kimi {
+        Kimi::new(KimiConfig {
+            api_key: "test-key".to_string(),
+            base_url: format!("{}/", server.uri()),
+            model: "kimi-k2.6".to_string(),
+        })
+    }
+
+    #[test]
+    fn metadata_exposes_provider_and_model() {
+        // Arrange
+        let model = Kimi::new(KimiConfig {
+            api_key: "test-key".to_string(),
+            base_url: "https://api.moonshot.example/v1".to_string(),
+            model: "kimi-k2.6".to_string(),
+        });
+
+        // Act
+        let metadata = model::ModelBackend::metadata(&model);
+
+        // Assert
+        assert_eq!(metadata.provider(), "moonshot_ai");
+        assert_eq!(metadata.model(), "kimi-k2.6");
+    }
+
+    async fn mount_structured_response(
+        server: &MockServer,
+        prompt: &str,
+        schema: &Value,
+        content: &str,
+    ) {
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(bearer_token("test-key"))
+            .and(body_json(json!({
+                "messages": [
+                    {
+                        "content": format!("{STRUCTURED_OUTPUT_INSTRUCTION}{schema}"),
+                        "role": "system"
+                    },
+                    {"content": prompt, "role": "user"}
+                ],
+                "model": "kimi-k2.6",
+                "response_format": {"type": "json_object"}
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": content}
+                }]
+            })))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn accepts_object_root_in_type_array() {
+        // Arrange
+        let server = MockServer::start().await;
+        let schema_value = json!({ "type": ["object"] });
+        mount_structured_response(&server, "return an object", &schema_value, "{}").await;
+        let model = kimi(&server);
+        let schema = crate::OutputSchema::new(schema_value).expect("schema should be valid");
+
+        // Act
+        let response = model
+            .complete(model::ModelRequest::new("return an object", schema))
+            .await
+            .expect("Kimi request should succeed");
+
+        // Assert
+        assert_eq!(response.output(), &json!({}));
+    }
+
+    #[tokio::test]
+    async fn completes_structured_request() {
+        // Arrange
+        let server = MockServer::start().await;
+        let schema_value = person_schema_value();
+        mount_structured_response(
+            &server,
+            "extract the name",
+            &schema_value,
+            r#"{"name":"Ada"}"#,
+        )
+        .await;
+        let model = kimi(&server);
+
+        // Act
+        let response = model
+            .complete(request("extract the name"))
+            .await
+            .expect("Kimi request should succeed");
+
+        // Assert
+        assert_eq!(response.output(), &json!({ "name": "Ada" }));
+    }
+
+    #[tokio::test]
+    async fn rejects_structured_response_stopped_for_length() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "length",
+                    "message": {"content": r#"{"name":"Ada"}"#}
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let model = kimi(&server);
+
+        // Act
+        let error = model
+            .complete(request("extract the name"))
+            .await
+            .expect_err("truncated response should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            model::ModelError::IncompleteResponse { reason } if reason == "length"
+        ));
+    }
+
+    #[tokio::test]
+    async fn bounds_incomplete_response_reason() {
+        // Arrange
+        let server = MockServer::start().await;
+        let finish_reason = "x".repeat(1024);
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": finish_reason.clone(),
+                    "message": {"content": r#"{"name":"Ada"}"#}
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let model = kimi(&server);
+
+        // Act
+        let error = model
+            .complete(request("extract the name"))
+            .await
+            .expect_err("incomplete response should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            model::ModelError::IncompleteResponse { reason }
+                if reason == schema_contract::bounded_diagnostic(finish_reason)
+        ));
+    }
+
+    #[tokio::test]
+    async fn accepts_near_limit_escaped_structured_output() {
+        // Arrange
+        let server = MockServer::start().await;
+        let empty_content =
+            serde_json::to_string(&json!({ "value": "" })).expect("content should serialize");
+        let value =
+            "\\".repeat((schema_contract::RESPONSE_CONTENT_LIMIT_BYTES - empty_content.len()) / 2);
+        let content =
+            serde_json::to_string(&json!({ "value": value })).expect("content should serialize");
+        let body = serde_json::to_vec(&json!({
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {"content": content}
+            }]
+        }))
+        .expect("response should serialize");
+        assert!(schema_contract::RESPONSE_CONTENT_LIMIT_BYTES - content.len() <= 1);
+        assert!(
+            body.len()
+                > schema_contract::RESPONSE_CONTENT_LIMIT_BYTES + RESPONSE_ENVELOPE_LIMIT_BYTES
+        );
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+            .mount(&server)
+            .await;
+        let model = kimi(&server);
+
+        // Act
+        let response = model
+            .complete(model::ModelRequest::new(
+                "return escaped content",
+                escaped_value_schema(),
+            ))
+            .await
+            .expect("near-limit escaped output should succeed");
+
+        // Assert
+        assert_eq!(
+            response
+                .output()
+                .get("value")
+                .and_then(Value::as_str)
+                .map(str::len),
+            Some(value.len())
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_success_body_before_decoding() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(vec![
+                b'x';
+                SUCCESS_BODY_LIMIT_BYTES
+                    + 1
+            ]))
+            .mount(&server)
+            .await;
+        let model = kimi(&server);
+
+        // Act
+        let error = model
+            .complete(request("hello"))
+            .await
+            .expect_err("oversized successful response should fail");
+
+        // Assert
+        assert!(matches!(error, model::ModelError::ResponseBodyTooLarge));
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_response_content() {
+        // Arrange
+        let server = MockServer::start().await;
+        let content = "x".repeat(schema_contract::RESPONSE_CONTENT_LIMIT_BYTES + 1);
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": content}
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let model = kimi(&server);
+
+        // Act
+        let error = model
+            .complete(request("hello"))
+            .await
+            .expect_err("oversized response content should fail");
+
+        // Assert
+        assert!(matches!(error, model::ModelError::ResponseContentTooLarge));
+    }
+
+    #[tokio::test]
+    async fn rejects_schemas_without_explicit_object_root() {
+        // Arrange
+        let server = MockServer::start().await;
+        let model = kimi(&server);
+        let schema_values = [
+            json!({ "type": "array" }),
+            json!({ "not": { "type": "object" } }),
+            json!({
+                "$defs": {
+                    "result": { "type": "object" }
+                },
+                "$ref": "#/$defs/result"
+            }),
+        ];
+
+        // Act
+        let mut errors = Vec::new();
+        for schema_value in schema_values {
+            let schema = crate::OutputSchema::new(schema_value).expect("schema should be valid");
+            errors.push(
+                model
+                    .complete(model::ModelRequest::new("list names", schema))
+                    .await
+                    .expect_err("schema without an explicit object root should fail"),
+            );
+        }
+
+        // Assert
+        assert!(
+            errors
+                .into_iter()
+                .all(|error| matches!(error, model::ModelError::UnsupportedOutputSchema { .. }))
+        );
+        assert!(
+            server
+                .received_requests()
+                .await
+                .expect("request recording should be enabled")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_malformed_structured_output() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": "not JSON"}
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let model = kimi(&server);
+
+        // Act
+        let error = model
+            .complete(request("extract the name"))
+            .await
+            .expect_err("malformed JSON should fail");
+
+        // Assert
+        assert!(matches!(error, model::ModelError::InvalidJson { .. }));
+    }
+
+    #[tokio::test]
+    async fn rejects_structured_output_schema_violation() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": r#"{"name":42}"#}
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let model = kimi(&server);
+
+        // Act
+        let error = model
+            .complete(request("extract the name"))
+            .await
+            .expect_err("schema violation should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            model::ModelError::SchemaViolation { path, reason }
+                if path == "/name" && reason.contains("string")
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_successful_response_without_choices() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": []
+            })))
+            .mount(&server)
+            .await;
+        let model = kimi(&server);
+
+        // Act
+        let error = model
+            .complete(request("hello"))
+            .await
+            .expect_err("missing response choice should fail");
+
+        // Assert
+        assert!(matches!(error, model::ModelError::InvalidResponse));
+    }
+
+    #[tokio::test]
+    async fn rejects_successful_response_without_content() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": null}
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let model = kimi(&server);
+
+        // Act
+        let error = model
+            .complete(request("hello"))
+            .await
+            .expect_err("missing response content should fail");
+
+        // Assert
+        assert!(matches!(error, model::ModelError::InvalidResponse));
+    }
+
+    #[tokio::test]
+    async fn returns_request_error_for_http_failure() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": {"message": "invalid API key"}
+            })))
+            .mount(&server)
+            .await;
+        let model = kimi(&server);
+
+        // Act
+        let error = model
+            .complete(request("hello"))
+            .await
+            .expect_err("HTTP failure should fail");
+
+        // Assert
+        assert_eq!(
+            error.to_string(),
+            "model request failed: Kimi returned HTTP 401 Unauthorized: \
+             {\"error\":{\"message\":\"invalid API key\"}}"
+        );
+        let provider_error = std::error::Error::source(&error)
+            .expect("HTTP failure should retain its provider error");
+        let source = provider_error
+            .source()
+            .and_then(|source| source.downcast_ref::<reqwest::Error>())
+            .expect("HTTP failure should retain its reqwest source");
+        assert_eq!(source.status(), Some(reqwest::StatusCode::UNAUTHORIZED));
+    }
+
+    #[tokio::test]
+    async fn bounds_http_error_body() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(500).set_body_string("x".repeat(ERROR_BODY_LIMIT_BYTES + 1)),
+            )
+            .mount(&server)
+            .await;
+        let model = kimi(&server);
+
+        // Act
+        let error = model
+            .complete(request("hello"))
+            .await
+            .expect_err("HTTP failure should fail");
+        let message = error.to_string();
+
+        // Assert
+        assert_eq!(
+            message,
+            format!(
+                "model request failed: Kimi returned HTTP 500 Internal Server Error: {} ...",
+                "x".repeat(ERROR_BODY_LIMIT_BYTES)
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn returns_request_error_for_malformed_response() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not JSON"))
+            .mount(&server)
+            .await;
+        let model = kimi(&server);
+
+        // Act
+        let error = model
+            .complete(request("hello"))
+            .await
+            .expect_err("malformed response should fail");
+
+        // Assert
+        assert!(matches!(error, model::ModelError::Request(_)));
+    }
+}

--- a/crates/ag-harness/src/provider/qwen.rs
+++ b/crates/ag-harness/src/provider/qwen.rs
@@ -1,19 +1,12 @@
-use std::time::Duration;
+use std::sync::Arc;
 
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use thiserror::Error;
 
-use crate::{model, schema_contract};
+use crate::{chat_completion, model, schema_contract};
 
-const ERROR_BODY_LIMIT_BYTES: usize = 4 * 1024;
-const JSON_STRING_MAX_EXPANSION: usize = 6;
 const PROVIDER_NAME: &str = "alibaba_cloud";
-const RESPONSE_ENVELOPE_LIMIT_BYTES: usize = 64 * 1024;
-const REQUEST_TIMEOUT: Duration = Duration::from_mins(1);
-const SUCCESS_BODY_LIMIT_BYTES: usize = schema_contract::RESPONSE_CONTENT_LIMIT_BYTES
-    * JSON_STRING_MAX_EXPANSION
-    + RESPONSE_ENVELOPE_LIMIT_BYTES;
 const STRUCTURED_OUTPUT_INSTRUCTION: &str = concat!(
     "Return only one JSON object. The object must validate against this JSON Schema. ",
     "Do not include Markdown fences or any other text.\n\nJSON Schema:\n",
@@ -35,82 +28,39 @@ pub struct QwenConfig {
 /// Qwen implementation of the provider-neutral [`model::ModelBackend`]
 /// strategy.
 pub struct Qwen {
-    client: reqwest::Client,
+    client: Arc<dyn chat_completion::ChatCompletionClient>,
     config: QwenConfig,
 }
 
 impl Qwen {
     /// Creates a Qwen model adapter.
     pub fn new(config: QwenConfig) -> Self {
-        Self {
-            client: reqwest::Client::new(),
-            config,
-        }
+        Self::with_client(config, chat_completion::default_client())
     }
 
-    fn endpoint(&self) -> String {
-        format!(
-            "{}/chat/completions",
-            self.config.base_url.trim_end_matches('/')
-        )
+    fn with_client(
+        config: QwenConfig,
+        client: Arc<dyn chat_completion::ChatCompletionClient>,
+    ) -> Self {
+        Self { client, config }
     }
 
-    async fn error_body_summary(
-        response: &mut reqwest::Response,
-    ) -> Result<String, reqwest::Error> {
-        let mut body = Vec::new();
-        let mut is_truncated = false;
-
-        while let Some(chunk) = response.chunk().await? {
-            let remaining = ERROR_BODY_LIMIT_BYTES.saturating_sub(body.len());
-
-            if chunk.len() > remaining {
-                body.extend_from_slice(&chunk[..remaining]);
-                is_truncated = true;
-
-                break;
+    fn map_completion_error(error: chat_completion::ChatCompletionError) -> model::ModelError {
+        match error {
+            chat_completion::ChatCompletionError::Http {
+                body,
+                source,
+                status,
+            } => model::ModelError::request(QwenHttpError {
+                body,
+                source,
+                status,
+            }),
+            chat_completion::ChatCompletionError::ResponseBodyTooLarge => {
+                model::ModelError::ResponseBodyTooLarge
             }
-
-            body.extend_from_slice(&chunk);
+            error => model::ModelError::request(error),
         }
-
-        let mut summary = String::from_utf8_lossy(&body)
-            .split_whitespace()
-            .collect::<Vec<_>>()
-            .join(" ");
-        if is_truncated {
-            summary.push_str(" ...");
-        }
-
-        Ok(summary)
-    }
-
-    async fn success_body(response: &mut reqwest::Response) -> Result<Vec<u8>, model::ModelError> {
-        let limit = u64::try_from(SUCCESS_BODY_LIMIT_BYTES).unwrap_or(u64::MAX);
-        if response
-            .content_length()
-            .is_some_and(|content_length| content_length > limit)
-        {
-            return Err(model::ModelError::ResponseBodyTooLarge);
-        }
-
-        let mut body = Vec::new();
-        while let Some(chunk) = response.chunk().await.map_err(model::ModelError::request)? {
-            Self::append_success_chunk(&mut body, &chunk)?;
-        }
-
-        Ok(body)
-    }
-
-    fn append_success_chunk(body: &mut Vec<u8>, chunk: &[u8]) -> Result<(), model::ModelError> {
-        let remaining = SUCCESS_BODY_LIMIT_BYTES.saturating_sub(body.len());
-        if chunk.len() > remaining {
-            return Err(model::ModelError::ResponseBodyTooLarge);
-        }
-
-        body.extend_from_slice(chunk);
-
-        Ok(())
     }
 }
 
@@ -146,48 +96,24 @@ impl model::ModelBackend for Qwen {
                 kind: "json_object",
             },
         };
-
-        let mut response = self
+        let payload = serde_json::to_value(payload).map_err(model::ModelError::request)?;
+        let completion = self
             .client
-            .post(self.endpoint())
-            .bearer_auth(&self.config.api_key)
-            .timeout(REQUEST_TIMEOUT)
-            .json(&payload)
-            .send()
+            .complete(chat_completion::ChatCompletionRequest::new(
+                &self.config.api_key,
+                chat_completion::endpoint(&self.config.base_url),
+                payload,
+            ))
             .await
-            .map_err(model::ModelError::request)?;
-
-        if let Err(source) = response.error_for_status_ref() {
-            let body = Self::error_body_summary(&mut response)
-                .await
-                .map_err(model::ModelError::request)?;
-            let error = QwenHttpError {
-                body,
-                source,
-                status: response.status(),
-            };
-
-            return Err(model::ModelError::request(error));
-        }
-
-        let body = Self::success_body(&mut response).await?;
-        let response =
-            serde_json::from_slice::<QwenResponse>(&body).map_err(model::ModelError::request)?;
-
-        let choice = response
-            .choices
-            .into_iter()
-            .next()
+            .map_err(Self::map_completion_error)?
             .ok_or(model::ModelError::InvalidResponse)?;
-        if choice.finish_reason != "stop" {
+        let (finish_reason, content) = completion.into_parts();
+        if finish_reason != "stop" {
             return Err(model::ModelError::IncompleteResponse {
-                reason: schema_contract::bounded_diagnostic(choice.finish_reason),
+                reason: schema_contract::bounded_diagnostic(finish_reason),
             });
         }
-        let text = choice
-            .message
-            .content
-            .ok_or(model::ModelError::InvalidResponse)?;
+        let text = content.ok_or(model::ModelError::InvalidResponse)?;
 
         Ok(text)
     }
@@ -221,22 +147,6 @@ struct QwenResponseFormat {
     kind: &'static str,
 }
 
-#[derive(Deserialize)]
-struct QwenResponse {
-    choices: Vec<QwenChoice>,
-}
-
-#[derive(Deserialize)]
-struct QwenChoice {
-    finish_reason: String,
-    message: QwenResponseMessage,
-}
-
-#[derive(Deserialize)]
-struct QwenResponseMessage {
-    content: Option<String>,
-}
-
 #[cfg(test)]
 mod tests {
     use serde_json::json;
@@ -245,6 +155,31 @@ mod tests {
 
     use super::*;
     use crate::Model;
+    use crate::chat_completion::{
+        ChatCompletion, ChatCompletionClient, ChatCompletionError, ChatCompletionRequest,
+        ERROR_BODY_LIMIT_BYTES, RESPONSE_ENVELOPE_LIMIT_BYTES, SUCCESS_BODY_LIMIT_BYTES,
+    };
+
+    struct StubClient;
+
+    #[async_trait]
+    impl ChatCompletionClient for StubClient {
+        async fn complete(
+            &self,
+            request: ChatCompletionRequest<'_>,
+        ) -> Result<Option<ChatCompletion>, ChatCompletionError> {
+            let (api_key, endpoint, payload) = request.into_parts();
+            assert_eq!(api_key, "stub-key");
+            assert_eq!(endpoint, "https://stub.example/v1/chat/completions");
+            assert_eq!(payload["model"], "qwen-stub");
+            assert_eq!(payload["response_format"]["type"], "json_object");
+
+            Ok(Some(ChatCompletion::new(
+                "stop".to_string(),
+                Some(r#"{"name":"Ada"}"#.to_string()),
+            )))
+        }
+    }
 
     fn person_schema_value() -> serde_json::Value {
         json!({
@@ -333,6 +268,28 @@ mod tests {
             .complete(request("extract the name"))
             .await
             .expect("Qwen request should succeed");
+
+        // Assert
+        assert_eq!(response.output(), &json!({ "name": "Ada" }));
+    }
+
+    #[tokio::test]
+    async fn completes_through_injected_client() {
+        // Arrange
+        let model = Qwen::with_client(
+            QwenConfig {
+                api_key: "stub-key".to_string(),
+                base_url: "https://stub.example/v1/".to_string(),
+                model: "qwen-stub".to_string(),
+            },
+            Arc::new(StubClient),
+        );
+
+        // Act
+        let response = model
+            .complete(request("extract the name"))
+            .await
+            .expect("stubbed Qwen request should succeed");
 
         // Assert
         assert_eq!(response.output(), &json!({ "name": "Ada" }));
@@ -467,19 +424,6 @@ mod tests {
             .complete(request("hello"))
             .await
             .expect_err("oversized successful response should fail");
-
-        // Assert
-        assert!(matches!(error, model::ModelError::ResponseBodyTooLarge));
-    }
-
-    #[test]
-    fn rejects_success_chunk_that_exceeds_remaining_capacity() {
-        // Arrange
-        let mut body = vec![0; SUCCESS_BODY_LIMIT_BYTES - 1];
-
-        // Act
-        let error = Qwen::append_success_chunk(&mut body, &[0, 1])
-            .expect_err("chunk exceeding the limit should fail");
 
         // Assert
         assert!(matches!(error, model::ModelError::ResponseBodyTooLarge));
@@ -659,6 +603,13 @@ mod tests {
             "model request failed: Qwen returned HTTP 401 Unauthorized: \
              {\"error\":{\"message\":\"invalid API key\"}}"
         );
+        let provider_error = std::error::Error::source(&error)
+            .expect("HTTP failure should retain its provider error");
+        let source = provider_error
+            .source()
+            .and_then(|source| source.downcast_ref::<reqwest::Error>())
+            .expect("HTTP failure should retain its reqwest source");
+        assert_eq!(source.status(), Some(reqwest::StatusCode::UNAUTHORIZED));
     }
 
     #[tokio::test]

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -1,208 +1,59 @@
 +++
 title = "ag-harness Design"
-description = "Design for the planned ag-harness runtime."
+description = "Provider-neutral model and runtime boundaries for ag-harness."
 weight = 6
 +++
 
-# `ag-harness` - a light LLM harness
+# `ag-harness` Design
 
-`ag-harness` is the base layer between an application and an LLM. Rust-native,
-app-facing and lightweight. It provides just the essentials: an agent loop, three core
-tools, session management, and a typed event stream, leaving the actual product
-decisions entirely to your app.
+`ag-harness` is a small, Rust-native boundary between applications and LLM providers. It
+exposes provider-neutral model calls while preserving provider-specific capabilities.
 
 ```mermaid
 flowchart LR
-    T["TUI"] --> H["ag-harness"]
-    C["CLI"] --> H
-    W["HTTP"] --> H
-    H --> A["Anthropic"]
-    H --> O["OpenAI"]
-    H --> Q["Qwen"]
+    A[Application] --> M[Model lifecycle]
+    M --> Q[Qwen backend]
+    M --> K[Kimi backend]
+    Q --> C[Chat Completions]
+    K --> C
 ```
 
-## Core features
+## Model Boundary
 
-- **Three built-in tools** - `read`, `write`, `bash`.
-- **Structured edits** - the `write` tool applies git-style diff patches and emits
-  clean, targeted diffs.
-- **Permission policy** - every tool call passes a policy check.
-- **Persisted sessions** - session state and required data are saved.
+`Model` owns request-duration telemetry and validates every response against the
+request's `OutputSchema`. Provider adapters implement `ModelBackend` to supply stable
+identity and raw assistant output. Provider payloads, authentication, HTTP types, and
+capability rules remain private.
 
-## Architecture
+Provider-owned adapters and compatibility rules live under the private `provider`
+module. API-family clients remain separate so multiple providers can reuse a wire
+protocol without sharing provider policy.
 
-### Crates
+Qwen and Kimi share Chat Completions request execution and bounded response decoding.
+Both providers request JSON Object output, include the requested `OutputSchema` in the
+system instruction, and rely on shared local schema validation before returning a
+successful response.
 
-```
-agentty/
-├── crates/
-│   ├── ag-harness            # facade
-│   ├── ag-harness-protocol   # Op, Event, Diff, Usage
-│   ├── ag-harness-core       # loop, tools, sessions, context, storage
-```
-
-The current foundation lives entirely in `ag-harness`: the provider-neutral `Model`
-contract owns telemetry and structured-output validation for every request.
-Provider-specific adapters implement `ModelBackend` to supply model identity and raw
-assistant output. `Qwen` is the first adapter.
-
-## Session management
-
-- One host process manages multiple independent sessions.
-- An active session runs as an async task; sessions run in parallel.
-- Each session processes its prompts in sequence.
-- Session state is saved on disk and loaded when resumed.
-- The app coordinates work across sessions.
-- Closing the host process stops active turns; saved sessions remain resumable.
-
-```mermaid
-flowchart TB
-    H["Harness process"] --> S["Session management"]
-    S --> A["Session A"]
-    S --> B["Session B"]
-    S --> C["Session C"]
-    A --> AT["Async task"]
-    B --> BT["Async task"]
-    C --> CT["Async task"]
-```
-
-## Memory management
-
-- Active session state is kept in memory.
-- Session state is saved on disk.
-- Idle sessions reload from disk when resumed.
-
-## Agent loop
-
-A turn loops until the model responds without requesting a tool:
-
-```mermaid
-flowchart TD
-    A[user prompt] --> B[assemble context]
-    B --> C[call model, stream reply]
-    C --> D{tool requested?}
-    D -- yes --> E[policy check → run tool]
-    E --> B
-    D -- no --> F[turn complete]
-```
-
-### One tool call
-
-```mermaid
-sequenceDiagram
-    participant M as Model
-    participant H as Harness
-    participant App
-    M->>H: write(parser.rs, patch)
-    H->>H: policy → allowed?
-    H->>H: apply patch
-    H-->>App: Structured diff event
-    H->>M: tool result → loop continues
-```
-
-## Editing
-
-- **Write** - the model produces a git diff patch; the harness applies it. Alternative
-  edit methods (exact-match string replacement, etc.) are future experiments.
-- **Diff** - applied changes are streamed back as structured file-diff events,
-  renderable directly as git diffs.
-- **Output caps** - oversized tool output is truncated head+tail with a marker, so one
-  careless command can't flood the session's context. Per-tool limits; `read` supports
-  line ranges for precise re-reads.
-
-## Context
-
-- **Project discovery** - finds the project root and `AGENTS.md`; the model explores the
-  rest via `bash`.
-- **Base prompt** - one minimal system prompt.
-
-## Structured output
-
-The model contract requires provider-neutral structured output:
-
-- The caller supplies the expected JSON shape as a provider-independent schema.
-- Each adapter uses the strongest structured-output mechanism its provider supports and
-  returns raw assistant text. The shared `Model` lifecycle parses and validates the
-  returned JSON against the caller's schema.
-- Provider-specific request fields remain inside the adapter. For Qwen, the adapter uses
-  JSON Object mode and performs schema validation in the harness because Qwen guarantees
-  valid JSON, not schema conformance.
-- Every new model adapter must implement these structured-output semantics before it is
-  added.
-
-Configurations that cannot satisfy the contract, such as Qwen thinking mode, return an
-explicit unsupported-configuration error rather than silently falling back to
-unstructured text.
+Schemas without an explicit object root and unsupported configurations fail explicitly
+rather than falling back to unstructured output.
 
 ## Telemetry
 
-- **Metric** - records one duration observation per call, including Qwen/model
-  breakdowns.
-- **Labels** - provider and model only.
-- **Ownership** - the shared `Model` lifecycle records duration for every
-  `ModelBackend`, including failed and cancelled requests; binaries configure and flush
-  the OTLP metrics exporter.
-- **Lifecycle** - histogram state is cumulative and process-local; the one-shot example
-  verifies export rather than cross-run totals.
+The shared `Model` lifecycle records `gen_ai.client.operation.duration` for every
+backend request, including failures and cancellations. Application binaries own
+OpenTelemetry SDK setup, export, and shutdown. The Qwen and Kimi examples configure
+OTLP/HTTP metrics through the standard `OTEL_EXPORTER_OTLP_ENDPOINT` and
+`OTEL_EXPORTER_OTLP_HEADERS` environment variables. Each histogram observation is one
+model call; aggregate its count by `gen_ai.provider.name` to separate providers. Their
+default service names are `ag-harness-qwen` and `ag-harness-kimi`, while
+`OTEL_SERVICE_NAME` remains an application-level override.
 
-```mermaid
-flowchart LR
-    C["Model lifecycle"] --> M["Duration histogram"]
-    M --> O["OTLP collector"]
-    O --> P["Prometheus"]
-    P --> G["Grafana"]
-```
+## Runtime Direction
 
-## Permissions
+Agent loops, tools, permissions, and persisted sessions should build on the model
+boundary without introducing provider concepts into the application-facing API. Split
+additional crates only when a boundary must be reused independently or shared across a
+process boundary.
 
-All tools are denied by default. The session policy explicitly allows tools and, for
-`bash`, the permitted commands:
-
-```rust
-Policy {
-    read: Allow,
-    write: Deny,
-    bash: AllowCommands(["cargo test", "git status", "rg *"]),
-}
-```
-
-## Model tiers
-
-`ag-harness` will provide the ability to work with different AI model API tiers for the
-best cost and performance:
-
-- **Model variety** - frontier vs fast models: cheaper models for simpler tasks.
-- **Batch/Flex processing** - designed for latency-tolerant, non-critical workloads,
-  such as async jobs completed within 24 hours at 50% off.
-- **Priority processing** - faster responses at a premium for latency-critical turns.
-
-## Library API
-
-- **Harness** - creates and resumes sessions.
-- **Session** - holds model, policy, working directory, and state.
-- **Turn** - runs one prompt and streams text, diffs, completion, and failure events.
-- **App** - configures the session and renders its events.
-
-## Differences from existing harnesses
-
-- **User-facing products** (Claude Code, OpenCode, Aider): format output for humans;
-  `ag-harness` emits events for apps.
-- **Minimal harnesses** ([Pi](https://pi.dev/)): TypeScript-first, no permission layer;
-  `ag-harness` is Rust-native with an enforced policy hook.
-- **Vendor SDKs**: vendor-locked; `ag-harness` is model-agnostic.
-- **Rust model-API crates** (`rig`): abstract the model call only; `ag-harness` adds the
-  loop, persisted sessions, tools, permissions.
-- **Heavy harnesses**: bundle orchestration; `ag-harness` leaves it to the app.
-
-## Next iterations
-
-1. **Tool round trip.** Support one model-requested tool through execution to the final
-   response.
-1. **Second provider.** Integrate another model API through the structured-output
-   contract.
-
-## Roadmap
-
-1. **v1 - library.** `ag-harness` - unified crate integrated into agentty.
-1. **Service wrapper.** `ag-harness-service` (JSON-RPC 2.0 over Unix socket, WebSocket
-   for remote) + `ag-harness-client`.
+The next runtime iteration is one complete tool round trip from model request through
+policy-controlled execution to the final response.

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -31,10 +31,9 @@ For file-level detail, read the module docstrings directly.
   metadata, commit/diff/push/pull sync, rebase/conflict handling, and squash-merge
   workflows behind the `GitClient` boundary.
 - `crates/ag-harness/`: Application-facing LLM harness crate with the provider-neutral
-  `Model` contract, its first Qwen adapter, and a backend-neutral request-duration
-  metric. Application binaries own OpenTelemetry SDK and OTLP exporter setup. Its local
-  `AGENTS.md` records the intended agent loop, tools, session, event, and permission
-  boundaries.
+  `Model` lifecycle, private provider adapters for Qwen and Kimi, shared Chat
+  Completions behavior, and backend-neutral request-duration telemetry. Application
+  binaries own telemetry setup.
 - `crates/ag-protocol/`: Shared structured response protocol library crate with
   transport-neutral response models, schema generation, parser diagnostics, protocol
   prompt envelopes, repair prompts, review-comment outcomes, and turn prompt payload


### PR DESCRIPTION
- Sends schema-guided JSON Object requests through a shared OpenAI-compatible client with bounded response bodies, preserved HTTP diagnostics, and local validation.
- Adds Kimi support with injectable transport tests and a runnable structured-output example.
- Centralizes example OTLP telemetry, covers all examples in workspace coverage checks, and documents provider-neutral harness boundaries.