### PR TITLE
Publishes `ag-harness` with the workspace release

### DIFF
--- a/.github/workflows/publish-crates-io.yml
+++ b/.github/workflows/publish-crates-io.yml
@@ -39,6 +39,11 @@ jobs:
           CRATES_IO_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish -p ag-git --token "$CRATES_IO_TOKEN"
 
+      - name: Publish `ag-harness` to crates.io
+        env:
+          CRATES_IO_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish -p ag-harness --token "$CRATES_IO_TOKEN"
+
       - name: Publish `testty` to crates.io
         env:
           CRATES_IO_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- release: publish `ag-harness` to crates.io with the workspace release.
+
 ## [v0.14.5] - 2026-08-11
 
 ### Changed


### PR DESCRIPTION
- Adds `ag-harness` to the crates.io publishing workflow.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)