### PR TITLE
Expand roadmap with open-source code reviewer

### DIFF
--- a/docs/site/sass/site.scss
+++ b/docs/site/sass/site.scss
@@ -786,8 +786,15 @@ svg {
 .roadmap-primary-row,
 .roadmap-future-row {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
     margin-top: clamp(2rem, 4vw, 3rem);
+}
+
+.roadmap-primary-row {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.roadmap-future-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .roadmap-node-direction {
@@ -800,12 +807,14 @@ svg {
     transform: translateY(-2px);
 }
 
-.roadmap-node-orchestrator {
+.roadmap-node-orchestrator,
+.roadmap-node-reviewer {
     margin: 0 0.4rem;
     border-color: color-mix(in srgb, var(--color-roadmap-future) 42%, var(--color-border));
 }
 
-.roadmap-node-orchestrator:hover {
+.roadmap-node-orchestrator:hover,
+.roadmap-node-reviewer:hover {
     border-color: color-mix(in srgb, var(--color-roadmap-future) 62%, var(--color-border));
     transform: translateY(-2px);
 }
@@ -2029,6 +2038,23 @@ svg {
     }
 }
 
+@media (max-width: 760px) {
+    .roadmap-primary-row {
+        grid-template-columns: 1fr;
+        gap: 0.85rem;
+    }
+
+    .roadmap-primary-row .roadmap-node {
+        margin: 0;
+    }
+
+    .roadmap-node-orchestrator:hover,
+    .roadmap-node-reviewer:hover {
+        border-color: color-mix(in srgb, var(--color-roadmap-future) 42%, var(--color-border));
+        transform: none;
+    }
+}
+
 @media (max-width: 680px) {
     .github-link-badges {
         display: none;
@@ -2053,11 +2079,6 @@ svg {
 
     .roadmap-node-direction {
         margin: 0;
-    }
-
-    .roadmap-node-orchestrator:hover {
-        border-color: color-mix(in srgb, var(--color-roadmap-future) 42%, var(--color-border));
-        transform: none;
     }
 
     /* Convert command tabs into touch-friendly rows and prevent command text truncation. */

--- a/docs/site/templates/index.html
+++ b/docs/site/templates/index.html
@@ -282,6 +282,13 @@
                         Coordinate specialized agents as one system: split work, run tasks in parallel, manage dependencies, and keep handoffs visible.
                     </p>
                 </article>
+                <article class="roadmap-node roadmap-node-direction roadmap-node-reviewer">
+                    <span class="roadmap-node-kicker roadmap-node-date roadmap-node-date-future"><i aria-hidden="true"></i>2026 Q3&ndash;Q4</span>
+                    <h3 class="roadmap-node-title">Open-Source Code Reviewer</h3>
+                    <p class="roadmap-node-text">
+                        Review pull requests across open-source GitHub projects, surface actionable findings, and help maintainers assess changes at scale.
+                    </p>
+                </article>
             </div>
             <div class="roadmap-future-row">
                 <article class="roadmap-node roadmap-node-direction">


### PR DESCRIPTION
- Add a 2026 Q3–Q4 roadmap card for reviewing pull requests across open-source GitHub projects.
- Arrange primary roadmap items across three columns and stack them on narrow screens.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)