### PR TITLE
Managed worker review test waits for session content before capturing help

### DIFF
--- a/crates/agentty/tests/e2e/orchestration.rs
+++ b/crates/agentty/tests/e2e/orchestration.rs
@@ -864,8 +864,9 @@ fn test_managed_worker_review_open_action() -> E2eResult {
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::switch_to_tab("Sessions"))
                     .press_key("j")
-                    .press_key("Enter")
-                    .wait_for_text("Managed by controller-0001", 5000)
+                    .compose(&common::open_selected_session_view_with_texts(&[
+                        "Managed by controller-0001",
+                    ]))
                     .compose(&common::open_help_overlay())
                     .capture_labeled(
                         "managed_worker_review_help",


### PR DESCRIPTION
Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)