### PR TITLE
Change summaries appear before focused reviews

### DIFF
--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -2119,15 +2119,15 @@ mod tests {
                 ),
             ],
         );
-        session.summary = Some(summary_fixture());
         session.status = Status::Review;
         let review_text = "## Review\n\n### Project Impact\n\n- Documentation-only change.\n\n### \
                            Suggestions\n\n- None.";
-        session.reconcile_transient_messages();
         set_review_transient(
             &mut session,
             TransientMessageBody::Markdown(review_text.to_string()),
         );
+        session.summary = Some(summary_fixture());
+        session.reconcile_transient_messages();
 
         // Act
         let lines = output_lines(&session, Rect::new(0, 0, 80, 8), line_context(), None);

--- a/crates/agentty/src/ui/session_output_assembly.rs
+++ b/crates/agentty/src/ui/session_output_assembly.rs
@@ -290,16 +290,22 @@ impl SessionOutputAssembly<'_> {
     }
 
     fn append_transient_messages(&mut self, anchor: TransientMessageAnchor) {
-        for message in self
-            .session
-            .transient_messages
-            .messages()
-            .iter()
-            .filter(|message| {
-                message.anchor == anchor
-                    && !matches!(&message.body, TransientMessageBody::Queued(_))
-            })
-        {
+        let transient_messages = &self.session.transient_messages;
+        let summary = if anchor == TransientMessageAnchor::AfterCompletedTurn {
+            transient_messages
+                .get(TransientMessageSlot::Summary)
+                .filter(|message| message.anchor == anchor)
+        } else {
+            None
+        };
+        let remaining_messages = transient_messages.messages().iter().filter(|message| {
+            message.anchor == anchor
+                && !(anchor == TransientMessageAnchor::AfterCompletedTurn
+                    && message.slot == TransientMessageSlot::Summary)
+                && !matches!(&message.body, TransientMessageBody::Queued(_))
+        });
+
+        for message in summary.into_iter().chain(remaining_messages) {
             if let Some(loader_line_index) = append_transient_message(
                 &mut self.lines,
                 message,

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1527,6 +1527,13 @@ fn seed_review_ready_session_with_persisted_focused_review(
                         .to_string(),
                 ),
             )
+            .await?;
+        database
+            .sessions()
+            .update_session_summary(
+                "review-shortcut-0001",
+                r#"{"turn":"Persisted the focused review.","session":"Review output survives session reloads."}"#,
+            )
             .await
     })?;
 
@@ -7094,6 +7101,7 @@ fn session_view_compact_mermaid_output() -> E2eResult {
 fn persisted_focused_review_survives_reload() -> E2eResult {
     // Arrange, Act, Assert
     FeatureTest::new("persisted_focused_review")
+        .with_terminal_size(100, 40)
         .with_git()
         .setup(seed_review_ready_session_with_persisted_focused_review)
         .run(
@@ -7117,6 +7125,11 @@ fn persisted_focused_review_survives_reload() -> E2eResult {
                     .into_iter()
                     .next()
                     .expect("project impact header should render");
+                let summary_header = frame
+                    .find_text("Change Summary")
+                    .into_iter()
+                    .next()
+                    .expect("change summary header should render");
                 let impact_finding = frame
                     .find_text("Persisted focused review finding.")
                     .into_iter()
@@ -7133,6 +7146,7 @@ fn persisted_focused_review_survives_reload() -> E2eResult {
                     .next()
                     .expect("empty suggestion should render");
 
+                assert!(summary_header.rect.row < impact_header.rect.row);
                 assert_eq!(impact_finding.rect.row, impact_header.rect.row + 1);
                 assert_eq!(empty_suggestion.rect.row, suggestions_header.rect.row + 1);
                 assertion::assert_not_visible(frame, "type \"/apply\" to verify and apply");

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -255,16 +255,17 @@ trigger this automatic review. Press `f` to append the cached review into the se
 output, or to see a loading message while generation is still running. The appended
 review stays visible across diff mode, question mode, session switching, project
 switching, and background session metadata refreshes, and is cleared when you submit the
-next prompt. Focused review includes the saved user and agent chat history for context.
-It uses inspection-only context: it may read files, search, inspect git history, and
-browse when needed, but it recommends verification commands instead of running checks
-itself. The review treats explicit decisions, accepted tradeoffs, and explanations in
-the chat as constraints, and only reopens a resolved suggestion when the current diff
-contradicts the resolution or inspection finds a new significant risk. `Project Impact`
-renders concise bullets directly beneath its heading. `Suggestions` uses the same
-compact spacing and formats its bullets as `[Severity]: Issue details`, using `[High]`
-or `[Medium]` when follow-up work is needed. Empty `Suggestions` output does not offer
-the `/apply` action. A turn stopped with `Ctrl+c` does not start a focused review
+next prompt. When both are visible, `Change Summary` appears before `Review`. Focused
+review includes the saved user and agent chat history for context. It uses inspection-
+only context: it may read files, search, inspect git history, and browse when needed,
+but it recommends verification commands instead of running checks itself. The review
+treats explicit decisions, accepted tradeoffs, and explanations in the chat as
+constraints, and only reopens a resolved suggestion when the current diff contradicts
+the resolution or inspection finds a new significant risk. `Project Impact` renders
+concise bullets directly beneath its heading. `Suggestions` uses the same compact
+spacing and formats its bullets as `[Severity]: Issue details`, using `[High]` or
+`[Medium]` when follow-up work is needed. Empty `Suggestions` output does not offer the
+`/apply` action. A turn stopped with `Ctrl+c` does not start a focused review
 automatically; press `f` for a manual one.
 
 ### Session Output Markdown


### PR DESCRIPTION
- Displays the persisted `Change Summary` before `Review` when both follow a completed turn.
- Keeps the ordering visible after session reloads and documents it in the workflow guide.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)