### PR TITLE
Publish and verify multi-architecture E2E images

### DIFF
--- a/.github/workflows/publish-e2e-image.yml
+++ b/.github/workflows/publish-e2e-image.yml
@@ -1,0 +1,163 @@
+name: Publish E2E Image
+run-name: Publish E2E image from ${{ github.ref_name }}
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+env:
+  E2E_REPOSITORY: ghcr.io/agentty-xyz/agentty-e2e
+
+concurrency:
+  group: publish-e2e-image
+  cancel-in-progress: false
+
+jobs:
+  require-default-branch:
+    name: Require default branch
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Verify selected branch
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          SELECTED_BRANCH: ${{ github.ref_name }}
+        run: test "$SELECTED_BRANCH" = "$DEFAULT_BRANCH"
+
+  build:
+    name: Build and test (${{ matrix.platform }})
+    needs: require-default-branch
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: amd64
+            platform: linux/amd64
+            runner: ubuntu-24.04
+            runner_arch: X64
+          - architecture: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            runner_arch: ARM64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Verify native runner architecture
+        env:
+          EXPECTED_RUNNER_ARCH: ${{ matrix.runner_arch }}
+        run: test "$RUNNER_ARCH" = "$EXPECTED_RUNNER_ARCH"
+
+      - name: Build candidate image
+        env:
+          ARCHITECTURE: ${{ matrix.architecture }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          candidate_image="${E2E_REPOSITORY}:build-${ARCHITECTURE}"
+          podman build \
+            --platform "$PLATFORM" \
+            --tag "$candidate_image" \
+            --file container/e2e.Containerfile \
+            container
+          test "$(podman image inspect --format '{{.Architecture}}' "$candidate_image")" = "$ARCHITECTURE"
+
+      - name: Run end-to-end feature suite
+        env:
+          ARCHITECTURE: ${{ matrix.architecture }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          candidate_image="${E2E_REPOSITORY}:build-${ARCHITECTURE}"
+          podman run --rm \
+            --platform "$PLATFORM" \
+            --mount type=bind,source="$GITHUB_WORKSPACE",target=/workspace,readonly=true \
+            --env CARGO_TARGET_DIR=/tmp/target \
+            "$candidate_image" \
+            prek run test-agentty-e2e --all-files --hook-stage manual
+
+      - name: Authenticate with GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: printf '%s' "$GHCR_TOKEN" | podman login ghcr.io --username "$GHCR_USER" --password-stdin
+
+      - name: Push candidate image
+        env:
+          ARCHITECTURE: ${{ matrix.architecture }}
+        run: |
+          candidate_image="${E2E_REPOSITORY}:build-${ARCHITECTURE}"
+          podman push "$candidate_image" "docker://${candidate_image}"
+
+  publish:
+    name: Publish and verify manifest
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.publish.outputs.digest }}
+
+    steps:
+      - name: Authenticate with GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: printf '%s' "$GHCR_TOKEN" | podman login ghcr.io --username "$GHCR_USER" --password-stdin
+
+      - name: Assemble manifest
+        run: |
+          podman manifest create "${E2E_REPOSITORY}:latest"
+          podman manifest add \
+            "${E2E_REPOSITORY}:latest" \
+            "docker://${E2E_REPOSITORY}:build-amd64"
+          podman manifest add \
+            "${E2E_REPOSITORY}:latest" \
+            "docker://${E2E_REPOSITORY}:build-arm64"
+
+      - name: Publish manifest
+        id: publish
+        run: |
+          digest_file=$(mktemp)
+          trap 'rm -f "$digest_file"' EXIT
+          podman manifest push --all \
+            --digestfile "$digest_file" \
+            "${E2E_REPOSITORY}:latest" \
+            "docker://${E2E_REPOSITORY}:latest"
+          digest=$(sed -n '1p' "$digest_file")
+          test -n "$digest"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Log out before anonymous verification
+        run: podman logout ghcr.io
+
+      - name: Verify published manifest
+        env:
+          PUBLISHED_IMAGE: ${{ env.E2E_REPOSITORY }}@${{ steps.publish.outputs.digest }}
+        run: |
+          skopeo inspect --raw "docker://${PUBLISHED_IMAGE}" | jq -e '
+            (.mediaType == "application/vnd.oci.image.index.v1+json"
+              or .mediaType == "application/vnd.docker.distribution.manifest.list.v2+json")
+            and ([
+              .manifests[].platform
+              | select(.os == "linux")
+              | .architecture
+            ] | unique | sort == ["amd64", "arm64"])
+          '
+          podman pull --platform linux/amd64 "$PUBLISHED_IMAGE"
+          podman pull --platform linux/arm64 "$PUBLISHED_IMAGE"
+
+      - name: Report published digest
+        env:
+          PUBLISHED_IMAGE: ${{ env.E2E_REPOSITORY }}@${{ steps.publish.outputs.digest }}
+        run: |
+          printf '## Published E2E image\n\n`%s`\n' "$PUBLISHED_IMAGE" >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,15 +357,18 @@ the full suite.
 - **User-visible UI behavior:** Satisfy the MANDATORY feature-test gate, then run the
   focused E2E workflow. For routine validation, run E2E feature tests with
   `TESTTY_GIF_MODE=check` so agents verify GIF freshness without launching VHS/Chrome.
-  When intentionally regenerating GIF assets, record in the pinned `linux/amd64` image
-  from `container/e2e.Containerfile` with `TESTTY_GIF_MODE=generate` so committed hash
-  sidecars match the container CI verifies them in; follow
-  `skills/feature-test/SKILL.md` for the exact commands. If recording on the host
-  instead, `TESTTY_GIF_MODE=force` must run from an unsandboxed shell (a normal
-  terminal, or one command explicitly approved to bypass the agent sandbox): VHS records
-  through localhost sockets (`ttyd` plus Chrome DevTools), so a network-denied sandbox
-  crashes `vhs` before Chrome launches — an error easy to misdiagnose as a missing
-  browser binary. Do not run the full E2E feature suite locally;
+  When intentionally regenerating GIF assets, follow `skills/feature-test/SKILL.md` to
+  select `linux/amd64` or `linux/arm64` explicitly and run the pinned image from
+  `container/e2e.Containerfile` with `TESTTY_GIF_MODE=generate`. A digest is eligible
+  for ARM64 recording only after its published image index is verified to contain both
+  platforms. Publish replacements through the manual **Publish E2E Image** workflow in
+  `.github/workflows/publish-e2e-image.yml`; it tests both native variants before
+  reporting the digest. CI selects and verifies the `linux/amd64` variant. If recording
+  on the host instead, `TESTTY_GIF_MODE=force` must run from an unsandboxed shell (a
+  normal terminal, or one command explicitly approved to bypass the agent sandbox): VHS
+  records through localhost sockets (`ttyd` plus Chrome DevTools), so a network-denied
+  sandbox crashes `vhs` before Chrome launches — an error easy to misdiagnose as a
+  missing browser binary. Do not run the full E2E feature suite locally;
   `.github/workflows/presubmit.yml` and `.github/workflows/postsubmit.yml` run
   `test-agentty-e2e` in that image on GitHub.
 

--- a/container/e2e.Containerfile
+++ b/container/e2e.Containerfile
@@ -85,6 +85,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 FROM debian@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
 
+LABEL org.opencontainers.image.source="https://github.com/agentty-xyz/agentty"
+
 ENV CARGO_HOME=/usr/local/cargo \
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_TARGET_DIR=/opt/target \

--- a/crates/testty/docs/feature-gif-workflow.md
+++ b/crates/testty/docs/feature-gif-workflow.md
@@ -81,18 +81,27 @@ still show the real value.
 
 ## Canonical container workflow
 
-Agentty checks feature GIF freshness in one pinned `linux/amd64` container defined by
-`container/e2e.Containerfile`. Presubmit, postsubmit, and release workflows use Podman
-to pull the same GHCR image by digest, mount the checkout read-only, and run the suite
-in `check` mode. CI never records, rewrites, or commits feature artifacts.
+Agentty checks feature GIF freshness in the pinned `linux/amd64` variant of the image
+defined by `container/e2e.Containerfile`. Presubmit, postsubmit, and release workflows
+use Podman to pull the same GHCR image by digest, mount the checkout read-only, and run
+the suite in `check` mode. CI never records, rewrites, or commits feature artifacts. The
+Containerfile also supports native `linux/arm64` recording, but a digest is eligible for
+that workflow only after its published image index is verified to contain both
+architectures.
+
+The manually dispatched **Publish E2E Image** workflow builds and tests both variants on
+native GitHub-hosted runners, publishes their shared image index, verifies anonymous
+platform pulls, and reports the digest used to update the pinned references. The
+existing GHCR package must grant this repository Actions write access before the
+workflow's first run.
 
 When an intentional UI change makes a sidecar stale, a developer runs the affected test
 in that container with a writable checkout and `generate` mode. Only missing or stale
 GIFs are recorded. The developer reviews the changed GIF and hash sidecar, refreshes the
 matching PNG poster, and commits the three artifacts with the UI change.
 
-Use the exact digest-pinned Podman recording command in `skills/feature-test/SKILL.md`.
-It runs the local container as the host UID and GID so Linux bind mounts remain
-writable, while CI keeps the image's fixed non-root user and read-only checkout.
-Recording in the same container that performs the freshness check prevents host-specific
-output from churning committed artifacts.
+Use the exact platform-explicit, digest-pinned Podman recording command in
+`skills/feature-test/SKILL.md`. It runs the local container as the host UID and GID so
+Linux bind mounts remain writable, while CI keeps the image's fixed non-root user and
+read-only checkout. Recording in the same container that performs the freshness check
+prevents host-specific output from churning committed artifacts.

--- a/skills/feature-test/SKILL.md
+++ b/skills/feature-test/SKILL.md
@@ -225,6 +225,12 @@ instead of attempting to emulate its AMD64 image. The host needs a running Podma
 environment only — no local Chrome or VHS — and the localhost-socket sandbox restriction
 below does not apply inside the container.
 
+A published digest is multi-architecture only when it resolves to an image index or
+manifest list containing both `linux/amd64` and `linux/arm64`; the Containerfile's
+support for both architectures does not prove that the registry reference contains both.
+Pull the immutable digest with an explicit platform so a missing variant fails instead
+of silently running the wrong architecture through emulation.
+
 On macOS or Windows, initialize the Podman machine once with `podman machine init`, then
 start it with `podman machine start` before pulling or running the image. Linux hosts
 run Podman directly without a machine.
@@ -247,7 +253,7 @@ case "$(uname -m)" in
   x86_64 | amd64)
     e2e_platform=linux/amd64
     e2e_image="${published_e2e_image}"
-    podman pull "${e2e_image}"
+    podman pull --platform "${e2e_platform}" "${e2e_image}"
     ;;
   arm64 | aarch64)
     e2e_platform=linux/arm64
@@ -301,23 +307,84 @@ nonempty-poster integrity check; a failed recording preserves the last valid pos
 Only maintainers changing `container/e2e.Containerfile` should build and publish a
 replacement image. Build both supported platforms into one manifest, run affected
 focused feature tests against the native candidate for each available architecture, then
-push `latest` after authenticating Podman to GHCR with package-write permission:
+push `latest`. The preferred path is the manual **Publish E2E Image** workflow in
+`.github/workflows/publish-e2e-image.yml`, dispatched from the repository's default
+branch. It builds and runs the E2E suite on native `ubuntu-24.04` AMD64 and
+`ubuntu-24.04-arm` ARM64 runners, publishes architecture-specific candidates, assembles
+the manifest, logs out of GHCR, verifies anonymous access to both variants, and reports
+the digest in the workflow summary.
+
+Before its first run, a package administrator must connect the existing `agentty-e2e`
+package to this repository or grant this repository write access under the package's
+**Manage Actions access** settings. The package predates this workflow, so the
+workflow's `packages: write` permission cannot authorize an unconnected package by
+itself. `container/e2e.Containerfile` carries the `org.opencontainers.image.source`
+label to preserve the repository association on subsequent publications.
+
+Copy the reported digest into every workflow `E2E_IMAGE` value and the
+`published_e2e_image` assignment above. After the pinned digest contains both platforms,
+the ARM64 recording branch can replace its native build with an explicit pull of that
+published image. Do not update the repository when either native test or either platform
+pull fails. Re-record every feature affected by a tool, browser, font, or rendering
+change and refresh its PNG poster before updating the digest and artifacts together.
+
+The following local flow remains available to maintainers with GHCR package-write
+permission. Use an explicit registry destination so a later single-image push cannot be
+confused with the manifest-list publication. Because the Containerfile contains `RUN`
+instructions, the combined build requires binfmt/QEMU emulation for the non-native
+platform; without it, use the manual workflow instead.
+
+The publication verification command also requires `jq` on the maintainer host.
 
 ```sh
+e2e_repository=ghcr.io/agentty-xyz/agentty-e2e
+e2e_digest_file=$(mktemp)
+trap 'rm -f "${e2e_digest_file}"' EXIT
+
 podman build --jobs 2 \
   --platform linux/amd64,linux/arm64 \
-  --manifest ghcr.io/agentty-xyz/agentty-e2e:latest \
+  --manifest "${e2e_repository}:latest" \
   --file container/e2e.Containerfile \
   container
 
-podman manifest push --all ghcr.io/agentty-xyz/agentty-e2e:latest
+podman manifest push --all \
+  --digestfile "${e2e_digest_file}" \
+  "${e2e_repository}:latest" \
+  "docker://${e2e_repository}:latest"
+
+e2e_digest=$(sed -n '1p' "${e2e_digest_file}")
+test -n "${e2e_digest}"
+rm "${e2e_digest_file}"
+trap - EXIT
+e2e_published_image="${e2e_repository}@${e2e_digest}"
 ```
 
-Copy the digest reported by `podman push` into every workflow `E2E_IMAGE` value and the
-local recording command above. Verify that the digest can be pulled without registry
-credentials so forked pull-request CI can use it. Re-record every feature affected by a
-tool, browser, font, or rendering change and refresh its PNG poster before committing
-the new digest and artifacts together.
+Before copying the digest reported by `podman manifest push`, inspect its
+digest-qualified remote reference and require both Linux platforms. Using the digest
+instead of `latest` prevents Podman from satisfying the inspection with the local
+pre-push manifest. This check rejects a single-image manifest even if that image itself
+is `linux/amd64` or `linux/arm64`:
+
+```sh
+podman logout ghcr.io
+
+podman manifest inspect "${e2e_published_image}" | jq -e '
+  (.mediaType == "application/vnd.oci.image.index.v1+json"
+    or .mediaType == "application/vnd.docker.distribution.manifest.list.v2+json")
+  and ([
+    .manifests[].platform
+    | select(.os == "linux")
+    | .architecture
+  ] | unique | sort == ["amd64", "arm64"])
+'
+
+podman pull --platform linux/amd64 "${e2e_published_image}"
+podman pull --platform linux/arm64 "${e2e_published_image}"
+```
+
+Do not update the repository when logout, inspection, or either platform pull fails. The
+logout makes the inspection and pulls exercise the same anonymous access that forked
+pull-request CI requires.
 
 ### Host recording caveats
 
@@ -420,6 +487,8 @@ When using the legacy pattern, create the Zola page manually at
 - [ ] A same-named PNG poster exists, shows a meaningful stable frame, and was refreshed
   after the latest GIF change.
 - [ ] The generated GIF exists and is nonempty before its hash sidecar is accepted.
+- [ ] Container recording selects `linux/amd64` or `linux/arm64` explicitly, and every
+  pulled digest contains the selected platform.
 - [ ] Focused E2E workflow passes with
   `TESTTY_GIF_MODE=check cargo nextest run --locked --profile ci -p agentty --test e2e test_{name}`.
 - [ ] Zola site validates with `prek run zola-check --all-files --hook-stage manual`


### PR DESCRIPTION
- Build and test native `linux/amd64` and `linux/arm64` variants before publishing a shared manifest digest.
- Pin recording and CI pulls and runs to explicit platforms, then verify anonymous access to both variants.
- Document the manual publication workflow and GHCR package access requirements.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)