### PR TITLE
Version 0.14.4 ships orchestration and harness improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.14.4] - 2026-08-09
+
+### Added
+
+- agentty: add provider-enforced read-only research waves with configurable
+  auto-approval, separate research and implementation planning, persisted reports, and
+  verification-gated follow-up work.
+- ag-harness: add Kimi support, a shared OpenAI-compatible Chat Completions transport,
+  and request-duration telemetry for successful, failed, and cancelled model calls.
+
+### Changed
+
+- agentty: queue review-request publishing behind active turns, preserve focused-review
+  ordering around durable notices, and expose publish progress without breaking branch
+  operation serialization.
+- agentty: tighten structured session, review, and orchestration prompt contracts around
+  untrusted input, workspace isolation, read-only Git access, quality checks, and
+  schema-driven responses.
+- agentty: reuse cached diff, Markdown, and session-row render data across layout and
+  paint paths.
+- ci: use pinned Rust toolchains and centralize coverage, E2E, and multi-architecture
+  image validation across workflows.
+- docs: add the open-source pull-request reviewer to the public roadmap.
+- release: bump workspace crate metadata and lockfile package versions to `0.14.4`.
+
+### Fixed
+
+- agentty: clear stale terminal content when navigation changes the routed surface while
+  preserving search positions and normal within-page diff rendering.
+- agentty: accept only valid terminal Codex answers for completed focused reviews while
+  ignoring commentary, blank fallbacks, and unsupported assistant items.
+
+### Contributors
+
+- @andagaev
+- @minev-dev
+
 ## [v0.14.3] - 2026-08-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "image",
  "mockall",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "mockall",
  "serde",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "mockall",
  "rustix",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "ag-harness"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "async-trait",
  "jsonschema",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "askama",
  "schemars 1.2.2",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "ag-session"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "ag-agent",
  "ag-forge",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "clap",
  "tempfile",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "base64 0.23.0",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.14.3"
+version = "0.14.4"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -16,14 +16,14 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.14.3" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.14.3" }
-ag-forge = { path = "crates/ag-forge", version = "0.14.3" }
-ag-git = { path = "crates/ag-git", version = "0.14.3" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.14.3" }
-ag-session = { path = "crates/ag-session", version = "0.14.3" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.14.3" }
-testty = { path = "crates/testty", version = "0.14.3" }
+ag-agent = { path = "crates/ag-agent", version = "0.14.4" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.14.4" }
+ag-forge = { path = "crates/ag-forge", version = "0.14.4" }
+ag-git = { path = "crates/ag-git", version = "0.14.4" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.14.4" }
+ag-session = { path = "crates/ag-session", version = "0.14.4" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.14.4" }
+testty = { path = "crates/testty", version = "0.14.4" }
 async-trait = "0.1"
 agent-client-protocol = "2.0.0"
 assert_cmd = "2"


### PR DESCRIPTION
- Adds provider-enforced research waves, persisted reports, verification-gated follow-up work, Kimi support, and shared OpenAI-compatible transport telemetry.
- Improves review publishing, rendering caches, prompt contracts, and terminal navigation and response handling.
- Updates the changelog, workspace crate metadata, and lockfile for `0.14.4`.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)