### PR TITLE
Shares cached render data across UI layouts

### DIFF
--- a/crates/agentty/src/runtime/mode/review_comment.rs
+++ b/crates/agentty/src/runtime/mode/review_comment.rs
@@ -93,14 +93,14 @@ pub(crate) async fn handle_with_cache(
                 comment_error.as_deref(),
                 is_loading_comments,
                 &diff,
+                page::review_comment::ReviewCommentRenderCaches {
+                    diff_layout: render_cache_store.diff_layout_cache(),
+                    markdown: render_cache_store.markdown_render_cache(),
+                },
                 selected_comment_index,
                 content_area,
-                render_cache_store.markdown_render_cache(),
             );
-            scroll_offset = scroll_offset
-                .min(max_scroll_offset)
-                .saturating_add(1)
-                .min(max_scroll_offset);
+            scroll_offset = increment_scroll_offset(scroll_offset, max_scroll_offset);
         }
         KeyCode::Up => {
             scroll_offset = scroll_offset.saturating_sub(1);
@@ -120,6 +120,14 @@ pub(crate) async fn handle_with_cache(
     };
 
     EventResult::Continue
+}
+
+/// Advances one detail row while clamping stale and terminal offsets.
+fn increment_scroll_offset(scroll_offset: u16, max_scroll_offset: u16) -> u16 {
+    scroll_offset
+        .min(max_scroll_offset)
+        .saturating_add(1)
+        .min(max_scroll_offset)
 }
 
 /// Returns whether the review-comments page still belongs to a session that

--- a/crates/agentty/src/ui/page/diff.rs
+++ b/crates/agentty/src/ui/page/diff.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
 use std::hash::Hasher;
+use std::ops::Range;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -82,6 +83,7 @@ impl OwnedDiffLine {
 #[derive(Clone)]
 pub(crate) struct DiffContentSnapshot {
     all_files_summary: DiffSelectionChangeSummary,
+    file_line_ranges: Arc<HashMap<String, Vec<Range<usize>>>>,
     file_list_lines: Arc<[Line<'static>]>,
     key: DiffContentCacheKey,
     parsed_lines: Arc<[OwnedDiffLine]>,
@@ -138,6 +140,26 @@ impl DiffContentSnapshot {
         self.tree_items.len()
     }
 
+    /// Returns cached diff body rows for `path` without walking unrelated
+    /// files.
+    pub(crate) fn file_lines(&self, path: &str) -> Vec<DiffLine<'_>> {
+        let Some(ranges) = self.file_line_ranges.get(path) else {
+            return Vec::new();
+        };
+
+        ranges
+            .iter()
+            .flat_map(|range| self.parsed_lines[range.clone()].iter())
+            .filter(|line| {
+                matches!(
+                    line.kind,
+                    DiffLineKind::Addition | DiffLineKind::Deletion | DiffLineKind::Context
+                )
+            })
+            .map(OwnedDiffLine::borrowed)
+            .collect()
+    }
+
     /// Returns the selected repository-relative markdown file path.
     pub(crate) fn selected_markdown_path(&self, selected_index: usize) -> Option<&str> {
         let FileTreeItem::File(path) = self.tree_items.get(selected_index)? else {
@@ -171,7 +193,7 @@ impl DiffContentSnapshot {
         diff_util::filter_diff_lines(&parsed_lines, selected_item)
     }
 
-    /// Returns the complete parsed diff as borrowed lines.
+    /// Returns the complete cached diff snapshot as borrowed lines.
     fn borrowed_lines(&self) -> Vec<DiffLine<'_>> {
         self.parsed_lines
             .iter()
@@ -234,6 +256,54 @@ impl DiffContentSnapshot {
             .collect();
 
         (all_files_summary, selection_summaries)
+    }
+
+    /// Indexes each old and new file path to its parsed-line ranges.
+    fn file_line_ranges(parsed_lines: &[DiffLine<'_>]) -> HashMap<String, Vec<Range<usize>>> {
+        let mut file_line_ranges = HashMap::new();
+        let mut current_paths = None;
+        let mut current_start_index = 0;
+
+        for (line_index, line) in parsed_lines.iter().enumerate() {
+            if line.kind != DiffLineKind::FileHeader || !line.content.starts_with("diff --git") {
+                continue;
+            }
+
+            if let Some(paths) = current_paths.take() {
+                Self::store_file_line_range(
+                    &mut file_line_ranges,
+                    paths,
+                    current_start_index..line_index,
+                );
+            }
+            current_paths = diff_util::diff_header_paths(line.content);
+            current_start_index = line_index.saturating_add(1);
+        }
+
+        if let Some(paths) = current_paths {
+            Self::store_file_line_range(
+                &mut file_line_ranges,
+                paths,
+                current_start_index..parsed_lines.len(),
+            );
+        }
+
+        file_line_ranges
+    }
+
+    /// Adds one file block under both rename-aware paths without duplication.
+    fn store_file_line_range(
+        file_line_ranges: &mut HashMap<String, Vec<Range<usize>>>,
+        (old_path, new_path): (String, String),
+        range: Range<usize>,
+    ) {
+        file_line_ranges
+            .entry(old_path.clone())
+            .or_default()
+            .push(range.clone());
+        if new_path != old_path {
+            file_line_ranges.entry(new_path).or_default().push(range);
+        }
     }
 
     /// Aggregates file-level change totals into folder-prefix totals.
@@ -325,10 +395,13 @@ struct DiffLayoutCacheEntry {
 /// Bounded cache for parsed diff content and fully assembled diff layouts.
 ///
 /// The parsed-content layer avoids re-parsing the same raw diff and rebuilding
-/// file-tree metadata on every frame. The rendered-layout layer sits above
-/// styled diff assembly so scroll metrics and frame painting reuse the same
-/// rows for unchanged diff content, selection, panel width/height, scrollbar
-/// gutter state, and active style version.
+/// file-tree metadata or per-path line ranges on every frame. Its key is the
+/// raw diff's hash and byte length, so replacing the diff invalidates the
+/// snapshot. The rendered-layout layer sits above styled diff assembly so
+/// scroll metrics and frame painting
+/// reuse the same rows until diff content, selection, panel width/height,
+/// scrollbar gutter state, or the active style version changes. Both LRU
+/// layers evict their oldest entries at their fixed limits.
 pub struct DiffLayoutCache {
     content_entries: RefCell<VecDeque<DiffContentCacheEntry>>,
     layout_entries: RefCell<VecDeque<DiffLayoutCacheEntry>>,
@@ -355,8 +428,10 @@ impl DiffLayoutCache {
         let (file_list_lines, tree_items) = FileExplorer::file_tree(&parsed_lines);
         let (all_files_summary, selection_summaries) =
             DiffContentSnapshot::change_summaries(&parsed_lines, &tree_items);
+        let file_line_ranges = DiffContentSnapshot::file_line_ranges(&parsed_lines);
         let snapshot = DiffContentSnapshot {
             all_files_summary,
+            file_line_ranges: Arc::new(file_line_ranges),
             file_list_lines: Arc::from(file_list_lines),
             key,
             parsed_lines: Arc::from(
@@ -1051,6 +1126,10 @@ mod tests {
             &second_content.parsed_lines
         ));
         assert!(Arc::ptr_eq(
+            &first_content.file_line_ranges,
+            &second_content.file_line_ranges
+        ));
+        assert!(Arc::ptr_eq(
             &first_content.file_list_lines,
             &second_content.file_list_lines
         ));
@@ -1058,6 +1137,46 @@ mod tests {
             &first_content.selection_summaries,
             &second_content.selection_summaries
         ));
+    }
+
+    #[test]
+    fn test_diff_content_snapshot_indexes_repeated_and_renamed_file_blocks() {
+        // Arrange
+        let cache = DiffLayoutCache::default();
+        let content = cache.content(concat!(
+            "diff --git a/src/old.rs b/src/new.rs\n",
+            "index 111..222 100644\n",
+            "@@ -1 +1 @@\n",
+            "-old first\n",
+            "+new first\n",
+            "diff --git malformed\n",
+            "+ignored malformed\n",
+            "diff --git a/src/new.rs b/src/new.rs\n",
+            "@@ -2 +2 @@\n",
+            " unchanged second\n",
+        ));
+
+        // Act
+        let old_path_lines = content.file_lines("src/old.rs");
+        let new_path_lines = content.file_lines("src/new.rs");
+        let missing_path_lines = content.file_lines("src/missing.rs");
+
+        // Assert
+        assert_eq!(
+            old_path_lines
+                .iter()
+                .map(|line| line.content)
+                .collect::<Vec<_>>(),
+            vec!["old first", "new first"]
+        );
+        assert_eq!(
+            new_path_lines
+                .iter()
+                .map(|line| line.content)
+                .collect::<Vec<_>>(),
+            vec!["old first", "new first", "unchanged second"]
+        );
+        assert!(missing_path_lines.is_empty());
     }
 
     #[test]

--- a/crates/agentty/src/ui/page/review_comment.rs
+++ b/crates/agentty/src/ui/page/review_comment.rs
@@ -14,7 +14,9 @@ use crate::domain::session::Session;
 use crate::presentation::app_mode::{ReviewCommentAction, ReviewCommentActionSelection};
 use crate::presentation::{help_action, review_comment as review_comment_selection};
 use crate::ui::component::vertical_scrollbar::VerticalScrollbar;
-use crate::ui::diff_util::{DiffLine, DiffLineKind};
+use crate::ui::diff_util::DiffLine;
+#[cfg(test)]
+use crate::ui::diff_util::DiffLineKind;
 use crate::ui::{Component, Page, diff_util, help_format, markdown, review_comment_format, style};
 
 const CODE_CONTEXT_RADIUS: usize = 3;
@@ -26,10 +28,19 @@ pub struct ReviewCommentPage<'a> {
     comment_snapshot: Option<&'a ReviewCommentSnapshot>,
     diff: &'a str,
     is_loading_comments: bool,
-    markdown_render_cache: &'a markdown::MarkdownRenderCache,
+    render_caches: ReviewCommentRenderCaches<'a>,
     scroll_offset: u16,
     selected_comment_index: usize,
     session: &'a Session,
+}
+
+/// Shared bounded caches used to derive review-comment detail rows.
+#[derive(Clone, Copy)]
+pub struct ReviewCommentRenderCaches<'a> {
+    /// Parsed-diff cache shared with the main diff page.
+    pub diff_layout: &'a crate::ui::page::diff::DiffLayoutCache,
+    /// Styled Markdown cache shared with other text surfaces.
+    pub markdown: &'a markdown::MarkdownRenderCache,
 }
 
 /// Borrowed inputs needed to construct one review-comment page renderer.
@@ -45,8 +56,8 @@ pub struct ReviewCommentPageInput<'a> {
     pub diff: &'a str,
     /// Whether the forge comment request is still running.
     pub is_loading_comments: bool,
-    /// Shared cache used for styled Markdown and embedded HTML comment bodies.
-    pub markdown_render_cache: &'a markdown::MarkdownRenderCache,
+    /// Shared bounded caches used by paint and scroll metrics.
+    pub render_caches: ReviewCommentRenderCaches<'a>,
     /// Vertical offset inside the selected comment detail panel.
     pub scroll_offset: u16,
     /// Selected general comment or inline thread index.
@@ -64,7 +75,7 @@ impl<'a> ReviewCommentPage<'a> {
             comment_snapshot,
             diff,
             is_loading_comments,
-            markdown_render_cache,
+            render_caches,
             scroll_offset,
             selected_comment_index,
             session,
@@ -76,7 +87,7 @@ impl<'a> ReviewCommentPage<'a> {
             comment_snapshot,
             diff,
             is_loading_comments,
-            markdown_render_cache,
+            render_caches,
             scroll_offset,
             selected_comment_index,
             session,
@@ -145,8 +156,8 @@ impl<'a> ReviewCommentPage<'a> {
             self.comment_error,
             self.is_loading_comments,
             self.diff,
+            self.render_caches,
             self.selected_comment_index,
-            self.markdown_render_cache,
             content_width,
         );
         let viewport_height = area.height.saturating_sub(2);
@@ -199,9 +210,9 @@ pub(crate) fn review_comment_view_max_scroll_offset(
     comment_error: Option<&str>,
     is_loading_comments: bool,
     diff: &str,
+    render_caches: ReviewCommentRenderCaches<'_>,
     selected_comment_index: usize,
     area: Rect,
-    markdown_render_cache: &markdown::MarkdownRenderCache,
 ) -> u16 {
     let detail_area = diff_util::diff_page_areas(area).diff_area;
     let viewport_height = detail_area.height.saturating_sub(2);
@@ -214,8 +225,8 @@ pub(crate) fn review_comment_view_max_scroll_offset(
         comment_error,
         is_loading_comments,
         diff,
+        render_caches,
         selected_comment_index,
-        markdown_render_cache,
         content_width,
     )
     .len();
@@ -338,8 +349,8 @@ fn comment_detail_lines(
     comment_error: Option<&str>,
     is_loading_comments: bool,
     diff: &str,
+    render_caches: ReviewCommentRenderCaches<'_>,
     selected_comment_index: usize,
-    markdown_render_cache: &markdown::MarkdownRenderCache,
     width: usize,
 ) -> Vec<Line<'static>> {
     let Some(rows) = rows else {
@@ -358,10 +369,16 @@ fn comment_detail_lines(
 
     match entry {
         review_comment_selection::ReviewCommentEntry::General(comment) => {
-            general_comment_detail_lines(comment, markdown_render_cache, width)
+            general_comment_detail_lines(comment, render_caches.markdown, width)
         }
         review_comment_selection::ReviewCommentEntry::Thread(thread) => {
-            thread_comment_detail_lines(thread, diff, markdown_render_cache, width)
+            thread_comment_detail_lines(
+                thread,
+                diff,
+                render_caches.diff_layout,
+                render_caches.markdown,
+                width,
+            )
         }
     }
 }
@@ -398,6 +415,7 @@ fn general_comment_detail_lines(
 fn thread_comment_detail_lines(
     thread: &ReviewCommentThread,
     diff: &str,
+    diff_layout_cache: &crate::ui::page::diff::DiffLayoutCache,
     markdown_render_cache: &markdown::MarkdownRenderCache,
     width: usize,
 ) -> Vec<Line<'static>> {
@@ -411,7 +429,7 @@ fn thread_comment_detail_lines(
         Line::default(),
         section_line("Code context"),
     ];
-    lines.extend(code_context_lines(thread, diff, width));
+    lines.extend(code_context_lines(thread, diff, diff_layout_cache, width));
     lines.extend([Line::default(), section_line("Conversation")]);
     review_comment_format::append_comment_bodies(
         &mut lines,
@@ -427,6 +445,7 @@ fn thread_comment_detail_lines(
 fn code_context_lines(
     thread: &ReviewCommentThread,
     diff: &str,
+    diff_layout_cache: &crate::ui::page::diff::DiffLayoutCache,
     width: usize,
 ) -> Vec<Line<'static>> {
     if thread.is_outdated == Some(true) {
@@ -439,8 +458,8 @@ fn code_context_lines(
         )];
     }
 
-    let parsed_lines = diff_util::parse_diff_lines(diff);
-    let file_lines = diff_file_lines(&parsed_lines, &thread.path);
+    let parsed_content = diff_layout_cache.content(diff);
+    let file_lines = parsed_content.file_lines(&thread.path);
     if file_lines.is_empty() {
         return vec![muted_line(
             "No current diff context is available for this file.",
@@ -475,31 +494,6 @@ fn code_context_lines(
             code_context_line(line, is_anchor, gutter_width, width)
         })
         .collect()
-}
-
-/// Returns diff body lines belonging to `path`, excluding diff metadata.
-fn diff_file_lines<'a>(parsed_lines: &'a [DiffLine<'a>], path: &str) -> Vec<DiffLine<'a>> {
-    let mut is_selected_file = false;
-    let mut lines = Vec::new();
-
-    for line in parsed_lines {
-        if line.kind == DiffLineKind::FileHeader && line.content.starts_with("diff --git") {
-            is_selected_file = diff_util::diff_header_paths(line.content)
-                .is_some_and(|(old_path, new_path)| old_path == path || new_path == path);
-
-            continue;
-        }
-        if is_selected_file
-            && matches!(
-                line.kind,
-                DiffLineKind::Addition | DiffLineKind::Deletion | DiffLineKind::Context
-            )
-        {
-            lines.push(*line);
-        }
-    }
-
-    lines
 }
 
 /// Returns whether one diff row belongs to an inclusive thread anchor range.
@@ -716,6 +710,7 @@ mod tests {
         let session = SessionFixtureBuilder::new()
             .title(Some("Review comments session".to_string()))
             .build();
+        let diff_layout_cache = crate::ui::page::diff::DiffLayoutCache::default();
         let markdown_render_cache = markdown::MarkdownRenderCache::default();
         let backend = TestBackend::new(terminal_size.0, terminal_size.1);
         let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
@@ -728,7 +723,10 @@ mod tests {
                     comment_snapshot: snapshot,
                     diff: SAMPLE_DIFF,
                     is_loading_comments,
-                    markdown_render_cache: &markdown_render_cache,
+                    render_caches: ReviewCommentRenderCaches {
+                        diff_layout: &diff_layout_cache,
+                        markdown: &markdown_render_cache,
+                    },
                     scroll_offset,
                     selected_comment_index,
                     session: &session,
@@ -895,6 +893,7 @@ mod tests {
     fn test_review_comment_view_max_scroll_offset_reflects_detail_overflow() {
         // Arrange
         let snapshot = comment_snapshot();
+        let diff_layout_cache = crate::ui::page::diff::DiffLayoutCache::default();
         let markdown_render_cache = markdown::MarkdownRenderCache::default();
 
         // Act
@@ -903,9 +902,12 @@ mod tests {
             None,
             false,
             SAMPLE_DIFF,
+            ReviewCommentRenderCaches {
+                diff_layout: &diff_layout_cache,
+                markdown: &markdown_render_cache,
+            },
             0,
             Rect::new(0, 0, 80, 10),
-            &markdown_render_cache,
         );
 
         // Assert
@@ -916,9 +918,10 @@ mod tests {
     fn test_code_context_lines_include_and_highlight_attached_new_line() {
         // Arrange
         let thread = inline_thread(2);
+        let diff_layout_cache = crate::ui::page::diff::DiffLayoutCache::default();
 
         // Act
-        let lines = code_context_lines(&thread, SAMPLE_DIFF, 80);
+        let lines = code_context_lines(&thread, SAMPLE_DIFF, &diff_layout_cache, 80);
 
         // Assert
         let attached_line = lines
@@ -935,13 +938,49 @@ mod tests {
     }
 
     #[test]
+    fn test_code_context_lines_repeat_inline_derivation_with_one_shared_cache() {
+        // Arrange
+        let thread = inline_thread(2);
+        let diff_layout_cache = crate::ui::page::diff::DiffLayoutCache::default();
+        let diff = concat!(
+            "diff --git a/src/unrelated.rs b/src/unrelated.rs\n",
+            "@@ -1 +1 @@\n",
+            "-unrelated old\n",
+            "+unrelated new\n",
+            "diff --git a/src/main.rs b/src/main.rs\n",
+            "@@ -1,3 +1,4 @@\n",
+            " fn main() {\n",
+            "+    println!(\"hello\");\n",
+            " }\n",
+        );
+
+        // Act
+        let first_lines = code_context_lines(&thread, diff, &diff_layout_cache, 80);
+        let repeated_lines = code_context_lines(&thread, diff, &diff_layout_cache, 80);
+
+        // Assert
+        assert_eq!(first_lines, repeated_lines);
+        assert!(
+            repeated_lines
+                .iter()
+                .all(|line| !line.to_string().contains("unrelated"))
+        );
+        assert!(
+            repeated_lines
+                .iter()
+                .any(|line| line.to_string().contains("println!"))
+        );
+    }
+
+    #[test]
     fn test_code_context_lines_highlight_every_line_in_multiline_anchor_range() {
         // Arrange
         let mut thread = inline_thread(2);
         thread.start_line = Some(1);
+        let diff_layout_cache = crate::ui::page::diff::DiffLayoutCache::default();
 
         // Act
-        let lines = code_context_lines(&thread, SAMPLE_DIFF, 80);
+        let lines = code_context_lines(&thread, SAMPLE_DIFF, &diff_layout_cache, 80);
 
         // Assert
         let start_line = lines
@@ -1019,9 +1058,10 @@ mod tests {
     fn test_code_context_lines_explain_file_level_anchor_without_synthetic_code() {
         // Arrange
         let thread = file_thread();
+        let diff_layout_cache = crate::ui::page::diff::DiffLayoutCache::default();
 
         // Act
-        let lines = code_context_lines(&thread, SAMPLE_DIFF, 80);
+        let lines = code_context_lines(&thread, SAMPLE_DIFF, &diff_layout_cache, 80);
 
         // Assert
         assert_eq!(
@@ -1041,9 +1081,10 @@ mod tests {
         // Arrange
         let mut thread = inline_thread(2);
         thread.is_outdated = Some(true);
+        let diff_layout_cache = crate::ui::page::diff::DiffLayoutCache::default();
 
         // Act
-        let lines = code_context_lines(&thread, SAMPLE_DIFF, 80);
+        let lines = code_context_lines(&thread, SAMPLE_DIFF, &diff_layout_cache, 80);
 
         // Assert
         assert_eq!(
@@ -1068,12 +1109,16 @@ mod tests {
         let outside_thread = inline_thread(99);
         let mut missing_anchor_thread = inline_thread(2);
         missing_anchor_thread.line = None;
+        let diff_layout_cache = crate::ui::page::diff::DiffLayoutCache::default();
 
         // Act
-        let old_lines = code_context_lines(&old_thread, SAMPLE_DIFF, 80);
-        let missing_file_lines = code_context_lines(&missing_file_thread, SAMPLE_DIFF, 80);
-        let outside_lines = code_context_lines(&outside_thread, SAMPLE_DIFF, 80);
-        let missing_anchor_lines = code_context_lines(&missing_anchor_thread, SAMPLE_DIFF, 80);
+        let old_lines = code_context_lines(&old_thread, SAMPLE_DIFF, &diff_layout_cache, 80);
+        let missing_file_lines =
+            code_context_lines(&missing_file_thread, SAMPLE_DIFF, &diff_layout_cache, 80);
+        let outside_lines =
+            code_context_lines(&outside_thread, SAMPLE_DIFF, &diff_layout_cache, 80);
+        let missing_anchor_lines =
+            code_context_lines(&missing_anchor_thread, SAMPLE_DIFF, &diff_layout_cache, 80);
         let file_side_matches = diff_line_matches_anchor(
             &DiffLine {
                 content: "file",
@@ -1119,6 +1164,7 @@ mod tests {
             threads: vec![inline_thread(2)],
         };
         let rows = review_comment_selection::grouped_review_comment_rows(&snapshot);
+        let diff_layout_cache = crate::ui::page::diff::DiffLayoutCache::default();
         let markdown_render_cache = markdown::MarkdownRenderCache::default();
 
         // Act
@@ -1127,8 +1173,11 @@ mod tests {
             None,
             false,
             SAMPLE_DIFF,
+            ReviewCommentRenderCaches {
+                diff_layout: &diff_layout_cache,
+                markdown: &markdown_render_cache,
+            },
             0,
-            &markdown_render_cache,
             80,
         );
         let text = lines

--- a/crates/agentty/src/ui/page/session_list.rs
+++ b/crates/agentty/src/ui/page/session_list.rs
@@ -54,6 +54,121 @@ impl<'a> SessionListPage<'a> {
     }
 }
 
+/// Render-ready cells and exact display widths derived once per session row.
+struct PreparedSessionCells {
+    model_cell: Line<'static>,
+    model_width: usize,
+    status_cell: Cell<'static>,
+    status_width: usize,
+    timer_label: String,
+    timer_width: usize,
+}
+
+impl PreparedSessionCells {
+    /// Builds the model, status, and timer values shared by layout and paint.
+    fn new(
+        session: &Session,
+        _default_reasoning_level: ReasoningLevel,
+        wall_clock_unix_seconds: i64,
+    ) -> Self {
+        let reasoning_level = session.effective_reasoning_level();
+        let model_name = session.agent.model().as_str();
+        let model_width = model_name
+            .chars()
+            .count()
+            .saturating_add(reasoning_level.as_str().chars().count())
+            .saturating_add(3);
+        let model_cell = Line::from(vec![
+            Span::raw(model_name),
+            Span::raw(" ["),
+            Span::styled(
+                reasoning_level.as_str(),
+                Style::default().fg(reasoning_level_color(reasoning_level)),
+            ),
+            Span::raw("]"),
+        ]);
+
+        let status = session.status;
+        let status_label = session_list_status_label(session).into_owned();
+        let forge_indicator = session.forge_indicator();
+        let forge_indicator_width = if forge_indicator.is_empty() {
+            0
+        } else {
+            forge_indicator.chars().count().saturating_add(1)
+        };
+        let status_width = status_label
+            .chars()
+            .count()
+            .saturating_add(forge_indicator_width);
+        let status_cell = if forge_indicator.is_empty() {
+            Cell::from(status_label).style(Style::default().fg(style::status_color(status)))
+        } else {
+            let review_state = session.review_request.as_ref().map(|rr| rr.summary.state);
+            let indicator_color = style::forge_indicator_color(review_state);
+
+            Cell::from(Line::from(vec![
+                Span::styled(
+                    format!("{status_label} "),
+                    Style::default().fg(style::status_color(status)),
+                ),
+                Span::styled(forge_indicator, Style::default().fg(indicator_color)),
+            ]))
+        };
+
+        let timer_label = if session.has_in_progress_timer() {
+            format_duration_compact(session.in_progress_duration_seconds(wall_clock_unix_seconds))
+        } else {
+            String::new()
+        };
+        let timer_width = timer_label.chars().count();
+
+        Self {
+            model_cell,
+            model_width,
+            status_cell,
+            status_width,
+            timer_label,
+            timer_width,
+        }
+    }
+}
+
+/// Grouped table row carrying the session cells prepared for this frame.
+enum PreparedSessionRow<'a> {
+    GroupLabel(SessionGroup),
+    Session {
+        cells: PreparedSessionCells,
+        session: &'a Session,
+        tree_position: SessionTreePosition,
+    },
+}
+
+impl<'a> PreparedSessionRow<'a> {
+    /// Converts one grouped domain row into its render-ready representation.
+    fn new(
+        row: &GroupedSessionRow<'a>,
+        default_reasoning_level: ReasoningLevel,
+        wall_clock_unix_seconds: i64,
+    ) -> Self {
+        match row {
+            GroupedSessionRow::GroupLabel(group) => Self::GroupLabel(*group),
+            GroupedSessionRow::Session {
+                session,
+                tree_position,
+                ..
+            } => Self::Session {
+                cells: PreparedSessionCells::new(
+                    session,
+                    default_reasoning_level,
+                    wall_clock_unix_seconds,
+                ),
+                session,
+                tree_position: *tree_position,
+            },
+        }
+    }
+}
+
 impl Page for SessionListPage<'_> {
     /// Renders the grouped session table directly below the tab header plus
     /// the list footer.
@@ -73,11 +188,16 @@ impl Page for SessionListPage<'_> {
             .borders(Borders::ALL)
             .title("Sessions")
             .border_style(style::border_style());
+        let table_rows = prepared_session_rows(
+            self.sessions,
+            self.default_reasoning_level,
+            self.wall_clock_unix_seconds,
+        );
         let column_constraints = [
             Constraint::Fill(1),
-            model_column_width(self.sessions, self.default_reasoning_level),
-            status_column_width(self.sessions),
-            timer_column_width(self.sessions, self.wall_clock_unix_seconds),
+            model_column_width(&table_rows),
+            status_column_width(&table_rows),
+            timer_column_width(&table_rows),
         ];
         let title_column_width = first_table_column_width(
             block.inner(areas.main_area).width,
@@ -85,20 +205,13 @@ impl Page for SessionListPage<'_> {
             TABLE_COLUMN_SPACING,
             0,
         );
-        let table_rows = session_order::grouped_session_rows(self.sessions);
         let selected_session_id = selected_session_id(self.sessions, self.table_state.selected());
         let selected_row = selected_render_row(&table_rows, selected_session_id);
+        let is_empty = table_rows.is_empty();
         let rows = table_rows
-            .iter()
-            .map(|table_row| {
-                render_table_row(
-                    table_row,
-                    title_column_width,
-                    self.default_reasoning_level,
-                    self.wall_clock_unix_seconds,
-                )
-            })
-            .chain(table_rows.is_empty().then(render_empty_sessions_hint_row));
+            .into_iter()
+            .map(|table_row| render_table_row(table_row, title_column_width))
+            .chain(is_empty.then(render_empty_sessions_hint_row));
         let table = Table::new(rows, column_constraints)
             .column_spacing(TABLE_COLUMN_SPACING)
             .header(header)
@@ -175,37 +288,38 @@ fn selected_session_id(sessions: &[Session], selected_index: Option<usize>) -> O
 
 /// Maps selected session id to the grouped table row index.
 fn selected_render_row(
-    rows: &[GroupedSessionRow<'_>],
+    rows: &[PreparedSessionRow<'_>],
     selected_session_id: Option<&str>,
 ) -> Option<usize> {
     let selected_session_id = selected_session_id?;
 
     rows.iter().position(|row| match row {
-        GroupedSessionRow::GroupLabel(_) => false,
-        GroupedSessionRow::Session { session, .. } => session.id == selected_session_id,
+        PreparedSessionRow::GroupLabel(_) => false,
+        PreparedSessionRow::Session { session, .. } => session.id == selected_session_id,
     })
 }
 
-/// Converts one grouped row descriptor into a `ratatui` table row.
-fn render_table_row(
-    row: &GroupedSessionRow<'_>,
-    title_column_width: usize,
+/// Prepares every grouped row once so layout sizing and painting share values.
+fn prepared_session_rows(
+    sessions: &[Session],
     default_reasoning_level: ReasoningLevel,
     wall_clock_unix_seconds: i64,
-) -> Row<'static> {
+) -> Vec<PreparedSessionRow<'_>> {
+    session_order::grouped_session_rows(sessions)
+        .into_iter()
+        .map(|row| PreparedSessionRow::new(&row, default_reasoning_level, wall_clock_unix_seconds))
+        .collect()
+}
+
+/// Converts one grouped row descriptor into a `ratatui` table row.
+fn render_table_row(row: PreparedSessionRow<'_>, title_column_width: usize) -> Row<'static> {
     match row {
-        GroupedSessionRow::GroupLabel(group) => render_group_label_row(*group),
-        GroupedSessionRow::Session {
+        PreparedSessionRow::GroupLabel(group) => render_group_label_row(group),
+        PreparedSessionRow::Session {
+            cells,
             session,
             tree_position,
-            ..
-        } => render_session_row(
-            session,
-            *tree_position,
-            title_column_width,
-            default_reasoning_level,
-            wall_clock_unix_seconds,
-        ),
+        } => render_session_row(session, tree_position, cells, title_column_width),
     }
 }
 
@@ -237,11 +351,9 @@ fn render_empty_sessions_hint_row() -> Row<'static> {
 fn render_session_row(
     session: &Session,
     tree_position: SessionTreePosition,
+    cells: PreparedSessionCells,
     title_column_width: usize,
-    default_reasoning_level: ReasoningLevel,
-    wall_clock_unix_seconds: i64,
 ) -> Row<'static> {
-    let status = session.status;
     let title_spans = render_session_title(
         session,
         title_column_width.saturating_sub(tree_position_width(tree_position)),
@@ -252,35 +364,11 @@ fn render_session_row(
         title_line_spans.push(Span::styled(tree_label, tree_prefix_style()));
     }
     title_line_spans.extend(title_spans);
-    let timer_label = if session.has_in_progress_timer() {
-        format_duration_compact(session.in_progress_duration_seconds(wall_clock_unix_seconds))
-    } else {
-        String::new()
-    };
-    let forge_indicator = session.forge_indicator();
-    let status_label = session_list_status_label(session).into_owned();
-    let status_cell = if forge_indicator.is_empty() {
-        Cell::from(status_label).style(Style::default().fg(style::status_color(status)))
-    } else {
-        let review_state = session.review_request.as_ref().map(|rr| rr.summary.state);
-        let indicator_color = style::forge_indicator_color(review_state);
-
-        Cell::from(Line::from(vec![
-            Span::styled(
-                format!("{status_label} "),
-                Style::default().fg(style::status_color(status)),
-            ),
-            Span::styled(forge_indicator, Style::default().fg(indicator_color)),
-        ]))
-    };
     let cells = vec![
         Cell::from(Line::from(title_line_spans)),
-        Cell::from(session_model_and_reasoning_level_line(
-            session,
-            default_reasoning_level,
-        )),
-        status_cell,
-        Cell::from(timer_label),
+        Cell::from(cells.model_cell),
+        cells.status_cell,
+        Cell::from(cells.timer_label),
     ];
 
     Row::new(cells)
@@ -308,47 +396,15 @@ fn tree_prefix_style() -> Style {
     Style::default().fg(style::palette::text_muted())
 }
 
-/// Calculates the width of the model column from known session values.
-pub(crate) fn model_column_width(
-    sessions: &[Session],
-    default_reasoning_level: ReasoningLevel,
-) -> Constraint {
-    text_column_width(
+/// Calculates the model width from the same prepared cells used for paint.
+fn model_column_width(rows: &[PreparedSessionRow<'_>]) -> Constraint {
+    column_width(
         "Model",
-        sessions
-            .iter()
-            .map(|session| session_model_and_reasoning_level(session, default_reasoning_level)),
+        rows.iter().filter_map(|row| match row {
+            PreparedSessionRow::GroupLabel(_) => None,
+            PreparedSessionRow::Session { cells, .. } => Some(cells.model_width),
+        }),
     )
-}
-
-/// Formats model name together with the effective reasoning level label.
-fn session_model_and_reasoning_level(
-    session: &Session,
-    _default_reasoning_level: ReasoningLevel,
-) -> String {
-    let reasoning_level = session.effective_reasoning_level();
-
-    format!(
-        "{} [{}]",
-        session.agent.model().as_str(),
-        reasoning_level.as_str()
-    )
-}
-
-/// Builds a styled model column cell where the reasoning label is colorized.
-fn session_model_and_reasoning_level_line(
-    session: &Session,
-    _default_reasoning_level: ReasoningLevel,
-) -> Line<'static> {
-    let reasoning_level = session.effective_reasoning_level();
-    let color = reasoning_level_color(reasoning_level);
-
-    Line::from(vec![
-        Span::raw(session.agent.model().as_str()),
-        Span::raw(" ["),
-        Span::styled(reasoning_level.as_str(), Style::default().fg(color)),
-        Span::raw("]"),
-    ])
 }
 
 /// Returns the palette color for one reasoning effort level.
@@ -361,47 +417,27 @@ fn reasoning_level_color(reasoning_level: ReasoningLevel) -> Color {
     }
 }
 
-/// Calculates the width of the status column from every supported session
-/// status label plus the widest possible forge indicator suffix.
-fn status_column_width(sessions: &[Session]) -> Constraint {
-    let static_width = text_column_width(
-        "Status",
-        Status::ALL.iter().map(std::string::ToString::to_string),
-    );
+/// Calculates the status width from static labels and prepared painted cells.
+fn status_column_width(rows: &[PreparedSessionRow<'_>]) -> Constraint {
+    let static_widths = Status::ALL
+        .iter()
+        .map(|status| status.to_string().chars().count());
+    let session_widths = rows.iter().filter_map(|row| match row {
+        PreparedSessionRow::GroupLabel(_) => None,
+        PreparedSessionRow::Session { cells, .. } => Some(cells.status_width),
+    });
 
-    let session_width = text_column_width(
-        "Status",
-        sessions.iter().map(|session| {
-            let forge_indicator = session.forge_indicator();
-            let status_label = session_list_status_label(session);
-            if forge_indicator.is_empty() {
-                status_label.into_owned()
-            } else {
-                format!("{status_label} {forge_indicator}")
-            }
-        }),
-    );
-
-    match (static_width, session_width) {
-        (Constraint::Length(static_len), Constraint::Length(session_len)) => {
-            Constraint::Length(static_len.max(session_len))
-        }
-        _ => static_width,
-    }
+    column_width("Status", static_widths.chain(session_widths))
 }
 
-/// Calculates the width of the timer column from known session durations.
-fn timer_column_width(sessions: &[Session], wall_clock_unix_seconds: i64) -> Constraint {
-    text_column_width(
+/// Calculates the timer width from the same prepared labels used for paint.
+fn timer_column_width(rows: &[PreparedSessionRow<'_>]) -> Constraint {
+    column_width(
         "Timer",
-        sessions
-            .iter()
-            .filter(|session| session.has_in_progress_timer())
-            .map(|session| {
-                format_duration_compact(
-                    session.in_progress_duration_seconds(wall_clock_unix_seconds),
-                )
-            }),
+        rows.iter().filter_map(|row| match row {
+            PreparedSessionRow::GroupLabel(_) => None,
+            PreparedSessionRow::Session { cells, .. } => Some(cells.timer_width),
+        }),
     )
 }
 
@@ -437,13 +473,9 @@ fn size_color(size: SessionSize) -> Color {
     }
 }
 
-fn text_column_width<T>(header: &str, values: impl Iterator<Item = T>) -> Constraint
-where
-    T: AsRef<str>,
-{
-    let column_width = values
-        .map(|value| value.as_ref().chars().count())
-        .fold(header.chars().count(), usize::max);
+/// Converts the maximum prepared display width into a table constraint.
+fn column_width(header: &str, widths: impl Iterator<Item = usize>) -> Constraint {
+    let column_width = widths.fold(header.chars().count(), usize::max);
     let column_width = u16::try_from(column_width).unwrap_or(u16::MAX);
 
     Constraint::Length(column_width)
@@ -651,7 +683,7 @@ mod tests {
             crate::test_support::titled_session_fixture("merge-1", Status::Merging),
             crate::test_support::titled_session_fixture("active-2", Status::Draft),
         ];
-        let rows = session_order::grouped_session_rows(&sessions);
+        let rows = prepared_session_rows(&sessions, ReasoningLevel::default(), 0);
         let selected_session_id = selected_session_id(&sessions, Some(3));
 
         // Act
@@ -684,7 +716,12 @@ mod tests {
         let project_names = ["api", "very-long-project-name"];
 
         // Act
-        let width = text_column_width("Project", project_names.into_iter());
+        let width = column_width(
+            "Project",
+            project_names
+                .into_iter()
+                .map(|project_name| project_name.chars().count()),
+        );
 
         // Assert
         assert_eq!(width, Constraint::Length(expected_width));
@@ -710,9 +747,10 @@ mod tests {
         );
         medium_session.reasoning_level_override = Some(ReasoningLevel::Medium);
         let sessions = vec![default_session, medium_session];
+        let rows = prepared_session_rows(&sessions, ReasoningLevel::Low, 0);
 
         // Act
-        let width = model_column_width(&sessions, ReasoningLevel::Low);
+        let width = model_column_width(&rows);
 
         // Assert
         assert_eq!(width, Constraint::Length(expected_width));
@@ -934,9 +972,10 @@ mod tests {
         let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
         let mut table_state = TableState::default();
         table_state.select(Some(0));
+        let rows = prepared_session_rows(&sessions, ReasoningLevel::High, 0);
 
         // Act
-        let width = status_column_width(&sessions);
+        let width = status_column_width(&rows);
         terminal
             .draw(|frame| {
                 SessionListPage::new(&sessions, &mut table_state, ReasoningLevel::High, 0)
@@ -963,9 +1002,10 @@ mod tests {
         archived_session.in_progress_total_seconds = 3_661;
         let sessions = vec![active_session, archived_session];
         let expected_width = u16::try_from("1h1m1s".chars().count()).unwrap_or(u16::MAX);
+        let rows = prepared_session_rows(&sessions, ReasoningLevel::default(), 160);
 
         // Act
-        let width = timer_column_width(&sessions, 160);
+        let width = timer_column_width(&rows);
 
         // Assert
         assert_eq!(width, Constraint::Length(expected_width));

--- a/crates/agentty/src/ui/router.rs
+++ b/crates/agentty/src/ui/router.rs
@@ -663,7 +663,10 @@ fn render_review_comments_surface(
         comment_snapshot: comment_snapshot.as_ref(),
         diff,
         is_loading_comments: *is_loading_comments,
-        markdown_render_cache: resources.markdown_render_cache,
+        render_caches: page::review_comment::ReviewCommentRenderCaches {
+            diff_layout: resources.diff_layout_cache,
+            markdown: resources.markdown_render_cache,
+        },
         scroll_offset: *scroll_offset,
         selected_comment_index: *selected_comment_index,
         session,


### PR DESCRIPTION
- Review-comment rendering reuses cached parsed diff snapshots and Markdown renders.
- Session-list rows prepare painted cells once so column widths match rendered content.
- Review-comment scrolling clamps stale offsets through a dedicated increment helper.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)