### PR TITLE
Diff mode scrolls selected files while Files stays focused

### DIFF
--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -772,7 +772,11 @@ pub(crate) fn diff_actions(can_comment: bool) -> Vec<HelpAction> {
         HelpAction::new("files", "f/Esc/Left", "Focus changed files"),
         HelpAction::new("comments", "c", "Focus review comments"),
         HelpAction::new("preview", "p", "Toggle selected markdown preview"),
-        HelpAction::new("select line", "Up/Down", "Select changed line"),
+        HelpAction::new(
+            "scroll/select line",
+            "J/K/Up/Down",
+            "Scroll a file or select a changed line",
+        ),
     ];
     if can_comment {
         actions.push(HelpAction::new(
@@ -2162,7 +2166,7 @@ mod tests {
                 "f/Esc/Left",
                 "c",
                 "p",
-                "Up/Down",
+                "J/K/Up/Down",
                 "Enter/Esc",
                 "s",
                 "a",

--- a/crates/agentty/src/runtime/mode/diff.rs
+++ b/crates/agentty/src/runtime/mode/diff.rs
@@ -533,6 +533,10 @@ fn apply_navigation_key(
     key: KeyEvent,
     navigation: &mut DiffKeyNavigation<'_>,
 ) -> bool {
+    if apply_unfocused_scroll_key(render_cache_store, content_area, key, navigation) {
+        return false;
+    }
+
     match key.code {
         KeyCode::Char(character @ ('j' | 'k'))
             if *navigation.focus == DiffFocus::Files && is_plain_char_key(key, character) =>
@@ -622,6 +626,45 @@ fn apply_navigation_key(
     }
 
     false
+}
+
+/// Applies a row-scroll key without moving focus out of the Files pane.
+fn apply_unfocused_scroll_key(
+    render_cache_store: &RenderCacheStore,
+    content_area: Rect,
+    key: KeyEvent,
+    navigation: &mut DiffKeyNavigation<'_>,
+) -> bool {
+    if *navigation.focus != DiffFocus::Files {
+        return false;
+    }
+    let direction = match key.code {
+        KeyCode::Down | KeyCode::Char('J' | 'j')
+            if is_unfocused_scroll_key(key, KeyCode::Down, 'j') =>
+        {
+            DiffContentDirection::Next
+        }
+        KeyCode::Up | KeyCode::Char('K' | 'k')
+            if is_unfocused_scroll_key(key, KeyCode::Up, 'k') =>
+        {
+            DiffContentDirection::Previous
+        }
+        _ => return false,
+    };
+    let mut content_navigation = navigation.content_navigation();
+    scroll_content_by_row(
+        &mut content_navigation,
+        content_area,
+        render_cache_store,
+        direction,
+    );
+
+    true
+}
+
+/// Returns whether a key scrolls the right pane while Files stays focused.
+fn is_unfocused_scroll_key(key: KeyEvent, arrow_key: KeyCode, character: char) -> bool {
+    key.code == arrow_key || is_shift_char_key(key, character)
 }
 
 /// Returns whether a key moves through the active right-hand content pane.
@@ -714,27 +757,7 @@ fn move_content_selection(
         render_cache_store.diff_layout_cache(),
         navigation.preview,
     ) {
-        let max_scroll_offset = diff_max_scroll_offset(
-            &DiffScrollLimitInput {
-                content_area,
-                diff: navigation.diff,
-                diff_layout_cache: render_cache_store.diff_layout_cache(),
-                line_comments: navigation.line_comments,
-                markdown_render_cache: render_cache_store.markdown_render_cache(),
-                preview: navigation.preview,
-                selected_index: navigation.file_explorer_selected_index,
-            },
-            navigation.scroll_cache,
-        );
-        *navigation.scroll_offset = match direction {
-            DiffContentDirection::Next => (*navigation.scroll_offset)
-                .min(max_scroll_offset)
-                .saturating_add(1)
-                .min(max_scroll_offset),
-            DiffContentDirection::Previous => (*navigation.scroll_offset)
-                .min(max_scroll_offset)
-                .saturating_sub(1),
-        };
+        scroll_content_by_row(navigation, content_area, render_cache_store, direction);
 
         return;
     }
@@ -759,6 +782,37 @@ fn move_content_selection(
             *navigation.scroll_offset,
         )
         .unwrap_or(*navigation.scroll_offset);
+}
+
+/// Scrolls the selected file or preview by one rendered row without changing
+/// pane focus or the selected changed-line cursor.
+fn scroll_content_by_row(
+    navigation: &mut DiffContentNavigation<'_>,
+    content_area: Rect,
+    render_cache_store: &RenderCacheStore,
+    direction: DiffContentDirection,
+) {
+    let max_scroll_offset = diff_max_scroll_offset(
+        &DiffScrollLimitInput {
+            content_area,
+            diff: navigation.diff,
+            diff_layout_cache: render_cache_store.diff_layout_cache(),
+            line_comments: navigation.line_comments,
+            markdown_render_cache: render_cache_store.markdown_render_cache(),
+            preview: navigation.preview,
+            selected_index: navigation.file_explorer_selected_index,
+        },
+        navigation.scroll_cache,
+    );
+    *navigation.scroll_offset = match direction {
+        DiffContentDirection::Next => (*navigation.scroll_offset)
+            .min(max_scroll_offset)
+            .saturating_add(1)
+            .min(max_scroll_offset),
+        DiffContentDirection::Previous => (*navigation.scroll_offset)
+            .min(max_scroll_offset)
+            .saturating_sub(1),
+    };
 }
 
 /// Returns whether the active selection is currently showing markdown preview
@@ -1600,6 +1654,47 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_file_focus_scrolls_with_arrows_and_shift_j_k() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+        app.mode = AppMode::Diff {
+            session_id: "session-id".into(),
+            diff: scrollable_diff_fixture(),
+            scroll_offset: 0,
+            file_explorer_selected_index: 0,
+            focus: DiffFocus::Files,
+            line_comments: DiffLineComments::default(),
+            selected_diff_line_index: 7,
+            preview: DiffPreview::default(),
+            review_comments: None,
+            restore: None,
+            scroll_cache: None,
+        };
+        let navigation = [
+            (KeyEvent::new(KeyCode::Down, KeyModifiers::NONE), 1),
+            (KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT), 2),
+            (KeyEvent::new(KeyCode::Up, KeyModifiers::NONE), 1),
+            (KeyEvent::new(KeyCode::Char('k'), KeyModifiers::SHIFT), 0),
+        ];
+
+        // Act & Assert
+        for (key, expected_scroll_offset) in navigation {
+            let event_result = handle(&mut app, TEST_TERMINAL_SIZE, key);
+
+            assert!(matches!(event_result, EventResult::Continue));
+            assert!(matches!(
+                &app.mode,
+                AppMode::Diff {
+                    focus: DiffFocus::Files,
+                    scroll_offset,
+                    selected_diff_line_index: 7,
+                    ..
+                } if *scroll_offset == expected_scroll_offset
+            ));
+        }
     }
 
     #[tokio::test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -7079,8 +7079,8 @@ fn test_slow_diff_loading_remains_cancelable() -> E2eResult {
     Ok(())
 }
 
-/// Verify that `Enter` moves focus from a selected file into the right-hand
-/// patch and line navigation scrolls through the file's changed lines.
+/// Verify that the right-hand patch scrolls while Files remains focused, then
+/// `Enter` moves focus into changed-line navigation.
 #[test]
 fn test_diff_changed_line_navigation() -> E2eResult {
     // Arrange, Act, Assert
@@ -7096,7 +7096,15 @@ fn test_diff_changed_line_navigation() -> E2eResult {
                     .press_key("d")
                     .wait_for_text("main.rs", 5000)
                     .press_key("j")
-                    .wait_for_stable_frame(200, 3000)
+                    .wait_for_stable_frame(200, 3000);
+                let scenario = (0..70).fold(scenario, |scenario, _| scenario.press_key("Down"));
+                let scenario = scenario
+                    .wait_for_text("changed line 70", 5000)
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled(
+                        "diff_file_scroll",
+                        "Selected file scrolled without leaving Files focus",
+                    )
                     .press_key("Enter")
                     .wait_for_text("Esc/Left: files", 5000);
                 let scenario = (0..70).fold(scenario, |scenario, _| scenario.press_key("Down"));
@@ -7110,9 +7118,22 @@ fn test_diff_changed_line_navigation() -> E2eResult {
                         "Changed-line cursor scrolled through the selected file",
                     )
             },
-            |frame, _report| {
+            |frame, report| {
+                let file_focus_frame = common::frame_from_capture(&report.captures[0]);
+                let file_focus_full =
+                    Region::full(file_focus_frame.cols(), file_focus_frame.rows());
                 let full = Region::full(frame.cols(), frame.rows());
 
+                assertion::assert_text_in_region(
+                    &file_focus_frame,
+                    "changed line 70",
+                    &file_focus_full,
+                );
+                assertion::assert_text_in_region(
+                    &file_focus_frame,
+                    "j/k: select file",
+                    &file_focus_full,
+                );
                 assertion::assert_text_in_region(frame, "changed line 70", &full);
                 assertion::assert_text_in_region(frame, "Esc/Left: files", &full);
                 assertion::assert_text_in_region(frame, "j/k: select line", &full);

--- a/crates/testty/src/session.rs
+++ b/crates/testty/src/session.rs
@@ -353,7 +353,9 @@ impl PtySession {
                         Some(self.run_eventually(*timeout, *poll, predicate.as_ref())?);
                 }
                 Step::Capture | Step::CaptureLabeled { .. } => {
-                    current_frame = Some(self.capture_frame());
+                    if current_frame.is_none() {
+                        current_frame = Some(self.capture_frame());
+                    }
                 }
                 Step::ViewingPause(_) => {
                     // No-op in PTY execution — only affects VHS tape output.
@@ -725,6 +727,50 @@ mod tests {
         assert!(
             frame.all_text().contains("done:hello"),
             "final frame must include output produced after the wait"
+        );
+    }
+
+    #[test]
+    fn execute_steps_captures_without_a_reusable_frame() {
+        // Arrange
+        let mut session = PtySessionBuilder::new("/bin/sh")
+            .args(["-c", "printf 'ready\\n'; sleep 60"])
+            .spawn()
+            .expect("failed to spawn shell script");
+        let steps = [Step::capture()];
+
+        // Act
+        let frame = session
+            .execute_steps(&steps)
+            .expect("step execution should succeed");
+
+        // Assert
+        assert!(frame.all_text().contains("ready"));
+    }
+
+    #[test]
+    fn execute_steps_reuses_wait_frame_for_capture() {
+        // Arrange — the second output arrives after the wait's read window but
+        // within a fresh capture's read window.
+        let mut session = PtySessionBuilder::new("/bin/sh")
+            .args([
+                "-c",
+                "sleep 0.2; printf 'ready\\n'; sleep 0.25; printf 'later\\n'; sleep 60",
+            ])
+            .spawn()
+            .expect("failed to spawn delayed shell script");
+        let steps = [Step::wait_for_text("ready", 3_000), Step::capture()];
+
+        // Act
+        let frame = session
+            .execute_steps(&steps)
+            .expect("step execution should succeed");
+
+        // Assert
+        assert!(frame.all_text().contains("ready"));
+        assert!(
+            !frame.all_text().contains("later"),
+            "capture must reuse the frame supplied by the preceding wait"
         );
     }
 

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -270,27 +270,29 @@ and standalone comments are read-only.
 ## Diff Mode
 
 Pressing `d` from session view opens Diff mode focused on Files with the right panel
-showing the git diff. Press `Enter` on a file to focus its changes, then press `Enter`
-again to edit the selected changed line inline. After finishing with `Enter` or `Esc`,
-use `j` / `k` or the arrow keys to move the line cursor and press `Enter` to edit the
-selected line. `Esc`, `Left`, `h`, or `f` returns focus to the file tree. Linked review
-requests add a Comments section below Files; `c` focuses Comments while the file tree is
-focused, and `f` returns to Files. The Comments section keeps its own `Enter` action for
-submitting marked review threads. Press `s` to submit every inline diff comment together
-in the next turn.
+showing the git diff. While Files remains focused, use `Shift+j` / `Shift+k` or `Up` /
+`Down` to scroll the selected file without moving focus. Press `Enter` on a file to
+focus its changes, then press `Enter` again to edit the selected changed line inline.
+After finishing with `Enter` or `Esc`, use `j` / `k` or the arrow keys to move the line
+cursor and press `Enter` to edit the selected line. `Esc`, `Left`, `h`, or `f` returns
+focus to the file tree. Linked review requests add a Comments section below Files; `c`
+focuses Comments while the file tree is focused, and `f` returns to Files. The Comments
+section keeps its own `Enter` action for submitting marked review threads. Press `s` to
+submit every inline diff comment together in the next turn.
 
-| Key                | Action                                    |
-| ------------------ | ----------------------------------------- |
-| `q`                | Back to session                           |
-| `Esc`              | Focus Files, or leave from Files          |
-| `j` / `k`          | Select a file or changed line             |
-| `Enter`            | Focus a file, or edit/finish a comment    |
-| `Up` / `Down`      | Select a changed line or scroll a preview |
-| `Left` / `h` / `f` | Return to Files                           |
-| `p`                | Toggle markdown preview                   |
-| `c`                | Focus linked review comments              |
-| `s`                | Submit all inline comments                |
-| `?`                | Help                                      |
+| Key                   | Action                                                 |
+| --------------------- | ------------------------------------------------------ |
+| `q`                   | Back to session                                        |
+| `Esc`                 | Focus Files, or leave from Files                       |
+| `j` / `k`             | Select a file or changed line                          |
+| `Shift+j` / `Shift+k` | Scroll selected file, or select a changed line         |
+| `Enter`               | Focus a file, or edit/finish a comment                 |
+| `Up` / `Down`         | Scroll selected file, select a line, or scroll preview |
+| `Left` / `h` / `f`    | Return to Files                                        |
+| `p`                   | Toggle markdown preview                                |
+| `c`                   | Focus linked review comments                           |
+| `s`                   | Submit all inline comments                             |
+| `?`                   | Help                                                   |
 
 <a id="usage-diff-totals"></a> The diff panel title includes aggregate `+added` and
 `-removed` line totals. Every file and folder row in the left panel shows its own

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -216,32 +216,34 @@ closed; otherwise `d` becomes available and reloads the diff. Full diffs load in
 background; press `q` or `Esc` on **Loading diff...** to return immediately while a
 large repository is still being inspected.
 
-Inside diff view, press `Enter` on a file to move focus from the file tree to its patch,
-then press `Enter` again to open an inline editor beneath the selected added or removed
-line. Type the feedback, then press `Enter` or `Esc` to finish without leaving Diff
-mode. Use `j` / `k` or the arrow keys to move through changed lines while Agentty keeps
-the cursor visible, and press `Enter` on any selected line to add or edit its comment.
-Finishing empty text removes the comment. Completed comments keep a distinct inset
-background, and the active editor uses the stronger selection highlight. The linked
-review-request Comments section retains its separate `Enter` action for submitting
-marked review threads. Press `s` to submit every finished line comment together as the
-next session turn. The submitted prompt uses one compact row per comment with its
-repository-relative path, old or new side, and line number, and keeps draft instructions
-or image attachments that were present before opening the diff. Deleted-line rows also
-include their captured pre-change source text because that context is absent from the
-current worktree. Inline comment editing and submission are available only when the
-session can accept a reply. Read-only diffs such as `Merged` sessions keep line
-navigation but omit the comment actions from the footer and help overlay. Press `Esc`,
-`Left`, `h`, or `f` to return to the file tree. Select a changed markdown file and press
-`p` to render its complete post-change worktree content, including supported Mermaid
-diagrams. Preview remains active across file navigation; non-markdown selections keep
-showing raw diff lines, and files that are deleted, binary, too large, or unreadable
-show a concise notice. Press `p` again to restore the patch view. Pressing `q` returns
-to the sessions list and saves the complete composer; reopening the session restores the
-typed draft with input focus. Pressing `Tab` again returns focus to the composer. The
-same focus toggle, `d` diff preview, and `q` preservation flow are available while
-answering clarification questions. Long transcripts show a slim scrollbar on the right
-side of the output panel to indicate the current position.
+Inside diff view, `Shift+j` / `Shift+k` and `Up` / `Down` scroll the selected file while
+Files remains focused. Press `Enter` on a file to move focus from the file tree to its
+patch, then press `Enter` again to open an inline editor beneath the selected added or
+removed line. Type the feedback, then press `Enter` or `Esc` to finish without leaving
+Diff mode. Use `j` / `k` or the arrow keys to move through changed lines while Agentty
+keeps the cursor visible, and press `Enter` on any selected line to add or edit its
+comment. Finishing empty text removes the comment. Completed comments keep a distinct
+inset background, and the active editor uses the stronger selection highlight. The
+linked review-request Comments section retains its separate `Enter` action for
+submitting marked review threads. Press `s` to submit every finished line comment
+together as the next session turn. The submitted prompt uses one compact row per comment
+with its repository-relative path, old or new side, and line number, and keeps draft
+instructions or image attachments that were present before opening the diff.
+Deleted-line rows also include their captured pre-change source text because that
+context is absent from the current worktree. Inline comment editing and submission are
+available only when the session can accept a reply. Read-only diffs such as `Merged`
+sessions keep line navigation but omit the comment actions from the footer and help
+overlay. Press `Esc`, `Left`, `h`, or `f` to return to the file tree. Select a changed
+markdown file and press `p` to render its complete post-change worktree content,
+including supported Mermaid diagrams. Preview remains active across file navigation;
+non-markdown selections keep showing raw diff lines, and files that are deleted, binary,
+too large, or unreadable show a concise notice. Press `p` again to restore the patch
+view. Pressing `q` returns to the sessions list and saves the complete composer;
+reopening the session restores the typed draft with input focus. Pressing `Tab` again
+returns focus to the composer. The same focus toggle, `d` diff preview, and `q`
+preservation flow are available while answering clarification questions. Long
+transcripts show a slim scrollbar on the right side of the output panel to indicate the
+current position.
 
 Pressing `r` during a running turn queues session sync on the same session worker. The
 session stays **InProgress** while the active turn runs, then moves to **Rebasing** when


### PR DESCRIPTION
- `Shift+j` / `Shift+k` and arrow keys scroll the selected file without moving the changed-line selection.
- `Enter` still transitions into changed-line navigation.
- Capture steps reuse the frame produced by a preceding wait.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)