### PR TITLE
Hides generated review prompts during resolution

### DIFF
--- a/crates/ag-session/src/message.rs
+++ b/crates/ag-session/src/message.rs
@@ -13,6 +13,8 @@ const USER_PROMPT_PREFIX: &str = " › ";
 pub enum SessionMessageKind {
     /// Raw user prompt text without TUI prompt markers or transcript padding.
     UserPrompt,
+    /// Generated agent-facing prompt retained for replay but hidden from chat.
+    AgentPrompt,
     /// Raw assistant answer text without transcript padding.
     AssistantAnswer,
     /// Generic workflow notice emitted by Agentty session workflows.
@@ -24,6 +26,7 @@ impl SessionMessageKind {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::UserPrompt => "user_prompt",
+            Self::AgentPrompt => "agent_prompt",
             Self::AssistantAnswer => "assistant_answer",
             Self::WorkflowNotice => "workflow_notice",
         }
@@ -32,7 +35,15 @@ impl SessionMessageKind {
     /// Returns whether this kind represents a raw conversation message that
     /// belongs in the normal `session_message` store.
     pub fn is_conversation_message(self) -> bool {
-        matches!(self, Self::UserPrompt | Self::AssistantAnswer)
+        matches!(
+            self,
+            Self::UserPrompt | Self::AgentPrompt | Self::AssistantAnswer
+        )
+    }
+
+    /// Returns whether this kind starts one user-visible or generated turn.
+    pub fn is_prompt(self) -> bool {
+        matches!(self, Self::UserPrompt | Self::AgentPrompt)
     }
 }
 
@@ -48,6 +59,7 @@ impl FromStr for SessionMessageKind {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "user_prompt" => Ok(Self::UserPrompt),
+            "agent_prompt" => Ok(Self::AgentPrompt),
             "assistant_answer" => Ok(Self::AssistantAnswer),
             "workflow_notice" => Ok(Self::WorkflowNotice),
             _ => Err(SessionMessageKindParseError {
@@ -243,7 +255,9 @@ fn transcript_content_hash(messages: &[SessionMessage]) -> u64 {
 /// preserve exact content so status blocks keep their spacing.
 pub fn stored_message_content(kind: SessionMessageKind, content: &str) -> String {
     match kind {
-        SessionMessageKind::UserPrompt => normalized_user_prompt_content(content),
+        SessionMessageKind::UserPrompt | SessionMessageKind::AgentPrompt => {
+            normalized_user_prompt_content(content)
+        }
         SessionMessageKind::AssistantAnswer => normalized_message_content(content),
         SessionMessageKind::WorkflowNotice => content.to_string(),
     }
@@ -253,7 +267,7 @@ impl SessionMessage {
     /// Appends this message to a formatted transcript display buffer.
     fn append_display_text(&self, output: &mut String) {
         match self.kind {
-            SessionMessageKind::UserPrompt => {
+            SessionMessageKind::UserPrompt | SessionMessageKind::AgentPrompt => {
                 append_user_prompt_display_text(output, &self.content);
             }
             SessionMessageKind::AssistantAnswer => {
@@ -346,17 +360,26 @@ mod tests {
     #[test]
     fn test_session_message_kind_round_trips_database_value() {
         // Arrange
-        let kind = SessionMessageKind::AssistantAnswer;
+        let kinds = [
+            SessionMessageKind::UserPrompt,
+            SessionMessageKind::AgentPrompt,
+            SessionMessageKind::AssistantAnswer,
+            SessionMessageKind::WorkflowNotice,
+        ];
 
         // Act
-        let parsed = kind
-            .as_str()
-            .parse::<SessionMessageKind>()
-            .expect("kind should parse");
+        let parsed = kinds.map(|kind| {
+            kind.as_str()
+                .parse::<SessionMessageKind>()
+                .expect("kind should parse")
+        });
 
         // Assert
-        assert_eq!(parsed, kind);
-        assert_eq!(kind.to_string(), "assistant_answer");
+        assert_eq!(parsed, kinds);
+        assert_eq!(SessionMessageKind::AgentPrompt.to_string(), "agent_prompt");
+        assert!(SessionMessageKind::AgentPrompt.is_conversation_message());
+        assert!(SessionMessageKind::AgentPrompt.is_prompt());
+        assert!(!SessionMessageKind::AssistantAnswer.is_prompt());
     }
 
     #[test]
@@ -430,6 +453,29 @@ mod tests {
         assert_eq!(
             transcript.replay_text().expect("expected replay text"),
             " › first\n   second\n\n"
+        );
+    }
+
+    #[test]
+    fn test_session_transcript_replays_generated_agent_prompt() {
+        // Arrange
+        let messages = vec![SessionMessage::conversation(
+            1,
+            SessionMessageKind::AgentPrompt,
+            "resolve review comments",
+        )];
+
+        // Act
+        let transcript = SessionTranscript::new(messages);
+
+        // Assert
+        assert_eq!(
+            transcript.replay_text().expect("expected replay text"),
+            " › resolve review comments\n\n"
+        );
+        assert_eq!(
+            stored_message_content(SessionMessageKind::AgentPrompt, "\n  generated  \n"),
+            "  generated"
         );
     }
 

--- a/crates/agentty/src/app/prompt_intent.rs
+++ b/crates/agentty/src/app/prompt_intent.rs
@@ -12,8 +12,12 @@ use crate::domain::agent::{AgentKind, AgentModel, AgentSelection, ReasoningLevel
 use crate::domain::composer::PromptAttachment;
 use crate::domain::personality::PersonalitySummary;
 use crate::domain::review;
-use crate::domain::session::{Session, SessionId, Status};
+use crate::domain::session::{SessionId, Status};
 use crate::domain::transcript_notice::TranscriptNotice;
+use crate::domain::transient_message::{
+    TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
+    TransientMessageSlot,
+};
 use crate::domain::turn_prompt::{TurnPrompt, TurnPromptAttachment, TurnPromptTextSource};
 use crate::infra::clipboard_image;
 use crate::presentation::app_mode::{ReviewCommentAction, ReviewCommentActionSelection};
@@ -110,13 +114,15 @@ impl App {
         snapshot: &ReviewCommentSnapshot,
         selections: &[ReviewCommentActionSelection],
     ) -> ReviewCommentResolutionOutcome {
-        let can_reply = self
+        let Some(session_index) = self
             .sessions
             .sessions()
             .iter()
-            .find(|session| session.id == *session_id)
-            .is_some_and(Session::allows_review_comment_reply);
-        if !can_reply {
+            .position(|session| session.id == *session_id)
+        else {
+            return ReviewCommentResolutionOutcome::KeepReviewComments;
+        };
+        if !self.sessions.sessions()[session_index].allows_review_comment_reply() {
             return ReviewCommentResolutionOutcome::KeepReviewComments;
         }
 
@@ -132,6 +138,7 @@ impl App {
             .sessions()
             .update_session_focused_review(session_id, None, None, None)
             .await;
+        let comment_count = thread_ids.len();
         let enqueued = self
             .sessions
             .reply_to_review_comments(&self.services, session_id, prompt, thread_ids)
@@ -139,6 +146,19 @@ impl App {
         if !enqueued {
             return ReviewCommentResolutionOutcome::KeepReviewComments;
         }
+
+        // Reply enqueueing cannot reorder the exclusively borrowed session state,
+        // so the validated index remains stable across the awaited operation.
+        let session = &mut self.sessions.sessions_mut()[session_index];
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading(review_comment_resolution_loading_text(
+                comment_count,
+            )),
+            lifecycle: TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::ReviewCommentResolution,
+            turn_position: None,
+        });
 
         ReviewCommentResolutionOutcome::ShowSession {
             session_id: session_id.clone(),
@@ -562,6 +582,17 @@ impl App {
     }
 }
 
+/// Formats the in-progress label for one accepted review-comment batch.
+fn review_comment_resolution_loading_text(comment_count: usize) -> String {
+    let noun = if comment_count == 1 {
+        "review comment"
+    } else {
+        "review comments"
+    };
+
+    format!("Resolving {comment_count} {noun}...")
+}
+
 /// Builds the agent-facing `/apply` prompt from focused-review suggestions.
 ///
 /// The prompt explicitly asks the agent to verify each suggestion against the
@@ -608,7 +639,7 @@ pub(crate) fn build_resolve_review_comment_prompt(
         .trim_end()
         .replace("{{ fenced_review_comments }}", &fenced_review_comments);
 
-    Some((TurnPrompt::from_text(prompt), thread_ids))
+    Some((TurnPrompt::from_agent_data(prompt), thread_ids))
 }
 
 /// Returns the actionable inline threads selected for a turn.
@@ -1050,7 +1081,7 @@ mod tests {
             prompt.attachments,
             [] as [ag_protocol::TurnPromptAttachment; 0]
         );
-        assert_eq!(prompt.text_source, TurnPromptTextSource::UserPrompt);
+        assert_eq!(prompt.text_source, TurnPromptTextSource::AgentData);
     }
 
     /// Ensures an already-satisfied address request can resolve without a new
@@ -1362,6 +1393,23 @@ mod tests {
         assert_eq!(duplicate_apply, PromptApplyOutcome::ClearComposer);
     }
 
+    #[test]
+    fn test_review_comment_resolution_loading_text_pluralizes_comment_count() {
+        // Arrange
+        let cases = [
+            (1, "Resolving 1 review comment..."),
+            (2, "Resolving 2 review comments..."),
+        ];
+
+        // Act, Assert
+        for (comment_count, expected) in cases {
+            assert_eq!(
+                review_comment_resolution_loading_text(comment_count),
+                expected
+            );
+        }
+    }
+
     #[tokio::test]
     async fn test_resolve_session_review_comments_keeps_page_when_enqueue_fails() {
         // Arrange
@@ -1407,8 +1455,12 @@ mod tests {
             "thread-current",
             ReviewCommentAction::Address,
         )];
+        let missing_session_id = SessionId::from("missing-session");
 
         // Act
+        let missing = app
+            .resolve_session_review_comments(&missing_session_id, &snapshot, &selections)
+            .await;
         let blocked = app
             .resolve_session_review_comments(&session_id, &snapshot, &selections)
             .await;
@@ -1422,6 +1474,7 @@ mod tests {
             .await;
 
         // Assert
+        assert_eq!(missing, ReviewCommentResolutionOutcome::KeepReviewComments);
         assert_eq!(blocked, ReviewCommentResolutionOutcome::KeepReviewComments);
         assert_eq!(
             empty_selection,

--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -873,6 +873,9 @@ impl SessionManager {
         session.questions.clone_from(&turn_applied_state.questions);
         session.summary.clone_from(&turn_applied_state.summary);
         session.hydrate_summary_transient();
+        session
+            .transient_messages
+            .retract(TransientMessageSlot::ReviewCommentResolution);
         session.stats.input_tokens = session
             .stats
             .input_tokens

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -1117,7 +1117,7 @@ fn test_apply_session_speed_mode_updated_updates_only_matching_session() {
 }
 
 #[tokio::test]
-async fn test_apply_turn_applied_state_clears_active_prompt_output() {
+async fn test_apply_turn_applied_state_clears_active_prompt_and_resolution_loader() {
     // Arrange
     let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
     let mut app = new_test_app(temp_dir.path().to_path_buf()).await;
@@ -1130,6 +1130,15 @@ async fn test_apply_turn_applied_state_clears_active_prompt_output() {
     );
     app.sessions
         .set_active_prompt_output("session-id", " › Prompt\n\n".to_string());
+    app.sessions.sessions_mut()[0]
+        .transient_messages
+        .upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading("Resolving 1 review comment...".to_string()),
+            lifecycle: TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::ReviewCommentResolution,
+            turn_position: None,
+        });
 
     // Act
     app.sessions.apply_turn_applied_state(
@@ -1147,6 +1156,12 @@ async fn test_apply_turn_applied_state_clears_active_prompt_output() {
         !app.sessions
             .active_prompt_outputs()
             .contains_key("session-id")
+    );
+    assert!(
+        app.sessions.sessions()[0]
+            .transient_messages
+            .get(TransientMessageSlot::ReviewCommentResolution)
+            .is_none()
     );
 }
 
@@ -2690,6 +2705,111 @@ async fn test_resolve_session_review_comments_enqueues_turn_and_clears_focused_r
     // Arrange
     let dir = tempdir().expect("failed to create temp dir");
     let mut app = new_test_app_with_git(dir.path()).await;
+    let session_id = prepare_review_comment_resolution_session(&mut app).await;
+    let snapshot = review_comment_resolution_snapshot();
+    let (done_tx, mut done_rx) = tokio::sync::mpsc::unbounded_channel();
+    let turn_release = Arc::new(Notify::new());
+    let mut mock_channel = MockAgentChannel::new();
+    let turn_release_for_agent = Arc::clone(&turn_release);
+    mock_channel
+        .expect_run_turn()
+        .once()
+        .returning(move |_, request, _| {
+            assert!(request.prompt.text.contains("Thread ID: thread-42"));
+            let done_tx = done_tx.clone();
+            let turn_release = Arc::clone(&turn_release_for_agent);
+
+            Box::pin(async move {
+                let _ = done_tx.send(());
+                turn_release.notified().await;
+
+                Ok(TurnResult {
+                    assistant_message: AgentResponse::plain("Resolved the review comment."),
+                    context_reset: false,
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    provider_conversation_id: None,
+                })
+            })
+        });
+    mock_channel
+        .expect_shutdown_session()
+        .returning(|_| Box::pin(async { Ok(()) }));
+    app.sessions
+        .worker_service
+        .test_agent_channels
+        .insert(session_id.clone(), Arc::new(mock_channel));
+    let comment_actions = vec![ReviewCommentActionSelection {
+        action: ReviewCommentAction::Address,
+        thread_id: "thread-42".to_string(),
+    }];
+
+    // Act
+    let outcome = app
+        .resolve_session_review_comments(&session_id, &snapshot, &comment_actions)
+        .await;
+    done_rx.recv().await.expect("turn should start");
+    app.sessions.sync_from_handles();
+    let active_session = &app.sessions.sessions()[0];
+    let active_status = active_session.status;
+    let resolution_loader = active_session
+        .transient_messages
+        .get(TransientMessageSlot::ReviewCommentResolution)
+        .map(|message| message.body.text().to_string());
+    let generated_prompt_kind = active_session
+        .transcript
+        .as_ref()
+        .and_then(|transcript| transcript.messages().last())
+        .map(|message| message.kind);
+    turn_release.notify_one();
+    wait_for_status(&mut app, &session_id, Status::Review).await;
+    let focused_reviews = app
+        .services
+        .db()
+        .sessions()
+        .load_session_focused_reviews_for_project(app.active_project_id())
+        .await
+        .expect("failed to load focused reviews");
+    let persisted_messages = app
+        .services
+        .db()
+        .sessions()
+        .load_session_messages(session_id.as_str())
+        .await
+        .expect("session messages should load");
+    let persisted_generated_prompt = persisted_messages
+        .iter()
+        .find(|message| message.content.contains("Thread ID: thread-42"));
+
+    // Assert
+    assert_eq!(
+        outcome,
+        ReviewCommentResolutionOutcome::ShowSession {
+            session_id: session_id.clone(),
+        }
+    );
+    assert!(!app.review_cache.contains_key(&session_id));
+    assert_eq!(active_status, Status::InProgress);
+    assert_eq!(
+        resolution_loader.as_deref(),
+        Some("Resolving 1 review comment...")
+    );
+    assert_eq!(
+        generated_prompt_kind,
+        Some(crate::domain::session_message::SessionMessageKind::AgentPrompt)
+    );
+    assert!(matches!(
+        persisted_generated_prompt,
+        Some(message) if message.kind == "agent_prompt"
+    ));
+    assert_eq!(
+        focused_reviews,
+        [] as [crate::infra::db::SessionFocusedReviewRow; 0]
+    );
+}
+
+/// Prepares one review-ready session with persisted focused-review output.
+async fn prepare_review_comment_resolution_session(app: &mut App) -> SessionId {
     let session_id: SessionId = app
         .create_session()
         .await
@@ -2726,66 +2846,8 @@ async fn test_resolve_session_review_comments_enqueues_turn_and_clears_focused_r
         )
         .await
         .expect("failed to persist focused review");
-    let snapshot = review_comment_resolution_snapshot();
-    let (done_tx, mut done_rx) = tokio::sync::mpsc::unbounded_channel();
-    let mut mock_channel = MockAgentChannel::new();
-    mock_channel
-        .expect_run_turn()
-        .once()
-        .returning(move |_, request, _| {
-            assert!(request.prompt.text.contains("Thread ID: thread-42"));
-            let done_tx = done_tx.clone();
 
-            Box::pin(async move {
-                let _ = done_tx.send(());
-
-                Ok(TurnResult {
-                    assistant_message: AgentResponse::plain("Resolved the review comment."),
-                    context_reset: false,
-                    input_tokens: 0,
-                    output_tokens: 0,
-                    provider_conversation_id: None,
-                })
-            })
-        });
-    mock_channel
-        .expect_shutdown_session()
-        .returning(|_| Box::pin(async { Ok(()) }));
-    app.sessions
-        .worker_service
-        .test_agent_channels
-        .insert(session_id.clone(), Arc::new(mock_channel));
-    let comment_actions = vec![ReviewCommentActionSelection {
-        action: ReviewCommentAction::Address,
-        thread_id: "thread-42".to_string(),
-    }];
-
-    // Act
-    let outcome = app
-        .resolve_session_review_comments(&session_id, &snapshot, &comment_actions)
-        .await;
-    done_rx.recv().await.expect("turn should start");
-    wait_for_status(&mut app, &session_id, Status::Review).await;
-    let focused_reviews = app
-        .services
-        .db()
-        .sessions()
-        .load_session_focused_reviews_for_project(app.active_project_id())
-        .await
-        .expect("failed to load focused reviews");
-
-    // Assert
-    assert_eq!(
-        outcome,
-        ReviewCommentResolutionOutcome::ShowSession {
-            session_id: session_id.clone(),
-        }
-    );
-    assert!(!app.review_cache.contains_key(&session_id));
-    assert_eq!(
-        focused_reviews,
-        [] as [crate::infra::db::SessionFocusedReviewRow; 0]
-    );
+    session_id
 }
 
 /// Builds one actionable inline review thread for session-resolution tests.

--- a/crates/agentty/src/app/session/state.rs
+++ b/crates/agentty/src/app/session/state.rs
@@ -181,15 +181,22 @@ impl SessionState {
     /// Carrying transient output across that refresh keeps active loaders
     /// visible until their owning reducer resolves them.
     pub(crate) fn replace_sessions(&mut self, mut sessions: Vec<Session>) {
-        let transient_messages_by_session_id: HashMap<SessionId, _> = self
+        let transient_state_by_session_id: HashMap<SessionId, _> = self
             .sessions
             .iter()
-            .map(|session| (session.id.clone(), session.transient_messages.clone()))
+            .map(|session| {
+                (
+                    session.id.clone(),
+                    (session.status, session.transient_messages.clone()),
+                )
+            })
             .collect();
         for session in &mut sessions {
-            if let Some(transient_messages) = transient_messages_by_session_id.get(&session.id) {
+            if let Some((previous_status, transient_messages)) =
+                transient_state_by_session_id.get(&session.id)
+            {
                 session.transient_messages.clone_from(transient_messages);
-                session.reconcile_transient_messages();
+                session.reconcile_status_transition(*previous_status);
             }
         }
 
@@ -232,8 +239,9 @@ impl SessionState {
             return;
         };
 
+        let previous_status = session.status;
         Self::sync_session_with_handles(session, session_handles);
-        session.reconcile_transient_messages();
+        session.reconcile_status_transition(previous_status);
     }
 
     /// Copies current values from runtime handles into plain `Session` fields.
@@ -249,8 +257,9 @@ impl SessionState {
                 continue;
             };
 
+            let previous_status = session.status;
             Self::sync_session_with_handles(session, session_handles);
-            session.reconcile_transient_messages();
+            session.reconcile_status_transition(previous_status);
         }
     }
 
@@ -642,6 +651,46 @@ mod tests {
         // Assert
         assert_eq!(session_replay_text(&session), "New\n\n");
         assert_eq!(session.status, Status::InProgress);
+    }
+
+    #[test]
+    /// Verifies a failed turn's status sync clears its review-resolution
+    /// loader.
+    fn sync_from_handles_clears_review_resolution_loader_after_failed_turn() {
+        // Arrange
+        let session_id = SessionId::from("failed-review-resolution");
+        let mut session = SessionFixtureBuilder::new()
+            .id(session_id.as_str())
+            .status(Status::InProgress)
+            .build();
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading("Resolving 2 review comments...".to_string()),
+            lifecycle: TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::ReviewCommentResolution,
+            turn_position: None,
+        });
+        let handles = HashMap::from([(session_id, SessionHandles::new(Status::Review))]);
+        let mut state = SessionState::new(
+            handles,
+            vec![session],
+            SelectionState::default(),
+            Arc::new(FixedClock::new()),
+            0,
+            0,
+        );
+
+        // Act
+        state.sync_from_handles();
+
+        // Assert
+        assert_eq!(state.sessions[0].status, Status::Review);
+        assert!(
+            state.sessions[0]
+                .transient_messages
+                .get(TransientMessageSlot::ReviewCommentResolution)
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -122,12 +122,37 @@ impl ReplyEligibility {
     }
 }
 
+/// Transcript and output treatment for a submitted reply prompt.
+#[derive(Clone, Copy)]
+enum ReplyPromptPresentation {
+    /// Persist and render a normal user prompt.
+    Visible,
+    /// Persist generated agent context without rendering it in chat.
+    HiddenAgent,
+}
+
+impl ReplyPromptPresentation {
+    /// Returns the durable transcript kind for this presentation mode.
+    fn message_kind(self) -> SessionMessageKind {
+        match self {
+            Self::Visible => SessionMessageKind::UserPrompt,
+            Self::HiddenAgent => SessionMessageKind::AgentPrompt,
+        }
+    }
+
+    /// Returns whether the submitted prompt should render in session output.
+    fn is_visible(self) -> bool {
+        matches!(self, Self::Visible)
+    }
+}
+
 /// Reply-command behavior selected by the caller.
 struct ReplyOptions {
     defer_prompt_until_enqueued: bool,
     eligibility: ReplyEligibility,
     operation_id: Option<String>,
     persist_prompt: bool,
+    prompt_presentation: ReplyPromptPresentation,
     requires_existing_worker: bool,
     review_comment_thread_ids: Vec<String>,
 }
@@ -140,6 +165,7 @@ impl ReplyOptions {
             eligibility: ReplyEligibility::Standard,
             operation_id: None,
             persist_prompt: true,
+            prompt_presentation: ReplyPromptPresentation::Visible,
             requires_existing_worker: false,
             review_comment_thread_ids,
         }
@@ -153,6 +179,7 @@ impl ReplyOptions {
             eligibility: ReplyEligibility::QuestionAnswer,
             operation_id: None,
             persist_prompt: true,
+            prompt_presentation: ReplyPromptPresentation::Visible,
             requires_existing_worker,
             review_comment_thread_ids: Vec::new(),
         }
@@ -165,8 +192,22 @@ impl ReplyOptions {
             eligibility: ReplyEligibility::Standard,
             operation_id: Some(operation_id),
             persist_prompt,
+            prompt_presentation: ReplyPromptPresentation::Visible,
             requires_existing_worker: false,
             review_comment_thread_ids: Vec::new(),
+        }
+    }
+
+    /// Builds hidden generated-prompt behavior for forge review comments.
+    fn review_comments(review_comment_thread_ids: Vec<String>) -> Self {
+        Self {
+            defer_prompt_until_enqueued: false,
+            eligibility: ReplyEligibility::Standard,
+            operation_id: None,
+            persist_prompt: true,
+            prompt_presentation: ReplyPromptPresentation::HiddenAgent,
+            requires_existing_worker: false,
+            review_comment_thread_ids,
         }
     }
 }
@@ -1564,7 +1605,7 @@ impl SessionManager {
             session_id,
             prompt,
             session_agent,
-            ReplyOptions::standard(review_comment_thread_ids),
+            ReplyOptions::review_comments(review_comment_thread_ids),
         )
         .await
     }
@@ -2109,6 +2150,7 @@ impl SessionManager {
             eligibility,
             operation_id,
             persist_prompt,
+            prompt_presentation,
             requires_existing_worker,
             review_comment_thread_ids,
         } = options;
@@ -2139,24 +2181,14 @@ impl SessionManager {
         let status_transition =
             StatusTransition::from_services(services, handles, persisted_session_id.clone());
 
-        let effective_prompt = prompt;
-
-        if let Some(title) = title_to_save {
-            self.persist_first_message_metadata(
-                services,
-                &persisted_session_id,
-                &effective_prompt.text,
-                &title,
-            )
-            .await;
-
-            if !status_transition.apply(Status::InProgress).await {
-                warn!(
-                    session_id = %persisted_session_id,
-                    "skipped reply status update because the in-memory status did not transition to in-progress"
-                );
-            }
-        }
+        self.persist_initial_reply_metadata(
+            services,
+            &status_transition,
+            &persisted_session_id,
+            &prompt.text,
+            title_to_save,
+        )
+        .await;
 
         if persist_prompt && !defer_prompt_until_enqueued {
             self.append_reply_prompt_line(
@@ -2164,7 +2196,8 @@ impl SessionManager {
                 &transcript,
                 &app_event_tx,
                 &persisted_session_id,
-                &effective_prompt,
+                &prompt,
+                prompt_presentation,
             )
             .await;
         }
@@ -2177,7 +2210,7 @@ impl SessionManager {
         let command = Self::build_session_command(BuildSessionCommandInput {
             is_first_message,
             operation_id,
-            prompt: effective_prompt.clone(),
+            prompt: prompt.clone(),
             published_upstream_ref,
             replay_transcript,
             review_comment_thread_ids,
@@ -2188,7 +2221,7 @@ impl SessionManager {
                 services,
                 &transcript,
                 &persisted_session_id,
-                &effective_prompt,
+                &prompt,
                 command,
                 ReplyEnqueueOptions {
                     idempotent,
@@ -2206,12 +2239,37 @@ impl SessionManager {
                 &transcript,
                 &app_event_tx,
                 &persisted_session_id,
-                &effective_prompt,
+                &prompt,
+                prompt_presentation,
             )
             .await;
         }
 
         enqueued != ReplyEnqueueOutcome::Failed
+    }
+
+    /// Persists first-message metadata and starts a reply that targets a
+    /// blank draft session.
+    async fn persist_initial_reply_metadata(
+        &self,
+        services: &AppServices,
+        status_transition: &StatusTransition,
+        session_id: &SessionId,
+        prompt: &str,
+        title: Option<String>,
+    ) {
+        let Some(title) = title else {
+            return;
+        };
+
+        self.persist_first_message_metadata(services, session_id, prompt, &title)
+            .await;
+        if !status_transition.apply(Status::InProgress).await {
+            warn!(
+                session_id = %session_id,
+                "skipped reply status update because the in-memory status did not transition to in-progress"
+            );
+        }
     }
 
     /// Validates reply eligibility and gathers per-session values needed for
@@ -2319,9 +2377,9 @@ impl SessionManager {
         app_event_tx: &mpsc::UnboundedSender<AppEvent>,
         session_id: &str,
         prompt: &TurnPrompt,
+        presentation: ReplyPromptPresentation,
     ) {
         let prompt_transcript_text = prompt.transcript_text();
-        let reply_line = Self::formatted_prompt_output(prompt, true);
         SessionTaskService::append_session_transcript_message(
             transcript,
             services.db(),
@@ -2329,12 +2387,15 @@ impl SessionManager {
             &services.session_update_versions(),
             session_id,
             SessionTranscriptMessageAppend {
-                kind: SessionMessageKind::UserPrompt,
+                kind: presentation.message_kind(),
                 raw_content: &prompt_transcript_text,
             },
         )
         .await;
-        self.set_active_prompt_output(session_id, reply_line);
+        if presentation.is_visible() {
+            let reply_line = Self::formatted_prompt_output(prompt, true);
+            self.set_active_prompt_output(session_id, reply_line);
+        }
     }
 
     /// Formats one user prompt block for persisted session output.
@@ -4819,6 +4880,53 @@ mod tests {
                 .content
                 .contains("active session worker is unavailable")
         );
+    }
+
+    #[tokio::test]
+    async fn test_persist_initial_reply_metadata_keeps_terminal_status() {
+        // Arrange
+        let session = test_session("", Status::Merged, None, "");
+        let session_id = session.id.clone();
+        let database = database_with_session(&session).await;
+        let session_manager = session_manager_with_one_session(session);
+        let (services, mut event_rx) = test_services_with_event_receiver(
+            &database,
+            Arc::new(git::MockGitClient::new()),
+            Arc::new(forge::MockReviewRequestClient::new()),
+        );
+        let handles = SessionHandles::new(Status::Merged);
+        let status_transition =
+            StatusTransition::from_services(&services, &handles, session_id.clone());
+
+        // Act
+        session_manager
+            .persist_initial_reply_metadata(
+                &services,
+                &status_transition,
+                &session_id,
+                "Initial prompt",
+                Some("Initial title".to_string()),
+            )
+            .await;
+        let session_row = database
+            .sessions()
+            .load_sessions()
+            .await
+            .expect("sessions should load")
+            .into_iter()
+            .find(|row| session_id == row.id)
+            .expect("session row should exist");
+        let live_status = *handles
+            .status
+            .lock()
+            .expect("status lock should be available");
+
+        // Assert
+        assert_eq!(live_status, Status::Merged);
+        assert_eq!(session_row.status, Status::Merged.to_string());
+        assert_eq!(session_row.prompt, "Initial prompt");
+        assert_eq!(session_row.title.as_deref(), Some("Initial title"));
+        assert!(event_rx.try_recv().is_err());
     }
 
     #[test]

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -323,10 +323,7 @@ impl Session {
             .messages()
             .iter()
             .rev()
-            .find_map(|message| {
-                (message.kind == crate::domain::session_message::SessionMessageKind::UserPrompt)
-                    .then_some(message.position)
-            })
+            .find_map(|message| message.kind.is_prompt().then_some(message.position))
     }
 
     /// Rebuilds the visible summary slot from the latest persisted summary.
@@ -361,6 +358,16 @@ impl Session {
             slot: TransientMessageSlot::Summary,
             turn_position: self.latest_user_prompt_position(),
         });
+    }
+
+    /// Resolves turn-scoped messages when a snapshot leaves an active turn.
+    pub(crate) fn reconcile_status_transition(&mut self, previous_status: Status) {
+        if previous_status == Status::InProgress && self.status != Status::InProgress {
+            self.transient_messages
+                .retract(TransientMessageSlot::ReviewCommentResolution);
+        }
+
+        self.reconcile_transient_messages();
     }
 
     /// Applies turn-bound lifecycle cleanup after reducer-owned snapshot sync.
@@ -1730,6 +1737,25 @@ pub(crate) mod tests {
                 .expect("branch workflow should retain the completed summary");
             assert_eq!(summary.body.text(), "Completed summary");
         }
+    }
+
+    #[test]
+    fn test_latest_user_prompt_position_tracks_generated_turn() {
+        // Arrange
+        let mut session = SessionFixtureBuilder::new().status(Status::Review).build();
+        session.transcript = Some(SessionTranscript::new(vec![
+            crate::domain::session_message::SessionMessage::conversation(
+                7,
+                crate::domain::session_message::SessionMessageKind::AgentPrompt,
+                "resolve comments",
+            ),
+        ]));
+
+        // Act
+        let latest_prompt_position = session.latest_user_prompt_position();
+
+        // Assert
+        assert_eq!(latest_prompt_position, Some(7));
     }
 
     #[test]

--- a/crates/agentty/src/domain/transient_message.rs
+++ b/crates/agentty/src/domain/transient_message.rs
@@ -11,6 +11,8 @@ pub(crate) enum TransientMessageSlot {
     Summary,
     /// Focused review loading, result, or failure output.
     Review,
+    /// Active agent turn resolving selected forge review comments.
+    ReviewCommentResolution,
     /// Short-lived workflow feedback produced while finalizing a turn.
     WorkflowNotice,
     /// Live status for child sessions managed by an orchestrator.

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -10,6 +10,7 @@ use crate::app::session::{SessionTaskService, remote_branch_name_from_upstream_r
 use crate::app::{self, App, AppEvent, OrchestrationApprovalOutcome, ReviewCacheEntry};
 use crate::domain::input::InputState;
 use crate::domain::session::{FollowUpTaskAction, PublishBranchAction, SessionId, Status};
+use crate::domain::session_message::SessionMessageKind;
 use crate::domain::transcript_notice::TranscriptNotice;
 use crate::presentation::app_mode::{
     AppMode, ChatFocus, ConfirmationIntent, ConfirmationViewMode, DiffSidebarFocus, HelpContext,
@@ -918,7 +919,9 @@ async fn cancel_in_progress_turn(app: &mut App, session_id: &str) {
         .iter_mut()
         .find(|session| session.id == session_id)
     {
+        let previous_status = session.status;
         session.status = Status::Review;
+        session.reconcile_status_transition(previous_status);
     }
 
     suppress_auto_review_for_stopped_turn(app, session_id);
@@ -1097,58 +1100,29 @@ where
     ))
 }
 
-/// Extracts user prompt history entries from persisted session output text.
-///
-/// The parser accepts both legacy multiline prompts (raw continuation lines)
-/// and the current continuation-prefixed format where follow-up lines start
-/// with three spaces.
-fn prompt_history_entries(output: &str) -> Vec<String> {
-    let mut entries = Vec::new();
-    let mut output_lines = output.lines().peekable();
-
-    while let Some(line) = output_lines.next() {
-        let Some(first_prompt_line) = line.strip_prefix(" › ") else {
-            continue;
-        };
-
-        let mut prompt = first_prompt_line.to_string();
-
-        while let Some(next_line) = output_lines.peek().copied() {
-            if next_line.is_empty() {
-                break;
-            }
-
-            let prompt_line = next_line.strip_prefix("   ").unwrap_or(next_line);
-            prompt.push('\n');
-            prompt.push_str(prompt_line);
-            // Advance past the consumed continuation line.
-            let _ = output_lines.next();
-        }
-
-        entries.push(prompt);
-    }
-
-    entries
-}
-
 /// Returns prompt-history entries for the session-view prompt composer.
 ///
 /// Draft sessions use the staged prompt stored in `prompt` directly because
 /// they have not yet written user prompts into the persisted transcript.
+/// Started sessions read typed user rows so generated agent prompts remain
+/// available for provider replay without entering user-facing history.
 fn session_prompt_history_entries(session: &crate::domain::session::Session) -> Vec<String> {
     if session.status == Status::Draft && session.is_draft_session() {
         return vec![session.prompt.clone()];
     }
 
-    let Some(transcript_text) = session
+    session
         .transcript
         .as_ref()
-        .and_then(crate::domain::session_message::SessionTranscript::replay_text)
-    else {
-        return Vec::new();
-    };
-
-    prompt_history_entries(&transcript_text)
+        .map(|transcript| {
+            transcript
+                .messages()
+                .iter()
+                .filter(|message| message.kind == SessionMessageKind::UserPrompt)
+                .map(|message| message.content.clone())
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Opens review mode and serves cached review or loading status.
@@ -1228,7 +1202,11 @@ mod tests {
         ForgeKind, QueuedMessage, ReviewRequest, ReviewRequestState, ReviewRequestSummary,
         SessionRole,
     };
-    use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
+    use crate::domain::session_message::{SessionMessage, SessionTranscript};
+    use crate::domain::transient_message::{
+        TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
+        TransientMessageSlot,
+    };
     use crate::domain::turn_prompt::TurnPrompt;
     use crate::infra::tmux::{MockTmuxClient, TmuxClient};
     use crate::presentation::app_mode::PromptModeSnapshot;
@@ -1896,51 +1874,41 @@ mod tests {
     }
 
     #[test]
-    fn test_prompt_history_entries_extracts_user_prompts() {
+    fn test_session_prompt_history_entries_excludes_generated_agent_prompts() {
         // Arrange
-        let output = " › first\n\nassistant\n\n › second\n\n";
+        let mut session = crate::test_support::SessionFixtureBuilder::new()
+            .status(Status::Review)
+            .build();
+        session.transcript = Some(SessionTranscript::new(vec![
+            SessionMessage::conversation(
+                0,
+                SessionMessageKind::UserPrompt,
+                "first line\n\nsecond line",
+            ),
+            SessionMessage::conversation(
+                1,
+                SessionMessageKind::AgentPrompt,
+                "Process the selected review comments",
+            ),
+            SessionMessage::conversation(
+                2,
+                SessionMessageKind::AssistantAnswer,
+                "Resolved the review comments",
+            ),
+            SessionMessage::conversation(3, SessionMessageKind::UserPrompt, "latest prompt"),
+        ]));
 
         // Act
-        let entries = prompt_history_entries(output);
+        let entries = session_prompt_history_entries(&session);
 
         // Assert
-        assert_eq!(entries, vec!["first".to_string(), "second".to_string()]);
-    }
-
-    #[test]
-    fn test_prompt_history_entries_keeps_multiline_prompts() {
-        // Arrange
-        let output = " › first line\n   second line\n\nassistant\n\n";
-
-        // Act
-        let entries = prompt_history_entries(output);
-
-        // Assert
-        assert_eq!(entries, vec!["first line\nsecond line".to_string()]);
-    }
-
-    #[test]
-    fn test_prompt_history_entries_keeps_multiple_blank_lines_in_prompts() {
-        // Arrange
-        let output = " › first line\n   \n   \n   after gap\n\nassistant\n\n";
-
-        // Act
-        let entries = prompt_history_entries(output);
-
-        // Assert
-        assert_eq!(entries, vec!["first line\n\n\nafter gap".to_string()]);
-    }
-
-    #[test]
-    fn test_prompt_history_entries_ignores_non_prompt_lines() {
-        // Arrange
-        let output = "assistant line\n\n";
-
-        // Act
-        let entries = prompt_history_entries(output);
-
-        // Assert
-        assert_eq!(entries, [] as [std::string::String; 0]);
+        assert_eq!(
+            entries,
+            vec![
+                "first line\n\nsecond line".to_string(),
+                "latest prompt".to_string()
+            ]
+        );
     }
 
     #[tokio::test]
@@ -4218,6 +4186,15 @@ mod tests {
         // state after the first press has already drained queued messages.
         let (mut app, _base_dir, session_id) = new_test_app_with_session().await;
         app.sessions.sessions_mut()[0].status = Status::InProgress;
+        app.sessions.sessions_mut()[0]
+            .transient_messages
+            .upsert(TransientMessage {
+                anchor: TransientMessageAnchor::Tail,
+                body: TransientMessageBody::Loading("Resolving 2 review comments...".to_string()),
+                lifecycle: TransientMessageLifecycle::UntilResolved,
+                slot: TransientMessageSlot::ReviewCommentResolution,
+                turn_position: None,
+            });
         let _ = app
             .services
             .db()
@@ -4252,6 +4229,12 @@ mod tests {
             .lock()
             .expect("lock failed");
         assert_eq!(handle_status, Status::Review);
+        assert!(
+            app.sessions.sessions()[0]
+                .transient_messages
+                .get(TransientMessageSlot::ReviewCommentResolution)
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/agentty/src/ui/layout.rs
+++ b/crates/agentty/src/ui/layout.rs
@@ -1240,9 +1240,13 @@ mod tests {
         // Arrange
 
         // Act
-        let status_line =
-            session_output_status_line(Status::InProgress, Some("Inspecting changed files"), None)
-                .expect("in-progress sessions should render a status line");
+        let status_line = session_output_status_line(
+            Status::InProgress,
+            Some("Inspecting changed files"),
+            None,
+            None,
+        )
+        .expect("in-progress sessions should render a status line");
 
         // Assert
         assert!(
@@ -1257,9 +1261,13 @@ mod tests {
         // Arrange
 
         // Act
-        let status_line =
-            session_output_status_line(Status::InProgress, Some(COMMITTING_PROGRESS_LABEL), None)
-                .expect("in-progress sessions should render a status line");
+        let status_line = session_output_status_line(
+            Status::InProgress,
+            Some(COMMITTING_PROGRESS_LABEL),
+            None,
+            None,
+        )
+        .expect("in-progress sessions should render a status line");
 
         // Assert
         assert!(status_line.to_string().contains(COMMITTING_PROGRESS_LABEL));
@@ -1279,6 +1287,7 @@ mod tests {
             Status::AgentReview,
             None,
             Some("Reviewing changes with gpt-5.6-sol"),
+            None,
         )
         .expect("agent-review sessions should render a status line");
 
@@ -1295,7 +1304,7 @@ mod tests {
         // Arrange
 
         // Act
-        let status_line = session_output_status_line(Status::AgentReview, None, None)
+        let status_line = session_output_status_line(Status::AgentReview, None, None, None)
             .expect("agent-review sessions should render a status line");
 
         // Assert
@@ -1307,7 +1316,7 @@ mod tests {
         // Arrange
 
         // Act
-        let status_line = session_output_status_line(Status::Merging, None, None)
+        let status_line = session_output_status_line(Status::Merging, None, None, None)
             .expect("merging sessions should render a status line");
 
         // Assert

--- a/crates/agentty/src/ui/session_format.rs
+++ b/crates/agentty/src/ui/session_format.rs
@@ -315,6 +315,7 @@ pub fn session_output_status_line(
     status: Status,
     active_progress: Option<&str>,
     review_status_message: Option<&str>,
+    review_comment_resolution_message: Option<&str>,
 ) -> Option<Line<'static>> {
     if !matches!(
         status,
@@ -328,8 +329,12 @@ pub fn session_output_status_line(
         return None;
     }
 
-    let status_message =
-        session_output_status_message(status, active_progress, review_status_message);
+    let status_message = session_output_status_message(
+        status,
+        active_progress,
+        review_status_message,
+        review_comment_resolution_message,
+    );
 
     Some(Line::from(vec![Span::styled(
         format!("{} {status_message}", session_output_status_icon(status)),
@@ -411,20 +416,29 @@ fn session_output_status_message(
     status: Status,
     active_progress: Option<&str>,
     review_status_message: Option<&str>,
+    review_comment_resolution_message: Option<&str>,
 ) -> String {
     match status {
-        Status::InProgress => active_progress
+        Status::InProgress => review_comment_resolution_message
             .map(str::trim)
-            .filter(|progress| !progress.is_empty())
+            .filter(|message| !message.is_empty())
             .map_or_else(
-                || "Working...".to_string(),
-                |progress| {
-                    if progress == COMMITTING_PROGRESS_LABEL {
-                        progress.to_string()
-                    } else {
-                        format!("Working... {progress}")
-                    }
+                || {
+                    active_progress
+                        .map(str::trim)
+                        .filter(|progress| !progress.is_empty())
+                        .map_or_else(
+                            || "Working...".to_string(),
+                            |progress| {
+                                if progress == COMMITTING_PROGRESS_LABEL {
+                                    progress.to_string()
+                                } else {
+                                    format!("Working... {progress}")
+                                }
+                            },
+                        )
                 },
+                ToString::to_string,
             ),
         Status::AgentReview => review_status_message
             .map(str::trim)
@@ -684,7 +698,7 @@ mod tests {
         let status = Status::Merged;
 
         // Act
-        let message = session_output_status_message(status, None, None);
+        let message = session_output_status_message(status, None, None, None);
         let icon = session_output_status_icon(status);
 
         // Assert

--- a/crates/agentty/src/ui/session_output_assembly.rs
+++ b/crates/agentty/src/ui/session_output_assembly.rs
@@ -84,6 +84,7 @@ pub(crate) fn layout_from_body(
         session.status,
         active_progress,
         review_loading_message(session),
+        review_comment_resolution_loading_message(session),
     );
 
     SessionOutputLines {
@@ -340,6 +341,7 @@ impl SessionOutputAssembly<'_> {
             self.status,
             self.active_progress,
             review_loading_message(self.session),
+            review_comment_resolution_loading_message(self.session),
         );
     }
 }
@@ -390,10 +392,14 @@ fn append_session_tail_lines(
     status: Status,
     active_progress: Option<&str>,
     review_status_message: Option<&str>,
+    review_comment_resolution_message: Option<&str>,
 ) -> Option<usize> {
-    if let Some(status_line) =
-        session_format::session_output_status_line(status, active_progress, review_status_message)
-    {
+    if let Some(status_line) = session_format::session_output_status_line(
+        status,
+        active_progress,
+        review_status_message,
+        review_comment_resolution_message,
+    ) {
         append_block_separator(lines, SessionOutputSeparator::Always);
         let active_loader_line_index =
             session_format::session_output_uses_tachyon_loader(status).then_some(lines.len());
@@ -427,6 +433,18 @@ fn review_loading_message(session: &Session) -> Option<&str> {
         })
 }
 
+fn review_comment_resolution_loading_message(session: &Session) -> Option<&str> {
+    session
+        .transient_messages
+        .get(TransientMessageSlot::ReviewCommentResolution)
+        .and_then(|message| match &message.body {
+            TransientMessageBody::Loading(message) => Some(message.as_str()),
+            TransientMessageBody::Markdown(_)
+            | TransientMessageBody::Plain(_)
+            | TransientMessageBody::Queued(_) => None,
+        })
+}
+
 fn append_transient_message(
     lines: &mut Vec<Line<'static>>,
     message: &TransientMessage,
@@ -440,11 +458,7 @@ fn append_transient_message(
                     session_format::session_output_summary_markdown(markdown)
                 }
                 TransientMessageSlot::Review => session_format::format_review_markdown(markdown),
-                TransientMessageSlot::WorkflowNotice
-                | TransientMessageSlot::Orchestration
-                | TransientMessageSlot::BranchPublish
-                | TransientMessageSlot::SyncQueue
-                | TransientMessageSlot::PublishedBranchSync => markdown.clone(),
+                _ => markdown.clone(),
             };
             append_markdown_lines(lines, &markdown, inner_width, markdown_render_cache);
 
@@ -457,7 +471,10 @@ fn append_transient_message(
             None
         }
         TransientMessageBody::Loading(status_message) => {
-            if message.slot == TransientMessageSlot::Review {
+            if matches!(
+                message.slot,
+                TransientMessageSlot::Review | TransientMessageSlot::ReviewCommentResolution
+            ) {
                 return None;
             }
 
@@ -534,7 +551,7 @@ fn active_prompt_message_index(status: Status, messages: &[SessionMessage]) -> O
 
     messages
         .iter()
-        .rposition(|message| message.kind == SessionMessageKind::UserPrompt)
+        .rposition(|message| message.kind.is_prompt())
 }
 
 fn trailing_workflow_notice_start(messages: &[SessionMessage]) -> Option<usize> {
@@ -642,6 +659,7 @@ fn append_transcript_messages(
             SessionMessageKind::UserPrompt => {
                 append_user_prompt(lines, &message.content, inner_width, markdown_render_cache);
             }
+            SessionMessageKind::AgentPrompt => {}
             SessionMessageKind::AssistantAnswer | SessionMessageKind::WorkflowNotice => {
                 append_markdown_lines(lines, &message.content, inner_width, markdown_render_cache);
             }
@@ -968,6 +986,67 @@ mod tests {
         // Assert
         assert_eq!(loader_line_index, None);
         assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn test_generated_review_prompt_is_hidden_behind_resolution_loader() {
+        // Arrange
+        let mut session = crate::test_support::SessionFixtureBuilder::new()
+            .status(Status::InProgress)
+            .build();
+        session.transcript = Some(SessionTranscript::new(vec![
+            SessionMessage::conversation(0, SessionMessageKind::UserPrompt, "initial request"),
+            SessionMessage::conversation(1, SessionMessageKind::AssistantAnswer, "initial answer"),
+            SessionMessage::conversation(
+                2,
+                SessionMessageKind::AgentPrompt,
+                "Process the following selected forge review comments",
+            ),
+        ]));
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Loading("Resolving 3 review comments...".to_string()),
+            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::ReviewCommentResolution,
+            turn_position: None,
+        });
+
+        // Act
+        let output = output_lines(&session, 80, Some("Inspecting files"), None);
+        let rendered_text = output
+            .lines
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Assert
+        assert!(rendered_text.contains("initial request"));
+        assert!(rendered_text.contains("initial answer"));
+        assert!(rendered_text.contains("Resolving 3 review comments..."));
+        assert!(!rendered_text.contains("Process the following"));
+        assert!(!rendered_text.contains("Inspecting files"));
+        assert!(output.active_loader_line_index.is_some());
+        assert_eq!(output.transient_loader_line_index, None);
+    }
+
+    #[test]
+    fn test_review_comment_resolution_loader_ignores_non_loading_body() {
+        // Arrange
+        let mut session = crate::test_support::SessionFixtureBuilder::new().build();
+        session.transient_messages.upsert(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Plain("not loading".to_string()),
+            lifecycle: crate::domain::transient_message::TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::ReviewCommentResolution,
+            turn_position: None,
+        });
+
+        // Act
+        let loading_message = review_comment_resolution_loading_message(&session);
+
+        // Assert
+        assert_eq!(loading_message, None);
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/orchestration.rs
+++ b/crates/agentty/tests/e2e/orchestration.rs
@@ -908,8 +908,9 @@ fn managed_worker_review_hides_open_outside_tmux() -> E2eResult {
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::switch_to_tab("Sessions"))
                     .press_key("j")
-                    .press_key("Enter")
-                    .wait_for_text("Managed by controller-0001", 5000)
+                    .compose(&common::open_selected_session_view_with_texts(&[
+                        "Managed by controller-0001",
+                    ]))
                     .compose(&common::open_help_overlay())
                     .capture_labeled(
                         "managed_worker_review_help",

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -83,6 +83,9 @@ const RESOLVED_DECISION_REVIEW_TEXT: &str = "Resolved session decision honored."
 const REVIEW_REQUEST_TIMELINE_NOTICE_TEXT: &str =
     "Created PR https://github.com/agentty-xyz/agentty/pull/42";
 
+/// User-authored prompt retained in composer history after review resolution.
+const REVIEW_HISTORY_PROMPT_TEXT: &str = "Explain the review status loader";
+
 /// Stable policy phrase the focused-review stub expects in the prompt.
 ///
 /// This intentionally matches only the durable concept instead of one full
@@ -2497,7 +2500,7 @@ esac
 }
 
 /// Seeds the linked-review fixture with a delayed Claude turn so the feature
-/// scenario can observe the generated resolution prompt in progress.
+/// scenario can observe the review-resolution loader in progress.
 fn seed_review_comment_agent_resolution(
     env: &BuilderEnv,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -2535,6 +2538,14 @@ fn seed_review_comment_agent_resolution(
         database
             .sessions()
             .update_session_model("review-shortcut-0001", "claude-haiku-4-5-20251001")
+            .await?;
+        database
+            .sessions()
+            .append_session_message(
+                "review-shortcut-0001",
+                SessionMessageKind::UserPrompt,
+                REVIEW_HISTORY_PROMPT_TEXT,
+            )
             .await
     })?;
 
@@ -7112,13 +7123,21 @@ fn session_review_comment_agent_resolution() -> E2eResult {
                         "Comments marked to address and deny before batch submission",
                     )
                     .press_key("Enter")
-                    .wait_for_text("Process the following selected forge review comments", 5000)
-                    .wait_for_text("Working...", 5000)
-                    .wait_for_stable_frame(300, 5000)
+                    .wait_for_text("Resolving 2 review comments...", 5000)
                     .viewing_pause_ms(1500)
                     .capture_labeled(
                         "agent_review_comment_resolution",
                         "Address and deny batch submitted to the session agent",
+                    )
+                    .wait_for_text("Processed the selected review threads.", 15000)
+                    .wait_for_text("Enter: reply", 15000)
+                    .press_key("Enter")
+                    .wait_for_text("Type your message", 5000)
+                    .press_key("Up")
+                    .wait_for_text(REVIEW_HISTORY_PROMPT_TEXT, 5000)
+                    .capture_labeled(
+                        "review_comment_prompt_history",
+                        "Composer history retains only user-authored prompts",
                     )
             },
             |frame, report| {
@@ -7126,18 +7145,22 @@ fn session_review_comment_agent_resolution() -> E2eResult {
                 let selection_full = Region::full(selection_frame.cols(), selection_frame.rows());
                 assertion::assert_text_in_region(&selection_frame, "[A]", &selection_full);
                 assertion::assert_text_in_region(&selection_frame, "[D]", &selection_full);
+                let loader_frame = common::frame_from_capture(&report.captures[1]);
+                let loader_full = Region::full(loader_frame.cols(), loader_frame.rows());
+                assertion::assert_text_in_region(
+                    &loader_frame,
+                    "Resolving 2 review comments...",
+                    &loader_full,
+                );
                 let full = Region::full(frame.cols(), frame.rows());
 
-                assertion::assert_text_in_region(
+                assertion::assert_text_in_region(frame, REVIEW_HISTORY_PROMPT_TEXT, &full);
+                assertion::assert_not_visible(
                     frame,
                     "Process the following selected forge review comments",
-                    &full,
                 );
-                assertion::assert_text_in_region(frame, "Thread ID: thread-inline", &full);
-                assertion::assert_text_in_region(frame, "Requested action: Address", &full);
-                assertion::assert_text_in_region(frame, "Thread ID: thread-file", &full);
-                assertion::assert_text_in_region(frame, "Requested action: Deny", &full);
-                assertion::assert_text_in_region(frame, "Working...", &full);
+                assertion::assert_not_visible(frame, "Thread ID: thread-inline");
+                assertion::assert_not_visible(frame, "Requested action: Address");
             },
         )?;
 

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -228,7 +228,9 @@ Pressing the same action again clears that row; pressing the other action replac
 `a`, `d`, and `Enter` appear only while the session can accept a turn, and `Enter`
 appears only after at least one row is marked. Unresolved outdated threads remain
 actionable through their forge thread ID, although their original code context is no
-longer available. Resolved threads and standalone comments are read-only.
+longer available. Submission returns the session to **InProgress** with a count-aware
+resolution loader; the generated batch prompt remains hidden from chat. Resolved threads
+and standalone comments are read-only.
 
 ## Publish Popup
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -48,15 +48,17 @@ on the left, while the selected entry's metadata, attached current-diff context,
 conversation appear on the right. In **Review**, **AgentReview**, or **Question**, press
 `a` to send the selected actionable inline thread to the active session agent or `A` to
 send every actionable inline thread. Standalone comments are read-only because they do
-not have forge thread IDs. Conversation bodies render Markdown and common embedded HTML
-through the same shared text-rendering path used by review-request details.
-Forge-authored description and comment input is capped at `1 MiB` before normalization;
-truncated bodies end with `[Forge content truncated at 1 MiB.]`. The timer ticks only
-while the session is actively working. `Done` sessions use `c` to start a continuation
-draft and no longer expose review comments. File-level comments show an explicit
-no-line-context message instead of a synthetic code anchor. Each session stores the
-project's Smart reasoning default when it is created, so later default changes affect
-new sessions without relabeling existing ones.
+not have forge thread IDs. After submission, the session returns to **InProgress** and
+shows a count-aware `Resolving … review comments...` loader without exposing the
+generated agent instructions as a user message. Conversation bodies render Markdown and
+common embedded HTML through the same shared text-rendering path used by review-request
+details. Forge-authored description and comment input is capped at `1 MiB` before
+normalization; truncated bodies end with `[Forge content truncated at 1 MiB.]`. The
+timer ticks only while the session is actively working. `Done` sessions use `c` to start
+a continuation draft and no longer expose review comments. File-level comments show an
+explicit no-line-context message instead of a synthetic code anchor. Each session stores
+the project's Smart reasoning default when it is created, so later default changes
+affect new sessions without relabeling existing ones.
 
 The top status bar shows the current version and update status, and rotates short
 page-scoped `FYI:` messages once per minute in the **Sessions** list and session chat


### PR DESCRIPTION
- Persists batch review prompts as replayable `AgentPrompt` messages without rendering them in chat.
- Shows a count-aware resolution loader and clears it when the turn completes, fails, or is canceled.
- Treats generated prompts as prompt boundaries for session state and transcript replay.
- Excludes generated batch prompts from composer history.
- Retains user-authored prompt history during transcript replay.
- Makes the managed-worker outside-tmux E2E transition resilient under parallel CI load without changing product behavior or feature artifacts.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)