### PR TITLE
VHS recording uses the canonical container

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,13 +364,12 @@ the full suite.
   platforms. Publish replacements through the manual **Publish E2E Image** workflow in
   `.github/workflows/publish-e2e-image.yml`; it tests both native variants before
   reporting the digest. CI selects and verifies the `linux/amd64` variant. If recording
-  on the host instead, `TESTTY_GIF_MODE=force` must run from an unsandboxed shell (a
-  normal terminal, or one command explicitly approved to bypass the agent sandbox): VHS
-  records through localhost sockets (`ttyd` plus Chrome DevTools), so a network-denied
-  sandbox crashes `vhs` before Chrome launches — an error easy to misdiagnose as a
-  missing browser binary. Do not run the full E2E feature suite locally;
-  `.github/workflows/presubmit.yml` and `.github/workflows/postsubmit.yml` run
-  `test-agentty-e2e` in that image on GitHub.
+  from an agent session, never invoke host-side `vhs` or set `TESTTY_GIF_MODE=generate`
+  / `TESTTY_GIF_MODE=force`; use the pinned container. On macOS, VHS launches a local
+  Chromium process that can abort during AppKit registration and show a **Chromium quit
+  unexpectedly** dialog. Do not suppress macOS crash reporting to hide this failure. Do
+  not run the full E2E feature suite locally; `.github/workflows/presubmit.yml` and
+  `.github/workflows/postsubmit.yml` run `test-agentty-e2e` in that image on GitHub.
 
 ### Autofix Discipline
 

--- a/crates/testty/docs/feature-gif-workflow.md
+++ b/crates/testty/docs/feature-gif-workflow.md
@@ -115,6 +115,12 @@ previous GIF, hash sidecar, and poster. The developer reviews the changed GIF an
 sidecar, refreshes the matching PNG poster, and commits the three artifacts with the UI
 change.
 
+Do not run generation modes directly on a macOS host. VHS launches a local Chromium
+process, which can abort during AppKit registration and show a **Chromium quit
+unexpectedly** dialog. Host-side validation should use `check` mode; intentional
+recording should use the canonical container. Do not suppress macOS crash reporting to
+hide the browser failure.
+
 Use the exact platform-explicit, digest-pinned Podman recording command in
 `skills/feature-test/SKILL.md`. It runs the local container as the host UID and GID so
 Linux bind mounts remain writable, while CI keeps the image's fixed non-root user and

--- a/skills/feature-test/SKILL.md
+++ b/skills/feature-test/SKILL.md
@@ -208,8 +208,10 @@ prek run zola-check --all-files --hook-stage manual
 ```
 
 Routine agent validation must use `TESTTY_GIF_MODE=check` so the semantic PTY assertions
-still run while GIF freshness is checked without invoking VHS or launching Chrome. Use
-`TESTTY_GIF_MODE=force` only when intentionally regenerating GIF assets.
+still run while GIF freshness is checked without invoking VHS or launching Chrome. Never
+run host-side `vhs`, `TESTTY_GIF_MODE=generate`, or `TESTTY_GIF_MODE=force` from an
+agent session. Intentional regeneration uses `TESTTY_GIF_MODE=generate` inside the
+canonical container below.
 
 ### Record in the canonical container
 
@@ -388,14 +390,16 @@ Do not update the repository when logout, inspection, or either platform pull fa
 logout makes the inspection and pulls exercise the same anonymous access that forked
 pull-request CI requires.
 
-### Host recording caveats
+### Host recording prohibition
 
-`force` mode must run from an unsandboxed shell — a normal user terminal, or a single
-agent command explicitly approved to bypass the sandbox. VHS records through localhost
-sockets (`ttyd` plus the Chrome DevTools protocol), and sandboxed agent shells deny all
-network, so `vhs` segfaults in `randomPort()` before Chrome ever launches. That failure
-is easy to misdiagnose as a missing browser binary: having Chrome, `vhs`, `ttyd`, and
-`ffmpeg` installed is not enough — the shell must also allow localhost sockets.
+Do not run VHS recording directly on a developer host from an agent session. VHS records
+through localhost sockets (`ttyd` plus the Chrome DevTools protocol), and sandboxed
+agent shells can deny that network access and crash `vhs` before Chrome launches. On
+macOS, even an unsandboxed host run launches a local Chromium process that can abort
+during AppKit registration and show a **Chromium quit unexpectedly** dialog. This
+prohibition also covers direct `vhs` commands and ignored tests that regenerate demo
+assets. Use the platform-explicit Podman workflow above for every intentional recording;
+do not suppress macOS crash reporting to hide the browser failure.
 
 In default `generate-if-stale` mode, machines without VHS still run and assert the test
 correctly, then gracefully skip GIF generation. In `force` mode, VHS must be installed
@@ -403,8 +407,9 @@ because regeneration was explicitly requested.
 
 The `TESTTY_GIF_MODE` env var selects the freshness mode used by `FeatureTest`:
 
-- unset / `generate` / `generate-if-stale` (default) — regenerate when the on-disk hash
-  sidecar is missing or stale, otherwise reuse the committed GIF.
+- unset — leave GIF work off while still running the PTY scenario and assertions.
+- `generate` / `generate-if-stale` — regenerate when the on-disk hash sidecar is missing
+  or stale, otherwise reuse the committed GIF. Use only inside the canonical container.
 - `check` / `check-only` — compute the would-be hash and compare it to the on-disk
   sidecar without invoking VHS or touching the GIF output directory. The harness fails
   the test when a committed sidecar has drifted, an existing sidecar is invalid, or the
@@ -415,7 +420,8 @@ The `TESTTY_GIF_MODE` env var selects the freshness mode used by `FeatureTest`:
   recording run publishes their artifacts.
 - `force` / `always` / `always-generate` — bypass the hash cache and re-run VHS
   unconditionally. VHS must be installed: a missing VHS binary fails the test instead of
-  being silently skipped, because regeneration was explicitly requested.
+  being silently skipped, because regeneration was explicitly requested. Do not use this
+  mode on a developer host or from an agent session.
 
 Run `prek run zola-check --all-files --hook-stage manual` after the test to catch broken
 frontmatter or template integration before the page reaches CI. This requires Zola to be


### PR DESCRIPTION
- Prohibit host-side `vhs` and GIF generation modes from agent sessions.
- Route intentional recording through the platform-explicit, digest-pinned container while retaining `TESTTY_GIF_MODE=check` for routine validation.
- Document macOS Chromium failure and crash-reporting guidance.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)