### PR TITLE
Runs bounded repository reads and stale-safe unified-diff writes through the model harness

### DIFF
--- a/crates/ag-harness/Cargo.toml
+++ b/crates/ag-harness/Cargo.toml
@@ -17,6 +17,7 @@ reqwest.workspace = true
 rustix.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
+tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 
@@ -24,7 +25,6 @@ tokio.workspace = true
 mockall.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
-tempfile.workspace = true
 wiremock.workspace = true
 
 [lints]

--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -1,19 +1,25 @@
 # `ag-harness`
 
-Run a model with repository-scoped tools and validated structured output.
+Run a model with bounded repository tools and validated structured output.
 
 ```rust
 use ag_harness::{Harness, MUSE_SPARK_1_2, Muse, Tool};
 
 let harness = Harness::new(Muse::from_env(MUSE_SPARK_1_2)?)
     .repository(repository_root)
-    .allow(Tool::Read);
+    .allow(Tool::Read)
+    .allow(Tool::Write);
 
 let output = harness.run(prompt, output_schema).await?;
 ```
 
 Provide `MODEL_API_KEY`, a repository root, explicitly allowed tools, a prompt, and an
 `OutputSchema`. Expect schema-validated JSON or a typed error.
+
+Tools are denied by default and repository tools require an explicit root. `read`
+returns bounded file content; `write` applies one bounded unified diff to one text file.
+Both use the injected `FileSystem` boundary without shell commands, and the model may
+continue calling allowed tools until it returns schema-valid JSON.
 
 Use `ModelWithMetadata::complete_with_metadata()` for normalized completion metadata.
 

--- a/crates/ag-harness/src/chat_completion.rs
+++ b/crates/ag-harness/src/chat_completion.rs
@@ -307,11 +307,8 @@ impl ChatCompletionBackend {
         calls: Vec<ChatCompletionToolCall>,
         metadata: model::CompletionMetadata,
     ) -> GeneratedResponse {
-        match Self::decode_tool_call_parts(request, content, reasoning_content.as_deref(), calls) {
-            Ok((id, arguments)) => GeneratedResponse::ToolCall {
-                call: tool::ToolCall::read(id, arguments, reasoning_content),
-                metadata,
-            },
+        match Self::decode_tool_call_parts(request, content, reasoning_content, calls) {
+            Ok(call) => GeneratedResponse::ToolCall { call, metadata },
             Err(error) => GeneratedResponse::failed(error, metadata),
         }
     }
@@ -319,9 +316,9 @@ impl ChatCompletionBackend {
     fn decode_tool_call_parts(
         request: &model::ModelRequest,
         content: Option<&str>,
-        reasoning_content: Option<&str>,
+        reasoning_content: Option<String>,
         mut calls: Vec<ChatCompletionToolCall>,
-    ) -> Result<(String, tool::ReadArguments), model::ModelError> {
+    ) -> Result<tool::ToolCall, model::ModelError> {
         if content.is_some_and(|content| !content.is_empty()) {
             return Err(model::ModelError::ToolCallWithContent);
         }
@@ -346,18 +343,27 @@ impl ChatCompletionBackend {
         }
         schema_contract::ensure_content_size(&function.arguments)
             .map_err(model::ModelError::from)?;
-        if let Some(reasoning_content) = reasoning_content {
+        if let Some(reasoning_content) = reasoning_content.as_deref() {
             schema_contract::ensure_content_size(reasoning_content)
                 .map_err(model::ModelError::from)?;
         }
-        let arguments =
-            serde_json::from_str::<tool::ReadArguments>(&function.arguments).map_err(|error| {
-                model::ModelError::InvalidToolArguments {
+        let call = if function.name == "write" {
+            let arguments = serde_json::from_str::<tool::WriteArguments>(&function.arguments)
+                .map_err(|error| model::ModelError::InvalidToolArguments {
                     reason: schema_contract::bounded_diagnostic(error),
-                }
-            })?;
+                })?;
 
-        Ok((call.id, arguments))
+            tool::ToolCall::write(call.id, arguments, reasoning_content)
+        } else {
+            let arguments = serde_json::from_str::<tool::ReadArguments>(&function.arguments)
+                .map_err(|error| model::ModelError::InvalidToolArguments {
+                    reason: schema_contract::bounded_diagnostic(error),
+                })?;
+
+            tool::ToolCall::read(call.id, arguments, reasoning_content)
+        };
+
+        Ok(call)
     }
 }
 
@@ -992,6 +998,85 @@ mod tests {
         assert_eq!(metadata.system_fingerprint(), None);
         assert_eq!(metadata.usage(), None);
         assert!(empty_response.into_completion().is_none());
+    }
+
+    #[test]
+    fn decodes_advertised_write_tool_call() {
+        // Arrange
+        let schema = schema_contract::OutputSchema::new(serde_json::json!({
+            "type": "object"
+        }))
+        .expect("schema should be valid");
+        let request =
+            model::ModelRequest::new("update", schema).with_tool(tool::ToolDefinition::write());
+        let calls = vec![ChatCompletionToolCall {
+            function: serde_json::json!({
+                "name": "write",
+                "arguments": r#"{"path":"src/lib.rs","patch":"--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n"}"#
+            }),
+            id: "call_write".to_string(),
+            kind: "function".to_string(),
+        }];
+
+        // Act
+        let response = ChatCompletionBackend::decode_tool_call(
+            &request,
+            None,
+            None,
+            calls,
+            model::CompletionMetadata::new("tool_calls".to_string(), None, None, None, None),
+        );
+
+        // Assert
+        assert!(matches!(
+            response,
+            GeneratedResponse::ToolCall {
+                ref call,
+                ref metadata,
+            } if metadata.finish_reason() == "tool_calls"
+                && call.name() == "write"
+                    && call.write_arguments().is_some_and(|arguments| {
+                        arguments.path() == "src/lib.rs"
+                            && arguments.patch().starts_with("--- a/src/lib.rs")
+                    })
+        ));
+    }
+
+    #[test]
+    fn retains_metadata_for_invalid_advertised_write_arguments() {
+        // Arrange
+        let schema = schema_contract::OutputSchema::new(serde_json::json!({
+            "type": "object"
+        }))
+        .expect("schema should be valid");
+        let request =
+            model::ModelRequest::new("update", schema).with_tool(tool::ToolDefinition::write());
+        let calls = vec![ChatCompletionToolCall {
+            function: serde_json::json!({
+                "name": "write",
+                "arguments": r#"{"path":"src/lib.rs","patch":""}"#
+            }),
+            id: "call_write".to_string(),
+            kind: "function".to_string(),
+        }];
+
+        // Act
+        let response = ChatCompletionBackend::decode_tool_call(
+            &request,
+            None,
+            None,
+            calls,
+            model::CompletionMetadata::new("tool_calls".to_string(), None, None, None, None),
+        );
+
+        // Assert
+        assert!(matches!(
+            response,
+            GeneratedResponse::Failed {
+                error: model::ModelError::InvalidToolArguments { .. },
+                metadata,
+            } if metadata.finish_reason() == "tool_calls"
+        ));
     }
 
     #[test]

--- a/crates/ag-harness/src/file_system.rs
+++ b/crates/ag-harness/src/file_system.rs
@@ -1,9 +1,19 @@
-use std::ffi::OsStr;
-use std::io;
+use std::ffi::{OsStr, OsString};
+use std::io::{self, Write as _};
+#[cfg(target_vendor = "apple")]
+use std::io::{Read as _, Seek as _, SeekFrom};
+use std::os::fd::OwnedFd;
+#[cfg(any(target_os = "android", target_os = "linux"))]
+use std::os::unix::ffi::OsStringExt as _;
 use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use rustix::fs::{FileType, Mode, OFlags};
+#[cfg(target_vendor = "apple")]
+use rustix::fs::CopyfileFlags;
+use rustix::fs::{AtFlags, FileType, FlockOperation, Mode, OFlags, RenameFlags};
 use tokio::io::AsyncRead;
 
 const DIRECTORY_OPEN_FLAGS: OFlags = OFlags::RDONLY
@@ -14,12 +24,30 @@ const FILE_OPEN_FLAGS: OFlags = OFlags::RDONLY
     .union(OFlags::CLOEXEC)
     .union(OFlags::NOFOLLOW)
     .union(OFlags::NONBLOCK);
+const TEMPORARY_OPEN_FLAGS: OFlags = OFlags::WRONLY
+    .union(OFlags::CLOEXEC)
+    .union(OFlags::CREATE)
+    .union(OFlags::EXCL)
+    .union(OFlags::NOFOLLOW);
+const DIRECTORY_MODE: Mode = Mode::RWXU
+    .union(Mode::RGRP)
+    .union(Mode::XGRP)
+    .union(Mode::ROTH)
+    .union(Mode::XOTH);
+const TEMPORARY_MODE: Mode = Mode::RUSR.union(Mode::WUSR);
+const UPDATE_LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(10);
+const UPDATE_LOCK_TIMEOUT: Duration = Duration::from_secs(1);
+#[cfg(target_vendor = "apple")]
+const COPYFILE_PACK: CopyfileFlags = CopyfileFlags::from_bits_retain(1 << 22);
+#[cfg(any(target_os = "android", target_os = "linux"))]
+const XATTR_BUFFER_SIZE: usize = 64 * 1024;
+static TEMPORARY_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 /// Asynchronous filesystem boundary used by harness tools.
 ///
-/// The harness uses this boundary for diagnostic path resolution and
-/// descriptor-relative opening, keeping repository containment inside the
-/// filesystem operation.
+/// The harness uses this boundary for diagnostic path resolution,
+/// descriptor-relative opening, and stale-safe replacement, keeping repository
+/// containment inside the filesystem operation.
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait FileSystem: Send + Sync {
@@ -42,6 +70,49 @@ pub trait FileSystem: Send + Sync {
         root: &Path,
         path: &Path,
     ) -> io::Result<Box<dyn AsyncRead + Send + Unpin>>;
+
+    /// Safely creates or replaces one repository-relative regular file.
+    ///
+    /// `expected` is `None` for a create-only operation. For replacement it
+    /// contains the exact bytes that must still be present when the prepared
+    /// file is atomically exchanged with the target, preventing stale model
+    /// context from overwriting newer content.
+    /// Replacements preserve the target's ownership and access-control
+    /// metadata or fail and restore the original file.
+    /// Missing parent directories are created without following symlinks.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error when containment cannot be enforced, the target
+    /// changed, a create target already exists, or the replacement
+    /// cannot be completed.
+    async fn replace_beneath(
+        &self,
+        root: &Path,
+        path: &Path,
+        expected: Option<Vec<u8>>,
+        content: Vec<u8>,
+    ) -> io::Result<()>;
+}
+
+struct ParentDirectory {
+    descriptor: OwnedFd,
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct AccessMetadata {
+    attributes: Vec<ExtendedAttribute>,
+    group: rustix::fs::Gid,
+    mode: Mode,
+    owner: rustix::fs::Uid,
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ExtendedAttribute {
+    name: OsString,
+    value: Vec<u8>,
 }
 
 /// Tokio-backed filesystem implementation for local repositories.
@@ -82,6 +153,551 @@ impl LocalFileSystem {
 
         Ok(std::fs::File::from(descriptor))
     }
+
+    fn replace_beneath(
+        root: &Path,
+        relative_path: &Path,
+        expected: Option<&[u8]>,
+        content: &[u8],
+    ) -> io::Result<()> {
+        let (parent, file_name) = Self::open_parent_beneath(root, relative_path)?;
+        let temporary_name = Self::temporary_name();
+        let descriptor = rustix::fs::openat(
+            &parent.descriptor,
+            &temporary_name,
+            TEMPORARY_OPEN_FLAGS,
+            TEMPORARY_MODE,
+        )
+        .map_err(io::Error::from)?;
+        let mut temporary_file = std::fs::File::from(descriptor);
+        let mut remove_temporary = true;
+        let operation = (|| {
+            temporary_file.write_all(content)?;
+            temporary_file.sync_all()?;
+            if let Some(expected) = expected {
+                let update = Self::install_update(
+                    &parent.descriptor,
+                    &temporary_file,
+                    &file_name,
+                    &temporary_name,
+                    expected,
+                    &mut remove_temporary,
+                );
+                update?;
+            } else {
+                rustix::fs::renameat_with(
+                    &parent.descriptor,
+                    &temporary_name,
+                    &parent.descriptor,
+                    &file_name,
+                    RenameFlags::NOREPLACE,
+                )
+                .map_err(io::Error::from)?;
+                remove_temporary = false;
+                let _ = rustix::fs::fsync(&parent.descriptor);
+            }
+
+            Ok(())
+        })();
+        if remove_temporary {
+            let _ = rustix::fs::unlinkat(&parent.descriptor, &temporary_name, AtFlags::empty());
+        }
+
+        operation
+    }
+
+    fn install_update(
+        parent: &OwnedFd,
+        temporary_file: &std::fs::File,
+        file_name: &OsStr,
+        temporary_name: &OsStr,
+        expected: &[u8],
+        remove_temporary: &mut bool,
+    ) -> io::Result<()> {
+        Self::install_update_with_metadata(
+            parent,
+            temporary_file,
+            file_name,
+            temporary_name,
+            expected,
+            remove_temporary,
+            Self::copy_metadata,
+        )
+    }
+
+    fn install_update_with_metadata(
+        parent: &OwnedFd,
+        temporary_file: &std::fs::File,
+        file_name: &OsStr,
+        temporary_name: &OsStr,
+        expected: &[u8],
+        remove_temporary: &mut bool,
+        copy_metadata: impl FnOnce(&std::fs::File, &std::fs::File) -> io::Result<()>,
+    ) -> io::Result<()> {
+        Self::acquire_update_lock(parent, UPDATE_LOCK_TIMEOUT)?;
+        let original_file = match Self::verify_target(parent, file_name, expected) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "write target changed since it was read",
+                ));
+            }
+            Err(error) => return Err(error),
+        };
+        rustix::fs::renameat_with(
+            parent,
+            temporary_name,
+            parent,
+            file_name,
+            RenameFlags::EXCHANGE,
+        )
+        .map_err(io::Error::from)?;
+        *remove_temporary = false;
+        let metadata_result =
+            copy_metadata(&original_file, temporary_file).and_then(|()| temporary_file.sync_all());
+        if let Err(error) = metadata_result {
+            Self::roll_back_exchange(
+                parent,
+                temporary_file,
+                file_name,
+                temporary_name,
+                remove_temporary,
+            )?;
+
+            return Err(error);
+        }
+        Self::validate_exchange(
+            parent,
+            temporary_file,
+            file_name,
+            temporary_name,
+            expected,
+            remove_temporary,
+        )
+    }
+
+    fn acquire_update_lock(parent: &OwnedFd, timeout: Duration) -> io::Result<()> {
+        Self::acquire_update_lock_with(timeout, || {
+            rustix::fs::flock(parent, FlockOperation::NonBlockingLockExclusive)
+                .map_err(io::Error::from)
+        })
+    }
+
+    fn acquire_update_lock_with(
+        timeout: Duration,
+        mut try_lock: impl FnMut() -> io::Result<()>,
+    ) -> io::Result<()> {
+        let started_at = Instant::now();
+        loop {
+            match try_lock() {
+                Ok(()) => return Ok(()),
+                Err(error) => {
+                    if error.kind() != io::ErrorKind::WouldBlock {
+                        return Err(error);
+                    }
+                }
+            }
+
+            let remaining = timeout.saturating_sub(started_at.elapsed());
+            if remaining.is_zero() {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "timed out waiting for the write coordination lock",
+                ));
+            }
+            thread::sleep(UPDATE_LOCK_RETRY_INTERVAL.min(remaining));
+        }
+    }
+
+    #[cfg(target_vendor = "apple")]
+    fn copy_metadata(source: &std::fs::File, destination: &std::fs::File) -> io::Result<()> {
+        let mut expected = Self::apple_metadata_snapshot(source)?;
+        Self::apple_copyfile(source, destination, CopyfileFlags::METADATA)?;
+
+        Self::verify_apple_metadata(&mut expected, source, destination)
+    }
+
+    #[cfg(target_vendor = "apple")]
+    fn verify_apple_metadata(
+        expected: &mut std::fs::File,
+        source: &std::fs::File,
+        destination: &std::fs::File,
+    ) -> io::Result<()> {
+        let mut current_source = Self::apple_metadata_snapshot(source)?;
+        let mut current_destination = Self::apple_metadata_snapshot(destination)?;
+        if !Self::files_match(expected, &mut current_source)?
+            || !Self::files_match(expected, &mut current_destination)?
+        {
+            return Err(Self::metadata_changed_error());
+        }
+
+        Ok(())
+    }
+
+    #[cfg(target_vendor = "apple")]
+    fn apple_metadata_snapshot(source: &std::fs::File) -> io::Result<std::fs::File> {
+        let snapshot = tempfile::tempfile()?;
+        let flags = CopyfileFlags::METADATA.union(COPYFILE_PACK);
+        Self::apple_copyfile(source, &snapshot, flags)?;
+
+        Ok(snapshot)
+    }
+
+    #[cfg(target_vendor = "apple")]
+    #[expect(
+        unsafe_code,
+        reason = "rustix exposes Apple's stateful fcopyfile metadata API as unsafe"
+    )]
+    fn apple_copyfile(
+        source: &std::fs::File,
+        destination: &std::fs::File,
+        flags: CopyfileFlags,
+    ) -> io::Result<()> {
+        let state = rustix::fs::copyfile_state_alloc().map_err(io::Error::from)?;
+        // SAFETY: `state` was allocated immediately above and remains live until
+        // the matching `copyfile_state_free` call below.
+        let copy_result = unsafe { rustix::fs::fcopyfile(source, destination, state, flags) }
+            .map_err(io::Error::from);
+        // SAFETY: This is the one matching free for the live state allocated above.
+        let free_result =
+            unsafe { rustix::fs::copyfile_state_free(state) }.map_err(io::Error::from);
+
+        copy_result.and(free_result)
+    }
+
+    #[cfg(target_vendor = "apple")]
+    fn files_match(left: &mut std::fs::File, right: &mut std::fs::File) -> io::Result<bool> {
+        let left_length = left.metadata()?.len();
+        if left_length != right.metadata()?.len() {
+            return Ok(false);
+        }
+        let mut remaining = left_length;
+        left.seek(SeekFrom::Start(0))?;
+        right.seek(SeekFrom::Start(0))?;
+        let mut left_buffer = [0_u8; 8 * 1024];
+        let mut right_buffer = [0_u8; 8 * 1024];
+        while remaining > 0 {
+            let buffer_length = u64::try_from(left_buffer.len()).unwrap_or(u64::MAX);
+            let chunk_length =
+                usize::try_from(remaining.min(buffer_length)).unwrap_or(left_buffer.len());
+            left.read_exact(&mut left_buffer[..chunk_length])?;
+            right.read_exact(&mut right_buffer[..chunk_length])?;
+            if left_buffer[..chunk_length] != right_buffer[..chunk_length] {
+                return Ok(false);
+            }
+            remaining -= u64::try_from(chunk_length).unwrap_or(remaining);
+        }
+
+        Ok(true)
+    }
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    fn copy_metadata(source: &std::fs::File, destination: &std::fs::File) -> io::Result<()> {
+        let expected = Self::access_metadata(source)?;
+        let destination_names = Self::extended_attribute_names(destination)?;
+
+        rustix::fs::fchown(destination, Some(expected.owner), Some(expected.group))
+            .map_err(io::Error::from)?;
+        for name in destination_names.iter().filter(|name| {
+            !expected
+                .attributes
+                .iter()
+                .any(|attribute| &attribute.name == *name)
+        }) {
+            rustix::fs::fremovexattr(destination, name).map_err(io::Error::from)?;
+        }
+        for attribute in &expected.attributes {
+            rustix::fs::fsetxattr(
+                destination,
+                &attribute.name,
+                &attribute.value,
+                rustix::fs::XattrFlags::empty(),
+            )
+            .map_err(io::Error::from)?;
+        }
+        rustix::fs::fchmod(destination, expected.mode).map_err(io::Error::from)?;
+
+        Self::verify_copied_metadata(source, destination, &expected)
+    }
+
+    #[cfg(not(any(target_vendor = "apple", target_os = "android", target_os = "linux")))]
+    fn copy_metadata(_source: &std::fs::File, _destination: &std::fs::File) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "safe write metadata preservation is unsupported on this platform",
+        ))
+    }
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    fn extended_attribute_names(file: &std::fs::File) -> io::Result<Vec<OsString>> {
+        let mut buffer = vec![0_u8; XATTR_BUFFER_SIZE];
+        let length = rustix::fs::flistxattr(file, &mut buffer).map_err(io::Error::from)?;
+        buffer.truncate(length);
+
+        let mut names = buffer
+            .split(|byte| *byte == 0)
+            .filter(|name| !name.is_empty())
+            .map(|name| OsString::from_vec(name.to_vec()))
+            .collect::<Vec<_>>();
+        names.sort();
+
+        Ok(names)
+    }
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    fn extended_attribute(file: &std::fs::File, name: &OsStr) -> io::Result<Vec<u8>> {
+        let mut value = vec![0_u8; XATTR_BUFFER_SIZE];
+        let length = rustix::fs::fgetxattr(file, name, &mut value).map_err(io::Error::from)?;
+        value.truncate(length);
+
+        Ok(value)
+    }
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    fn access_metadata(file: &std::fs::File) -> io::Result<AccessMetadata> {
+        let metadata = rustix::fs::fstat(file).map_err(io::Error::from)?;
+        let attributes = Self::extended_attribute_names(file)?
+            .into_iter()
+            .map(|name| {
+                let value = Self::extended_attribute(file, &name)?;
+
+                Ok(ExtendedAttribute { name, value })
+            })
+            .collect::<io::Result<Vec<_>>>()?;
+
+        Ok(AccessMetadata {
+            attributes,
+            group: rustix::fs::Gid::from_raw(metadata.st_gid),
+            mode: Mode::from_bits_truncate(metadata.st_mode),
+            owner: rustix::fs::Uid::from_raw(metadata.st_uid),
+        })
+    }
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    fn verify_copied_metadata(
+        source: &std::fs::File,
+        destination: &std::fs::File,
+        expected: &AccessMetadata,
+    ) -> io::Result<()> {
+        if Self::access_metadata(source)? != *expected
+            || Self::access_metadata(destination)? != *expected
+        {
+            return Err(Self::metadata_changed_error());
+        }
+
+        Ok(())
+    }
+
+    fn metadata_changed_error() -> io::Error {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "write target metadata changed during replacement",
+        )
+    }
+
+    fn roll_back_exchange(
+        parent: &OwnedFd,
+        prepared_file: &std::fs::File,
+        file_name: &OsStr,
+        temporary_name: &OsStr,
+        remove_temporary: &mut bool,
+    ) -> io::Result<()> {
+        rustix::fs::renameat_with(
+            parent,
+            temporary_name,
+            parent,
+            file_name,
+            RenameFlags::EXCHANGE,
+        )
+        .map_err(io::Error::from)
+        .map_err(Self::map_exchange_error)?;
+        *remove_temporary = false;
+        if !Self::path_matches_file(parent, temporary_name, prepared_file)? {
+            rustix::fs::renameat_with(
+                parent,
+                temporary_name,
+                parent,
+                file_name,
+                RenameFlags::EXCHANGE,
+            )
+            .map_err(io::Error::from)?;
+
+            return Err(Self::concurrent_target_error());
+        }
+        *remove_temporary = true;
+
+        rustix::fs::fsync(parent).map_err(io::Error::from)
+    }
+
+    fn validate_exchange(
+        parent: &OwnedFd,
+        prepared_file: &std::fs::File,
+        file_name: &OsStr,
+        temporary_name: &OsStr,
+        expected: &[u8],
+        remove_temporary: &mut bool,
+    ) -> io::Result<()> {
+        if let Err(error) = Self::verify_target(parent, temporary_name, expected) {
+            Self::roll_back_exchange(
+                parent,
+                prepared_file,
+                file_name,
+                temporary_name,
+                remove_temporary,
+            )?;
+
+            return Err(error);
+        }
+        if !Self::path_matches_file(parent, file_name, prepared_file)? {
+            return Err(Self::concurrent_target_error());
+        }
+        let exchange_is_durable = rustix::fs::fsync(parent).is_ok();
+        if exchange_is_durable
+            && rustix::fs::unlinkat(parent, temporary_name, AtFlags::empty()).is_ok()
+        {
+            let _ = rustix::fs::fsync(parent);
+        }
+
+        Ok(())
+    }
+
+    fn path_matches_file(
+        parent: &OwnedFd,
+        file_name: &OsStr,
+        expected_file: &std::fs::File,
+    ) -> io::Result<bool> {
+        let expected = rustix::fs::fstat(expected_file).map_err(io::Error::from)?;
+        let current = match rustix::fs::statat(parent, file_name, AtFlags::SYMLINK_NOFOLLOW) {
+            Ok(current) => current,
+            Err(error) if io::Error::from(error).kind() == io::ErrorKind::NotFound => {
+                return Ok(false);
+            }
+            Err(error) => return Err(io::Error::from(error)),
+        };
+
+        Ok(expected.st_dev == current.st_dev && expected.st_ino == current.st_ino)
+    }
+
+    fn concurrent_target_error() -> io::Error {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "write target changed during atomic replacement",
+        )
+    }
+
+    fn map_exchange_error(error: io::Error) -> io::Error {
+        if error.kind() == io::ErrorKind::NotFound {
+            return Self::concurrent_target_error();
+        }
+
+        error
+    }
+
+    fn open_parent_beneath(
+        root: &Path,
+        relative_path: &Path,
+    ) -> io::Result<(ParentDirectory, OsString)> {
+        let mut directory =
+            rustix::fs::open(root, DIRECTORY_OPEN_FLAGS, Mode::empty()).map_err(io::Error::from)?;
+        let mut components = relative_path
+            .components()
+            .map(|component| match component {
+                Component::Normal(component) => Ok(component.to_os_string()),
+                _ => Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "write path must be repository-relative",
+                )),
+            })
+            .collect::<io::Result<Vec<OsString>>>()?;
+        let file_name = components.pop().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "write path must not be empty")
+        })?;
+
+        for component in components {
+            match rustix::fs::openat(&directory, &component, DIRECTORY_OPEN_FLAGS, Mode::empty()) {
+                Ok(descriptor) => directory = descriptor,
+                Err(error) if io::Error::from(error).kind() == io::ErrorKind::NotFound => {
+                    Self::create_directory(&directory, &component)?;
+                    directory = rustix::fs::openat(
+                        &directory,
+                        &component,
+                        DIRECTORY_OPEN_FLAGS,
+                        Mode::empty(),
+                    )
+                    .map_err(io::Error::from)?;
+                }
+                Err(error) => return Err(io::Error::from(error)),
+            }
+        }
+
+        Ok((
+            ParentDirectory {
+                descriptor: directory,
+            },
+            file_name,
+        ))
+    }
+
+    fn create_directory(parent: &OwnedFd, name: &OsStr) -> io::Result<()> {
+        match rustix::fs::mkdirat(parent, name, DIRECTORY_MODE) {
+            Ok(()) => Ok(()),
+            Err(error) if io::Error::from(error).kind() == io::ErrorKind::AlreadyExists => Ok(()),
+            Err(error) => Err(io::Error::from(error)),
+        }
+    }
+
+    fn verify_target(
+        parent: &OwnedFd,
+        file_name: &OsStr,
+        expected: &[u8],
+    ) -> io::Result<std::fs::File> {
+        let descriptor = rustix::fs::openat(parent, file_name, FILE_OPEN_FLAGS, Mode::empty())
+            .map_err(io::Error::from)?;
+        let metadata = rustix::fs::fstat(&descriptor).map_err(io::Error::from)?;
+        if !FileType::from_raw_mode(metadata.st_mode).is_file() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "write path must name a regular file",
+            ));
+        }
+        let mut target = std::fs::File::from(descriptor);
+        if !Self::target_matches(&mut target, expected)? {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "write target changed since it was read",
+            ));
+        }
+
+        Ok(target)
+    }
+
+    fn target_matches(target: &mut impl io::Read, expected: &[u8]) -> io::Result<bool> {
+        let mut buffer = [0_u8; 8 * 1024];
+        for expected_chunk in expected.chunks(buffer.len()) {
+            match target.read_exact(&mut buffer[..expected_chunk.len()]) {
+                Ok(()) if &buffer[..expected_chunk.len()] == expected_chunk => {}
+                Ok(()) => return Ok(false),
+                Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(false),
+                Err(error) => return Err(error),
+            }
+        }
+        let mut extra = [0_u8; 1];
+        match target.read_exact(&mut extra) {
+            Ok(()) => Ok(false),
+            Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => Ok(true),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn temporary_name() -> OsString {
+        let sequence = TEMPORARY_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+
+        OsString::from(format!(
+            ".ag-harness-write-{}-{sequence}",
+            std::process::id()
+        ))
+    }
 }
 
 #[async_trait]
@@ -103,16 +719,39 @@ impl FileSystem for LocalFileSystem {
 
         Ok(Box::new(tokio::fs::File::from_std(file)))
     }
+
+    async fn replace_beneath(
+        &self,
+        root: &Path,
+        path: &Path,
+        expected: Option<Vec<u8>>,
+        content: Vec<u8>,
+    ) -> io::Result<()> {
+        let root = root.to_path_buf();
+        let path = path.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            Self::replace_beneath(&root, &path, expected.as_deref(), &content)
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write as _;
-    use std::os::unix::fs::symlink;
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _, symlink};
 
     use tokio::io::AsyncReadExt as _;
 
     use super::*;
+
+    struct FailingReader;
+
+    impl io::Read for FailingReader {
+        fn read(&mut self, _buffer: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::other("read failed"))
+        }
+    }
 
     #[tokio::test]
     async fn local_file_system_canonicalizes_and_opens_file() {
@@ -237,5 +876,965 @@ mod tests {
         // Assert
         assert!(FILE_OPEN_FLAGS.contains(OFlags::NONBLOCK));
         assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[tokio::test]
+    async fn local_file_system_creates_nested_file_atomically() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        let file_system = LocalFileSystem;
+
+        // Act
+        file_system
+            .replace_beneath(
+                repository.path(),
+                Path::new("nested/output.txt"),
+                None,
+                b"created\n".to_vec(),
+            )
+            .await
+            .expect("new file should be written");
+
+        // Assert
+        assert_eq!(
+            std::fs::read(repository.path().join("nested/output.txt"))
+                .expect("created file should be readable"),
+            b"created\n"
+        );
+        assert_eq!(
+            std::fs::metadata(repository.path().join("nested/output.txt"))
+                .expect("created file metadata should be readable")
+                .permissions()
+                .mode()
+                & 0o077,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn local_file_system_replaces_expected_content_and_preserves_access_metadata() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        let nested = repository.path().join("nested");
+        std::fs::create_dir(&nested).expect("nested directory should be created");
+        let path = nested.join("script.sh");
+        std::fs::write(&path, b"old\n").expect("fixture should be written");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o750))
+            .expect("fixture mode should be set");
+        let original_file = std::fs::File::open(&path).expect("fixture should open");
+        rustix::fs::fsetxattr(
+            &original_file,
+            "user.ag-harness-test",
+            b"preserved",
+            rustix::fs::XattrFlags::empty(),
+        )
+        .expect("fixture xattr should be set");
+        let original_metadata = original_file
+            .metadata()
+            .expect("fixture metadata should read");
+        let file_system = LocalFileSystem;
+
+        // Act
+        file_system
+            .replace_beneath(
+                repository.path(),
+                Path::new("nested/script.sh"),
+                Some(b"old\n".to_vec()),
+                b"new\n".to_vec(),
+            )
+            .await
+            .expect("existing file should be replaced");
+
+        // Assert
+        assert_eq!(
+            std::fs::read(&path).expect("file should be readable"),
+            b"new\n"
+        );
+        let updated_file = std::fs::File::open(&path).expect("updated file should open");
+        let updated_metadata = updated_file
+            .metadata()
+            .expect("updated metadata should read");
+        assert_eq!(updated_metadata.permissions().mode() & 0o777, 0o750);
+        assert_eq!(updated_metadata.uid(), original_metadata.uid());
+        assert_eq!(updated_metadata.gid(), original_metadata.gid());
+        let mut xattr = [0_u8; 16];
+        let xattr_length = rustix::fs::fgetxattr(&updated_file, "user.ag-harness-test", &mut xattr)
+            .expect("updated xattr should read");
+        assert_eq!(&xattr[..xattr_length], b"preserved");
+    }
+
+    #[tokio::test]
+    async fn local_file_system_rejects_stale_or_existing_target() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        std::fs::write(repository.path().join("output.txt"), b"current")
+            .expect("fixture should be written");
+        let file_system = LocalFileSystem;
+
+        // Act
+        let stale_error = file_system
+            .replace_beneath(
+                repository.path(),
+                Path::new("output.txt"),
+                Some(b"stale".to_vec()),
+                b"replacement".to_vec(),
+            )
+            .await
+            .expect_err("stale replacement should fail");
+        let create_error = file_system
+            .replace_beneath(
+                repository.path(),
+                Path::new("output.txt"),
+                None,
+                b"replacement".to_vec(),
+            )
+            .await
+            .expect_err("create over existing file should fail");
+        let missing_error = file_system
+            .replace_beneath(
+                repository.path(),
+                Path::new("deleted.txt"),
+                Some(b"previous".to_vec()),
+                b"replacement".to_vec(),
+            )
+            .await
+            .expect_err("missing update target should be rejected as stale");
+
+        // Assert
+        assert_eq!(stale_error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(create_error.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(missing_error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(
+            std::fs::read(repository.path().join("output.txt"))
+                .expect("original file should remain"),
+            b"current"
+        );
+    }
+
+    #[test]
+    fn local_file_system_does_not_overwrite_target_changed_at_install() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        std::fs::write(repository.path().join("output.txt"), b"newer")
+            .expect("newer target should be written");
+        std::fs::write(repository.path().join(".prepared"), b"model change")
+            .expect("prepared file should be written");
+        let (parent, file_name) =
+            LocalFileSystem::open_parent_beneath(repository.path(), Path::new("output.txt"))
+                .expect("target parent should open");
+        let prepared_file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(repository.path().join(".prepared"))
+            .expect("prepared file should open");
+        let mut remove_prepared = true;
+
+        // Act
+        let error = LocalFileSystem::install_update(
+            &parent.descriptor,
+            &prepared_file,
+            &file_name,
+            OsStr::new(".prepared"),
+            b"stale",
+            &mut remove_prepared,
+        )
+        .expect_err("changed target should reject installation");
+
+        // Assert
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(remove_prepared);
+        assert_eq!(
+            std::fs::read(repository.path().join("output.txt"))
+                .expect("newer target should remain"),
+            b"newer"
+        );
+    }
+
+    #[test]
+    fn local_file_system_bounds_update_lock_wait() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        let (lock_owner, _) =
+            LocalFileSystem::open_parent_beneath(repository.path(), Path::new("output.txt"))
+                .expect("first parent descriptor should open");
+        let (lock_waiter, _) =
+            LocalFileSystem::open_parent_beneath(repository.path(), Path::new("output.txt"))
+                .expect("second parent descriptor should open");
+        rustix::fs::flock(&lock_owner.descriptor, FlockOperation::LockExclusive)
+            .expect("fixture lock should be acquired");
+
+        // Act
+        let error = LocalFileSystem::acquire_update_lock(
+            &lock_waiter.descriptor,
+            Duration::from_millis(20),
+        )
+        .expect_err("competing lock should time out");
+
+        // Assert
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    }
+
+    #[test]
+    fn local_file_system_propagates_update_lock_errors() {
+        // Arrange
+        let expected_kind = io::ErrorKind::PermissionDenied;
+
+        // Act
+        let error = LocalFileSystem::acquire_update_lock_with(Duration::ZERO, || {
+            Err(io::Error::new(expected_kind, "lock failed"))
+        })
+        .expect_err("lock error should propagate");
+
+        // Assert
+        assert_eq!(error.kind(), expected_kind);
+    }
+
+    #[cfg(target_vendor = "apple")]
+    #[test]
+    fn local_file_system_detects_apple_metadata_added_after_snapshot() {
+        // Arrange
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let path = directory.path().join("source");
+        std::fs::write(&path, b"source").expect("source should be written");
+        let source = std::fs::File::open(path).expect("source should open");
+        let mut expected =
+            LocalFileSystem::apple_metadata_snapshot(&source).expect("metadata should snapshot");
+        rustix::fs::fsetxattr(
+            &source,
+            "user.ag-harness-added",
+            b"added",
+            rustix::fs::XattrFlags::empty(),
+        )
+        .expect("source xattr should be added");
+
+        // Act
+        let error = LocalFileSystem::verify_apple_metadata(&mut expected, &source, &source)
+            .expect_err("added source metadata should reject the snapshot");
+
+        // Assert
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[cfg(target_vendor = "apple")]
+    #[test]
+    fn local_file_system_compares_complete_metadata_archives() {
+        // Arrange
+        let mut left = tempfile::tempfile().expect("left archive should open");
+        let mut different = tempfile::tempfile().expect("different archive should open");
+        let mut longer = tempfile::tempfile().expect("longer archive should open");
+        left.write_all(b"left").expect("left archive should write");
+        different
+            .write_all(b"diff")
+            .expect("different archive should write");
+        longer
+            .write_all(b"longer")
+            .expect("longer archive should write");
+
+        // Act
+        let content_matches = LocalFileSystem::files_match(&mut left, &mut different)
+            .expect("equal-length archives should compare");
+        let length_matches = LocalFileSystem::files_match(&mut left, &mut longer)
+            .expect("different-length archives should compare");
+
+        // Assert
+        assert!(!content_matches);
+        assert!(!length_matches);
+    }
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[test]
+    fn local_file_system_removes_destination_only_extended_attributes() {
+        // Arrange
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let source_path = directory.path().join("source");
+        let destination_path = directory.path().join("destination");
+        std::fs::write(&source_path, b"source").expect("source should be written");
+        std::fs::write(&destination_path, b"destination").expect("destination should be written");
+        let source = std::fs::File::open(source_path).expect("source should open");
+        let destination = std::fs::File::open(destination_path).expect("destination should open");
+        rustix::fs::fsetxattr(
+            &destination,
+            "user.ag-harness-extra",
+            b"remove",
+            rustix::fs::XattrFlags::empty(),
+        )
+        .expect("destination xattr should be set");
+
+        // Act
+        LocalFileSystem::copy_metadata(&source, &destination)
+            .expect("source metadata should be copied");
+
+        // Assert
+        assert_eq!(
+            LocalFileSystem::extended_attribute_names(&destination)
+                .expect("destination xattrs should list"),
+            Vec::<OsString>::new()
+        );
+    }
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[test]
+    fn local_file_system_rejects_mismatched_copied_extended_attributes() {
+        // Arrange
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let source_path = directory.path().join("source");
+        let destination_path = directory.path().join("destination");
+        std::fs::write(&source_path, b"source").expect("source should be written");
+        std::fs::write(&destination_path, b"destination").expect("destination should be written");
+        let source = std::fs::File::open(source_path).expect("source should open");
+        let destination = std::fs::File::open(destination_path).expect("destination should open");
+        rustix::fs::fsetxattr(
+            &source,
+            "user.ag-harness-test",
+            b"source",
+            rustix::fs::XattrFlags::empty(),
+        )
+        .expect("source xattr should be set");
+        rustix::fs::fsetxattr(
+            &destination,
+            "user.ag-harness-test",
+            b"destination",
+            rustix::fs::XattrFlags::empty(),
+        )
+        .expect("destination xattr should be set");
+        let expected =
+            LocalFileSystem::access_metadata(&source).expect("source metadata should snapshot");
+
+        // Act
+        let error = LocalFileSystem::verify_copied_metadata(&source, &destination, &expected)
+            .expect_err("different xattr values should fail verification");
+
+        // Assert
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[test]
+    fn local_file_system_detects_extended_attributes_added_after_snapshot() {
+        // Arrange
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let source_path = directory.path().join("source");
+        let destination_path = directory.path().join("destination");
+        std::fs::write(&source_path, b"source").expect("source should be written");
+        std::fs::write(&destination_path, b"destination").expect("destination should be written");
+        let source = std::fs::File::open(source_path).expect("source should open");
+        let destination = std::fs::File::open(destination_path).expect("destination should open");
+        let expected =
+            LocalFileSystem::access_metadata(&source).expect("source metadata should snapshot");
+        rustix::fs::fsetxattr(
+            &source,
+            "user.ag-harness-added",
+            b"added",
+            rustix::fs::XattrFlags::empty(),
+        )
+        .expect("source xattr should be added");
+
+        // Act
+        let error = LocalFileSystem::verify_copied_metadata(&source, &destination, &expected)
+            .expect_err("added source xattr should fail verification");
+
+        // Assert
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn local_file_system_refreshes_target_mode_before_exchange() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        let target_path = repository.path().join("output.txt");
+        let prepared_path = repository.path().join(".prepared");
+        std::fs::write(&target_path, b"expected").expect("target should be written");
+        std::fs::set_permissions(&target_path, std::fs::Permissions::from_mode(0o751))
+            .expect("target mode should be set");
+        std::fs::write(&prepared_path, b"model change").expect("prepared file should be written");
+        std::fs::set_permissions(&prepared_path, std::fs::Permissions::from_mode(0o600))
+            .expect("prepared mode should be set");
+        let prepared_file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&prepared_path)
+            .expect("prepared file should open");
+        let (parent, file_name) =
+            LocalFileSystem::open_parent_beneath(repository.path(), Path::new("output.txt"))
+                .expect("target parent should open");
+        let mut remove_prepared = true;
+
+        // Act
+        LocalFileSystem::install_update(
+            &parent.descriptor,
+            &prepared_file,
+            &file_name,
+            OsStr::new(".prepared"),
+            b"expected",
+            &mut remove_prepared,
+        )
+        .expect("prepared file should be installed");
+
+        // Assert
+        assert!(!remove_prepared);
+        assert_eq!(
+            std::fs::read(&target_path).expect("target should read"),
+            b"model change"
+        );
+        assert_eq!(
+            std::fs::metadata(&target_path)
+                .expect("target metadata should read")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o751
+        );
+        assert!(!prepared_path.exists());
+    }
+
+    #[test]
+    fn local_file_system_rolls_back_failed_mode_installation() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        let target_path = repository.path().join("output.txt");
+        let prepared_path = repository.path().join(".prepared");
+        std::fs::write(&target_path, b"expected").expect("target should be written");
+        std::fs::write(&prepared_path, b"model change").expect("prepared file should be written");
+        let prepared_file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&prepared_path)
+            .expect("prepared file should open");
+        let (parent, file_name) =
+            LocalFileSystem::open_parent_beneath(repository.path(), Path::new("output.txt"))
+                .expect("target parent should open");
+        let mut remove_prepared = true;
+
+        // Act
+        let error = LocalFileSystem::install_update_with_metadata(
+            &parent.descriptor,
+            &prepared_file,
+            &file_name,
+            OsStr::new(".prepared"),
+            b"expected",
+            &mut remove_prepared,
+            |_, _| Err(io::Error::other("injected metadata failure")),
+        )
+        .expect_err("failed metadata installation should roll back");
+
+        // Assert
+        assert_ne!(error.kind(), io::ErrorKind::NotFound);
+        assert!(remove_prepared);
+        assert_eq!(
+            std::fs::read(&target_path).expect("target should be readable"),
+            b"expected"
+        );
+        assert_eq!(
+            std::fs::read(&prepared_path).expect("prepared file should be readable"),
+            b"model change"
+        );
+    }
+
+    #[test]
+    fn local_file_system_preserves_recovery_when_metadata_rollback_fails() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        let target_path = repository.path().join("output.txt");
+        let prepared_path = repository.path().join(".prepared");
+        std::fs::write(&target_path, b"expected").expect("target should be written");
+        std::fs::write(&prepared_path, b"model change").expect("prepared file should be written");
+        let prepared_file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&prepared_path)
+            .expect("prepared file should open");
+        let (parent, file_name) =
+            LocalFileSystem::open_parent_beneath(repository.path(), Path::new("output.txt"))
+                .expect("target parent should open");
+        let mut remove_prepared = true;
+
+        // Act
+        let error = LocalFileSystem::install_update_with_metadata(
+            &parent.descriptor,
+            &prepared_file,
+            &file_name,
+            OsStr::new(".prepared"),
+            b"expected",
+            &mut remove_prepared,
+            |_, _| {
+                std::fs::remove_file(&target_path)?;
+
+                Err(io::Error::other("injected metadata failure"))
+            },
+        )
+        .expect_err("failed rollback should preserve the recovery file");
+
+        // Assert
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(!remove_prepared);
+        assert!(!target_path.exists());
+        assert_eq!(
+            std::fs::read(prepared_path).expect("original target should remain recoverable"),
+            b"expected"
+        );
+    }
+
+    #[test]
+    fn local_file_system_rolls_back_stale_atomic_exchange() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        std::fs::write(repository.path().join("output.txt"), b"model change")
+            .expect("exchanged model file should be written");
+        std::fs::write(repository.path().join(".prepared"), b"newer")
+            .expect("captured newer file should be written");
+        let prepared_file = std::fs::File::open(repository.path().join("output.txt"))
+            .expect("model file should open");
+        let (parent, file_name) =
+            LocalFileSystem::open_parent_beneath(repository.path(), Path::new("output.txt"))
+                .expect("target parent should open");
+        let mut remove_prepared = false;
+
+        // Act
+        let error = LocalFileSystem::validate_exchange(
+            &parent.descriptor,
+            &prepared_file,
+            &file_name,
+            OsStr::new(".prepared"),
+            b"expected",
+            &mut remove_prepared,
+        )
+        .expect_err("stale exchange should be rolled back");
+
+        // Assert
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(remove_prepared);
+        assert_eq!(
+            std::fs::read(repository.path().join("output.txt"))
+                .expect("newer target should be restored"),
+            b"newer"
+        );
+        assert_eq!(
+            std::fs::read(repository.path().join(".prepared"))
+                .expect("model file should remain recoverable"),
+            b"model change"
+        );
+    }
+
+    #[test]
+    fn local_file_system_rejects_replaced_target_after_exchange() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        let target_path = repository.path().join("output.txt");
+        let captured_path = repository.path().join(".captured");
+        let prepared_path = repository.path().join(".opened-prepared");
+        std::fs::write(&target_path, b"concurrent").expect("concurrent target should be written");
+        std::fs::write(&captured_path, b"expected").expect("captured file should be written");
+        std::fs::write(&prepared_path, b"model change").expect("prepared file should be written");
+        let prepared_file = std::fs::File::open(prepared_path).expect("prepared file should open");
+        let (parent, file_name) =
+            LocalFileSystem::open_parent_beneath(repository.path(), Path::new("output.txt"))
+                .expect("target parent should open");
+        let mut remove_captured = false;
+
+        // Act
+        let error = LocalFileSystem::validate_exchange(
+            &parent.descriptor,
+            &prepared_file,
+            &file_name,
+            OsStr::new(".captured"),
+            b"expected",
+            &mut remove_captured,
+        )
+        .expect_err("replaced target should be rejected");
+
+        // Assert
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(!remove_captured);
+        assert_eq!(
+            std::fs::read(target_path).expect("concurrent target should remain"),
+            b"concurrent"
+        );
+        assert_eq!(
+            std::fs::read(captured_path).expect("captured target should remain recoverable"),
+            b"expected"
+        );
+    }
+
+    #[test]
+    fn local_file_system_reports_target_identity_lookup_errors() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        let expected_path = repository.path().join("expected.txt");
+        std::fs::write(&expected_path, b"expected").expect("expected file should be written");
+        std::fs::write(repository.path().join("blocked"), b"file")
+            .expect("blocking file should be written");
+        let expected_file = std::fs::File::open(expected_path).expect("expected file should open");
+        let (parent, _) =
+            LocalFileSystem::open_parent_beneath(repository.path(), Path::new("output.txt"))
+                .expect("target parent should open");
+
+        // Act
+        let missing_matches = LocalFileSystem::path_matches_file(
+            &parent.descriptor,
+            OsStr::new("missing.txt"),
+            &expected_file,
+        )
+        .expect("missing target should compare");
+        let traversal_error = LocalFileSystem::path_matches_file(
+            &parent.descriptor,
+            OsStr::new("blocked/child"),
+            &expected_file,
+        )
+        .expect_err("non-directory traversal should fail");
+
+        // Assert
+        assert!(!missing_matches);
+        assert_eq!(traversal_error.kind(), io::ErrorKind::NotADirectory);
+    }
+
+    #[test]
+    fn local_file_system_restores_concurrent_target_during_rollback() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        let target_path = repository.path().join("output.txt");
+        let captured_path = repository.path().join(".captured");
+        let prepared_path = repository.path().join(".opened-prepared");
+        std::fs::write(&target_path, b"concurrent").expect("concurrent target should be written");
+        std::fs::write(&captured_path, b"newer").expect("captured file should be written");
+        std::fs::write(&prepared_path, b"model change").expect("prepared file should be written");
+        let prepared_file = std::fs::File::open(prepared_path).expect("prepared file should open");
+        let (parent, file_name) =
+            LocalFileSystem::open_parent_beneath(repository.path(), Path::new("output.txt"))
+                .expect("target parent should open");
+        let mut remove_captured = false;
+
+        // Act
+        let error = LocalFileSystem::validate_exchange(
+            &parent.descriptor,
+            &prepared_file,
+            &file_name,
+            OsStr::new(".captured"),
+            b"expected",
+            &mut remove_captured,
+        )
+        .expect_err("concurrent rollback target should be rejected");
+
+        // Assert
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(!remove_captured);
+        assert_eq!(
+            std::fs::read(target_path).expect("concurrent target should be restored"),
+            b"concurrent"
+        );
+        assert_eq!(
+            std::fs::read(captured_path).expect("captured target should remain recoverable"),
+            b"newer"
+        );
+    }
+
+    #[test]
+    fn local_file_system_preserves_recovery_when_exchange_path_disappears() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        let target_path = repository.path().join("output.txt");
+        let prepared_path = repository.path().join(".prepared");
+        std::fs::write(&target_path, b"model change").expect("model file should be written");
+        std::fs::write(&prepared_path, b"newer").expect("captured file should be written");
+        let prepared_file = std::fs::File::open(&target_path).expect("model file should open");
+        let (parent, file_name) =
+            LocalFileSystem::open_parent_beneath(repository.path(), Path::new("output.txt"))
+                .expect("target parent should open");
+        std::fs::remove_file(&target_path).expect("model path should disappear");
+        let mut remove_prepared = false;
+
+        // Act
+        let error = LocalFileSystem::validate_exchange(
+            &parent.descriptor,
+            &prepared_file,
+            &file_name,
+            OsStr::new(".prepared"),
+            b"expected",
+            &mut remove_prepared,
+        )
+        .expect_err("stale exchange should be rejected");
+
+        // Assert
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(!remove_prepared);
+        assert!(!target_path.exists());
+        assert_eq!(
+            std::fs::read(prepared_path).expect("captured target should remain recoverable"),
+            b"newer"
+        );
+    }
+
+    #[test]
+    fn local_file_system_reports_failed_exchange_rollback() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        let prepared_path = repository.path().join(".opened-prepared");
+        std::fs::write(&prepared_path, b"model change").expect("prepared file should be written");
+        let prepared_file = std::fs::File::open(prepared_path).expect("prepared file should open");
+        let (parent, file_name) =
+            LocalFileSystem::open_parent_beneath(repository.path(), Path::new("output.txt"))
+                .expect("target parent should open");
+        let mut remove_prepared = false;
+
+        // Act
+        let error = LocalFileSystem::roll_back_exchange(
+            &parent.descriptor,
+            &prepared_file,
+            &file_name,
+            OsStr::new(".missing-prepared"),
+            &mut remove_prepared,
+        )
+        .expect_err("missing rollback paths should fail");
+
+        // Assert
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(!remove_prepared);
+    }
+
+    #[test]
+    fn local_file_system_preserves_non_missing_exchange_errors() {
+        // Arrange
+        let permission_error = io::Error::new(io::ErrorKind::PermissionDenied, "denied");
+
+        // Act
+        let mapped = LocalFileSystem::map_exchange_error(permission_error);
+
+        // Assert
+        assert_eq!(mapped.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(mapped.to_string(), "denied");
+    }
+
+    #[test]
+    fn local_file_system_keeps_committed_write_when_cleanup_fails() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        let target_path = repository.path().join("output.txt");
+        let captured_path = repository.path().join(".captured");
+        std::fs::write(&target_path, b"model change").expect("target should be written");
+        std::fs::write(&captured_path, b"expected").expect("captured file should be written");
+        let prepared_file = std::fs::File::open(&target_path).expect("model file should open");
+        let (parent, file_name) =
+            LocalFileSystem::open_parent_beneath(repository.path(), Path::new("output.txt"))
+                .expect("target parent should open");
+        std::fs::set_permissions(repository.path(), std::fs::Permissions::from_mode(0o555))
+            .expect("repository should become read-only");
+        let mut remove_captured = false;
+
+        // Act
+        let result = LocalFileSystem::validate_exchange(
+            &parent.descriptor,
+            &prepared_file,
+            &file_name,
+            OsStr::new(".captured"),
+            b"expected",
+            &mut remove_captured,
+        );
+        std::fs::set_permissions(repository.path(), std::fs::Permissions::from_mode(0o755))
+            .expect("repository permissions should be restored");
+
+        // Assert
+        result.expect("post-commit cleanup failure should not fail the write");
+        assert_eq!(
+            std::fs::read(&target_path).expect("target should read"),
+            b"model change"
+        );
+        assert_eq!(
+            std::fs::read(&captured_path).expect("recovery file should read"),
+            b"expected"
+        );
+        assert!(!remove_captured);
+    }
+
+    #[test]
+    fn local_file_system_preserves_target_when_exchange_fails() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        std::fs::write(repository.path().join("output.txt"), b"expected")
+            .expect("target should be written");
+        let prepared_path = repository.path().join(".opened-prepared");
+        std::fs::write(&prepared_path, b"model change").expect("prepared file should be written");
+        let prepared_file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(prepared_path)
+            .expect("prepared file should open");
+        let (parent, file_name) =
+            LocalFileSystem::open_parent_beneath(repository.path(), Path::new("output.txt"))
+                .expect("target parent should open");
+        let mut remove_prepared = true;
+
+        // Act
+        let error = LocalFileSystem::install_update(
+            &parent.descriptor,
+            &prepared_file,
+            &file_name,
+            OsStr::new(".missing-prepared"),
+            b"expected",
+            &mut remove_prepared,
+        )
+        .expect_err("missing prepared file should fail exchange");
+
+        // Assert
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+        assert!(remove_prepared);
+        assert_eq!(
+            std::fs::read(repository.path().join("output.txt"))
+                .expect("target should remain available"),
+            b"expected"
+        );
+    }
+
+    #[test]
+    fn target_comparison_reads_at_most_one_byte_past_expected() {
+        // Arrange
+        let expected = b"expected";
+        let mut exact = io::Cursor::new(expected);
+        let mut shorter = io::Cursor::new(b"expect".as_slice());
+        let mut different = io::Cursor::new(b"expEcted".as_slice());
+        let mut longer = io::Cursor::new(b"expected and arbitrarily more data".as_slice());
+        let mut expected_failure = FailingReader;
+        let mut extra_failure = FailingReader;
+
+        // Act
+        let exact_matches = LocalFileSystem::target_matches(&mut exact, expected)
+            .expect("exact target should compare");
+        let shorter_matches = LocalFileSystem::target_matches(&mut shorter, expected)
+            .expect("short target should compare");
+        let different_matches = LocalFileSystem::target_matches(&mut different, expected)
+            .expect("different target should compare");
+        let longer_matches = LocalFileSystem::target_matches(&mut longer, expected)
+            .expect("long target should compare");
+        let expected_error = LocalFileSystem::target_matches(&mut expected_failure, expected)
+            .expect_err("expected-content read error should propagate");
+        let extra_error = LocalFileSystem::target_matches(&mut extra_failure, b"")
+            .expect_err("extra-byte read error should propagate");
+
+        // Assert
+        assert!(exact_matches);
+        assert!(!shorter_matches);
+        assert!(!different_matches);
+        assert!(!longer_matches);
+        assert_eq!(longer.position(), (expected.len() + 1) as u64);
+        assert_eq!(expected_error.kind(), io::ErrorKind::Other);
+        assert_eq!(extra_error.kind(), io::ErrorKind::Other);
+    }
+
+    #[tokio::test]
+    async fn local_file_system_keeps_created_directories_after_failed_write() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        let file_system = LocalFileSystem;
+
+        // Act
+        let error = file_system
+            .replace_beneath(
+                repository.path(),
+                Path::new("nested/deeper/output.txt"),
+                Some(b"missing".to_vec()),
+                b"replacement".to_vec(),
+            )
+            .await
+            .expect_err("replacement of missing target should fail");
+
+        // Assert
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(repository.path().join("nested/deeper").is_dir());
+    }
+
+    #[test]
+    fn local_file_system_handles_directory_creation_outcomes() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        let (parent, _) =
+            LocalFileSystem::open_parent_beneath(repository.path(), Path::new("output.txt"))
+                .expect("target parent should open");
+
+        // Act
+        LocalFileSystem::create_directory(&parent.descriptor, OsStr::new("created"))
+            .expect("missing directory should be created");
+        let existing = LocalFileSystem::create_directory(&parent.descriptor, OsStr::new("created"));
+        let missing_parent =
+            LocalFileSystem::create_directory(&parent.descriptor, OsStr::new("missing/child"))
+                .expect_err("missing parent should fail creation");
+
+        // Assert
+        existing.expect("existing directory should be accepted");
+        assert!(repository.path().join("created").is_dir());
+        assert_eq!(missing_parent.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[tokio::test]
+    async fn local_file_system_rejects_write_symlink_traversal() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        let outside = tempfile::tempdir().expect("outside directory should be created");
+        let outside_file = outside.path().join("outside.txt");
+        std::fs::write(&outside_file, b"outside").expect("outside file should be written");
+        symlink(outside.path(), repository.path().join("directory-link"))
+            .expect("directory symlink should be created");
+        symlink(&outside_file, repository.path().join("file-link"))
+            .expect("file symlink should be created");
+        let file_system = LocalFileSystem;
+
+        // Act
+        let directory_error = file_system
+            .replace_beneath(
+                repository.path(),
+                Path::new("directory-link/outside.txt"),
+                Some(b"outside".to_vec()),
+                b"changed".to_vec(),
+            )
+            .await
+            .expect_err("directory symlink should not be followed");
+        let file_error = file_system
+            .replace_beneath(
+                repository.path(),
+                Path::new("file-link"),
+                Some(b"outside".to_vec()),
+                b"changed".to_vec(),
+            )
+            .await
+            .expect_err("file symlink should not be followed");
+
+        // Assert
+        assert_ne!(directory_error.kind(), io::ErrorKind::NotFound);
+        assert_ne!(file_error.kind(), io::ErrorKind::NotFound);
+        assert_eq!(
+            std::fs::read(outside_file).expect("outside file should remain"),
+            b"outside"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_file_system_rejects_invalid_write_paths_and_special_files() {
+        // Arrange
+        let repository = tempfile::tempdir().expect("repository should be created");
+        std::fs::create_dir(repository.path().join("directory"))
+            .expect("directory fixture should be created");
+        let file_system = LocalFileSystem;
+
+        // Act
+        let empty_error = file_system
+            .replace_beneath(repository.path(), Path::new(""), None, Vec::new())
+            .await
+            .expect_err("empty write path should fail");
+        let parent_error = file_system
+            .replace_beneath(repository.path(), Path::new("../file"), None, Vec::new())
+            .await
+            .expect_err("parent traversal should fail");
+        let directory_error = file_system
+            .replace_beneath(
+                repository.path(),
+                Path::new("directory"),
+                Some(Vec::new()),
+                Vec::new(),
+            )
+            .await
+            .expect_err("directory target should fail");
+        let long_name = "x".repeat(256);
+        let long_name_error = file_system
+            .replace_beneath(repository.path(), Path::new(&long_name), None, Vec::new())
+            .await
+            .expect_err("overlong target name should fail");
+
+        // Assert
+        assert_eq!(empty_error.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(parent_error.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(directory_error.kind(), io::ErrorKind::InvalidInput);
+        assert_ne!(long_name_error.kind(), io::ErrorKind::NotFound);
     }
 }

--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -13,7 +13,10 @@ use crate::model::{Model, ModelError, ModelRequest, ModelResponse};
 use crate::policy::Policy;
 use crate::read::{ReadError, ReadTool};
 use crate::schema_contract::OutputSchema;
-use crate::tool::{Tool, ToolDefinition};
+use crate::tool::{
+    ReadArguments, Tool, ToolCall, ToolCallArguments, ToolDefinition, WriteArguments,
+};
+use crate::write::{WriteError, WriteTool};
 
 const DEFAULT_MAX_TOOL_CALLS: usize = 8;
 
@@ -91,7 +94,7 @@ impl Harness {
     /// # Errors
     ///
     /// Returns [`TurnError`] when the model fails, requests a denied tool,
-    /// exceeds the call limit, or the requested repository read fails.
+    /// exceeds the call limit, or a requested repository operation fails.
     pub async fn run(
         &self,
         prompt: impl Into<String>,
@@ -121,20 +124,30 @@ impl Harness {
         if self.lifecycle.is_enabled() {
             request.mark_lifecycle_observed();
         }
-        let read_tool = if self.policy.allows(Tool::Read) {
+        let read_allowed = self.policy.allows(Tool::Read);
+        let write_allowed = self.policy.allows(Tool::Write);
+        let mut read_tool = None;
+        let mut write_tool = None;
+        if read_allowed || write_allowed {
             let repository_root = self
                 .repository_root
                 .as_ref()
                 .ok_or(TurnError::RepositoryRequired)?;
-            request = request.with_tool(ToolDefinition::read());
-
-            Some(ReadTool::new(
-                self.file_system.clone(),
-                repository_root.clone(),
-            ))
-        } else {
-            None
-        };
+            if read_allowed {
+                request = request.with_tool(ToolDefinition::read());
+                read_tool = Some(ReadTool::new(
+                    self.file_system.clone(),
+                    repository_root.clone(),
+                ));
+            }
+            if write_allowed {
+                request = request.with_tool(ToolDefinition::write());
+                write_tool = Some(WriteTool::new(
+                    self.file_system.clone(),
+                    repository_root.clone(),
+                ));
+            }
+        }
         let mut completed_tool_calls = 0_usize;
         let mut model_request_index = 0_u64;
 
@@ -164,47 +177,76 @@ impl Harness {
             match response {
                 ModelResponse::Output(output) => return Ok(output),
                 ModelResponse::ToolCall(call) => {
-                    let mut tool_lifecycle = self
-                        .lifecycle
-                        .request_tool(call.name().to_string(), turn_id);
-                    let Some(read_tool) = read_tool.as_ref() else {
-                        if let Some(tool_lifecycle) = tool_lifecycle {
-                            tool_lifecycle.denied();
-                        }
-
-                        return Err(TurnError::ToolDenied {
-                            name: call.name().to_string(),
-                        });
-                    };
-                    if completed_tool_calls >= self.max_tool_calls {
-                        if let Some(tool_lifecycle) = tool_lifecycle {
-                            tool_lifecycle.failed(ToolErrorType::CallLimit);
-                        }
-
-                        return Err(TurnError::ToolCallLimit {
-                            limit: self.max_tool_calls,
-                        });
-                    }
-                    if let Some(tool_lifecycle) = tool_lifecycle.as_mut() {
-                        tool_lifecycle.started();
-                    }
-                    let output = match read_tool.execute(call.arguments()).await {
-                        Ok(output) => output,
-                        Err(error) => {
-                            if let Some(tool_lifecycle) = tool_lifecycle {
-                                tool_lifecycle.failed(ToolErrorType::Execution);
-                            }
-
-                            return Err(error.into());
-                        }
-                    };
-                    let result = output.to_tool_result().map_err(ReadError::from)?;
-                    if let Some(tool_lifecycle) = tool_lifecycle {
-                        tool_lifecycle.completed();
-                    }
+                    let result = self
+                        .execute_tool_call(
+                            &call,
+                            read_tool.as_ref(),
+                            write_tool.as_ref(),
+                            completed_tool_calls,
+                            turn_id,
+                        )
+                        .await?;
                     request.record_tool_result(call, result);
                     completed_tool_calls += 1;
                 }
+            }
+        }
+    }
+
+    async fn execute_tool_call(
+        &self,
+        call: &ToolCall,
+        read_tool: Option<&ReadTool>,
+        write_tool: Option<&WriteTool>,
+        completed_tool_calls: usize,
+        turn_id: Option<LifecycleId>,
+    ) -> Result<String, TurnError> {
+        let mut tool_lifecycle = self
+            .lifecycle
+            .request_tool(call.name().to_string(), turn_id);
+        let execution = match call.arguments() {
+            ToolCallArguments::Read(arguments) => {
+                read_tool.map(|tool| ToolExecution::Read(tool, arguments))
+            }
+            ToolCallArguments::Write(arguments) => {
+                write_tool.map(|tool| ToolExecution::Write(tool, arguments))
+            }
+        };
+        let Some(execution) = execution else {
+            if let Some(tool_lifecycle) = tool_lifecycle {
+                tool_lifecycle.denied();
+            }
+
+            return Err(TurnError::ToolDenied {
+                name: call.name().to_string(),
+            });
+        };
+        if completed_tool_calls >= self.max_tool_calls {
+            if let Some(tool_lifecycle) = tool_lifecycle {
+                tool_lifecycle.failed(ToolErrorType::CallLimit);
+            }
+
+            return Err(TurnError::ToolCallLimit {
+                limit: self.max_tool_calls,
+            });
+        }
+        if let Some(tool_lifecycle) = tool_lifecycle.as_mut() {
+            tool_lifecycle.started();
+        }
+        match execute_tool(execution).await {
+            Ok(result) => {
+                if let Some(tool_lifecycle) = tool_lifecycle {
+                    tool_lifecycle.completed();
+                }
+
+                Ok(result)
+            }
+            Err(error) => {
+                if let Some(tool_lifecycle) = tool_lifecycle {
+                    tool_lifecycle.failed(ToolErrorType::Execution);
+                }
+
+                Err(error)
             }
         }
     }
@@ -226,8 +268,11 @@ pub enum TurnError {
     #[error(transparent)]
     Read(#[from] ReadError),
     /// Repository-scoped tools were enabled without a repository root.
-    #[error("repository root is required when the read tool is allowed")]
+    #[error("repository root is required when a repository tool is allowed")]
     RepositoryRequired,
+    /// A repository write failed.
+    #[error(transparent)]
+    Write(#[from] WriteError),
     /// The model exceeded the bounded number of calls in one turn.
     #[error("model exceeded the per-turn tool call limit of {limit}")]
     ToolCallLimit {
@@ -242,10 +287,37 @@ impl TurnError {
         match self {
             Self::Model(error) => TurnErrorType::Model(error.error_type()),
             Self::ToolDenied { .. } => TurnErrorType::ToolDenied,
-            Self::Read(_) => TurnErrorType::Tool,
+            Self::Read(_) | Self::Write(_) => TurnErrorType::Tool,
             Self::RepositoryRequired => TurnErrorType::RepositoryRequired,
             Self::ToolCallLimit { .. } => TurnErrorType::ToolCallLimit,
         }
+    }
+}
+
+enum ToolExecution<'a> {
+    Read(&'a ReadTool, &'a ReadArguments),
+    Write(&'a WriteTool, &'a WriteArguments),
+}
+
+async fn execute_tool(execution: ToolExecution<'_>) -> Result<String, TurnError> {
+    match execution {
+        ToolExecution::Read(read_tool, arguments) => read_tool
+            .execute(arguments)
+            .await?
+            .to_tool_result()
+            .map_err(ReadError::from)
+            .map_err(TurnError::from),
+        ToolExecution::Write(write_tool, arguments) => match write_tool.execute(arguments).await {
+            Ok(output) => output
+                .to_tool_result()
+                .map_err(WriteError::from)
+                .map_err(TurnError::from),
+            Err(error) if error.is_model_correctable() => error
+                .to_tool_result(arguments.path())
+                .map_err(WriteError::from)
+                .map_err(TurnError::from),
+            Err(error) => Err(error.into()),
+        },
     }
 }
 
@@ -261,7 +333,6 @@ mod tests {
     use super::*;
     use crate::file_system::MockFileSystem;
     use crate::model::{MockModel, ModelMessage};
-    use crate::tool::{ReadArguments, ToolCall};
 
     fn object_schema() -> OutputSchema {
         OutputSchema::new(json!({
@@ -287,6 +358,16 @@ mod tests {
         response: ModelResponse,
     ) -> (ModelResponse, Option<crate::CompletionMetadata>) {
         (response, None)
+    }
+
+    fn write_call(id: &str, patch: &str) -> ToolCall {
+        let arguments = serde_json::from_value::<WriteArguments>(json!({
+            "path": "src/lib.rs",
+            "patch": patch
+        }))
+        .expect("write arguments should be valid");
+
+        ToolCall::write(id.to_string(), arguments, None)
     }
 
     fn readable_file_system() -> MockFileSystem {
@@ -549,6 +630,204 @@ mod tests {
         // Assert
         assert!(matches!(&error, TurnError::RepositoryRequired));
         assert_eq!(error.error_type(), TurnErrorType::RepositoryRequired);
+    }
+
+    #[tokio::test]
+    async fn completes_write_tool_round_trip() {
+        // Arrange
+        let patch = "--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
+        let mut model = MockModel::new();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        model
+            .expect_complete_with_optional_metadata()
+            .times(2)
+            .returning(move |request| {
+                let call_index = call_count.fetch_add(1, Ordering::SeqCst);
+                if call_index == 0 {
+                    assert_eq!(request.tools(), &[ToolDefinition::write()]);
+
+                    return Ok(response_without_metadata(ModelResponse::ToolCall(
+                        write_call("call_write", patch),
+                    )));
+                }
+                assert!(matches!(
+                    &request.messages()[2],
+                    ModelMessage::ToolResult {
+                        call_id,
+                        content,
+                        name,
+                    }
+                        if call_id == "call_write"
+                            && name == "write"
+                            && serde_json::from_str::<Value>(content).is_ok_and(|value| {
+                                value == json!({
+                                    "bytes_written": 4,
+                                    "path": "src/lib.rs",
+                                    "status": "applied"
+                                })
+                            })
+                ));
+
+                Ok(response_without_metadata(ModelResponse::Output(json!({
+                    "summary": "updated"
+                }))))
+            });
+        let mut file_system = MockFileSystem::new();
+        file_system
+            .expect_canonicalize()
+            .times(1)
+            .returning(|_| Ok(PathBuf::from("/repo")));
+        file_system
+            .expect_open_beneath()
+            .times(1)
+            .returning(|_, _| Ok(Box::new(Cursor::new(b"old\n".to_vec()))));
+        file_system
+            .expect_replace_beneath()
+            .times(1)
+            .withf(|_, _, expected, content| {
+                expected.as_deref() == Some(b"old\n".as_slice()) && content == b"new\n"
+            })
+            .returning(|_, _, _, _| Ok(()));
+        let harness = Harness::new(model)
+            .file_system(file_system)
+            .repository("repo")
+            .allow(Tool::Write);
+
+        // Act
+        let output = harness
+            .run("update the file", object_schema())
+            .await
+            .expect("write round trip should succeed");
+
+        // Assert
+        assert_eq!(output, json!({ "summary": "updated" }));
+    }
+
+    #[tokio::test]
+    async fn returns_correctable_write_rejection_to_model() {
+        // Arrange
+        let mut model = MockModel::new();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        model
+            .expect_complete_with_optional_metadata()
+            .times(2)
+            .returning(move |request| {
+                if call_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                    return Ok(response_without_metadata(ModelResponse::ToolCall(
+                        write_call("call_write", "not a unified diff"),
+                    )));
+                }
+                assert!(matches!(
+                    &request.messages()[2],
+                    ModelMessage::ToolResult { content, .. }
+                        if serde_json::from_str::<Value>(content)
+                            .is_ok_and(|value| value["status"] == "rejected")
+                ));
+
+                Ok(response_without_metadata(ModelResponse::Output(json!({
+                    "summary": "recovered"
+                }))))
+            });
+        let mut file_system = MockFileSystem::new();
+        file_system
+            .expect_canonicalize()
+            .times(1)
+            .returning(|_| Ok(PathBuf::from("/repo")));
+        file_system
+            .expect_open_beneath()
+            .times(1)
+            .returning(|_, _| Ok(Box::new(Cursor::new(b"old\n".to_vec()))));
+        file_system.expect_replace_beneath().times(0);
+        let harness = Harness::new(model)
+            .file_system(file_system)
+            .repository("repo")
+            .allow(Tool::Write);
+
+        // Act
+        let output = harness
+            .run("update", object_schema())
+            .await
+            .expect("model should recover from rejected patch");
+
+        // Assert
+        assert_eq!(output, json!({ "summary": "recovered" }));
+    }
+
+    #[tokio::test]
+    async fn returns_terminal_write_boundary_failure() {
+        // Arrange
+        let mut model = MockModel::new();
+        model
+            .expect_complete_with_optional_metadata()
+            .times(1)
+            .returning(|_| {
+                Ok(response_without_metadata(ModelResponse::ToolCall(
+                    write_call(
+                        "call_write",
+                        "--- /dev/null\n+++ b/src/lib.rs\n@@ -0,0 +1 @@\n+new\n",
+                    ),
+                )))
+            });
+        let mut file_system = MockFileSystem::new();
+        file_system
+            .expect_canonicalize()
+            .times(1)
+            .returning(|_| Err(io::Error::new(io::ErrorKind::NotFound, "missing root")));
+        let harness = Harness::new(model)
+            .file_system(file_system)
+            .repository("repo")
+            .allow(Tool::Write);
+
+        // Act
+        let error = harness
+            .run("update", object_schema())
+            .await
+            .expect_err("write boundary failure should end turn");
+
+        // Assert
+        assert!(matches!(
+            &error,
+            TurnError::Write(WriteError::RepositoryRoot { .. })
+        ));
+        assert_eq!(error.error_type(), TurnErrorType::Tool);
+    }
+
+    #[tokio::test]
+    async fn rejects_write_call_when_policy_denies_write() {
+        // Arrange
+        let mut model = MockModel::new();
+        model
+            .expect_complete_with_optional_metadata()
+            .times(1)
+            .returning(|request| {
+                assert_eq!(request.tools(), []);
+
+                Ok(response_without_metadata(ModelResponse::ToolCall(
+                    write_call(
+                        "call_denied",
+                        "--- /dev/null\n+++ b/src/lib.rs\n@@ -0,0 +1 @@\n+new\n",
+                    ),
+                )))
+            });
+        let mut file_system = MockFileSystem::new();
+        file_system.expect_canonicalize().times(0);
+        file_system.expect_open_beneath().times(0);
+        file_system.expect_replace_beneath().times(0);
+        let harness = Harness::new(model)
+            .file_system(file_system)
+            .repository("repo");
+
+        // Act
+        let error = harness
+            .run("update", object_schema())
+            .await
+            .expect_err("denied write should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            TurnError::ToolDenied { name } if name == "write"
+        ));
     }
 
     #[tokio::test]

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -1,7 +1,9 @@
 //! Lightweight, Rust-native LLM harness for application-facing agent workflows.
 //!
-//! The crate provides a provider-neutral model client, normalized completion
-//! metadata, validated structured output, and private provider backends.
+//! The crate provides a provider-neutral model loop, normalized completion
+//! metadata, validated structured output, and deny-by-default repository read
+//! and patch tools. Provider and local filesystem implementations remain
+//! behind injectable boundaries.
 
 mod chat_completion;
 mod file_system;
@@ -14,6 +16,7 @@ mod read;
 mod schema_contract;
 mod telemetry;
 mod tool;
+mod write;
 
 pub use file_system::{FileSystem, LocalFileSystem};
 pub use harness::{Harness, TurnError};
@@ -31,4 +34,5 @@ pub use provider::{
 };
 pub use read::{ReadError, ReadOutput};
 pub use schema_contract::{OutputSchema, OutputSchemaError};
-pub use tool::{ReadArguments, Tool, ToolCall, ToolDefinition};
+pub use tool::{ReadArguments, Tool, ToolCall, ToolCallArguments, ToolDefinition, WriteArguments};
+pub use write::{WriteError, WriteOutput};

--- a/crates/ag-harness/src/policy.rs
+++ b/crates/ag-harness/src/policy.rs
@@ -4,18 +4,21 @@ use crate::tool::Tool;
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(crate) struct Policy {
     read: bool,
+    write: bool,
 }
 
 impl Policy {
     pub(crate) fn allow(&mut self, tool: Tool) {
         match tool {
             Tool::Read => self.read = true,
+            Tool::Write => self.write = true,
         }
     }
 
     pub(crate) fn allows(self, tool: Tool) -> bool {
         match tool {
             Tool::Read => self.read,
+            Tool::Write => self.write,
         }
     }
 }
@@ -30,12 +33,15 @@ mod tests {
         let mut policy = Policy::default();
 
         // Act
-        let denied_by_default = policy.allows(Tool::Read);
+        let read_denied_by_default = policy.allows(Tool::Read);
+        let write_denied_by_default = policy.allows(Tool::Write);
         policy.allow(Tool::Read);
-        let explicitly_allowed = policy.allows(Tool::Read);
+        policy.allow(Tool::Write);
 
         // Assert
-        assert!(!denied_by_default);
-        assert!(explicitly_allowed);
+        assert!(!read_denied_by_default);
+        assert!(!write_denied_by_default);
+        assert!(policy.allows(Tool::Read));
+        assert!(policy.allows(Tool::Write));
     }
 }

--- a/crates/ag-harness/src/provider/kimi.rs
+++ b/crates/ag-harness/src/provider/kimi.rs
@@ -268,9 +268,12 @@ mod tests {
             .expect("response should contain a tool call");
         assert_eq!(call.id(), "call_kimi_read");
         assert_eq!(call.name(), "read");
-        assert_eq!(call.arguments().path(), "Cargo.toml");
-        assert_eq!(call.arguments().offset(), Some(1));
-        assert_eq!(call.arguments().limit(), Some(12));
+        let arguments = call
+            .read_arguments()
+            .expect("provider should decode read arguments");
+        assert_eq!(arguments.path(), "Cargo.toml");
+        assert_eq!(arguments.offset(), Some(1));
+        assert_eq!(arguments.limit(), Some(12));
     }
 
     #[tokio::test]

--- a/crates/ag-harness/src/provider/muse.rs
+++ b/crates/ag-harness/src/provider/muse.rs
@@ -376,9 +376,12 @@ mod tests {
             .expect("response should contain a tool call");
         assert_eq!(call.id(), "call_muse_read");
         assert_eq!(call.name(), "read");
-        assert_eq!(call.arguments().path(), "Cargo.toml");
-        assert_eq!(call.arguments().offset(), Some(1));
-        assert_eq!(call.arguments().limit(), Some(12));
+        let arguments = call
+            .read_arguments()
+            .expect("provider should decode read arguments");
+        assert_eq!(arguments.path(), "Cargo.toml");
+        assert_eq!(arguments.offset(), Some(1));
+        assert_eq!(arguments.limit(), Some(12));
     }
 
     #[tokio::test]

--- a/crates/ag-harness/src/provider/qwen.rs
+++ b/crates/ag-harness/src/provider/qwen.rs
@@ -315,9 +315,12 @@ mod tests {
             .expect("response should contain a tool call");
         assert_eq!(call.id(), "call_qwen_read");
         assert_eq!(call.name(), "read");
-        assert_eq!(call.arguments().path(), "Cargo.toml");
-        assert_eq!(call.arguments().offset(), Some(1));
-        assert_eq!(call.arguments().limit(), Some(12));
+        let arguments = call
+            .read_arguments()
+            .expect("provider should decode read arguments");
+        assert_eq!(arguments.path(), "Cargo.toml");
+        assert_eq!(arguments.offset(), Some(1));
+        assert_eq!(arguments.limit(), Some(12));
     }
 
     #[tokio::test]

--- a/crates/ag-harness/src/tool.rs
+++ b/crates/ag-harness/src/tool.rs
@@ -7,12 +7,18 @@ use serde_json::{Number, Value, json};
 const READ_DESCRIPTION: &str =
     "Read a repository-relative file, optionally selecting a line range.";
 const READ_NAME: &str = "read";
+const MAX_PATCH_BYTES: usize = 1024 * 1024;
+const MAX_PATH_BYTES: usize = 4 * 1024;
+const WRITE_DESCRIPTION: &str = "Apply one unified diff to one repository-relative text file.";
+const WRITE_NAME: &str = "write";
 
 /// Built-in tool that can be enabled for a harness run.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Tool {
     /// Repository-relative file reads.
     Read,
+    /// Repository-relative patch writes.
+    Write,
 }
 
 /// Provider-neutral definition of a native model tool.
@@ -35,11 +41,7 @@ impl ToolDefinition {
             parameters: json!({
                 "type": "object",
                 "properties": {
-                    "path": {
-                        "type": "string",
-                        "minLength": 1,
-                        "pattern": "^(?:[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.\\.[^/\\\\\\u0000]+)(?:/(?:[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.\\.[^/\\\\\\u0000]+))*$"
-                    },
+                    "path": repository_path_schema(),
                     "offset": {
                         "type": "integer",
                         "minimum": 1,
@@ -52,6 +54,27 @@ impl ToolDefinition {
                     }
                 },
                 "required": ["path"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    /// Defines the native `write` function tool.
+    pub fn write() -> Self {
+        Self {
+            description: WRITE_DESCRIPTION,
+            name: WRITE_NAME,
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "path": repository_path_schema(),
+                    "patch": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": MAX_PATCH_BYTES
+                    }
+                },
+                "required": ["path", "patch"],
                 "additionalProperties": false
             }),
         }
@@ -73,12 +96,20 @@ impl ToolDefinition {
     }
 }
 
+fn repository_path_schema() -> Value {
+    json!({
+        "type": "string",
+        "minLength": 1,
+        "maxLength": MAX_PATH_BYTES,
+        "pattern": "^(?:[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.\\.[^/\\\\\\u0000]+)(?:/(?:[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.\\.[^/\\\\\\u0000]+))*$"
+    })
+}
+
 /// Provider-neutral model request for one native tool invocation.
 #[derive(Clone, Eq, PartialEq)]
 pub struct ToolCall {
-    arguments: ReadArguments,
+    arguments: ToolArguments,
     id: String,
-    name: String,
     reasoning_content: Option<String>,
 }
 
@@ -88,7 +119,7 @@ impl fmt::Debug for ToolCall {
             .debug_struct("ToolCall")
             .field("arguments", &self.arguments)
             .field("id", &self.id)
-            .field("name", &self.name)
+            .field("name", &self.name())
             .field(
                 "reasoning_content",
                 &self.reasoning_content.as_ref().map(|_| "[REDACTED]"),
@@ -98,9 +129,28 @@ impl fmt::Debug for ToolCall {
 }
 
 impl ToolCall {
-    /// Returns the typed arguments supplied to the `read` function.
-    pub fn arguments(&self) -> &ReadArguments {
-        &self.arguments
+    /// Returns the typed arguments for this native tool call.
+    pub fn arguments(&self) -> ToolCallArguments<'_> {
+        match &self.arguments {
+            ToolArguments::Read(arguments) => ToolCallArguments::Read(arguments),
+            ToolArguments::Write(arguments) => ToolCallArguments::Write(arguments),
+        }
+    }
+
+    /// Returns typed `read` arguments when this is a `read` call.
+    pub fn read_arguments(&self) -> Option<&ReadArguments> {
+        match &self.arguments {
+            ToolArguments::Read(arguments) => Some(arguments),
+            ToolArguments::Write(_) => None,
+        }
+    }
+
+    /// Returns typed `write` arguments when this is a `write` call.
+    pub fn write_arguments(&self) -> Option<&WriteArguments> {
+        match &self.arguments {
+            ToolArguments::Read(_) => None,
+            ToolArguments::Write(arguments) => Some(arguments),
+        }
     }
 
     /// Returns the provider-assigned call identifier.
@@ -109,8 +159,11 @@ impl ToolCall {
     }
 
     /// Returns the requested native function name.
-    pub fn name(&self) -> &str {
-        &self.name
+    pub fn name(&self) -> &'static str {
+        match self.arguments {
+            ToolArguments::Read(_) => READ_NAME,
+            ToolArguments::Write(_) => WRITE_NAME,
+        }
     }
 
     pub(crate) fn read(
@@ -119,20 +172,49 @@ impl ToolCall {
         reasoning_content: Option<String>,
     ) -> Self {
         Self {
-            arguments,
+            arguments: ToolArguments::Read(arguments),
             id,
-            name: READ_NAME.to_string(),
+            reasoning_content,
+        }
+    }
+
+    pub(crate) fn write(
+        id: String,
+        arguments: WriteArguments,
+        reasoning_content: Option<String>,
+    ) -> Self {
+        Self {
+            arguments: ToolArguments::Write(arguments),
+            id,
             reasoning_content,
         }
     }
 
     pub(crate) fn arguments_json(&self) -> Result<String, serde_json::Error> {
-        serde_json::to_string(&self.arguments)
+        match &self.arguments {
+            ToolArguments::Read(arguments) => serde_json::to_string(arguments),
+            ToolArguments::Write(arguments) => serde_json::to_string(arguments),
+        }
     }
 
     pub(crate) fn reasoning_content(&self) -> Option<&str> {
         self.reasoning_content.as_deref()
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ToolArguments {
+    Read(ReadArguments),
+    Write(WriteArguments),
+}
+
+/// Borrowed typed arguments for one native tool call.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ToolCallArguments<'a> {
+    /// Arguments for a repository read.
+    Read(&'a ReadArguments),
+    /// Arguments for a repository patch write.
+    Write(&'a WriteArguments),
 }
 
 /// Validated arguments for the native `read` function.
@@ -174,6 +256,46 @@ impl ReadArguments {
     pub fn path(&self) -> &str {
         &self.path
     }
+}
+
+/// Validated arguments for the native `write` function.
+///
+/// `path` names exactly one repository-relative text file and `patch` is a
+/// standard unified diff that creates or updates that same file.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WriteArguments {
+    #[serde(deserialize_with = "deserialize_bounded_patch")]
+    patch: String,
+    #[serde(deserialize_with = "deserialize_repository_path")]
+    path: String,
+}
+
+impl WriteArguments {
+    /// Returns the unified diff supplied by the model.
+    pub fn patch(&self) -> &str {
+        &self.patch
+    }
+
+    /// Returns the repository-relative path to write.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+}
+
+fn deserialize_bounded_patch<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let patch = String::deserialize(deserializer)?;
+    if patch.is_empty() {
+        return Err(de::Error::custom("patch must not be empty"));
+    }
+    if patch.len() > MAX_PATCH_BYTES {
+        return Err(de::Error::custom("patch exceeds the byte limit"));
+    }
+
+    Ok(patch)
 }
 
 fn deserialize_optional_positive_integer<'de, D>(
@@ -233,6 +355,9 @@ where
     let path = String::deserialize(deserializer)?;
     if path.is_empty() {
         return Err(de::Error::custom("path must not be empty"));
+    }
+    if path.len() > MAX_PATH_BYTES {
+        return Err(de::Error::custom("path exceeds the byte limit"));
     }
     if path.starts_with('/') || path.contains('\\') {
         return Err(de::Error::custom("path must be repository-relative"));
@@ -323,6 +448,92 @@ mod tests {
 
         // Assert
         assert!(results.into_iter().all(|is_valid| !is_valid));
+    }
+
+    #[test]
+    fn write_definition_exposes_native_function_contract() {
+        // Arrange and Act
+        let definition = ToolDefinition::write();
+        let validator =
+            Validator::new(definition.parameters()).expect("write argument schema should compile");
+
+        // Assert
+        assert_eq!(definition.name(), "write");
+        assert_eq!(
+            definition.description(),
+            "Apply one unified diff to one repository-relative text file."
+        );
+        assert!(validator.is_valid(&json!({
+            "path": "src/lib.rs",
+            "patch": "--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n"
+        })));
+    }
+
+    #[test]
+    fn write_definition_and_arguments_reject_invalid_input() {
+        // Arrange
+        let definition = ToolDefinition::write();
+        let validator =
+            Validator::new(definition.parameters()).expect("write argument schema should compile");
+        let values = [
+            json!({}),
+            json!({ "path": "src/lib.rs" }),
+            json!({ "path": "src/lib.rs", "patch": "" }),
+            json!({ "path": "../lib.rs", "patch": "patch" }),
+            json!({ "path": "src/lib.rs", "patch": "patch", "extra": true }),
+            json!({ "path": "a".repeat(MAX_PATH_BYTES + 1), "patch": "patch" }),
+            json!({ "path": "src/lib.rs", "patch": "x".repeat(MAX_PATCH_BYTES + 1) }),
+        ];
+
+        // Act
+        let schema_results = values.clone().map(|value| validator.is_valid(&value));
+        let decode_results = values.map(serde_json::from_value::<WriteArguments>);
+
+        // Assert
+        assert!(schema_results.into_iter().all(|valid| !valid));
+        assert!(decode_results.into_iter().all(|result| result.is_err()));
+    }
+
+    #[test]
+    fn tool_call_exposes_matching_typed_arguments_and_serialization() {
+        // Arrange
+        let read_arguments = serde_json::from_value(json!({ "path": "Cargo.toml" }))
+            .expect("read arguments should decode");
+        let write_arguments = serde_json::from_value(json!({
+            "path": "src/lib.rs",
+            "patch": "patch"
+        }))
+        .expect("write arguments should decode");
+        let read = ToolCall::read(
+            "read-id".to_string(),
+            read_arguments,
+            Some("secret".to_string()),
+        );
+        let write = ToolCall::write("write-id".to_string(), write_arguments, None);
+
+        // Act
+        let read_json = read.arguments_json().expect("read arguments should encode");
+        let write_json = write
+            .arguments_json()
+            .expect("write arguments should encode");
+
+        // Assert
+        assert!(read.read_arguments().is_some());
+        assert!(read.write_arguments().is_none());
+        assert!(write.read_arguments().is_none());
+        assert_eq!(read.name(), "read");
+        assert_eq!(write.name(), "write");
+        let write_arguments = write
+            .write_arguments()
+            .expect("write arguments should be exposed");
+        assert_eq!(write_arguments.path(), "src/lib.rs");
+        assert_eq!(write_arguments.patch(), "patch");
+        assert_eq!(read_json, r#"{"path":"Cargo.toml"}"#);
+        assert_eq!(write_json, r#"{"patch":"patch","path":"src/lib.rs"}"#);
+        assert_eq!(read.reasoning_content(), Some("secret"));
+        assert!(format!("{read:?}").contains("[REDACTED]"));
+        assert!(matches!(read.arguments(), ToolCallArguments::Read(_)));
+        assert!(matches!(write.arguments(), ToolCallArguments::Write(_)));
     }
 
     #[test]

--- a/crates/ag-harness/src/write.rs
+++ b/crates/ag-harness/src/write.rs
@@ -1,0 +1,1242 @@
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::Serialize;
+use thiserror::Error;
+use tokio::io::AsyncReadExt as _;
+
+use crate::file_system::FileSystem;
+use crate::schema_contract;
+use crate::tool::WriteArguments;
+
+const BYTE_ORDER_MARK: &[u8] = b"\xef\xbb\xbf";
+const MAX_FILE_BYTES: usize = 2 * 1024 * 1024;
+
+/// Successful result of applying one repository write.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WriteOutput {
+    bytes_written: usize,
+    path: String,
+    status: &'static str,
+}
+
+impl WriteOutput {
+    /// Returns the number of bytes in the resulting file.
+    pub fn bytes_written(&self) -> usize {
+        self.bytes_written
+    }
+
+    /// Returns the repository-relative path that was written.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub(crate) fn to_tool_result(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+
+    fn new(path: String, bytes_written: usize) -> Self {
+        Self {
+            bytes_written,
+            path,
+            status: "applied",
+        }
+    }
+}
+
+/// Failure returned while validating or applying one repository write.
+#[derive(Debug, Error)]
+pub enum WriteError {
+    /// The existing file is not valid UTF-8 text.
+    #[error("write target `{path}` is not UTF-8 text")]
+    BinaryTarget {
+        /// Repository-relative target path.
+        path: String,
+    },
+    /// The bounded tool result could not be encoded for the model.
+    #[error("failed to encode write result: {0}")]
+    Encode(#[from] serde_json::Error),
+    /// The patch made no change to the target.
+    #[error("patch does not change `{path}`")]
+    NoChange {
+        /// Repository-relative target path.
+        path: String,
+    },
+    /// The patch could not be parsed or applied.
+    #[error("invalid patch: {reason}")]
+    Patch {
+        /// Bounded validation diagnostic.
+        reason: String,
+    },
+    /// The patch headers do not name the requested path.
+    #[error("patch headers do not match write path `{path}`")]
+    PathMismatch {
+        /// Repository-relative target path.
+        path: String,
+    },
+    /// Reading the current target failed.
+    #[error("failed to read write target `{path}`: {source}")]
+    ReadTarget {
+        /// Repository-relative target path.
+        path: String,
+        /// Underlying filesystem failure.
+        #[source]
+        source: io::Error,
+    },
+    /// The trusted repository root could not be resolved.
+    #[error("failed to resolve repository root `{path}`: {source}")]
+    RepositoryRoot {
+        /// Repository root supplied by the host.
+        path: PathBuf,
+        /// Underlying filesystem failure.
+        #[source]
+        source: io::Error,
+    },
+    /// The existing target exceeds the write safety limit.
+    #[error("write target `{path}` exceeds the {limit}-byte limit")]
+    TargetTooLarge {
+        /// Configured byte limit.
+        limit: usize,
+        /// Repository-relative target path.
+        path: String,
+    },
+    /// The requested diff operation is outside the one-file create/update
+    /// subset.
+    #[error("unsupported patch operation: {reason}")]
+    Unsupported {
+        /// Bounded explanation of the unsupported operation.
+        reason: String,
+    },
+    /// Atomically replacing the target failed.
+    #[error("failed to write target `{path}`: {source}")]
+    WriteTarget {
+        /// Repository-relative target path.
+        path: String,
+        /// Underlying filesystem failure.
+        #[source]
+        source: io::Error,
+    },
+}
+
+impl WriteError {
+    pub(crate) fn is_model_correctable(&self) -> bool {
+        match self {
+            Self::BinaryTarget { .. }
+            | Self::NoChange { .. }
+            | Self::Patch { .. }
+            | Self::PathMismatch { .. }
+            | Self::TargetTooLarge { .. }
+            | Self::Unsupported { .. } => true,
+            Self::WriteTarget { source, .. } => matches!(
+                source.kind(),
+                io::ErrorKind::AlreadyExists | io::ErrorKind::InvalidData
+            ),
+            Self::Encode(_) | Self::ReadTarget { .. } | Self::RepositoryRoot { .. } => false,
+        }
+    }
+
+    pub(crate) fn to_tool_result(&self, path: &str) -> Result<String, serde_json::Error> {
+        #[derive(Serialize)]
+        struct RejectedWrite<'a> {
+            error: String,
+            path: &'a str,
+            status: &'static str,
+        }
+
+        serde_json::to_string(&RejectedWrite {
+            error: schema_contract::bounded_diagnostic(self),
+            path,
+            status: "rejected",
+        })
+    }
+}
+
+pub(crate) struct WriteTool {
+    file_system: Arc<dyn FileSystem>,
+    repository_root: PathBuf,
+}
+
+impl WriteTool {
+    pub(crate) fn new(file_system: Arc<dyn FileSystem>, repository_root: PathBuf) -> Self {
+        Self {
+            file_system,
+            repository_root,
+        }
+    }
+
+    pub(crate) async fn execute(
+        &self,
+        arguments: &WriteArguments,
+    ) -> Result<WriteOutput, WriteError> {
+        let root = self
+            .file_system
+            .canonicalize(&self.repository_root)
+            .await
+            .map_err(|source| WriteError::RepositoryRoot {
+                path: self.repository_root.clone(),
+                source,
+            })?;
+        let current = self.read_current(&root, arguments.path()).await?;
+        let result = apply_unified_diff(arguments.path(), current.as_deref(), arguments.patch())?;
+        if result.len() > MAX_FILE_BYTES {
+            return Err(WriteError::TargetTooLarge {
+                limit: MAX_FILE_BYTES,
+                path: arguments.path().to_string(),
+            });
+        }
+        if current.as_deref() == Some(result.as_slice()) {
+            return Err(WriteError::NoChange {
+                path: arguments.path().to_string(),
+            });
+        }
+        let bytes_written = result.len();
+        self.file_system
+            .replace_beneath(&root, Path::new(arguments.path()), current, result)
+            .await
+            .map_err(|source| WriteError::WriteTarget {
+                path: arguments.path().to_string(),
+                source,
+            })?;
+
+        Ok(WriteOutput::new(
+            arguments.path().to_string(),
+            bytes_written,
+        ))
+    }
+
+    async fn read_current(&self, root: &Path, path: &str) -> Result<Option<Vec<u8>>, WriteError> {
+        let file = match self.file_system.open_beneath(root, Path::new(path)).await {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => {
+                return Err(WriteError::ReadTarget {
+                    path: path.to_string(),
+                    source,
+                });
+            }
+        };
+        let mut content = Vec::new();
+        file.take((MAX_FILE_BYTES + 1) as u64)
+            .read_to_end(&mut content)
+            .await
+            .map_err(|source| WriteError::ReadTarget {
+                path: path.to_string(),
+                source,
+            })?;
+        if content.len() > MAX_FILE_BYTES {
+            return Err(WriteError::TargetTooLarge {
+                limit: MAX_FILE_BYTES,
+                path: path.to_string(),
+            });
+        }
+
+        Ok(Some(content))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TextLine {
+    content: String,
+    newline: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PatchLineKind {
+    Addition,
+    Context,
+    Removal,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PatchLine {
+    kind: PatchLineKind,
+    text: TextLine,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Hunk {
+    lines: Vec<PatchLine>,
+    new_count: usize,
+    new_start: usize,
+    old_count: usize,
+    old_start: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct UnifiedDiff {
+    hunks: Vec<Hunk>,
+    modified_path: String,
+    original_path: String,
+}
+
+fn apply_unified_diff(
+    requested_path: &str,
+    current: Option<&[u8]>,
+    unified_patch: &str,
+) -> Result<Vec<u8>, WriteError> {
+    let diff = parse_unified_diff(unified_patch)?;
+    validate_headers(requested_path, current.is_some(), &diff)?;
+    let (bom, text) = decode_text(requested_path, current.unwrap_or_default())?;
+    let (line_ending, normalized) = normalize_line_endings(requested_path, text)?;
+    let mut output = apply_hunks(&normalized, &diff.hunks)?;
+    if line_ending == "\r\n" {
+        output = output.replace('\n', "\r\n");
+    }
+    let mut bytes = Vec::with_capacity(bom.len() + output.len());
+    bytes.extend_from_slice(bom);
+    bytes.extend_from_slice(output.as_bytes());
+
+    Ok(bytes)
+}
+
+fn parse_unified_diff(patch: &str) -> Result<UnifiedDiff, WriteError> {
+    let normalized = patch.replace("\r\n", "\n");
+    if normalized.contains('\r') {
+        return Err(patch_error("patch contains unsupported carriage returns"));
+    }
+    let mut lines = normalized.split_inclusive('\n').peekable();
+    let original_path = parse_header(lines.next(), "--- ")?;
+    let modified_path = parse_header(lines.next(), "+++ ")?;
+    let mut hunks = Vec::new();
+    let mut old_side_terminated = false;
+    let mut new_side_terminated = false;
+    while let Some(header) = lines.next() {
+        let header = strip_patch_newline(header);
+        let (old_start, old_count, new_start, new_count) = parse_hunk_header(header)?;
+        let mut hunk_lines: Vec<PatchLine> = Vec::new();
+        let mut previous_line_had_marker = false;
+        while let Some(line) = lines.next_if(|line| !line.starts_with("@@ ")) {
+            let line = strip_patch_newline(line);
+            if line == "\\ No newline at end of file" {
+                if previous_line_had_marker {
+                    return Err(patch_error("newline marker cannot be repeated"));
+                }
+                let previous = hunk_lines
+                    .last_mut()
+                    .ok_or_else(|| patch_error("newline marker has no preceding patch line"))?;
+                previous.text.newline = false;
+                match previous.kind {
+                    PatchLineKind::Addition => new_side_terminated = true,
+                    PatchLineKind::Context => {
+                        old_side_terminated = true;
+                        new_side_terminated = true;
+                    }
+                    PatchLineKind::Removal => old_side_terminated = true,
+                }
+                previous_line_had_marker = true;
+                continue;
+            }
+            let (prefix, content) = line
+                .split_at_checked(1)
+                .ok_or_else(|| patch_error("hunk contains an empty patch line"))?;
+            let kind = match prefix {
+                "+" => PatchLineKind::Addition,
+                " " => PatchLineKind::Context,
+                "-" => PatchLineKind::Removal,
+                _ => return Err(patch_error("hunk line must start with space, `+`, or `-`")),
+            };
+            if (old_side_terminated && kind != PatchLineKind::Addition)
+                || (new_side_terminated && kind != PatchLineKind::Removal)
+            {
+                return Err(patch_error(
+                    "newline marker must terminate its affected file side",
+                ));
+            }
+            hunk_lines.push(PatchLine {
+                kind,
+                text: TextLine {
+                    content: content.to_string(),
+                    newline: true,
+                },
+            });
+            previous_line_had_marker = false;
+        }
+        let actual_old = hunk_lines
+            .iter()
+            .filter(|line| line.kind != PatchLineKind::Addition)
+            .count();
+        let actual_new = hunk_lines
+            .iter()
+            .filter(|line| line.kind != PatchLineKind::Removal)
+            .count();
+        if actual_old != old_count || actual_new != new_count {
+            return Err(patch_error("hunk line counts do not match its header"));
+        }
+        hunks.push(Hunk {
+            lines: hunk_lines,
+            new_count,
+            new_start,
+            old_count,
+            old_start,
+        });
+    }
+    if hunks.is_empty() {
+        return Err(patch_error("patch must contain at least one hunk"));
+    }
+
+    Ok(UnifiedDiff {
+        hunks,
+        modified_path,
+        original_path,
+    })
+}
+
+fn parse_header(line: Option<&str>, prefix: &str) -> Result<String, WriteError> {
+    let line = line.ok_or_else(|| patch_error("patch is missing file headers"))?;
+    let line = strip_patch_newline(line);
+    let path = line
+        .strip_prefix(prefix)
+        .ok_or_else(|| patch_error("patch must start with `---` and `+++` file headers"))?
+        .split('\t')
+        .next()
+        .unwrap_or_default();
+    if path.is_empty() {
+        return Err(patch_error("patch file header path must not be empty"));
+    }
+
+    Ok(path.to_string())
+}
+
+fn parse_hunk_header(header: &str) -> Result<(usize, usize, usize, usize), WriteError> {
+    let ranges = header
+        .strip_prefix("@@ -")
+        .and_then(|header| header.split_once(" @@").map(|(ranges, _)| ranges))
+        .ok_or_else(|| patch_error("invalid unified diff hunk header"))?;
+    let (old_range, new_range) = ranges
+        .split_once(" +")
+        .ok_or_else(|| patch_error("invalid unified diff hunk ranges"))?;
+    let (old_start, old_count) = parse_range(old_range)?;
+    let (new_start, new_count) = parse_range(new_range)?;
+
+    Ok((old_start, old_count, new_start, new_count))
+}
+
+fn parse_range(range: &str) -> Result<(usize, usize), WriteError> {
+    let (start, count) = range.split_once(',').unwrap_or((range, "1"));
+    let start = start
+        .parse::<usize>()
+        .map_err(|_| patch_error("hunk range start is not a valid integer"))?;
+    let count = count
+        .parse::<usize>()
+        .map_err(|_| patch_error("hunk range count is not a valid integer"))?;
+
+    Ok((start, count))
+}
+
+fn validate_headers(path: &str, exists: bool, diff: &UnifiedDiff) -> Result<(), WriteError> {
+    if diff.modified_path == "/dev/null" {
+        return Err(WriteError::Unsupported {
+            reason: "file deletion is not supported".to_string(),
+        });
+    }
+    if header_path(&diff.modified_path) != path {
+        return Err(WriteError::PathMismatch {
+            path: path.to_string(),
+        });
+    }
+    if exists {
+        if diff.original_path == "/dev/null" {
+            return Err(WriteError::Unsupported {
+                reason: "create patch targets an existing file".to_string(),
+            });
+        }
+        if header_path(&diff.original_path) != path {
+            return Err(WriteError::Unsupported {
+                reason: "file rename is not supported".to_string(),
+            });
+        }
+    } else if diff.original_path != "/dev/null" {
+        return Err(WriteError::Unsupported {
+            reason: "new files require `/dev/null` as the original path".to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn header_path(path: &str) -> &str {
+    path.strip_prefix("a/")
+        .or_else(|| path.strip_prefix("b/"))
+        .unwrap_or(path)
+}
+
+fn decode_text<'a>(path: &str, bytes: &'a [u8]) -> Result<(&'a [u8], &'a str), WriteError> {
+    let (bom, text) = bytes
+        .strip_prefix(BYTE_ORDER_MARK)
+        .map_or((&[][..], bytes), |text| (BYTE_ORDER_MARK, text));
+    let text = std::str::from_utf8(text).map_err(|_| WriteError::BinaryTarget {
+        path: path.to_string(),
+    })?;
+
+    Ok((bom, text))
+}
+
+fn normalize_line_endings<'a>(
+    path: &str,
+    text: &'a str,
+) -> Result<(&'static str, std::borrow::Cow<'a, str>), WriteError> {
+    let bytes = text.as_bytes();
+    let has_crlf = bytes.windows(2).any(|pair| pair == b"\r\n");
+    let has_bare_lf = bytes
+        .iter()
+        .enumerate()
+        .any(|(index, byte)| *byte == b'\n' && (index == 0 || bytes[index - 1] != b'\r'));
+    let has_lone_cr = bytes
+        .iter()
+        .enumerate()
+        .any(|(index, byte)| *byte == b'\r' && bytes.get(index + 1) != Some(&b'\n'));
+    if has_lone_cr || (has_crlf && has_bare_lf) {
+        return Err(WriteError::Unsupported {
+            reason: format!("mixed or unsupported line endings in `{path}`"),
+        });
+    }
+    if has_crlf {
+        return Ok(("\r\n", std::borrow::Cow::Owned(text.replace("\r\n", "\n"))));
+    }
+
+    Ok(("\n", std::borrow::Cow::Borrowed(text)))
+}
+
+fn apply_hunks(current: &str, hunks: &[Hunk]) -> Result<String, WriteError> {
+    let mut source_lines = current.split_inclusive('\n');
+    let mut output = String::with_capacity(current.len());
+    let mut output_index = 0;
+    let mut source_index = 0;
+    let mut previous_original_end = None;
+    let mut new_side_terminated = false;
+    for hunk in hunks {
+        let original_index = if hunk.old_count == 0 {
+            hunk.old_start
+        } else {
+            hunk.old_start
+                .checked_sub(1)
+                .ok_or_else(|| patch_error("non-empty hunk cannot start at original line zero"))?
+        };
+        let modified_index = if hunk.new_count == 0 {
+            hunk.new_start
+        } else {
+            hunk.new_start
+                .checked_sub(1)
+                .ok_or_else(|| patch_error("non-empty hunk cannot start at modified line zero"))?
+        };
+        if previous_original_end.is_some_and(|end| original_index < end) {
+            return Err(patch_error(
+                "hunks must use ascending, non-overlapping original ranges",
+            ));
+        }
+        previous_original_end = Some(
+            original_index
+                .checked_add(hunk.old_count)
+                .ok_or_else(|| patch_error("hunk original range overflowed"))?,
+        );
+        while source_index < original_index {
+            if new_side_terminated {
+                return Err(patch_error(
+                    "newline marker must terminate its affected file side",
+                ));
+            }
+            let source_line = source_lines
+                .next()
+                .ok_or_else(|| patch_error("hunk starts beyond the end of the target"))?;
+            output.push_str(source_line);
+            output_index += 1;
+            source_index += 1;
+        }
+        if modified_index != output_index {
+            return Err(patch_error(
+                "hunk modified range does not match its original range",
+            ));
+        }
+        for line in &hunk.lines {
+            match line.kind {
+                PatchLineKind::Addition => {
+                    push_text_line(&mut output, &line.text);
+                    output_index += 1;
+                    new_side_terminated = !line.text.newline;
+                }
+                PatchLineKind::Context => {
+                    let source_line = source_lines
+                        .next()
+                        .ok_or_else(|| patch_error("hunk context does not match the target"))?;
+                    if !source_line_matches(source_line, &line.text) {
+                        return Err(patch_error("hunk context does not match the target"));
+                    }
+                    output.push_str(source_line);
+                    output_index += 1;
+                    source_index += 1;
+                    new_side_terminated = !line.text.newline;
+                }
+                PatchLineKind::Removal => {
+                    let source_line = source_lines
+                        .next()
+                        .ok_or_else(|| patch_error("hunk removal does not match the target"))?;
+                    if !source_line_matches(source_line, &line.text) {
+                        return Err(patch_error("hunk removal does not match the target"));
+                    }
+                    source_index += 1;
+                }
+            }
+        }
+    }
+    if new_side_terminated && source_lines.next().is_some() {
+        return Err(patch_error(
+            "newline marker must terminate its affected file side",
+        ));
+    }
+    for source_line in source_lines {
+        output.push_str(source_line);
+    }
+
+    Ok(output)
+}
+
+fn source_line_matches(source: &str, expected: &TextLine) -> bool {
+    source.ends_with('\n') == expected.newline
+        && source.strip_suffix('\n').unwrap_or(source) == expected.content
+}
+
+fn push_text_line(output: &mut String, line: &TextLine) {
+    output.push_str(&line.content);
+    if line.newline {
+        output.push('\n');
+    }
+}
+
+fn strip_patch_newline(line: &str) -> &str {
+    line.strip_suffix('\n').unwrap_or(line)
+}
+
+fn patch_error(reason: impl Into<String>) -> WriteError {
+    WriteError::Patch {
+        reason: schema_contract::bounded_diagnostic(reason.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Write as _;
+    use std::io::Cursor;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use serde_json::json;
+    use tokio::io::{AsyncRead, ReadBuf};
+
+    use super::*;
+    use crate::file_system::MockFileSystem;
+
+    fn arguments(file_path: &str, unified_diff: &str) -> WriteArguments {
+        serde_json::from_value(json!({ "path": file_path, "patch": unified_diff }))
+            .expect("write arguments should be valid")
+    }
+
+    fn rooted_file_system() -> MockFileSystem {
+        let mut file_system = MockFileSystem::new();
+        file_system
+            .expect_canonicalize()
+            .once()
+            .returning(|_| Ok(PathBuf::from("/repo")));
+
+        file_system
+    }
+
+    struct FailingReader;
+
+    impl AsyncRead for FailingReader {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _context: &mut Context<'_>,
+            _buffer: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Ready(Err(io::Error::other("read failed")))
+        }
+    }
+
+    #[test]
+    fn applies_update_and_create_patches() {
+        // Arrange
+        let update = "--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1,2 +1,2 @@\n one\n-two\n+three\n";
+        let create = "--- /dev/null\n+++ b/new.txt\n@@ -0,0 +1,2 @@\n+hello\n+world\n";
+
+        // Act
+        let updated = apply_unified_diff("src/lib.rs", Some(b"one\ntwo\n"), update)
+            .expect("update patch should apply");
+        let created =
+            apply_unified_diff("new.txt", None, create).expect("create patch should apply");
+
+        // Assert
+        assert_eq!(updated, b"one\nthree\n");
+        assert_eq!(created, b"hello\nworld\n");
+    }
+
+    #[test]
+    fn preserves_crlf_bom_and_final_newline_conventions() {
+        // Arrange
+        let patch = concat!(
+            "--- a/file.txt\r\n",
+            "+++ b/file.txt\r\n",
+            "@@ -1 +1 @@\r\n",
+            "-old\r\n",
+            "\\ No newline at end of file\r\n",
+            "+new\r\n",
+            "\\ No newline at end of file\r\n",
+        );
+        let current = b"\xef\xbb\xbfold";
+
+        // Act
+        let output = apply_unified_diff("file.txt", Some(current), patch)
+            .expect("patch should preserve text conventions");
+        let regular = apply_unified_diff(
+            "file.txt",
+            Some(b"one\r\ntwo\r\n"),
+            "--- a/file.txt\n+++ b/file.txt\n@@ -1,2 +1,2 @@\n one\n-two\n+three\n",
+        )
+        .expect("patch should preserve regular CRLF text");
+
+        // Assert
+        assert_eq!(output, b"\xef\xbb\xbfnew");
+        assert_eq!(regular, b"one\r\nthree\r\n");
+    }
+
+    #[test]
+    fn permits_old_side_termination_before_new_additions() {
+        // Arrange
+        let patch = concat!(
+            "--- a/file.txt\n",
+            "+++ b/file.txt\n",
+            "@@ -1 +1,2 @@\n",
+            "-old\n",
+            "\\ No newline at end of file\n",
+            "+old\n",
+            "+new\n",
+        );
+
+        // Act
+        let output = apply_unified_diff("file.txt", Some(b"old"), patch)
+            .expect("new-side additions may follow old-side termination");
+
+        // Assert
+        assert_eq!(output, b"old\nnew\n");
+    }
+
+    #[test]
+    fn rejects_new_side_termination_before_unchanged_output() {
+        // Arrange
+        let patches = [
+            concat!(
+                "--- a/file.txt\n",
+                "+++ b/file.txt\n",
+                "@@ -1 +1,2 @@\n",
+                " first\n",
+                "+joined\n",
+                "\\ No newline at end of file\n",
+            ),
+            concat!(
+                "--- a/file.txt\n",
+                "+++ b/file.txt\n",
+                "@@ -1,0 +2 @@\n",
+                "+joined\n",
+                "\\ No newline at end of file\n",
+                "@@ -3 +2,0 @@\n",
+                "-third\n",
+            ),
+        ];
+
+        // Act
+        let errors = patches.map(|patch| {
+            apply_unified_diff("file.txt", Some(b"first\nsecond\nthird\n"), patch)
+                .expect_err("unchanged output cannot follow new-side termination")
+        });
+
+        // Assert
+        assert!(
+            errors
+                .iter()
+                .all(|error| matches!(error, WriteError::Patch { .. }))
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_unified_diffs() {
+        // Arrange
+        let patches = [
+            "",
+            "--- a/file\n",
+            "bad\n+++ b/file\n@@ -0,0 +1 @@\n+x\n",
+            "--- \n+++ b/file\n@@ -0,0 +1 @@\n+x\n",
+            "--- a/file\n+++ b/file\n",
+            "--- a/file\n+++ b/file\nnot-a-hunk\n",
+            "--- a/file\n+++ b/file\n@@ -1 1 @@\n x\n",
+            "--- a/file\n+++ b/file\n@@ -x +1 @@\n x\n",
+            "--- a/file\n+++ b/file\n@@ -1 +x @@\n x\n",
+            "--- a/file\n+++ b/file\n@@ -1 +1 @@\n",
+            "--- a/file\n+++ b/file\n@@ -1 +1 @@\n?x\n",
+            "--- a/file\n+++ b/file\n@@ -1 +1 @@\n\\ No newline at end of file\n",
+            concat!(
+                "--- a/file\n+++ b/file\n@@ -0,0 +1,2 @@\n",
+                "+first\n\\ No newline at end of file\n+second\n",
+            ),
+            concat!(
+                "--- a/file\n+++ b/file\n@@ -1,2 +1,2 @@\n",
+                " first\n\\ No newline at end of file\n-second\n+second\n",
+            ),
+            concat!(
+                "--- a/file\n+++ /dev/null\n@@ -1 +0,0 @@\n",
+                "-old\n\\ No newline at end of file\n",
+                "\\ No newline at end of file\n",
+            ),
+            "--- a/file\n+++ b/file\n@@ -1,2 +1 @@\n x\n",
+            "--- a/file\n+++ b/file\n@@ -1 +1,2 @@\n x\n",
+            "--- a/file\r+++ b/file\r@@ -1 +1 @@\r x",
+        ];
+
+        // Act
+        let errors = patches.map(|patch| {
+            parse_unified_diff(patch).expect_err("malformed patch should be rejected")
+        });
+
+        // Assert
+        assert!(
+            errors
+                .iter()
+                .all(|error| matches!(error, WriteError::Patch { .. }))
+        );
+    }
+
+    #[test]
+    fn rejects_delete_rename_and_header_mismatch() {
+        // Arrange
+        let cases = [
+            (
+                "file",
+                Some(b"x".as_slice()),
+                "--- a/file\n+++ /dev/null\n@@ -1 +0,0 @@\n-x\n",
+            ),
+            (
+                "other",
+                Some(b"x".as_slice()),
+                "--- a/file\n+++ b/file\n@@ -1 +1 @@\n-x\n+y\n",
+            ),
+            (
+                "file",
+                Some(b"x".as_slice()),
+                "--- /dev/null\n+++ b/file\n@@ -0,0 +1 @@\n+x\n",
+            ),
+            (
+                "file",
+                Some(b"x".as_slice()),
+                "--- a/old\n+++ b/file\n@@ -1 +1 @@\n-x\n+y\n",
+            ),
+            ("file", None, "--- a/file\n+++ b/file\n@@ -0,0 +1 @@\n+x\n"),
+        ];
+
+        // Act
+        let errors = cases.map(|(path, current, patch)| {
+            apply_unified_diff(path, current, patch)
+                .expect_err("unsupported file operation should be rejected")
+        });
+
+        // Assert
+        assert!(matches!(errors[0], WriteError::Unsupported { .. }));
+        assert!(matches!(errors[1], WriteError::PathMismatch { .. }));
+        assert!(
+            errors[2..]
+                .iter()
+                .all(|error| matches!(error, WriteError::Unsupported { .. }))
+        );
+    }
+
+    #[test]
+    fn rejects_binary_and_mixed_line_ending_targets() {
+        // Arrange
+        let patch = "--- a/file\n+++ b/file\n@@ -1 +1 @@\n-old\n+new\n";
+        let targets = [
+            b"\xff".as_slice(),
+            b"old\r\nnext\n".as_slice(),
+            b"old\rnext".as_slice(),
+        ];
+
+        // Act
+        let errors = targets.map(|target| {
+            apply_unified_diff("file", Some(target), patch)
+                .expect_err("unsupported target text should fail")
+        });
+
+        // Assert
+        assert!(matches!(errors[0], WriteError::BinaryTarget { .. }));
+        assert!(
+            errors[1..]
+                .iter()
+                .all(|error| matches!(error, WriteError::Unsupported { .. }))
+        );
+    }
+
+    #[test]
+    fn rejects_hunks_that_do_not_match_target() {
+        // Arrange
+        let patches = [
+            "--- a/file\n+++ b/file\n@@ -1 +1 @@\n other\n",
+            "--- a/file\n+++ b/file\n@@ -1 +1 @@\n-other\n+new\n",
+            "--- a/file\n+++ b/file\n@@ -3,0 +3,1 @@\n+new\n",
+            "--- a/file\n+++ b/file\n@@ -0 +1 @@\n-old\n+new\n",
+            "--- a/file\n+++ b/file\n@@ -1,0 +0,1 @@\n+new\n",
+            "--- a/file\n+++ b/file\n@@ -2,0 +2,1 @@\n+new\n",
+        ];
+
+        // Act
+        let errors = patches.map(|patch| {
+            apply_unified_diff("file", Some(b"old\n"), patch)
+                .expect_err("non-matching hunk should be rejected")
+        });
+
+        // Assert
+        assert!(
+            errors
+                .iter()
+                .all(|error| matches!(error, WriteError::Patch { .. }))
+        );
+    }
+
+    #[test]
+    fn rejects_out_of_order_hunks_before_offset_adjustment() {
+        // Arrange
+        let patch = concat!(
+            "--- a/file\n",
+            "+++ b/file\n",
+            "@@ -3 +3,2 @@\n",
+            " target\n",
+            "+extra\n",
+            "@@ -1 +1 @@\n",
+            "-first\n",
+            "+changed\n",
+        );
+
+        // Act
+        let error = apply_unified_diff("file", Some(b"first\nfirst\ntarget\n"), patch)
+            .expect_err("out-of-order hunks should fail");
+
+        // Assert
+        assert!(matches!(error, WriteError::Patch { .. }));
+        assert!(error.to_string().contains("ascending"));
+    }
+
+    #[test]
+    fn applies_zero_count_hunk_at_unified_diff_boundary() {
+        // Arrange
+        let patch = "--- a/file\n+++ b/file\n@@ -1,0 +2,1 @@\n+inserted\n";
+
+        // Act
+        let output = apply_unified_diff("file", Some(b"first\nsecond\n"), patch)
+            .expect("standard insertion hunk should apply");
+
+        // Assert
+        assert_eq!(output, b"first\ninserted\nsecond\n");
+    }
+
+    #[test]
+    fn rejects_inconsistent_modified_hunk_boundary() {
+        // Arrange
+        let patch = "--- a/file\n+++ b/file\n@@ -2,0 +2,1 @@\n+inserted\n";
+
+        // Act
+        let error = apply_unified_diff("file", Some(b"first\nsecond\n"), patch)
+            .expect_err("inconsistent modified range should fail");
+
+        // Assert
+        assert!(matches!(error, WriteError::Patch { .. }));
+        assert!(error.to_string().contains("modified range"));
+    }
+
+    #[test]
+    fn applies_many_insertions_in_linear_order() {
+        // Arrange
+        let mut current = String::new();
+        for index in 0..4_096 {
+            writeln!(current, "line-{index}").expect("string write should succeed");
+        }
+        let mut patch = String::from("--- a/file\n+++ b/file\n");
+        let mut inserted = String::new();
+        for index in 0..2_000 {
+            let new_start = 2_049 + index;
+            write!(patch, "@@ -2048,0 +{new_start} @@\n+insert-{index}\n")
+                .expect("patch write should succeed");
+            writeln!(inserted, "insert-{index}").expect("expected write should succeed");
+        }
+        let mut expected = String::new();
+        for index in 0..4_096 {
+            if index == 2_048 {
+                expected.push_str(&inserted);
+            }
+            writeln!(expected, "line-{index}").expect("expected write should succeed");
+        }
+
+        // Act
+        let output = apply_unified_diff("file", Some(current.as_bytes()), &patch)
+            .expect("insertion hunks should apply");
+
+        // Assert
+        assert_eq!(output, expected.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn write_tool_applies_patch_through_file_system_boundary() {
+        // Arrange
+        let mut file_system = rooted_file_system();
+        file_system
+            .expect_open_beneath()
+            .times(1)
+            .returning(|_, _| Ok(Box::new(Cursor::new(b"old\n".to_vec()))));
+        file_system
+            .expect_replace_beneath()
+            .times(1)
+            .withf(|root, path, expected, content| {
+                root == Path::new("/repo")
+                    && path == Path::new("file.txt")
+                    && expected.as_deref() == Some(b"old\n".as_slice())
+                    && content == b"new\n"
+            })
+            .returning(|_, _, _, _| Ok(()));
+        let tool = WriteTool::new(Arc::new(file_system), PathBuf::from("repo"));
+        let arguments = arguments(
+            "file.txt",
+            "--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-old\n+new\n",
+        );
+
+        // Act
+        let output = tool
+            .execute(&arguments)
+            .await
+            .expect("write should succeed");
+
+        // Assert
+        assert_eq!(output.path(), "file.txt");
+        assert_eq!(output.bytes_written(), 4);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(
+                &output.to_tool_result().expect("result should encode")
+            )
+            .expect("result should be JSON"),
+            json!({ "bytes_written": 4, "path": "file.txt", "status": "applied" })
+        );
+    }
+
+    #[tokio::test]
+    async fn write_tool_creates_missing_file() {
+        // Arrange
+        let mut file_system = rooted_file_system();
+        file_system
+            .expect_open_beneath()
+            .times(1)
+            .returning(|_, _| Err(io::Error::new(io::ErrorKind::NotFound, "missing")));
+        file_system
+            .expect_replace_beneath()
+            .times(1)
+            .withf(|_, _, expected, content| expected.is_none() && content == b"new\n")
+            .returning(|_, _, _, _| Ok(()));
+        let tool = WriteTool::new(Arc::new(file_system), PathBuf::from("repo"));
+        let arguments = arguments(
+            "file.txt",
+            "--- /dev/null\n+++ b/file.txt\n@@ -0,0 +1 @@\n+new\n",
+        );
+
+        // Act
+        let output = tool
+            .execute(&arguments)
+            .await
+            .expect("missing file should be created");
+
+        // Assert
+        assert_eq!(output.bytes_written(), 4);
+    }
+
+    #[tokio::test]
+    async fn write_tool_rejects_patch_that_makes_no_change() {
+        // Arrange
+        let mut file_system = rooted_file_system();
+        file_system
+            .expect_open_beneath()
+            .times(1)
+            .returning(|_, _| Ok(Box::new(Cursor::new(b"old\n".to_vec()))));
+        file_system.expect_replace_beneath().times(0);
+        let tool = WriteTool::new(Arc::new(file_system), PathBuf::from("repo"));
+        let arguments = arguments(
+            "file.txt",
+            "--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n old\n",
+        );
+
+        // Act
+        let error = tool
+            .execute(&arguments)
+            .await
+            .expect_err("no-op patch should fail");
+
+        // Assert
+        assert!(matches!(error, WriteError::NoChange { .. }));
+        assert!(error.is_model_correctable());
+    }
+
+    #[tokio::test]
+    async fn write_tool_returns_typed_replace_failure() {
+        // Arrange
+        let mut file_system = rooted_file_system();
+        file_system
+            .expect_open_beneath()
+            .times(1)
+            .returning(|_, _| Ok(Box::new(Cursor::new(b"old\n".to_vec()))));
+        file_system
+            .expect_replace_beneath()
+            .times(1)
+            .returning(|_, _, _, _| Err(io::Error::new(io::ErrorKind::PermissionDenied, "denied")));
+        let tool = WriteTool::new(Arc::new(file_system), PathBuf::from("repo"));
+        let arguments = arguments(
+            "file.txt",
+            "--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-old\n+new\n",
+        );
+
+        // Act
+        let error = tool
+            .execute(&arguments)
+            .await
+            .expect_err("replace failure should be typed");
+
+        // Assert
+        assert!(matches!(error, WriteError::WriteTarget { .. }));
+        assert!(!error.is_model_correctable());
+    }
+
+    #[tokio::test]
+    async fn write_tool_returns_typed_boundary_failures() {
+        // Arrange
+        let mut root_failure = MockFileSystem::new();
+        root_failure
+            .expect_canonicalize()
+            .times(1)
+            .returning(|_| Err(io::Error::new(io::ErrorKind::NotFound, "missing root")));
+        let root_tool = WriteTool::new(Arc::new(root_failure), PathBuf::from("repo"));
+        let mut read_failure = rooted_file_system();
+        read_failure
+            .expect_open_beneath()
+            .times(1)
+            .returning(|_, _| Err(io::Error::new(io::ErrorKind::PermissionDenied, "denied")));
+        let read_tool = WriteTool::new(Arc::new(read_failure), PathBuf::from("repo"));
+        let mut content_failure = rooted_file_system();
+        content_failure
+            .expect_open_beneath()
+            .once()
+            .returning(|_, _| Ok(Box::new(FailingReader)));
+        let content_tool = WriteTool::new(Arc::new(content_failure), PathBuf::from("repo"));
+        let arguments = arguments(
+            "file.txt",
+            "--- /dev/null\n+++ b/file.txt\n@@ -0,0 +1 @@\n+new\n",
+        );
+
+        // Act
+        let root_error = root_tool
+            .execute(&arguments)
+            .await
+            .expect_err("missing root should fail");
+        let read_error = read_tool
+            .execute(&arguments)
+            .await
+            .expect_err("read boundary failure should fail");
+        let content_error = content_tool
+            .execute(&arguments)
+            .await
+            .expect_err("content read failure should fail");
+
+        // Assert
+        assert!(matches!(root_error, WriteError::RepositoryRoot { .. }));
+        assert!(matches!(read_error, WriteError::ReadTarget { .. }));
+        assert!(matches!(content_error, WriteError::ReadTarget { .. }));
+        assert!(!root_error.is_model_correctable());
+        assert!(!read_error.is_model_correctable());
+    }
+
+    #[tokio::test]
+    async fn write_tool_bounds_target_and_returns_correctable_rejection() {
+        // Arrange
+        let mut file_system = rooted_file_system();
+        file_system
+            .expect_open_beneath()
+            .times(1)
+            .returning(|_, _| Ok(Box::new(Cursor::new(vec![b'x'; MAX_FILE_BYTES + 1]))));
+        file_system.expect_replace_beneath().times(0);
+        let tool = WriteTool::new(Arc::new(file_system), PathBuf::from("repo"));
+        let arguments = arguments(
+            "file.txt",
+            "--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-x\n+y\n",
+        );
+
+        // Act
+        let error = tool
+            .execute(&arguments)
+            .await
+            .expect_err("oversized target should fail");
+        let result = error
+            .to_tool_result("file.txt")
+            .expect("rejection should encode");
+
+        // Assert
+        assert!(matches!(error, WriteError::TargetTooLarge { .. }));
+        assert!(error.is_model_correctable());
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&result).expect("rejection should be JSON")
+                ["status"],
+            "rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_tool_bounds_resulting_file() {
+        // Arrange
+        let current = b"x\n".repeat(MAX_FILE_BYTES / 2);
+        let mut file_system = rooted_file_system();
+        file_system
+            .expect_open_beneath()
+            .times(1)
+            .return_once(move |_, _| Ok(Box::new(Cursor::new(current))));
+        file_system.expect_replace_beneath().times(0);
+        let tool = WriteTool::new(Arc::new(file_system), PathBuf::from("repo"));
+        let arguments = arguments(
+            "file.txt",
+            "--- a/file.txt\n+++ b/file.txt\n@@ -1048576,0 +1048577,1 @@\n+extra\n",
+        );
+
+        // Act
+        let error = tool
+            .execute(&arguments)
+            .await
+            .expect_err("oversized result should fail");
+
+        // Assert
+        assert!(matches!(error, WriteError::TargetTooLarge { .. }));
+    }
+
+    #[test]
+    fn classifies_stale_write_as_model_correctable() {
+        // Arrange
+        let stale = WriteError::WriteTarget {
+            path: "file.txt".to_string(),
+            source: io::Error::new(io::ErrorKind::InvalidData, "stale"),
+        };
+        let denied = WriteError::WriteTarget {
+            path: "file.txt".to_string(),
+            source: io::Error::new(io::ErrorKind::PermissionDenied, "denied"),
+        };
+        let existing = WriteError::WriteTarget {
+            path: "file.txt".to_string(),
+            source: io::Error::new(io::ErrorKind::AlreadyExists, "existing"),
+        };
+        let unrelated_missing = WriteError::WriteTarget {
+            path: "file.txt".to_string(),
+            source: io::Error::new(io::ErrorKind::NotFound, "unrelated missing path"),
+        };
+
+        // Act and Assert
+        assert!(stale.is_model_correctable());
+        assert!(existing.is_model_correctable());
+        assert!(!denied.is_model_correctable());
+        assert!(!unrelated_missing.is_model_correctable());
+    }
+}

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -89,9 +89,11 @@ training. The Muse example defaults to the standard model and accepts an explici
 
 The current tool foundation includes:
 
-- A shared native `read` contract across Qwen, Kimi, and Muse.
-- Repository-scoped read round trips with explicit permission.
-- Schema-validated terminal output and typed failures.
+- Shared, typed `read` and `write` calls across Qwen, Kimi, and Muse.
+- Explicit repository roots and deny-by-default permissions through `Harness::allow()`.
+- Bounded tool execution and continuation to schema-validated terminal output.
+- Descriptor-relative file access without symlink traversal.
+- One-file unified-diff writes with stale-safe atomic replacement and typed failures.
 
 ## Session management
 
@@ -151,8 +153,8 @@ sequenceDiagram
 
 - **Write** - the model produces a git diff patch; the harness applies it. Alternative
   edit methods (exact-match string replacement, etc.) are future experiments.
-- **Diff** - applied changes are streamed back as structured file-diff events,
-  renderable directly as git diffs.
+- **Diff** - persisted sessions will stream applied changes as structured file-diff
+  events; current writes return bounded status metadata.
 - **Output caps** - oversized tool output is truncated head+tail with a marker, so one
   careless command can't flood the session's context. Per-tool limits; `read` supports
   line ranges for precise re-reads.
@@ -199,15 +201,13 @@ bounded, redacted, and disabled by default.
 
 ## Permissions
 
-All tools are denied by default. The session policy explicitly allows tools and, for
-`bash`, the permitted commands:
+All tools are denied by default. Applications enable current tools explicitly:
 
 ```rust
-Policy {
-    read: Allow,
-    write: Deny,
-    bash: AllowCommands(["cargo test", "git status", "rg *"]),
-}
+Harness::new(model)
+    .repository(repository_root)
+    .allow(Tool::Read)
+    .allow(Tool::Write)
 ```
 
 ## Model tiers
@@ -222,10 +222,10 @@ best cost and performance:
 
 ## Library API
 
-- **Harness** - creates and resumes sessions.
-- **Session** - holds model, policy, working directory, and state.
-- **Turn** - runs one prompt and streams text, diffs, completion, and failure events.
-- **App** - configures the session and renders its events.
+- **Harness** - runs bounded tool calls to validated terminal JSON.
+- **Model** - provider-neutral completion boundary.
+- **FileSystem** - injectable repository I/O boundary.
+- **Session, Turn, App** - planned persistence and event-streaming layers.
 
 ## Differences from existing harnesses
 
@@ -241,7 +241,7 @@ best cost and performance:
 ## Next iterations
 
 - [x] **Read tool round trip.** Complete a model-requested repository read.
-- [ ] **Write tool round trip.** Complete a model-requested repository write.
+- [x] **Write tool round trip.** Complete a model-requested repository write.
 - [x] **Completion metadata foundation.** Normalize provider response identity, finish
   outcome, optional token usage, and stable model failure classifications.
 - [x] **Lifecycle event foundation.** Emit ordered, correlated, metadata-only turn,

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -33,8 +33,8 @@ For file-level detail, read the module docstrings directly.
   object-safe `Model` boundary, its `ModelClient` implementation, private Qwen, Kimi,
   and Muse policies, a shared Chat Completions backend with JSON Object and JSON Schema
   modes, backend-neutral request-duration telemetry, and a deny-by-default `Harness`
-  loop that executes bounded repository reads through an injectable `FileSystem`.
-  Application binaries own telemetry setup.
+  loop that executes bounded repository reads and stale-safe patch writes through an
+  injectable `FileSystem`. Application binaries own telemetry setup.
 - `crates/ag-protocol/`: Shared structured response protocol library crate with
   transport-neutral response models, schema generation, parser diagnostics, protocol
   prompt envelopes, repair prompts, review-comment outcomes, and turn prompt payload


### PR DESCRIPTION
- Advertises typed `write` tools under explicit policy control and applies bounded one-file unified diffs.
- Uses symlink-safe descriptor-relative atomic replacement with stale-content checks and no-replace creation.
- Returns model-correctable patch rejections while preserving terminal filesystem failures as typed turn errors.
- Adds stale-content capture, failed-write directory rollback, ordered hunk validation, regression coverage, and architecture documentation updates.
- Hardens write replacement against missing-path crash windows and unbounded stale-verification reads.
- Executes deny-by-default `read` and `write` tools through typed provider continuations and schema-validated terminal output.
- Applies one-file unified diffs with bounded text handling, stale-content checks, symlink-safe traversal, atomic replacement, and permission preservation.
- Returns typed terminal failures or bounded model-correctable rejections and documents the runnable provider examples and harness design.
- Preserves file access metadata across atomic replacement and bounds directory-lock acquisition.
- Verifies metadata stability, validates no-newline patch structure, and lets the model recover when an update target is concurrently deleted.
- Preserves extended attributes during atomic replacement and keeps update-lock behavior consistent across supported Unix platforms.
- Verifies atomic-exchange identities, retains failed-write parent directories, preserves concurrent replacements during rollback, and validates both sides of unified-diff hunk coordinates.
- Limits the README to a concise API and tool behavior overview.
- Adds the requested Clippy compatibility fixes.