### PR TITLE
Removes legacy requested-review tab migration

### DIFF
--- a/crates/ag-forge/src/gitlab.rs
+++ b/crates/ag-forge/src/gitlab.rs
@@ -139,8 +139,8 @@ impl ReviewRequestAdapter for GitLabReviewRequestAdapter {
     }
 
     /// Fetches merge-request discussions through GitLab's REST API and
-    /// normalizes diff notes plus review-request-wide notes for
-    /// requested-review detail.
+    /// normalizes diff notes plus review-request-wide notes for session
+    /// review-comment views.
     fn fetch_authenticated_review_comment_snapshot(
         &self,
         remote: ForgeRemote,
@@ -737,7 +737,7 @@ struct GitLabDiscussionNote {
     note_type: Option<String>,
 }
 
-/// Minimal GitLab note author data shown in requested-review detail.
+/// Minimal GitLab note author data shown in session review-comment views.
 #[derive(Clone, Deserialize)]
 struct GitLabDiscussionAuthor {
     name: Option<String>,

--- a/crates/ag-forge/src/model.rs
+++ b/crates/ag-forge/src/model.rs
@@ -254,9 +254,9 @@ pub enum ReviewCommentAnchorSide {
 /// One review thread anchored to a line of the review request diff.
 ///
 /// Threads group chronological `comments` that share the same anchor. Agentty
-/// renders these in requested-review detail, grouped by file and sorted by
-/// `(path, line)` before display. Session-linked review workflows also use the
-/// native `id` to reply and resolve a thread after its fix is pushed.
+/// renders these in session review-comment views, grouped by file and sorted
+/// by `(path, line)` before display. Session-linked review workflows also use
+/// the native `id` to reply and resolve a thread after its fix is pushed.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReviewCommentThread {
     /// Diff side used with `line` when placing this thread inline.

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -963,60 +963,6 @@ async fn test_new_with_clients_restores_persisted_active_tab() {
 }
 
 #[tokio::test]
-async fn test_new_with_clients_replaces_obsolete_tabs() {
-    // Arrange
-    let temp_dir = tempdir().expect("failed to create temp dir");
-    let agentty_home = temp_dir.path().join("agentty-home");
-    let project_path = temp_dir.path().join("project");
-    fs::create_dir_all(&agentty_home).expect("failed to create agentty home");
-    fs::create_dir_all(project_path.join(".git")).expect("failed to create project git marker");
-    let database = AppRepositories::in_memory().await;
-    let project_id = database
-        .projects()
-        .upsert_project(&project_path.to_string_lossy(), Some("main".to_string()))
-        .await
-        .expect("failed to insert project");
-    database
-        .settings()
-        .set_active_project_id(project_id)
-        .await
-        .expect("failed to persist active project");
-    for obsolete_tab in ["Inbox", "Issues"] {
-        database
-            .settings()
-            .upsert_setting(SettingName::ActiveTab, obsolete_tab)
-            .await
-            .expect("failed to persist obsolete active tab");
-
-        // Act
-        let app = App::new_with_clients(
-            agentty_home.clone(),
-            project_path.clone(),
-            Some("main".to_string()),
-            database.clone(),
-            crate::test_support::test_app_clients(),
-        )
-        .await
-        .expect("failed to build app");
-        let persisted_tab = app
-            .services
-            .db()
-            .settings()
-            .get_setting(SettingName::ActiveTab)
-            .await
-            .expect("failed to load active tab");
-
-        // Assert
-        assert_eq!(app.tabs.current(), Tab::Sessions, "{obsolete_tab}");
-        assert_eq!(
-            persisted_tab.as_deref(),
-            Some(Tab::Sessions.as_str()),
-            "{obsolete_tab}"
-        );
-    }
-}
-
-#[tokio::test]
 async fn test_new_with_clients_defaults_to_sessions_when_active_project_exists() {
     // Arrange
     let temp_dir = tempdir().expect("failed to create temp dir");
@@ -4972,7 +4918,7 @@ fn install_mock_review_request_client(
     );
 }
 
-/// Builds one GitHub remote fixture for requested-review state tests.
+/// Builds one GitHub remote fixture for review-comment state tests.
 fn forge_remote() -> forge::ForgeRemote {
     forge::ForgeRemote {
         command_working_directory: None,
@@ -4985,8 +4931,7 @@ fn forge_remote() -> forge::ForgeRemote {
     }
 }
 
-/// Builds one requested-review comment snapshot fixture for app-state
-/// detail tests.
+/// Builds one review-comment snapshot fixture for app-state detail tests.
 fn review_comment_snapshot() -> forge::ReviewCommentSnapshot {
     forge::ReviewCommentSnapshot {
         pr_level_comments: vec![forge::ReviewComment {

--- a/crates/agentty/src/app/startup.rs
+++ b/crates/agentty/src/app/startup.rs
@@ -275,19 +275,11 @@ impl AppStartup {
             return tab;
         }
 
-        let fallback_tab = if had_active_project_setting {
+        if had_active_project_setting {
             Tab::Sessions
         } else {
             Tab::Projects
-        };
-        if matches!(persisted_tab.as_deref(), Some("Inbox" | "Issues")) {
-            let _ = db
-                .settings()
-                .upsert_setting(SettingName::ActiveTab, fallback_tab.as_str())
-                .await;
         }
-
-        fallback_tab
     }
 
     /// Spawns app-wide background tasks that are not owned by the sync

--- a/crates/agentty/src/app/task.rs
+++ b/crates/agentty/src/app/task.rs
@@ -1,4 +1,4 @@
-//! App-wide background task helpers for requested-review loads, version
+//! App-wide background task helpers for session review-comment loads, version
 //! checks, and review-assist generation.
 //!
 //! Recurring git-status and review-request polling lives in the sync
@@ -1148,7 +1148,7 @@ mod tests {
         assert!(prompt.contains("+```\n"));
     }
 
-    /// Builds one GitHub remote fixture for requested-review task tests.
+    /// Builds one GitHub remote fixture for review-comment task tests.
     fn forge_remote() -> ForgeRemote {
         ForgeRemote {
             command_working_directory: None,


### PR DESCRIPTION
- Stops rewriting persisted `Inbox` and `Issues` active-tab values during startup.
- Aligns review-comment documentation and fixtures with session review-comment views.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)