### PR TITLE
Replaces Gemini 3.6 Flash with Gemini 3.7 Flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- agentty: replace Gemini 3.6 Flash with Gemini 3.7 Flash for the Gemini and Antigravity
+  providers, migrating persisted selections to the replacement.
+
 ## [v0.14.6] - 2026-08-13
 
 ### Added

--- a/crates/ag-agent/src/agent/antigravity.rs
+++ b/crates/ag-agent/src/agent/antigravity.rs
@@ -518,7 +518,7 @@ mod tests {
             local_image_path: attachment_directory.join("one.png"),
         };
         let backend = supported_backend();
-        let requested_model = "gemini-3.6-flash";
+        let requested_model = "gemini-3.7-flash";
 
         // Act
         let command = AgentBackend::build_command(

--- a/crates/ag-agent/src/agent/gemini.rs
+++ b/crates/ag-agent/src/agent/gemini.rs
@@ -71,7 +71,7 @@ mod tests {
                 folder: temp_directory.path(),
                 main_checkout_root: None,
                 replay_transcript: None,
-                model: "gemini-3.6-flash",
+                model: "gemini-3.7-flash",
                 permission_mode: crate::model::permission::PermissionMode::AutoEdit,
                 personality_prompt: None,
                 prompt: "Generate title",
@@ -87,7 +87,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         // Assert
-        assert_eq!(args, vec!["--acp", "--model", "gemini-3.6-flash"]);
+        assert_eq!(args, vec!["--acp", "--model", "gemini-3.7-flash"]);
         assert_eq!(command.get_current_dir(), Some(temp_directory.path()));
     }
 
@@ -107,7 +107,7 @@ mod tests {
                 folder: temp_directory.path(),
                 main_checkout_root: None,
                 replay_transcript: None,
-                model: "gemini-3.6-flash",
+                model: "gemini-3.7-flash",
                 permission_mode: crate::model::permission::PermissionMode::ReadOnly,
                 personality_prompt: None,
                 prompt: "Inspect the architecture",
@@ -128,7 +128,7 @@ mod tests {
             vec![
                 "--acp",
                 "--model",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "--approval-mode",
                 "plan",
                 "--sandbox"

--- a/crates/ag-agent/src/model/agent.rs
+++ b/crates/ag-agent/src/model/agent.rs
@@ -90,8 +90,8 @@ pub enum AgentModel {
     Gpt56Terra,
     /// Codex Luna model backed by `gpt-5.6-luna`.
     Gpt56Luna,
-    /// Fast Gemini model backed by `gemini-3.6-flash`.
-    Gemini36Flash,
+    /// Fast Gemini model backed by `gemini-3.7-flash`.
+    Gemini37Flash,
     /// Lightweight Gemini model backed by `gemini-3.5-flash-lite`.
     Gemini35FlashLite,
     /// Higher-quality Gemini preview model backed by `gemini-3.1-pro-preview`.
@@ -177,7 +177,7 @@ impl AgentModel {
             Self::Gpt56Sol => "gpt-5.6-sol",
             Self::Gpt56Terra => "gpt-5.6-terra",
             Self::Gpt56Luna => "gpt-5.6-luna",
-            Self::Gemini36Flash => "gemini-3.6-flash",
+            Self::Gemini37Flash => "gemini-3.7-flash",
             Self::Gemini35FlashLite => "gemini-3.5-flash-lite",
             Self::Gemini31Pro => "gemini-3.1-pro-preview",
             Self::Gpt53CodexSpark => "gpt-5.3-codex-spark",
@@ -230,7 +230,8 @@ impl AgentModel {
         const RETIRED_MODEL_REPLACEMENTS: &[(&str, AgentModel)] = &[
             ("gemini-3-pro-preview", AgentModel::Gemini31Pro),
             ("gemini-3.1-pro", AgentModel::Gemini31Pro),
-            ("gemini-3-flash-preview", AgentModel::Gemini36Flash),
+            ("gemini-3-flash-preview", AgentModel::Gemini37Flash),
+            ("gemini-3.6-flash", AgentModel::Gemini37Flash),
             ("gemini-3.5-flash", AgentModel::Gemini35FlashLite),
             (
                 "gemini-3.1-flash-lite-preview",
@@ -513,7 +514,7 @@ impl FromStr for AgentModel {
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
-            "gemini-3.6-flash" => Ok(Self::Gemini36Flash),
+            "gemini-3.7-flash" => Ok(Self::Gemini37Flash),
             "gemini-3.5-flash-lite" => Ok(Self::Gemini35FlashLite),
             "gemini-3.1-pro-preview" => Ok(Self::Gemini31Pro),
             "gpt-5.6-sol" => Ok(Self::Gpt56Sol),
@@ -537,7 +538,7 @@ impl AgentSelectionMetadata for AgentModel {
     fn description(&self) -> &'static str {
         match self {
             Self::Gemini31Pro => "Higher-quality Gemini model for deeper reasoning.",
-            Self::Gemini36Flash => "Fast Gemini model for agentic and multimodal tasks.",
+            Self::Gemini37Flash => "Fast Gemini model for agentic and multimodal tasks.",
             Self::Gemini35FlashLite => {
                 "Lightweight Gemini model for fast, cost-conscious workloads."
             }
@@ -594,12 +595,12 @@ impl AgentKind {
     pub fn models(self) -> &'static [AgentModel] {
         const ANTIGRAVITY_MODELS: &[AgentModel] = &[
             AgentModel::Gemini31Pro,
-            AgentModel::Gemini36Flash,
+            AgentModel::Gemini37Flash,
             AgentModel::Gemini35FlashLite,
         ];
         const GEMINI_MODELS: &[AgentModel] = &[
             AgentModel::Gemini31Pro,
-            AgentModel::Gemini36Flash,
+            AgentModel::Gemini37Flash,
             AgentModel::Gemini35FlashLite,
         ];
         const CLAUDE_MODELS: &[AgentModel] = &[
@@ -710,7 +711,7 @@ mod tests {
     fn test_parse_model_returns_none_for_models_from_other_providers() {
         // Arrange
         let claude_kind = AgentKind::Claude;
-        let antigravity_model = AgentModel::Gemini36Flash.as_str();
+        let antigravity_model = AgentModel::Gemini37Flash.as_str();
 
         // Act
         let parsed_model = claude_kind.parse_model(antigravity_model);
@@ -747,12 +748,12 @@ mod tests {
 
         // Act
         let parsed_pro = antigravity_kind.parse_model("gemini-3.1-pro-preview");
-        let parsed_flash_36 = antigravity_kind.parse_model("gemini-3.6-flash");
+        let parsed_flash_37 = antigravity_kind.parse_model("gemini-3.7-flash");
         let parsed_flash_35_lite = antigravity_kind.parse_model("gemini-3.5-flash-lite");
 
         // Assert
         assert_eq!(parsed_pro, Some(AgentModel::Gemini31Pro));
-        assert_eq!(parsed_flash_36, Some(AgentModel::Gemini36Flash));
+        assert_eq!(parsed_flash_37, Some(AgentModel::Gemini37Flash));
         assert_eq!(parsed_flash_35_lite, Some(AgentModel::Gemini35FlashLite));
     }
 
@@ -764,10 +765,10 @@ mod tests {
         let gemini_kind = AgentKind::Gemini;
 
         // Act
-        let parsed_model = gemini_kind.parse_model("gemini-3.6-flash");
+        let parsed_model = gemini_kind.parse_model("gemini-3.7-flash");
 
         // Assert
-        assert_eq!(parsed_model, Some(AgentModel::Gemini36Flash));
+        assert_eq!(parsed_model, Some(AgentModel::Gemini37Flash));
     }
 
     #[test]
@@ -790,7 +791,7 @@ mod tests {
         // Arrange
         let models = [
             AgentModel::Gemini31Pro,
-            AgentModel::Gemini36Flash,
+            AgentModel::Gemini37Flash,
             AgentModel::Gemini35FlashLite,
         ];
 
@@ -875,7 +876,8 @@ mod tests {
         let retired_ids = [
             ("gemini-3-pro-preview", AgentModel::Gemini31Pro),
             ("gemini-3.1-pro", AgentModel::Gemini31Pro),
-            ("gemini-3-flash-preview", AgentModel::Gemini36Flash),
+            ("gemini-3-flash-preview", AgentModel::Gemini37Flash),
+            ("gemini-3.6-flash", AgentModel::Gemini37Flash),
             ("gemini-3.5-flash", AgentModel::Gemini35FlashLite),
             (
                 "gemini-3.1-flash-lite-preview",
@@ -898,7 +900,7 @@ mod tests {
         let selectable_parses = retired_ids.map(|(retired_id, _)| retired_id.parse::<AgentModel>());
         let current_replacements = [
             "gemini-3.1-pro-preview",
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "gemini-3.5-flash-lite",
             "claude-opus-5",
         ]
@@ -928,6 +930,7 @@ mod tests {
         let parsed_sonnet_5 = AgentModel::parse_persisted("claude-sonnet-5");
         let parsed_gpt_54_mini = AgentModel::parse_persisted("gpt-5.4-mini");
         let parsed_gpt_54 = AgentModel::parse_persisted("gpt-5.4");
+        let parsed_gemini_37_flash = AgentModel::parse_persisted("gemini-3.7-flash");
         let parsed_gemini_36_flash = AgentModel::parse_persisted("gemini-3.6-flash");
         let parsed_gemini_35_flash = AgentModel::parse_persisted("gemini-3.5-flash");
         let parsed_gemini_3_flash_preview = AgentModel::parse_persisted("gemini-3-flash-preview");
@@ -944,9 +947,10 @@ mod tests {
         assert_eq!(parsed_sonnet_5, Ok(AgentModel::ClaudeSonnet5));
         assert_eq!(parsed_gpt_54_mini, Ok(AgentModel::Gpt56Luna));
         assert_eq!(parsed_gpt_54, Ok(AgentModel::Gpt56Sol));
-        assert_eq!(parsed_gemini_36_flash, Ok(AgentModel::Gemini36Flash));
+        assert_eq!(parsed_gemini_37_flash, Ok(AgentModel::Gemini37Flash));
+        assert_eq!(parsed_gemini_36_flash, Ok(AgentModel::Gemini37Flash));
         assert_eq!(parsed_gemini_35_flash, Ok(AgentModel::Gemini35FlashLite));
-        assert_eq!(parsed_gemini_3_flash_preview, Ok(AgentModel::Gemini36Flash));
+        assert_eq!(parsed_gemini_3_flash_preview, Ok(AgentModel::Gemini37Flash));
         assert_eq!(
             parsed_gemini_35_flash_lite,
             Ok(AgentModel::Gemini35FlashLite)
@@ -966,7 +970,7 @@ mod tests {
         // Arrange
 
         // Act
-        let selection = parse_persisted_session_agent_model(Some("codex"), "gemini-3.6-flash");
+        let selection = parse_persisted_session_agent_model(Some("codex"), "gemini-3.7-flash");
 
         // Assert
         assert_eq!(selection.kind(), AgentKind::Codex);
@@ -981,11 +985,11 @@ mod tests {
 
         // Act
         let selection =
-            parse_persisted_session_agent_model(Some("antigravity"), "gemini-3.6-flash");
+            parse_persisted_session_agent_model(Some("antigravity"), "gemini-3.7-flash");
 
         // Assert
         assert_eq!(selection.kind(), AgentKind::Antigravity);
-        assert_eq!(selection.model(), AgentModel::Gemini36Flash);
+        assert_eq!(selection.model(), AgentModel::Gemini37Flash);
     }
 
     #[test]
@@ -1038,11 +1042,11 @@ mod tests {
         // Arrange
 
         // Act
-        let selection = parse_persisted_session_agent_model(None, "gemini-3.6-flash");
+        let selection = parse_persisted_session_agent_model(None, "gemini-3.7-flash");
 
         // Assert
         assert_eq!(selection.kind(), AgentKind::Antigravity);
-        assert_eq!(selection.model(), AgentModel::Gemini36Flash);
+        assert_eq!(selection.model(), AgentModel::Gemini37Flash);
     }
 
     #[test]
@@ -1144,7 +1148,7 @@ mod tests {
         // Arrange
         let models = [
             AgentModel::Gemini31Pro,
-            AgentModel::Gemini36Flash,
+            AgentModel::Gemini37Flash,
             AgentModel::Gemini35FlashLite,
         ];
 
@@ -1259,7 +1263,7 @@ mod tests {
                 AgentModel::Gpt56Luna,
                 AgentModel::Gpt53CodexSpark,
                 AgentModel::Gemini31Pro,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
                 AgentModel::Gemini35FlashLite,
             ]
         );
@@ -1280,7 +1284,7 @@ mod tests {
             selectable_models,
             vec![
                 AgentModel::Gemini31Pro,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
                 AgentModel::Gemini35FlashLite,
             ]
         );
@@ -1331,7 +1335,7 @@ mod tests {
     /// run the selected model.
     fn test_resolve_agent_selection_for_model_preserves_preferred_shared_provider() {
         // Arrange
-        let model = AgentModel::Gemini36Flash;
+        let model = AgentModel::Gemini37Flash;
         let available_agent_kinds = [AgentKind::Gemini, AgentKind::Antigravity];
 
         // Act
@@ -1353,7 +1357,7 @@ mod tests {
     /// preferred provider cannot run the selected model.
     fn test_resolve_agent_selection_for_model_uses_available_provider_order() {
         // Arrange
-        let model = AgentModel::Gemini36Flash;
+        let model = AgentModel::Gemini37Flash;
         let available_agent_kinds = [AgentKind::Gemini, AgentKind::Antigravity];
 
         // Act

--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -661,7 +661,7 @@ mod tests {
             .sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 &Status::InProgress.to_string(),
                 project_id,

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -733,7 +733,7 @@ async fn test_new_prefers_active_session_for_initial_selection() {
         .sessions()
         .insert_session(
             active_session_id,
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "main",
             &Status::Review.to_string(),
             project_id,
@@ -744,7 +744,7 @@ async fn test_new_prefers_active_session_for_initial_selection() {
         .sessions()
         .insert_session(
             archive_session_id,
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "main",
             &Status::Done.to_string(),
             project_id,
@@ -879,7 +879,7 @@ async fn test_new_with_clients_falls_back_from_stale_active_project_and_loads_cu
         .sessions()
         .insert_session(
             current_session_id,
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "main",
             &Status::Review.to_string(),
             current_project_id,
@@ -890,7 +890,7 @@ async fn test_new_with_clients_falls_back_from_stale_active_project_and_loads_cu
         .sessions()
         .insert_session(
             missing_session_id,
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "main",
             &Status::Review.to_string(),
             missing_project_id,
@@ -2780,7 +2780,7 @@ fn app_event_batch_collect_event_keeps_latest_same_session_updates() {
     // Act
     event_batch.collect_event(AppEvent::SessionModelUpdated {
         session_id: "session-a".into(),
-        session_agent: AgentSelection::new(AgentKind::Gemini, AgentModel::Gemini36Flash),
+        session_agent: AgentSelection::new(AgentKind::Gemini, AgentModel::Gemini37Flash),
     });
     event_batch.collect_event(AppEvent::SessionModelUpdated {
         session_id: "session-a".into(),
@@ -3330,7 +3330,7 @@ async fn apply_app_events_review_request_status_transition_updates_session() {
         .sessions()
         .insert_session(
             session_id,
-            AgentModel::Gemini36Flash.as_str(),
+            AgentModel::Gemini37Flash.as_str(),
             "main",
             &Status::Review.to_string(),
             project_id,
@@ -3387,7 +3387,7 @@ async fn apply_app_events_review_request_status_survives_same_batch_sync_refresh
         .sessions()
         .insert_session(
             session_id,
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "main",
             &Status::Review.to_string(),
             project_id,
@@ -4454,7 +4454,7 @@ async fn apply_app_events_refresh_keeps_viewed_merging_session_without_worktree(
         .sessions()
         .insert_session(
             "session-1",
-            AgentModel::Gemini36Flash.as_str(),
+            AgentModel::Gemini37Flash.as_str(),
             "main",
             &Status::Merging.to_string(),
             project_id,
@@ -4714,7 +4714,7 @@ async fn apply_app_events_refresh_projects_reloads_project_active_session_count(
         .sessions()
         .insert_session(
             "session-active",
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "main",
             &Status::Review.to_string(),
             project_id,
@@ -5884,7 +5884,7 @@ async fn insert_review_session_with_data_dir(app: &App, session_id: &str) {
         .sessions()
         .insert_session(
             session_id,
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "main",
             &Status::Review.to_string(),
             app.active_project_id(),
@@ -6065,7 +6065,7 @@ async fn manual_sync_surfaces_restack_failure_and_keeps_parent_merged() {
         .sessions()
         .insert_stacked_draft_session(
             "child-session",
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "wt/parent",
             &Status::Draft.to_string(),
             session_id,
@@ -6173,7 +6173,7 @@ async fn test_apply_review_request_status_update_persists_summary() {
         .sessions()
         .insert_session(
             session_id,
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "main",
             &Status::Review.to_string(),
             project_id,
@@ -6231,7 +6231,7 @@ async fn test_apply_review_request_status_update_closed_cancels_session() {
         .sessions()
         .insert_session(
             session_id,
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "main",
             &Status::Review.to_string(),
             project_id,
@@ -6290,7 +6290,7 @@ async fn test_apply_review_request_status_update_closed_cancels_stacked_child() 
         .sessions()
         .insert_session(
             session_id,
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "main",
             &Status::Review.to_string(),
             project_id,
@@ -6302,7 +6302,7 @@ async fn test_apply_review_request_status_update_closed_cancels_stacked_child() 
         .sessions()
         .insert_stacked_draft_session(
             child_session_id,
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "wt/session",
             &Status::Draft.to_string(),
             session_id,
@@ -6488,7 +6488,7 @@ async fn test_apply_review_request_status_update_merged_restacks_stacked_child()
         .sessions()
         .insert_stacked_draft_session(
             child_session_id,
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "wt/session",
             &Status::Draft.to_string(),
             session_id,
@@ -6586,7 +6586,7 @@ async fn manual_sync_archives_merged_parent_and_merged_stacked_child() {
         .sessions()
         .insert_stacked_draft_session(
             child_session_id,
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "wt/session-id",
             &Status::Review.to_string(),
             parent_session_id,

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -719,7 +719,7 @@ fn add_manual_session_with_status(
         role: SessionRole::default(),
         agent: crate::domain::agent::AgentSelection::new(
             crate::domain::agent::AgentKind::Antigravity,
-            crate::domain::agent::AgentModel::Gemini36Flash,
+            crate::domain::agent::AgentModel::Gemini37Flash,
         ),
         parent_session_id: None,
         personality_id: None,
@@ -2611,7 +2611,7 @@ async fn test_reply_first_message_uses_full_prompt_text_as_title() {
             &session_id,
             prompt,
             Arc::new(backend),
-            AgentModel::Gemini36Flash,
+            AgentModel::Gemini37Flash,
         )
         .await;
 
@@ -3179,7 +3179,7 @@ async fn test_create_session_uses_default_smart_model_setting_and_most_recent_pe
         .await
         .expect("failed to upsert project");
     db.sessions()
-        .insert_session("alpha0001", "gemini-3.6-flash", "main", "Done", project_id)
+        .insert_session("alpha0001", "gemini-3.7-flash", "main", "Done", project_id)
         .await
         .expect("failed to insert alpha0001");
     db.sessions()
@@ -3249,7 +3249,7 @@ async fn test_load_existing_sessions_ordered_by_updated_at_desc() {
         .await
         .expect("failed to insert alpha000");
     db.sessions()
-        .insert_session("beta0000", "gemini-3.6-flash", "main", "Done", project_id)
+        .insert_session("beta0000", "gemini-3.7-flash", "main", "Done", project_id)
         .await
         .expect("failed to insert beta0000");
 
@@ -3448,7 +3448,7 @@ async fn test_refresh_sessions_if_needed_reloads_and_preserves_selection() {
     db.sessions()
         .insert_session(
             "alpha000",
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "main",
             "InProgress",
             project_id,
@@ -3518,7 +3518,7 @@ async fn test_periodic_session_refresh_preserves_focused_review_states() {
         db.sessions()
             .insert_session(
                 session_id,
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 &Status::Review.to_string(),
                 project_id,
@@ -3610,7 +3610,7 @@ async fn test_refresh_sessions_loads_question_detail_when_another_session_is_sel
     db.sessions()
         .insert_session(
             "alpha000",
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "main",
             "Question",
             project_id,
@@ -3708,7 +3708,7 @@ async fn test_refresh_sessions_loads_diff_help_detail_when_another_session_is_se
         .await
         .expect("failed to upsert project");
     db.sessions()
-        .insert_session("alpha000", "gemini-3.6-flash", "main", "Review", project_id)
+        .insert_session("alpha000", "gemini-3.7-flash", "main", "Review", project_id)
         .await
         .expect("failed to insert alpha000");
     db.sessions()
@@ -3817,7 +3817,7 @@ async fn test_load_done_session_without_folder_kept() {
         .await
         .expect("failed to upsert project");
     db.sessions()
-        .insert_session("missing01", "gemini-3.6-flash", "main", "Done", project_id)
+        .insert_session("missing01", "gemini-3.7-flash", "main", "Done", project_id)
         .await
         .expect("failed to insert");
 
@@ -3849,7 +3849,7 @@ async fn test_load_in_progress_session_without_folder_skipped() {
     db.sessions()
         .insert_session(
             "missing02",
-            "gemini-3.6-flash",
+            "gemini-3.7-flash",
             "main",
             "InProgress",
             project_id,
@@ -5638,7 +5638,7 @@ async fn test_sync_main_uses_active_project_branch_from_context() {
         app.projects.working_dir().to_path_buf(),
         None,
         Arc::new(mock_git_client),
-        AgentModel::Gemini36Flash,
+        AgentModel::Gemini37Flash,
     )
     .await;
 
@@ -5676,7 +5676,7 @@ async fn test_sync_main_requires_clean_selected_project_branch() {
         app.projects.working_dir().to_path_buf(),
         None,
         Arc::new(mock_git_client),
-        AgentModel::Gemini36Flash,
+        AgentModel::Gemini37Flash,
     )
     .await;
 
@@ -5701,7 +5701,7 @@ async fn test_sync_main_returns_error_without_upstream_remote() {
         app.projects.working_dir().to_path_buf(),
         None,
         app.services.git_client(),
-        AgentModel::Gemini36Flash,
+        AgentModel::Gemini37Flash,
     )
     .await;
 
@@ -5764,7 +5764,7 @@ async fn test_sync_main_pushes_local_commits_to_remote() {
         dir.path().to_path_buf(),
         None,
         Arc::new(mock_git_client),
-        AgentModel::Gemini36Flash,
+        AgentModel::Gemini37Flash,
     )
     .await;
 

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -868,7 +868,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 session_id,
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -953,7 +953,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 session_with_worktree_id,
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "Draft",
                 project_id,
@@ -963,7 +963,7 @@ mod tests {
         db.sessions()
             .insert_draft_session(
                 session_without_worktree_id,
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "Draft",
                 project_id,
@@ -1015,7 +1015,7 @@ mod tests {
 
         let session_id = "test-session";
         db.sessions()
-            .insert_session(session_id, "gemini-3.6-flash", "main", "Review", project_id)
+            .insert_session(session_id, "gemini-3.7-flash", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         db.sessions()
@@ -1103,7 +1103,7 @@ mod tests {
 
         let session_id = "inactive-session";
         db.sessions()
-            .insert_session(session_id, "gemini-3.6-flash", "main", "Review", project_id)
+            .insert_session(session_id, "gemini-3.7-flash", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         db.sessions()
@@ -1180,7 +1180,7 @@ mod tests {
 
         let session_id = "active-session";
         db.sessions()
-            .insert_session(session_id, "gemini-3.6-flash", "main", "Review", project_id)
+            .insert_session(session_id, "gemini-3.7-flash", "main", "Review", project_id)
             .await
             .expect("failed to insert session");
         db.sessions()
@@ -1272,7 +1272,7 @@ mod tests {
 
         let session_id = "test-session";
         db.sessions()
-            .insert_session(session_id, "gemini-3.6-flash", "main", "Done", project_id)
+            .insert_session(session_id, "gemini-3.7-flash", "main", "Done", project_id)
             .await
             .expect("failed to insert session");
 
@@ -1655,7 +1655,7 @@ WHERE id = ?
 
         let session_id = "test-session";
         db.sessions()
-            .insert_session(session_id, "gemini-3.6-flash", "main", "Done", project_id)
+            .insert_session(session_id, "gemini-3.7-flash", "main", "Done", project_id)
             .await
             .expect("failed to insert session");
         db.reviews()

--- a/crates/agentty/src/app/session/workflow/merge.rs
+++ b/crates/agentty/src/app/session/workflow/merge.rs
@@ -3127,7 +3127,7 @@ mod tests {
 
     /// Returns the agent selection used by rebase workflow tests.
     fn test_session_agent() -> AgentSelection {
-        AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash)
+        AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash)
     }
 
     /// Returns an empty forge boundary for tests that do not sync metadata.
@@ -3317,7 +3317,7 @@ mod tests {
                 rebase_plan: RebasePlan::target("main".to_string()),
                 session_agent: AgentSelection::new(
                     AgentKind::Antigravity,
-                    AgentModel::Gemini36Flash,
+                    AgentModel::Gemini37Flash,
                 ),
                 session_update_versions: Arc::default(),
             },
@@ -3354,7 +3354,7 @@ mod tests {
                 session_update_versions: Arc::default(),
                 session_agent: AgentSelection::new(
                     AgentKind::Antigravity,
-                    AgentModel::Gemini36Flash,
+                    AgentModel::Gemini37Flash,
                 ),
                 source_branch: "wt/session-123".to_string(),
                 status: Arc::new(Mutex::new(Status::Merging)),
@@ -3397,7 +3397,7 @@ mod tests {
             folder,
             fs_client: test_fs_client(),
             git_client,
-            session_agent: AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash),
+            session_agent: AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash),
             sync_assist_client,
         }
     }
@@ -3989,7 +3989,7 @@ mod tests {
             one_shot_client: test_one_shot_client(),
             transcript: empty_transcript(),
             rebase_plan: RebasePlan::target("origin/main".to_string()),
-            session_agent: AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash),
+            session_agent: AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash),
             session_update_versions: Arc::default(),
         };
 
@@ -4732,7 +4732,7 @@ mod tests {
             Some(app_event_tx),
             test_fs_client(),
             Arc::new(mock_git_client),
-            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash),
+            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash),
             Arc::new(mock_sync_assist_client),
         )
         .await;
@@ -4823,7 +4823,7 @@ mod tests {
             None,
             test_fs_client(),
             Arc::new(mock_git_client),
-            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash),
+            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash),
             Arc::new(mock_sync_assist_client),
         )
         .await;
@@ -5136,7 +5136,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess-rebase",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "Rebasing",
                 project_id,
@@ -5284,7 +5284,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess-rebase",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "Rebasing",
                 project_id,
@@ -5498,7 +5498,7 @@ mod tests {
             one_shot_client: &metadata_sync_one_shot_client(),
             rebase_result: Ok("Successfully synced wt/sess-rebase onto main".to_string()),
             review_request_client: &review_request_client,
-            session_agent: AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash),
+            session_agent: AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash),
             session_update_versions: &session_update_versions,
             status_transition: &status_transition,
             transcript: &transcript,
@@ -5637,7 +5637,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess-no-push",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "Rebasing",
                 project_id,

--- a/crates/agentty/src/app/session/workflow/post_turn.rs
+++ b/crates/agentty/src/app/session/workflow/post_turn.rs
@@ -1117,7 +1117,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "session-id",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -1157,7 +1157,7 @@ mod tests {
                         review_comment_thread_ids: Vec::new(),
                         session_agent: AgentSelection::new(
                             AgentKind::Antigravity,
-                            AgentModel::Gemini36Flash,
+                            AgentModel::Gemini37Flash,
                         ),
                     },
                     None,

--- a/crates/agentty/src/app/session/workflow/published_branch.rs
+++ b/crates/agentty/src/app/session/workflow/published_branch.rs
@@ -1063,7 +1063,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "session-id",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "Review",
                 project_id,

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -1631,7 +1631,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -1655,7 +1655,7 @@ mod tests {
                 base_branch: "main",
                 id: "sess1",
                 is_draft: false,
-                model: "gemini-3.6-flash",
+                model: "gemini-3.7-flash",
                 orchestration_task_id: None,
                 parent_session_id: None,
                 personality_id: None,
@@ -1684,7 +1684,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 &status.to_string(),
                 project_id,
@@ -2401,7 +2401,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -2469,7 +2469,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -2514,7 +2514,7 @@ mod tests {
         // Pre-cancel the token to simulate a previous turn's cancellation.
         let stale_token = CancellationToken::new();
         stale_token.cancel();
-        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash);
+        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash);
 
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
@@ -2636,7 +2636,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -2740,7 +2740,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -2831,7 +2831,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -2928,7 +2928,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -2997,14 +2997,14 @@ mod tests {
     }
 
     /// Builds the default turn metadata used by session worker tests that
-    /// exercise the `Gemini36Flash` path without branch publication.
+    /// exercise the `Gemini37Flash` path without branch publication.
     fn default_turn_metadata() -> TurnMetadata {
         TurnMetadata {
             published_upstream_ref: None,
             review_comment_thread_ids: Vec::new(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
         }
     }
@@ -3181,7 +3181,7 @@ mod tests {
                     applied_personality_id: personality.applied_personality_id,
                     applied_personality_prompt_hash: personality.applied_personality_prompt_hash,
                     instruction_conversation_id: None,
-                    model: AgentModel::Gemini36Flash.as_str().to_string(),
+                    model: AgentModel::Gemini37Flash.as_str().to_string(),
                     provider_conversation_id: None,
                     questions_json: "[]".to_string(),
                     summary: String::new(),
@@ -3233,7 +3233,7 @@ mod tests {
             session_id: "sess-preturn".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -3242,7 +3242,7 @@ mod tests {
             continuation: TurnContinuation::fresh(),
             folder: context.folder.clone(),
             main_checkout_root: None,
-            model: "gemini-3.6-flash".to_string(),
+            model: "gemini-3.7-flash".to_string(),
             permission_mode: ag_agent::PermissionMode::AutoEdit,
             personality: ag_agent::PersonalityPrompt::default(),
             prompt: "test".into(),
@@ -3309,7 +3309,7 @@ mod tests {
             session_id: "sess-timeout".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -3318,7 +3318,7 @@ mod tests {
             continuation: TurnContinuation::fresh(),
             folder: context.folder.clone(),
             main_checkout_root: None,
-            model: "gemini-3.6-flash".to_string(),
+            model: "gemini-3.7-flash".to_string(),
             permission_mode: ag_agent::PermissionMode::AutoEdit,
             personality: ag_agent::PersonalityPrompt::default(),
             prompt: "test".into(),
@@ -3382,7 +3382,7 @@ mod tests {
             session_id: "sess-term".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -3428,7 +3428,7 @@ mod tests {
             session_id: "sess-nopid".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -3533,7 +3533,7 @@ mod tests {
                 base_branch: "main",
                 id: "sess1",
                 is_draft: false,
-                model: "gemini-3.6-flash",
+                model: "gemini-3.7-flash",
                 orchestration_task_id: None,
                 parent_session_id: None,
                 personality_id: None,
@@ -3548,7 +3548,7 @@ mod tests {
 
         let mut mock_git_client = MockGitClient::new();
         mock_git_client.expect_is_worktree_clean().never();
-        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash);
+        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash);
         let context = SessionWorkerContext {
             app_event_tx: mpsc::unbounded_channel().0,
             branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -3594,7 +3594,7 @@ mod tests {
             review_comment_thread_ids: Vec::new(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
         };
         let status = apply_worker_turn_result(&context, turn_metadata, turn_result)
@@ -3661,7 +3661,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -3679,7 +3679,7 @@ mod tests {
                 review_comment_thread_ids: Vec::new(),
                 session_agent: AgentSelection::new(
                     crate::domain::agent::AgentKind::Antigravity,
-                    crate::domain::agent::AgentModel::Gemini36Flash,
+                    crate::domain::agent::AgentModel::Gemini37Flash,
                 ),
             },
             Ok(turn_result),
@@ -3747,7 +3747,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -3760,7 +3760,7 @@ mod tests {
                 review_comment_thread_ids: Vec::new(),
                 session_agent: AgentSelection::new(
                     crate::domain::agent::AgentKind::Antigravity,
-                    crate::domain::agent::AgentModel::Gemini36Flash,
+                    crate::domain::agent::AgentModel::Gemini37Flash,
                 ),
             },
             Ok(successful_turn_result("Implemented the change.")),
@@ -3809,7 +3809,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -4137,7 +4137,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -4145,7 +4145,7 @@ mod tests {
             .await
             .expect("failed to insert session");
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
-        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash);
+        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash);
         let mut mock_git_client = MockGitClient::new();
         mock_git_client
             .expect_is_worktree_clean()
@@ -4179,7 +4179,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -4233,7 +4233,7 @@ mod tests {
         insert_in_progress_session_with_review_request(&db).await;
         let folder = base_dir.path().join("sess1");
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
-        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash);
+        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash);
         let mut sequence = Sequence::new();
         let mock_git_client = review_resolution_git_client(&mut sequence);
         let review_request_client = review_resolution_client(folder.clone(), &mut sequence);
@@ -4336,7 +4336,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -4344,7 +4344,7 @@ mod tests {
             .await
             .expect("failed to insert session");
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
-        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash);
+        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash);
         let mut mock_git_client = MockGitClient::new();
         mock_git_client
             .expect_is_worktree_clean()
@@ -4376,7 +4376,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -4434,7 +4434,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -4446,7 +4446,7 @@ mod tests {
             .await
             .expect("failed to insert queued sync operation");
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
-        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash);
+        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash);
         let mut mock_git_client = MockGitClient::new();
         mock_git_client
             .expect_is_worktree_clean()
@@ -4474,7 +4474,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -4532,7 +4532,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -4540,7 +4540,7 @@ mod tests {
             .await
             .expect("failed to insert session");
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
-        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash);
+        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash);
         let mut mock_git_client = MockGitClient::new();
         mock_git_client
             .expect_is_worktree_clean()
@@ -4643,7 +4643,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -4675,7 +4675,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -4703,7 +4703,7 @@ mod tests {
             review_comment_thread_ids: Vec::new(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
         };
         let error = apply_worker_turn_result(&context, turn_metadata, turn_result)
@@ -4749,7 +4749,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -4784,7 +4784,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -4812,7 +4812,7 @@ mod tests {
             review_comment_thread_ids: Vec::new(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
         };
         let status = apply_worker_turn_result(&context, turn_metadata, turn_result)
@@ -4873,7 +4873,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -5466,7 +5466,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -5526,7 +5526,7 @@ mod tests {
             .await
             .expect("failed to upsert project");
         db.sessions()
-            .insert_session("sess1", "gemini-3.6-flash", "main", "Rebasing", project_id)
+            .insert_session("sess1", "gemini-3.7-flash", "main", "Rebasing", project_id)
             .await
             .expect("failed to insert session");
         db.operations()
@@ -5579,7 +5579,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -5616,7 +5616,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -5649,7 +5649,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -5690,7 +5690,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -5724,7 +5724,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -5778,7 +5778,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
@@ -5824,7 +5824,7 @@ mod tests {
         db.sessions()
             .insert_session(
                 "sess1",
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -5887,7 +5887,7 @@ mod tests {
             session_id: "sess1".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(status)),
         };
@@ -5920,7 +5920,7 @@ mod tests {
             session_id: "sess".into(),
             session_agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             status: Arc::new(Mutex::new(Status::InProgress)),
         }

--- a/crates/agentty/src/app/setting.rs
+++ b/crates/agentty/src/app/setting.rs
@@ -1237,7 +1237,7 @@ mod tests {
         let loaded_selection = load_default_smart_agent_setting(
             &services,
             Some(project_id),
-            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash),
+            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash),
         )
         .await;
 
@@ -1460,7 +1460,7 @@ mod tests {
         );
         assert_eq!(
             settings.default_fast_selection,
-            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash)
+            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash)
         );
         assert_eq!(
             settings.default_review_selection,
@@ -1478,7 +1478,7 @@ mod tests {
             ),
             (
                 SettingName::DefaultFastModel,
-                AgentModel::Gemini36Flash.as_str(),
+                AgentModel::Gemini37Flash.as_str(),
             ),
             (SettingName::DefaultFastAgent, AgentKind::Antigravity.name()),
             (

--- a/crates/agentty/src/app/task.rs
+++ b/crates/agentty/src/app/task.rs
@@ -886,12 +886,12 @@ mod tests {
         // Arrange
         let session_folder = Path::new("/tmp/review-assist-provider");
         let review_selection =
-            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash);
+            AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash);
         let review_diff = "diff --git a/src/lib.rs b/src/lib.rs";
         let mut one_shot_client = agent::MockOneShotClient::new();
         one_shot_client.expect_submit().returning(|request| {
             assert_eq!(request.agent_kind, AgentKind::Antigravity);
-            assert_eq!(request.model, AgentModel::Gemini36Flash);
+            assert_eq!(request.model, AgentModel::Gemini37Flash);
             assert_eq!(request.reasoning_level, ReasoningLevel::Low);
 
             Ok(agent::OneShotSubmission {

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -2129,7 +2129,7 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             role: SessionRole::default(),
             agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             parent_session_id: None,
             personality_id: None,
@@ -2203,7 +2203,7 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             role: SessionRole::default(),
             agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             parent_session_id: None,
             personality_id: None,
@@ -2250,7 +2250,7 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             role: SessionRole::default(),
             agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             parent_session_id: None,
             personality_id: None,
@@ -2297,7 +2297,7 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             role: SessionRole::default(),
             agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             parent_session_id: None,
             personality_id: None,
@@ -2344,7 +2344,7 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
             role: SessionRole::default(),
             agent: AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini36Flash,
+                AgentModel::Gemini37Flash,
             ),
             parent_session_id: None,
             personality_id: None,

--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -1361,7 +1361,7 @@ mod tests {
             role: SessionRole::default(),
             agent: crate::domain::agent::AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                crate::domain::agent::AgentModel::Gemini36Flash,
+                crate::domain::agent::AgentModel::Gemini37Flash,
             ),
             parent_session_id: None,
             personality_id: None,
@@ -1441,7 +1441,7 @@ mod tests {
             role: SessionRole::default(),
             agent: crate::domain::agent::AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                crate::domain::agent::AgentModel::Gemini36Flash,
+                crate::domain::agent::AgentModel::Gemini37Flash,
             ),
             parent_session_id: None,
             personality_id: None,
@@ -1517,7 +1517,7 @@ mod tests {
             .sessions()
             .insert_session(
                 session_id,
-                "gemini-3.6-flash",
+                "gemini-3.7-flash",
                 "main",
                 "InProgress",
                 project_id,
@@ -3181,7 +3181,7 @@ mod tests {
             role: SessionRole::default(),
             agent: crate::domain::agent::AgentSelection::new(
                 crate::domain::agent::AgentKind::Antigravity,
-                crate::domain::agent::AgentModel::Gemini36Flash,
+                crate::domain::agent::AgentModel::Gemini37Flash,
             ),
             parent_session_id: None,
             personality_id: None,

--- a/crates/agentty/src/test_support.rs
+++ b/crates/agentty/src/test_support.rs
@@ -237,7 +237,7 @@ impl SessionFixtureBuilder {
     pub(crate) fn new() -> Self {
         Self {
             session: Session {
-                agent: AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini36Flash),
+                agent: AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash),
                 base_branch: "main".to_string(),
                 created_at: 0,
                 draft_attachments: Vec::new(),

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -5394,7 +5394,7 @@ fn gemini_model_picker_lists_current_models() -> E2eResult {
                     .press_key("Enter")
                     .wait_for_text("/model Agent", 3000)
                     .press_key("Enter")
-                    .wait_for_text("gemini-3.6-flash", 3000)
+                    .wait_for_text("gemini-3.7-flash", 3000)
                     .capture_labeled(
                         "gemini_model_picker",
                         "Gemini model picker lists current models",
@@ -5402,7 +5402,7 @@ fn gemini_model_picker_lists_current_models() -> E2eResult {
             },
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(frame, "gemini-3.6-flash", &full);
+                assertion::assert_text_in_region(frame, "gemini-3.7-flash", &full);
                 assertion::assert_text_in_region(frame, "gemini-3.5-flash-lite", &full);
             },
         )?;
@@ -5565,7 +5565,7 @@ fn antigravity_model_picker_includes_gemini_models() -> E2eResult {
                     .press_key("Enter")
                     .wait_for_text("/model Agent", 3000)
                     .press_key("Enter")
-                    .wait_for_text("gemini-3.6-flash", 3000)
+                    .wait_for_text("gemini-3.7-flash", 3000)
                     .capture_labeled(
                         "antigravity_model_picker",
                         "Antigravity model picker includes Gemini models",
@@ -5574,7 +5574,7 @@ fn antigravity_model_picker_includes_gemini_models() -> E2eResult {
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "gemini-3.1-pro-preview", &full);
-                assertion::assert_text_in_region(frame, "gemini-3.6-flash", &full);
+                assertion::assert_text_in_region(frame, "gemini-3.7-flash", &full);
                 assertion::assert_text_in_region(frame, "gemini-3.5-flash-lite", &full);
             },
         )?;

--- a/crates/agentty/tests/protocol_compliance_e2e.rs
+++ b/crates/agentty/tests/protocol_compliance_e2e.rs
@@ -54,13 +54,13 @@ async fn codex_protocol_compliance_e2e() {
     }
 }
 
-/// Verifies real Gemini Flash (`gemini-3.6-flash`) turn execution
+/// Verifies real Gemini Flash (`gemini-3.7-flash`) turn execution
 /// through `create_agent_channel()` yields a non-empty protocol `answer`.
 #[tokio::test]
 #[ignore = "requires real Gemini CLI credentials and network"]
 async fn gemini_flash_protocol_compliance_e2e() {
     // Arrange
-    let model = AgentModel::Gemini36Flash;
+    let model = AgentModel::Gemini37Flash;
     if provider_preflight_skip_reason(AgentKind::Gemini)
         .await
         .is_some()

--- a/docs/site/content/docs/agents/backends.md
+++ b/docs/site/content/docs/agents/backends.md
@@ -174,7 +174,7 @@ entries with different trade-offs between speed, quality, and cost.
 Both providers share the same Gemini model ids:
 
 - `gemini-3.1-pro-preview` (default): Higher-quality Gemini model for deeper reasoning.
-- `gemini-3.6-flash`: Fast Gemini model for agentic and multimodal tasks.
+- `gemini-3.7-flash`: Fast Gemini model for agentic and multimodal tasks.
 - `gemini-3.5-flash-lite`: Lightweight Gemini model for fast, cost-conscious workloads.
 
 ### Claude Models


### PR DESCRIPTION
- Migrates persisted Gemini 3.6 Flash selections and updates Gemini and Antigravity provider models, tests, and documentation.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)