### PR TITLE
Preserves focused reviews across project switches

### DIFF
--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -1740,31 +1740,43 @@ impl App {
     /// Persists current focused-review generations and requeues transient
     /// failures through the foreground reducer.
     pub(crate) async fn persist_focused_review_updates(
-        &self,
+        &mut self,
         focused_review_persistence: Vec<FocusedReviewPersistence>,
     ) {
-        self.persist_focused_review_retries(
-            focused_review_persistence
-                .into_iter()
-                .map(FocusedReviewPersistenceRetry::initial)
-                .collect(),
-        )
-        .await;
+        let retries = focused_review_persistence
+            .into_iter()
+            .map(|persistence_update| {
+                self.pending_focused_review_persistence.insert(
+                    persistence_update.session_id.clone(),
+                    persistence_update.clone(),
+                );
+
+                FocusedReviewPersistenceRetry::initial(persistence_update)
+            })
+            .collect();
+
+        self.persist_focused_review_retries(retries).await;
     }
 
     /// Applies bounded focused-review persistence attempts while discarding
     /// retries superseded by newer cache state.
     async fn persist_focused_review_retries(
-        &self,
+        &mut self,
         focused_review_retries: Vec<FocusedReviewPersistenceRetry>,
     ) {
         for retry in focused_review_retries {
-            let persistence_update = &retry.persistence_update;
-            if !self
+            let persistence_update = retry.persistence_update.clone();
+            let is_current_persistence = self
+                .pending_focused_review_persistence
+                .get(&persistence_update.session_id)
+                == Some(&persistence_update);
+            let is_current_cache = self
                 .review_cache
                 .get(&persistence_update.session_id)
-                .is_some_and(|cache_entry| cache_entry.matches_persistence(persistence_update))
-            {
+                .is_some_and(|cache_entry| cache_entry.matches_persistence(&persistence_update));
+            if !is_current_persistence || !is_current_cache {
+                self.remove_current_focused_review_persistence(&persistence_update);
+
                 continue;
             }
 
@@ -1783,11 +1795,36 @@ impl App {
                     persistence_update.text.clone(),
                 )
                 .await;
-            Self::handle_focused_review_persistence_result(
+            let retry_scheduled = Self::handle_focused_review_persistence_result(
                 self.services.event_sender(),
                 retry,
                 result,
             );
+            if !retry_scheduled {
+                self.remove_current_focused_review_persistence(&persistence_update);
+            }
+        }
+
+        app::review::prune_review_cache(
+            &mut self.review_cache,
+            &self.pending_focused_review_persistence,
+            self.sessions.state(),
+        );
+    }
+
+    /// Clears one settled or stale pending write without removing a newer
+    /// focused-review generation for the same session.
+    fn remove_current_focused_review_persistence(
+        &mut self,
+        persistence_update: &FocusedReviewPersistence,
+    ) {
+        if self
+            .pending_focused_review_persistence
+            .get(&persistence_update.session_id)
+            == Some(persistence_update)
+        {
+            self.pending_focused_review_persistence
+                .remove(&persistence_update.session_id);
         }
     }
 
@@ -1797,27 +1834,30 @@ impl App {
         app_event_tx: tokio::sync::mpsc::UnboundedSender<AppEvent>,
         retry: FocusedReviewPersistenceRetry,
         result: Result<(), DbError>,
-    ) {
-        if let Err(error) = result {
-            let session_id = retry.persistence_update.session_id.clone();
-            let Some(retry) = retry.next() else {
-                warn!(
-                    session_id = %session_id,
-                    error = %error,
-                    "focused-review persistence retries exhausted; durable orchestration state \
-                     will recover the review on restart"
-                );
-
-                return;
-            };
+    ) -> bool {
+        let Err(error) = result else {
+            return false;
+        };
+        let session_id = retry.persistence_update.session_id.clone();
+        let Some(retry) = retry.next() else {
             warn!(
                 session_id = %session_id,
-                retry_attempt = retry.attempt,
                 error = %error,
-                "failed to persist focused review; scheduling retry"
+                "focused-review persistence retries exhausted; durable orchestration state \
+                 will recover the review on restart"
             );
-            app::task::TaskService::spawn_focused_review_persistence_retry(app_event_tx, retry);
-        }
+
+            return false;
+        };
+        warn!(
+            session_id = %session_id,
+            retry_attempt = retry.attempt,
+            error = %error,
+            "failed to persist focused review; scheduling retry"
+        );
+        app::task::TaskService::spawn_focused_review_persistence_retry(app_event_tx, retry);
+
+        true
     }
 
     /// Starts focused review generation for sessions that just entered review.
@@ -2929,6 +2969,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn completed_focused_review_persists_for_inactive_project() {
+        // Arrange
+        let (mut app, base_dir) = crate::test_support::new_test_app().await;
+        let inactive_project_path = base_dir.path().join("inactive-project");
+        let inactive_project_id = app
+            .services
+            .db()
+            .projects()
+            .upsert_project(&inactive_project_path.to_string_lossy(), None)
+            .await
+            .expect("failed to insert inactive project");
+        let session_id = SessionId::from("inactive-review");
+        let review_text = "## Review\nInactive project finding.";
+        app.services
+            .db()
+            .sessions()
+            .insert_session(
+                session_id.as_str(),
+                "gpt-5.6-sol",
+                "main",
+                "Review",
+                inactive_project_id,
+            )
+            .await
+            .expect("failed to insert inactive review session");
+        app.review_cache.insert(
+            session_id.clone(),
+            app::review::ReviewCacheEntry::Loading { diff_hash: 42 },
+        );
+
+        // Act
+        app.apply_app_events(AppEvent::ReviewPrepared {
+            diff_hash: 42,
+            review_text: review_text.to_string(),
+            session_id: session_id.clone(),
+        })
+        .await;
+        let persisted_reviews = app
+            .services
+            .db()
+            .sessions()
+            .load_session_focused_reviews_for_project(inactive_project_id)
+            .await
+            .expect("failed to load inactive project review");
+
+        // Assert
+        assert_eq!(persisted_reviews.len(), 1);
+        assert_eq!(persisted_reviews[0].session_id, session_id.as_str());
+        assert_eq!(persisted_reviews[0].diff_hash, "42");
+        assert_eq!(persisted_reviews[0].text, review_text);
+        assert!(!app.review_cache.contains_key(&session_id));
+        assert!(app.pending_focused_review_persistence.is_empty());
+    }
+
+    #[tokio::test]
     async fn failed_focused_review_persistence_retries_without_replaying_stale_state() {
         // Arrange
         let (mut app, _base_dir) = crate::test_support::new_test_app().await;
@@ -2952,8 +3047,12 @@ mod tests {
             status: crate::domain::review::FocusedReviewStatus::Ready,
             text: Some("review output".to_string()),
         };
+        app.pending_focused_review_persistence.insert(
+            persistence_update.session_id.clone(),
+            persistence_update.clone(),
+        );
         let (retry_tx, mut retry_rx) = tokio::sync::mpsc::unbounded_channel();
-        App::handle_focused_review_persistence_result(
+        let retry_scheduled = App::handle_focused_review_persistence_result(
             retry_tx,
             FocusedReviewPersistenceRetry::initial(persistence_update.clone()),
             Err(DbError::Query(sqlx::Error::PoolClosed)),
@@ -2985,7 +3084,7 @@ mod tests {
             .await
             .expect("failed to load retried focused review");
         let (exhausted_tx, mut exhausted_rx) = tokio::sync::mpsc::unbounded_channel();
-        App::handle_focused_review_persistence_result(
+        let exhausted_retry_scheduled = App::handle_focused_review_persistence_result(
             exhausted_tx,
             FocusedReviewPersistenceRetry {
                 attempt: app::review::MAX_FOCUSED_REVIEW_PERSISTENCE_RETRIES,
@@ -3000,6 +3099,8 @@ mod tests {
         assert_eq!(persisted[0].session_id, "session-1");
         assert_eq!(persisted[0].diff_hash, "42");
         assert_eq!(persisted[0].text, "review output");
+        assert!(retry_scheduled);
+        assert!(!exhausted_retry_scheduled);
         assert_eq!(exhausted_event, None);
     }
 

--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -168,6 +168,7 @@ impl App {
                 crate::presentation::settings::SettingsPresentationState::default(),
             tabs: crate::app::tab::TabManager::new(initial_tab),
             prompt_progress: std::collections::HashMap::new(),
+            pending_focused_review_persistence: std::collections::HashMap::new(),
             pending_session_diff_requests: std::collections::HashMap::new(),
             projects,
             services,

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -20,8 +20,8 @@ use app::branch_publish::{BranchPublishTaskFailure, branch_push_failure, push_se
 use app::merge_queue::{MergeQueue, MergeQueueProgress};
 use app::project::ProjectManager;
 use app::review::{
-    ReviewCacheEntry, mark_session_agent_review, review_failure_message, review_loading_message,
-    review_view_text, start_review_assist as spawn_review_assist,
+    FocusedReviewPersistence, ReviewCacheEntry, mark_session_agent_review, review_failure_message,
+    review_loading_message, review_view_text, start_review_assist as spawn_review_assist,
 };
 use app::service::AppServices;
 use app::session::SessionManager;
@@ -271,6 +271,9 @@ pub struct App {
     /// switches, is hydrated after restart, and is ready when the user presses
     /// `f`.
     pub(crate) review_cache: HashMap<SessionId, ReviewCacheEntry>,
+    /// Retains focused-review cache generations until their durable writes
+    /// settle so project-scoped refreshes cannot discard off-project output.
+    pub(crate) pending_focused_review_persistence: HashMap<SessionId, FocusedReviewPersistence>,
     /// Tracks background session-diff loads by request generation so stale
     /// completions cannot change the active mode or review generation.
     pub(crate) pending_session_diff_requests: HashMap<u64, PendingSessionDiffRequest>,
@@ -1481,7 +1484,11 @@ impl App {
             .refresh_sessions_if_needed(&mut self.mode, &self.projects, &self.services)
             .await;
         if refreshed {
-            app::review::prune_review_cache(&mut self.review_cache, self.sessions.state());
+            app::review::prune_review_cache(
+                &mut self.review_cache,
+                &self.pending_focused_review_persistence,
+                self.sessions.state(),
+            );
             app::review::hydrate_review_transients(
                 &self.review_cache,
                 self.sessions.state_mut(),
@@ -1497,7 +1504,11 @@ impl App {
         self.sessions
             .refresh_sessions_now(&mut self.mode, &self.projects, &self.services)
             .await;
-        app::review::prune_review_cache(&mut self.review_cache, self.sessions.state());
+        app::review::prune_review_cache(
+            &mut self.review_cache,
+            &self.pending_focused_review_persistence,
+            self.sessions.state(),
+        );
         app::review::hydrate_review_transients(
             &self.review_cache,
             self.sessions.state_mut(),

--- a/crates/agentty/src/app/review.rs
+++ b/crates/agentty/src/app/review.rs
@@ -213,11 +213,11 @@ pub(crate) fn hydrate_review_transient(
 /// Evicts inactive completed review entries while retaining in-flight work.
 ///
 /// A `Loading` entry must survive project switches so its eventual result can
-/// still be validated and persisted. Once that result arrives,
-/// [`apply_review_updates()`] replaces the entry and this pruning step removes
-/// it unless the session belongs to the currently loaded project.
+/// still be validated and persisted. Completed entries also remain while
+/// their durable write is pending; settled inactive entries are removed.
 pub(crate) fn prune_review_cache(
     review_cache: &mut HashMap<SessionId, ReviewCacheEntry>,
+    pending_persistence: &HashMap<SessionId, FocusedReviewPersistence>,
     session_state: &SessionState,
 ) {
     let active_session_ids = session_state
@@ -229,6 +229,7 @@ pub(crate) fn prune_review_cache(
     review_cache.retain(|session_id, cache_entry| {
         active_session_ids.contains(session_id.as_str())
             || matches!(cache_entry, ReviewCacheEntry::Loading { .. })
+            || pending_persistence.contains_key(session_id)
     });
 }
 
@@ -368,8 +369,6 @@ pub(crate) fn apply_review_updates(
             persistence_updates.push(persistence_update);
         }
     }
-
-    prune_review_cache(review_cache, session_state);
 
     persistence_updates
 }
@@ -801,10 +800,11 @@ mod tests {
     }
 
     #[test]
-    fn prune_review_cache_retains_active_and_loading_entries() {
+    fn prune_review_cache_retains_active_loading_and_pending_entries() {
         // Arrange
         let active_session_id = SessionId::from("active-session");
         let loading_session_id = SessionId::from("loading-session");
+        let pending_session_id = SessionId::from("inactive-ready");
         let mut review_cache = HashMap::from([
             (
                 active_session_id.clone(),
@@ -833,14 +833,24 @@ mod tests {
                 ReviewCacheEntry::Loading { diff_hash: 4 },
             ),
         ]);
+        let pending_persistence = HashMap::from([(
+            pending_session_id.clone(),
+            FocusedReviewPersistence {
+                diff_hash: Some(2),
+                session_id: pending_session_id.clone(),
+                status: FocusedReviewStatus::Ready,
+                text: Some("inactive review".to_string()),
+            },
+        )]);
         let session_state = session_state_with_stale_review(&active_session_id);
 
         // Act
-        prune_review_cache(&mut review_cache, &session_state);
+        prune_review_cache(&mut review_cache, &pending_persistence, &session_state);
 
         // Assert
-        assert_eq!(review_cache.len(), 2);
+        assert_eq!(review_cache.len(), 3);
         assert!(review_cache.contains_key(&active_session_id));
+        assert!(review_cache.contains_key(&pending_session_id));
         assert!(matches!(
             review_cache.get(&loading_session_id),
             Some(ReviewCacheEntry::Loading { diff_hash: 4 })
@@ -848,7 +858,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_review_updates_persists_and_evicts_inactive_success() {
+    fn apply_review_updates_retains_inactive_success_until_persistence() {
         // Arrange
         let session_id = SessionId::from("session-persist-review");
         let diff_hash = 19;
@@ -871,7 +881,10 @@ mod tests {
                 text: Some(review_text.to_string()),
             }]
         );
-        assert!(!review_cache.contains_key(&session_id));
+        assert!(matches!(
+            review_cache.get(&session_id),
+            Some(ReviewCacheEntry::Ready { diff_hash: 19, text }) if text == review_text
+        ));
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/common.rs
+++ b/crates/agentty/tests/e2e/common.rs
@@ -362,6 +362,88 @@ pub(crate) fn seed_session(
     Ok(())
 }
 
+/// Seed one additional never-opened Git project and start Agentty on the
+/// Sessions tab so project-switching scenarios share deterministic setup.
+///
+/// # Errors
+///
+/// Returns an error if the project repository or persisted metadata cannot
+/// be created.
+pub(crate) fn seed_second_project(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    seed_additional_project(env, "zeta-project")
+}
+
+/// Seed one project whose label sorts before `test-project`, making it MRU
+/// row zero after both projects receive the same pinned last-opened time.
+///
+/// # Errors
+///
+/// Returns an error if the project repository or persisted metadata cannot
+/// be created.
+pub(crate) fn seed_mru_first_second_project(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    seed_additional_project(env, "alpha-project")
+}
+
+/// Seed one additional never-opened Git project with the provided directory
+/// and display label.
+fn seed_additional_project(
+    env: &BuilderEnv,
+    project_name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let temp_root = env
+        .workdir
+        .parent()
+        .ok_or("missing temp root for second project")?;
+    let second_project_dir = temp_root.join(project_name);
+    std::fs::create_dir_all(&second_project_dir)?;
+    init_git_repository(&second_project_dir)?;
+
+    let second_project_path = second_project_dir.canonicalize()?;
+    let runtime = seed_runtime()?;
+    runtime.block_on(async {
+        let database = open_database(env).await?;
+        database
+            .projects()
+            .upsert_project(
+                &second_project_path.to_string_lossy(),
+                Some("main".to_string()),
+            )
+            .await?;
+        agentty::test_support::persist_active_tab_for_test(&database, agentty::app::Tab::Sessions)
+            .await?;
+
+        Ok::<(), agentty::db::DbError>(())
+    })?;
+
+    Ok(())
+}
+
+/// Initialize one deterministic `main`-branch Git repository for project
+/// switching scenarios.
+fn init_git_repository(directory: &Path) -> std::io::Result<()> {
+    let run = |arguments: &[&str]| -> std::io::Result<()> {
+        let output = std::process::Command::new("git")
+            .args(arguments)
+            .current_dir(directory)
+            .output()?;
+        if !output.status.success() {
+            return Err(std::io::Error::other(format!(
+                "git {} failed: {}",
+                arguments.join(" "),
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+
+        Ok(())
+    };
+    run(&["init", "-b", "main"])?;
+    run(&["config", "user.email", "test@test.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["commit", "--allow-empty", "-m", "init"])
+}
+
 /// Create the current-thread Tokio runtime used by synchronous E2E seeders.
 ///
 /// The E2E tests are synchronous `#[test]` functions, so database setup uses a

--- a/crates/agentty/tests/e2e/project.rs
+++ b/crates/agentty/tests/e2e/project.rs
@@ -1,12 +1,10 @@
 //! Projects page E2E tests: project dashboard activity and summary data.
 
-use std::path::Path;
-
 use testty::assertion;
 use testty::region::Region;
 
 use crate::common;
-use crate::common::{BuilderEnv, FeatureTest};
+use crate::common::FeatureTest;
 
 /// Verify that the Projects tab lists the registered git project name and
 /// branch from the temp workdir and shows dashboard activity plus work stats.
@@ -69,7 +67,7 @@ fn test_project_switcher() {
     // Arrange, Act, Assert
     FeatureTest::new("project_switcher")
         .with_git()
-        .setup(seed_second_project)
+        .setup(common::seed_second_project)
         .zola(
             "Project switcher",
             "Switch the active project from the Sessions view with a quick MRU popup.",
@@ -136,58 +134,4 @@ fn test_project_switcher() {
             },
         )
         .expect("feature test failed");
-}
-
-/// Seed one additional never-opened git project so the switcher popup lists
-/// two registered projects, and start the app on the Sessions tab.
-fn seed_second_project(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
-    let temp_root = env
-        .workdir
-        .parent()
-        .ok_or("missing temp root for second project")?;
-    let second_project_dir = temp_root.join("zeta-project");
-    std::fs::create_dir_all(&second_project_dir)?;
-    init_git_repository(&second_project_dir)?;
-
-    let second_project_path = second_project_dir.canonicalize()?;
-    let runtime = common::seed_runtime()?;
-    runtime.block_on(async {
-        let database = common::open_database(env).await?;
-        database
-            .projects()
-            .upsert_project(
-                &second_project_path.to_string_lossy(),
-                Some("main".to_string()),
-            )
-            .await?;
-        agentty::test_support::persist_active_tab_for_test(&database, agentty::app::Tab::Sessions)
-            .await?;
-
-        Ok::<(), agentty::db::DbError>(())
-    })?;
-
-    Ok(())
-}
-
-/// Initialize a `main`-branch git repository with one empty commit in `dir`.
-fn init_git_repository(dir: &Path) -> std::io::Result<()> {
-    let run = |args: &[&str]| -> std::io::Result<()> {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()?;
-        if !output.status.success() {
-            return Err(std::io::Error::other(format!(
-                "git {} failed: {}",
-                args.join(" "),
-                String::from_utf8_lossy(&output.stderr)
-            )));
-        }
-
-        Ok(())
-    };
-    run(&["init", "-b", "main"])?;
-    run(&["config", "user.email", "test@test.com"])?;
-    run(&["config", "user.name", "Test"])?;
-    run(&["commit", "--allow-empty", "-m", "init"])
 }

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -78,7 +78,6 @@ const PROMPT_FOCUS_DRAFT_TEXT: &str = "Draft kept while reading chat";
 /// Focused-review output emitted when the prompt carries both the saved
 /// decision and the instruction to honor it.
 const RESOLVED_DECISION_REVIEW_TEXT: &str = "Resolved session decision honored.";
-
 /// Review-request notice body used by the timeline-order regression.
 const REVIEW_REQUEST_TIMELINE_NOTICE_TEXT: &str =
     "Created PR https://github.com/agentty-xyz/agentty/pull/42";
@@ -1598,6 +1597,13 @@ fn seed_review_ready_session_with_persisted_focused_review(
     })?;
 
     Ok(())
+}
+
+/// Seeds one persisted focused review plus a second project so the review can
+/// be restored after switching away from its owning project and back.
+fn seed_cross_project_focused_review(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    seed_review_ready_session_with_persisted_focused_review(env)?;
+    common::seed_mru_first_second_project(env)
 }
 
 /// Seeds two review-ready sessions with distinct persisted focused reviews so
@@ -7529,6 +7535,48 @@ fn focused_reviews_survive_session_switching() -> E2eResult {
                     "Persisted focused review finding.",
                     &final_full,
                 );
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify a persisted focused review remains available after users switch
+/// away from its owning project and back.
+#[test]
+fn focused_review_survives_project_switching() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("focused_review_survives_project_switching")
+        .with_git()
+        .setup(seed_cross_project_focused_review)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .press_key("p")
+                    .wait_for_text("Switch project", 5000)
+                    .press_key("j")
+                    .press_key("Enter")
+                    .wait_for_text("Project: alpha-project", 5000)
+                    .press_key("p")
+                    .wait_for_text("Switch project", 5000)
+                    .press_key("j")
+                    .press_key("Enter")
+                    .wait_for_text("Project: test-project", 5000)
+                    .wait_for_text("Review-ready session shortcuts", 5000)
+                    .press_key("j")
+                    .press_key("Enter")
+                    .wait_for_text("Persisted focused review finding.", 5000)
+                    .capture_labeled(
+                        "restored_review",
+                        "Focused review restored after project switching",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Persisted focused review finding.", &full);
+                assertion::assert_text_in_region(frame, "Suggestions", &full);
+                assertion::assert_not_visible(frame, "Reviewing changes with");
             },
         )?;
 


### PR DESCRIPTION
- Keeps completed focused-review cache entries until durable persistence settles, so inactive project refreshes do not discard pending output.
- Adds end-to-end coverage for restoring a focused review after switching away from and back to its project.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)