### PR TITLE
Shows queued work in FIFO order with calm status indicators

### DIFF
--- a/crates/agentty/src/app/branch_publish.rs
+++ b/crates/agentty/src/app/branch_publish.rs
@@ -189,7 +189,7 @@ pub(crate) fn branch_publish_loading_label(publish_branch_action: PublishBranchA
 /// Returns the inline label shown while review-request creation waits behind
 /// an active session turn.
 pub(crate) fn review_request_queued_label() -> String {
-    "Review request queued; publishing after the current turn finishes...".to_string()
+    "review request — publish after this turn".to_string()
 }
 
 /// Returns the inline success title for a completed branch-publish action.
@@ -913,6 +913,15 @@ mod tests {
 
     use super::*;
     use crate::infra::db::AppRepositories;
+
+    #[test]
+    fn review_request_queued_label_describes_waiting_without_loading_punctuation() {
+        // Arrange, Act
+        let label = review_request_queued_label();
+
+        // Assert
+        assert_eq!(label, "review request — publish after this turn");
+    }
 
     fn expect_safe_session_branch_push(mock_git_client: &mut git::MockGitClient, session_id: &str) {
         let expected_branch = session::session_branch(session_id);

--- a/crates/agentty/src/app/core/draw.rs
+++ b/crates/agentty/src/app/core/draw.rs
@@ -3,7 +3,6 @@
 use super::state::{App, UpdateStatus};
 use crate::app::tab::Tab;
 use crate::domain::session::{Session, Status};
-use crate::domain::transient_message::{TransientMessageBody, TransientMessageSlot};
 use crate::presentation::app_mode::{AppMode, ConfirmationViewMode, HelpContext};
 
 impl App {
@@ -129,13 +128,11 @@ impl App {
                 session.status,
                 Status::AgentReview | Status::InProgress | Status::Merging | Status::Rebasing
             )
-            || session.transient_messages.messages().iter().any(|message| {
-                matches!(
-                    message.slot,
-                    TransientMessageSlot::Orchestration
-                        | TransientMessageSlot::BranchPublish
-                        | TransientMessageSlot::PublishedBranchSync
-                ) && matches!(&message.body, TransientMessageBody::Loading(_))
-            })
+            || session
+                .transient_messages
+                .messages()
+                .iter()
+                .any(|message| message.body.is_pending_indicator())
+            || !session.queued_messages.is_empty()
     }
 }

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -156,9 +156,13 @@ pub(crate) enum AppEvent {
         result: Box<BranchPublishTaskResult>,
         session_id: SessionId,
     },
+    /// Indicates a queued review-request action resolved without starting.
+    BranchPublishActionResolved { session_id: SessionId },
     /// Indicates a queued review-request action has begun executing on its
     /// session worker.
     BranchPublishActionStarted { session_id: SessionId },
+    /// Indicates a queued session sync has either started or failed visibly.
+    SessionQueuedSyncResolved { session_id: SessionId },
     /// Indicates review assist output became available for a session.
     ReviewPrepared {
         diff_hash: u64,
@@ -231,6 +235,7 @@ pub(super) struct AppEventBatch {
     pub(super) agent_cli_updates: Option<Vec<AgentCliInfo>>,
     pub(super) at_mention_entries_updates: HashMap<SessionId, Vec<FileEntry>>,
     pub(super) branch_publish_action_updates: Vec<BranchPublishActionUpdate>,
+    pub(super) branch_publish_resolved_session_ids: HashSet<SessionId>,
     pub(super) branch_publish_started_session_ids: HashSet<SessionId>,
     pub(super) diff_preview_updates: Vec<DiffPreviewUpdate>,
     pub(super) focused_review_persistence_retries: Vec<FocusedReviewPersistenceRetry>,
@@ -243,6 +248,7 @@ pub(super) struct AppEventBatch {
     pub(super) session_update_versions: HashMap<SessionId, u64>,
     pub(super) session_model_updates: HashMap<SessionId, crate::domain::agent::AgentSelection>,
     pub(super) session_orchestration_progress_updates: HashMap<SessionId, Option<String>>,
+    pub(super) session_queued_sync_resolved_ids: HashSet<SessionId>,
     pub(super) session_personality_updates: HashMap<SessionId, Option<String>>,
     pub(super) session_reasoning_level_updates:
         HashMap<SessionId, crate::domain::agent::ReasoningLevel>,
@@ -355,6 +361,7 @@ impl AppEventBatch {
             || !self.applied_turns.is_empty()
             || !self.at_mention_entries_updates.is_empty()
             || !self.branch_publish_action_updates.is_empty()
+            || !self.branch_publish_resolved_session_ids.is_empty()
             || !self.branch_publish_started_session_ids.is_empty()
             || !self.diff_preview_updates.is_empty()
             || !self.published_branch_sync_updates.is_empty()
@@ -364,6 +371,7 @@ impl AppEventBatch {
             || !self.session_orchestration_progress_updates.is_empty()
             || !self.session_personality_updates.is_empty()
             || !self.session_progress_updates.is_empty()
+            || !self.session_queued_sync_resolved_ids.is_empty()
             || !self.session_review_comment_snapshots.is_empty()
             || !self.session_reasoning_level_updates.is_empty()
             || !self.session_speed_mode_updates.is_empty()
@@ -447,7 +455,9 @@ impl AppEventBatch {
             | AppEvent::SessionDiffStatsUpdated { .. }
             | AppEvent::SessionTitleGenerationFinished { .. }
             | AppEvent::BranchPublishActionCompleted { .. }
+            | AppEvent::BranchPublishActionResolved { .. }
             | AppEvent::BranchPublishActionStarted { .. }
+            | AppEvent::SessionQueuedSyncResolved { .. }
             | AppEvent::ReviewPrepared { .. }
             | AppEvent::ReviewPreparationFailed { .. }
             | AppEvent::FocusedReviewPersistenceRetry { .. }
@@ -520,7 +530,9 @@ impl AppEventBatch {
                     .insert(session_id, generation);
             }
             event @ (AppEvent::BranchPublishActionCompleted { .. }
+            | AppEvent::BranchPublishActionResolved { .. }
             | AppEvent::BranchPublishActionStarted { .. }
+            | AppEvent::SessionQueuedSyncResolved { .. }
             | AppEvent::ReviewPrepared { .. }
             | AppEvent::ReviewPreparationFailed { .. }
             | AppEvent::FocusedReviewPersistenceRetry { .. }
@@ -554,8 +566,14 @@ impl AppEventBatch {
             AppEvent::BranchPublishActionCompleted { result, session_id } => {
                 self.collect_branch_publish_action_completed(*result, session_id);
             }
+            AppEvent::BranchPublishActionResolved { session_id } => {
+                self.branch_publish_resolved_session_ids.insert(session_id);
+            }
             AppEvent::BranchPublishActionStarted { session_id } => {
                 self.branch_publish_started_session_ids.insert(session_id);
+            }
+            AppEvent::SessionQueuedSyncResolved { session_id } => {
+                self.session_queued_sync_resolved_ids.insert(session_id);
             }
             AppEvent::ReviewPrepared {
                 diff_hash,
@@ -880,9 +898,7 @@ impl App {
         self.apply_batch_session_snapshot_updates(&mut event_batch);
         self.apply_app_event_effects(after_snapshot_effects).await;
 
-        self.apply_branch_publish_starts(std::mem::take(
-            &mut event_batch.branch_publish_started_session_ids,
-        ));
+        self.apply_worker_action_transitions(&mut event_batch);
 
         for branch_publish_action_update in
             std::mem::take(&mut event_batch.branch_publish_action_updates)
@@ -974,6 +990,19 @@ impl App {
         }
     }
 
+    /// Applies queued worker actions that started or otherwise resolved.
+    fn apply_worker_action_transitions(&mut self, event_batch: &mut AppEventBatch) {
+        self.apply_branch_publish_starts(std::mem::take(
+            &mut event_batch.branch_publish_started_session_ids,
+        ));
+        self.apply_branch_publish_resolutions(std::mem::take(
+            &mut event_batch.branch_publish_resolved_session_ids,
+        ));
+        self.apply_session_queued_sync_resolutions(std::mem::take(
+            &mut event_batch.session_queued_sync_resolved_ids,
+        ));
+    }
+
     /// Replaces queued review-request labels when their worker actions start.
     fn apply_branch_publish_starts(&mut self, session_ids: HashSet<SessionId>) {
         for session_id in session_ids {
@@ -981,6 +1010,20 @@ impl App {
                 &session_id,
                 Self::branch_publish_loading_label(PublishBranchAction::PublishPullRequest),
             );
+        }
+    }
+
+    /// Removes queued review-request labels that resolved without starting.
+    fn apply_branch_publish_resolutions(&mut self, session_ids: HashSet<SessionId>) {
+        for session_id in session_ids {
+            self.sessions.resolve_queued_branch_publish(&session_id);
+        }
+    }
+
+    /// Removes queued-sync labels once work starts or a visible failure lands.
+    fn apply_session_queued_sync_resolutions(&mut self, session_ids: HashSet<SessionId>) {
+        for session_id in session_ids {
+            self.sessions.resolve_queued_session_sync(&session_id);
         }
     }
 

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -1224,7 +1224,6 @@ impl App {
         };
 
         if publish_branch_action == PublishBranchAction::PublishPullRequest {
-            let is_queued = branch_publish_context.session.status == Status::InProgress;
             let branch_operation_lock = Arc::clone(&branch_publish_context.branch_operation_lock);
             // Reserve an idle branch before persistence. An existing owner
             // already serializes worker execution, so the UI never waits here.
@@ -1238,23 +1237,22 @@ impl App {
                     None,
                 )
                 .await;
-            let loading_label = if is_queued {
-                review_request_queued_label()
-            } else {
-                Self::branch_publish_loading_label(publish_branch_action)
-            };
-            if let Err(error) = enqueue_result {
-                self.sessions
-                    .start_branch_publish(session_id, loading_label);
-                self.sessions.finish_branch_publish(
+            match enqueue_result {
+                Err(error) => self.sessions.finish_branch_publish(
                     session_id,
                     TransientMessageBody::Markdown(format!(
                         "**Review request publish failed**\n\n{error}"
                     )),
-                );
-            } else {
-                self.sessions
-                    .start_branch_publish(session_id, loading_label);
+                ),
+                Ok(Some(queued_order)) => self.sessions.queue_branch_publish(
+                    session_id,
+                    queued_order,
+                    review_request_queued_label(),
+                ),
+                Ok(None) => self.sessions.start_branch_publish(
+                    session_id,
+                    Self::branch_publish_loading_label(publish_branch_action),
+                ),
             }
             self.mode = restore_view.into_view_mode();
 

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -18,16 +18,17 @@ use crate::domain::composer::PromptAttachment;
 use crate::domain::file_entry::FileEntry;
 use crate::domain::question::QuestionItem;
 use crate::domain::session::{
-    ForgeKind, PublishedBranchSyncStatus, ReviewRequest, ReviewRequestState, ReviewRequestSummary,
-    SESSION_DATA_DIR, SessionDiffState, SessionDiffStats, SessionFollowUpTask, SessionHandles,
-    SessionRole, SessionSize, SessionStats, Status,
+    ForgeKind, PublishedBranchSyncStatus, QueuedMessage, ReviewRequest, ReviewRequestState,
+    ReviewRequestSummary, SESSION_DATA_DIR, SessionDiffState, SessionDiffStats,
+    SessionFollowUpTask, SessionHandles, SessionRole, SessionSize, SessionStats, Status,
 };
 use crate::domain::session_message::{SessionMessageKind, SessionTranscript};
 use crate::domain::setting::SettingName;
 use crate::domain::transient_message::{
-    TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
-    TransientMessageSlot,
+    QueuedAction, TransientMessage, TransientMessageAnchor, TransientMessageBody,
+    TransientMessageLifecycle, TransientMessageSlot,
 };
+use crate::domain::turn_prompt::TurnPrompt;
 use crate::infra::db::AppRepositories;
 use crate::infra::project_discovery::{HOME_PROJECT_SCAN_MAX_RESULTS, RealProjectDiscoveryClient};
 use crate::infra::tmux::{MockTmuxClient, TmuxClient};
@@ -230,6 +231,48 @@ async fn review_comments_page_has_no_tick_driven_ui() {
 
     // Assert
     assert!(!has_tick_driven_ui);
+}
+
+#[tokio::test]
+async fn queued_session_work_has_tick_driven_ui() {
+    // Arrange
+    let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+    let mut session = crate::test_support::SessionFixtureBuilder::new()
+        .id("session-id")
+        .status(Status::Review)
+        .build();
+    session.transient_messages.upsert(TransientMessage {
+        anchor: TransientMessageAnchor::Tail,
+        body: TransientMessageBody::Queued(QueuedAction::new(
+            0,
+            "sync after this turn".to_string(),
+        )),
+        lifecycle: TransientMessageLifecycle::UntilResolved,
+        slot: TransientMessageSlot::SyncQueue,
+        turn_position: None,
+    });
+    app.sessions.push_session(session);
+    app.mode = test_view_app_mode("session-id");
+
+    // Act
+    let queued_action_has_tick_driven_ui = app.has_visible_tick_driven_ui();
+    let session = app
+        .sessions
+        .sessions_mut()
+        .first_mut()
+        .expect("queued session should remain available");
+    session
+        .transient_messages
+        .retract(TransientMessageSlot::SyncQueue);
+    session.queued_messages.push(QueuedMessage::new(
+        1,
+        TurnPrompt::from_text("follow up".to_string()),
+    ));
+    let queued_message_has_tick_driven_ui = app.has_visible_tick_driven_ui();
+
+    // Assert
+    assert!(queued_action_has_tick_driven_ui);
+    assert!(queued_message_has_tick_driven_ui);
 }
 
 #[tokio::test]
@@ -1433,6 +1476,66 @@ async fn review_request_enqueue_does_not_wait_for_existing_branch_operation() {
 }
 
 #[tokio::test]
+async fn running_review_request_action_queues_on_existing_worker() {
+    // Arrange
+    let (mut app, _temp_dir) = crate::test_support::new_git_test_app().await;
+    let session_id = app
+        .create_session()
+        .await
+        .expect("session should be created");
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::Done);
+    let branch_operation_lock = Arc::clone(
+        &app.sessions
+            .session_handles_or_err(&session_id)
+            .expect("expected session handles")
+            .branch_operation_lock,
+    );
+    let existing_operation_guard = Arc::clone(&branch_operation_lock).lock_owned().await;
+    app.start_publish_branch_action(
+        ConfirmationViewMode {
+            scroll_offset: None,
+            session_id: session_id.clone().into(),
+        },
+        &session_id,
+        PublishBranchAction::PublishPullRequest,
+        None,
+    )
+    .await;
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::InProgress);
+
+    // Act
+    app.start_publish_branch_action(
+        ConfirmationViewMode {
+            scroll_offset: Some(4),
+            session_id: session_id.clone().into(),
+        },
+        &session_id,
+        PublishBranchAction::PublishPullRequest,
+        None,
+    )
+    .await;
+    let publish_body = app.sessions.state().sessions()[0]
+        .transient_messages
+        .get(TransientMessageSlot::BranchPublish)
+        .map(|message| &message.body);
+
+    // Assert
+    assert!(matches!(
+        app.mode,
+        AppMode::View {
+            session_id: ref viewed_session_id,
+            scroll_offset: Some(4),
+        } if viewed_session_id == &session_id
+    ));
+    assert!(matches!(
+        publish_body,
+        Some(TransientMessageBody::Queued(action))
+            if action.order == 0 && action.text == "review request — publish after this turn"
+    ));
+    drop(existing_operation_guard);
+}
+
+#[tokio::test]
 async fn review_request_enqueue_failure_replaces_queued_status_with_error() {
     // Arrange
     let (mut app, _temp_dir) = crate::test_support::new_git_test_app().await;
@@ -1948,9 +2051,10 @@ async fn apply_branch_publish_started_replaces_queued_label() {
         Arc::new(MockTmuxClient::new()),
     )
     .await;
-    app.sessions.start_branch_publish(
+    app.sessions.queue_branch_publish(
         "session-1",
-        "Review request queued; publishing after the current turn finishes...".to_string(),
+        0,
+        "review request — publish after this turn".to_string(),
     );
 
     // Act
@@ -1966,6 +2070,64 @@ async fn apply_branch_publish_started_replaces_queued_label() {
             .get(crate::domain::transient_message::TransientMessageSlot::BranchPublish)
             .map(|message| message.body.text()),
         Some("Publishing review request...")
+    );
+}
+
+#[tokio::test]
+async fn apply_branch_publish_resolved_retracts_waiting_row() {
+    // Arrange
+    let session_folder = tempdir().expect("failed to create temp dir");
+    let mut app = new_test_app_with_selected_session(
+        session_folder.path().to_path_buf(),
+        "",
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    app.sessions.queue_branch_publish(
+        "session-1",
+        0,
+        "review request — publish after this turn".to_string(),
+    );
+
+    // Act
+    app.apply_app_events(AppEvent::BranchPublishActionResolved {
+        session_id: "session-1".into(),
+    })
+    .await;
+
+    // Assert
+    assert!(
+        app.sessions.state().sessions()[0]
+            .transient_messages
+            .get(TransientMessageSlot::BranchPublish)
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn apply_queued_sync_resolved_retracts_waiting_row() {
+    // Arrange
+    let session_folder = tempdir().expect("failed to create temp dir");
+    let mut app = new_test_app_with_selected_session(
+        session_folder.path().to_path_buf(),
+        "",
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    app.sessions.queue_session_sync("session-1", 0);
+
+    // Act
+    app.apply_app_events(AppEvent::SessionQueuedSyncResolved {
+        session_id: "session-1".into(),
+    })
+    .await;
+
+    // Assert
+    assert!(
+        app.sessions.state().sessions()[0]
+            .transient_messages
+            .get(TransientMessageSlot::SyncQueue)
+            .is_none()
     );
 }
 
@@ -2773,6 +2935,12 @@ fn app_event_batch_collect_event_keeps_publish_results_and_latest_reviews() {
     event_batch.collect_event(AppEvent::BranchPublishActionStarted {
         session_id: "session-a".into(),
     });
+    event_batch.collect_event(AppEvent::BranchPublishActionResolved {
+        session_id: "session-b".into(),
+    });
+    event_batch.collect_event(AppEvent::SessionQueuedSyncResolved {
+        session_id: "session-b".into(),
+    });
 
     // Assert
     assert_eq!(
@@ -2804,8 +2972,18 @@ fn app_event_batch_collect_event_keeps_publish_results_and_latest_reviews() {
     );
     assert!(
         event_batch
+            .branch_publish_resolved_session_ids
+            .contains("session-b")
+    );
+    assert!(
+        event_batch
             .branch_publish_started_session_ids
             .contains("session-a")
+    );
+    assert!(
+        event_batch
+            .session_queued_sync_resolved_ids
+            .contains("session-b")
     );
     assert!(event_batch.should_refresh_git_status);
 }

--- a/crates/agentty/src/app/prompt_intent.rs
+++ b/crates/agentty/src/app/prompt_intent.rs
@@ -1252,10 +1252,7 @@ mod tests {
                 session_id: session_id.clone(),
             }
         );
-        assert_eq!(
-            app.sessions.sessions()[0].queued_messages,
-            [] as [std::string::String; 0]
-        );
+        assert!(app.sessions.sessions()[0].queued_messages.is_empty());
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/service.rs
+++ b/crates/agentty/src/app/service.rs
@@ -328,7 +328,9 @@ fn app_event_label(event: &AppEvent) -> &'static str {
         AppEvent::SessionDiffStatsUpdated { .. } => "SessionDiffStatsUpdated",
         AppEvent::SessionTitleGenerationFinished { .. } => "SessionTitleGenerationFinished",
         AppEvent::BranchPublishActionCompleted { .. } => "BranchPublishActionCompleted",
+        AppEvent::BranchPublishActionResolved { .. } => "BranchPublishActionResolved",
         AppEvent::BranchPublishActionStarted { .. } => "BranchPublishActionStarted",
+        AppEvent::SessionQueuedSyncResolved { .. } => "SessionQueuedSyncResolved",
         AppEvent::ReviewPrepared { .. } => "ReviewPrepared",
         AppEvent::ReviewPreparationFailed { .. } => "ReviewPreparationFailed",
         AppEvent::FocusedReviewPersistenceRetry { .. } => "FocusedReviewPersistenceRetry",
@@ -448,6 +450,34 @@ mod tests {
 
         // Assert
         assert_eq!(label, "BranchPublishActionStarted");
+    }
+
+    #[test]
+    fn app_event_label_names_branch_publish_resolutions() {
+        // Arrange
+        let event = AppEvent::BranchPublishActionResolved {
+            session_id: "session-id".into(),
+        };
+
+        // Act
+        let label = app_event_label(&event);
+
+        // Assert
+        assert_eq!(label, "BranchPublishActionResolved");
+    }
+
+    #[test]
+    fn app_event_label_names_queued_sync_resolutions() {
+        // Arrange
+        let event = AppEvent::SessionQueuedSyncResolved {
+            session_id: "session-id".into(),
+        };
+
+        // Act
+        let label = app_event_label(&event);
+
+        // Assert
+        assert_eq!(label, "SessionQueuedSyncResolved");
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -28,8 +28,8 @@ use crate::domain::session::{
 use crate::domain::session_message::SessionMessageKind;
 use crate::domain::transcript_notice::TranscriptNotice;
 use crate::domain::transient_message::{
-    TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
-    TransientMessageSlot,
+    QueuedAction, TransientMessage, TransientMessageAnchor, TransientMessageBody,
+    TransientMessageLifecycle, TransientMessageSlot,
 };
 
 /// Low-frequency fallback interval for metadata-based session refresh.
@@ -561,6 +561,78 @@ impl SessionManager {
                 slot: TransientMessageSlot::BranchPublish,
                 turn_position: session.latest_user_prompt_position(),
             });
+        }
+    }
+
+    /// Shows one review-request publish action waiting behind the active turn.
+    pub(crate) fn queue_branch_publish(
+        &mut self,
+        session_id: &str,
+        order: u64,
+        queued_label: String,
+    ) {
+        if let Some(session) = self
+            .state
+            .sessions
+            .iter_mut()
+            .find(|session| session.id == session_id)
+        {
+            session.transient_messages.upsert(TransientMessage {
+                anchor: TransientMessageAnchor::Tail,
+                body: TransientMessageBody::Queued(QueuedAction::new(order, queued_label)),
+                lifecycle: TransientMessageLifecycle::UntilResolved,
+                slot: TransientMessageSlot::BranchPublish,
+                turn_position: session.latest_user_prompt_position(),
+            });
+        }
+    }
+
+    /// Removes a queued review-request row that resolved without starting.
+    pub(crate) fn resolve_queued_branch_publish(&mut self, session_id: &str) {
+        if let Some(session) = self
+            .state
+            .sessions
+            .iter_mut()
+            .find(|session| session.id == session_id)
+        {
+            session
+                .transient_messages
+                .retract(TransientMessageSlot::BranchPublish);
+        }
+    }
+
+    /// Shows one session sync waiting behind the active turn.
+    pub(crate) fn queue_session_sync(&mut self, session_id: &str, order: u64) {
+        if let Some(session) = self
+            .state
+            .sessions
+            .iter_mut()
+            .find(|session| session.id == session_id)
+        {
+            session.transient_messages.upsert(TransientMessage {
+                anchor: TransientMessageAnchor::Tail,
+                body: TransientMessageBody::Queued(QueuedAction::new(
+                    order,
+                    "sync — rebase onto the base branch after this turn".to_string(),
+                )),
+                lifecycle: TransientMessageLifecycle::UntilResolved,
+                slot: TransientMessageSlot::SyncQueue,
+                turn_position: session.latest_user_prompt_position(),
+            });
+        }
+    }
+
+    /// Removes a queued-sync row after its worker command resolves or starts.
+    pub(crate) fn resolve_queued_session_sync(&mut self, session_id: &str) {
+        if let Some(session) = self
+            .state
+            .sessions
+            .iter_mut()
+            .find(|session| session.id == session_id)
+        {
+            session
+                .transient_messages
+                .retract(TransientMessageSlot::SyncQueue);
         }
     }
 

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -875,6 +875,56 @@ fn test_append_workflow_notice_anchors_active_status_notices_after_active_turn()
 }
 
 #[test]
+fn test_queued_session_actions_use_explicit_waiting_slots_until_resolved() {
+    // Arrange
+    let mut session_manager = test_session_manager("session-id", None);
+
+    // Act
+    session_manager.queue_branch_publish(
+        "session-id",
+        3,
+        "review request — publish after this turn".to_string(),
+    );
+    session_manager.queue_session_sync("session-id", 4);
+
+    // Assert
+    let transient_messages = &session_manager.sessions()[0].transient_messages;
+    assert!(matches!(
+        transient_messages
+            .get(TransientMessageSlot::BranchPublish)
+            .map(|message| &message.body),
+        Some(TransientMessageBody::Queued(label))
+            if label.order == 3 && label.text == "review request — publish after this turn"
+    ));
+    assert!(matches!(
+        transient_messages
+            .get(TransientMessageSlot::SyncQueue)
+            .map(|message| &message.body),
+        Some(TransientMessageBody::Queued(label))
+            if label.order == 4
+                && label.text == "sync — rebase onto the base branch after this turn"
+    ));
+
+    // Act
+    session_manager.resolve_queued_branch_publish("session-id");
+    session_manager.resolve_queued_session_sync("session-id");
+
+    // Assert
+    assert!(
+        session_manager.sessions()[0]
+            .transient_messages
+            .get(TransientMessageSlot::BranchPublish)
+            .is_none()
+    );
+    assert!(
+        session_manager.sessions()[0]
+            .transient_messages
+            .get(TransientMessageSlot::SyncQueue)
+            .is_none()
+    );
+}
+
+#[test]
 fn test_finish_review_request_publish_keeps_loading_review_at_tail() {
     // Arrange
     let mut session_manager = test_session_manager("session-id", None);
@@ -2870,7 +2920,7 @@ async fn test_enqueue_message_pushes_prompt_onto_in_memory_queue() {
         .iter()
         .find(|session| session.id == session_id)
         .expect("session present");
-    assert_eq!(session.queued_messages, vec!["queued reply".to_string()]);
+    assert_eq!(session.queued_messages[0].transcript_text(), "queued reply");
     let handles = app
         .sessions
         .session_handles()
@@ -2887,7 +2937,7 @@ async fn test_enqueue_message_pushes_prompt_onto_in_memory_queue() {
 /// `Session` snapshot with `queued_messages: Vec::new()`. The post-reload
 /// `sync_session_with_handles` did not restore `queued_messages` from the
 /// handles, so the just-pushed entry was silently wiped on the next
-/// reducer pass and the inline `queued ›` row briefly disappeared from
+/// reducer pass and the inline `≡ queued ›` row briefly disappeared from
 /// the transcript before reappearing on a later mutation.
 async fn test_enqueue_message_survives_refresh_sessions_reducer_pass() {
     // Arrange
@@ -2911,8 +2961,8 @@ async fn test_enqueue_message_survives_refresh_sessions_reducer_pass() {
         .find(|session| session.id == session_id)
         .expect("session present");
     assert_eq!(
-        session.queued_messages,
-        vec!["queued reply".to_string()],
+        session.queued_messages[0].transcript_text(),
+        "queued reply",
         "queued_messages snapshot must be re-projected from handles after a RefreshSessions \
          reducer pass instead of being wiped to an empty vec"
     );
@@ -2946,7 +2996,7 @@ async fn test_enqueue_message_rejects_empty_payload() {
         .iter()
         .find(|session| session.id == session_id)
         .expect("session present");
-    assert_eq!(session.queued_messages, [] as [std::string::String; 0]);
+    assert!(session.queued_messages.is_empty());
 }
 
 #[tokio::test]
@@ -4200,28 +4250,23 @@ async fn test_running_turn_finishes_before_queued_sync_and_later_chat() {
         .expect("later chat message should queue");
 
     // Assert
-    app.sessions.sync_from_handles();
-    assert_eq!(app.sessions.sessions()[0].status, Status::InProgress);
-    let active_turn_was_cancelled = app
-        .sessions
-        .session_handles()
-        .get(session_id.as_str())
-        .expect("missing session handles")
-        .cancel_token
-        .lock()
-        .expect("cancel token lock should not be poisoned")
-        .is_cancelled();
-    assert!(!active_turn_was_cancelled);
-    assert!(!session_replay_text(&app.sessions.sessions()[0]).contains("Successfully synced"));
+    assert_sync_waits_without_canceling_turn(&mut app, &session_id);
 
     // Act
     release_first_turn.notify_one();
     assert_eq!(turn_started_rx.recv().await, Some(1));
-    wait_for_output_contains(&mut app, &session_id, "Queued turn completed", 300).await;
+    wait_for_output_contains_after_events(&mut app, &session_id, "Queued turn completed", 300)
+        .await;
 
     // Assert
     app.sessions.sync_from_handles();
     let transcript = session_replay_text(&app.sessions.sessions()[0]);
+    assert!(
+        app.sessions.sessions()[0]
+            .transient_messages
+            .get(TransientMessageSlot::SyncQueue)
+            .is_none()
+    );
     let initial_answer_index = transcript
         .find("Initial turn completed")
         .expect("missing completed initial turn");
@@ -4233,6 +4278,29 @@ async fn test_running_turn_finishes_before_queued_sync_and_later_chat() {
         .expect("missing later queued prompt");
     assert!(initial_answer_index < sync_completion_index);
     assert!(sync_completion_index < queued_prompt_index);
+}
+
+fn assert_sync_waits_without_canceling_turn(app: &mut App, session_id: &str) {
+    app.sessions.sync_from_handles();
+    assert_eq!(app.sessions.sessions()[0].status, Status::InProgress);
+    let active_turn_was_cancelled = app
+        .sessions
+        .session_handles()
+        .get(session_id)
+        .expect("missing session handles")
+        .cancel_token
+        .lock()
+        .expect("cancel token lock should not be poisoned")
+        .is_cancelled();
+    assert!(!active_turn_was_cancelled);
+    assert!(!session_replay_text(&app.sessions.sessions()[0]).contains("Successfully synced"));
+    assert!(matches!(
+        app.sessions.sessions()[0]
+            .transient_messages
+            .get(TransientMessageSlot::SyncQueue)
+            .map(|message| &message.body),
+        Some(TransientMessageBody::Queued(_))
+    ));
 }
 
 #[tokio::test]

--- a/crates/agentty/src/app/session/state.rs
+++ b/crates/agentty/src/app/session/state.rs
@@ -423,7 +423,7 @@ impl SessionState {
     ///
     /// The handles are the single source of truth for `status`, the typed
     /// transcript, and the in-memory chat queue. `queued_messages` is rebuilt
-    /// from `SessionHandles::queued_message_transcripts()` so any
+    /// from `SessionHandles::queued_message_snapshot()` so any
     /// handle-driven mutation (lifecycle enqueue, worker drain between
     /// turns, runtime LIFO pop) becomes visible on the very next sync
     /// without callers also having to mirror the change into the snapshot
@@ -437,7 +437,7 @@ impl SessionState {
             session.transcript = (!transcript.is_empty()).then(|| transcript.clone());
         }
 
-        session.queued_messages = session_handles.queued_message_transcripts();
+        session.queued_messages = session_handles.queued_message_snapshot();
     }
 
     /// Advances the selected follow-up task for one session in the requested

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -24,7 +24,7 @@ use crate::domain::agent::{
     AgentKind, AgentSelection, AgentSelectionMetadata, ReasoningLevel, SpeedMode,
 };
 use crate::domain::session::{
-    ReviewRequest, SESSION_DATA_DIR, Session, SessionHandles, SessionId, Status,
+    QueuedMessage, ReviewRequest, SESSION_DATA_DIR, Session, SessionHandles, SessionId, Status,
     can_merge_session_branch_in_stack as stack_can_merge_session_branch,
     can_mutate_session_branch_in_stack as stack_can_mutate_session_branch,
     can_rebase_session_branch_in_stack as stack_can_rebase_session_branch,
@@ -1546,7 +1546,7 @@ impl SessionManager {
     /// press cancels the active turn.
     ///
     /// The just-pushed entry is mirrored into the render snapshot via
-    /// [`SessionState::sync_session_from_handle`] so the inline `queued ›`
+    /// [`SessionState::sync_session_from_handle`] so the inline `≡ queued ›`
     /// row appears on the very next frame, and the targeted
     /// [`AppEvent::SessionUpdated`] event triggers a single-session redraw
     /// without paying for a full DB-backed `RefreshSessions` reload.
@@ -1578,8 +1578,9 @@ impl SessionManager {
 
         // Sync critical section (single push, no `.await`); `std::sync::Mutex`
         // is the correct choice per CLAUDE.md §"Mutex Selection".
+        let order = handles.next_queued_work_order();
         if let Ok(mut guard) = handles.queued_messages.lock() {
-            guard.push_back(prompt);
+            guard.push_back(QueuedMessage::new(order, prompt));
         }
 
         self.state.sync_session_from_handle(session_id);
@@ -2457,7 +2458,7 @@ impl SessionManager {
             self.worker_service_mut()
                 .enqueue_existing_session_command(services, &persisted_session_id, command)
                 .await
-                .map(|()| true)
+                .map(|_| true)
         } else {
             self.enqueue_session_command(services, persisted_session_id, command)
                 .await

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -12,7 +12,7 @@ use crate::domain::agent::{
 };
 use crate::domain::question::QuestionItem;
 use crate::domain::session::{
-    DailyActivity, ReviewRequest, ReviewRequestSummary, Session, SessionDiffState,
+    DailyActivity, QueuedMessage, ReviewRequest, ReviewRequestSummary, Session, SessionDiffState,
     SessionDiffStats, SessionFollowUpTask, SessionHandles, SessionId, SessionRole, SessionSize,
     SessionStats, Status, activity_day_key_with_offset,
 };
@@ -74,7 +74,7 @@ struct LoadedSessionInput {
     session_agent: AgentSelection,
     session_id: SessionId,
     session_prompt: String,
-    session_queued_messages: Vec<String>,
+    session_queued_messages: Vec<QueuedMessage>,
     session_questions: Vec<QuestionItem>,
     session_summary: Option<String>,
     session_status: Status,
@@ -312,7 +312,7 @@ impl SessionManager {
         let speed_mode = row.speed_mode.parse::<SpeedMode>().unwrap_or_default();
         let session_queued_messages = handles
             .get(&session_id)
-            .map(SessionHandles::queued_message_transcripts)
+            .map(SessionHandles::queued_message_snapshot)
             .unwrap_or_default();
         let (role, orchestration_metadata) =
             Self::loaded_orchestration_metadata(&row, orchestration_metadata);

--- a/crates/agentty/src/app/session/workflow/merge.rs
+++ b/crates/agentty/src/app/session/workflow/merge.rs
@@ -876,17 +876,11 @@ impl SessionMergeService {
                 return Ok(());
             }
 
-            manager
+            let queued_order = manager
                 .worker_service_mut()
                 .enqueue_existing_session_command(services, &persisted_session_id, command)
                 .await?;
-            SessionTaskService::emit_session_workflow_notice(
-                &services.event_sender(),
-                persisted_session_id.as_str(),
-                TranscriptNotice::Rebase.format(
-                    "Queued sync; this session will rebase after the current turn finishes.",
-                ),
-            );
+            manager.queue_session_sync(persisted_session_id.as_str(), queued_order);
         } else {
             let handles = manager
                 .session_handles_or_err(session_id)
@@ -1862,6 +1856,9 @@ impl SessionManager {
         status_transition
             .apply_or_invalid_transition(Status::Rebasing)
             .await?;
+        let _ = app_event_tx.send(AppEvent::SessionQueuedSyncResolved {
+            session_id: id.clone(),
+        });
 
         let rebase_result: Result<String, SessionError> = async {
             let rebase_plan = Self::resolve_session_rebase_plan(

--- a/crates/agentty/src/app/session/workflow/post_turn.rs
+++ b/crates/agentty/src/app/session/workflow/post_turn.rs
@@ -20,10 +20,11 @@ use crate::app::assist::AssistContext;
 use crate::app::service::SessionUpdateVersionMap;
 use crate::app::session::{Clock, SessionError, TurnAppliedState};
 use crate::app::{AppEvent, orchestration};
-use crate::domain::session::{SessionFollowUpTask, SessionId, SessionRole, SessionStats, Status};
+use crate::domain::session::{
+    QueuedMessage, SessionFollowUpTask, SessionId, SessionRole, SessionStats, Status,
+};
 use crate::domain::session_message::{SessionMessageKind, SessionTranscript};
 use crate::domain::transcript_notice::TranscriptNotice;
-use crate::domain::turn_prompt::TurnPrompt;
 use crate::infra::db::{AppRepositories, SessionTurnMetadata};
 use crate::infra::fs::FsClient;
 
@@ -61,7 +62,7 @@ pub(super) struct PostTurnContext {
     /// Provider-neutral boundary used by post-turn auto-commit prompts.
     pub(super) one_shot_client: Arc<dyn OneShotClient>,
     /// In-memory queue checked before starting detached auto-push effects.
-    pub(super) queued_messages: Arc<Mutex<VecDeque<TurnPrompt>>>,
+    pub(super) queued_messages: Arc<Mutex<VecDeque<QueuedMessage>>>,
     /// Forge boundary used for optional linked PR/MR metadata refresh.
     pub(super) review_request_client: Arc<dyn forge::ReviewRequestClient>,
     /// Per-app session update versions shared with the main runtime.

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -32,8 +33,11 @@ use crate::app::service::SessionUpdateVersionMap;
 use crate::app::session::{Clock, SessionError, unix_timestamp_from_system_time};
 use crate::app::{AppEvent, AppServices, SessionManager};
 use crate::domain::agent::AgentSelection;
-use crate::domain::session::{PublishBranchAction, ReviewRequest, SessionId, SessionStats, Status};
+use crate::domain::session::{
+    PublishBranchAction, QueuedMessage, ReviewRequest, SessionId, SessionStats, Status,
+};
 use crate::domain::session_message::{SessionMessageKind, SessionTranscript};
+use crate::domain::transcript_notice::TranscriptNotice;
 use crate::domain::turn_prompt::TurnPrompt;
 use crate::infra::db::{AppRepositories, OperationRepository, SessionOperationRow};
 use crate::infra::fs::FsClient;
@@ -151,6 +155,56 @@ impl SessionCommand {
     }
 }
 
+/// Worker command paired with its shared queue order when it was submitted
+/// behind active work.
+struct ScheduledSessionCommand {
+    command: SessionCommand,
+    queued_order: Option<u64>,
+}
+
+impl ScheduledSessionCommand {
+    /// Returns whether this command can make a questioned session runnable.
+    fn can_run_while_question(&self) -> bool {
+        self.queued_order.is_none() || matches!(self.command, SessionCommand::Run { .. })
+    }
+
+    /// Wraps a command that is ready to run without joining the visible queue.
+    fn immediate(command: SessionCommand) -> Self {
+        Self {
+            command,
+            queued_order: None,
+        }
+    }
+
+    /// Wraps a command queued at the supplied shared submission order.
+    fn queued(command: SessionCommand, queued_order: u64) -> Self {
+        Self {
+            command,
+            queued_order: Some(queued_order),
+        }
+    }
+}
+
+/// Sender and shared ordering source owned by one active session worker.
+#[derive(Clone)]
+struct SessionWorkerHandle {
+    queued_work_sequence: Arc<AtomicU64>,
+    sender: mpsc::UnboundedSender<ScheduledSessionCommand>,
+}
+
+impl SessionWorkerHandle {
+    /// Reserves the next submission order shared with queued chat messages.
+    fn next_queued_work_order(&self) -> u64 {
+        self.queued_work_sequence.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+/// Next unit selected from the combined action and chat queues.
+enum ScheduledSessionWork {
+    Command(Box<ScheduledSessionCommand>),
+    Message(QueuedMessage),
+}
+
 /// Returns whether the session has a queued or running rebase operation.
 pub(super) fn has_unfinished_rebase_operation(
     operations: &[SessionOperationRow],
@@ -201,7 +255,7 @@ pub(super) struct SessionWorkerContext {
     /// Shared with [`SessionHandles::queued_messages`]. The worker drains
     /// this queue between turns; the lifecycle pushes new entries when a
     /// user submits a chat message during a running turn.
-    pub(super) queued_messages: Arc<Mutex<VecDeque<TurnPrompt>>>,
+    pub(super) queued_messages: Arc<Mutex<VecDeque<QueuedMessage>>>,
     pub(super) review_request_client: Arc<dyn forge::ReviewRequestClient>,
     /// Per-app session update versions shared with the main runtime.
     pub(super) session_update_versions: SessionUpdateVersionMap,
@@ -213,8 +267,16 @@ pub(super) struct SessionWorkerContext {
 }
 
 impl SessionWorkerContext {
-    /// Pops the next queued prompt for dispatch as a follow-up turn.
-    fn pop_queued_prompt(&self) -> Option<TurnPrompt> {
+    /// Returns the submission order of the next queued chat prompt.
+    fn next_queued_message_order(&self) -> Option<u64> {
+        self.queued_messages
+            .lock()
+            .ok()
+            .and_then(|guard| guard.front().map(QueuedMessage::order))
+    }
+
+    /// Pops the next queued chat message for dispatch as a follow-up turn.
+    fn pop_queued_message(&self) -> Option<QueuedMessage> {
         // Sync critical section (single pop, no `.await`); `std::sync::Mutex`
         // is the correct choice per CLAUDE.md §"Mutex Selection".
         self.queued_messages
@@ -539,7 +601,8 @@ pub(super) struct SessionWorkerRuntime {
     child_pid: Arc<Mutex<Option<u32>>>,
     folder: PathBuf,
     personality_catalog_client: Arc<dyn PersonalityCatalogClient>,
-    queued_messages: Arc<Mutex<VecDeque<TurnPrompt>>>,
+    queued_messages: Arc<Mutex<VecDeque<QueuedMessage>>>,
+    queued_work_sequence: Arc<AtomicU64>,
     review_request_client: Arc<dyn forge::ReviewRequestClient>,
     /// Per-app session update versions shared with the main runtime.
     session_update_versions: SessionUpdateVersionMap,
@@ -559,7 +622,7 @@ pub(crate) struct SessionWorkerService {
     /// default factory, enabling deterministic command execution without
     /// spawning real provider processes.
     pub(in crate::app::session) test_agent_channels: HashMap<SessionId, Arc<dyn AgentChannel>>,
-    workers: HashMap<SessionId, mpsc::UnboundedSender<SessionCommand>>,
+    workers: HashMap<SessionId, SessionWorkerHandle>,
 }
 
 impl SessionWorkerService {
@@ -657,9 +720,9 @@ impl SessionWorkerService {
         command: SessionCommand,
     ) -> Result<(), SessionError> {
         let session_id = runtime.session_id.clone();
-        let sender = self.ensure_session_worker(services, &runtime);
+        let worker = self.ensure_session_worker(services, &runtime);
 
-        self.persist_and_send_command(services, &session_id, sender, command)
+        self.persist_and_send_command(services, &session_id, worker, command)
             .await
     }
 
@@ -688,9 +751,14 @@ impl SessionWorkerService {
             return Ok(false);
         }
 
-        let sender = self.ensure_session_worker(services, &runtime);
-        self.send_persisted_command(services.db().operations(), &session_id, sender, command)
-            .await?;
+        let worker = self.ensure_session_worker(services, &runtime);
+        self.send_persisted_command(
+            services.db().operations(),
+            &session_id,
+            worker.sender,
+            ScheduledSessionCommand::immediate(command),
+        )
+        .await?;
 
         Ok(true)
     }
@@ -710,16 +778,30 @@ impl SessionWorkerService {
         services: &AppServices,
         session_id: &SessionId,
         command: SessionCommand,
-    ) -> Result<(), SessionError> {
-        let sender = self.workers.get(session_id).cloned().ok_or_else(|| {
+    ) -> Result<u64, SessionError> {
+        let worker = self.workers.get(session_id).cloned().ok_or_else(|| {
             SessionError::Workflow(
                 "Cannot queue session action because the active session worker is unavailable"
                     .to_string(),
             )
         })?;
+        let operation_id = command.operation_id().to_string();
+        services
+            .db()
+            .operations()
+            .insert_session_operation(&operation_id, session_id, command.kind())
+            .await?;
+        let queued_order = worker.next_queued_work_order();
 
-        self.persist_and_send_command(services, session_id, sender, command)
-            .await
+        self.send_persisted_command(
+            services.db().operations(),
+            session_id,
+            worker.sender,
+            ScheduledSessionCommand::queued(command, queued_order),
+        )
+        .await?;
+
+        Ok(queued_order)
     }
 
     /// Drops the in-memory worker sender for a session.
@@ -738,9 +820,9 @@ impl SessionWorkerService {
         &mut self,
         services: &AppServices,
         runtime: &SessionWorkerRuntime,
-    ) -> mpsc::UnboundedSender<SessionCommand> {
-        if let Some(sender) = self.workers.get(&runtime.session_id) {
-            return sender.clone();
+    ) -> SessionWorkerHandle {
+        if let Some(worker) = self.workers.get(&runtime.session_id) {
+            return worker.clone();
         }
 
         // When a pre-registered channel exists, reuse it; otherwise fall back
@@ -776,11 +858,15 @@ impl SessionWorkerService {
             transcript: Arc::clone(&runtime.transcript),
         };
         let (sender, receiver) = mpsc::unbounded_channel();
+        let worker = SessionWorkerHandle {
+            queued_work_sequence: Arc::clone(&runtime.queued_work_sequence),
+            sender,
+        };
         self.workers
-            .insert(runtime.session_id.clone(), sender.clone());
+            .insert(runtime.session_id.clone(), worker.clone());
         Self::spawn_session_worker(context, services.one_shot_client(), receiver);
 
-        sender
+        worker
     }
 
     /// Persists one operation and sends its command to the selected worker.
@@ -788,7 +874,7 @@ impl SessionWorkerService {
         &mut self,
         services: &AppServices,
         session_id: &SessionId,
-        sender: mpsc::UnboundedSender<SessionCommand>,
+        worker: SessionWorkerHandle,
         command: SessionCommand,
     ) -> Result<(), SessionError> {
         let operation_id = command.operation_id().to_string();
@@ -798,8 +884,13 @@ impl SessionWorkerService {
             .insert_session_operation(&operation_id, session_id, command.kind())
             .await?;
 
-        self.send_persisted_command(services.db().operations(), session_id, sender, command)
-            .await
+        self.send_persisted_command(
+            services.db().operations(),
+            session_id,
+            worker.sender,
+            ScheduledSessionCommand::immediate(command),
+        )
+        .await
     }
 
     /// Sends one command whose operation row has already been persisted.
@@ -807,11 +898,11 @@ impl SessionWorkerService {
         &mut self,
         operations: &dyn OperationRepository,
         session_id: &SessionId,
-        sender: mpsc::UnboundedSender<SessionCommand>,
-        command: SessionCommand,
+        sender: mpsc::UnboundedSender<ScheduledSessionCommand>,
+        scheduled_command: ScheduledSessionCommand,
     ) -> Result<(), SessionError> {
-        let operation_id = command.operation_id().to_string();
-        if sender.send(command).is_err() {
+        let operation_id = scheduled_command.command.operation_id().to_string();
+        if sender.send(scheduled_command).is_err() {
             self.workers.remove(session_id);
             // Best-effort: operation tracking metadata is non-critical.
             let _ = operations
@@ -828,41 +919,42 @@ impl SessionWorkerService {
 
     /// Spawns the background loop that executes queued session commands.
     ///
-    /// After each command completes the worker drains
-    /// [`SessionWorkerContext::queued_messages`] inline so user prompts
-    /// submitted while a turn was running dispatch as follow-up turns
-    /// without bouncing the session through `Review` between them. Drainage
-    /// pauses while the session is in `Question` state and resumes once
-    /// status returns to a runnable state. A turn stopped by the user
-    /// (`Ctrl+C`) clears the queue so canceled work does not silently leak
-    /// into the next session activity.
+    /// Queued workflow actions and chat messages share one submission order,
+    /// so the next displayed row is always the next work executed. Scheduling
+    /// pauses while the session is in `Question` state, except for an
+    /// immediate answer command that makes the session runnable again. A turn
+    /// stopped by the user (`Ctrl+C`) clears queued chat so canceled work does
+    /// not silently leak into the next session activity.
     fn spawn_session_worker(
         context: SessionWorkerContext,
         one_shot_client: Arc<dyn OneShotClient>,
-        mut receiver: mpsc::UnboundedReceiver<SessionCommand>,
+        mut receiver: mpsc::UnboundedReceiver<ScheduledSessionCommand>,
     ) {
         tokio::spawn(async move {
-            while let Some(command) = receiver.recv().await {
-                let mut next_command = Some(command);
-                while let Some(command) = next_command.take() {
-                    let result =
-                        Self::process_session_command(&context, &one_shot_client, command).await;
-                    if matches!(result, Some(Err(SessionError::StoppedByUser(_)))) {
-                        context.clear_queued_messages();
-                        Self::emit_queue_session_updated(&context);
-
-                        break;
-                    }
-
-                    next_command = receiver.try_recv().ok();
-                    if next_command.is_some() {
-                        continue;
-                    }
-
-                    next_command =
-                        Self::drain_queued_messages(&context, &one_shot_client, &mut receiver)
-                            .await;
+            let mut pending_commands = VecDeque::new();
+            loop {
+                while let Ok(command) = receiver.try_recv() {
+                    pending_commands.push_back(command);
                 }
+
+                let Some(work) = Self::next_scheduled_work(&context, &mut pending_commands) else {
+                    let Some(command) = receiver.recv().await else {
+                        break;
+                    };
+                    pending_commands.push_back(command);
+
+                    continue;
+                };
+                let result = match work {
+                    ScheduledSessionWork::Command(command) => {
+                        Self::process_session_command(&context, &one_shot_client, command.command)
+                            .await
+                    }
+                    ScheduledSessionWork::Message(message) => {
+                        Self::process_queued_message(&context, &one_shot_client, message).await
+                    }
+                };
+                Self::clear_queued_messages_after_stop(&context, result.as_ref());
             }
 
             // Best-effort: session transport may already be torn down.
@@ -877,6 +969,60 @@ impl SessionWorkerService {
                 *guard = None;
             }
         });
+    }
+
+    /// Selects the oldest runnable work across workflow and chat queues.
+    fn next_scheduled_work(
+        context: &SessionWorkerContext,
+        pending_commands: &mut VecDeque<ScheduledSessionCommand>,
+    ) -> Option<ScheduledSessionWork> {
+        if matches!(context.current_status(), Status::Question) {
+            let runnable_index = pending_commands
+                .iter()
+                .position(ScheduledSessionCommand::can_run_while_question)?;
+
+            return pending_commands
+                .remove(runnable_index)
+                .map(Box::new)
+                .map(ScheduledSessionWork::Command);
+        }
+        if pending_commands
+            .front()
+            .is_some_and(|command| command.queued_order.is_none())
+        {
+            return pending_commands
+                .pop_front()
+                .map(Box::new)
+                .map(ScheduledSessionWork::Command);
+        }
+
+        let command_order = pending_commands
+            .front()
+            .and_then(|command| command.queued_order);
+        let message_order = context.next_queued_message_order();
+        if command_order.is_some_and(|command_order| {
+            message_order.is_none_or(|message_order| command_order <= message_order)
+        }) {
+            return pending_commands
+                .pop_front()
+                .map(Box::new)
+                .map(ScheduledSessionWork::Command);
+        }
+
+        context
+            .pop_queued_message()
+            .map(ScheduledSessionWork::Message)
+    }
+
+    /// Clears pending chat messages when the work just stopped by user action.
+    fn clear_queued_messages_after_stop(
+        context: &SessionWorkerContext,
+        result: Option<&Result<(), SessionError>>,
+    ) {
+        if matches!(result, Some(Err(SessionError::StoppedByUser(_)))) {
+            context.clear_queued_messages();
+            Self::emit_queue_session_updated(context);
+        }
     }
 
     /// Executes one queued session command including its operation
@@ -902,7 +1048,7 @@ impl SessionWorkerService {
             Self::should_skip_worker_command(context, &operation_id).await
         };
         if should_skip {
-            Self::complete_skipped_review_request_response(&command);
+            Self::complete_skipped_session_command(context, &command);
 
             return None;
         }
@@ -930,9 +1076,25 @@ impl SessionWorkerService {
         Some(result)
     }
 
-    /// Answers a programmatic review-request caller when its queued command
-    /// is canceled or otherwise finished before worker execution begins.
-    fn complete_skipped_review_request_response(command: &SessionCommand) {
+    /// Resolves external observers when a queued command is canceled or
+    /// otherwise finishes before worker execution begins.
+    fn complete_skipped_session_command(context: &SessionWorkerContext, command: &SessionCommand) {
+        if matches!(command, SessionCommand::CreateReviewRequest { .. }) {
+            let _ = context
+                .app_event_tx
+                .send(AppEvent::BranchPublishActionResolved {
+                    session_id: context.session_id.clone(),
+                });
+        }
+
+        if matches!(command, SessionCommand::Rebase { .. }) {
+            let _ = context
+                .app_event_tx
+                .send(AppEvent::SessionQueuedSyncResolved {
+                    session_id: context.session_id.clone(),
+                });
+        }
+
         if let SessionCommand::CreateReviewRequest {
             response: Some(response),
             ..
@@ -946,66 +1108,45 @@ impl SessionWorkerService {
         }
     }
 
-    /// Pops queued prompts and dispatches them as follow-up `SessionResume`
-    /// turns until the queue is empty, the session enters `Question` state,
-    /// or a worker command is pending.
+    /// Dispatches one queued chat message as a follow-up `SessionResume` turn.
     ///
-    /// Each drained turn is persisted as its own `reply` operation with a
-    /// fresh identifier so cancellation, retry, and operation tracking
-    /// behave the same as a normal reply. Worker commands are checked before
-    /// every queued turn, so a command received during an active turn waits
-    /// for that turn to finish and then preempts the remaining chat queue.
-    /// The drain stops on the first user-stopped turn and clears the remaining
-    /// queue so `Ctrl+C` cancels the queued work cleanly.
-    async fn drain_queued_messages(
+    /// The turn is persisted as its own `reply` operation with a fresh
+    /// identifier so cancellation, retry, and operation tracking behave the
+    /// same as a normal reply.
+    async fn process_queued_message(
         context: &SessionWorkerContext,
         one_shot_client: &Arc<dyn OneShotClient>,
-        receiver: &mut mpsc::UnboundedReceiver<SessionCommand>,
-    ) -> Option<SessionCommand> {
-        loop {
-            if matches!(context.current_status(), Status::Question) {
-                return None;
-            }
-            if let Ok(command) = receiver.try_recv() {
-                return Some(command);
-            }
-            let prompt = context.pop_queued_prompt()?;
+        message: QueuedMessage,
+    ) -> Option<Result<(), SessionError>> {
+        let prompt = message.into_prompt();
 
-            // Mirror the queue change into render snapshots so the inline
-            // "queued" rows disappear as soon as drainage starts the
-            // follow-up turn. The targeted `SessionUpdated` event re-syncs
-            // only this session's snapshot from handles instead of paying for
-            // a full DB-backed `RefreshSessions` reload.
-            Self::emit_queue_session_updated(context);
+        // Mirror the queue change into render snapshots so the inline queued
+        // row disappears as soon as the follow-up turn starts. The targeted
+        // event re-syncs only this session from handles.
+        Self::emit_queue_session_updated(context);
 
-            let operation_id = Uuid::new_v4().to_string();
-            // Best-effort: operation tracking metadata is non-critical.
-            let _ = context
-                .db
-                .operations()
-                .insert_session_operation(&operation_id, &context.session_id, "reply")
-                .await;
-            let published_upstream_ref = context.load_published_upstream_ref().await;
-            append_drained_prompt_to_transcript(context, &prompt).await;
-            let command = SessionCommand::Run {
-                operation_id,
-                request_kind: AgentRequestKind::SessionResume,
-                replay_transcript: None,
-                prompt,
-                turn_metadata: TurnMetadata {
-                    published_upstream_ref,
-                    review_comment_thread_ids: Vec::new(),
-                    session_agent: context.session_agent,
-                },
-            };
-            let result = Self::process_session_command(context, one_shot_client, command).await;
-            if matches!(result, Some(Err(SessionError::StoppedByUser(_)))) {
-                context.clear_queued_messages();
-                Self::emit_queue_session_updated(context);
+        let operation_id = Uuid::new_v4().to_string();
+        // Best-effort: operation tracking metadata is non-critical.
+        let _ = context
+            .db
+            .operations()
+            .insert_session_operation(&operation_id, &context.session_id, "reply")
+            .await;
+        let published_upstream_ref = context.load_published_upstream_ref().await;
+        append_drained_prompt_to_transcript(context, &prompt).await;
+        let command = SessionCommand::Run {
+            operation_id,
+            request_kind: AgentRequestKind::SessionResume,
+            replay_transcript: None,
+            prompt,
+            turn_metadata: TurnMetadata {
+                published_upstream_ref,
+                review_comment_thread_ids: Vec::new(),
+                session_agent: context.session_agent,
+            },
+        };
 
-                return None;
-            }
-        }
+        Self::process_session_command(context, one_shot_client, command).await
     }
 
     /// Emits a targeted [`AppEvent::SessionUpdated`] for the worker's session
@@ -1131,13 +1272,21 @@ impl SessionWorkerService {
         one_shot_client: Arc<dyn OneShotClient>,
         base_branch: String,
     ) -> Result<(), SessionError> {
-        let validation = isolation::validate_session_worktree(
+        let validation = match isolation::validate_session_worktree(
             context.fs_client.as_ref(),
             context.git_client.as_ref(),
             &context.folder,
             &context.session_id,
         )
-        .await?;
+        .await
+        {
+            Ok(validation) => validation,
+            Err(error) => {
+                Self::record_rebase_validation_failure(context, &error).await;
+
+                return Err(error);
+            }
+        };
         let assist_client = Arc::new(SessionWorkerRebaseAssistClient::from_context(
             context,
             validation.main_checkout,
@@ -1162,6 +1311,29 @@ impl SessionWorkerService {
             transcript: Arc::clone(&context.transcript),
         })
         .await
+    }
+
+    /// Persists one pre-rebase validation failure before resolving its queue
+    /// row.
+    async fn record_rebase_validation_failure(
+        context: &SessionWorkerContext,
+        error: &SessionError,
+    ) {
+        let notice = TranscriptNotice::RebaseError.format(error);
+        SessionTaskService::append_workflow_notice(
+            &context.transcript,
+            &context.db,
+            &context.app_event_tx,
+            &context.session_update_versions,
+            &context.session_id,
+            &notice,
+        )
+        .await;
+        let _ = context
+            .app_event_tx
+            .send(AppEvent::SessionQueuedSyncResolved {
+                session_id: context.session_id.clone(),
+            });
     }
 
     /// Returns whether a queued command should be skipped before execution.
@@ -1273,7 +1445,7 @@ impl SessionManager {
         branch_publish_session: BranchPublishTaskSession,
         remote_branch_name: Option<String>,
         response_tx: Option<oneshot::Sender<Result<ReviewRequest, ag_session::SessionError>>>,
-    ) -> Result<(), SessionError> {
+    ) -> Result<Option<u64>, SessionError> {
         let session_id = branch_publish_session.id.clone();
         let status = branch_publish_session.status;
         let response = response_tx.map(|response_tx| Arc::new(Mutex::new(Some(response_tx))));
@@ -1287,9 +1459,11 @@ impl SessionManager {
             self.worker_service_mut()
                 .enqueue_existing_session_command(services, &session_id, command)
                 .await
+                .map(Some)
         } else {
             self.enqueue_session_command(services, &session_id, command)
                 .await
+                .map(|()| None)
         };
         if let Err(error) = &result
             && let Some(response) = response
@@ -1352,6 +1526,7 @@ impl SessionManager {
             folder: session.folder.clone(),
             personality_catalog_client: services.personality_catalog_client(),
             queued_messages: Arc::clone(&handles.queued_messages),
+            queued_work_sequence: Arc::clone(&handles.queued_work_sequence),
             review_request_client: services.review_request_client(),
             session_update_versions: services.session_update_versions(),
             session_id: session.id.clone(),
@@ -1392,7 +1567,6 @@ mod tests {
     use mockall::Sequence;
     use serde_json;
     use tempfile::tempdir;
-    use tokio::sync::Notify;
     use tracing::instrument::WithSubscriber;
 
     use super::super::post_turn::{
@@ -1853,7 +2027,7 @@ mod tests {
     #[tokio::test]
     async fn test_skipped_review_request_command_answers_programmatic_caller() {
         // Arrange
-        let (context, db, _queue, _base_dir) =
+        let (mut context, db, _queue, _base_dir) =
             queue_test_context(MockAgentChannel::new(), VecDeque::new(), Status::Review).await;
         db.operations()
             .insert_session_operation(
@@ -1868,6 +2042,8 @@ mod tests {
             .await
             .expect("review-request operation should be canceled");
         let (response_tx, response_rx) = oneshot::channel();
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        context.app_event_tx = app_event_tx;
         let command = SessionCommand::CreateReviewRequest {
             branch_publish_session: BranchPublishTaskSession {
                 base_branch: "main".to_string(),
@@ -1892,6 +2068,10 @@ mod tests {
         let response = response_rx
             .await
             .expect("skipped review-request response should be delivered");
+        let app_event = app_event_rx
+            .recv()
+            .await
+            .expect("skipped review-request should resolve its queued row");
 
         // Assert
         assert!(command_result.is_none());
@@ -1901,6 +2081,52 @@ mod tests {
                 SKIPPED_CREATE_REVIEW_REQUEST_REASON.to_string()
             ))
         );
+        assert!(matches!(
+            app_event,
+            AppEvent::BranchPublishActionResolved { session_id } if session_id == "sess1"
+        ));
+        assert!(app_event_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_skipped_rebase_command_resolves_queued_sync() {
+        // Arrange
+        let (mut context, db, _queue, _base_dir) =
+            queue_test_context(MockAgentChannel::new(), VecDeque::new(), Status::InProgress).await;
+        db.operations()
+            .insert_session_operation("op-rebase", &context.session_id, REBASE_OPERATION_KIND)
+            .await
+            .expect("rebase operation should be inserted");
+        db.operations()
+            .request_cancel_for_session_operations(&context.session_id)
+            .await
+            .expect("rebase operation should be canceled");
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        context.app_event_tx = app_event_tx;
+        let command = SessionCommand::Rebase {
+            base_branch: "main".to_string(),
+            operation_id: "op-rebase".to_string(),
+        };
+
+        // Act
+        let command_result = SessionWorkerService::process_session_command(
+            &context,
+            &auto_commit_one_shot_client(),
+            command,
+        )
+        .await;
+        let app_event = app_event_rx
+            .recv()
+            .await
+            .expect("skipped rebase should resolve its queued row");
+
+        // Assert
+        assert!(command_result.is_none());
+        assert!(matches!(
+            app_event,
+            AppEvent::SessionQueuedSyncResolved { session_id } if session_id == "sess1"
+        ));
+        assert!(app_event_rx.try_recv().is_err());
     }
 
     #[tokio::test]
@@ -1923,7 +2149,7 @@ mod tests {
                 database.operations(),
                 &SessionId::from("sess1"),
                 sender,
-                resume_command("rollup-failed"),
+                ScheduledSessionCommand::immediate(resume_command("rollup-failed")),
             )
             .await;
         let unfinished = database
@@ -4138,8 +4364,9 @@ mod tests {
             git_client: Arc::new(mock_git_client),
             transcript: empty_transcript(),
             personality_catalog_client: Arc::new(RealPersonalityCatalogClient),
-            queued_messages: Arc::new(Mutex::new(VecDeque::from([TurnPrompt::from_text(
-                "queued follow-up".to_string(),
+            queued_messages: Arc::new(Mutex::new(VecDeque::from([queued_message(
+                0,
+                "queued follow-up",
             )]))),
             review_request_client: Arc::new(forge::MockReviewRequestClient::new()),
 
@@ -4962,6 +5189,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_queued_rebase_validation_failure_persists_error_before_resolving_row() {
+        // Arrange
+        let mut context = queue_helper_context(Arc::new(Mutex::new(VecDeque::new()))).await;
+        context.session_id = "sess1".into();
+        context.folder = PathBuf::from("missing-session-worktree");
+        *context.status.lock().expect("status lock") = Status::Review;
+        insert_in_progress_test_session(&context.db).await;
+        let mut fs_client = fs::MockFsClient::new();
+        fs_client.expect_is_dir().once().return_const(false);
+        context.fs_client = Arc::new(fs_client);
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        context.app_event_tx = app_event_tx;
+
+        // Act
+        let error = SessionWorkerService::run_rebase_command(
+            &context,
+            auto_commit_one_shot_client(),
+            "main".to_string(),
+        )
+        .await
+        .expect_err("missing worktree should reject queued sync");
+        let persisted_messages = context
+            .db
+            .sessions()
+            .load_session_messages("sess1")
+            .await
+            .expect("failed to load persisted session messages");
+        let events = std::iter::from_fn(|| app_event_rx.try_recv().ok()).collect::<Vec<_>>();
+
+        // Assert
+        assert!(error.to_string().contains("Session isolation violation"));
+        assert!(transcript_text(&context.transcript).contains("[Sync Error]"));
+        assert_eq!(persisted_messages.len(), 1);
+        assert_eq!(persisted_messages[0].kind, "workflow_notice");
+        assert!(persisted_messages[0].content.contains("[Sync Error]"));
+        assert!(matches!(
+            events.as_slice(),
+            [
+                AppEvent::SessionUpdated { session_id, .. },
+                AppEvent::SessionQueuedSyncResolved {
+                    session_id: resolved_session_id,
+                },
+            ] if session_id == "sess1" && resolved_session_id == "sess1"
+        ));
+        assert_eq!(*context.status.lock().expect("status lock"), Status::Review);
+    }
+
+    #[tokio::test]
     /// Verifies recovery stops immediately when unfinished operations cannot
     /// be loaded from storage.
     async fn test_fail_unfinished_operations_from_previous_run_returns_load_error() {
@@ -5514,14 +5789,18 @@ mod tests {
     /// [`MockAgentChannel`], a fresh in-memory database, and the queued
     /// prompt list. The session row is pre-inserted as `InProgress` so the
     /// worker reaches drainage without first transitioning status.
+    fn queued_message(order: u64, text: &str) -> QueuedMessage {
+        QueuedMessage::new(order, TurnPrompt::from_text(text.to_string()))
+    }
+
     async fn queue_test_context(
         channel: MockAgentChannel,
-        queued_messages: VecDeque<TurnPrompt>,
+        queued_messages: VecDeque<QueuedMessage>,
         status: Status,
     ) -> (
         SessionWorkerContext,
         AppRepositories,
-        Arc<Mutex<VecDeque<TurnPrompt>>>,
+        Arc<Mutex<VecDeque<QueuedMessage>>>,
         tempfile::TempDir,
     ) {
         // Arrange
@@ -5609,7 +5888,9 @@ mod tests {
     /// Builds one [`SessionWorkerContext`] whose only meaningful state is the
     /// shared `queued_messages` mutex; every other field is wired with a stub
     /// value because these tests only exercise the queue helpers.
-    async fn queue_helper_context(queue: Arc<Mutex<VecDeque<TurnPrompt>>>) -> SessionWorkerContext {
+    async fn queue_helper_context(
+        queue: Arc<Mutex<VecDeque<QueuedMessage>>>,
+    ) -> SessionWorkerContext {
         SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
             branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -5636,22 +5917,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_pop_queued_prompt_returns_messages_in_submission_order() {
+    async fn test_pop_queued_message_returns_messages_in_submission_order() {
         // Arrange
-        let queue: Arc<Mutex<VecDeque<TurnPrompt>>> = Arc::new(Mutex::new(VecDeque::from([
-            TurnPrompt::from_text("first".to_string()),
-            TurnPrompt::from_text("second".to_string()),
+        let queue = Arc::new(Mutex::new(VecDeque::from([
+            queued_message(0, "first"),
+            queued_message(1, "second"),
         ])));
         let context = queue_helper_context(Arc::clone(&queue)).await;
 
         // Act
-        let first_pop = context.pop_queued_prompt();
-        let second_pop = context.pop_queued_prompt();
-        let empty_pop = context.pop_queued_prompt();
+        let first_pop = context.pop_queued_message();
+        let second_pop = context.pop_queued_message();
+        let empty_pop = context.pop_queued_message();
 
         // Assert
-        assert_eq!(first_pop.expect("first prompt").text, "first");
-        assert_eq!(second_pop.expect("second prompt").text, "second");
+        assert_eq!(first_pop.expect("first prompt").transcript_text(), "first");
+        assert_eq!(
+            second_pop.expect("second prompt").transcript_text(),
+            "second"
+        );
         assert!(empty_pop.is_none());
         assert!(queue.lock().expect("queue lock").is_empty());
     }
@@ -5659,9 +5943,9 @@ mod tests {
     #[tokio::test]
     async fn test_clear_queued_messages_drops_all_pending_prompts() {
         // Arrange
-        let queue: Arc<Mutex<VecDeque<TurnPrompt>>> = Arc::new(Mutex::new(VecDeque::from([
-            TurnPrompt::from_text("alpha".to_string()),
-            TurnPrompt::from_text("beta".to_string()),
+        let queue = Arc::new(Mutex::new(VecDeque::from([
+            queued_message(0, "alpha"),
+            queued_message(1, "beta"),
         ])));
         let context = queue_helper_context(Arc::clone(&queue)).await;
 
@@ -5675,10 +5959,10 @@ mod tests {
     #[tokio::test]
     async fn test_clear_queued_messages_updates_shared_queue_state() {
         // Arrange
-        let queue: Arc<Mutex<VecDeque<TurnPrompt>>> =
-            Arc::new(Mutex::new(VecDeque::from([TurnPrompt::from_text(
-                "queued reply".to_string(),
-            )])));
+        let queue = Arc::new(Mutex::new(VecDeque::from([queued_message(
+            0,
+            "queued reply",
+        )])));
         let context = queue_helper_context(Arc::clone(&queue)).await;
 
         // Act
@@ -5692,107 +5976,139 @@ mod tests {
     }
 
     #[tokio::test]
-    /// Verifies that drainage holds while the session is in `Question` state
-    /// so queued prompts wait for the clarification flow to resolve before
-    /// dispatching as new turns.
-    async fn test_drain_queued_messages_pauses_while_status_is_question() {
+    async fn test_next_scheduled_work_follows_shared_submission_order() {
         // Arrange
-        let mut mock_channel = MockAgentChannel::new();
-        mock_channel.expect_run_turn().never().returning(|_, _, _| {
-            Box::pin(async { unreachable!("drain must not dispatch while status is Question") })
-        });
-        let queued = VecDeque::from([TurnPrompt::from_text("queued reply".to_string())]);
-        let (context, _db, queue_handle, _base_dir) =
-            queue_test_context(mock_channel, queued, Status::Question).await;
-        let (_command_tx, mut command_rx) = mpsc::unbounded_channel();
-
-        // Act
-        let one_shot_client = auto_commit_one_shot_client();
-        let next_command = SessionWorkerService::drain_queued_messages(
-            &context,
-            &one_shot_client,
-            &mut command_rx,
-        )
-        .await;
-
-        // Assert — queued prompt remains untouched until status becomes
-        // runnable again.
-        assert!(next_command.is_none());
-        let queue = queue_handle.lock().expect("queue lock");
-        assert_eq!(queue.len(), 1);
-        assert_eq!(queue.front().expect("queued head").text, "queued reply");
-    }
-
-    #[tokio::test]
-    /// Verifies a worker command received during one drained chat turn runs
-    /// before the remaining queued chat instead of waiting for the full batch.
-    async fn test_drain_queued_messages_yields_to_command_between_turns() {
-        // Arrange
-        let turn_started = Arc::new(Notify::new());
-        let turn_started_for_channel = Arc::clone(&turn_started);
-        let release_turn = Arc::new(Notify::new());
-        let release_turn_for_channel = Arc::clone(&release_turn);
-        let mut mock_channel = MockAgentChannel::new();
-        mock_channel
-            .expect_run_turn()
-            .times(1)
-            .withf(|_, request, _| request.prompt.text == "queued first")
-            .returning(move |_, _, _| {
-                let turn_started = Arc::clone(&turn_started_for_channel);
-                let release_turn = Arc::clone(&release_turn_for_channel);
-
-                Box::pin(async move {
-                    turn_started.notify_one();
-                    release_turn.notified().await;
-
-                    Ok(successful_turn_result("First queued turn completed."))
-                })
-            });
         let queued = VecDeque::from([
-            TurnPrompt::from_text("queued first".to_string()),
-            TurnPrompt::from_text("queued second".to_string()),
+            queued_message(0, "queued first"),
+            queued_message(1, "queued second"),
         ]);
         let (context, _db, queue_handle, _base_dir) =
-            queue_test_context(mock_channel, queued, Status::InProgress).await;
-        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+            queue_test_context(MockAgentChannel::new(), queued, Status::InProgress).await;
+        let mut pending_commands = VecDeque::from([ScheduledSessionCommand::queued(
+            SessionCommand::Rebase {
+                base_branch: "main".to_string(),
+                operation_id: "queued-rebase".to_string(),
+            },
+            2,
+        )]);
 
         // Act
-        let one_shot_client = auto_commit_one_shot_client();
-        let drain_future = SessionWorkerService::drain_queued_messages(
-            &context,
-            &one_shot_client,
-            &mut command_rx,
-        );
-        let enqueue_command_future = async {
-            turn_started.notified().await;
-            command_tx
-                .send(SessionCommand::Rebase {
-                    base_branch: "main".to_string(),
-                    operation_id: "queued-rebase".to_string(),
-                })
-                .expect("worker command receiver should remain available");
-            release_turn.notify_one();
-        };
-        let (next_command, ()) = tokio::join!(drain_future, enqueue_command_future);
+        let first_work = SessionWorkerService::next_scheduled_work(&context, &mut pending_commands);
+        let second_work =
+            SessionWorkerService::next_scheduled_work(&context, &mut pending_commands);
+        let third_work = SessionWorkerService::next_scheduled_work(&context, &mut pending_commands);
+        queue_handle
+            .lock()
+            .expect("queue lock")
+            .push_back(queued_message(4, "queued last"));
+        pending_commands.push_back(ScheduledSessionCommand::queued(
+            SessionCommand::Rebase {
+                base_branch: "main".to_string(),
+                operation_id: "older-rebase".to_string(),
+            },
+            3,
+        ));
+        let fourth_work =
+            SessionWorkerService::next_scheduled_work(&context, &mut pending_commands);
+        pending_commands.push_front(ScheduledSessionCommand::immediate(resume_command(
+            "immediate-reply",
+        )));
+        let fifth_work = SessionWorkerService::next_scheduled_work(&context, &mut pending_commands);
+        let sixth_work = SessionWorkerService::next_scheduled_work(&context, &mut pending_commands);
 
         // Assert
         assert!(matches!(
-            next_command,
-            Some(SessionCommand::Rebase { operation_id, .. })
-                if operation_id == "queued-rebase"
+            first_work,
+            Some(ScheduledSessionWork::Message(message))
+                if message.transcript_text() == "queued first"
         ));
-        let queue = queue_handle.lock().expect("queue lock");
-        assert_eq!(queue.len(), 1);
-        assert_eq!(
-            queue.front().expect("remaining queued prompt").text,
-            "queued second"
-        );
+        assert!(matches!(
+            second_work,
+            Some(ScheduledSessionWork::Message(message))
+                if message.transcript_text() == "queued second"
+        ));
+        assert!(matches!(
+            third_work,
+            Some(ScheduledSessionWork::Command(command))
+                if command.queued_order == Some(2)
+                    && matches!(
+                        &command.command,
+                        SessionCommand::Rebase { operation_id, .. }
+                            if operation_id == "queued-rebase"
+                    )
+        ));
+        assert!(matches!(
+            fourth_work,
+            Some(ScheduledSessionWork::Command(command))
+                if command.queued_order == Some(3)
+                    && matches!(
+                        &command.command,
+                        SessionCommand::Rebase { operation_id, .. }
+                            if operation_id == "older-rebase"
+                    )
+        ));
+        assert!(matches!(
+            fifth_work,
+            Some(ScheduledSessionWork::Command(command))
+                if command.queued_order.is_none()
+                    && matches!(
+                        &command.command,
+                        SessionCommand::Run { operation_id, .. }
+                            if operation_id == "immediate-reply"
+                    )
+        ));
+        assert!(matches!(
+            sixth_work,
+            Some(ScheduledSessionWork::Message(message))
+                if message.transcript_text() == "queued last"
+        ));
+        assert!(queue_handle.lock().expect("queue lock").is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_next_scheduled_work_pauses_queued_work_for_question() {
+        // Arrange
+        let queued = VecDeque::from([queued_message(1, "queued reply")]);
+        let (context, _db, queue_handle, _base_dir) =
+            queue_test_context(MockAgentChannel::new(), queued, Status::Question).await;
+        let mut pending_commands = VecDeque::from([ScheduledSessionCommand::queued(
+            SessionCommand::Rebase {
+                base_branch: "main".to_string(),
+                operation_id: "queued-rebase".to_string(),
+            },
+            0,
+        )]);
+
+        // Act
+        let paused_work =
+            SessionWorkerService::next_scheduled_work(&context, &mut pending_commands);
+        pending_commands.push_back(ScheduledSessionCommand::queued(
+            resume_command("question-answer"),
+            2,
+        ));
+        let answer_work =
+            SessionWorkerService::next_scheduled_work(&context, &mut pending_commands);
+
+        // Assert
+        assert!(paused_work.is_none());
+        assert!(matches!(
+            answer_work,
+            Some(ScheduledSessionWork::Command(command))
+                if command.queued_order == Some(2)
+                    && matches!(
+                        &command.command,
+                        SessionCommand::Run { operation_id, .. }
+                            if operation_id == "question-answer"
+                    )
+        ));
+        assert_eq!(pending_commands.len(), 1);
+        assert_eq!(queue_handle.lock().expect("queue lock").len(), 1);
     }
 
     #[tokio::test]
     /// Verifies the last queued follow-up turn reloads the persisted
     /// published branch and starts auto-push after the queue has drained.
-    async fn test_drain_queued_messages_auto_pushes_after_last_published_branch_follow_up() {
+    async fn test_process_queued_message_auto_pushes_after_last_published_branch_follow_up() {
         // Arrange
         let mut mock_channel = MockAgentChannel::new();
         mock_channel
@@ -5802,10 +6118,9 @@ mod tests {
                 session_id == "sess1" && request.prompt.text == "queued reply"
             })
             .returning(|_, _, _| Box::pin(async { Ok(successful_turn_result("Queued done.")) }));
-        let queued = VecDeque::from([TurnPrompt::from_text("queued reply".to_string())]);
+        let queued = VecDeque::from([queued_message(0, "queued reply")]);
         let (mut context, db, queue_handle, base_dir) =
             queue_test_context(mock_channel, queued, Status::InProgress).await;
-        let (_command_tx, mut command_rx) = mpsc::unbounded_channel();
         db.sessions()
             .update_session_published_upstream_ref(
                 "sess1",
@@ -5858,12 +6173,11 @@ mod tests {
 
         // Act
         let one_shot_client = auto_commit_one_shot_client();
-        let next_command = SessionWorkerService::drain_queued_messages(
-            &context,
-            &one_shot_client,
-            &mut command_rx,
-        )
-        .await;
+        let message = context
+            .pop_queued_message()
+            .expect("queued message should be available");
+        let turn_result =
+            SessionWorkerService::process_queued_message(&context, &one_shot_client, message).await;
         let sync_events = tokio::time::timeout(Duration::from_secs(1), async {
             let mut sync_events = Vec::new();
             while sync_events.len() < 2 {
@@ -5885,7 +6199,7 @@ mod tests {
         .expect("timed out waiting for sync events");
 
         // Assert
-        assert!(next_command.is_none());
+        assert!(matches!(turn_result, Some(Ok(()))));
         assert!(queue_handle.lock().expect("queue lock").is_empty());
         assert_eq!(sync_events[0].2, PublishedBranchSyncStatus::InProgress);
         assert_eq!(sync_events[1].2, PublishedBranchSyncStatus::Succeeded);
@@ -5895,11 +6209,11 @@ mod tests {
     }
 
     #[tokio::test]
-    /// Verifies that drainage stops and clears every queued prompt once the
+    /// Verifies that the scheduler clears every queued prompt once the
     /// running queued turn returns `StoppedByUser`, matching the `Ctrl+C`
     /// expectation that cancellation drops pending follow-ups together with
     /// the active turn.
-    async fn test_drain_queued_messages_clears_queue_when_user_stops_running_turn() {
+    async fn test_process_queued_message_clears_queue_when_user_stops_running_turn() {
         // Arrange
         let mut mock_channel = MockAgentChannel::new();
         mock_channel
@@ -5916,25 +6230,27 @@ mod tests {
             .expect_shutdown_session()
             .returning(|_| Box::pin(async { Ok(()) }));
         let queued = VecDeque::from([
-            TurnPrompt::from_text("queued first".to_string()),
-            TurnPrompt::from_text("queued second".to_string()),
+            queued_message(0, "queued first"),
+            queued_message(1, "queued second"),
         ]);
         let (context, _db, queue_handle, _base_dir) =
             queue_test_context(mock_channel, queued, Status::InProgress).await;
-        let (_command_tx, mut command_rx) = mpsc::unbounded_channel();
 
         // Act
         let one_shot_client = auto_commit_one_shot_client();
-        let next_command = SessionWorkerService::drain_queued_messages(
-            &context,
-            &one_shot_client,
-            &mut command_rx,
-        )
-        .await;
+        let message = context
+            .pop_queued_message()
+            .expect("queued message should be available");
+        let turn_result =
+            SessionWorkerService::process_queued_message(&context, &one_shot_client, message).await;
+        SessionWorkerService::clear_queued_messages_after_stop(&context, turn_result.as_ref());
 
-        // Assert — first prompt was dispatched, the StoppedByUser result
-        // propagated, and the remaining queued prompt was cleared.
-        assert!(next_command.is_none());
+        // Assert — first prompt was dispatched, the stopped result propagated,
+        // and the remaining queued prompt was cleared.
+        assert!(matches!(
+            turn_result,
+            Some(Err(SessionError::StoppedByUser(_)))
+        ));
         let queue = queue_handle.lock().expect("queue lock");
         assert!(queue.is_empty(), "queue should be cleared on Ctrl+C");
     }

--- a/crates/agentty/src/app/session_api.rs
+++ b/crates/agentty/src/app/session_api.rs
@@ -263,8 +263,6 @@ impl App {
 
             return;
         };
-        let is_queued =
-            branch_publish_context.session.status == crate::domain::session::Status::InProgress;
         let branch_operation_lock = Arc::clone(&branch_publish_context.branch_operation_lock);
         // Reserve an idle branch before persistence. An existing owner
         // already serializes worker execution, so the runtime actor never waits here.
@@ -278,20 +276,22 @@ impl App {
                 Some(response_tx),
             )
             .await;
-        let loading_label = if is_queued {
-            review_request_queued_label()
-        } else {
-            branch_publish_loading_label(PublishBranchAction::PublishPullRequest)
-        };
-        self.sessions
-            .start_branch_publish(&session_id, loading_label);
-        if let Err(error) = enqueue_result {
-            self.sessions.finish_branch_publish(
+        match enqueue_result {
+            Err(error) => self.sessions.finish_branch_publish(
                 &session_id,
                 crate::domain::transient_message::TransientMessageBody::Markdown(format!(
                     "**Review request publish failed**\n\n{error}"
                 )),
-            );
+            ),
+            Ok(Some(queued_order)) => self.sessions.queue_branch_publish(
+                &session_id,
+                queued_order,
+                review_request_queued_label(),
+            ),
+            Ok(None) => self.sessions.start_branch_publish(
+                &session_id,
+                branch_publish_loading_label(PublishBranchAction::PublishPullRequest),
+            ),
         }
     }
 
@@ -480,7 +480,13 @@ impl App {
         let queued_messages = self
             .sessions
             .session_for_id(session_id)
-            .map(|session| session.queued_messages.clone())
+            .map(|session| {
+                session
+                    .queued_messages
+                    .iter()
+                    .map(|message| message.transcript_text().to_string())
+                    .collect()
+            })
             .unwrap_or_default();
 
         build_api_session(row, message_rows, queued_messages).map(Some)
@@ -1179,6 +1185,7 @@ mod tests {
     use super::*;
     use crate::domain::orchestration::OrchestrationTaskKind;
     use crate::domain::session::Status;
+    use crate::domain::transient_message::{TransientMessageBody, TransientMessageSlot};
     use crate::infra::db::PersistedOrchestrationTask;
 
     async fn request_session_creation(
@@ -2063,6 +2070,62 @@ mod tests {
             ),
             "unexpected review-request response: {response_after_unlock:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn review_request_runtime_handler_queues_on_existing_worker() {
+        // Arrange
+        let (mut app, _temp_dir) = crate::test_support::new_git_test_app().await;
+        let session_id = SessionId::from(
+            app.create_session()
+                .await
+                .expect("regular session should be created"),
+        );
+        crate::test_support::set_session_status_for_test(
+            &mut app,
+            &session_id,
+            SessionStatus::Done,
+        );
+        let branch_operation_lock = Arc::clone(
+            &app.sessions
+                .session_handles_or_err(&session_id)
+                .expect("expected session handles")
+                .branch_operation_lock,
+        );
+        let existing_operation_guard = Arc::clone(&branch_operation_lock).lock_owned().await;
+        let (first_response_tx, _first_response_rx) = oneshot::channel();
+        app.start_api_review_request_publish(
+            session_id.clone(),
+            SessionRuntimeAccess::User,
+            first_response_tx,
+        )
+        .await;
+        crate::test_support::set_session_status_for_test(
+            &mut app,
+            &session_id,
+            SessionStatus::InProgress,
+        );
+        let (queued_response_tx, _queued_response_rx) = oneshot::channel();
+
+        // Act
+        app.start_api_review_request_publish(
+            session_id.clone(),
+            SessionRuntimeAccess::User,
+            queued_response_tx,
+        )
+        .await;
+        let publish_body = app.sessions.state().sessions()[0]
+            .transient_messages
+            .get(TransientMessageSlot::BranchPublish)
+            .map(|message| &message.body);
+
+        // Assert
+        assert!(matches!(
+            publish_body,
+            Some(TransientMessageBody::Queued(action))
+                if action.order == 0 && action.text == "review request — publish after this turn"
+        ));
+        drop(existing_operation_guard);
     }
 
     #[tokio::test]
@@ -2983,10 +3046,7 @@ mod tests {
             ApiSessionError::Operation("Session has no questions to answer".to_string())
         );
         assert_eq!(resumed_turn_kind, AgentRequestKind::SessionResume);
-        assert_eq!(
-            queued_messages_before_transition,
-            [] as [std::string::String; 0]
-        );
+        assert!(queued_messages_before_transition.is_empty());
         assert_eq!(session.questions, [] as [ag_protocol::QuestionItem; 0]);
         assert_eq!(session.queued_messages, [] as [std::string::String; 0]);
         assert_eq!(clarification_answer_count(&session), 1);

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 pub use ag_agent::{SessionDiffState, SessionStats, SpeedMode};
@@ -274,9 +274,10 @@ pub struct Session {
     pub project_name: String,
     /// Initial user prompt used to create the session.
     pub prompt: String,
-    /// Transcript text for each chat message queued while the active turn is
-    /// running, mirrored from [`SessionHandles::queued_messages`] for render.
-    pub queued_messages: Vec<String>,
+    /// Chat messages queued while the active turn is running, mirrored from
+    /// [`SessionHandles::queued_messages`] for render in submission order
+    /// alongside queued workflow actions.
+    pub queued_messages: Vec<QueuedMessage>,
     /// Session-scoped reasoning override selected through prompt slash
     /// commands.
     pub reasoning_level_override: Option<ReasoningLevel>,
@@ -580,7 +581,7 @@ impl Session {
         let is_publish_active = self
             .transient_messages
             .get(TransientMessageSlot::BranchPublish)
-            .is_some_and(|message| matches!(&message.body, TransientMessageBody::Loading(_)));
+            .is_some_and(|message| message.body.is_pending_indicator());
 
         (self.accepts_user_turns()
             && self.owns_branch_changes()
@@ -813,6 +814,51 @@ fn find_session<'a>(sessions: &'a [Session], session_id: &str) -> Option<&'a Ses
         .find(|session| session.id.as_str() == session_id)
 }
 
+/// One chat prompt waiting behind active session work.
+///
+/// `order` comes from the same session-local sequence as queued workflow
+/// actions, allowing the worker and renderer to preserve one FIFO order
+/// across both kinds of work.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QueuedMessage {
+    order: u64,
+    prompt: TurnPrompt,
+    transcript_text: String,
+}
+
+impl QueuedMessage {
+    /// Creates one queued chat prompt at its reserved submission order.
+    pub(crate) fn new(order: u64, prompt: TurnPrompt) -> Self {
+        let transcript_text = prompt.transcript_text();
+
+        Self {
+            order,
+            prompt,
+            transcript_text,
+        }
+    }
+
+    /// Consumes the queue entry and returns its structured prompt.
+    pub(crate) fn into_prompt(self) -> TurnPrompt {
+        self.prompt
+    }
+
+    /// Returns the session-local submission order shared with queued actions.
+    pub(crate) fn order(&self) -> u64 {
+        self.order
+    }
+
+    /// Returns the structured prompt without consuming the queue entry.
+    pub(crate) fn prompt(&self) -> &TurnPrompt {
+        &self.prompt
+    }
+
+    /// Returns the transcript rendering of the queued prompt.
+    pub(crate) fn transcript_text(&self) -> &str {
+        &self.transcript_text
+    }
+}
+
 /// Shared runtime handles for one active session worker.
 pub struct SessionHandles {
     /// Serializes branch-publish ownership with queued branch operations.
@@ -834,7 +880,9 @@ pub struct SessionHandles {
     /// Pushed by the chat composer when the user submits while the session is
     /// `InProgress`; popped by the session worker between turns. The queue is
     /// session-local and discarded on app restart.
-    pub queued_messages: Arc<Mutex<VecDeque<TurnPrompt>>>,
+    pub queued_messages: Arc<Mutex<VecDeque<QueuedMessage>>>,
+    /// Monotonic submission order shared by queued chat and workflow actions.
+    pub queued_work_sequence: Arc<AtomicU64>,
     /// Shared mutable status synchronized with persistence/UI.
     pub status: Arc<Mutex<Status>>,
     /// Shared typed transcript snapshot mirrored to the render layer.
@@ -854,6 +902,7 @@ impl SessionHandles {
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             child_pid: Arc::new(Mutex::new(None)),
             queued_messages: Arc::new(Mutex::new(VecDeque::new())),
+            queued_work_sequence: Arc::new(AtomicU64::new(0)),
             status: Arc::new(Mutex::new(status)),
             transcript: Arc::new(Mutex::new(SessionTranscript::default())),
             transcript_is_hydrated: AtomicBool::new(true),
@@ -867,6 +916,7 @@ impl SessionHandles {
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             child_pid: Arc::new(Mutex::new(None)),
             queued_messages: Arc::new(Mutex::new(VecDeque::new())),
+            queued_work_sequence: Arc::new(AtomicU64::new(0)),
             status: Arc::new(Mutex::new(status)),
             transcript: Arc::new(Mutex::new(SessionTranscript::default())),
             transcript_is_hydrated: AtomicBool::new(false),
@@ -880,6 +930,7 @@ impl SessionHandles {
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             child_pid: Arc::new(Mutex::new(None)),
             queued_messages: Arc::new(Mutex::new(VecDeque::new())),
+            queued_work_sequence: Arc::new(AtomicU64::new(0)),
             status: Arc::new(Mutex::new(status)),
             transcript: Arc::new(Mutex::new(transcript)),
             transcript_is_hydrated: AtomicBool::new(true),
@@ -908,20 +959,20 @@ impl SessionHandles {
         Some(transcript.clone())
     }
 
-    /// Returns the transcript text for each queued message in submission
-    /// order so callers can mirror queue contents into render snapshots.
-    pub fn queued_message_transcripts(&self) -> Vec<String> {
+    /// Reserves the next shared submission order for queued session work.
+    pub(crate) fn next_queued_work_order(&self) -> u64 {
+        self.queued_work_sequence.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Returns queued chat messages in submission order so callers can mirror
+    /// queue contents into render snapshots.
+    pub fn queued_message_snapshot(&self) -> Vec<QueuedMessage> {
         // Sync critical section (read-only clone, no `.await`);
         // `std::sync::Mutex` is the correct choice per CLAUDE.md §"Mutex
         // Selection".
         self.queued_messages
             .lock()
-            .map(|guard| {
-                guard
-                    .iter()
-                    .map(TurnPrompt::transcript_text)
-                    .collect::<Vec<_>>()
-            })
+            .map(|guard| guard.iter().cloned().collect::<Vec<_>>())
             .unwrap_or_default()
     }
 
@@ -962,6 +1013,7 @@ pub(crate) mod tests {
 
     use super::*;
     use crate::domain::agent::AgentModel;
+    use crate::domain::transient_message::QueuedAction;
     use crate::test_support::SessionFixtureBuilder;
 
     #[test]
@@ -2108,21 +2160,29 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
 
     #[test]
     fn test_publish_pull_request_action_returns_none_while_publish_is_active() {
-        // Arrange
-        let mut session = crate::test_support::session_fixture("session-id", Status::Review);
-        session.transient_messages.upsert(TransientMessage {
-            anchor: TransientMessageAnchor::Tail,
-            body: TransientMessageBody::Loading("Publishing review request...".to_string()),
-            lifecycle: TransientMessageLifecycle::UntilResolved,
-            slot: TransientMessageSlot::BranchPublish,
-            turn_position: None,
-        });
+        for body in [
+            TransientMessageBody::Queued(QueuedAction::new(
+                0,
+                "publish after this turn".to_string(),
+            )),
+            TransientMessageBody::Loading("Publishing review request...".to_string()),
+        ] {
+            // Arrange
+            let mut session = crate::test_support::session_fixture("session-id", Status::Review);
+            session.transient_messages.upsert(TransientMessage {
+                anchor: TransientMessageAnchor::Tail,
+                body,
+                lifecycle: TransientMessageLifecycle::UntilResolved,
+                slot: TransientMessageSlot::BranchPublish,
+                turn_position: None,
+            });
 
-        // Act
-        let action = session.publish_pull_request_action();
+            // Act
+            let action = session.publish_pull_request_action();
 
-        // Assert
-        assert_eq!(action, None);
+            // Assert
+            assert_eq!(action, None);
+        }
     }
 
     #[test]

--- a/crates/agentty/src/domain/transient_message.rs
+++ b/crates/agentty/src/domain/transient_message.rs
@@ -17,6 +17,8 @@ pub(crate) enum TransientMessageSlot {
     Orchestration,
     /// Manual branch or review-request publish progress and result.
     BranchPublish,
+    /// Session sync waiting behind the active worker command.
+    SyncQueue,
     /// Published-branch auto-push progress replaced by its durable result.
     PublishedBranchSync,
 }
@@ -61,6 +63,8 @@ pub(crate) enum TransientMessageBody {
     Plain(String),
     /// Animated status text with explicit loading semantics.
     Loading(String),
+    /// Calm waiting text for work queued behind the active command.
+    Queued(QueuedAction),
 }
 
 impl TransientMessageBody {
@@ -68,7 +72,29 @@ impl TransientMessageBody {
     pub(crate) fn text(&self) -> &str {
         match self {
             Self::Markdown(text) | Self::Plain(text) | Self::Loading(text) => text,
+            Self::Queued(action) => &action.text,
         }
+    }
+
+    /// Returns whether this body renders a time-driven pending indicator.
+    pub(crate) fn is_pending_indicator(&self) -> bool {
+        matches!(self, Self::Loading(_) | Self::Queued(_))
+    }
+}
+
+/// Display metadata for one workflow action in the shared session queue.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct QueuedAction {
+    /// Session-local submission order shared with queued chat messages.
+    pub(crate) order: u64,
+    /// Calm waiting label shown in session output.
+    pub(crate) text: String,
+}
+
+impl QueuedAction {
+    /// Creates queued-action display metadata at its reserved order.
+    pub(crate) fn new(order: u64, text: String) -> Self {
+        Self { order, text }
     }
 }
 
@@ -204,6 +230,36 @@ impl Default for TransientMessageStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn queued_body_exposes_plain_display_text() {
+        // Arrange
+        let body =
+            TransientMessageBody::Queued(QueuedAction::new(2, "sync after this turn".to_string()));
+
+        // Act
+        let text = body.text();
+
+        // Assert
+        assert_eq!(text, "sync after this turn");
+    }
+
+    #[test]
+    fn pending_indicator_only_matches_loading_and_queued_bodies() {
+        // Arrange
+        let bodies = [
+            TransientMessageBody::Markdown("result".to_string()),
+            TransientMessageBody::Plain("failure".to_string()),
+            TransientMessageBody::Loading("working".to_string()),
+            TransientMessageBody::Queued(QueuedAction::new(0, "waiting".to_string())),
+        ];
+
+        // Act
+        let pending_indicators = bodies.map(|body| body.is_pending_indicator());
+
+        // Assert
+        assert_eq!(pending_indicators, [false, false, true, true]);
+    }
 
     fn message(slot: TransientMessageSlot, text: &str, turn_position: i64) -> TransientMessage {
         TransientMessage {

--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -4299,7 +4299,7 @@ mod tests {
         );
         assert_eq!(app.sessions.sessions()[0].queued_messages.len(), 1);
         assert_eq!(
-            app.sessions.sessions()[0].queued_messages[0],
+            app.sessions.sessions()[0].queued_messages[0].transcript_text(),
             "/model gpt-5",
             "queued message preserves the original slash-prefixed text"
         );
@@ -4333,10 +4333,10 @@ mod tests {
             .lock()
             .expect("queue lock");
         assert_eq!(queued_messages.len(), 1);
-        assert_eq!(queued_messages[0].text, "queued after rebase");
+        assert_eq!(queued_messages[0].transcript_text(), "queued after rebase");
         assert_eq!(
-            app.sessions.sessions()[0].queued_messages,
-            vec!["queued after rebase".to_string()]
+            app.sessions.sessions()[0].queued_messages[0].transcript_text(),
+            "queued after rebase"
         );
     }
 

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -799,19 +799,20 @@ async fn end_in_progress_turn(app: &mut App, session_id: &str) {
 /// token, persisted status, and auto-review suppression untouched so the
 /// running turn can keep streaming.
 async fn pop_last_queued_chat_message_if_any(app: &mut App, session_id: &str) -> bool {
-    let popped_prompt = app
+    let popped_message = app
         .sessions
         .session_handles()
         .get(session_id)
         .and_then(|handles| handles.queued_messages.lock().ok()?.pop_back());
 
-    let Some(popped_prompt) = popped_prompt else {
+    let Some(popped_message) = popped_message else {
         return false;
     };
 
     app.sessions.sync_session_from_handle(session_id);
 
-    app.cleanup_prompt_attachment_files(&popped_prompt).await;
+    app.cleanup_prompt_attachment_files(popped_message.prompt())
+        .await;
 
     app.services.emit_app_event(AppEvent::SessionUpdated {
         session_id: session_id.into(),
@@ -1282,15 +1283,21 @@ mod tests {
     use crate::domain::agent::AgentModel;
     use crate::domain::orchestration::OrchestrationStatus;
     use crate::domain::session::{
-        ForgeKind, ReviewRequest, ReviewRequestState, ReviewRequestSummary, SessionRole,
+        ForgeKind, QueuedMessage, ReviewRequest, ReviewRequestState, ReviewRequestSummary,
+        SessionRole,
     };
     use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
+    use crate::domain::turn_prompt::TurnPrompt;
     use crate::infra::tmux::{MockTmuxClient, TmuxClient};
     use crate::presentation::app_mode::PromptModeSnapshot;
     use crate::presentation::prompt::PromptSlashState;
     use crate::runtime::mode::session_output_metric;
     use crate::ui::component::session_output::SessionOutputLineContext;
     use crate::ui::page::session_chat::SessionChatPage;
+
+    fn queued_message(order: u64, text: &str) -> QueuedMessage {
+        QueuedMessage::new(order, TurnPrompt::from_text(text.to_string()))
+    }
 
     fn session_replay_text(session: &crate::domain::session::Session) -> String {
         session
@@ -3969,16 +3976,16 @@ mod tests {
         let queued_messages = std::sync::Arc::clone(&handles.queued_messages);
         {
             let mut queued = queued_messages.lock().expect("queued_messages lock");
-            queued.push_back(crate::domain::turn_prompt::TurnPrompt::from("first queued"));
-            queued.push_back(crate::domain::turn_prompt::TurnPrompt::from(
-                "second queued",
-            ));
+            queued.push_back(queued_message(0, "first queued"));
+            queued.push_back(queued_message(1, "second queued"));
         }
         app.sessions
             .session_handles_mut()
             .insert(session_id.clone().into(), handles);
-        app.sessions.sessions_mut()[0].queued_messages =
-            vec!["first queued".to_string(), "second queued".to_string()];
+        app.sessions.sessions_mut()[0].queued_messages = vec![
+            queued_message(0, "first queued"),
+            queued_message(1, "second queued"),
+        ];
 
         // Act — first Ctrl+C while the queue is non-empty.
         end_in_progress_turn(&mut app, &session_id).await;
@@ -3990,7 +3997,7 @@ mod tests {
             .lock()
             .expect("queued_messages lock")
             .iter()
-            .map(crate::domain::turn_prompt::TurnPrompt::transcript_text)
+            .map(|message| message.transcript_text().to_string())
             .collect();
         assert_eq!(
             remaining_handle_queue,
@@ -3998,8 +4005,8 @@ mod tests {
             "only the most recently queued chat message should be popped on first Ctrl+C"
         );
         assert_eq!(
-            app.sessions.sessions()[0].queued_messages,
-            vec!["first queued".to_string()],
+            app.sessions.sessions()[0].queued_messages[0].transcript_text(),
+            "first queued",
             "snapshot queued_messages should mirror the handle after LIFO pop"
         );
         assert_eq!(
@@ -4043,16 +4050,16 @@ mod tests {
         let queued_messages = std::sync::Arc::clone(&handles.queued_messages);
         {
             let mut queued = queued_messages.lock().expect("queued_messages lock");
-            queued.push_back(crate::domain::turn_prompt::TurnPrompt::from("first queued"));
-            queued.push_back(crate::domain::turn_prompt::TurnPrompt::from(
-                "second queued",
-            ));
+            queued.push_back(queued_message(0, "first queued"));
+            queued.push_back(queued_message(1, "second queued"));
         }
         app.sessions
             .session_handles_mut()
             .insert(session_id.clone().into(), handles);
-        app.sessions.sessions_mut()[0].queued_messages =
-            vec!["first queued".to_string(), "second queued".to_string()];
+        app.sessions.sessions_mut()[0].queued_messages = vec![
+            queued_message(0, "first queued"),
+            queued_message(1, "second queued"),
+        ];
 
         // Act — first press pops "second queued".
         end_in_progress_turn(&mut app, &session_id).await;
@@ -4158,16 +4165,16 @@ mod tests {
         let queued_messages = std::sync::Arc::clone(&handles.queued_messages);
         {
             let mut queued = queued_messages.lock().expect("queued_messages lock");
-            queued.push_back(crate::domain::turn_prompt::TurnPrompt::from("first queued"));
-            queued.push_back(crate::domain::turn_prompt::TurnPrompt::from(
-                "second queued",
-            ));
+            queued.push_back(queued_message(0, "first queued"));
+            queued.push_back(queued_message(1, "second queued"));
         }
         app.sessions
             .session_handles_mut()
             .insert(session_id.clone().into(), handles);
-        app.sessions.sessions_mut()[0].queued_messages =
-            vec!["first queued".to_string(), "second queued".to_string()];
+        app.sessions.sessions_mut()[0].queued_messages = vec![
+            queued_message(0, "first queued"),
+            queued_message(1, "second queued"),
+        ];
 
         // Simulate the worker `pop_front` draining the oldest entry before
         // the snapshot has been refreshed.

--- a/crates/agentty/src/ui/component.rs
+++ b/crates/agentty/src/ui/component.rs
@@ -20,6 +20,8 @@ pub mod launch_configuration_overlay;
 pub mod project_switcher_overlay;
 /// Remote branch name input popup.
 pub mod publish_branch_overlay;
+/// Calm pulse for queued-action indicators.
+pub mod queue_pulse;
 /// New-session action selector popup.
 pub mod session_creation_overlay;
 /// Session transcript, progress, and result rendering.

--- a/crates/agentty/src/ui/component/queue_pulse.rs
+++ b/crates/agentty/src/ui/component/queue_pulse.rs
@@ -1,0 +1,75 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use tachyonfx::{Duration, Effect, Interpolation, fx};
+
+use crate::ui::style;
+
+const QUEUE_PULSE_FRAME_COUNT: usize = 20;
+const QUEUE_PULSE_HALF_PERIOD_MS: u32 = 1_000;
+const QUEUE_PULSE_STEP_MS: u32 = 100;
+
+/// Stateless calm breathing effect for one queued-action glyph.
+///
+/// The effect fades from subtle to normal text and back over two seconds.
+/// Applying an absolute frame offset keeps every queued row synchronized and
+/// deterministic without retaining per-row animation state.
+pub(crate) struct QueuePulseEffect;
+
+impl QueuePulseEffect {
+    /// Applies one deterministic pulse frame to `area`.
+    pub(crate) fn apply_stateless(buffer: &mut Buffer, area: Rect, spinner_frame: usize) {
+        let mut effect = Self::build_effect();
+        let frame_offset = spinner_frame % QUEUE_PULSE_FRAME_COUNT;
+        let phase_ms = u32::try_from(frame_offset).unwrap_or_default() * QUEUE_PULSE_STEP_MS;
+
+        effect.process(Duration::from_millis(phase_ms), buffer, area);
+    }
+
+    /// Builds a repeating fade that is visually slower than active loaders.
+    fn build_effect() -> Effect {
+        fx::repeating(fx::ping_pong(fx::fade_to_fg(
+            style::palette::text(),
+            (QUEUE_PULSE_HALF_PERIOD_MS, Interpolation::SineInOut),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_apply_stateless_breathes_from_subtle_toward_normal_text() {
+        // Arrange
+        let area = Rect::new(0, 0, 1, 1);
+        let mut buffer = Buffer::empty(area);
+        buffer[(0, 0)]
+            .set_symbol("≡")
+            .set_fg(style::palette::text_subtle());
+
+        // Act
+        QueuePulseEffect::apply_stateless(&mut buffer, area, 5);
+
+        // Assert
+        assert_ne!(buffer[(0, 0)].fg, style::palette::text_subtle());
+        assert_ne!(buffer[(0, 0)].fg, style::palette::warning());
+    }
+
+    #[test]
+    fn test_apply_stateless_wraps_after_full_period() {
+        // Arrange
+        let area = Rect::new(0, 0, 1, 1);
+        let mut first_cycle = Buffer::empty(area);
+        first_cycle[(0, 0)]
+            .set_symbol("≡")
+            .set_fg(style::palette::text_subtle());
+        let mut second_cycle = first_cycle.clone();
+
+        // Act
+        QueuePulseEffect::apply_stateless(&mut first_cycle, area, 5);
+        QueuePulseEffect::apply_stateless(&mut second_cycle, area, 25);
+
+        // Assert
+        assert_eq!(first_cycle[(0, 0)].fg, second_cycle[(0, 0)].fg);
+    }
+}

--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -11,14 +11,15 @@ use ratatui::text::Line;
 use ratatui::widgets::{Block, Paragraph};
 use rustc_hash::FxHasher;
 
-use crate::domain::session::{Session, SessionId, Status};
+use crate::domain::session::{QueuedMessage, Session, SessionId, Status};
+use crate::ui::component::queue_pulse::QueuePulseEffect;
 use crate::ui::component::tachyon_loader::TachyonLoaderEffect;
 use crate::ui::component::vertical_scrollbar::VerticalScrollbar;
 #[cfg(test)]
 use crate::ui::component::vertical_scrollbar::{SCROLLBAR_THUMB_SYMBOL, SCROLLBAR_TRACK_SYMBOL};
 #[cfg(test)]
 use crate::ui::icon::Icon;
-use crate::ui::icon::TACHYON_LOADER_WIDTH;
+use crate::ui::icon::{QUEUED_ACTION_WIDTH, TACHYON_LOADER_WIDTH};
 use crate::ui::input_layout::{bottom_pinned_scroll_offset, panel_inner_width};
 use crate::ui::session_output_assembly::{self, SessionOutputBody, SessionOutputLines};
 use crate::ui::{Component, markdown, session_format, style};
@@ -181,6 +182,8 @@ pub(crate) struct SessionOutputLayout {
     pub(crate) line_count: u16,
     /// Rendered lines shared between scroll metrics and frame painting.
     pub(crate) lines: Arc<[Line<'static>]>,
+    /// Indices of queued rows whose leading glyph receives a calm pulse.
+    pub(crate) queued_line_indices: Arc<[usize]>,
     /// Index of an explicit transient loader row within `lines`, when present.
     pub(crate) transient_loader_line_index: Option<usize>,
 }
@@ -578,6 +581,7 @@ impl<'a> SessionOutput<'a> {
             active_loader_line_index: output_lines.active_loader_line_index,
             line_count,
             lines: Arc::from(output_lines.lines),
+            queued_line_indices: Arc::from(output_lines.queued_line_indices),
             transient_loader_line_index: output_lines.transient_loader_line_index,
         }
     }
@@ -600,7 +604,10 @@ impl<'a> SessionOutput<'a> {
             markdown_render_version,
             output_width: u16::try_from(inner_width).unwrap_or(u16::MAX),
             queued_messages: TextFingerprint::from_texts(
-                session.queued_messages.iter().map(String::as_str),
+                session
+                    .queued_messages
+                    .iter()
+                    .map(QueuedMessage::transcript_text),
             ),
             session_id: session.id.clone(),
             session_update_version: context.session_update_version,
@@ -630,7 +637,10 @@ impl<'a> SessionOutput<'a> {
             markdown_render_version,
             output_width: u16::try_from(inner_width).unwrap_or(u16::MAX),
             queued_messages: TextFingerprint::from_texts(
-                session.queued_messages.iter().map(String::as_str),
+                session
+                    .queued_messages
+                    .iter()
+                    .map(QueuedMessage::transcript_text),
             ),
             session_id: session.id.clone(),
             theme_cache_version: style::active_theme_cache_version(),
@@ -650,14 +660,15 @@ impl<'a> SessionOutput<'a> {
         TextFingerprint::from_text(None)
     }
 
-    /// Returns the screen area occupied by a loader glyph when its row is
-    /// currently visible inside the scrolled output panel.
-    fn loader_area(
+    /// Returns the screen area occupied by a leading indicator when its row
+    /// is currently visible inside the scrolled output panel.
+    fn indicator_area(
         output_area: Rect,
-        loader_line_index: Option<usize>,
+        line_index: usize,
         final_scroll: u16,
+        indicator_width: u16,
     ) -> Option<Rect> {
-        if output_area.width < TACHYON_LOADER_WIDTH {
+        if output_area.width < indicator_width {
             return None;
         }
 
@@ -666,22 +677,19 @@ impl<'a> SessionOutput<'a> {
             return None;
         }
 
-        let status_line_index = loader_line_index?;
         let first_visible_line_index = usize::from(final_scroll);
         let last_visible_line_index =
             first_visible_line_index.saturating_add(usize::from(inner_area.height));
-        if status_line_index < first_visible_line_index
-            || status_line_index >= last_visible_line_index
-        {
+        if line_index < first_visible_line_index || line_index >= last_visible_line_index {
             return None;
         }
 
-        let row_offset = u16::try_from(status_line_index - first_visible_line_index).ok()?;
+        let row_offset = u16::try_from(line_index - first_visible_line_index).ok()?;
 
         Some(Rect::new(
             inner_area.x,
             inner_area.y.saturating_add(row_offset),
-            TACHYON_LOADER_WIDTH,
+            indicator_width,
             1,
         ))
     }
@@ -760,15 +768,22 @@ impl Component for SessionOutput<'_> {
             self.scroll_offset,
         );
         let active_loader_area = if session_format::session_output_uses_tachyon_loader(status) {
-            Self::loader_area(output_area, layout.active_loader_line_index, final_scroll)
+            layout.active_loader_line_index.and_then(|line_index| {
+                Self::indicator_area(output_area, line_index, final_scroll, TACHYON_LOADER_WIDTH)
+            })
         } else {
             None
         };
-        let transient_loader_area = Self::loader_area(
-            output_area,
-            layout.transient_loader_line_index,
-            final_scroll,
-        );
+        let transient_loader_area = layout.transient_loader_line_index.and_then(|line_index| {
+            Self::indicator_area(output_area, line_index, final_scroll, TACHYON_LOADER_WIDTH)
+        });
+        let queued_indicator_areas = layout
+            .queued_line_indices
+            .iter()
+            .filter_map(|line_index| {
+                Self::indicator_area(output_area, *line_index, final_scroll, QUEUED_ACTION_WIDTH)
+            })
+            .collect::<Vec<_>>();
 
         let paint_lines = text_util::borrowed_paint_lines(&layout.lines);
         let paragraph = Paragraph::new(paint_lines)
@@ -800,6 +815,9 @@ impl Component for SessionOutput<'_> {
         if let Some(loader_area) = transient_loader_area {
             TachyonLoaderEffect::apply_stateless(f.buffer_mut(), loader_area, spinner_frame);
         }
+        for queued_indicator_area in queued_indicator_areas {
+            QueuePulseEffect::apply_stateless(f.buffer_mut(), queued_indicator_area, spinner_frame);
+        }
     }
 }
 
@@ -817,9 +835,10 @@ mod tests {
     use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
     use crate::domain::theme::ColorTheme;
     use crate::domain::transient_message::{
-        TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
-        TransientMessageSlot,
+        QueuedAction, TransientMessage, TransientMessageAnchor, TransientMessageBody,
+        TransientMessageLifecycle, TransientMessageSlot,
     };
+    use crate::domain::turn_prompt::TurnPrompt;
     use crate::ui::prompt_block::{self, USER_PROMPT_PREFIX};
 
     /// Builds one output-line context with defaults suitable for tests.
@@ -829,6 +848,10 @@ mod tests {
             active_progress: None,
             session_update_version: 0,
         }
+    }
+
+    fn queued_message(order: u64, text: &str) -> QueuedMessage {
+        QueuedMessage::new(order, TurnPrompt::from_text(text.to_string()))
     }
 
     /// Posts one focused-review slot for renderer tests.
@@ -956,6 +979,59 @@ mod tests {
             .collect::<String>();
         assert!(rendered_text.contains(SCROLLBAR_TRACK_SYMBOL));
         assert!(rendered_text.contains(SCROLLBAR_THUMB_SYMBOL));
+    }
+
+    #[test]
+    fn test_render_animates_transient_loader_and_queued_indicator() {
+        // Arrange
+        let mut session = session_fixture();
+        session.status = Status::Review;
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading("Publishing review request...".to_string()),
+            lifecycle: TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::BranchPublish,
+            turn_position: None,
+        });
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Queued(QueuedAction::new(
+                0,
+                "sync after this turn".to_string(),
+            )),
+            lifecycle: TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::SyncQueue,
+            turn_position: None,
+        });
+        let backend = ratatui::backend::TestBackend::new(80, 10);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+        let tachyon_cell_symbol = Icon::TachyonLoader
+            .as_str()
+            .chars()
+            .next()
+            .expect("tachyon loader should contain a cell")
+            .to_string();
+
+        // Act
+        terminal
+            .draw(|frame| {
+                SessionOutput::new(&session)
+                    .spinner_frame(5)
+                    .render(frame, frame.area());
+            })
+            .expect("failed to draw session output");
+        let buffer = terminal.backend().buffer();
+        let queued_indicator = buffer
+            .content()
+            .iter()
+            .find(|cell| cell.symbol() == Icon::QueuedAction.as_str())
+            .expect("queued indicator should be rendered");
+
+        // Assert
+        assert_ne!(queued_indicator.fg, style::palette::text_subtle());
+        assert!(buffer.content().iter().any(|cell| {
+            cell.symbol() == tachyon_cell_symbol && cell.fg == style::palette::warning()
+        }));
     }
 
     #[test]
@@ -1321,7 +1397,7 @@ mod tests {
             context,
             Some(&markdown_render_cache),
         );
-        session.queued_messages = vec!["queued reply".to_string()];
+        session.queued_messages = vec![queued_message(0, "queued reply")];
         let queued_layout = output_layout_cache.layout(
             &session,
             Rect::new(0, 0, 80, 8),
@@ -1647,36 +1723,36 @@ mod tests {
     }
 
     #[test]
-    fn test_loader_area_tracks_scrolled_row() {
+    fn test_indicator_area_tracks_scrolled_row() {
         // Arrange
         let output_area = Rect::new(2, 3, 80, 10);
 
         // Act
-        let loader_area = SessionOutput::loader_area(output_area, Some(19), 12);
+        let loader_area = SessionOutput::indicator_area(output_area, 19, 12, TACHYON_LOADER_WIDTH);
 
         // Assert
         assert_eq!(loader_area, Some(Rect::new(2, 11, TACHYON_LOADER_WIDTH, 1)));
     }
 
     #[test]
-    fn test_loader_area_locates_row_before_following_hint() {
+    fn test_indicator_area_locates_row_before_following_hint() {
         // Arrange
         let output_area = Rect::new(0, 0, 80, 8);
 
         // Act
-        let loader_area = SessionOutput::loader_area(output_area, Some(1), 0);
+        let loader_area = SessionOutput::indicator_area(output_area, 1, 0, TACHYON_LOADER_WIDTH);
 
         // Assert
         assert_eq!(loader_area, Some(Rect::new(0, 2, TACHYON_LOADER_WIDTH, 1)));
     }
 
     #[test]
-    fn test_loader_area_skips_missing_line_index() {
+    fn test_indicator_area_skips_line_outside_viewport() {
         // Arrange
         let output_area = Rect::new(0, 0, 80, 10);
 
         // Act
-        let loader_area = SessionOutput::loader_area(output_area, None, 0);
+        let loader_area = SessionOutput::indicator_area(output_area, 20, 0, QUEUED_ACTION_WIDTH);
 
         // Assert
         assert_eq!(loader_area, None);
@@ -2302,8 +2378,8 @@ mod tests {
             "[Review Request] Created PR 42",
             "[Sync] Successfully synced onto main",
             "[Branch Push] Auto-pushed published branch.",
-            "queued › Verify the spacing.",
-            "queued › Keep one empty line.",
+            "≡ queued › Verify the spacing.",
+            "≡ queued › Keep one empty line.",
         ];
         set_conversation_transcript(
             &mut session,
@@ -2328,8 +2404,8 @@ mod tests {
             ],
         );
         session.queued_messages = vec![
-            "\nVerify the spacing.\n".to_string(),
-            " \nKeep one empty line.\n\t".to_string(),
+            queued_message(0, "\nVerify the spacing.\n"),
+            queued_message(1, " \nKeep one empty line.\n\t"),
         ];
 
         // Act
@@ -2348,7 +2424,12 @@ mod tests {
             .collect::<Vec<_>>();
 
         // Assert
-        assert!(message_rows.windows(2).all(|rows| rows[1] == rows[0] + 2));
+        assert!(
+            message_rows[..6]
+                .windows(2)
+                .all(|rows| rows[1] == rows[0] + 2)
+        );
+        assert_eq!(message_rows[6], message_rows[5] + 1);
     }
 
     /// Verifies queued-message edge trimming preserves blank lines within a
@@ -2358,8 +2439,8 @@ mod tests {
         // Arrange
         let mut lines = vec![Line::from("Previous message.")];
         let queued_messages = vec![
-            "\nFirst queued message.\n".to_string(),
-            " \nSecond queued message.\n\nMore context.\n\t".to_string(),
+            queued_message(0, "\nFirst queued message.\n"),
+            queued_message(1, " \nSecond queued message.\n\nMore context.\n\t"),
         ];
 
         // Act
@@ -2372,11 +2453,10 @@ mod tests {
             vec![
                 "Previous message.",
                 "",
-                "queued › First queued message.",
-                "",
-                "queued › Second queued message.",
-                "        ",
-                "        More context.",
+                "≡ queued › First queued message.",
+                "≡ queued › Second queued message.",
+                "           ",
+                "           More context.",
                 "",
             ]
         );
@@ -2603,7 +2683,7 @@ mod tests {
                 (SessionMessageKind::AssistantAnswer, "working"),
             ],
         );
-        session.queued_messages = vec!["follow up\nwith context".to_string()];
+        session.queued_messages = vec![queued_message(0, "follow up\nwith context")];
         session.summary = Some(summary_fixture());
         session.status = Status::InProgress;
 
@@ -2636,7 +2716,7 @@ mod tests {
         assert!(!text.contains("Change Summary"));
         assert!(commit_index < prompt_index);
         assert!(prompt_index < queued_index);
-        assert!(text.contains("        with context"));
+        assert!(text.contains("           with context"));
     }
 
     #[test]
@@ -2653,7 +2733,7 @@ mod tests {
             ],
         );
         session.status = Status::InProgress;
-        session.queued_messages = vec!["queued follow-up".to_string()];
+        session.queued_messages = vec![queued_message(0, "queued follow-up")];
         session.transient_messages.upsert(TransientMessage {
             anchor: TransientMessageAnchor::AfterActiveTurn,
             body: TransientMessageBody::Markdown(
@@ -2710,7 +2790,7 @@ mod tests {
             ],
         );
         session.status = Status::Rebasing;
-        session.queued_messages = vec!["address review comments".to_string()];
+        session.queued_messages = vec![queued_message(0, "address review comments")];
 
         // Act
         let lines = output_lines(&session, Rect::new(0, 0, 80, 12), line_context(), None);

--- a/crates/agentty/src/ui/icon.rs
+++ b/crates/agentty/src/ui/icon.rs
@@ -4,6 +4,10 @@ use std::fmt;
 pub(crate) const TACHYON_LOADER_GLYPH: &str = "▌▌▌";
 /// Display width of [`TACHYON_LOADER_GLYPH`] in terminal cells.
 pub(crate) const TACHYON_LOADER_WIDTH: u16 = 3;
+/// Stable queued-action glyph painted by the calm pulse effect.
+pub(crate) const QUEUED_ACTION_GLYPH: &str = "≡";
+/// Display width of [`QUEUED_ACTION_GLYPH`] in terminal cells.
+pub(crate) const QUEUED_ACTION_WIDTH: u16 = 1;
 
 /// A collection of icons used throughout the terminal UI.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -20,6 +24,8 @@ pub enum Icon {
     GitBranch,
     /// A pending status symbol (·).
     Pending,
+    /// A queued-action symbol (≡).
+    QueuedAction,
     /// A compact loader symbol animated by Tachyonfx after render.
     TachyonLoader,
     /// A stable loader glyph animated by shared Tachyonfx effects after render.
@@ -48,6 +54,7 @@ impl Icon {
             Icon::Cross => "✗",
             Icon::GitBranch => "●",
             Icon::Pending => "·",
+            Icon::QueuedAction => QUEUED_ACTION_GLYPH,
             Icon::TachyonLoader | Icon::Spinner => TACHYON_LOADER_GLYPH,
             Icon::Warn => "!",
         }
@@ -73,6 +80,7 @@ mod tests {
         assert_eq!(Icon::Cross.as_str(), "✗");
         assert_eq!(Icon::GitBranch.as_str(), "●");
         assert_eq!(Icon::Pending.as_str(), "·");
+        assert_eq!(Icon::QueuedAction.as_str(), QUEUED_ACTION_GLYPH);
         assert_eq!(Icon::TachyonLoader.as_str(), TACHYON_LOADER_GLYPH);
         assert_eq!(Icon::Warn.as_str(), "!");
     }
@@ -111,6 +119,7 @@ mod tests {
             Icon::Cross,
             Icon::GitBranch,
             Icon::Pending,
+            Icon::QueuedAction,
             Icon::TachyonLoader,
             Icon::Spinner,
             Icon::Warn,

--- a/crates/agentty/src/ui/session_format.rs
+++ b/crates/agentty/src/ui/session_format.rs
@@ -346,6 +346,42 @@ pub(crate) fn session_output_transient_loading_lines(message: &str) -> Vec<Line<
     lines
 }
 
+/// Builds calm queued-work rows with one distinct indicator on the first row.
+pub(crate) fn session_output_queued_lines(
+    message: &str,
+    first_line_prefix: &str,
+) -> Vec<Line<'static>> {
+    let queued_style = Style::default()
+        .fg(style::palette::text_subtle())
+        .add_modifier(Modifier::ITALIC);
+    let message_lines = message.trim().lines().collect::<Vec<_>>();
+    let Some(first_content_line_index) = message_lines
+        .iter()
+        .position(|message_line| !message_line.trim().is_empty())
+    else {
+        return Vec::new();
+    };
+    let last_content_line_index = message_lines
+        .iter()
+        .rposition(|message_line| !message_line.trim().is_empty())
+        .unwrap_or(first_content_line_index);
+    let continuation_indent = " ".repeat(2 + first_line_prefix.chars().count());
+
+    message_lines[first_content_line_index..=last_content_line_index]
+        .iter()
+        .enumerate()
+        .map(|(line_index, message_line)| {
+            let rendered_text = if line_index == 0 {
+                format!("{} {first_line_prefix}{message_line}", Icon::QueuedAction)
+            } else {
+                format!("{continuation_indent}{message_line}")
+            };
+
+            Line::styled(rendered_text, queued_style)
+        })
+        .collect()
+}
+
 /// Returns one rendered summary section or the shared empty placeholder.
 fn summary_section_text(summary_text: &str) -> &str {
     let trimmed_summary = summary_text.trim();

--- a/crates/agentty/src/ui/session_output_assembly.rs
+++ b/crates/agentty/src/ui/session_output_assembly.rs
@@ -11,14 +11,16 @@ use std::sync::Arc;
 use ag_tui_text::text_util;
 use ratatui::text::Line;
 
-use crate::domain::session::{Session, Status};
+use crate::domain::session::{QueuedMessage, Session, Status};
 use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
 use crate::domain::transient_message::{
     TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageSlot,
 };
 use crate::ui::markdown::{self, render_markdown};
 use crate::ui::prompt_block::{self, USER_PROMPT_PREFIX, USER_PROMPT_RIGHT_GUTTER_WIDTH};
-use crate::ui::{session_format, style};
+use crate::ui::session_format;
+#[cfg(test)]
+use crate::ui::style;
 
 const DRAFT_PREVIEW_HEADER: &str = "## Draft Session";
 const DRAFT_PREVIEW_EMPTY_NOTE: &str = "No draft messages staged yet. Use `Enter` to stage the \
@@ -38,6 +40,7 @@ const USER_PROMPT_TAB_WIDTH: usize = 4;
 pub(crate) struct SessionOutputLines {
     pub(crate) active_loader_line_index: Option<usize>,
     pub(crate) lines: Vec<Line<'static>>,
+    pub(crate) queued_line_indices: Vec<usize>,
     pub(crate) transient_loader_line_index: Option<usize>,
 }
 
@@ -45,6 +48,7 @@ pub(crate) struct SessionOutputLines {
 #[derive(Clone)]
 pub(crate) struct SessionOutputBody {
     pub(crate) lines: Arc<[Line<'static>]>,
+    pub(crate) queued_line_indices: Arc<[usize]>,
     pub(crate) transient_loader_line_index: Option<usize>,
 }
 
@@ -85,6 +89,7 @@ pub(crate) fn layout_from_body(
     SessionOutputLines {
         active_loader_line_index,
         lines,
+        queued_line_indices: body.queued_line_indices.iter().copied().collect(),
         transient_loader_line_index: body.transient_loader_line_index,
     }
 }
@@ -125,9 +130,9 @@ fn section_display_text(section: &SessionOutputTranscriptSection<'_>) -> String 
 #[cfg(test)]
 pub(crate) fn append_queued_message_lines(
     lines: &mut Vec<Line<'static>>,
-    queued_messages: &[String],
+    queued_messages: &[QueuedMessage],
 ) {
-    append_queued_messages(lines, queued_messages);
+    append_queued_entries(lines, &[], queued_messages);
 }
 
 /// Appends one user prompt block while retaining its prompt marker and shading.
@@ -186,6 +191,7 @@ struct SessionOutputAssembly<'a> {
     inner_width: usize,
     lines: Vec<Line<'static>>,
     markdown_render_cache: Option<&'a markdown::MarkdownRenderCache>,
+    queued_line_indices: Vec<usize>,
     session: &'a Session,
     status: Status,
     transient_loader_line_index: Option<usize>,
@@ -225,6 +231,7 @@ impl SessionOutputAssembly<'_> {
         SessionOutputLines {
             active_loader_line_index: self.active_loader_line_index,
             lines: self.lines,
+            queued_line_indices: self.queued_line_indices,
             transient_loader_line_index: self.transient_loader_line_index,
         }
     }
@@ -238,6 +245,7 @@ impl SessionOutputAssembly<'_> {
 
         SessionOutputBody {
             lines: Arc::from(self.lines),
+            queued_line_indices: Arc::from(self.queued_line_indices),
             transient_loader_line_index: self.transient_loader_line_index,
         }
     }
@@ -287,7 +295,10 @@ impl SessionOutputAssembly<'_> {
             .transient_messages
             .messages()
             .iter()
-            .filter(|message| message.anchor == anchor)
+            .filter(|message| {
+                message.anchor == anchor
+                    && !matches!(&message.body, TransientMessageBody::Queued(_))
+            })
         {
             if let Some(loader_line_index) = append_transient_message(
                 &mut self.lines,
@@ -310,7 +321,11 @@ impl SessionOutputAssembly<'_> {
     }
 
     fn append_queued_messages(&mut self) {
-        append_queued_messages(&mut self.lines, &self.session.queued_messages);
+        self.queued_line_indices = append_queued_entries(
+            &mut self.lines,
+            self.session.transient_messages.messages(),
+            &self.session.queued_messages,
+        );
     }
 
     fn append_session_tail(&mut self) {
@@ -342,6 +357,7 @@ fn output_assembly<'assembly>(
         inner_width,
         lines: Vec::new(),
         markdown_render_cache,
+        queued_line_indices: Vec::new(),
         session,
         status,
         transient_loader_line_index: None,
@@ -399,7 +415,9 @@ fn review_loading_message(session: &Session) -> Option<&str> {
         .get(TransientMessageSlot::Review)
         .and_then(|message| match &message.body {
             TransientMessageBody::Loading(message) => Some(message.as_str()),
-            TransientMessageBody::Markdown(_) | TransientMessageBody::Plain(_) => None,
+            TransientMessageBody::Markdown(_)
+            | TransientMessageBody::Plain(_)
+            | TransientMessageBody::Queued(_) => None,
         })
 }
 
@@ -419,6 +437,7 @@ fn append_transient_message(
                 TransientMessageSlot::WorkflowNotice
                 | TransientMessageSlot::Orchestration
                 | TransientMessageSlot::BranchPublish
+                | TransientMessageSlot::SyncQueue
                 | TransientMessageSlot::PublishedBranchSync => markdown.clone(),
             };
             append_markdown_lines(lines, &markdown, inner_width, markdown_render_cache);
@@ -444,6 +463,7 @@ fn append_transient_message(
 
             Some(loader_line_index)
         }
+        TransientMessageBody::Queued(_) => None,
     }
 }
 
@@ -623,55 +643,65 @@ fn append_transcript_messages(
     }
 }
 
-fn append_queued_messages(lines: &mut Vec<Line<'static>>, queued_messages: &[String]) {
-    if queued_messages.is_empty() {
-        return;
-    }
-
-    let queued_style = ratatui::style::Style::default()
-        .fg(style::palette::text_subtle())
-        .add_modifier(ratatui::style::Modifier::ITALIC);
+fn append_queued_entries(
+    lines: &mut Vec<Line<'static>>,
+    transient_messages: &[TransientMessage],
+    queued_messages: &[QueuedMessage],
+) -> Vec<usize> {
+    let mut queued_line_indices = Vec::new();
     let mut has_rendered_message = false;
-    for queued_text in queued_messages {
-        let message_lines = queued_text.split('\n').collect::<Vec<_>>();
-        let Some(first_content_line_index) = message_lines
-            .iter()
-            .position(|message_line| !message_line.trim().is_empty())
-        else {
-            continue;
-        };
-        let last_content_line_index = message_lines
-            .iter()
-            .rposition(|message_line| !message_line.trim().is_empty())
-            .unwrap_or(first_content_line_index);
-        let separator = if has_rendered_message {
-            SessionOutputSeparator::AfterPreviousContent
-        } else {
-            SessionOutputSeparator::Always
-        };
-        append_block_separator(lines, separator);
-
-        for (line_index, message_line) in message_lines
-            [first_content_line_index..=last_content_line_index]
-            .iter()
-            .enumerate()
-        {
-            let prefix = if line_index == 0 {
-                "queued › "
+    let mut queued_entries = transient_messages
+        .iter()
+        .filter_map(|message| {
+            if let TransientMessageBody::Queued(queued_action) = &message.body {
+                Some((queued_action.order, queued_action.text.as_str(), ""))
             } else {
-                "        "
-            };
-            lines.push(Line::styled(
-                format!("{prefix}{message_line}"),
-                queued_style,
-            ));
-        }
-        has_rendered_message = true;
+                None
+            }
+        })
+        .chain(
+            queued_messages
+                .iter()
+                .map(|message| (message.order(), message.transcript_text(), "queued › ")),
+        )
+        .collect::<Vec<_>>();
+    queued_entries.sort_by_key(|(order, _, _)| *order);
+
+    for (_, queued_text, first_line_prefix) in queued_entries {
+        append_queued_entry(
+            lines,
+            &mut queued_line_indices,
+            &mut has_rendered_message,
+            queued_text,
+            first_line_prefix,
+        );
     }
 
     if has_rendered_message {
         lines.push(Line::from(""));
     }
+
+    queued_line_indices
+}
+
+fn append_queued_entry(
+    lines: &mut Vec<Line<'static>>,
+    queued_line_indices: &mut Vec<usize>,
+    has_rendered_message: &mut bool,
+    message: &str,
+    first_line_prefix: &str,
+) {
+    let queued_lines = session_format::session_output_queued_lines(message, first_line_prefix);
+    if queued_lines.is_empty() {
+        return;
+    }
+    if !*has_rendered_message {
+        append_block_separator(lines, SessionOutputSeparator::Always);
+    }
+
+    queued_line_indices.push(lines.len());
+    lines.extend(queued_lines);
+    *has_rendered_message = true;
 }
 
 fn append_user_prompt(
@@ -867,6 +897,12 @@ fn rendered_markdown_lines(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::transient_message::QueuedAction;
+    use crate::domain::turn_prompt::TurnPrompt;
+
+    fn queued_message(order: u64, text: &str) -> QueuedMessage {
+        QueuedMessage::new(order, TurnPrompt::from_text(text.to_string()))
+    }
 
     #[test]
     fn test_section_display_text_handles_empty_and_markdown_sections() {
@@ -890,16 +926,91 @@ mod tests {
     fn test_queued_messages_skip_blank_entries() {
         // Arrange
         let mut lines = Vec::new();
-        let queued_messages = vec![" \n\t".to_string(), "queued reply".to_string()];
+        let queued_messages = vec![
+            queued_message(0, " \n\t"),
+            queued_message(1, "queued reply"),
+        ];
 
         // Act
-        append_queued_messages(&mut lines, &queued_messages);
+        append_queued_entries(&mut lines, &[], &queued_messages);
 
         // Assert
         assert_eq!(
             lines.iter().map(ToString::to_string).collect::<Vec<_>>(),
-            ["", "queued › queued reply", ""]
+            ["", "≡ queued › queued reply", ""]
         );
+    }
+
+    #[test]
+    fn test_transient_message_appender_skips_queued_actions() {
+        // Arrange
+        let mut lines = Vec::new();
+        let message = TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Queued(QueuedAction::new(
+                0,
+                "sync after this turn".to_string(),
+            )),
+            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::SyncQueue,
+            turn_position: None,
+        };
+
+        // Act
+        let loader_line_index = append_transient_message(&mut lines, &message, 80, None);
+
+        // Assert
+        assert_eq!(loader_line_index, None);
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn test_queued_entries_follow_shared_submission_order() {
+        // Arrange
+        let mut lines = vec![Line::from("Active turn")];
+        let transient_messages = vec![
+            TransientMessage {
+                anchor: TransientMessageAnchor::Tail,
+                body: TransientMessageBody::Queued(QueuedAction::new(
+                    0,
+                    "sync after this turn".to_string(),
+                )),
+                lifecycle:
+                    crate::domain::transient_message::TransientMessageLifecycle::UntilResolved,
+                slot: TransientMessageSlot::SyncQueue,
+                turn_position: Some(1),
+            },
+            TransientMessage {
+                anchor: TransientMessageAnchor::Tail,
+                body: TransientMessageBody::Queued(QueuedAction::new(
+                    2,
+                    "publish review request".to_string(),
+                )),
+                lifecycle:
+                    crate::domain::transient_message::TransientMessageLifecycle::UntilResolved,
+                slot: TransientMessageSlot::BranchPublish,
+                turn_position: Some(1),
+            },
+        ];
+        let queued_messages = vec![queued_message(1, "follow up")];
+
+        // Act
+        let queued_line_indices =
+            append_queued_entries(&mut lines, &transient_messages, &queued_messages);
+
+        // Assert
+        assert_eq!(
+            lines.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            [
+                "Active turn",
+                "",
+                "≡ sync after this turn",
+                "≡ queued › follow up",
+                "≡ publish review request",
+                "",
+            ]
+        );
+        assert_eq!(queued_line_indices, [2, 3, 4]);
     }
 
     #[test]
@@ -994,7 +1105,7 @@ mod tests {
             SessionMessage::conversation(1, SessionMessageKind::AssistantAnswer, "first answer"),
             SessionMessage::conversation(2, SessionMessageKind::UserPrompt, "active prompt"),
         ]));
-        session.queued_messages = vec!["queued reply".to_string()];
+        session.queued_messages = vec![queued_message(0, "queued reply")];
 
         // Act
         let output = output_lines(&session, 80, None, None)

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1827,18 +1827,29 @@ const QUEUED_SYNC_TURN_ANSWER: &str = "Running turn completed before sync";
 /// Answer emitted before queued review-request creation begins.
 const QUEUED_REVIEW_REQUEST_TURN_ANSWER: &str =
     "Running turn completed before review request creation";
+/// Answer emitted for the chat message queued before review-request creation.
+const QUEUED_REVIEW_FOLLOW_UP_ANSWER: &str = "Queued review follow-up completed before publish";
 
 /// Installs a delayed Claude turn so the scenario can queue sync while the
-/// worker is still active, then observe the answer before the rebase result.
-fn install_delayed_sync_claude_stub(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+/// worker is still active, optionally forcing its later validation to fail.
+fn install_delayed_sync_claude_stub(
+    env: &BuilderEnv,
+    fail_sync_validation: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let claude_path = env.stub_bin.join("claude");
+    let validation_failure_marker = env.stub_bin.join("queued-sync-validation-failure");
+    let mark_validation_failure = if fail_sync_validation {
+        format!("touch '{}'; ", validation_failure_marker.display())
+    } else {
+        String::new()
+    };
     let script = format!(
         r#"#!/bin/sh
 if [ "$1" = "update" ]; then exit 0; fi
 if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
 cat > /dev/null 2>&1
 sleep 10
-printf '%s\n' '{{"type":"system","subtype":"init"}}'
+{mark_validation_failure}printf '%s\n' '{{"type":"system","subtype":"init"}}'
 printf '%s\n' '{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"{QUEUED_SYNC_TURN_ANSWER}"}}]}}}}'
 printf '%s\n' '{{"type":"result","subtype":"success","result":"{{\"answer\":\"{QUEUED_SYNC_TURN_ANSWER}\",\"questions\":[],\"summary\":null}}","usage":{{"input_tokens":5,"output_tokens":9}}}}'
 "#
@@ -1848,7 +1859,39 @@ printf '%s\n' '{{"type":"result","subtype":"success","result":"{{\"answer\":\"{Q
     #[cfg(unix)]
     std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o755))?;
 
+    if fail_sync_validation {
+        install_sync_validation_failure_git_stub(env, &validation_failure_marker)?;
+    }
+
     seed_project_settings(env, &[("DefaultSmartModel", "claude-haiku-4-5-20251001")])
+}
+
+/// Installs a Git wrapper that fails only the marked queued-sync validation.
+fn install_sync_validation_failure_git_stub(
+    env: &BuilderEnv,
+    validation_failure_marker: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let real_git = std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
+        .map(|path| path.join("git"))
+        .find(|path| path.is_file())
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "git not found"))?;
+    let git_path = env.stub_bin.join("git");
+    let script = format!(
+        r#"#!/bin/sh
+if [ -f '{}' ] && [ "$1" = "rev-parse" ] && [ "$2" = "--is-bare-repository" ]; then
+  printf '%s\n' 'forced queued-sync validation failure' >&2
+  exit 1
+fi
+exec '{}' "$@"
+"#,
+        validation_failure_marker.display(),
+        real_git.display()
+    );
+    std::fs::write(&git_path, script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&git_path, std::fs::Permissions::from_mode(0o755))?;
+
+    Ok(())
 }
 
 /// Installs delayed agent, Git, and GitHub stubs so review-request creation
@@ -1932,6 +1975,60 @@ esac
     std::fs::set_permissions(&gh_path, std::fs::Permissions::from_mode(0o755))?;
 
     seed_project_settings(env, &[("DefaultSmartModel", "claude-haiku-4-5-20251001")])
+}
+
+/// Extends the queued-review stubs with enough turn latency for a deliberate
+/// cancellation after the publish action has been queued.
+fn install_cancelled_queued_review_request_stubs(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    install_queued_review_request_stubs(env)?;
+
+    let claude_path = env.stub_bin.join("claude");
+    let claude_script = std::fs::read_to_string(&claude_path)?;
+    let delayed_script = claude_script.replacen("sleep 8", "sleep 30", 1);
+    if delayed_script == claude_script {
+        return Err("queued review-request stub is missing its turn delay".into());
+    }
+    std::fs::write(&claude_path, delayed_script)?;
+
+    Ok(())
+}
+
+/// Extends the queued-review stubs with a distinct second agent turn so the
+/// mixed FIFO feature can prove the chat message executes before publishing.
+fn install_fifo_queued_review_request_stubs(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    install_queued_review_request_stubs(env)?;
+
+    let claude_path = env.stub_bin.join("claude");
+    let claude_script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
+cat > /dev/null 2>&1
+turn_marker="${{0}}.turn"
+if [ -f "$turn_marker" ]; then
+  printf '%s\n' '{{"type":"system","subtype":"init"}}'
+  printf '%s\n' '{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"{QUEUED_REVIEW_FOLLOW_UP_ANSWER}"}}]}}}}'
+  printf '%s\n' '{{"type":"result","subtype":"success","result":"{{\"answer\":\"{QUEUED_REVIEW_FOLLOW_UP_ANSWER}\",\"questions\":[],\"summary\":null}}","usage":{{"input_tokens":5,"output_tokens":9}}}}'
+else
+  touch "$turn_marker"
+  # Keep the first turn active while the PTY driver queues both items, even
+  # when the E2E test group is running four scenarios concurrently.
+  sleep 20
+  printf '%s\n' '{{"type":"system","subtype":"init"}}'
+  printf '%s\n' '{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"{QUEUED_REVIEW_REQUEST_TURN_ANSWER}"}}]}}}}'
+  printf '%s\n' '{{"type":"result","subtype":"success","result":"{{\"answer\":\"{QUEUED_REVIEW_REQUEST_TURN_ANSWER}\",\"questions\":[],\"summary\":null}}","usage":{{"input_tokens":5,"output_tokens":9}}}}'
+fi
+"#
+    );
+    std::fs::write(&claude_path, claude_script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o755))?;
+
+    Ok(())
 }
 
 /// Installs a Claude stub that reports whether Agentty passed web-capable
@@ -3468,7 +3565,7 @@ fn session_queue_chat_messages_during_in_progress_turn() -> E2eResult {
                     .write_text("first queued")
                     .wait_for_text("first queued", 3000)
                     .press_key("Enter")
-                    .wait_for_text("queued ›", 5000)
+                    .wait_for_text("≡ queued ›", 5000)
                     .press_key("Enter")
                     .wait_for_stable_frame(300, 5000)
                     .write_text("second queued")
@@ -3507,7 +3604,7 @@ fn session_queue_chat_messages_during_in_progress_turn() -> E2eResult {
             |frame, report| {
                 let queued_frame = common::frame_from_capture(&report.captures[0]);
                 let queued_full = Region::full(queued_frame.cols(), queued_frame.rows());
-                assertion::assert_text_in_region(&queued_frame, "queued ›", &queued_full);
+                assertion::assert_text_in_region(&queued_frame, "≡ queued ›", &queued_full);
                 assertion::assert_text_in_region(&queued_frame, "first queued", &queued_full);
                 assertion::assert_text_in_region(&queued_frame, "second queued", &queued_full);
 
@@ -3519,7 +3616,11 @@ fn session_queue_chat_messages_during_in_progress_turn() -> E2eResult {
                     "Ctrl+c: stop",
                     &after_first_full,
                 );
-                assertion::assert_text_in_region(&after_first_frame, "queued ›", &after_first_full);
+                assertion::assert_text_in_region(
+                    &after_first_frame,
+                    "≡ queued ›",
+                    &after_first_full,
+                );
                 assertion::assert_text_in_region(
                     &after_first_frame,
                     "first queued",
@@ -3571,7 +3672,7 @@ fn session_queue_chat_message_during_rebase() -> E2eResult {
                     .write_text("follow up after sync")
                     .wait_for_text("follow up after sync", 3000)
                     .press_key("Enter")
-                    .wait_for_text("queued ›", 5000)
+                    .wait_for_text("≡ queued ›", 5000)
                     .viewing_pause_ms(1000)
                     .capture_labeled(
                         "message_queued_during_rebase",
@@ -3587,7 +3688,7 @@ fn session_queue_chat_message_during_rebase() -> E2eResult {
                     "[Sync Assist] Resolving existing conflicts.",
                     &full,
                 );
-                assertion::assert_text_in_region(frame, "queued ›", &full);
+                assertion::assert_text_in_region(frame, "≡ queued ›", &full);
                 assertion::assert_text_in_region(frame, "follow up after sync", &full);
                 let commit_row = frame
                     .find_text("[Commit] No changes to commit.")
@@ -3623,7 +3724,7 @@ fn session_running_turn_shows_sync_shortcut() -> E2eResult {
     // Arrange, Act, Assert
     FeatureTest::new("session_running_sync_shortcut")
         .with_git()
-        .setup(install_delayed_sync_claude_stub)
+        .setup(|env| install_delayed_sync_claude_stub(env, false))
         .run(
             |scenario| {
                 scenario
@@ -3638,7 +3739,7 @@ fn session_running_turn_shows_sync_shortcut() -> E2eResult {
                     .wait_for_text("Ctrl+c: stop", 5000)
                     .wait_for_text("r: sync", 5000)
                     .press_key("r")
-                    .wait_for_text("will rebase after the current turn finishes", 5000)
+                    .wait_for_text("rebase onto the base branch after this turn", 5000)
                     .viewing_pause_ms(1000)
                     .capture_labeled(
                         "running_sync_queued",
@@ -3657,7 +3758,7 @@ fn session_running_turn_shows_sync_shortcut() -> E2eResult {
                 let queued_full = Region::full(queued_frame.cols(), queued_frame.rows());
                 assertion::assert_text_in_region(
                     &queued_frame,
-                    "will rebase after the current turn finishes",
+                    "≡ sync — rebase onto the base branch after this turn",
                     &queued_full,
                 );
                 assertion::assert_text_in_region(&queued_frame, "Ctrl+c: stop", &queued_full);
@@ -3668,7 +3769,7 @@ fn session_running_turn_shows_sync_shortcut() -> E2eResult {
                     .rect
                     .row;
                 let queued_sync_row = queued_frame
-                    .find_text("will rebase after the current turn finishes")
+                    .find_text("rebase onto the base branch after this turn")
                     .first()
                     .expect("missing queued sync notice")
                     .rect
@@ -3680,6 +3781,7 @@ fn session_running_turn_shows_sync_shortcut() -> E2eResult {
                 assertion::assert_text_in_region(frame, "[Sync] Successfully synced", &full);
                 assertion::assert_text_in_region(frame, "Enter: reply", &full);
                 assertion::assert_not_visible(frame, "[Stopped]");
+                assertion::assert_not_visible(frame, "≡ sync —");
 
                 let answer_row = frame
                     .find_text(QUEUED_SYNC_TURN_ANSWER)
@@ -3694,6 +3796,142 @@ fn session_running_turn_shows_sync_shortcut() -> E2eResult {
                     .rect
                     .row;
                 assert!(answer_row < sync_row);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify stopping an active turn also removes its canceled queued-sync row
+/// without promoting the skipped command to active rebase work.
+#[test]
+fn session_queued_sync_clears_when_turn_is_cancelled() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_queued_sync_cancelled_with_turn")
+        .with_git()
+        .setup(|env| install_delayed_sync_claude_stub(env, false))
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("Cancel the turn and queued sync")
+                    .wait_for_text("Cancel the turn and queued sync", 3000)
+                    .press_key("Enter")
+                    .wait_for_text("Ctrl+c: stop", 5000)
+                    .press_key("r")
+                    .wait_for_text("rebase onto the base branch after this turn", 5000)
+                    .capture_labeled(
+                        "queued_sync_before_turn_cancel",
+                        "Sync waits behind the active turn before cancellation",
+                    )
+                    .press_key("ctrl+c")
+                    .eventually(
+                        Duration::from_secs(10),
+                        Duration::from_millis(100),
+                        |frame| {
+                            let full = Region::full(frame.cols(), frame.rows());
+                            assertion::match_text_in_region(frame, "Enter: reply", &full)?;
+
+                            assertion::match_not_visible(frame, "≡ sync —")
+                        },
+                    )
+                    .capture_labeled(
+                        "queued_sync_cleared_after_turn_cancel",
+                        "Canceled queued sync disappears without starting rebase",
+                    )
+            },
+            |frame, report| {
+                let queued_frame = common::frame_from_capture(&report.captures[0]);
+                let queued_full = Region::full(queued_frame.cols(), queued_frame.rows());
+                assertion::assert_text_in_region(
+                    &queued_frame,
+                    "≡ sync — rebase onto the base branch after this turn",
+                    &queued_full,
+                );
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Enter: reply", &full);
+                assertion::assert_not_visible(frame, "≡ sync —");
+                assertion::assert_not_visible(frame, "Rebasing...");
+                assertion::assert_not_visible(frame, "[Sync] Successfully synced");
+                assertion::assert_not_visible(frame, QUEUED_SYNC_TURN_ANSWER);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify queued sync validation failures replace waiting state with a
+/// durable error without briefly presenting the sync as active work.
+#[test]
+fn session_queued_sync_validation_failure_is_visible() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_queued_sync_validation_failure")
+        .with_git()
+        .setup(|env| install_delayed_sync_claude_stub(env, true))
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("Fail queued sync validation")
+                    .wait_for_text("Fail queued sync validation", 3000)
+                    .press_key("Enter")
+                    .wait_for_text("Ctrl+c: stop", 5000)
+                    .press_key("r")
+                    .wait_for_text("rebase onto the base branch after this turn", 5000)
+                    .capture_labeled(
+                        "queued_sync_waiting",
+                        "Sync remains queued behind the active turn",
+                    )
+                    .wait_for_text(QUEUED_SYNC_TURN_ANSWER, 30000)
+                    .wait_for_text("[Sync Error] Session isolation violation", 10000)
+                    .wait_for_text("Enter: reply", 5000)
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled(
+                        "queued_sync_validation_failed",
+                        "Validation failure replaces queued sync with a durable error",
+                    )
+            },
+            |frame, report| {
+                let queued_frame = common::frame_from_capture(&report.captures[0]);
+                let queued_full = Region::full(queued_frame.cols(), queued_frame.rows());
+                assertion::assert_text_in_region(
+                    &queued_frame,
+                    "≡ sync — rebase onto the base branch after this turn",
+                    &queued_full,
+                );
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, QUEUED_SYNC_TURN_ANSWER, &full);
+                assertion::assert_text_in_region(
+                    frame,
+                    "[Sync Error] Session isolation violation",
+                    &full,
+                );
+                assertion::assert_text_in_region(frame, "Enter: reply", &full);
+                assertion::assert_not_visible(frame, "≡ sync —");
+                assertion::assert_not_visible(frame, "Rebasing...");
+                let answer_row = frame
+                    .find_text(QUEUED_SYNC_TURN_ANSWER)
+                    .first()
+                    .expect("missing completed turn answer")
+                    .rect
+                    .row;
+                let error_row = frame
+                    .find_text("[Sync Error] Session isolation violation")
+                    .first()
+                    .expect("missing queued sync validation error")
+                    .rect
+                    .row;
+                assert!(answer_row < error_row);
             },
         )?;
 
@@ -3728,10 +3966,7 @@ fn review_request_creation_queues_during_running_turn() -> E2eResult {
                     .press_key("p")
                     .wait_for_text("Publish Review Request", 5000)
                     .press_key("Enter")
-                    .wait_for_text(
-                        "Review request queued; publishing after the current turn finishes...",
-                        5000,
-                    )
+                    .wait_for_text("≡ review request — publish after this turn", 5000)
                     .viewing_pause_ms(1200)
                     .capture_labeled(
                         "review_request_queued",
@@ -3754,7 +3989,7 @@ fn review_request_creation_queues_during_running_turn() -> E2eResult {
                 let queued_full = Region::full(queued_frame.cols(), queued_frame.rows());
                 assertion::assert_text_in_region(
                     &queued_frame,
-                    "Review request queued; publishing after the current turn finishes...",
+                    "≡ review request — publish after this turn",
                     &queued_full,
                 );
                 assertion::assert_text_in_region(
@@ -3776,6 +4011,7 @@ fn review_request_creation_queues_during_running_turn() -> E2eResult {
                     "Publishing review request...",
                     &started_full,
                 );
+                assertion::assert_not_visible(&started_frame, "≡ review request —");
 
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(
@@ -3783,7 +4019,159 @@ fn review_request_creation_queues_during_running_turn() -> E2eResult {
                     "[Review Request] Created PR https://github.com/agentty-xyz/agentty/pull/42",
                     &full,
                 );
-                assertion::assert_not_visible(frame, "Review request queued;");
+                assertion::assert_not_visible(frame, "≡ review request —");
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify stopping an active turn also removes its canceled queued
+/// review-request row without promoting the skipped command to publish work.
+#[test]
+fn review_request_queued_creation_clears_when_turn_is_cancelled() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("review_request_queued_creation_cancelled_with_turn")
+        .with_git()
+        .setup(install_cancelled_queued_review_request_stubs)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("Cancel the turn and queued review request")
+                    .wait_for_text("Cancel the turn and queued review request", 3000)
+                    .press_key("Enter")
+                    .wait_for_text("Ctrl+c: stop", 5000)
+                    .wait_for_text("p: PR", 5000)
+                    .press_key("p")
+                    .wait_for_text("Publish Review Request", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("≡ review request — publish after this turn", 5000)
+                    .capture_labeled(
+                        "queued_review_request_before_turn_cancel",
+                        "Review-request creation waits behind the active turn",
+                    )
+                    .press_key("ctrl+c")
+                    .eventually(
+                        Duration::from_secs(10),
+                        Duration::from_millis(100),
+                        |frame| {
+                            let full = Region::full(frame.cols(), frame.rows());
+                            assertion::match_text_in_region(frame, "Enter: reply", &full)?;
+
+                            assertion::match_not_visible(frame, "≡ review request —")
+                        },
+                    )
+                    .press_key("p")
+                    .wait_for_text("Publish Review Request", 5000)
+                    .capture_labeled(
+                        "queued_review_request_cleared_after_turn_cancel",
+                        "Canceled review-request row disappears and publish opens again",
+                    )
+            },
+            |frame, report| {
+                let queued_frame = common::frame_from_capture(&report.captures[0]);
+                let queued_full = Region::full(queued_frame.cols(), queued_frame.rows());
+                assertion::assert_text_in_region(
+                    &queued_frame,
+                    "≡ review request — publish after this turn",
+                    &queued_full,
+                );
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Publish Review Request", &full);
+                assertion::assert_not_visible(frame, "≡ review request —");
+                assertion::assert_not_visible(frame, "Publishing review request...");
+                assertion::assert_not_visible(frame, "[Review Request] Created PR");
+                assertion::assert_not_visible(frame, QUEUED_REVIEW_REQUEST_TURN_ANSWER);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify mixed chat and workflow work renders and executes from top to
+/// bottom in the order each item was submitted.
+#[test]
+fn session_queued_work_uses_fifo_display_and_execution_order() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_queued_work_fifo")
+        .with_git()
+        .setup(install_fifo_queued_review_request_stubs)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("Queue mixed work")
+                    .wait_for_text("Queue mixed work", 3000)
+                    .press_key("Enter")
+                    .wait_for_text("p: PR", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Type your message", 5000)
+                    .write_text("Review once more")
+                    .wait_for_text("Review once more", 3000)
+                    .press_key("Enter")
+                    .wait_for_text("≡ queued › Review once more", 5000)
+                    .press_key("p")
+                    .wait_for_text("Publish Review Request", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("≡ review request — publish after this turn", 5000)
+                    .capture_labeled(
+                        "mixed_queue_submission_order",
+                        "Queued chat appears above the later review-request action",
+                    )
+                    .wait_for_text(QUEUED_REVIEW_REQUEST_TURN_ANSWER, 30000)
+                    .wait_for_text(QUEUED_REVIEW_FOLLOW_UP_ANSWER, 10000)
+                    .wait_for_text("[Review Request] Created PR", 15000)
+                    .capture_labeled(
+                        "mixed_queue_execution_order",
+                        "Queued chat completes before the later review-request action",
+                    )
+            },
+            |frame, report| {
+                let queued_frame = common::frame_from_capture(&report.captures[0]);
+                let queued_chat_row = queued_frame
+                    .find_text("queued › Review once more")
+                    .first()
+                    .expect("missing queued chat message")
+                    .rect
+                    .row;
+                let queued_publish_row = queued_frame
+                    .find_text("review request — publish after this turn")
+                    .first()
+                    .expect("missing queued review-request action")
+                    .rect
+                    .row;
+                assert!(queued_chat_row < queued_publish_row);
+
+                let active_answer_row = frame
+                    .find_text(QUEUED_REVIEW_REQUEST_TURN_ANSWER)
+                    .first()
+                    .expect("missing active turn answer")
+                    .rect
+                    .row;
+                let queued_answer_row = frame
+                    .find_text(QUEUED_REVIEW_FOLLOW_UP_ANSWER)
+                    .first()
+                    .expect("missing queued chat answer")
+                    .rect
+                    .row;
+                let review_request_row = frame
+                    .find_text("[Review Request] Created PR")
+                    .first()
+                    .expect("missing created review request")
+                    .rect
+                    .row;
+                assert!(active_answer_row < queued_answer_row);
+                assert!(queued_answer_row < review_request_row);
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -167,28 +167,45 @@ ordered `session_message` rows (typed `UserPrompt`, `AssistantAnswer`, `Workflow
 rows). Replaceable output lives in the session's typed transient-message slots instead
 of render-time visibility predicates. Each slot has stable identity, typed content, an
 output anchor, and an explicit lifecycle. Reducer paths upsert or retract summary,
-focused-review, workflow-feedback, manual-branch-publish, and published-branch-sync
-slots; starting a later turn clears older turn-scoped slots in one place.
+focused-review, workflow-feedback, queued-sync, manual-branch-publish, and
+published-branch-sync slots; starting a later turn clears older turn-scoped slots in one
+place. Transient bodies distinguish calm `Queued` rows from animated `Loading` rows. The
+output assembler gathers every queued transient into the same block as the handle-backed
+chat queue. Queued chat and worker commands reserve from one session-local submission
+sequence; the output assembler sorts the combined rows by that sequence, and the worker
+uses the same value to select the next runnable item.
 
 Manual branch publishing and review-request creation return from the branch-name popup
 to `AppMode::View`. Review-request creation is persisted on the per-session worker, so
-an action accepted during an active turn renders a queued row and executes before later
-queued chat. A worker-start event replaces that row with animated publish progress; the
-terminal reducer event then replaces it with inline success or failure output without
-changing whichever app mode is active at completion. Successful review-request creation
-retracts the transient row and appends its single-line URL result as a durable
-`WorkflowNotice` at the current transcript position. If focused review already completed
-at the output tail, the reducer first moves that result into completed-turn placement so
-the newer review-request notice remains below it. An in-flight focused review stays at
-the tail and therefore appears after the notice when it completes later. Later turns
-leave the durable result in its original history position instead of reconstructing a
-transient between turns. The manual task holds the same per-session branch-operation
-lock as completed-turn auto-push for its full push and forge-metadata workflow. Queued
-review-request creation also registers as unfinished branch work before the current turn
-can start automatic publishing. Its UI and API handlers only attempt a non-blocking lock
-reservation while persisting the command; when another branch action already owns the
-lock, they return after queueing and let the worker wait without stalling the foreground
-event loop.
+an action accepted during an active turn renders at its submission position and executes
+after earlier queued chat but before later queued chat. A worker-start event replaces
+that row with animated publish progress; the terminal reducer event then replaces it
+with inline success or failure output without changing whichever app mode is active at
+completion. Successful review-request creation retracts the transient row and appends
+its single-line URL result as a durable `WorkflowNotice` at the current transcript
+position. If focused review already completed at the output tail, the reducer first
+moves that result into completed-turn placement so the newer review-request notice
+remains below it. An in-flight focused review stays at the tail and therefore appears
+after the notice when it completes later. Later turns leave the durable result in its
+original history position instead of reconstructing a transient between turns. The
+manual task holds the same per-session branch-operation lock as completed-turn auto-push
+for its full push and forge-metadata workflow. Queued review-request creation also
+registers as unfinished branch work before the current turn can start automatic
+publishing. Its UI and API handlers only attempt a non-blocking lock reservation while
+persisting the command; when another branch action already owns the lock, they return
+after queueing and let the worker wait without stalling the foreground event loop. If
+turn cancellation marks a queued review-request operation canceled before it starts, the
+worker emits a resolution event; the reducer retracts the `BranchPublish` slot so the
+waiting row and its publish-action suppression cannot outlive the canceled command.
+
+Queued sync uses its own replaceable slot instead of appending a waiting notice to the
+transcript. Worktree validation runs while the slot remains queued. After a successful
+`Rebasing` status transition, a resolution event retracts the slot as the existing
+`Rebasing...` loader becomes active. Validation failures append a durable `[Sync Error]`
+notice before sending the same resolution event, so waiting state never disappears
+without an active state or visible result. If turn cancellation marks the queued rebase
+operation canceled before execution, the worker's skip path sends that resolution event
+without starting rebase work.
 
 Published-branch auto-push completion sends one terminal reducer event carrying its
 `WorkflowNotice`. After accepting the current operation identifier, the reducer persists
@@ -198,8 +215,11 @@ frame can contain both the progress row and completed notice. The in-progress au
 slot uses the session-output tail so a durable sync result that started the push remains
 above it in chronological order; focused-review progress follows in the status tail. The
 output-layout cache keys the transient-store version rather than maintaining a separate
-fingerprint for every temporary channel. Structured clarification questions render in
-the bottom question panel (`AppMode::Question`), not inside the output component.
+fingerprint for every temporary channel. Assembly also records the first line of every
+queued row; the paint path applies one deterministic two-second pulse to those leading
+glyphs after paragraph rendering while the active Tachyon loader keeps its faster
+warning sweep. Structured clarification questions render in the bottom question panel
+(`AppMode::Question`), not inside the output component.
 
 Runtime owns one shared `RenderCacheStore` for markdown, diff, and session-output layout
 caches. The session-output cache keeps a bounded stable-body layer keyed by the typed
@@ -278,9 +298,10 @@ flowchart LR
    review-request creation. An **InProgress** branch action can enqueue only through the
    sender already owned by that worker; it cannot lazily create another worker. The same
    in-memory chat queue accepts follow-up prompts while the worker is **InProgress** or
-   **Rebasing**, and drains them after the active operation. The receiver is checked
-   between every pair of retractable queued-chat turns, so a command received during one
-   chat turn waits for that turn and then runs before the remaining chat queue.
+   **Rebasing**. Follow-up prompts and queued branch actions reserve one shared
+   submission sequence, so after the active operation the worker always selects the
+   earliest item across both queues. A command received during a queued chat turn waits
+   for that turn, then runs before only the messages submitted after it.
 1. Immediately before a chat turn, the worker resolves the persisted personality ID
    through `PersonalityCatalogClient`. The catalog scans only the session worktree's
    `.agents/agents` directory. The worker compares the resolved prompt fingerprint with

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -179,13 +179,20 @@ thought and tool-status text; the transcript itself updates only after the final
 result is parsed and persisted.
 
 Pressing `Enter` during a running turn or session sync opens the composer and queues the
-message inline with a `queued ›` prefix below the transcript messages and workflow
-notices that preceded it. Queued messages dispatch one-by-one as new turns after the
-active turn or sync finishes. During **InProgress**, each `Ctrl+c` press retracts the
-most recently queued message (LIFO) without interrupting the running turn; once the
+message inline with a `≡ queued ›` prefix below the active turn. All waiting work uses
+the same subdued, slowly pulsing `≡` indicator; warning-colored animation is reserved
+for work that is actively running. Queued worker actions such as sync or review-request
+publishing and queued chat messages share one first-in, first-out list. Rows appear from
+top to bottom in submission order, and the worker executes them in that same order after
+the active turn or sync finishes. During **InProgress**, each `Ctrl+c` press retracts
+the most recently queued message (LIFO) without interrupting the running turn; once the
 queue is empty, the next `Ctrl+c` stops the current turn and returns the session to
-**Review**. **Rebasing** keeps cancellation unavailable while still accepting queued
-messages. The queue is in-memory only and is discarded if `agentty` restarts.
+**Review**. If session sync is waiting behind that turn, the same stop cancels the sync
+and removes its queued row without entering **Rebasing**. A queued review-request action
+is canceled the same way: its waiting row disappears and `p` becomes available again
+without starting publish work. **Rebasing** keeps cancellation unavailable while still
+accepting queued messages. The chat queue is in-memory only and is discarded if
+`agentty` restarts.
 
 While the composer is open, `Tab` moves focus to the chat transcript above it so the
 conversation can be scrolled with `j` / `k`, `g` / `G`, and `Ctrl+D` / `Ctrl+U` without
@@ -210,22 +217,28 @@ session stays **InProgress** while the active turn runs, then moves to **Rebasin
 the queued sync command starts. The existing worker must accept the request; Agentty
 never creates a second worker from an **InProgress** status just to start sync. If sync
 arrives while Agentty is draining queued chat, the active chat turn finishes before sync
-runs, and sync runs before the remaining queued messages. Agentty shows a `[Sync]`
-notice below the active turn while the rebase is queued, and repeated `r` presses keep
-the single queued rebase instead of adding duplicates. Session sync reserves
-branch-publish ownership before it queues or starts, and retains that ownership through
-its post-rebase push. A completed turn or subsequent sync therefore cannot start a
-competing published-branch auto-push.
+runs; earlier queued messages stay ahead of sync, while later messages wait behind it.
+Agentty shows a `[Sync]` notice only when sync resolves; while it waits, the
+consolidated queue shows `≡ sync — rebase onto the base branch after this turn`. The
+waiting row disappears when the active `Rebasing...` loader starts. Agentty validates
+the session worktree before that promotion; a validation failure replaces the waiting
+row with a durable `[Sync Error]` notice without showing sync as active. Repeated `r`
+presses keep the single queued rebase instead of adding duplicates. Session sync
+reserves branch-publish ownership before it queues or starts, and retains that ownership
+through its post-rebase push. A completed turn or subsequent sync therefore cannot start
+a competing published-branch auto-push.
 
 Pressing `p` during a running turn opens the usual branch-name popup and queues
 review-request creation on that same worker. The session remains **InProgress** and
 shows a queued review-request row until the active turn finishes. Publishing then runs
-before any remaining queued chat messages, and the row changes to
-`Publishing review request...`. Like queued sync, the queued publish reserves branch
-ownership before the current turn reaches auto-push, so the completed turn cannot race
-the requested review creation. If another branch operation already owns that lock, the
-handler queues immediately without waiting and the worker serializes review-request
-creation behind the operation in progress.
+when it reaches the top of the shared queue, and the row changes to
+`Publishing review request...`; chat submitted before it runs first, while later chat
+waits behind it. The waiting label itself is not added to durable transcript history.
+Like queued sync, the queued publish reserves branch ownership before the current turn
+reaches auto-push, so the completed turn cannot race the requested review creation. If
+another branch operation already owns that lock, the handler queues immediately without
+waiting and the worker serializes review-request creation behind the operation in
+progress.
 
 Session output keeps workflow feedback in execution order. Commit feedback appears
 before its sync result, post-sync auto-push progress appears after that result, and
@@ -529,15 +542,16 @@ can retry without reporting a false terminal cancellation.
 - Agentty publishes with `git push --force-with-lease`, then creates or refreshes the
   linked review request. After confirmation, the popup closes and publishing continues
   on the session worker while session chat remains interactive. During **InProgress**,
-  the action waits behind the active turn and ahead of remaining queued chat. Inline
-  progress is replaced only after the forge URL is ready, including across intermediate
-  session refreshes. It becomes a one-line `[Review Request] Created PR URL` or
-  `[Review Request] Created MR URL` transcript notice recorded at that point in session
-  history, or failure details when the task finishes; `p` stays hidden while that
-  publish is active. Later turns do not move or reconstruct the creation notice. GitHub
-  projects publish pull requests; GitLab projects publish merge requests. Manual
-  publishing and completed-turn auto-push share one per-session branch-operation lock,
-  so whichever starts later waits instead of force-pushing the same branch concurrently.
+  the action waits behind the active turn at its submission position in the shared FIFO
+  queue. Inline progress is replaced only after the forge URL is ready, including across
+  intermediate session refreshes. It becomes a one-line
+  `[Review Request] Created PR URL` or `[Review Request] Created MR URL` transcript
+  notice recorded at that point in session history, or failure details when the task
+  finishes; `p` stays hidden while that publish is active. Later turns do not move or
+  reconstruct the creation notice. GitHub projects publish pull requests; GitLab
+  projects publish merge requests. Manual publishing and completed-turn auto-push share
+  one per-session branch-operation lock, so whichever starts later waits instead of
+  force-pushing the same branch concurrently.
 - Stacked child review requests target the parent review branch while the parent link is
   active.
 - When no review request is linked yet, only an open request for the same branch is


### PR DESCRIPTION
- Represents queued sync and review-request work as typed transient rows that retract when execution starts or queued sync resolves through validation failure or cancellation.
- Renders queued workflow actions and chat messages in one submission order with a synchronized two-second pulse while active loaders retain warning animation.
- Keeps waiting labels out of durable transcript history while preserving visible sync failures and completed review-request results.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)