### PR TITLE
Session refresh preserves active state after database failures

### DIFF
--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -4179,7 +4179,10 @@ async fn test_spawn_integration() {
 async fn test_running_turn_finishes_before_queued_sync_and_later_chat() {
     // Arrange
     let dir = tempdir().expect("failed to create temp dir");
-    let mut app = new_test_app_with_git(dir.path()).await;
+    let (database, pool) = AppRepositories::in_memory_with_pool()
+        .await
+        .expect("db should open");
+    let mut app = new_test_app_with_git_and_db(dir.path(), database).await;
     let release_first_turn = Arc::new(Notify::new());
     let release_first_turn_for_channel = Arc::clone(&release_first_turn);
     let turn_count = Arc::new(Mutex::new(0usize));
@@ -4246,6 +4249,7 @@ async fn test_running_turn_finishes_before_queued_sync_and_later_chat() {
         .await;
     assert_eq!(turn_started_rx.recv().await, Some(0));
     app.sessions.sync_from_handles();
+    refresh_with_session_table_unavailable(&mut app, &pool).await;
 
     // Act
     app.rebase_session(&session_id)
@@ -4283,6 +4287,19 @@ async fn test_running_turn_finishes_before_queued_sync_and_later_chat() {
         .expect("missing later queued prompt");
     assert!(initial_answer_index < sync_completion_index);
     assert!(sync_completion_index < queued_prompt_index);
+}
+
+/// Forces one session refresh to observe a failed primary row query.
+async fn refresh_with_session_table_unavailable(app: &mut App, pool: &sqlx::SqlitePool) {
+    sqlx::query("ALTER TABLE session RENAME TO unavailable_session")
+        .execute(pool)
+        .await
+        .expect("session table should become temporarily unavailable");
+    app.refresh_sessions_now().await;
+    sqlx::query("ALTER TABLE unavailable_session RENAME TO session")
+        .execute(pool)
+        .await
+        .expect("session table should become available again");
 }
 
 fn assert_sync_waits_without_canceling_turn(app: &mut App, session_id: &str) {

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -167,6 +167,22 @@ impl SessionManager {
         input: SessionLoadInput<'_>,
         handles: &mut HashMap<SessionId, SessionHandles>,
     ) -> (Vec<Session>, Vec<DailyActivity>, HashMap<SessionId, bool>) {
+        Self::try_load_sessions_with_fs_client(input, handles)
+            .await
+            .unwrap_or_default()
+    }
+
+    /// Loads session snapshots while preserving a session-list read failure.
+    ///
+    /// Refresh callers use this fallible path so a transient database error
+    /// cannot be mistaken for an empty project and tear down live workers.
+    ///
+    /// # Errors
+    /// Returns an error when the project's session rows cannot be loaded.
+    pub(crate) async fn try_load_sessions_with_fs_client(
+        input: SessionLoadInput<'_>,
+        handles: &mut HashMap<SessionId, SessionHandles>,
+    ) -> Result<(Vec<Session>, Vec<DailyActivity>, HashMap<SessionId, bool>), DbError> {
         let SessionLoadInput {
             active_project_id,
             active_session_id,
@@ -185,8 +201,7 @@ impl SessionManager {
         let db_rows = db
             .sessions()
             .load_sessions_for_project(active_project_id)
-            .await
-            .unwrap_or_default();
+            .await?;
         let activity_timestamps = db
             .activity()
             .load_session_activity_timestamps()
@@ -213,7 +228,7 @@ impl SessionManager {
             Self::push_loaded_session_row(&mut load_context, row).await;
         }
 
-        (sessions, stats_activity, session_worktree_availability)
+        Ok((sessions, stats_activity, session_worktree_availability))
     }
 
     /// Aggregates persisted activity timestamps using the clock-provided

--- a/crates/agentty/src/app/session/workflow/refresh.rs
+++ b/crates/agentty/src/app/session/workflow/refresh.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 use ag_forge as forge;
+use tracing::warn;
 
 use super::SESSION_REFRESH_INTERVAL;
 use super::load::SessionLoadInput;
@@ -127,7 +128,7 @@ impl SessionManager {
         let clock = services.clock();
         let fs_client = services.fs_client();
         let (mut sessions, stats_activity, session_worktree_availability) =
-            Self::load_sessions_with_fs_client(
+            match Self::try_load_sessions_with_fs_client(
                 SessionLoadInput {
                     active_project_id: projects.active_project_id(),
                     active_session_id: detail_session_id.as_deref(),
@@ -139,7 +140,18 @@ impl SessionManager {
                 },
                 self.state.handles_mut(),
             )
-            .await;
+            .await
+            {
+                Ok(loaded_sessions) => loaded_sessions,
+                Err(error) => {
+                    warn!(
+                        error = %error,
+                        "preserving active session state after refresh failure"
+                    );
+
+                    return;
+                }
+            };
         Self::preserve_live_orchestration_progress(&mut sessions, &live_orchestration_progress);
         self.state.replace_sessions(sessions);
         self.state

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -206,7 +206,9 @@ transcript. Worktree validation runs while the slot remains queued. After a succ
 notice before sending the same resolution event, so waiting state never disappears
 without an active state or visible result. If turn cancellation marks the queued rebase
 operation canceled before execution, the worker's skip path sends that resolution event
-without starting rebase work.
+without starting rebase work. Session-list refresh treats a failed primary row query as
+non-authoritative: it keeps the current snapshots and worker senders instead of treating
+the failure as an empty project and disconnecting an active queue.
 
 Published-branch auto-push completion sends one terminal reducer event carrying its
 `WorkflowNotice`. After accepting the current operation identifier, the reducer persists

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -226,15 +226,17 @@ the queued sync command starts. The existing worker must accept the request; Age
 never creates a second worker from an **InProgress** status just to start sync. If sync
 arrives while Agentty is draining queued chat, the active chat turn finishes before sync
 runs; earlier queued messages stay ahead of sync, while later messages wait behind it.
-Agentty shows a `[Sync]` notice only when sync resolves; while it waits, the
-consolidated queue shows `≡ sync — rebase onto the base branch after this turn`. The
-waiting row disappears when the active `Rebasing...` loader starts. Agentty validates
-the session worktree before that promotion; a validation failure replaces the waiting
-row with a durable `[Sync Error]` notice without showing sync as active. Repeated `r`
-presses keep the single queued rebase instead of adding duplicates. Session sync
-reserves branch-publish ownership before it queues or starts, and retains that ownership
-through its post-rebase push. A completed turn or subsequent sync therefore cannot start
-a competing published-branch auto-push.
+Transient session-list refresh failures preserve the current session snapshot and
+worker, so retrying `r` does not lose the active queue. Agentty shows a `[Sync]` notice
+only when sync resolves; while it waits, the consolidated queue shows
+`≡ sync — rebase onto the base branch after this turn`. The waiting row disappears when
+the active `Rebasing...` loader starts. Agentty validates the session worktree before
+that promotion; a validation failure replaces the waiting row with a durable
+`[Sync Error]` notice without showing sync as active. Repeated `r` presses keep the
+single queued rebase instead of adding duplicates. Session sync reserves branch-publish
+ownership before it queues or starts, and retains that ownership through its post-rebase
+push. A completed turn or subsequent sync therefore cannot start a competing
+published-branch auto-push.
 
 Pressing `p` during a running turn opens the usual branch-name popup and queues
 review-request creation on that same worker. The session remains **InProgress** and


### PR DESCRIPTION
- Failed primary session-row queries leave current snapshots and worker senders intact instead of appearing as an empty project.
- Regression coverage exercises an unavailable session table, and workflow docs describe retrying queued sync safely.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)