### PR TITLE
Model harness supports native read tool calls

### DIFF
--- a/crates/ag-harness/Cargo.toml
+++ b/crates/ag-harness/Cargo.toml
@@ -14,7 +14,7 @@ jsonschema.workspace = true
 opentelemetry.workspace = true
 reqwest.workspace = true
 serde.workspace = true
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["arbitrary_precision"] }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/ag-harness/examples/kimi.rs
+++ b/crates/ag-harness/examples/kimi.rs
@@ -47,7 +47,10 @@ async fn request_greeting(config: KimiConfig) -> Result<(), DynError> {
         ))
         .await?;
 
-    writeln!(io::stdout().lock(), "{}", response.output())?;
+    let output = response
+        .output()
+        .ok_or_else(|| io::Error::other("Kimi returned an unexpected tool call"))?;
+    writeln!(io::stdout().lock(), "{output}")?;
 
     Ok(())
 }

--- a/crates/ag-harness/examples/qwen.rs
+++ b/crates/ag-harness/examples/qwen.rs
@@ -47,7 +47,10 @@ async fn request_greeting(config: QwenConfig) -> Result<(), DynError> {
         ))
         .await?;
 
-    writeln!(io::stdout().lock(), "{}", response.output())?;
+    let output = response
+        .output()
+        .ok_or_else(|| io::Error::other("Qwen returned an unexpected tool call"))?;
+    writeln!(io::stdout().lock(), "{output}")?;
 
     Ok(())
 }

--- a/crates/ag-harness/src/chat_completion.rs
+++ b/crates/ag-harness/src/chat_completion.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 
-use crate::{model, schema_contract};
+use crate::{model, schema_contract, tool};
 
 pub(crate) const ERROR_BODY_LIMIT_BYTES: usize = 4 * 1024;
 const JSON_STRING_MAX_EXPANSION: usize = 6;
@@ -28,6 +28,12 @@ pub(crate) struct JsonObjectProviderPolicy {
     pub(crate) display_name: &'static str,
     pub(crate) telemetry_name: &'static str,
     pub(crate) unsupported_schema_reason: &'static str,
+}
+
+/// Provider-neutral result of decoding one Chat Completions choice.
+pub(crate) enum GeneratedResponse {
+    Output(String),
+    ToolCall(tool::ToolCall),
 }
 
 /// Shared JSON Object backend for OpenAI-compatible Chat Completions APIs.
@@ -59,7 +65,7 @@ impl JsonObjectBackend {
     pub(crate) async fn generate(
         &self,
         request: &model::ModelRequest,
-    ) -> Result<String, model::ModelError> {
+    ) -> Result<GeneratedResponse, model::ModelError> {
         if !request.schema().has_object_root() {
             return Err(model::ModelError::UnsupportedOutputSchema {
                 reason: self.policy.unsupported_schema_reason.to_string(),
@@ -84,6 +90,7 @@ impl JsonObjectBackend {
             response_format: JsonObjectResponseFormat {
                 kind: "json_object",
             },
+            tools: request.tools().iter().map(JsonObjectTool::from).collect(),
         };
         let payload = serde_json::to_value(payload).map_err(model::ModelError::request)?;
         let completion = self
@@ -96,15 +103,16 @@ impl JsonObjectBackend {
             .await
             .map_err(|error| self.map_completion_error(error))?
             .ok_or(model::ModelError::InvalidResponse)?;
-        let (finish_reason, content) = completion.into_parts();
-        if finish_reason != "stop" {
-            return Err(model::ModelError::IncompleteResponse {
+        let (finish_reason, content, tool_calls) = completion.into_parts();
+        match finish_reason.as_str() {
+            "stop" => content
+                .map(GeneratedResponse::Output)
+                .ok_or(model::ModelError::InvalidResponse),
+            "tool_calls" => Self::decode_tool_call(request, content.as_deref(), tool_calls),
+            _ => Err(model::ModelError::IncompleteResponse {
                 reason: schema_contract::bounded_diagnostic(finish_reason),
-            });
+            }),
         }
-        let text = content.ok_or(model::ModelError::InvalidResponse)?;
-
-        Ok(text)
     }
 
     /// Creates a JSON Object backend with an injected transport client.
@@ -140,6 +148,47 @@ impl JsonObjectBackend {
             error => model::ModelError::request(error),
         }
     }
+
+    fn decode_tool_call(
+        request: &model::ModelRequest,
+        content: Option<&str>,
+        mut calls: Vec<ChatCompletionToolCall>,
+    ) -> Result<GeneratedResponse, model::ModelError> {
+        if content.is_some_and(|content| !content.is_empty()) {
+            return Err(model::ModelError::ToolCallWithContent);
+        }
+        let call = match calls.len() {
+            0 => return Err(model::ModelError::MissingToolCall),
+            1 => calls.remove(0),
+            _ => return Err(model::ModelError::MultipleToolCalls),
+        };
+        if call.kind != "function" {
+            return Err(model::ModelError::UnsupportedToolType {
+                kind: schema_contract::bounded_diagnostic(call.kind),
+            });
+        }
+        let function = serde_json::from_value::<ChatCompletionFunctionCall>(call.function)
+            .map_err(|error| model::ModelError::InvalidToolArguments {
+                reason: schema_contract::bounded_diagnostic(error),
+            })?;
+        if !request.advertises_tool(&function.name) {
+            return Err(model::ModelError::UnsupportedToolName {
+                name: schema_contract::bounded_diagnostic(function.name),
+            });
+        }
+        schema_contract::ensure_content_size(&function.arguments)
+            .map_err(model::ModelError::from)?;
+        let arguments =
+            serde_json::from_str::<tool::ReadArguments>(&function.arguments).map_err(|error| {
+                model::ModelError::InvalidToolArguments {
+                    reason: schema_contract::bounded_diagnostic(error),
+                }
+            })?;
+
+        Ok(GeneratedResponse::ToolCall(tool::ToolCall::read(
+            call.id, arguments,
+        )))
+    }
 }
 
 /// One provider-authenticated request using the Chat Completions wire API.
@@ -169,6 +218,7 @@ impl<'a> ChatCompletionRequest<'a> {
 pub(crate) struct ChatCompletion {
     content: Option<String>,
     finish_reason: String,
+    tool_calls: Vec<ChatCompletionToolCall>,
 }
 
 impl ChatCompletion {
@@ -177,12 +227,13 @@ impl ChatCompletion {
         Self {
             content,
             finish_reason,
+            tool_calls: Vec::new(),
         }
     }
 
     /// Consumes the choice into provider-interpreted completion fields.
-    pub(crate) fn into_parts(self) -> (String, Option<String>) {
-        (self.finish_reason, self.content)
+    fn into_parts(self) -> (String, Option<String>, Vec<ChatCompletionToolCall>) {
+        (self.finish_reason, self.content, self.tool_calls)
     }
 }
 
@@ -244,11 +295,12 @@ impl ChatCompletionClient for ReqwestChatCompletionClient {
         let response = serde_json::from_slice::<ChatCompletionResponse>(&body)
             .map_err(ChatCompletionError::InvalidResponse)?;
 
-        Ok(response
-            .choices
-            .into_iter()
-            .next()
-            .map(|choice| ChatCompletion::new(choice.finish_reason, choice.message.content)))
+        Ok(response.choices.into_iter().next().map(|choice| {
+            let mut completion = ChatCompletion::new(choice.finish_reason, choice.message.content);
+            completion.tool_calls = choice.message.tool_calls.unwrap_or_default();
+
+            completion
+        }))
     }
 }
 
@@ -362,6 +414,8 @@ struct JsonObjectRequest<'a> {
     messages: Vec<JsonObjectMessage>,
     model: &'a str,
     response_format: JsonObjectResponseFormat,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tools: Vec<JsonObjectTool<'a>>,
 }
 
 #[derive(Serialize)]
@@ -374,6 +428,33 @@ struct JsonObjectMessage {
 struct JsonObjectResponseFormat {
     #[serde(rename = "type")]
     kind: &'static str,
+}
+
+#[derive(Serialize)]
+struct JsonObjectTool<'a> {
+    function: JsonObjectFunction<'a>,
+    #[serde(rename = "type")]
+    kind: &'static str,
+}
+
+impl<'a> From<&'a tool::ToolDefinition> for JsonObjectTool<'a> {
+    fn from(definition: &'a tool::ToolDefinition) -> Self {
+        Self {
+            function: JsonObjectFunction {
+                description: definition.description(),
+                name: definition.name(),
+                parameters: definition.parameters(),
+            },
+            kind: "function",
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct JsonObjectFunction<'a> {
+    description: &'static str,
+    name: &'static str,
+    parameters: &'a Value,
 }
 
 #[derive(Deserialize)]
@@ -390,6 +471,23 @@ struct ChatCompletionChoice {
 #[derive(Deserialize)]
 struct ChatCompletionMessage {
     content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<ChatCompletionToolCall>>,
+}
+
+#[derive(Deserialize)]
+struct ChatCompletionToolCall {
+    #[serde(default)]
+    function: Value,
+    id: String,
+    #[serde(rename = "type")]
+    kind: String,
+}
+
+#[derive(Deserialize)]
+struct ChatCompletionFunctionCall {
+    arguments: String,
+    name: String,
 }
 
 #[cfg(test)]

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -8,9 +8,11 @@ mod model;
 mod provider;
 mod schema_contract;
 mod telemetry;
+mod tool;
 
 pub use model::{
     Model, ModelClient, ModelError, ModelMetadata, ModelMetadataError, ModelRequest, ModelResponse,
 };
 pub use provider::{KimiConfig, QwenConfig};
 pub use schema_contract::{OutputSchema, OutputSchemaError};
+pub use tool::{ReadArguments, ToolCall, ToolDefinition};

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::provider::{self, KimiConfig, QwenConfig};
 use crate::schema_contract::{OutputSchema, OutputValidationError};
-use crate::{chat_completion, telemetry};
+use crate::{chat_completion, telemetry, tool};
 
 /// Object-safe boundary for provider-neutral model requests.
 ///
@@ -79,13 +79,18 @@ impl ModelClient {
     /// cannot be converted to the provider-neutral response.
     pub async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
         let _duration = telemetry::RequestDuration::start(self.metadata());
-        let output = self.backend.generate(&request).await?;
+        let response = self.backend.generate(&request).await?;
 
-        request
-            .schema()
-            .parse_and_validate(&output)
-            .map(ModelResponse::new)
-            .map_err(ModelError::from)
+        match response {
+            chat_completion::GeneratedResponse::Output(output) => request
+                .schema()
+                .parse_and_validate(&output)
+                .map(ModelResponse::from_output)
+                .map_err(ModelError::from),
+            chat_completion::GeneratedResponse::ToolCall(call) => {
+                Ok(ModelResponse::tool_call(call))
+            }
+        }
     }
 
     fn chat_completion(
@@ -165,6 +170,7 @@ pub enum ModelMetadataError {
 pub struct ModelRequest {
     prompt: String,
     schema: OutputSchema,
+    tools: Vec<tool::ToolDefinition>,
 }
 
 impl ModelRequest {
@@ -173,7 +179,16 @@ impl ModelRequest {
         Self {
             prompt: prompt.into(),
             schema,
+            tools: Vec::new(),
         }
+    }
+
+    /// Advertises one native function tool for this request.
+    #[must_use]
+    pub fn with_tool(mut self, tool: tool::ToolDefinition) -> Self {
+        self.tools.push(tool);
+
+        self
     }
 
     /// Returns the request prompt.
@@ -185,22 +200,49 @@ impl ModelRequest {
     pub fn schema(&self) -> &OutputSchema {
         &self.schema
     }
+
+    /// Returns the native function tools explicitly advertised by the caller.
+    pub fn tools(&self) -> &[tool::ToolDefinition] {
+        &self.tools
+    }
+
+    pub(crate) fn advertises_tool(&self, name: &str) -> bool {
+        self.tools.iter().any(|tool| tool.name() == name)
+    }
 }
 
 /// Provider-neutral output from one model request.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ModelResponse {
-    output: Value,
+pub enum ModelResponse {
+    /// Terminal, locally schema-validated model output.
+    Output(Value),
+    /// One validated native function call requiring application handling.
+    ToolCall(tool::ToolCall),
 }
 
 impl ModelResponse {
-    /// Returns the parsed, schema-validated output.
-    pub fn output(&self) -> &Value {
-        &self.output
+    /// Returns parsed, schema-validated terminal output, when present.
+    pub fn output(&self) -> Option<&Value> {
+        match self {
+            Self::Output(output) => Some(output),
+            Self::ToolCall(_) => None,
+        }
     }
 
-    fn new(output: Value) -> Self {
-        Self { output }
+    /// Returns the intermediate native function call, when present.
+    pub fn call(&self) -> Option<&tool::ToolCall> {
+        match self {
+            Self::Output(_) => None,
+            Self::ToolCall(call) => Some(call),
+        }
+    }
+
+    fn from_output(output: Value) -> Self {
+        Self::Output(output)
+    }
+
+    fn tool_call(call: tool::ToolCall) -> Self {
+        Self::ToolCall(call)
     }
 }
 
@@ -244,6 +286,33 @@ pub enum ModelError {
         /// root.
         path: String,
         /// Validator diagnostic for the failed constraint.
+        reason: String,
+    },
+    /// The provider returned tool calls without any call entries.
+    #[error("model returned no tool call")]
+    MissingToolCall,
+    /// The provider returned more than the single supported call.
+    #[error("model returned multiple tool calls")]
+    MultipleToolCalls,
+    /// A tool-call response also contained terminal assistant content.
+    #[error("model tool call response contained terminal content")]
+    ToolCallWithContent,
+    /// The provider returned an unsupported tool-call type.
+    #[error("model requested unsupported tool type: {kind}")]
+    UnsupportedToolType {
+        /// Provider tool type that is not a native function.
+        kind: String,
+    },
+    /// The provider returned an unsupported or unadvertised native function.
+    #[error("model requested unsupported tool: {name}")]
+    UnsupportedToolName {
+        /// Native function name that was not advertised for the request.
+        name: String,
+    },
+    /// The provider returned malformed or invalid native function arguments.
+    #[error("model returned invalid tool arguments: {reason}")]
+    InvalidToolArguments {
+        /// Bounded parser or validation diagnostic.
         reason: String,
     },
 }
@@ -354,6 +423,22 @@ mod tests {
         // Assert
         assert_eq!(request.prompt(), "hello");
         assert_eq!(request.schema(), &schema);
+        assert!(request.tools().is_empty());
+    }
+
+    #[test]
+    fn request_explicitly_advertises_read() {
+        // Arrange
+        let schema =
+            OutputSchema::new(json!({ "type": "object" })).expect("schema should be valid");
+
+        // Act
+        let request = ModelRequest::new("hello", schema).with_tool(tool::ToolDefinition::read());
+
+        // Assert
+        assert_eq!(request.tools(), &[tool::ToolDefinition::read()]);
+        assert!(request.advertises_tool("read"));
+        assert!(!request.advertises_tool("write"));
     }
 
     #[test]
@@ -362,10 +447,11 @@ mod tests {
         let value = json!({ "name": "Ada" });
 
         // Act
-        let response = ModelResponse::new(value.clone());
+        let response = ModelResponse::from_output(value.clone());
 
         // Assert
-        assert_eq!(response.output(), &value);
+        assert_eq!(response.output(), Some(&value));
+        assert!(response.call().is_none());
     }
 
     #[test]

--- a/crates/ag-harness/src/provider/kimi.rs
+++ b/crates/ag-harness/src/provider/kimi.rs
@@ -30,7 +30,7 @@ mod tests {
         ERROR_BODY_LIMIT_BYTES, RESPONSE_ENVELOPE_LIMIT_BYTES, STRUCTURED_OUTPUT_INSTRUCTION,
         SUCCESS_BODY_LIMIT_BYTES,
     };
-    use crate::{model, schema_contract};
+    use crate::{model, schema_contract, tool};
 
     fn person_schema_value() -> Value {
         json!({
@@ -49,6 +49,23 @@ mod tests {
 
     fn request(prompt: &str) -> model::ModelRequest {
         model::ModelRequest::new(prompt, person_schema())
+    }
+
+    fn read_request(prompt: &str) -> model::ModelRequest {
+        request(prompt).with_tool(tool::ToolDefinition::read())
+    }
+
+    fn read_tool_wire() -> Value {
+        let definition = tool::ToolDefinition::read();
+
+        json!({
+            "type": "function",
+            "function": {
+                "description": definition.description(),
+                "name": definition.name(),
+                "parameters": definition.parameters()
+            }
+        })
     }
 
     fn escaped_value_schema() -> crate::OutputSchema {
@@ -139,6 +156,36 @@ mod tests {
             .await;
     }
 
+    async fn mount_tool_response(server: &MockServer, prompt: &str, message: Value) {
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(bearer_token("test-key"))
+            .and(body_json(json!({
+                "messages": [
+                    {
+                        "content": format!(
+                            "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
+                            person_schema_value()
+                        ),
+                        "role": "system"
+                    },
+                    {"content": prompt, "role": "user"}
+                ],
+                "model": "kimi-k2.6",
+                "response_format": {"type": "json_object"},
+                "tools": [read_tool_wire()]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "tool_calls",
+                    "message": message
+                }]
+            })))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
     #[tokio::test]
     async fn accepts_object_root_in_type_array() {
         // Arrange
@@ -155,7 +202,7 @@ mod tests {
             .expect("Kimi request should succeed");
 
         // Assert
-        assert_eq!(response.output(), &json!({}));
+        assert_eq!(response.output(), Some(&json!({})));
     }
 
     #[tokio::test]
@@ -179,7 +226,156 @@ mod tests {
             .expect("Kimi request should succeed");
 
         // Assert
-        assert_eq!(response.output(), &json!({ "name": "Ada" }));
+        assert_eq!(response.output(), Some(&json!({ "name": "Ada" })));
+    }
+
+    #[tokio::test]
+    async fn advertises_and_decodes_read_tool_call() {
+        // Arrange
+        let server = MockServer::start().await;
+        mount_tool_response(
+            &server,
+            "inspect the manifest",
+            json!({
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_kimi_read",
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "arguments": r#"{"path":"Cargo.toml","offset":1,"limit":12}"#
+                    }
+                }]
+            }),
+        )
+        .await;
+        let model = kimi(&server);
+
+        // Act
+        let response = model
+            .complete(read_request("inspect the manifest"))
+            .await
+            .expect("Kimi read request should decode");
+
+        // Assert
+        assert!(response.output().is_none());
+        let call = response
+            .call()
+            .expect("response should contain a tool call");
+        assert_eq!(call.id(), "call_kimi_read");
+        assert_eq!(call.name(), "read");
+        assert_eq!(call.arguments().path(), "Cargo.toml");
+        assert_eq!(call.arguments().offset(), Some(1));
+        assert_eq!(call.arguments().limit(), Some(12));
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_and_multiple_tool_calls() {
+        // Arrange
+        let messages = [
+            (json!({"content": null}), "model returned no tool call"),
+            (
+                json!({
+                    "content": null,
+                    "tool_calls": [
+                        {
+                            "id": "call_one",
+                            "type": "function",
+                            "function": {"name": "read", "arguments": r#"{"path":"Cargo.toml"}"#}
+                        },
+                        {
+                            "id": "call_two",
+                            "type": "function",
+                            "function": {"name": "read", "arguments": r#"{"path":"README.md"}"#}
+                        }
+                    ]
+                }),
+                "model returned multiple tool calls",
+            ),
+        ];
+
+        // Act
+        let mut errors = Vec::new();
+        for (message, expected) in messages {
+            let server = MockServer::start().await;
+            mount_tool_response(&server, "inspect the manifest", message).await;
+            let error = kimi(&server)
+                .complete(read_request("inspect the manifest"))
+                .await
+                .expect_err("invalid tool-call count should fail");
+            errors.push((error.to_string(), expected));
+        }
+
+        // Assert
+        assert!(errors.iter().all(|(error, expected)| error == expected));
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_read_range() {
+        // Arrange
+        let server = MockServer::start().await;
+        mount_tool_response(
+            &server,
+            "inspect the manifest",
+            json!({
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_invalid_limit",
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "arguments": r#"{"path":"Cargo.toml","limit":0}"#
+                    }
+                }]
+            }),
+        )
+        .await;
+        let model = kimi(&server);
+
+        // Act
+        let error = model
+            .complete(read_request("inspect the manifest"))
+            .await
+            .expect_err("zero read limit should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            model::ModelError::InvalidToolArguments { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_read_arguments() {
+        // Arrange
+        let server = MockServer::start().await;
+        let arguments = format!(
+            r#"{{"path":"{}"}}"#,
+            "x".repeat(schema_contract::RESPONSE_CONTENT_LIMIT_BYTES)
+        );
+        mount_tool_response(
+            &server,
+            "inspect the manifest",
+            json!({
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_oversized",
+                    "type": "function",
+                    "function": {"name": "read", "arguments": arguments}
+                }]
+            }),
+        )
+        .await;
+        let model = kimi(&server);
+
+        // Act
+        let error = model
+            .complete(read_request("inspect the manifest"))
+            .await
+            .expect_err("oversized read arguments should fail");
+
+        // Assert
+        assert!(matches!(error, model::ModelError::ResponseContentTooLarge));
     }
 
     #[tokio::test]
@@ -284,6 +480,7 @@ mod tests {
         assert_eq!(
             response
                 .output()
+                .expect("response should contain terminal output")
                 .get("value")
                 .and_then(Value::as_str)
                 .map(str::len),

--- a/crates/ag-harness/src/provider/qwen.rs
+++ b/crates/ag-harness/src/provider/qwen.rs
@@ -34,7 +34,7 @@ mod tests {
         ERROR_BODY_LIMIT_BYTES, JsonObjectBackend, RESPONSE_ENVELOPE_LIMIT_BYTES,
         STRUCTURED_OUTPUT_INSTRUCTION, SUCCESS_BODY_LIMIT_BYTES,
     };
-    use crate::{model, schema_contract};
+    use crate::{model, schema_contract, tool};
 
     struct StubClient;
 
@@ -74,6 +74,23 @@ mod tests {
 
     fn request(prompt: &str) -> model::ModelRequest {
         model::ModelRequest::new(prompt, person_schema())
+    }
+
+    fn read_request(prompt: &str) -> model::ModelRequest {
+        request(prompt).with_tool(tool::ToolDefinition::read())
+    }
+
+    fn read_tool_wire() -> serde_json::Value {
+        let definition = tool::ToolDefinition::read();
+
+        json!({
+            "type": "function",
+            "function": {
+                "description": definition.description(),
+                "name": definition.name(),
+                "parameters": definition.parameters()
+            }
+        })
     }
 
     fn escaped_value_schema() -> crate::OutputSchema {
@@ -136,7 +153,37 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "choices": [{
                     "finish_reason": "stop",
-                    "message": {"content": content}
+                    "message": {"content": content, "tool_calls": null}
+                }]
+            })))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    async fn mount_tool_response(server: &MockServer, prompt: &str, message: serde_json::Value) {
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(bearer_token("test-key"))
+            .and(body_json(json!({
+                "messages": [
+                    {
+                        "content": format!(
+                            "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
+                            person_schema_value()
+                        ),
+                        "role": "system"
+                    },
+                    {"content": prompt, "role": "user"}
+                ],
+                "model": "qwen-plus",
+                "response_format": {"type": "json_object"},
+                "tools": [read_tool_wire()]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "tool_calls",
+                    "message": message
                 }]
             })))
             .expect(1)
@@ -145,7 +192,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn completes_structured_request() {
+    async fn completes_terminal_response_with_null_tool_calls() {
         // Arrange
         let server = MockServer::start().await;
         let schema_value = person_schema_value();
@@ -165,7 +212,160 @@ mod tests {
             .expect("Qwen request should succeed");
 
         // Assert
-        assert_eq!(response.output(), &json!({ "name": "Ada" }));
+        assert_eq!(response.output(), Some(&json!({ "name": "Ada" })));
+    }
+
+    #[tokio::test]
+    async fn advertises_and_decodes_read_tool_call() {
+        // Arrange
+        let server = MockServer::start().await;
+        mount_tool_response(
+            &server,
+            "inspect the manifest",
+            json!({
+                "content": "",
+                "tool_calls": [{
+                    "id": "call_qwen_read",
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "arguments": r#"{"path":"Cargo.toml","offset":1,"limit":12}"#
+                    }
+                }]
+            }),
+        )
+        .await;
+        let model = qwen(&server);
+
+        // Act
+        let response = model
+            .complete(read_request("inspect the manifest"))
+            .await
+            .expect("Qwen read request should decode");
+
+        // Assert
+        assert!(response.output().is_none());
+        let call = response
+            .call()
+            .expect("response should contain a tool call");
+        assert_eq!(call.id(), "call_qwen_read");
+        assert_eq!(call.name(), "read");
+        assert_eq!(call.arguments().path(), "Cargo.toml");
+        assert_eq!(call.arguments().offset(), Some(1));
+        assert_eq!(call.arguments().limit(), Some(12));
+    }
+
+    #[tokio::test]
+    async fn rejects_malformed_and_invalid_read_arguments() {
+        // Arrange
+        let cases = [
+            ("{", "model returned invalid tool arguments:"),
+            (
+                r#"{"path":"Cargo.toml","offset":0}"#,
+                "model returned invalid tool arguments:",
+            ),
+            (
+                r#"{"path":"Cargo.toml","extra":true}"#,
+                "model returned invalid tool arguments:",
+            ),
+        ];
+
+        // Act
+        let mut errors = Vec::new();
+        for (index, (arguments, expected)) in cases.into_iter().enumerate() {
+            let server = MockServer::start().await;
+            mount_tool_response(
+                &server,
+                "inspect the manifest",
+                json!({
+                    "content": null,
+                    "tool_calls": [{
+                        "id": format!("call_{index}"),
+                        "type": "function",
+                        "function": {"name": "read", "arguments": arguments}
+                    }]
+                }),
+            )
+            .await;
+            let error = qwen(&server)
+                .complete(read_request("inspect the manifest"))
+                .await
+                .expect_err("invalid read arguments should fail");
+            errors.push((error.to_string(), expected));
+        }
+
+        // Assert
+        assert!(
+            errors
+                .iter()
+                .all(|(error, expected)| error.starts_with(expected))
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_unsupported_tool_type_name_and_terminal_content() {
+        // Arrange
+        let messages = [
+            (
+                json!({
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_type",
+                        "type": "custom"
+                    }]
+                }),
+                "model requested unsupported tool type: custom",
+            ),
+            (
+                json!({
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_name",
+                        "type": "function",
+                        "function": {"name": "write", "arguments": r#"{"path":"Cargo.toml"}"#}
+                    }]
+                }),
+                "model requested unsupported tool: write",
+            ),
+            (
+                json!({
+                    "content": "done",
+                    "tool_calls": [{
+                        "id": "call_content",
+                        "type": "function",
+                        "function": {"name": "read", "arguments": r#"{"path":"Cargo.toml"}"#}
+                    }]
+                }),
+                "model tool call response contained terminal content",
+            ),
+            (
+                json!({
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_function_payload",
+                        "type": "function"
+                    }]
+                }),
+                "model returned invalid tool arguments:",
+            ),
+        ];
+
+        // Act
+        let mut errors = Vec::new();
+        for (message, expected) in messages {
+            let server = MockServer::start().await;
+            mount_tool_response(&server, "inspect the manifest", message).await;
+            let error = qwen(&server)
+                .complete(read_request("inspect the manifest"))
+                .await
+                .expect_err("unsupported tool response should fail");
+            errors.push((error.to_string(), expected));
+        }
+
+        // Assert
+        assert!(errors.iter().all(|(error, expected)| {
+            error == expected || (expected.ends_with(':') && error.starts_with(expected))
+        }));
     }
 
     #[tokio::test]
@@ -186,7 +386,11 @@ mod tests {
             .expect("stubbed Qwen request should succeed");
 
         // Assert
-        assert_eq!(output, r#"{"name":"Ada"}"#);
+        assert!(matches!(
+            output,
+            crate::chat_completion::GeneratedResponse::Output(output)
+                if output == r#"{"name":"Ada"}"#
+        ));
     }
 
     #[tokio::test]
@@ -291,6 +495,7 @@ mod tests {
         assert_eq!(
             response
                 .output()
+                .expect("response should contain terminal output")
                 .get("value")
                 .and_then(serde_json::Value::as_str)
                 .map(str::len),

--- a/crates/ag-harness/src/tool.rs
+++ b/crates/ag-harness/src/tool.rs
@@ -1,0 +1,405 @@
+use std::num::NonZeroU64;
+
+use serde::{Deserialize, Deserializer, de};
+use serde_json::{Number, Value, json};
+
+const READ_DESCRIPTION: &str =
+    "Read a repository-relative file, optionally selecting a line range.";
+const READ_NAME: &str = "read";
+
+/// Provider-neutral definition of a native model tool.
+///
+/// Definitions describe only the wire contract advertised to a model. They do
+/// not execute tools or access the filesystem.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ToolDefinition {
+    description: &'static str,
+    name: &'static str,
+    parameters: Value,
+}
+
+impl ToolDefinition {
+    /// Defines the native `read` function tool.
+    pub fn read() -> Self {
+        Self {
+            description: READ_DESCRIPTION,
+            name: READ_NAME,
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "minLength": 1,
+                        "pattern": "^(?:[^./\\u0000][^/\\u0000]*|\\.[^./\\u0000][^/\\u0000]*|\\.\\.[^/\\u0000]+)(?:/(?:[^./\\u0000][^/\\u0000]*|\\.[^./\\u0000][^/\\u0000]*|\\.\\.[^/\\u0000]+))*$"
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": u64::MAX
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": u64::MAX
+                    }
+                },
+                "required": ["path"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    /// Returns the description sent with the native function definition.
+    pub fn description(&self) -> &'static str {
+        self.description
+    }
+
+    /// Returns the native function name.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Returns the JSON Schema for the native function arguments.
+    pub fn parameters(&self) -> &Value {
+        &self.parameters
+    }
+}
+
+/// Provider-neutral model request for one native tool invocation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ToolCall {
+    arguments: ReadArguments,
+    id: String,
+    name: String,
+}
+
+impl ToolCall {
+    /// Returns the typed arguments supplied to the `read` function.
+    pub fn arguments(&self) -> &ReadArguments {
+        &self.arguments
+    }
+
+    /// Returns the provider-assigned call identifier.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Returns the requested native function name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(crate) fn read(id: String, arguments: ReadArguments) -> Self {
+        Self {
+            arguments,
+            id,
+            name: READ_NAME.to_string(),
+        }
+    }
+}
+
+/// Validated arguments for the native `read` function.
+///
+/// `path` is a non-empty repository-relative POSIX path. `offset`, when
+/// present, is a one-based line number, and `limit`, when present, is a
+/// positive maximum line count.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct ReadArguments {
+    #[serde(default, deserialize_with = "deserialize_optional_positive_integer")]
+    limit: Option<NonZeroU64>,
+    #[serde(default, deserialize_with = "deserialize_optional_positive_integer")]
+    offset: Option<NonZeroU64>,
+    #[serde(deserialize_with = "deserialize_repository_path")]
+    path: String,
+}
+
+impl ReadArguments {
+    /// Returns the optional positive maximum line count.
+    pub fn limit(&self) -> Option<u64> {
+        self.limit.map(NonZeroU64::get)
+    }
+
+    /// Returns the optional one-based starting line.
+    pub fn offset(&self) -> Option<u64> {
+        self.offset.map(NonZeroU64::get)
+    }
+
+    /// Returns the repository-relative path to read.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+}
+
+fn deserialize_optional_positive_integer<'de, D>(
+    deserializer: D,
+) -> Result<Option<NonZeroU64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let number = Number::deserialize(deserializer)?;
+    parse_positive_json_integer(&number.to_string())
+        .and_then(NonZeroU64::new)
+        .map(Some)
+        .ok_or_else(|| de::Error::custom("number must be an integer from 1 through u64::MAX"))
+}
+
+fn parse_positive_json_integer(number: &str) -> Option<u64> {
+    let (mantissa, exponent) = match number.split_once(['e', 'E']) {
+        Some((mantissa, exponent)) => (mantissa, exponent.parse::<i64>().ok()?),
+        None => (number, 0),
+    };
+    if mantissa.starts_with('-') {
+        return None;
+    }
+    let (whole, fraction) = mantissa.split_once('.').unwrap_or((mantissa, ""));
+    let mut digits = String::with_capacity(whole.len() + fraction.len());
+    digits.push_str(whole);
+    digits.push_str(fraction);
+    let scale = exponent.checked_sub(i64::try_from(fraction.len()).ok()?)?;
+    let appended_zeros = if scale < 0 {
+        let removed_digits = usize::try_from(scale.unsigned_abs()).ok()?;
+        if removed_digits >= digits.len()
+            || !digits[digits.len() - removed_digits..]
+                .bytes()
+                .all(|digit| digit == b'0')
+        {
+            return None;
+        }
+        digits.truncate(digits.len() - removed_digits);
+
+        0
+    } else {
+        usize::try_from(scale).ok()?
+    };
+    let digits = digits.trim_start_matches('0');
+    if digits.is_empty() || digits.len().checked_add(appended_zeros)? > 20 {
+        return None;
+    }
+    let value = digits.parse::<u64>().ok()?;
+
+    (0..appended_zeros).try_fold(value, |value, _| value.checked_mul(10))
+}
+
+fn deserialize_repository_path<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let path = String::deserialize(deserializer)?;
+    if path.is_empty() {
+        return Err(de::Error::custom("path must not be empty"));
+    }
+    if path.starts_with('/') {
+        return Err(de::Error::custom("path must be repository-relative"));
+    }
+    if path.contains('\0') {
+        return Err(de::Error::custom("path must not contain NUL"));
+    }
+    if path
+        .split('/')
+        .any(|component| component.is_empty() || matches!(component, "." | ".."))
+    {
+        return Err(de::Error::custom(
+            "path must not contain empty, current-directory, or parent-directory components",
+        ));
+    }
+
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use jsonschema::Validator;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn read_definition_exposes_native_function_contract() {
+        // Arrange and Act
+        let definition = ToolDefinition::read();
+        let validator =
+            Validator::new(definition.parameters()).expect("read argument schema should compile");
+
+        // Assert
+        assert_eq!(definition.name(), "read");
+        assert_eq!(
+            definition.description(),
+            "Read a repository-relative file, optionally selecting a line range."
+        );
+        assert!(validator.is_valid(&json!({ "path": "Cargo.toml" })));
+        assert!(validator.is_valid(&json!({
+            "path": "crates/ag-harness/src/lib.rs",
+            "offset": 1,
+            "limit": 12
+        })));
+        assert!(validator.is_valid(&json!({
+            "path": "Cargo.toml",
+            "offset": u64::MAX,
+            "limit": u64::MAX
+        })));
+        assert!(validator.is_valid(&json!({
+            "path": "Cargo.toml",
+            "offset": 1.0,
+            "limit": 1e0
+        })));
+    }
+
+    #[test]
+    fn read_definition_rejects_invalid_arguments() {
+        // Arrange
+        let definition = ToolDefinition::read();
+        let validator =
+            Validator::new(definition.parameters()).expect("read argument schema should compile");
+        let offset_above_maximum =
+            serde_json::from_str(r#"{"path":"Cargo.toml","offset":18446744073709551616}"#)
+                .expect("out-of-range offset fixture should be valid JSON");
+        let limit_above_maximum =
+            serde_json::from_str(r#"{"path":"Cargo.toml","limit":18446744073709551616}"#)
+                .expect("out-of-range limit fixture should be valid JSON");
+        let invalid_arguments = [
+            json!({}),
+            json!({ "path": "" }),
+            json!({ "path": "/Cargo.toml" }),
+            json!({ "path": "../Cargo.toml" }),
+            json!({ "path": "Cargo\0.toml" }),
+            json!({ "path": "Cargo.toml", "offset": 0 }),
+            json!({ "path": "Cargo.toml", "limit": 0 }),
+            json!({ "path": "Cargo.toml", "offset": null }),
+            json!({ "path": "Cargo.toml", "limit": null }),
+            json!({ "path": "Cargo.toml", "unexpected": true }),
+            offset_above_maximum,
+            limit_above_maximum,
+        ];
+
+        // Act
+        let results = invalid_arguments.map(|arguments| validator.is_valid(&arguments));
+
+        // Assert
+        assert!(results.into_iter().all(|is_valid| !is_valid));
+    }
+
+    #[test]
+    fn read_arguments_reject_invalid_repository_paths() {
+        // Arrange
+        let invalid_paths = [
+            "",
+            "/Cargo.toml",
+            "src//lib.rs",
+            "src/./lib.rs",
+            "../lib.rs",
+            "Cargo\0.toml",
+        ];
+
+        // Act
+        let errors = invalid_paths.map(|path| {
+            serde_json::from_value::<ReadArguments>(json!({ "path": path }))
+                .expect_err("invalid path should be rejected")
+        });
+
+        // Assert
+        assert!(
+            errors
+                .into_iter()
+                .all(|error| !error.to_string().is_empty())
+        );
+    }
+
+    #[test]
+    fn read_arguments_distinguish_missing_ranges_from_null() {
+        // Arrange
+        let omitted = json!({ "path": "Cargo.toml" });
+        let explicit_null = [
+            json!({ "path": "Cargo.toml", "offset": null }),
+            json!({ "path": "Cargo.toml", "limit": null }),
+        ];
+
+        // Act
+        let arguments = serde_json::from_value::<ReadArguments>(omitted)
+            .expect("omitted ranges should remain optional");
+        let errors = explicit_null.map(|value| {
+            serde_json::from_value::<ReadArguments>(value)
+                .expect_err("explicit null range should be rejected")
+        });
+
+        // Assert
+        assert_eq!(arguments.offset(), None);
+        assert_eq!(arguments.limit(), None);
+        assert!(
+            errors
+                .into_iter()
+                .all(|error| !error.to_string().is_empty())
+        );
+    }
+
+    #[test]
+    fn read_arguments_accept_maximum_ranges() {
+        // Arrange
+        let value = json!({
+            "path": "Cargo.toml",
+            "offset": u64::MAX,
+            "limit": u64::MAX
+        });
+
+        // Act
+        let arguments = serde_json::from_value::<ReadArguments>(value)
+            .expect("maximum u64 ranges should decode");
+
+        // Assert
+        assert_eq!(arguments.offset(), Some(u64::MAX));
+        assert_eq!(arguments.limit(), Some(u64::MAX));
+    }
+
+    #[test]
+    fn read_arguments_accept_integral_decimal_and_exponent_ranges() {
+        // Arrange
+        let values = [
+            (r#"{"path":"Cargo.toml","offset":1.0,"limit":1e0}"#, (1, 1)),
+            (
+                r#"{"path":"Cargo.toml","offset":1e2,"limit":100e-2}"#,
+                (100, 1),
+            ),
+            (
+                r#"{"path":"Cargo.toml","offset":18446744073709551615.0,"limit":18446744073709551615e0}"#,
+                (u64::MAX, u64::MAX),
+            ),
+        ];
+
+        // Act
+        let arguments = values.map(|(value, expected)| {
+            serde_json::from_str::<ReadArguments>(value)
+                .map(|arguments| (arguments, expected))
+                .expect("integral numeric forms should decode")
+        });
+
+        // Assert
+        assert!(arguments.iter().all(|(arguments, expected)| {
+            arguments.offset() == Some(expected.0) && arguments.limit() == Some(expected.1)
+        }));
+    }
+
+    #[test]
+    fn read_arguments_reject_non_integral_or_out_of_range_numbers() {
+        // Arrange
+        let values = [
+            r#"{"path":"Cargo.toml","offset":-1}"#,
+            r#"{"path":"Cargo.toml","limit":1.5}"#,
+            r#"{"path":"Cargo.toml","limit":1e-1}"#,
+            r#"{"path":"Cargo.toml","offset":18446744073709551616}"#,
+            r#"{"path":"Cargo.toml","offset":1e999999999999999999999}"#,
+        ];
+
+        // Act
+        let errors = values.map(|value| {
+            serde_json::from_str::<ReadArguments>(value)
+                .expect_err("non-integral or out-of-range number should fail")
+        });
+
+        // Assert
+        assert!(
+            errors
+                .into_iter()
+                .all(|error| !error.to_string().is_empty())
+        );
+    }
+}

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -71,6 +71,14 @@ system instruction, and rely on shared local schema validation before returning 
 successful response. Schemas without an explicit object root and unsupported
 configurations fail explicitly rather than falling back to unstructured output.
 
+The current wire-only tool foundation lets callers explicitly advertise the native
+`read` function on an individual `ModelRequest`. Qwen and Kimi translate the shared
+`ToolDefinition` into their Chat Completions payload and decode exactly one validated
+`ToolCall` with typed `ReadArguments`. A tool call remains distinct from terminal
+`ModelResponse` output, which continues through local `OutputSchema` validation. This
+slice stops at decoding: tool execution, filesystem access, tool-result messages, and
+the continuation loop remain future work.
+
 ## Session management
 
 - One host process manages multiple independent sessions.


### PR DESCRIPTION
- Advertises the shared `read` tool through Qwen and Kimi Chat Completions requests and decodes exactly one validated call with bounded repository-relative arguments.
- Keeps native tool calls distinct from schema-validated terminal output and rejects malformed, ambiguous, unsupported, or mixed-content responses.
- Limits this slice to wire-level definition and decoding; execution, tool-result messages, and continuation remain future work.
- Accepts schema-valid integral decimal and exponent forms for `offset` and `limit` losslessly across the bounded positive `u64` range while rejecting fractional and out-of-range values.
- Exposes optional terminal output and tool-call results while leaving tool execution, tool-result messages, and continuation for future work.