### PR TITLE
Records the v0.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.15.0] - 2026-08-15
+
+### Added
+
+- agentty: support navigating changed lines and drafting multiple inline comments in
+  Diff view, then submit completed comments together in the next turn.
+- ag-harness: run policy-approved repository reads through model tools with bounded,
+  symlink-safe filesystem access and provider-compatible continuation history.
+- agentty: mark sessions with merge conflicts before synchronization without changing
+  their indexes or worktrees.
+
+### Changed
+
+- agentty: load full session diffs in the background with cancelable, stale-safe
+  requests for Diff view, focused reviews, and `/apply` freshness checks.
+- agentty: compact uninterrupted folder chains in diff trees while preserving full
+  paths, branch structure, and stable navigation.
+- agentty: hide Diff actions for sessions known to have no changes and invalidate the
+  cached availability after opening writable worktrees.
+- agentty: keep generated review-resolution prompts out of chat and composer history
+  while preserving them for transcript replay and session state.
+- deps: update `taiki-e/install-action` from `2.85.9` to `2.85.10`.
+- release: bump workspace crate metadata and lockfile package versions to `0.15.0`.
+
+### Fixed
+
+- agentty: preserve completed focused reviews across project switches until durable
+  persistence settles.
+- agentty: preserve active session state and worker senders when database refreshes
+  fail.
+- agentty: preserve shifted punctuation in direct and SSH terminals by limiting xterm
+  CSI-u reporting to `tmux`.
+- agentty: preserve durable session goals in generated titles while retrying transient
+  provider failures and rejecting duplicated request text.
+
+### Contributors
+
+- @andagaev
+- @dependabot
+- @minev-dev
+
 ## [v0.14.7] - 2026-08-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.14.7"
+version = "0.15.0"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.14.7"
+version = "0.15.0"
 dependencies = [
  "image",
  "mockall",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.14.7"
+version = "0.15.0"
 dependencies = [
  "mockall",
  "serde",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.14.7"
+version = "0.15.0"
 dependencies = [
  "mockall",
  "rustix",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "ag-harness"
-version = "0.14.7"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "jsonschema",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.14.7"
+version = "0.15.0"
 dependencies = [
  "askama",
  "schemars 1.2.2",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "ag-session"
-version = "0.14.7"
+version = "0.15.0"
 dependencies = [
  "ag-agent",
  "ag-forge",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ag-store"
-version = "0.14.7"
+version = "0.15.0"
 dependencies = [
  "ag-agent",
  "ag-session",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.14.7"
+version = "0.15.0"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.14.7"
+version = "0.15.0"
 dependencies = [
  "clap",
  "tempfile",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.14.7"
+version = "0.15.0"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.14.7"
+version = "0.15.0"
 dependencies = [
  "base64 0.23.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.14.7"
+version = "0.15.0"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -16,15 +16,15 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.14.7" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.14.7" }
-ag-forge = { path = "crates/ag-forge", version = "0.14.7" }
-ag-git = { path = "crates/ag-git", version = "0.14.7" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.14.7" }
-ag-session = { path = "crates/ag-session", version = "0.14.7" }
-ag-store = { path = "crates/ag-store", version = "0.14.7" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.14.7" }
-testty = { path = "crates/testty", version = "0.14.7" }
+ag-agent = { path = "crates/ag-agent", version = "0.15.0" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.15.0" }
+ag-forge = { path = "crates/ag-forge", version = "0.15.0" }
+ag-git = { path = "crates/ag-git", version = "0.15.0" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.15.0" }
+ag-session = { path = "crates/ag-session", version = "0.15.0" }
+ag-store = { path = "crates/ag-store", version = "0.15.0" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.15.0" }
+testty = { path = "crates/testty", version = "0.15.0" }
 async-trait = "0.1"
 agent-client-protocol = "2.0.0"
 assert_cmd = "2"


### PR DESCRIPTION
- Adds Diff view navigation, inline comment drafting, background diff loading, compact trees, and conflict-aware session handling.
- Improves repository-read tooling, review persistence, terminal input handling, and session goal/title behavior.
- Bumps workspace packages to `0.15.0` and updates `taiki-e/install-action` to `2.85.10`.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)