### PR TITLE
Centralizes CI coverage and E2E validation

### DIFF
--- a/.github/actions/run-coverage/action.yml
+++ b/.github/actions/run-coverage/action.yml
@@ -1,0 +1,69 @@
+name: Run Agentty Coverage
+description: Generate, scan, summarize, and upload the workspace coverage report.
+
+inputs:
+  sonar-token:
+    description: SonarQube token used when the event is allowed to scan.
+    required: false
+  summarize:
+    description: Write LCOV totals to the GitHub Actions run summary.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Rust and `prek`
+      uses: ./.github/actions/setup-rust-prek
+      with:
+        cargo-llvm-cov: "true"
+        llvm-tools-preview: "true"
+
+    - name: Generate and check coverage report
+      shell: bash
+      run: prek run coverage --all-files --hook-stage manual
+
+    - name: SonarQube Scan
+      if: ${{ !cancelled() && hashFiles('coverage.lcov') != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
+      env:
+        SONAR_TOKEN: ${{ inputs.sonar-token }}
+
+    - name: Summarize coverage
+      if: ${{ inputs.summarize == 'true' && !cancelled() && hashFiles('coverage.lcov') != '' }}
+      shell: bash
+      run: |
+        # Summarize LCOV totals in the GitHub Actions run summary.
+        awk '
+          BEGIN {
+            print "## Test coverage"
+            print ""
+            print "| Metric | Covered | Total | Coverage |"
+            print "| --- | ---: | ---: | ---: |"
+          }
+          /^LF:/ { lines += substr($0, 4) }
+          /^LH:/ { covered_lines += substr($0, 4) }
+          /^FNF:/ { functions += substr($0, 5) }
+          /^FNH:/ { covered_functions += substr($0, 5) }
+          /^BRF:/ { branches += substr($0, 5) }
+          /^BRH:/ { covered_branches += substr($0, 5) }
+          END {
+            report("Lines", covered_lines, lines)
+            report("Functions", covered_functions, functions)
+            if (branches > 0) {
+              report("Branches", covered_branches, branches)
+            }
+          }
+          function report(label, covered, total) {
+            coverage = total == 0 ? "n/a" : sprintf("%.2f%%", covered * 100 / total)
+            printf "| %s | %d | %d | %s |\n", label, covered, total, coverage
+          }
+        ' coverage.lcov >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Upload coverage report
+      if: ${{ !cancelled() && hashFiles('coverage.lcov') != '' }}
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        fail_ci_if_error: true
+        files: coverage.lcov
+        use_oidc: true

--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -1,0 +1,30 @@
+name: Run Agentty E2E Suite
+description: Run the end-to-end feature suite in the pinned canonical container.
+
+inputs:
+  image:
+    description: Immutable Agentty E2E container image.
+    required: false
+    default: ghcr.io/agentty-xyz/agentty-e2e@sha256:d348629b6c449d33f5285c9ef2b7ea0ac3c47fcf264b1ec7f3f4c58a6952a696
+
+runs:
+  using: composite
+  steps:
+    - name: Pull the pinned E2E image
+      shell: bash
+      env:
+        E2E_IMAGE: ${{ inputs.image }}
+      run: podman pull "$E2E_IMAGE"
+
+    # The checkout is mounted read-only so `TESTTY_GIF_MODE=check` (set by
+    # the hook) verifies committed GIF hash sidecars without rewriting them.
+    - name: Run end-to-end feature suite
+      shell: bash
+      env:
+        E2E_IMAGE: ${{ inputs.image }}
+      run: >-
+        podman run --rm --platform linux/amd64
+        --mount type=bind,source="$PWD",target=/workspace,readonly=true
+        --env CARGO_TARGET_DIR=/tmp/target
+        "$E2E_IMAGE"
+        prek run test-agentty-e2e --all-files --hook-stage manual

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -10,7 +10,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  E2E_IMAGE: ghcr.io/agentty-xyz/agentty-e2e@sha256:d348629b6c449d33f5285c9ef2b7ea0ac3c47fcf264b1ec7f3f4c58a6952a696
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -73,58 +72,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Rust and `prek`
-        uses: ./.github/actions/setup-rust-prek
+      - name: Generate and publish coverage
+        uses: ./.github/actions/run-coverage
         with:
-          cargo-llvm-cov: "true"
-          llvm-tools-preview: "true"
-
-      - name: Generate and check coverage report
-        run: prek run coverage --all-files --hook-stage manual
-
-      - name: SonarQube Scan
-        if: ${{ !cancelled() && hashFiles('coverage.lcov') != '' }}
-        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-      - name: Summarize coverage
-        if: ${{ !cancelled() && hashFiles('coverage.lcov') != '' }}
-        run: |
-          # Summarize LCOV totals in the GitHub Actions run summary.
-          awk '
-            BEGIN {
-              print "## Test coverage"
-              print ""
-              print "| Metric | Covered | Total | Coverage |"
-              print "| --- | ---: | ---: | ---: |"
-            }
-            /^LF:/ { lines += substr($0, 4) }
-            /^LH:/ { covered_lines += substr($0, 4) }
-            /^FNF:/ { functions += substr($0, 5) }
-            /^FNH:/ { covered_functions += substr($0, 5) }
-            /^BRF:/ { branches += substr($0, 5) }
-            /^BRH:/ { covered_branches += substr($0, 5) }
-            END {
-              report("Lines", covered_lines, lines)
-              report("Functions", covered_functions, functions)
-              if (branches > 0) {
-                report("Branches", covered_branches, branches)
-              }
-            }
-            function report(label, covered, total) {
-              coverage = total == 0 ? "n/a" : sprintf("%.2f%%", covered * 100 / total)
-              printf "| %s | %d | %d | %s |\n", label, covered, total, coverage
-            }
-          ' coverage.lcov >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload coverage report
-        if: ${{ !cancelled() && hashFiles('coverage.lcov') != '' }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          fail_ci_if_error: true
-          files: coverage.lcov
-          use_oidc: true
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
+          summarize: "true"
 
   e2e:
     runs-on: ubuntu-latest
@@ -135,15 +87,5 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Pull the pinned E2E image
-        run: podman pull "$E2E_IMAGE"
-
-      # The checkout is mounted read-only so `TESTTY_GIF_MODE=check` (set by
-      # the hook) verifies committed GIF hash sidecars without rewriting them.
       - name: Run end-to-end feature suite
-        run: >-
-          podman run --rm --platform linux/amd64
-          --mount type=bind,source="$PWD",target=/workspace,readonly=true
-          --env CARGO_TARGET_DIR=/tmp/target
-          "$E2E_IMAGE"
-          prek run test-agentty-e2e --all-files --hook-stage manual
+        uses: ./.github/actions/run-e2e

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -8,9 +8,6 @@ on:
 permissions:
   contents: read
 
-env:
-  E2E_IMAGE: ghcr.io/agentty-xyz/agentty-e2e@sha256:d348629b6c449d33f5285c9ef2b7ea0ac3c47fcf264b1ec7f3f4c58a6952a696
-
 jobs:
   coverage:
     name: SonarQube
@@ -26,28 +23,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Rust and `prek`
-        uses: ./.github/actions/setup-rust-prek
+      - name: Generate and publish coverage
+        uses: ./.github/actions/run-coverage
         with:
-          cargo-llvm-cov: "true"
-          llvm-tools-preview: "true"
-
-      - name: Generate and check coverage report
-        run: prek run coverage --all-files --hook-stage manual
-
-      - name: SonarQube Scan
-        if: ${{ !cancelled() && hashFiles('coverage.lcov') != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-      - name: Upload coverage report
-        if: ${{ !cancelled() && hashFiles('coverage.lcov') != '' }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          fail_ci_if_error: true
-          files: coverage.lcov
-          use_oidc: true
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
 
   e2e:
     name: End-to-end feature tests
@@ -59,18 +38,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Pull the pinned E2E image
-        run: podman pull "$E2E_IMAGE"
-
-      # The checkout is mounted read-only so `TESTTY_GIF_MODE=check` (set by
-      # the hook) verifies committed GIF hash sidecars without rewriting them.
       - name: Run end-to-end feature suite
-        run: >-
-          podman run --rm --platform linux/amd64
-          --mount type=bind,source="$PWD",target=/workspace,readonly=true
-          --env CARGO_TARGET_DIR=/tmp/target
-          "$E2E_IMAGE"
-          prek run test-agentty-e2e --all-files --hook-stage manual
+        uses: ./.github/actions/run-e2e
 
   validate:
     name: Workspace checks

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -6,9 +6,6 @@ on:
 permissions:
   contents: read
 
-env:
-  E2E_IMAGE: ghcr.io/agentty-xyz/agentty-e2e@sha256:d348629b6c449d33f5285c9ef2b7ea0ac3c47fcf264b1ec7f3f4c58a6952a696
-
 jobs:
   validate:
     name: Release validation
@@ -29,15 +26,5 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Pull the pinned E2E image
-        run: podman pull "$E2E_IMAGE"
-
-      # The checkout is mounted read-only so `TESTTY_GIF_MODE=check` (set by
-      # the hook) verifies committed GIF hash sidecars without rewriting them.
       - name: Run end-to-end feature suite
-        run: >-
-          podman run --rm --platform linux/amd64
-          --mount type=bind,source="$PWD",target=/workspace,readonly=true
-          --env CARGO_TARGET_DIR=/tmp/target
-          "$E2E_IMAGE"
-          prek run test-agentty-e2e --all-files --hook-stage manual
+        uses: ./.github/actions/run-e2e

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -38,8 +38,8 @@ install-updater = true
 # Keep the generated `.github/workflows/release.yml` action refs pinned when
 # `dist init` regenerates the workflow.
 [dist.github-action-commits]
-"actions/checkout" = "de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
-"actions/attest-build-provenance" = "96278af6caaf10aea03fd8d33a09a777ca52d62f" # v3.2.0
-"actions/download-artifact" = "37930b1c2abaa49bbe596cd826c3c89aef350131" # v7.0.0
+"actions/checkout" = "3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
+"actions/attest-build-provenance" = "0f67c3f4856b2e3261c31976d6725780e5e4c373" # v4.1.1
+"actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8.0.1
 "actions/setup-node" = "48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e" # v6.4.0
-"actions/upload-artifact" = "b7c566a772e6b6bfb58ed0dc250532a479d7789f" # v6.0.0
+"actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7.0.1

--- a/skills/bump-version/SKILL.md
+++ b/skills/bump-version/SKILL.md
@@ -54,7 +54,6 @@ steps here.
    - Run the baseline repository validations from the `prek` hook catalog in
      `.pre-commit-config.yaml`:
      - `prek run --all-files`
-     - `prek run clippy --all-files --hook-stage manual`
      - `prek run test-workspace --all-files --hook-stage manual`
    - If validation fails, fix the underlying issue and rerun the failing hook before
      handoff.

--- a/skills/feature-test/SKILL.md
+++ b/skills/feature-test/SKILL.md
@@ -321,12 +321,13 @@ workflow's `packages: write` permission cannot authorize an unconnected package 
 itself. `container/e2e.Containerfile` carries the `org.opencontainers.image.source`
 label to preserve the repository association on subsequent publications.
 
-Copy the reported digest into every workflow `E2E_IMAGE` value and the
-`published_e2e_image` assignment above. After the pinned digest contains both platforms,
-the ARM64 recording branch can replace its native build with an explicit pull of that
-published image. Do not update the repository when either native test or either platform
-pull fails. Re-record every feature affected by a tool, browser, font, or rendering
-change and refresh its PNG poster before updating the digest and artifacts together.
+Copy the reported digest into the `image` default in
+`.github/actions/run-e2e/action.yml` and the `published_e2e_image` assignment above.
+After the pinned digest contains both platforms, the ARM64 recording branch can replace
+its native build with an explicit pull of that published image. Do not update the
+repository when either native test or either platform pull fails. Re-record every
+feature affected by a tool, browser, font, or rendering change and refresh its PNG
+poster before updating the digest and artifacts together.
 
 The following local flow remains available to maintainers with GHCR package-write
 permission. Use an explicit registry destination so a later single-image push cannot be


### PR DESCRIPTION
- Reuses composite actions across presubmit, postsubmit, and release checks.
- Preserves fork-safe SonarQube scanning, optional coverage summaries, and Codecov uploads.
- Aligns release action pins and feature-test guidance with centralized workflow configuration.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)