### PR TITLE
Adds Agentty Dark theme

### DIFF
--- a/crates/agentty/src/app/setting.rs
+++ b/crates/agentty/src/app/setting.rs
@@ -1641,6 +1641,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn settings_manager_new_loads_persisted_agentty_dark_theme() {
+        // Arrange
+        let (services, project_id) = test_services().await;
+        services
+            .db()
+            .settings()
+            .upsert_setting(SettingName::Theme, ColorTheme::AgenttyDark.as_str())
+            .await
+            .expect("failed to persist theme setting");
+
+        // Act
+        let manager = settings_manager(&services, project_id).await;
+
+        // Assert
+        assert_eq!(manager.settings().theme, ColorTheme::AgenttyDark);
+    }
+
+    #[tokio::test]
     async fn apply_operation_persists_role_model_and_reasoning_settings() {
         // Arrange
         let (services, project_id) = test_services().await;
@@ -2355,6 +2373,7 @@ mod tests {
         assert_eq!(dropdown.row_index, 0);
         assert_eq!(dropdown.selected_index, 0);
         assert_eq!(dropdown.options[1].label, "Agentty Green");
+        assert_eq!(dropdown.options[3].label, "Agentty Dark");
 
         manager.next_selector_dropdown_option();
         manager.select_selector_dropdown_option().await;

--- a/crates/agentty/src/domain/theme.rs
+++ b/crates/agentty/src/domain/theme.rs
@@ -12,11 +12,18 @@ pub enum ColorTheme {
     Green,
     /// A warm dark palette inspired by the Horizon editor theme.
     DarkHorizon,
+    /// A muted navy palette shown as `Agentty Dark`.
+    AgenttyDark,
 }
 
 impl ColorTheme {
     /// All selectable color themes in settings display order.
-    pub const ALL: [Self; 3] = [Self::Current, Self::Green, Self::DarkHorizon];
+    pub const ALL: [Self; 4] = [
+        Self::Current,
+        Self::Green,
+        Self::DarkHorizon,
+        Self::AgenttyDark,
+    ];
 
     /// Returns the persisted wire value for this theme.
     #[must_use]
@@ -25,6 +32,7 @@ impl ColorTheme {
             Self::Current => "current",
             Self::Green => "green",
             Self::DarkHorizon => "dark_horizon",
+            Self::AgenttyDark => "agentty_dark",
         }
     }
 
@@ -35,6 +43,7 @@ impl ColorTheme {
             Self::Current => "Agentty Default",
             Self::Green => "Agentty Green",
             Self::DarkHorizon => "Dark Horizon",
+            Self::AgenttyDark => "Agentty Dark",
         }
     }
 
@@ -48,6 +57,7 @@ impl ColorTheme {
             "current" => Some(Self::Current),
             "green" => Some(Self::Green),
             "dark_horizon" => Some(Self::DarkHorizon),
+            "agentty_dark" => Some(Self::AgenttyDark),
             _ => None,
         }
     }
@@ -117,15 +127,18 @@ mod tests {
         let current_theme = ColorTheme::Current;
         let green_theme = ColorTheme::Green;
         let dark_horizon_theme = ColorTheme::DarkHorizon;
+        let agentty_dark_theme = ColorTheme::AgenttyDark;
 
         // Act
         let next_theme = current_theme.next();
         let after_green_theme = green_theme.next();
-        let wrapped_theme = dark_horizon_theme.next();
+        let after_dark_horizon_theme = dark_horizon_theme.next();
+        let wrapped_theme = agentty_dark_theme.next();
 
         // Assert
         assert_eq!(next_theme, ColorTheme::Green);
         assert_eq!(after_green_theme, ColorTheme::DarkHorizon);
+        assert_eq!(after_dark_horizon_theme, ColorTheme::AgenttyDark);
         assert_eq!(wrapped_theme, ColorTheme::Current);
     }
 
@@ -139,5 +152,21 @@ mod tests {
 
         // Assert
         assert_eq!(theme, Some(ColorTheme::DarkHorizon));
+    }
+
+    #[test]
+    fn agentty_dark_has_persisted_value_and_label() {
+        // Arrange
+        let stored_value = "agentty_dark";
+
+        // Act
+        let theme = ColorTheme::parse_persisted(stored_value);
+        let persisted_value = ColorTheme::AgenttyDark.as_str();
+        let label = ColorTheme::AgenttyDark.label();
+
+        // Assert
+        assert_eq!(theme, Some(ColorTheme::AgenttyDark));
+        assert_eq!(persisted_value, stored_value);
+        assert_eq!(label, "Agentty Dark");
     }
 }

--- a/crates/agentty/src/ui/style.rs
+++ b/crates/agentty/src/ui/style.rs
@@ -312,6 +312,34 @@ const DARK_HORIZON_PALETTE: ThemePalette = ThemePalette {
     warning_soft: Color::Rgb(252, 215, 188),
 };
 
+/// Muted dark palette sampled from the Agentty interface reference: near-black
+/// navy surfaces, cyan focus, mint success, peach warning, crimson danger,
+/// lavender questions, and cool gray text.
+const AGENTTY_DARK_PALETTE: ThemePalette = ThemePalette {
+    accent: Color::Rgb(123, 222, 226),
+    accent_soft: Color::Rgb(159, 229, 233),
+    border: Color::Rgb(53, 60, 81),
+    danger: Color::Rgb(196, 80, 79),
+    danger_soft: Color::Rgb(177, 88, 89),
+    info: Color::Rgb(115, 158, 211),
+    question: Color::Rgb(176, 126, 215),
+    surface: Color::Rgb(22, 24, 31),
+    surface_clarification: Color::Rgb(33, 36, 48),
+    surface_danger: Color::Rgb(60, 34, 42),
+    surface_elevated: Color::Rgb(33, 36, 48),
+    surface_selection: Color::Rgb(46, 50, 67),
+    surface_success: Color::Rgb(36, 63, 54),
+    surface_overlay: Color::Rgb(11, 12, 15),
+    surface_prompt: Color::Rgb(22, 24, 31),
+    text: Color::Rgb(215, 217, 231),
+    text_muted: Color::Rgb(132, 137, 167),
+    text_subtle: Color::Rgb(97, 101, 127),
+    success: Color::Rgb(97, 206, 155),
+    success_soft: Color::Rgb(122, 192, 161),
+    warning: Color::Rgb(243, 196, 158),
+    warning_soft: Color::Rgb(222, 200, 184),
+};
+
 /// Sets the process-wide active color theme used by semantic palette tokens.
 pub fn set_active_theme(theme: ColorTheme) {
     let _lock_guard = ACTIVE_THEME_SCOPE_LOCK
@@ -421,6 +449,7 @@ pub fn forge_indicator_color(state: Option<ReviewRequestState>) -> Color {
 #[must_use]
 fn active_palette() -> ThemePalette {
     match active_theme() {
+        ColorTheme::AgenttyDark => AGENTTY_DARK_PALETTE,
         ColorTheme::Green => GREEN_PALETTE,
         ColorTheme::DarkHorizon => DARK_HORIZON_PALETTE,
         ColorTheme::Current => CURRENT_PALETTE,
@@ -433,6 +462,7 @@ fn active_theme() -> ColorTheme {
     match ACTIVE_THEME.load(Ordering::Relaxed) {
         1 => ColorTheme::Green,
         2 => ColorTheme::DarkHorizon,
+        3 => ColorTheme::AgenttyDark,
         _ => ColorTheme::Current,
     }
 }
@@ -454,6 +484,7 @@ const fn theme_index(theme: ColorTheme) -> u8 {
         ColorTheme::Current => 0,
         ColorTheme::Green => 1,
         ColorTheme::DarkHorizon => 2,
+        ColorTheme::AgenttyDark => 3,
     }
 }
 
@@ -638,6 +669,41 @@ mod tests {
         assert_eq!(palette.warning, Color::Rgb(250, 194, 154));
         assert_eq!(palette.danger, Color::Rgb(209, 67, 76));
         assert_eq!(palette.question, Color::Rgb(184, 119, 219));
+    }
+
+    #[test]
+    fn active_palette_returns_agentty_dark_reference_tones() {
+        // Arrange
+        let _theme_scope = scoped_active_theme(ColorTheme::AgenttyDark);
+
+        // Act
+        let palette = palette::active();
+
+        // Assert
+        assert_eq!(palette.surface, Color::Rgb(22, 24, 31));
+        assert_eq!(palette.surface_elevated, Color::Rgb(33, 36, 48));
+        assert_eq!(palette.surface_selection, Color::Rgb(46, 50, 67));
+        assert_eq!(palette.border, Color::Rgb(53, 60, 81));
+        assert_eq!(palette.text, Color::Rgb(215, 217, 231));
+        assert_eq!(palette.text_muted, Color::Rgb(132, 137, 167));
+        assert_eq!(palette.text_subtle, Color::Rgb(97, 101, 127));
+        assert_eq!(palette.accent, Color::Rgb(123, 222, 226));
+    }
+
+    #[test]
+    fn active_palette_returns_agentty_dark_status_tones() {
+        // Arrange
+        let _theme_scope = scoped_active_theme(ColorTheme::AgenttyDark);
+
+        // Act
+        let palette = palette::active();
+
+        // Assert
+        assert_eq!(palette.success, Color::Rgb(97, 206, 155));
+        assert_eq!(palette.warning, Color::Rgb(243, 196, 158));
+        assert_eq!(palette.danger, Color::Rgb(196, 80, 79));
+        assert_eq!(palette.question, Color::Rgb(176, 126, 215));
+        assert_eq!(palette.info, Color::Rgb(115, 158, 211));
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -3306,6 +3306,12 @@ fn session_list_selected_row_remains_readable_under_dark_horizon() -> E2eResult 
                     .press_key("j")
                     .wait_for_stable_frame(200, 3000)
                     .press_key("Enter")
+                    .wait_for_text("Agentty Dark", 5000)
+                    .press_key("Enter")
+                    .wait_for_stable_frame(200, 3000)
+                    .press_key("j")
+                    .wait_for_stable_frame(200, 3000)
+                    .press_key("Enter")
                     .wait_for_text("Agentty Default", 5000)
             },
             |_frame, report| {

--- a/crates/agentty/tests/e2e/setting.rs
+++ b/crates/agentty/tests/e2e/setting.rs
@@ -570,14 +570,16 @@ fn test_input_undo_redo() {
 }
 
 /// Verify that the `Theme` settings row dropdown selects `Agentty Default`,
-/// `Agentty Green`, and `Dark Horizon` and wraps back to `Agentty Default`.
+/// `Agentty Green`, `Dark Horizon`, and `Agentty Dark`, then wraps back to
+/// `Agentty Default`.
 #[test]
 fn settings_theme_switch() {
     // Arrange, Act, Assert
     FeatureTest::new("settings_theme_switch")
         .zola(
             "Settings theme switch",
-            "Select Agentty Default, Agentty Green, and Dark Horizon themes from settings.",
+            "Select Agentty Default, Agentty Green, Dark Horizon, and Agentty Dark themes from \
+             settings.",
             155,
         )
         .run(
@@ -617,10 +619,15 @@ fn settings_theme_switch() {
                     .press_key("Enter")
                     .wait_for_stable_frame(200, 3000)
                     .viewing_pause_ms(2500)
-                    .capture_labeled(
-                        "after_theme_switch_wrap_agentty_default",
-                        "Theme wraps back to Agentty Default",
-                    )
+                    .capture_labeled("agentty_dark", "Agentty Dark selected")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(200, 3000)
+                    .press_key("j")
+                    .wait_for_stable_frame(200, 3000)
+                    .press_key("Enter")
+                    .wait_for_stable_frame(200, 3000)
+                    .viewing_pause_ms(2500)
+                    .capture_labeled("wrapped_default", "Theme wraps to Agentty Default")
             },
             |frame, report| {
                 let full = Region::full(frame.cols(), frame.rows());
@@ -629,9 +636,9 @@ fn settings_theme_switch() {
 
                 assert_eq!(
                     report.captures.len(),
-                    4,
-                    "Expected 4 captures (initial Agentty Default, Agentty Green, Dark Horizon, \
-                     wrapped Agentty Default)"
+                    5,
+                    "Expected 5 captures (initial Agentty Default, Agentty Green, Dark Horizon, \
+                     Agentty Dark, wrapped Agentty Default)"
                 );
 
                 let before_frame = common::frame_from_capture(&report.captures[0]);
@@ -656,7 +663,16 @@ fn settings_theme_switch() {
                     &dark_horizon_full,
                 );
 
-                let wrapped_frame = common::frame_from_capture(&report.captures[3]);
+                let agentty_dark_frame = common::frame_from_capture(&report.captures[3]);
+                let agentty_dark_full =
+                    Region::full(agentty_dark_frame.cols(), agentty_dark_frame.rows());
+                assertion::assert_text_in_region(
+                    &agentty_dark_frame,
+                    "Agentty Dark",
+                    &agentty_dark_full,
+                );
+
+                let wrapped_frame = common::frame_from_capture(&report.captures[4]);
                 let wrapped_full = Region::full(wrapped_frame.cols(), wrapped_frame.rows());
                 assertion::assert_text_in_region(&wrapped_frame, "Agentty Default", &wrapped_full);
             },

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -108,14 +108,14 @@ highlighted in the table with a `* ` prefix and accented row text.
 </table>
 
 <a id="usage-settings-options"></a> The page is split into `Global settings` for the
-app-wide `Theme` row (`Agentty Default`, `Agentty Green`, or `Dark Horizon`) and
-`'<project>' settings` for Smart, Fast, and Review `agent/model [reasoning]` defaults,
-the commit coauthor toggle, and `Launch Configurations` rows described in
-[Workflow](@/docs/usage/workflow.md). Selector rows open dropdowns; use `j` / `k` to
-move through the dropdown. For a role default, press `Enter` after choosing the model,
-then choose and save its reasoning level with `Enter`. Other selectors save directly.
-The `Launch Configurations` row opens a list browser where each command is added,
-edited, deleted, or reordered as its own entry.
+app-wide `Theme` row (`Agentty Default`, `Agentty Green`, `Dark Horizon`, or
+`Agentty Dark`) and `'<project>' settings` for Smart, Fast, and Review
+`agent/model [reasoning]` defaults, the commit coauthor toggle, and
+`Launch Configurations` rows described in [Workflow](@/docs/usage/workflow.md). Selector
+rows open dropdowns; use `j` / `k` to move through the dropdown. For a role default,
+press `Enter` after choosing the model, then choose and save its reasoning level with
+`Enter`. Other selectors save directly. The `Launch Configurations` row opens a list
+browser where each command is added, edited, deleted, or reordered as its own entry.
 
 ## Session View
 

--- a/docs/site/content/features/settings_theme_switch.md
+++ b/docs/site/content/features/settings_theme_switch.md
@@ -1,6 +1,6 @@
 +++
 title = "Settings theme switch"
-description = "Select Agentty Default, Agentty Green, and Dark Horizon themes from settings."
+description = "Select Agentty Default, Agentty Green, Dark Horizon, and Agentty Dark themes from settings."
 weight = 155
 [extra]
 gif = "settings_theme_switch.gif"


### PR DESCRIPTION
- Exposes `Agentty Dark` as a persisted selectable theme with a muted navy palette.
- Covers theme cycling, persistence, palette tones, and settings UI with automated tests.
- Updates settings documentation for the new theme option.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)