### PR TITLE
Release 0.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.14.5] - 2026-08-11
+
+### Changed
+
+- agentty: show queued work in FIFO order with calm status indicators, preserve existing
+  session titles through refreshes, and generate titles in read-only mode for every
+  session role.
+- agentty: remove assigned GitHub issue and requested-review Inbox workflows, and skip
+  automatic reviews for orchestrator controllers.
+- ci: accommodate E2E rendering deadlines under CI contention and preserve valid
+  feature-recording artifacts while selecting native E2E images.
+- deps: update the GitHub Actions and version-update dependency groups.
+- release: bump workspace crate metadata and lockfile package versions to `0.14.5`.
+
+### Contributors
+
+- @dependabot
+- @minev-dev
+
 ## [v0.14.4] - 2026-08-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "image",
  "mockall",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "mockall",
  "serde",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "mockall",
  "rustix",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "ag-harness"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "async-trait",
  "jsonschema",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "askama",
  "schemars 1.2.2",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "ag-session"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "ag-agent",
  "ag-forge",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "clap",
  "tempfile",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "base64 0.23.0",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.14.4"
+version = "0.14.5"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -16,14 +16,14 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.14.4" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.14.4" }
-ag-forge = { path = "crates/ag-forge", version = "0.14.4" }
-ag-git = { path = "crates/ag-git", version = "0.14.4" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.14.4" }
-ag-session = { path = "crates/ag-session", version = "0.14.4" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.14.4" }
-testty = { path = "crates/testty", version = "0.14.4" }
+ag-agent = { path = "crates/ag-agent", version = "0.14.5" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.14.5" }
+ag-forge = { path = "crates/ag-forge", version = "0.14.5" }
+ag-git = { path = "crates/ag-git", version = "0.14.5" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.14.5" }
+ag-session = { path = "crates/ag-session", version = "0.14.5" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.14.5" }
+testty = { path = "crates/testty", version = "0.14.5" }
 async-trait = "0.1"
 agent-client-protocol = "2.0.0"
 assert_cmd = "2"


### PR DESCRIPTION
- Bump workspace crate metadata and lockfile package versions to `0.14.5`.
- Update internal published dependency constraints to `0.14.5`.
- Record the release changes and contributors in `CHANGELOG.md`.
- Record queue/status, session-title preservation, read-only title generation, and Inbox workflow removals with contributors in `CHANGELOG.md`.
- Record CI rendering and artifact handling changes plus GitHub Actions and version-update dependency updates in `CHANGELOG.md`.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)