### PR TITLE
Bump to v0.14.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,23 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.14.7] - 2026-08-13
+
+### Added
+
+- agentty: unify review comments with Diff mode through Files and Comments sidebar
+  focus, shared navigation, Markdown previews, comment actions, and context-sensitive
+  help.
+
 ### Changed
 
 - agentty: replace Gemini 3.6 Flash with Gemini 3.7 Flash for the Gemini and Antigravity
   providers, migrating persisted selections to the replacement.
+- release: bump workspace crate metadata and lockfile package versions to `0.14.7`.
+
+### Contributors
+
+- @minev-dev
 
 ## [v0.14.6] - 2026-08-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "image",
  "mockall",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "mockall",
  "serde",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "mockall",
  "rustix",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "ag-harness"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "async-trait",
  "jsonschema",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "askama",
  "schemars 1.2.2",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "ag-session"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "ag-agent",
  "ag-forge",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "ag-store"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "ag-agent",
  "ag-session",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "clap",
  "tempfile",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "base64 0.23.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.14.6"
+version = "0.14.7"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -16,15 +16,15 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.14.6" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.14.6" }
-ag-forge = { path = "crates/ag-forge", version = "0.14.6" }
-ag-git = { path = "crates/ag-git", version = "0.14.6" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.14.6" }
-ag-session = { path = "crates/ag-session", version = "0.14.6" }
-ag-store = { path = "crates/ag-store", version = "0.14.6" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.14.6" }
-testty = { path = "crates/testty", version = "0.14.6" }
+ag-agent = { path = "crates/ag-agent", version = "0.14.7" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.14.7" }
+ag-forge = { path = "crates/ag-forge", version = "0.14.7" }
+ag-git = { path = "crates/ag-git", version = "0.14.7" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.14.7" }
+ag-session = { path = "crates/ag-session", version = "0.14.7" }
+ag-store = { path = "crates/ag-store", version = "0.14.7" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.14.7" }
+testty = { path = "crates/testty", version = "0.14.7" }
 async-trait = "0.1"
 agent-client-protocol = "2.0.0"
 assert_cmd = "2"


### PR DESCRIPTION
- agentty: unify review comments with Diff mode through Files and Comments sidebar focus, shared navigation, Markdown previews, comment actions, and context-sensitive help.
- release: bump workspace crate metadata and lockfile package versions to `0.14.7`.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)