### PR TITLE
Pins rustc frontend threads

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+# The pinned nightly predates rustc's replacement `--jobs-frontend` flag.
+rustflags = ["-Z", "threads=8"]


### PR DESCRIPTION
- Configures eight frontend threads for the pinned nightly.
- Avoids the newer `--jobs-frontend` flag unsupported by that compiler.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)