### PR TITLE
Release version 0.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,40 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.14.6] - 2026-08-13
+
+### Added
+
+- ag-harness: add Muse structured-output support, public model identifiers, explicit
+  model overrides, OTLP/HTTP metrics, and live API verification.
+- ag-harness: support validated native `read` tool calls for Qwen and Kimi models.
+
 ### Changed
 
+- agentty: show per-row added and removed totals in the diff explorer.
+- agentty: add counts to populated session group headings and mute archived session
+  details.
+- agentty: show persisted change summaries before focused reviews.
+- agentty: require `tmux` before offering worktree-opening actions.
 - release: publish `ag-harness` to crates.io with the workspace release.
 - agentty: remove the `Agentty Dark` color theme from the settings selector.
+- persistence: extract reusable SQLite repositories and migrations into `ag-store`.
+- session: centralize shared frontend-neutral session models in `ag-session`.
+- ci: route VHS recording through the pinned canonical container and document pinned
+  GitHub Action versions.
+- deps: update the GitHub Actions and Rust dependency groups.
+- release: bump workspace crate metadata and lockfile package versions to `0.14.6`.
+
+### Fixed
+
+- agentty: align continuation guidance with completed and canceled session actions and
+  the current lowercase `c` key.
+
+### Contributors
+
+- @andagaev
+- @dependabot
+- @minev-dev
 
 ## [v0.14.5] - 2026-08-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "image",
  "mockall",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "mockall",
  "serde",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "mockall",
  "rustix",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "ag-harness"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "async-trait",
  "jsonschema",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "askama",
  "schemars 1.2.2",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "ag-session"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "ag-agent",
  "ag-forge",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "ag-store"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "ag-agent",
  "ag-session",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "clap",
  "tempfile",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "base64 0.23.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.14.5"
+version = "0.14.6"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -16,15 +16,15 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.14.5" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.14.5" }
-ag-forge = { path = "crates/ag-forge", version = "0.14.5" }
-ag-git = { path = "crates/ag-git", version = "0.14.5" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.14.5" }
-ag-session = { path = "crates/ag-session", version = "0.14.5" }
-ag-store = { path = "crates/ag-store", version = "0.14.5" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.14.5" }
-testty = { path = "crates/testty", version = "0.14.5" }
+ag-agent = { path = "crates/ag-agent", version = "0.14.6" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.14.6" }
+ag-forge = { path = "crates/ag-forge", version = "0.14.6" }
+ag-git = { path = "crates/ag-git", version = "0.14.6" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.14.6" }
+ag-session = { path = "crates/ag-session", version = "0.14.6" }
+ag-store = { path = "crates/ag-store", version = "0.14.6" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.14.6" }
+testty = { path = "crates/testty", version = "0.14.6" }
 async-trait = "0.1"
 agent-client-protocol = "2.0.0"
 assert_cmd = "2"


### PR DESCRIPTION
- Record the cumulative product, persistence, session, CI, and dependency changes in `CHANGELOG.md`.
- Align workspace package metadata and lockfile versions with `0.14.6`.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)