### PR TITLE
Harness supports Muse structured outputs

### DIFF
--- a/crates/ag-harness/examples/kimi.rs
+++ b/crates/ag-harness/examples/kimi.rs
@@ -1,26 +1,17 @@
 //! Requests structured output from a configured Kimi model and prints the
 //! validated JSON, with optional request-duration metrics over OTLP/HTTP.
 
-use std::io::{self, Write};
+use ag_harness::{KimiConfig, ModelClient};
 
-use ag_harness::{KimiConfig, ModelClient, ModelRequest, OutputSchema};
-
+#[path = "support/greeting.rs"]
+mod greeting;
+#[cfg(test)]
+#[path = "support/process_fixture.rs"]
+mod process_fixture;
 #[path = "support/telemetry.rs"]
 mod telemetry;
 
 use telemetry::DynError;
-
-const GREETING_SCHEMA: &str = r#"{
-    "type": "object",
-    "properties": {
-        "message": {
-            "type": "string",
-            "enum": ["hello"]
-        }
-    },
-    "required": ["message"],
-    "additionalProperties": false
-}"#;
 
 #[tokio::main]
 async fn main() -> Result<(), DynError> {
@@ -38,49 +29,14 @@ async fn run() -> Result<(), DynError> {
 }
 
 async fn request_greeting(config: KimiConfig) -> Result<(), DynError> {
-    let model = ModelClient::kimi(config)?;
-    let schema = OutputSchema::new(serde_json::from_str(GREETING_SCHEMA)?)?;
-    let response = model
-        .complete(ModelRequest::new(
-            "Return a JSON greeting with the message set to hello.",
-            schema,
-        ))
-        .await?;
+    let client = ModelClient::kimi(config)?;
 
-    let output = response
-        .output()
-        .ok_or_else(|| io::Error::other("Kimi returned an unexpected tool call"))?;
-    writeln!(io::stdout().lock(), "{output}")?;
-
-    Ok(())
+    greeting::request(client, "Kimi").await
 }
 
 #[cfg(test)]
 mod tests {
-    use std::process::{ExitStatus, Stdio};
-    use std::time::Duration;
-
-    use serde_json::json;
-    use tokio::process::{Child, Command};
-    use wiremock::matchers::{header, method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
-
     use super::*;
-
-    async fn wait_for_fixture(
-        child: &mut Child,
-        timeout_duration: Duration,
-    ) -> Result<ExitStatus, DynError> {
-        match tokio::time::timeout(timeout_duration, child.wait()).await {
-            Ok(status) => Ok(status?),
-            Err(error) => {
-                child.kill().await?;
-                child.wait().await?;
-
-                Err(error.into())
-            }
-        }
-    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn request_greeting_rejects_invalid_model() {
@@ -103,120 +59,35 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn process_exports_metrics_over_otlp_http_on_shutdown() {
         // Arrange
-        let kimi_server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/chat/completions"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "choices": [{
-                    "finish_reason": "stop",
-                    "message": {"content": r#"{"message":"hello"}"#}
-                }]
-            })))
-            .expect(1)
-            .mount(&kimi_server)
-            .await;
-        let otlp_server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/otlp/v1/metrics"))
-            .and(header("authorization", "Basic test-credentials"))
-            .respond_with(ResponseTemplate::new(200))
-            .expect(1)
-            .mount(&otlp_server)
-            .await;
-        let executable = std::env::current_exe().expect("test executable should be available");
-        let kimi_endpoint = kimi_server.uri();
-        let otlp_endpoint = format!("{}/otlp", otlp_server.uri());
+        let environment = process_fixture::ProviderEnvironment::new(
+            "KIMI_API_KEY",
+            "KIMI_BASE_URL",
+            Some(("KIMI_MODEL", Some("kimi-k2.6"))),
+        );
 
-        // Act
-        let mut child = Command::new(executable)
-            .arg("tests::process_fixture_runs_main")
-            .arg("--exact")
-            .arg("--nocapture")
-            .env("AG_HARNESS_RUN_MAIN_FIXTURE", "1")
-            .env("KIMI_API_KEY", "test-key")
-            .env("KIMI_BASE_URL", kimi_endpoint)
-            .env("KIMI_MODEL", "kimi-k2.6")
-            .env("OTEL_EXPORTER_OTLP_ENDPOINT", otlp_endpoint)
-            .env(
-                "OTEL_EXPORTER_OTLP_HEADERS",
-                "Authorization=Basic%20test-credentials",
-            )
-            .env_remove("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")
-            .env_remove("OTEL_EXPORTER_OTLP_METRICS_HEADERS")
-            .env_remove("OTEL_EXPORTER_OTLP_COMPRESSION")
-            .env_remove("OTEL_EXPORTER_OTLP_METRICS_COMPRESSION")
-            .env_remove("OTEL_EXPORTER_OTLP_METRICS_TIMEOUT")
-            .env_remove("OTEL_EXPORTER_OTLP_TIMEOUT")
-            .env_remove("OTEL_METRIC_EXPORT_INTERVAL")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .kill_on_drop(true)
-            .spawn()
-            .expect("fixture process should start");
-        let status = wait_for_fixture(&mut child, Duration::from_secs(10))
-            .await
-            .expect("fixture process should finish before the timeout");
-
-        // Assert
-        assert!(status.success(), "fixture process should succeed");
+        // Act and Assert
+        process_fixture::assert_exports_metrics(environment).await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn process_timeout_kills_and_reaps_fixture() {
         // Arrange
-        let kimi_server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/chat/completions"))
-            .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(10)))
-            .mount(&kimi_server)
-            .await;
-        let executable = std::env::current_exe().expect("test executable should be available");
-        let mut child = Command::new(executable)
-            .arg("tests::process_fixture_runs_main")
-            .arg("--exact")
-            .arg("--nocapture")
-            .env("AG_HARNESS_RUN_MAIN_FIXTURE", "1")
-            .env("KIMI_API_KEY", "test-key")
-            .env("KIMI_BASE_URL", kimi_server.uri())
-            .env("KIMI_MODEL", "kimi-k2.6")
-            .env_remove("OTEL_EXPORTER_OTLP_ENDPOINT")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .kill_on_drop(true)
-            .spawn()
-            .expect("fixture process should start");
-
-        // Act
-        let result = wait_for_fixture(&mut child, Duration::from_millis(100)).await;
-
-        // Assert
-        assert_eq!(
-            result
-                .expect_err("fixture should exceed the timeout")
-                .to_string(),
-            "deadline has elapsed"
+        let environment = process_fixture::ProviderEnvironment::new(
+            "KIMI_API_KEY",
+            "KIMI_BASE_URL",
+            Some(("KIMI_MODEL", Some("kimi-k2.6"))),
         );
-        assert!(
-            child
-                .try_wait()
-                .expect("reaped fixture status should be available")
-                .is_some(),
-            "timed-out fixture should be reaped"
-        );
+
+        // Act and Assert
+        process_fixture::assert_timeout_kills_and_reaps(environment).await;
     }
 
     #[test]
     fn process_fixture_runs_main() {
         // Arrange
-        let should_run = std::env::var_os("AG_HARNESS_RUN_MAIN_FIXTURE").is_some();
-        if !should_run {
-            return;
-        }
+        let run = main;
 
-        // Act
-        let result = main();
-
-        // Assert
-        result.expect("configured example should complete and flush metrics");
+        // Act and Assert
+        process_fixture::run_main_if_requested(run);
     }
 }

--- a/crates/ag-harness/examples/muse.rs
+++ b/crates/ag-harness/examples/muse.rs
@@ -1,0 +1,129 @@
+//! Requests structured output from Muse Spark and prints the validated JSON,
+//! with optional request-duration metrics over OTLP/HTTP.
+
+use ag_harness::{MUSE_SPARK_1_2, ModelClient, MuseConfig};
+
+#[path = "support/greeting.rs"]
+mod greeting;
+#[cfg(test)]
+#[path = "support/process_fixture.rs"]
+mod process_fixture;
+#[path = "support/telemetry.rs"]
+mod telemetry;
+
+use telemetry::DynError;
+
+const MODEL_API_BASE_URL: &str = "https://api.meta.ai/v1";
+
+#[tokio::main]
+async fn main() -> Result<(), DynError> {
+    telemetry::run_with_metrics("ag-harness-muse", run()).await
+}
+
+async fn run() -> Result<(), DynError> {
+    let config = config(
+        std::env::var("MODEL_API_KEY")?,
+        std::env::var("MODEL_API_BASE_URL").ok(),
+        std::env::var("MODEL_API_MODEL").ok(),
+    );
+
+    request_greeting(config).await
+}
+
+fn config(api_key: String, base_url: Option<String>, model: Option<String>) -> MuseConfig {
+    MuseConfig {
+        api_key,
+        base_url: base_url.unwrap_or_else(|| MODEL_API_BASE_URL.to_string()),
+        model: model.unwrap_or_else(|| MUSE_SPARK_1_2.to_string()),
+    }
+}
+
+async fn request_greeting(config: MuseConfig) -> Result<(), DynError> {
+    let client = ModelClient::muse(config)?;
+
+    greeting::request(client, "Muse").await
+}
+
+#[cfg(test)]
+mod tests {
+    use ag_harness::MUSE_SPARK_1_2_CONTRIBUTOR;
+
+    use super::*;
+
+    #[test]
+    fn configuration_uses_official_defaults() {
+        // Arrange and Act
+        let config = config("test-key".to_string(), None, None);
+
+        // Assert
+        assert_eq!(config.api_key, "test-key");
+        assert_eq!(config.base_url, "https://api.meta.ai/v1");
+        assert_eq!(config.model, "muse-spark-1.2");
+    }
+
+    #[test]
+    fn configuration_accepts_contributor_model() {
+        // Arrange and Act
+        let config = config(
+            "test-key".to_string(),
+            None,
+            Some(MUSE_SPARK_1_2_CONTRIBUTOR.to_string()),
+        );
+
+        // Assert
+        assert_eq!(config.model, "muse-spark-1.2-contributor");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn request_greeting_rejects_invalid_model() {
+        // Arrange
+        let config = MuseConfig {
+            api_key: "test-key".to_string(),
+            base_url: "https://example.com".to_string(),
+            model: "  ".to_string(),
+        };
+
+        // Act
+        let error = request_greeting(config)
+            .await
+            .expect_err("invalid model configuration should fail");
+
+        // Assert
+        assert_eq!(error.to_string(), "model identifier must not be empty");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn process_exports_metrics_over_otlp_http_on_shutdown() {
+        // Arrange
+        let environment = process_fixture::ProviderEnvironment::new(
+            "MODEL_API_KEY",
+            "MODEL_API_BASE_URL",
+            Some(("MODEL_API_MODEL", None)),
+        );
+
+        // Act and Assert
+        process_fixture::assert_exports_metrics(environment).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn process_timeout_kills_and_reaps_fixture() {
+        // Arrange
+        let environment = process_fixture::ProviderEnvironment::new(
+            "MODEL_API_KEY",
+            "MODEL_API_BASE_URL",
+            Some(("MODEL_API_MODEL", None)),
+        );
+
+        // Act and Assert
+        process_fixture::assert_timeout_kills_and_reaps(environment).await;
+    }
+
+    #[test]
+    fn process_fixture_runs_main() {
+        // Arrange
+        let run = main;
+
+        // Act and Assert
+        process_fixture::run_main_if_requested(run);
+    }
+}

--- a/crates/ag-harness/examples/qwen.rs
+++ b/crates/ag-harness/examples/qwen.rs
@@ -1,11 +1,13 @@
 //! Requests structured output from a configured Qwen model and prints the
 //! validated JSON, with optional request-duration metrics over OTLP/HTTP.
 
-use std::io::{self, Write};
+use ag_harness::{ModelClient, QwenConfig};
 
-use ag_harness::{ModelClient, ModelRequest, OutputSchema, QwenConfig};
-use serde_json::json;
-
+#[path = "support/greeting.rs"]
+mod greeting;
+#[cfg(test)]
+#[path = "support/process_fixture.rs"]
+mod process_fixture;
 #[path = "support/telemetry.rs"]
 mod telemetry;
 
@@ -28,58 +30,13 @@ async fn run() -> Result<(), DynError> {
 
 async fn request_greeting(config: QwenConfig) -> Result<(), DynError> {
     let client = ModelClient::qwen(config)?;
-    let schema = json!({
-        "type": "object",
-        "properties": {
-            "message": {
-                "type": "string",
-                "const": "hello"
-            }
-        },
-        "required": ["message"],
-        "additionalProperties": false
-    });
-    let schema = OutputSchema::new(schema)?;
-    let response = client
-        .complete(ModelRequest::new(
-            "Return a JSON greeting with the message set to hello.",
-            schema,
-        ))
-        .await?;
 
-    let output = response
-        .output()
-        .ok_or_else(|| io::Error::other("Qwen returned an unexpected tool call"))?;
-    writeln!(io::stdout().lock(), "{output}")?;
-
-    Ok(())
+    greeting::request(client, "Qwen").await
 }
 
 #[cfg(test)]
 mod tests {
-    use std::process::{ExitStatus, Stdio};
-    use std::time::Duration;
-
-    use tokio::process::{Child, Command};
-    use wiremock::matchers::{header, method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
-
     use super::*;
-
-    async fn wait_for_fixture(
-        child: &mut Child,
-        timeout_duration: Duration,
-    ) -> Result<ExitStatus, DynError> {
-        match tokio::time::timeout(timeout_duration, child.wait()).await {
-            Ok(status) => Ok(status?),
-            Err(error) => {
-                child.kill().await?;
-                child.wait().await?;
-
-                Err(error.into())
-            }
-        }
-    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn request_greeting_rejects_invalid_model() {
@@ -102,118 +59,35 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn process_exports_metrics_over_otlp_http_on_shutdown() {
         // Arrange
-        let qwen_server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/chat/completions"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "choices": [{
-                    "finish_reason": "stop",
-                    "message": {"content": r#"{"message":"hello"}"#}
-                }]
-            })))
-            .expect(1)
-            .mount(&qwen_server)
-            .await;
-        let otlp_server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/otlp/v1/metrics"))
-            .and(header("authorization", "Basic test-credentials"))
-            .respond_with(ResponseTemplate::new(200))
-            .expect(1)
-            .mount(&otlp_server)
-            .await;
-        let executable = std::env::current_exe().expect("test executable should be available");
-        let qwen_endpoint = qwen_server.uri();
-        let otlp_endpoint = format!("{}/otlp", otlp_server.uri());
+        let environment = process_fixture::ProviderEnvironment::new(
+            "DASHSCOPE_API_KEY",
+            "DASHSCOPE_BASE_URL",
+            None,
+        );
 
-        // Act
-        let mut child = Command::new(executable)
-            .arg("tests::process_fixture_runs_main")
-            .arg("--exact")
-            .arg("--nocapture")
-            .env("AG_HARNESS_RUN_MAIN_FIXTURE", "1")
-            .env("DASHSCOPE_API_KEY", "test-key")
-            .env("DASHSCOPE_BASE_URL", qwen_endpoint)
-            .env("OTEL_EXPORTER_OTLP_ENDPOINT", otlp_endpoint)
-            .env(
-                "OTEL_EXPORTER_OTLP_HEADERS",
-                "Authorization=Basic%20test-credentials",
-            )
-            .env_remove("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")
-            .env_remove("OTEL_EXPORTER_OTLP_METRICS_HEADERS")
-            .env_remove("OTEL_EXPORTER_OTLP_COMPRESSION")
-            .env_remove("OTEL_EXPORTER_OTLP_METRICS_COMPRESSION")
-            .env_remove("OTEL_EXPORTER_OTLP_METRICS_TIMEOUT")
-            .env_remove("OTEL_EXPORTER_OTLP_TIMEOUT")
-            .env_remove("OTEL_METRIC_EXPORT_INTERVAL")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .kill_on_drop(true)
-            .spawn()
-            .expect("fixture process should start");
-        let status = wait_for_fixture(&mut child, Duration::from_secs(10))
-            .await
-            .expect("fixture process should finish before the timeout");
-
-        // Assert
-        assert!(status.success(), "fixture process should succeed");
+        // Act and Assert
+        process_fixture::assert_exports_metrics(environment).await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn process_timeout_kills_and_reaps_fixture() {
         // Arrange
-        let qwen_server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/chat/completions"))
-            .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(10)))
-            .mount(&qwen_server)
-            .await;
-        let executable = std::env::current_exe().expect("test executable should be available");
-        let mut child = Command::new(executable)
-            .arg("tests::process_fixture_runs_main")
-            .arg("--exact")
-            .arg("--nocapture")
-            .env("AG_HARNESS_RUN_MAIN_FIXTURE", "1")
-            .env("DASHSCOPE_API_KEY", "test-key")
-            .env("DASHSCOPE_BASE_URL", qwen_server.uri())
-            .env_remove("OTEL_EXPORTER_OTLP_ENDPOINT")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .kill_on_drop(true)
-            .spawn()
-            .expect("fixture process should start");
-
-        // Act
-        let result = wait_for_fixture(&mut child, Duration::from_millis(100)).await;
-
-        // Assert
-        assert_eq!(
-            result
-                .expect_err("fixture should exceed the timeout")
-                .to_string(),
-            "deadline has elapsed"
+        let environment = process_fixture::ProviderEnvironment::new(
+            "DASHSCOPE_API_KEY",
+            "DASHSCOPE_BASE_URL",
+            None,
         );
-        assert!(
-            child
-                .try_wait()
-                .expect("reaped fixture status should be available")
-                .is_some(),
-            "timed-out fixture should be reaped"
-        );
+
+        // Act and Assert
+        process_fixture::assert_timeout_kills_and_reaps(environment).await;
     }
 
     #[test]
     fn process_fixture_runs_main() {
         // Arrange
-        let should_run = std::env::var_os("AG_HARNESS_RUN_MAIN_FIXTURE").is_some();
-        if !should_run {
-            return;
-        }
+        let run = main;
 
-        // Act
-        let result = main();
-
-        // Assert
-        result.expect("configured example should complete and flush metrics");
+        // Act and Assert
+        process_fixture::run_main_if_requested(run);
     }
 }

--- a/crates/ag-harness/examples/support/greeting.rs
+++ b/crates/ag-harness/examples/support/greeting.rs
@@ -1,0 +1,57 @@
+use std::io::{self, Write};
+
+use ag_harness::{ModelClient, ModelRequest, OutputSchema};
+use serde_json::{Value, json};
+
+use crate::telemetry::DynError;
+
+/// Requests and prints the validated greeting shared by provider examples.
+pub(crate) async fn request(client: ModelClient, provider_name: &str) -> Result<(), DynError> {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "message": {
+                "type": "string",
+                "const": "hello"
+            }
+        },
+        "required": ["message"],
+        "additionalProperties": false
+    });
+    let schema = OutputSchema::new(schema)?;
+    let response = client
+        .complete(ModelRequest::new(
+            "Return a JSON greeting with the message set to hello.",
+            schema,
+        ))
+        .await?;
+
+    write_output(response.output(), provider_name)?;
+
+    Ok(())
+}
+
+fn write_output(output: Option<&Value>, provider_name: &str) -> Result<(), io::Error> {
+    let output = output.ok_or_else(|| {
+        io::Error::other(format!("{provider_name} returned an unexpected tool call"))
+    })?;
+    writeln!(io::stdout().lock(), "{output}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_output_identifies_unexpected_tool_call_provider() {
+        // Arrange and Act
+        let error =
+            write_output(None, "Test provider").expect_err("missing structured output should fail");
+
+        // Assert
+        assert_eq!(
+            error.to_string(),
+            "Test provider returned an unexpected tool call"
+        );
+    }
+}

--- a/crates/ag-harness/examples/support/process_fixture.rs
+++ b/crates/ag-harness/examples/support/process_fixture.rs
@@ -1,0 +1,210 @@
+use std::ops::RangeInclusive;
+use std::process::{ExitStatus, Stdio};
+use std::time::Duration;
+
+use serde_json::json;
+use tokio::process::{Child, Command};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use crate::telemetry::DynError;
+
+const FIXTURE_TEST: &str = "tests::process_fixture_runs_main";
+
+/// Provider-specific environment variables supplied to an example fixture.
+pub(crate) struct ProviderEnvironment {
+    api_key_name: &'static str,
+    base_url_name: &'static str,
+    model: Option<ModelEnvironment>,
+}
+
+impl ProviderEnvironment {
+    /// Describes a provider and its optional model environment override.
+    pub(crate) const fn new(
+        api_key_name: &'static str,
+        base_url_name: &'static str,
+        model: Option<(&'static str, Option<&'static str>)>,
+    ) -> Self {
+        Self {
+            api_key_name,
+            base_url_name,
+            model: match model {
+                Some((variable, value)) => Some(ModelEnvironment { value, variable }),
+                None => None,
+            },
+        }
+    }
+
+    fn apply(&self, command: &mut Command, base_url: &str) {
+        command
+            .env(self.api_key_name, "test-key")
+            .env(self.base_url_name, base_url);
+
+        if let Some(model) = self.model {
+            match model.value {
+                Some(value) => {
+                    command.env(model.variable, value);
+                }
+                None => {
+                    command.env_remove(model.variable);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ModelEnvironment {
+    value: Option<&'static str>,
+    variable: &'static str,
+}
+
+/// Verifies that the example completes and flushes one OTLP metrics request.
+pub(crate) async fn assert_exports_metrics(environment: ProviderEnvironment) {
+    let model_server = model_server(
+        ResponseTemplate::new(200).set_body_json(json!({
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {"content": r#"{"message":"hello"}"#}
+            }]
+        })),
+        1..=1,
+    )
+    .await;
+    let otlp_server = metrics_server().await;
+    let otlp_endpoint = format!("{}/otlp", otlp_server.uri());
+    let mut child = spawn_fixture(environment, &model_server.uri(), Some(&otlp_endpoint));
+    let status = wait_for_fixture(&mut child, Duration::from_secs(10))
+        .await
+        .expect("fixture process should finish before the timeout");
+
+    assert!(status.success(), "fixture process should succeed");
+}
+
+/// Verifies that a stalled example process is killed and reaped after timeout.
+pub(crate) async fn assert_timeout_kills_and_reaps(environment: ProviderEnvironment) {
+    let model_server = model_server(
+        ResponseTemplate::new(200).set_delay(Duration::from_secs(10)),
+        0..=1,
+    )
+    .await;
+    let mut child = spawn_fixture(environment, &model_server.uri(), None);
+    let result = wait_for_fixture(&mut child, Duration::from_millis(100)).await;
+
+    assert_eq!(
+        result
+            .expect_err("fixture should exceed the timeout")
+            .to_string(),
+        "deadline has elapsed"
+    );
+    assert!(
+        child
+            .try_wait()
+            .expect("reaped fixture status should be available")
+            .is_some(),
+        "timed-out fixture should be reaped"
+    );
+}
+
+/// Runs the example entry point only inside its explicitly configured child
+/// fixture.
+pub(crate) fn run_main_if_requested(run: impl FnOnce() -> Result<(), DynError>) {
+    if std::env::var_os("AG_HARNESS_RUN_MAIN_FIXTURE").is_none() {
+        return;
+    }
+
+    run().expect("configured example should complete and flush metrics");
+}
+
+async fn model_server(
+    response: ResponseTemplate,
+    expected_requests: RangeInclusive<u64>,
+) -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(response)
+        .expect(expected_requests)
+        .mount(&server)
+        .await;
+
+    server
+}
+
+async fn metrics_server() -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/otlp/v1/metrics"))
+        .and(header("authorization", "Basic test-credentials"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    server
+}
+
+fn spawn_fixture(
+    environment: ProviderEnvironment,
+    model_endpoint: &str,
+    otlp_endpoint: Option<&str>,
+) -> Child {
+    let executable = std::env::current_exe().expect("test executable should be available");
+    let mut command = Command::new(executable);
+    command
+        .arg(FIXTURE_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("AG_HARNESS_RUN_MAIN_FIXTURE", "1")
+        .env_remove("OTEL_EXPORTER_OTLP_ENDPOINT")
+        .env_remove("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")
+        .env_remove("OTEL_EXPORTER_OTLP_HEADERS")
+        .env_remove("OTEL_EXPORTER_OTLP_METRICS_HEADERS")
+        .env_remove("OTEL_EXPORTER_OTLP_COMPRESSION")
+        .env_remove("OTEL_EXPORTER_OTLP_METRICS_COMPRESSION")
+        .env_remove("OTEL_EXPORTER_OTLP_METRICS_TIMEOUT")
+        .env_remove("OTEL_EXPORTER_OTLP_TIMEOUT")
+        .env_remove("OTEL_METRIC_EXPORT_INTERVAL")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    environment.apply(&mut command, model_endpoint);
+
+    if let Some(endpoint) = otlp_endpoint {
+        command.env("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint).env(
+            "OTEL_EXPORTER_OTLP_HEADERS",
+            "Authorization=Basic%20test-credentials",
+        );
+    }
+
+    command.spawn().expect("fixture process should start")
+}
+
+async fn wait_for_fixture(
+    child: &mut Child,
+    timeout_duration: Duration,
+) -> Result<ExitStatus, DynError> {
+    match tokio::time::timeout(timeout_duration, child.wait()).await {
+        Ok(status) => Ok(status?),
+        Err(error) => {
+            child.kill().await?;
+            child.wait().await?;
+
+            Err(error.into())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn optional_model_server_accepts_no_request() {
+        // Arrange
+        let server = model_server(ResponseTemplate::new(200), 0..=1).await;
+
+        // Act and Assert
+        server.verify().await;
+    }
+}

--- a/crates/ag-harness/src/chat_completion.rs
+++ b/crates/ag-harness/src/chat_completion.rs
@@ -22,10 +22,18 @@ pub(crate) const STRUCTURED_OUTPUT_INSTRUCTION: &str = concat!(
     "Do not include Markdown fences or any other text.\n\nJSON Schema:\n",
 );
 
-/// Provider policy applied by the shared JSON Object backend.
+/// Structured-output representation selected by one Chat Completions provider.
 #[derive(Clone, Copy)]
-pub(crate) struct JsonObjectProviderPolicy {
+pub(crate) enum StructuredOutputMode {
+    JsonObject,
+    JsonSchema,
+}
+
+/// Provider policy applied by the shared Chat Completions backend.
+#[derive(Clone, Copy)]
+pub(crate) struct ChatCompletionProviderPolicy {
     pub(crate) display_name: &'static str,
+    pub(crate) structured_output: StructuredOutputMode,
     pub(crate) telemetry_name: &'static str,
     pub(crate) unsupported_schema_reason: &'static str,
 }
@@ -36,22 +44,23 @@ pub(crate) enum GeneratedResponse {
     ToolCall(tool::ToolCall),
 }
 
-/// Shared JSON Object backend for OpenAI-compatible Chat Completions APIs.
-pub(crate) struct JsonObjectBackend {
+/// Shared structured-output backend for OpenAI-compatible Chat Completions
+/// APIs.
+pub(crate) struct ChatCompletionBackend {
     api_key: String,
     base_url: String,
     client: Arc<dyn ChatCompletionClient>,
     model: String,
-    policy: JsonObjectProviderPolicy,
+    policy: ChatCompletionProviderPolicy,
 }
 
-impl JsonObjectBackend {
-    /// Creates a JSON Object backend with the production HTTP client.
+impl ChatCompletionBackend {
+    /// Creates a structured-output backend with the production HTTP client.
     pub(crate) fn new(
         api_key: String,
         base_url: String,
         model: String,
-        policy: JsonObjectProviderPolicy,
+        policy: ChatCompletionProviderPolicy,
     ) -> Self {
         Self::with_client(api_key, base_url, model, policy, default_client())
     }
@@ -61,7 +70,7 @@ impl JsonObjectBackend {
         (self.policy.telemetry_name, &self.model)
     }
 
-    /// Generates raw JSON Object output through the shared wire lifecycle.
+    /// Generates raw structured output through the shared wire lifecycle.
     pub(crate) async fn generate(
         &self,
         request: &model::ModelRequest,
@@ -71,26 +80,15 @@ impl JsonObjectBackend {
                 reason: self.policy.unsupported_schema_reason.to_string(),
             });
         }
-        let messages = vec![
-            JsonObjectMessage {
-                content: format!(
-                    "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
-                    request.schema().value()
-                ),
-                role: "system",
-            },
-            JsonObjectMessage {
-                content: request.prompt().to_string(),
-                role: "user",
-            },
-        ];
-        let payload = JsonObjectRequest {
-            messages,
+        let payload = ChatCompletionPayload {
+            messages: self.messages(request),
             model: &self.model,
-            response_format: JsonObjectResponseFormat {
-                kind: "json_object",
-            },
-            tools: request.tools().iter().map(JsonObjectTool::from).collect(),
+            response_format: self.response_format(request.schema()),
+            tools: request
+                .tools()
+                .iter()
+                .map(ChatCompletionTool::from)
+                .collect(),
         };
         let payload = serde_json::to_value(payload).map_err(model::ModelError::request)?;
         let completion = self
@@ -115,12 +113,12 @@ impl JsonObjectBackend {
         }
     }
 
-    /// Creates a JSON Object backend with an injected transport client.
+    /// Creates a structured-output backend with an injected transport client.
     pub(crate) fn with_client(
         api_key: String,
         base_url: String,
         model: String,
-        policy: JsonObjectProviderPolicy,
+        policy: ChatCompletionProviderPolicy,
         client: Arc<dyn ChatCompletionClient>,
     ) -> Self {
         Self {
@@ -129,6 +127,44 @@ impl JsonObjectBackend {
             client,
             model,
             policy,
+        }
+    }
+
+    fn messages(&self, request: &model::ModelRequest) -> Vec<ChatCompletionMessagePayload> {
+        let mut messages = Vec::with_capacity(2);
+        if matches!(
+            self.policy.structured_output,
+            StructuredOutputMode::JsonObject
+        ) {
+            messages.push(ChatCompletionMessagePayload {
+                content: format!(
+                    "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
+                    request.schema().value()
+                ),
+                role: "system",
+            });
+        }
+        messages.push(ChatCompletionMessagePayload {
+            content: request.prompt().to_string(),
+            role: "user",
+        });
+
+        messages
+    }
+
+    fn response_format<'a>(&self, schema: &'a schema_contract::OutputSchema) -> ResponseFormat<'a> {
+        match self.policy.structured_output {
+            StructuredOutputMode::JsonObject => ResponseFormat {
+                json_schema: None,
+                kind: "json_object",
+            },
+            StructuredOutputMode::JsonSchema => ResponseFormat {
+                json_schema: Some(JsonSchemaResponseFormat {
+                    name: "ag_harness_output",
+                    schema: schema.value(),
+                }),
+                kind: "json_schema",
+            },
         }
     }
 
@@ -410,37 +446,45 @@ struct ProviderHttpError {
 }
 
 #[derive(Serialize)]
-struct JsonObjectRequest<'a> {
-    messages: Vec<JsonObjectMessage>,
+struct ChatCompletionPayload<'a> {
+    messages: Vec<ChatCompletionMessagePayload>,
     model: &'a str,
-    response_format: JsonObjectResponseFormat,
+    response_format: ResponseFormat<'a>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    tools: Vec<JsonObjectTool<'a>>,
+    tools: Vec<ChatCompletionTool<'a>>,
 }
 
 #[derive(Serialize)]
-struct JsonObjectMessage {
+struct ChatCompletionMessagePayload {
     content: String,
     role: &'static str,
 }
 
 #[derive(Serialize)]
-struct JsonObjectResponseFormat {
+struct ResponseFormat<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    json_schema: Option<JsonSchemaResponseFormat<'a>>,
     #[serde(rename = "type")]
     kind: &'static str,
 }
 
 #[derive(Serialize)]
-struct JsonObjectTool<'a> {
-    function: JsonObjectFunction<'a>,
+struct JsonSchemaResponseFormat<'a> {
+    name: &'static str,
+    schema: &'a Value,
+}
+
+#[derive(Serialize)]
+struct ChatCompletionTool<'a> {
+    function: ChatCompletionFunction<'a>,
     #[serde(rename = "type")]
     kind: &'static str,
 }
 
-impl<'a> From<&'a tool::ToolDefinition> for JsonObjectTool<'a> {
+impl<'a> From<&'a tool::ToolDefinition> for ChatCompletionTool<'a> {
     fn from(definition: &'a tool::ToolDefinition) -> Self {
         Self {
-            function: JsonObjectFunction {
+            function: ChatCompletionFunction {
                 description: definition.description(),
                 name: definition.name(),
                 parameters: definition.parameters(),
@@ -451,7 +495,7 @@ impl<'a> From<&'a tool::ToolDefinition> for JsonObjectTool<'a> {
 }
 
 #[derive(Serialize)]
-struct JsonObjectFunction<'a> {
+struct ChatCompletionFunction<'a> {
     description: &'static str,
     name: &'static str,
     parameters: &'a Value,

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -13,6 +13,8 @@ mod tool;
 pub use model::{
     Model, ModelClient, ModelError, ModelMetadata, ModelMetadataError, ModelRequest, ModelResponse,
 };
-pub use provider::{KimiConfig, QwenConfig};
+pub use provider::{
+    KimiConfig, MUSE_SPARK_1_2, MUSE_SPARK_1_2_CONTRIBUTOR, MuseConfig, QwenConfig,
+};
 pub use schema_contract::{OutputSchema, OutputSchemaError};
 pub use tool::{ReadArguments, ToolCall, ToolDefinition};

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 use thiserror::Error;
 
-use crate::provider::{self, KimiConfig, QwenConfig};
+use crate::provider::{self, KimiConfig, MuseConfig, QwenConfig};
 use crate::schema_contract::{OutputSchema, OutputValidationError};
 use crate::{chat_completion, telemetry, tool};
 
@@ -29,7 +29,7 @@ pub trait Model: Send + Sync {
 /// [`ModelClient::complete`], which owns telemetry and structured-output
 /// validation.
 pub struct ModelClient {
-    backend: chat_completion::JsonObjectBackend,
+    backend: chat_completion::ChatCompletionBackend,
     metadata: ModelMetadata,
 }
 
@@ -46,6 +46,21 @@ impl ModelClient {
             config.base_url,
             config.model,
             provider::KIMI_POLICY,
+        )
+    }
+
+    /// Creates a client backed by Meta's Model API for Muse models.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelMetadataError`] when the configured model identifier is
+    /// empty or contains only whitespace.
+    pub fn muse(config: MuseConfig) -> Result<Self, ModelMetadataError> {
+        Self::chat_completion(
+            config.api_key,
+            config.base_url,
+            config.model,
+            provider::MUSE_POLICY,
         )
     }
 
@@ -97,9 +112,9 @@ impl ModelClient {
         api_key: String,
         base_url: String,
         model: String,
-        policy: chat_completion::JsonObjectProviderPolicy,
+        policy: chat_completion::ChatCompletionProviderPolicy,
     ) -> Result<Self, ModelMetadataError> {
-        let backend = chat_completion::JsonObjectBackend::new(api_key, base_url, model, policy);
+        let backend = chat_completion::ChatCompletionBackend::new(api_key, base_url, model, policy);
         let (provider, model) = backend.identity();
         let metadata = ModelMetadata::new(provider, model)?;
 

--- a/crates/ag-harness/src/provider.rs
+++ b/crates/ag-harness/src/provider.rs
@@ -1,9 +1,12 @@
 //! Provider-specific model adapters.
 
 mod kimi;
+mod muse;
 mod qwen;
 
 pub use kimi::KimiConfig;
 pub(crate) use kimi::POLICY as KIMI_POLICY;
+pub(crate) use muse::POLICY as MUSE_POLICY;
+pub use muse::{MUSE_SPARK_1_2, MUSE_SPARK_1_2_CONTRIBUTOR, MuseConfig};
 pub(crate) use qwen::POLICY as QWEN_POLICY;
 pub use qwen::QwenConfig;

--- a/crates/ag-harness/src/provider/kimi.rs
+++ b/crates/ag-harness/src/provider/kimi.rs
@@ -1,9 +1,10 @@
 use crate::chat_completion;
 
 pub(crate) const PROVIDER_NAME: &str = "moonshot_ai";
-pub(crate) const POLICY: chat_completion::JsonObjectProviderPolicy =
-    chat_completion::JsonObjectProviderPolicy {
+pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
+    chat_completion::ChatCompletionProviderPolicy {
         display_name: "Kimi",
+        structured_output: chat_completion::StructuredOutputMode::JsonObject,
         telemetry_name: PROVIDER_NAME,
         unsupported_schema_reason: "Kimi JSON Object mode requires an explicit object root schema",
     };

--- a/crates/ag-harness/src/provider/muse.rs
+++ b/crates/ag-harness/src/provider/muse.rs
@@ -1,0 +1,312 @@
+use crate::chat_completion;
+
+/// Standard Muse Spark 1.2 model whose prompts and completions are not used
+/// to train Meta models.
+pub const MUSE_SPARK_1_2: &str = "muse-spark-1.2";
+
+/// Discounted Muse Spark 1.2 model that permits Meta to use prompts and
+/// completions to train future models.
+pub const MUSE_SPARK_1_2_CONTRIBUTOR: &str = "muse-spark-1.2-contributor";
+
+pub(crate) const PROVIDER_NAME: &str = "meta";
+pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
+    chat_completion::ChatCompletionProviderPolicy {
+        display_name: "Meta Model API",
+        structured_output: chat_completion::StructuredOutputMode::JsonSchema,
+        telemetry_name: PROVIDER_NAME,
+        unsupported_schema_reason: "Muse structured output requires an explicit object root schema",
+    };
+
+/// Configuration for a Muse model served through Meta's Model API.
+pub struct MuseConfig {
+    /// API key sent as a bearer token.
+    pub api_key: String,
+    /// API base URL ending in the OpenAI-compatible version path.
+    pub base_url: String,
+    /// Muse model identifier sent with each request.
+    pub model: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+    use wiremock::matchers::{bearer_token, body_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+    use crate::{model, tool};
+
+    fn person_schema_value() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        })
+    }
+
+    fn person_schema() -> crate::OutputSchema {
+        crate::OutputSchema::new(person_schema_value()).expect("schema should be valid")
+    }
+
+    fn request(prompt: &str) -> model::ModelRequest {
+        model::ModelRequest::new(prompt, person_schema())
+    }
+
+    fn read_request(prompt: &str) -> model::ModelRequest {
+        request(prompt).with_tool(tool::ToolDefinition::read())
+    }
+
+    fn read_tool_wire() -> Value {
+        let definition = tool::ToolDefinition::read();
+
+        json!({
+            "type": "function",
+            "function": {
+                "description": definition.description(),
+                "name": definition.name(),
+                "parameters": definition.parameters()
+            }
+        })
+    }
+
+    fn muse(server: &MockServer) -> model::ModelClient {
+        model::ModelClient::muse(MuseConfig {
+            api_key: "test-key".to_string(),
+            base_url: format!("{}/", server.uri()),
+            model: "muse-spark-1.2".to_string(),
+        })
+        .expect("fixture configuration should be valid")
+    }
+
+    fn response_format() -> Value {
+        json!({
+            "type": "json_schema",
+            "json_schema": {
+                "name": "ag_harness_output",
+                "schema": person_schema_value()
+            }
+        })
+    }
+
+    #[test]
+    fn exposes_standard_and_contributor_model_identifiers() {
+        // Arrange and Act
+        let models = [MUSE_SPARK_1_2, MUSE_SPARK_1_2_CONTRIBUTOR];
+
+        // Assert
+        assert_eq!(models, ["muse-spark-1.2", "muse-spark-1.2-contributor"]);
+    }
+
+    #[test]
+    fn metadata_exposes_provider_and_model() {
+        // Arrange
+        let model = model::ModelClient::muse(MuseConfig {
+            api_key: "test-key".to_string(),
+            base_url: "https://api.meta.ai/v1".to_string(),
+            model: MUSE_SPARK_1_2_CONTRIBUTOR.to_string(),
+        })
+        .expect("fixture configuration should be valid");
+
+        // Act
+        let metadata = model.metadata();
+
+        // Assert
+        assert_eq!(metadata.provider(), "meta");
+        assert_eq!(metadata.model(), "muse-spark-1.2-contributor");
+    }
+
+    #[test]
+    fn rejects_empty_model_during_construction() {
+        // Arrange
+        let config = MuseConfig {
+            api_key: "test-key".to_string(),
+            base_url: "https://api.meta.ai/v1".to_string(),
+            model: "  ".to_string(),
+        };
+
+        // Act
+        let error = model::ModelClient::muse(config)
+            .err()
+            .expect("empty model configuration should be rejected");
+
+        // Assert
+        assert_eq!(error, model::ModelMetadataError::EmptyModel);
+    }
+
+    #[tokio::test]
+    async fn completes_native_json_schema_request() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(bearer_token("test-key"))
+            .and(body_json(json!({
+                "messages": [
+                    {"content": "extract the name", "role": "user"}
+                ],
+                "model": "muse-spark-1.2",
+                "response_format": response_format()
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": r#"{"name":"Ada"}"#}
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let model = muse(&server);
+
+        // Act
+        let response = model
+            .complete(request("extract the name"))
+            .await
+            .expect("Muse request should succeed");
+
+        // Assert
+        assert_eq!(response.output(), Some(&json!({ "name": "Ada" })));
+    }
+
+    #[tokio::test]
+    async fn advertises_and_decodes_read_tool_call() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(bearer_token("test-key"))
+            .and(body_json(json!({
+                "messages": [
+                    {"content": "inspect the manifest", "role": "user"}
+                ],
+                "model": "muse-spark-1.2",
+                "response_format": response_format(),
+                "tools": [read_tool_wire()]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "content": null,
+                        "tool_calls": [{
+                            "id": "call_muse_read",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": r#"{"path":"Cargo.toml","offset":1,"limit":12}"#
+                            }
+                        }]
+                    }
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let model = muse(&server);
+
+        // Act
+        let response = model
+            .complete(read_request("inspect the manifest"))
+            .await
+            .expect("Muse read request should decode");
+
+        // Assert
+        assert!(response.output().is_none());
+        let call = response
+            .call()
+            .expect("response should contain a tool call");
+        assert_eq!(call.id(), "call_muse_read");
+        assert_eq!(call.name(), "read");
+        assert_eq!(call.arguments().path(), "Cargo.toml");
+        assert_eq!(call.arguments().offset(), Some(1));
+        assert_eq!(call.arguments().limit(), Some(12));
+    }
+
+    #[tokio::test]
+    async fn retains_local_schema_validation() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": r#"{"name":42}"#}
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let model = muse(&server);
+
+        // Act
+        let error = model
+            .complete(request("extract the name"))
+            .await
+            .expect_err("schema violation should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            model::ModelError::SchemaViolation { path, reason }
+                if path == "/name" && reason.contains("string")
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_schemas_without_explicit_object_root() {
+        // Arrange
+        let server = MockServer::start().await;
+        let model = muse(&server);
+        let schema =
+            crate::OutputSchema::new(json!({ "type": "array" })).expect("schema should be valid");
+
+        // Act
+        let error = model
+            .complete(model::ModelRequest::new("list names", schema))
+            .await
+            .expect_err("schema without an explicit object root should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            model::ModelError::UnsupportedOutputSchema { reason }
+                if reason == "Muse structured output requires an explicit object root schema"
+        ));
+        assert!(
+            server
+                .received_requests()
+                .await
+                .expect("request recording should be enabled")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn reports_meta_http_failure_without_exposing_the_key() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": {"message": "invalid API key"}
+            })))
+            .mount(&server)
+            .await;
+        let model = muse(&server);
+
+        // Act
+        let error = model
+            .complete(request("hello"))
+            .await
+            .expect_err("HTTP failure should fail");
+        let message = error.to_string();
+
+        // Assert
+        assert!(message.contains("Meta Model API returned HTTP 401 Unauthorized"));
+        assert!(message.contains("invalid API key"));
+        assert!(!message.contains("test-key"));
+    }
+}

--- a/crates/ag-harness/src/provider/qwen.rs
+++ b/crates/ag-harness/src/provider/qwen.rs
@@ -1,9 +1,10 @@
 use crate::chat_completion;
 
 pub(crate) const PROVIDER_NAME: &str = "alibaba_cloud";
-pub(crate) const POLICY: chat_completion::JsonObjectProviderPolicy =
-    chat_completion::JsonObjectProviderPolicy {
+pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
+    chat_completion::ChatCompletionProviderPolicy {
         display_name: "Qwen",
+        structured_output: chat_completion::StructuredOutputMode::JsonObject,
         telemetry_name: PROVIDER_NAME,
         unsupported_schema_reason: "Qwen JSON Object mode requires an explicit object root schema",
     };
@@ -30,8 +31,8 @@ mod tests {
 
     use super::*;
     use crate::chat_completion::{
-        ChatCompletion, ChatCompletionClient, ChatCompletionError, ChatCompletionRequest,
-        ERROR_BODY_LIMIT_BYTES, JsonObjectBackend, RESPONSE_ENVELOPE_LIMIT_BYTES,
+        ChatCompletion, ChatCompletionBackend, ChatCompletionClient, ChatCompletionError,
+        ChatCompletionRequest, ERROR_BODY_LIMIT_BYTES, RESPONSE_ENVELOPE_LIMIT_BYTES,
         STRUCTURED_OUTPUT_INSTRUCTION, SUCCESS_BODY_LIMIT_BYTES,
     };
     use crate::{model, schema_contract, tool};
@@ -371,7 +372,7 @@ mod tests {
     #[tokio::test]
     async fn completes_through_injected_client() {
         // Arrange
-        let model = JsonObjectBackend::with_client(
+        let model = ChatCompletionBackend::with_client(
             "stub-key".to_string(),
             "https://stub.example/v1/".to_string(),
             "qwen-stub".to_string(),

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -27,8 +27,10 @@ flowchart LR
     M --> L["ModelClient lifecycle"]
     L --> Q["Qwen policy"]
     L --> K["Kimi policy"]
-    Q --> J["JSON Object backend"]
+    L --> U["Muse policy"]
+    Q --> J["Structured backend"]
     K --> J
+    U --> J
     J --> O["Chat Completions"]
 ```
 
@@ -65,19 +67,30 @@ Provider-owned adapters and compatibility rules live under the private `provider
 module. API-family clients remain separate so multiple providers can reuse a wire
 protocol without sharing provider policy.
 
-Qwen and Kimi share Chat Completions request execution and bounded response decoding.
-Both providers request JSON Object output, include the requested `OutputSchema` in the
-system instruction, and rely on shared local schema validation before returning a
-successful response. Schemas without an explicit object root and unsupported
+Qwen, Kimi, and Muse share Chat Completions request execution and bounded response
+decoding. Qwen and Kimi request JSON Object output and include the requested
+`OutputSchema` in the system instruction. Muse uses Meta Model API's native JSON Schema
+response format instead. Every provider retains shared local schema validation before
+returning a successful response. Schemas without an explicit object root and unsupported
 configurations fail explicitly rather than falling back to unstructured output.
 
+Muse intentionally omits Meta's optional `strict` flag, whose documented default is
+`false`. That keeps standard JSON Schema available while Meta enforces service limits,
+such as schema depth and size, through bounded provider HTTP errors.
+
+Muse exposes both `MUSE_SPARK_1_2` and `MUSE_SPARK_1_2_CONTRIBUTOR`. The contributor
+model uses discounted pricing in exchange for permission to use its prompts and
+completions to train future Meta models; the standard model does not use that data for
+training. The Muse example defaults to the standard model and accepts an explicit
+`MODEL_API_MODEL` override so applications must opt in to the contributor terms.
+
 The current wire-only tool foundation lets callers explicitly advertise the native
-`read` function on an individual `ModelRequest`. Qwen and Kimi translate the shared
-`ToolDefinition` into their Chat Completions payload and decode exactly one validated
-`ToolCall` with typed `ReadArguments`. A tool call remains distinct from terminal
-`ModelResponse` output, which continues through local `OutputSchema` validation. This
-slice stops at decoding: tool execution, filesystem access, tool-result messages, and
-the continuation loop remain future work.
+`read` function on an individual `ModelRequest`. Qwen, Kimi, and Muse translate the
+shared `ToolDefinition` into their Chat Completions payload and decode exactly one
+validated `ToolCall` with typed `ReadArguments`. A tool call remains distinct from
+terminal `ModelResponse` output, which continues through local `OutputSchema`
+validation. This slice stops at decoding: tool execution, filesystem access, tool-result
+messages, and the continuation loop remain future work.
 
 ## Session management
 
@@ -171,12 +184,12 @@ unstructured text.
 
 The shared `ModelClient` lifecycle records `gen_ai.client.operation.duration` for every
 backend request, including failures and cancellations. Application binaries own
-OpenTelemetry SDK setup, export, and shutdown. The Qwen and Kimi examples configure
-OTLP/HTTP metrics through the standard `OTEL_EXPORTER_OTLP_ENDPOINT` and
+OpenTelemetry SDK setup, export, and shutdown. The Qwen, Kimi, and Muse examples
+configure OTLP/HTTP metrics through the standard `OTEL_EXPORTER_OTLP_ENDPOINT` and
 `OTEL_EXPORTER_OTLP_HEADERS` environment variables. Each histogram observation is one
 model call; aggregate its count by `gen_ai.provider.name` to separate providers. Their
-default service names are `ag-harness-qwen` and `ag-harness-kimi`, while
-`OTEL_SERVICE_NAME` remains an application-level override.
+default service names are `ag-harness-qwen`, `ag-harness-kimi`, and `ag-harness-muse`,
+while `OTEL_SERVICE_NAME` remains an application-level override.
 
 ```mermaid
 flowchart LR

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -30,9 +30,10 @@ For file-level detail, read the module docstrings directly.
   metadata, commit/diff/push/pull sync, rebase/conflict handling, and squash-merge
   workflows behind the `GitClient` boundary.
 - `crates/ag-harness/`: Application-facing LLM harness crate with the provider-neutral
-  object-safe `Model` boundary, its `ModelClient` implementation, private Qwen and Kimi
-  policies, a shared Chat Completions JSON Object backend, and backend-neutral
-  request-duration telemetry. Application binaries own telemetry setup.
+  object-safe `Model` boundary, its `ModelClient` implementation, private Qwen, Kimi,
+  and Muse policies, a shared Chat Completions backend with JSON Object and JSON Schema
+  modes, and backend-neutral request-duration telemetry. Application binaries own
+  telemetry setup.
 - `crates/ag-protocol/`: Shared structured response protocol library crate with
   transport-neutral response models, schema generation, parser diagnostics, protocol
   prompt envelopes, repair prompts, review-comment outcomes, and turn prompt payload


### PR DESCRIPTION
- Adds `MuseConfig` and a Muse Spark example that emits validated JSON with OTLP/HTTP metrics.
- Generalizes shared Chat Completions handling for native JSON Schema while preserving Qwen and Kimi JSON Object mode, local validation, and tool-call behavior.
- Adds public standard and contributor Muse Spark 1.2 model identifiers and an explicit model override.
- Adds documentation and live API verification for Muse standard and contributor models.
- Share greeting and process-fixture helpers across provider examples, including coverage for metrics export and timeout cleanup.
- Adds policy-driven Muse validation for provider-specific native structured-output compatibility, with comprehensive tests and updated architecture documentation.