### PR TITLE
Existing session titles survive refreshes

### DIFF
--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -15,7 +15,7 @@ use ag_forge::{
 };
 use ag_git as git;
 use ag_protocol::{
-    AgentResponse, TurnPrompt, TurnPromptAttachment, TurnPromptTextSource,
+    AgentResponse, QuestionItem, TurnPrompt, TurnPromptAttachment, TurnPromptTextSource,
     parse_agent_response_strict,
 };
 use tempfile::tempdir;
@@ -43,7 +43,9 @@ use crate::domain::transient_message::{
 use crate::infra::clock::{Clock, RealClock};
 use crate::infra::db::AppRepositories;
 use crate::infra::fs::{self as fs, FsClient};
-use crate::presentation::app_mode::{AppMode, ReviewCommentAction, ReviewCommentActionSelection};
+use crate::presentation::app_mode::{
+    AppMode, DiffPreview, HelpContext, ReviewCommentAction, ReviewCommentActionSelection,
+};
 
 /// Builds a filesystem mock that delegates operations to local disk.
 fn create_passthrough_mock_fs_client() -> fs::MockFsClient {
@@ -3542,7 +3544,7 @@ fn review_message_body<'a>(app: &'a App, session_id: &str) -> &'a TransientMessa
 }
 
 #[tokio::test]
-async fn test_refresh_sessions_if_needed_remaps_view_mode_index() {
+async fn test_refresh_sessions_loads_question_detail_when_another_session_is_selected() {
     // Arrange
     let dir = tempdir().expect("failed to create temp dir");
     let db = AppRepositories::in_memory().await;
@@ -3556,7 +3558,7 @@ async fn test_refresh_sessions_if_needed_remaps_view_mode_index() {
             "alpha000",
             "gemini-3.6-flash",
             "main",
-            "InProgress",
+            "Question",
             project_id,
         )
         .await
@@ -3565,6 +3567,14 @@ async fn test_refresh_sessions_if_needed_remaps_view_mode_index() {
         .insert_session("beta0000", "claude-opus-5", "main", "Done", project_id)
         .await
         .expect("failed to insert beta0000");
+    db.sessions()
+        .update_session_prompt("alpha000", "Alpha prompt")
+        .await
+        .expect("failed to set alpha000 prompt");
+    db.sessions()
+        .update_session_prompt("beta0000", "Beta prompt")
+        .await
+        .expect("failed to set beta0000 prompt");
     db.sessions()
         .update_session_updated_at("alpha000", 1)
         .await
@@ -3585,27 +3595,149 @@ async fn test_refresh_sessions_if_needed_remaps_view_mode_index() {
         db,
     )
     .await;
-    let selected_session_id = app.sessions.sessions()[1].id.clone();
-    app.mode = AppMode::View {
-        session_id: selected_session_id.clone(),
-        scroll_offset: None,
-    };
+    let question_session_id = SessionId::from("alpha000");
+    let selected_index = app
+        .sessions
+        .sessions()
+        .iter()
+        .position(|session| session.id == "beta0000")
+        .expect("beta0000 should be loaded");
+    app.sessions.select_session_index(Some(selected_index));
+    app.enter_question_mode(
+        &question_session_id,
+        vec![QuestionItem::new("Which target should be used?")],
+    );
 
     // Act
     app.services
         .db()
         .sessions()
-        .update_session_status_with_timing_at("alpha000", "Done", 0)
+        .update_session_status_with_timing_at("alpha000", "Question", 0)
         .await
         .expect("failed to update session status");
     app.refresh_sessions_now().await;
 
     // Assert
     assert_eq!(app.sessions.sessions()[0].id, "alpha000");
-    assert!(matches!(app.mode, AppMode::View { .. }));
-    if let AppMode::View { session_id, .. } = app.mode {
-        assert_eq!(session_id, selected_session_id);
+    assert!(matches!(
+        app.mode,
+        AppMode::Question { ref session_id, .. } if session_id == &question_session_id
+    ));
+    assert_eq!(
+        app.sessions
+            .selected_session()
+            .map(|session| session.id.as_str()),
+        Some("beta0000")
+    );
+    assert_eq!(
+        app.sessions
+            .session_for_id(&question_session_id)
+            .map(|session| session.prompt.as_str()),
+        Some("Alpha prompt")
+    );
+    assert_eq!(
+        app.sessions
+            .session_for_id("beta0000")
+            .map(|session| session.prompt.as_str()),
+        Some("")
+    );
+}
+
+#[tokio::test]
+async fn test_refresh_sessions_loads_diff_help_detail_when_another_session_is_selected() {
+    // Arrange
+    let dir = tempdir().expect("failed to create temp dir");
+    let db = AppRepositories::in_memory().await;
+    let project_id = db
+        .projects()
+        .upsert_project("/tmp/test", None)
+        .await
+        .expect("failed to upsert project");
+    db.sessions()
+        .insert_session("alpha000", "gemini-3.6-flash", "main", "Review", project_id)
+        .await
+        .expect("failed to insert alpha000");
+    db.sessions()
+        .insert_session("beta0000", "claude-opus-5", "main", "Done", project_id)
+        .await
+        .expect("failed to insert beta0000");
+    db.sessions()
+        .update_session_prompt("alpha000", "Alpha prompt")
+        .await
+        .expect("failed to set alpha000 prompt");
+    db.sessions()
+        .update_session_prompt("beta0000", "Beta prompt")
+        .await
+        .expect("failed to set beta0000 prompt");
+    db.sessions()
+        .update_session_updated_at("alpha000", 1)
+        .await
+        .expect("failed to set alpha000 timestamp");
+    db.sessions()
+        .update_session_updated_at("beta0000", 2)
+        .await
+        .expect("failed to set beta0000 timestamp");
+    for session_id in ["alpha000", "beta0000"] {
+        let session_dir = session_folder(dir.path(), session_id);
+        let data_dir = session_dir.join(SESSION_DATA_DIR);
+        std::fs::create_dir_all(&data_dir).expect("failed to create data dir");
     }
+    let mut app = new_test_app_with_db(
+        dir.path().to_path_buf(),
+        PathBuf::from("/tmp/test"),
+        None,
+        db,
+    )
+    .await;
+    let help_session_id = SessionId::from("alpha000");
+    let selected_index = app
+        .sessions
+        .sessions()
+        .iter()
+        .position(|session| session.id == "beta0000")
+        .expect("beta0000 should be loaded");
+    app.sessions.select_session_index(Some(selected_index));
+    app.mode = AppMode::Help {
+        context: HelpContext::Diff {
+            diff: String::new(),
+            file_explorer_selected_index: 0,
+            preview: DiffPreview::default(),
+            restore: None,
+            session_id: help_session_id.clone(),
+            scroll_offset: 0,
+        },
+        scroll_offset: 0,
+    };
+
+    // Act
+    app.refresh_sessions_now().await;
+
+    // Assert
+    assert!(matches!(
+        app.mode,
+        AppMode::Help {
+            context: HelpContext::Diff { ref session_id, .. },
+            ..
+        } if session_id == &help_session_id
+    ));
+    assert_eq!(
+        app.sessions
+            .selected_session()
+            .map(|session| session.id.as_str()),
+        Some("beta0000")
+    );
+    assert_eq!(
+        app.sessions
+            .session_for_id(&help_session_id)
+            .map(|session| session.prompt.as_str()),
+        Some("Alpha prompt")
+    );
+    assert_eq!(
+        app.sessions
+            .session_for_id("beta0000")
+            .map(|session| session.prompt.as_str()),
+        Some("")
+    );
 }
 
 #[tokio::test]

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -2199,7 +2199,7 @@ impl SessionManager {
 
         let session = &mut self.state.sessions[session_index];
 
-        let is_first_message = session.prompt.is_empty();
+        let is_first_message = session.status == Status::Draft && session.prompt.is_empty();
         if !reply_eligibility.allows(session.status, is_first_message) {
             return Err(SessionError::Workflow(
                 "Session must be in review status".to_string(),
@@ -4697,6 +4697,39 @@ mod tests {
         assert_eq!(context.2, "session-id");
         assert_eq!(context.3, None);
         assert_eq!(session_manager.sessions()[0].prompt, "Initial prompt");
+        assert_eq!(
+            session_manager.sessions()[0].title,
+            Some("Initial prompt".to_string())
+        );
+    }
+
+    /// Ensures lazily unloaded prompt detail cannot make a question answer
+    /// replace the existing session title as though it were the first prompt.
+    #[test]
+    fn test_prepare_reply_context_question_answer_keeps_existing_title() {
+        // Arrange
+        let session = test_session("", Status::Question, Some("Initial prompt"), "");
+        let mut session_manager = session_manager_with_one_session(session);
+        let prompt = TurnPrompt::from_text(
+            "Clarifications:\n1. Q: Which target?\n   A: Full project".to_string(),
+        );
+
+        // Act
+        let context = session_manager
+            .prepare_reply_context(
+                "session-id",
+                &prompt,
+                false,
+                ReplyEligibility::QuestionAnswer,
+            )
+            .expect("question answer context should be available");
+
+        // Assert
+        assert_eq!(context.0, None);
+        assert!(!context.1);
+        assert_eq!(context.2, "session-id");
+        assert_eq!(context.3, None);
+        assert_eq!(session_manager.sessions()[0].prompt, "");
         assert_eq!(
             session_manager.sessions()[0].title,
             Some("Initial prompt".to_string())

--- a/crates/agentty/src/app/session/workflow/refresh.rs
+++ b/crates/agentty/src/app/session/workflow/refresh.rs
@@ -10,7 +10,7 @@ use super::load::SessionLoadInput;
 use crate::app::session::SessionError;
 use crate::app::{AppServices, ProjectManager, SessionManager};
 use crate::domain::session::{ForgeKind, ReviewRequest, SessionId};
-use crate::presentation::app_mode::{AppMode, ConfirmationViewMode};
+use crate::presentation::app_mode::{AppMode, ConfirmationViewMode, HelpContext};
 
 impl SessionManager {
     /// Reloads session rows when the metadata cache indicates a change.
@@ -108,6 +108,9 @@ impl SessionManager {
         let selected_session_id = selected_index
             .and_then(|index| self.state.sessions.get(index))
             .map(|session| session.id.clone());
+        let detail_session_id = Self::mode_session_id(mode)
+            .cloned()
+            .or_else(|| selected_session_id.clone());
         let live_orchestration_progress = self
             .state
             .sessions
@@ -127,7 +130,7 @@ impl SessionManager {
             Self::load_sessions_with_fs_client(
                 SessionLoadInput {
                     active_project_id: projects.active_project_id(),
-                    active_session_id: selected_session_id.as_deref(),
+                    active_session_id: detail_session_id.as_deref(),
                     base: services.base_path(),
                     clock: clock.as_ref(),
                     db: services.db(),
@@ -163,6 +166,39 @@ impl SessionManager {
             self.state.updated_at_max = sessions_updated_at_max;
         } else {
             self.update_sessions_metadata_cache(services).await;
+        }
+    }
+
+    /// Returns the session whose detail is visible or being edited in the
+    /// current application mode.
+    fn mode_session_id(mode: &AppMode) -> Option<&SessionId> {
+        match mode {
+            AppMode::Confirmation {
+                session_id: Some(session_id),
+                ..
+            }
+            | AppMode::Prompt { session_id, .. }
+            | AppMode::Question { session_id, .. }
+            | AppMode::View { session_id, .. }
+            | AppMode::Diff { session_id, .. }
+            | AppMode::ReviewComments { session_id, .. }
+            | AppMode::Help {
+                context: HelpContext::View { session_id, .. } | HelpContext::Diff { session_id, .. },
+                ..
+            }
+            | AppMode::ViewInfoPopup {
+                restore_view: ConfirmationViewMode { session_id, .. },
+                ..
+            }
+            | AppMode::LaunchConfigurationSelector {
+                restore_view: ConfirmationViewMode { session_id, .. },
+                ..
+            }
+            | AppMode::PublishBranchInput {
+                restore_view: ConfirmationViewMode { session_id, .. },
+                ..
+            } => Some(session_id),
+            _ => None,
         }
     }
 
@@ -268,26 +304,7 @@ impl SessionManager {
 
     /// Switches back to list mode if the currently viewed session is missing.
     fn ensure_mode_session_exists(&self, mode: &mut AppMode) {
-        let mode_session_id = match &*mode {
-            AppMode::Confirmation {
-                session_id: Some(session_id),
-                ..
-            }
-            | AppMode::Prompt { session_id, .. }
-            | AppMode::Question { session_id, .. }
-            | AppMode::View { session_id, .. }
-            | AppMode::Diff { session_id, .. }
-            | AppMode::ReviewComments { session_id, .. }
-            | AppMode::LaunchConfigurationSelector {
-                restore_view: ConfirmationViewMode { session_id, .. },
-                ..
-            }
-            | AppMode::PublishBranchInput {
-                restore_view: ConfirmationViewMode { session_id, .. },
-                ..
-            } => Some(session_id),
-            _ => None,
-        };
+        let mode_session_id = Self::mode_session_id(mode);
         let Some(session_id) = mode_session_id else {
             return;
         };
@@ -350,13 +367,16 @@ mod tests {
     use crate::app::session::{Clock, SessionDefaults};
     use crate::app::{AppServices, SessionState};
     use crate::domain::agent::AgentKind;
+    use crate::domain::input::InputState;
     use crate::domain::selection::SelectionState;
     use crate::domain::session::{
-        ForgeKind, ReviewRequest, ReviewRequestState, ReviewRequestSummary, Session,
-        SessionHandles, Status,
+        ForgeKind, PublishBranchAction, ReviewRequest, ReviewRequestState, ReviewRequestSummary,
+        Session, SessionHandles, Status,
     };
     use crate::infra::db::AppRepositories;
     use crate::infra::fs;
+    use crate::presentation::app_mode::DiffPreview;
+    use crate::presentation::help_action::ViewSessionState;
 
     /// Builds a filesystem mock that delegates directory checks to local disk.
     fn create_passthrough_mock_fs_client() -> fs::MockFsClient {
@@ -789,6 +809,106 @@ mod tests {
 
         // Assert
         assert!(refresh_due);
+    }
+
+    #[test]
+    fn mode_session_id_uses_view_info_popup_restore_view() {
+        // Arrange
+        let mode = AppMode::ViewInfoPopup {
+            is_loading: false,
+            loading_label: "Refreshing review request...".to_string(),
+            message: "Review request refreshed.".to_string(),
+            restore_view: ConfirmationViewMode {
+                scroll_offset: Some(2),
+                session_id: "popup-session".into(),
+            },
+            title: "Review request refreshed".to_string(),
+        };
+
+        // Act
+        let session_id = SessionManager::mode_session_id(&mode);
+
+        // Assert
+        assert_eq!(session_id.map(SessionId::as_str), Some("popup-session"));
+    }
+
+    #[test]
+    fn mode_session_id_uses_view_help_context() {
+        // Arrange
+        let mode = AppMode::Help {
+            context: HelpContext::View {
+                can_fork_session: false,
+                can_merge_session_branch: false,
+                can_mutate_session_branch: false,
+                can_open_worktree: false,
+                can_rebase_session_branch: false,
+                can_reply_to_session: false,
+                can_start_staged_session: false,
+                can_view_review_comments: false,
+                publish_pull_request_action: None,
+                scroll_offset: Some(2),
+                session_id: "help-session".into(),
+                session_state: ViewSessionState::Review,
+            },
+            scroll_offset: 0,
+        };
+
+        // Act
+        let session_id = SessionManager::mode_session_id(&mode);
+
+        // Assert
+        assert_eq!(session_id.map(SessionId::as_str), Some("help-session"));
+    }
+
+    #[test]
+    fn mode_session_id_uses_diff_and_session_overlay_contexts() {
+        // Arrange
+        let modes = [
+            AppMode::Diff {
+                diff: String::new(),
+                file_explorer_selected_index: 0,
+                preview: DiffPreview::default(),
+                restore: None,
+                scroll_cache: None,
+                scroll_offset: 0,
+                session_id: "diff-session".into(),
+            },
+            AppMode::LaunchConfigurationSelector {
+                commands: vec!["cargo test".to_string()],
+                restore_view: ConfirmationViewMode {
+                    scroll_offset: None,
+                    session_id: "launch-session".into(),
+                },
+                selected_command_index: 0,
+            },
+            AppMode::PublishBranchInput {
+                default_branch_name: "wt/session".to_string(),
+                input: InputState::default(),
+                locked_upstream_ref: None,
+                publish_branch_action: PublishBranchAction::Push,
+                restore_view: ConfirmationViewMode {
+                    scroll_offset: None,
+                    session_id: "publish-session".into(),
+                },
+            },
+        ];
+
+        // Act
+        let session_ids = modes
+            .iter()
+            .map(SessionManager::mode_session_id)
+            .map(|session_id| session_id.map(SessionId::as_str))
+            .collect::<Vec<_>>();
+
+        // Assert
+        assert_eq!(
+            session_ids,
+            [
+                Some("diff-session"),
+                Some("launch-session"),
+                Some("publish-session"),
+            ]
+        );
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/orchestration.rs
+++ b/crates/agentty/tests/e2e/orchestration.rs
@@ -542,8 +542,8 @@ fn test_orchestrator_auto_review_scope() -> E2eResult {
                     .wait_for_text("Tab: focus | Enter: send", 5000)
                     .write_text(CONTROLLER_REVISION_PROMPT)
                     .press_key("Enter")
-                    .wait_for_text(CONTROLLER_REVISION_RESPONSE, 30000)
-                    .wait_for_stable_frame(300, 5000)
+                    .wait_for_text("Enter: reply", 30000)
+                    .wait_for_text("Phase: Running", 5000)
                     .capture_labeled(
                         "controller_review_ready",
                         "Controller remains review-ready after its turn",
@@ -564,7 +564,7 @@ fn test_orchestrator_auto_review_scope() -> E2eResult {
                     Region::full(controller_frame.cols(), controller_frame.rows());
                 assertion::assert_text_in_region(
                     &controller_frame,
-                    CONTROLLER_REVISION_RESPONSE,
+                    "Enter: reply",
                     &controller_full,
                 );
                 assertion::assert_text_in_region(

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -8,15 +8,16 @@
 use std::io::Read;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use agentty::db::{DB_DIR, DB_FILE, Database};
 use agentty::domain::agent::ReasoningLevel;
 use agentty::domain::session::{
-    ForgeKind, ReviewRequest, ReviewRequestState, ReviewRequestSummary, SessionSize,
+    ForgeKind, ReviewRequest, ReviewRequestState, ReviewRequestSummary,
 };
 use agentty::domain::session_message::SessionMessageKind;
 use agentty::test_support;
@@ -47,9 +48,18 @@ const REBASING_QUEUE_SESSION_ID: &str = "rebasing-queue-0001";
 /// Stable id for the seeded binary-only diff session.
 const BINARY_DIFF_SESSION_ID: &str = "binary-diff-0001";
 
-/// Stable id for the seeded clarification-question session used by the
-/// question-resume test.
-const QUESTION_RESUME_SESSION_ID: &str = "question-resume-0001";
+/// Stable id for the unrelated row selected before the refresh regression
+/// creates its question session.
+const QUESTION_REFRESH_SELECTED_SESSION_ID: &str = "question-refresh-selected";
+
+/// Initial prompt that must survive the title-generation refresh.
+const QUESTION_REFRESH_INITIAL_PROMPT: &str = "Implement the initial task";
+
+/// Generated title that must survive clarification submission.
+const QUESTION_REFRESH_TITLE: &str = "Keep the original task title";
+
+/// Final answer emitted after the clarification response resumes the worker.
+const QUESTION_REFRESH_FINAL_ANSWER: &str = "Clarifications accepted.";
 
 /// First clarification question shown when the seeded question session opens.
 const FIRST_QUESTION_TEXT: &str = "Use the default target branch?";
@@ -1627,56 +1637,55 @@ fn seed_rebasing_queue_session(env: &BuilderEnv) -> Result<(), Box<dyn std::erro
     Ok(())
 }
 
-/// Seeds one `Question`-status session with two option questions and a known
-/// empty diff state.
-fn seed_question_resume_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+/// Seeds an unrelated selected row and a prompt-aware agent stub for the
+/// question-refresh regression.
+fn seed_question_refresh_project(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     common::seed_session(
         env,
         SessionSeed::regular(
-            QUESTION_RESUME_SESSION_ID,
-            "gpt-5.6-sol",
+            QUESTION_REFRESH_SELECTED_SESSION_ID,
+            "claude-haiku-4-5-20251001",
             "main",
-            "Question",
+            "Done",
         )
-        .with_title("Question resume session"),
+        .with_title("Other session"),
     )?;
 
-    let session_worktree =
-        test_support::session_folder(&env.agentty_root.join("wt"), QUESTION_RESUME_SESSION_ID);
-    std::fs::create_dir_all(&session_worktree)?;
-    run_git(&session_worktree, &["init", "-b", "main"])?;
-    run_git(
-        &session_worktree,
-        &["config", "user.email", "test@test.com"],
-    )?;
-    run_git(&session_worktree, &["config", "user.name", "Test"])?;
-    std::fs::write(session_worktree.join("README.md"), "clean session\n")?;
-    run_git(&session_worktree, &["add", "."])?;
-    run_git(&session_worktree, &["commit", "-m", "init"])?;
-
-    let questions_json = format!(
-        r#"[{{"options":["Yes","No"],"text":"{FIRST_QUESTION_TEXT}"}},{{"options":["Unit","Integration"],"text":"{SECOND_QUESTION_TEXT}"}}]"#
+    let claude_path = env.stub_bin.join("claude");
+    let script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
+input=$(cat)
+case "$input" in
+  *"Generate a concise, commit-style title"*)
+    sleep 2
+    result='{{\"answer\":\"{QUESTION_REFRESH_TITLE}\",\"questions\":[],\"review_comment_outcomes\":[],\"summary\":null}}'
+    ;;
+  *"Clarifications:"*)
+    result='{{\"answer\":\"{QUESTION_REFRESH_FINAL_ANSWER}\",\"questions\":[],\"review_comment_outcomes\":[],\"summary\":null}}'
+    ;;
+  *)
+    result='{{\"answer\":\"Need two clarifications.\",\"questions\":[{{\"text\":\"{FIRST_QUESTION_TEXT}\",\"options\":[\"Yes\",\"No\"]}},{{\"text\":\"{SECOND_QUESTION_TEXT}\",\"options\":[\"Unit\",\"Integration\"]}}],\"review_comment_outcomes\":[],\"summary\":null}}'
+    ;;
+esac
+printf '%s\n' '{{"type":"system","subtype":"init"}}'
+printf '%s\n' "{{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"$result\",\"usage\":{{\"input_tokens\":5,\"output_tokens\":9}}}}"
+"#
     );
-    let runtime = common::seed_runtime()?;
+    std::fs::write(&claude_path, script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o755))?;
 
-    runtime.block_on(async {
-        let database = common::open_database(env).await?;
-
-        database
-            .sessions()
-            .update_session_questions(QUESTION_RESUME_SESSION_ID, &questions_json)
-            .await?;
-        database
-            .sessions()
-            .update_session_diff_stats(
-                0,
-                0,
-                false,
-                QUESTION_RESUME_SESSION_ID,
-                SessionSize::Xs.label(),
-            )
-            .await
-    })?;
+    seed_project_settings(
+        env,
+        &[
+            ("DefaultSmartAgent", "claude"),
+            ("DefaultSmartModel", "claude-haiku-4-5-20251001"),
+            ("DefaultFastAgent", "claude"),
+            ("DefaultFastModel", "claude-haiku-4-5-20251001"),
+        ],
+    )?;
 
     Ok(())
 }
@@ -3954,22 +3963,38 @@ fn session_stop_turn_returns_to_review() -> E2eResult {
 #[test]
 fn session_question_resume_after_leaving_to_list() -> E2eResult {
     // Arrange
+    let agentty_root = Arc::new(Mutex::new(None::<PathBuf>));
+    let setup_agentty_root = Arc::clone(&agentty_root);
+
     FeatureTest::new("session_question_resume")
         .with_git()
-        .setup(seed_question_resume_session)
+        .setup(move |env| {
+            setup_agentty_root
+                .lock()
+                .expect("agentty root capture should remain available")
+                .replace(env.agentty_root.clone());
+
+            seed_question_refresh_project(env)
+        })
         .run(
             |scenario| {
                 // Act
                 scenario
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::switch_to_tab("Sessions"))
-                    .wait_for_text("Question resume session", 5000)
+                    .wait_for_text("Other session", 5000)
+                    .press_key("a")
                     .press_key("Enter")
-                    .wait_for_text("Question 1/2", 5000)
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text(QUESTION_REFRESH_INITIAL_PROMPT)
+                    .wait_for_text(QUESTION_REFRESH_INITIAL_PROMPT, 3000)
+                    .press_key("Enter")
+                    .wait_for_text("Question 1/2", 30000)
+                    .wait_for_text(QUESTION_REFRESH_TITLE, 30000)
                     .wait_for_text("Tab: focus", 5000)
                     .capture_labeled(
                         "answer_focused",
-                        "Question mode starts with the answer input focused",
+                        "Title refresh completes while question mode remains active",
                     )
                     .press_key("Escape")
                     .wait_for_text(
@@ -3995,47 +4020,114 @@ fn session_question_resume_after_leaving_to_list() -> E2eResult {
                         "resumed_second_question",
                         "Reopening the session resumes at the second question",
                     )
+                    .press_key("Enter")
+                    .wait_for_text(QUESTION_REFRESH_FINAL_ANSWER, 30000)
+                    .capture_labeled(
+                        "title_preserved",
+                        "Clarification submission preserves title and initial prompt",
+                    )
             },
-            |frame, report| {
+            move |frame, report| {
                 // Assert
-                let answer_focused_frame = common::frame_from_capture(&report.captures[0]);
-                let answer_focused_full =
-                    Region::full(answer_focused_frame.cols(), answer_focused_frame.rows());
-                assertion::assert_text_in_region(
-                    &answer_focused_frame,
-                    "Tab: focus | Enter: send | q: sessions | Ctrl+C: end turn",
-                    &answer_focused_full,
-                );
+                assert_question_refresh_result(frame, report);
+                let agentty_root = agentty_root
+                    .lock()
+                    .expect("agentty root capture should remain available")
+                    .clone()
+                    .expect("feature setup should capture the agentty root");
+                let (persisted_title, persisted_prompt) =
+                    load_question_refresh_metadata(&agentty_root)
+                        .expect("question metadata should remain persisted");
 
-                let chat_focused_frame = common::frame_from_capture(&report.captures[1]);
-                let chat_focused_full =
-                    Region::full(chat_focused_frame.cols(), chat_focused_frame.rows());
-                assertion::assert_text_in_region(
-                    &chat_focused_frame,
-                    "Tab: focus | j/k: scroll | q: sessions",
-                    &chat_focused_full,
-                );
-                assertion::assert_not_visible(&chat_focused_frame, "d: diff");
-                assertion::assert_not_visible(&chat_focused_frame, "Ctrl+C");
-                assertion::assert_text_in_region(
-                    &chat_focused_frame,
-                    "Question 1/2",
-                    &chat_focused_full,
-                );
-                assertion::assert_text_in_region(
-                    &chat_focused_frame,
-                    FIRST_QUESTION_TEXT,
-                    &chat_focused_full,
-                );
-
-                let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(frame, "Question 2/2", &full);
-                assertion::assert_text_in_region(frame, SECOND_QUESTION_TEXT, &full);
-                assertion::assert_not_visible(frame, FIRST_QUESTION_TEXT);
+                assert_eq!(persisted_title.as_deref(), Some(QUESTION_REFRESH_TITLE));
+                assert_eq!(persisted_prompt, QUESTION_REFRESH_INITIAL_PROMPT);
             },
         )?;
 
     Ok(())
+}
+
+/// Asserts question progress and refreshed-title output for the
+/// question-refresh feature journey.
+fn assert_question_refresh_result(frame: &TerminalFrame, report: &ProofReport) {
+    let answer_focused_frame = common::frame_from_capture(&report.captures[0]);
+    let answer_focused_full =
+        Region::full(answer_focused_frame.cols(), answer_focused_frame.rows());
+    assertion::assert_text_in_region(
+        &answer_focused_frame,
+        "Tab: focus | Enter: send | q: sessions | Ctrl+C: end turn",
+        &answer_focused_full,
+    );
+    assertion::assert_text_in_region(
+        &answer_focused_frame,
+        QUESTION_REFRESH_TITLE,
+        &answer_focused_full,
+    );
+
+    let chat_focused_frame = common::frame_from_capture(&report.captures[1]);
+    let chat_focused_full = Region::full(chat_focused_frame.cols(), chat_focused_frame.rows());
+    assertion::assert_text_in_region(
+        &chat_focused_frame,
+        "Tab: focus | j/k: scroll | q: sessions",
+        &chat_focused_full,
+    );
+    assertion::assert_not_visible(&chat_focused_frame, "d: diff");
+    assertion::assert_not_visible(&chat_focused_frame, "Ctrl+C");
+    assertion::assert_text_in_region(&chat_focused_frame, "Question 1/2", &chat_focused_full);
+    assertion::assert_text_in_region(&chat_focused_frame, FIRST_QUESTION_TEXT, &chat_focused_full);
+
+    let resumed_frame = common::frame_from_capture(&report.captures[2]);
+    let resumed_full = Region::full(resumed_frame.cols(), resumed_frame.rows());
+    assertion::assert_text_in_region(&resumed_frame, "Question 2/2", &resumed_full);
+    assertion::assert_text_in_region(&resumed_frame, SECOND_QUESTION_TEXT, &resumed_full);
+    assertion::assert_not_visible(&resumed_frame, FIRST_QUESTION_TEXT);
+
+    let full = Region::full(frame.cols(), frame.rows());
+    assertion::assert_text_in_region(frame, QUESTION_REFRESH_TITLE, &full);
+    assertion::assert_text_in_region(frame, QUESTION_REFRESH_FINAL_ANSWER, &full);
+}
+
+/// Loads the newly created question session's title and prompt from the
+/// feature-test database.
+fn load_question_refresh_metadata(
+    agentty_root: &Path,
+) -> Result<(Option<String>, String), Box<dyn std::error::Error>> {
+    let runtime = common::seed_runtime()?;
+
+    runtime.block_on(async {
+        let database = Database::open(&agentty_root.join(DB_DIR).join(DB_FILE))
+            .await
+            .map_err(|error| std::io::Error::other(format!("feature database: {error}")))?;
+        let selected_session = database
+            .sessions()
+            .load_session(QUESTION_REFRESH_SELECTED_SESSION_ID)
+            .await
+            .map_err(|error| std::io::Error::other(format!("selected session: {error}")))?
+            .ok_or_else(|| std::io::Error::other("selected session does not exist"))?;
+        let project_id = selected_session
+            .project_id
+            .ok_or_else(|| std::io::Error::other("selected session has no project"))?;
+        let question_session_id = database
+            .sessions()
+            .load_sessions_for_project(project_id)
+            .await
+            .map_err(|error| std::io::Error::other(format!("project sessions: {error}")))?
+            .into_iter()
+            .find(|session| session.id != QUESTION_REFRESH_SELECTED_SESSION_ID)
+            .map(|session| session.id)
+            .ok_or_else(|| std::io::Error::other("new question session is not listed"))?;
+        let question_session = database
+            .sessions()
+            .load_session(&question_session_id)
+            .await
+            .map_err(|error| std::io::Error::other(format!("question session: {error}")))?
+            .ok_or_else(|| std::io::Error::other("question session does not exist"))?;
+
+        Result::<_, Box<dyn std::error::Error>>::Ok((
+            question_session.title,
+            question_session.prompt,
+        ))
+    })
 }
 
 /// Persists the `Sessions` tab as the startup tab.

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -674,7 +674,11 @@ their triggers:
   role, including temporary orchestration researchers. Issued and accepted candidate
   generations are tracked separately: empty responses leave older usable candidates
   eligible, newer accepted candidates supersede older ones, and draft edits or
-  commit-derived titles invalidate every outstanding candidate.
+  commit-derived titles invalidate every outstanding candidate. Session refreshes
+  hydrate transcript-scale detail for the session identified by the active application
+  mode, independently of the session-list table selection. Reply classification also
+  requires `Draft` status before an empty prompt can be treated as the first message, so
+  lightweight list rows cannot replace an existing title.
 
 - **At-mention file indexing** (`@` in prompt or question input): lists session files
   for the mention picker, falling back to the project root for unstarted drafts.

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -732,7 +732,9 @@ Any prompt without an actionable session goal keeps the provisional title; the f
 later prompt with actionable intent then supplies the refined title. Draft sessions
 regenerate the title as more drafts are staged. Generated title candidates are ordered,
 so an empty response does not discard an earlier usable candidate, while a slow response
-cannot replace a newer accepted candidate, draft, or commit-derived title.
+cannot replace a newer accepted candidate, draft, or commit-derived title. Clarification
+answers and other follow-up messages never become fallback titles for an already-started
+session, even when its transcript detail is loaded lazily.
 
 ## Settings Scope
 


### PR DESCRIPTION
- Refreshes load detail for the session shown by the active application mode, including help and popup views, independently of the session-list selection.
- Empty prompts count as first messages only for `Draft` sessions, so clarification answers and follow-up messages preserve existing titles.
- Unit and E2E tests cover title retention, and documentation describes the behavior.
- The question-resume regression now synchronizes on its durable final outcome instead of transient prompt rendering.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)