### PR TITLE
Publishes CI test results to Trunk

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,7 +3,11 @@ slow-timeout = "60s"
 
 [profile.ci]
 fail-fast = false
+retries = 0
 slow-timeout = { period = "60s", terminate-after = 3 }
+
+[profile.ci.junit]
+path = "junit.xml"
 
 [test-groups]
 agentty-e2e = { max-threads = 4 }

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -20,16 +20,28 @@ jobs:
   source-tests:
     name: Source tests (${{ matrix.member }})
     runs-on: ubuntu-latest
+    env:
+      TRUNK_API_TOKEN_AVAILABLE: ${{ secrets.TRUNK_API_TOKEN != '' }}
     strategy:
       fail-fast: false
       matrix:
         include:
+          - member: ag-agent
+            hook: test-ag-agent-src
+          - member: ag-clipboard
+            hook: test-ag-clipboard-src
           - member: ag-forge
             hook: test-ag-forge-src
           - member: ag-git
             hook: test-ag-git-src
+          - member: ag-harness
+            hook: test-ag-harness-src
           - member: ag-protocol
             hook: test-ag-protocol-src
+          - member: ag-session
+            hook: test-ag-session-src
+          - member: ag-store
+            hook: test-ag-store-src
           - member: ag-tui-text
             hook: test-ag-tui-text-src
           - member: agentty
@@ -49,7 +61,20 @@ jobs:
         uses: ./.github/actions/setup-rust-prek
 
       - name: Run source tests
+        id: source-tests
         run: prek run ${{ matrix.hook }} --all-files --hook-stage manual
+
+      - name: Upload source test results to Trunk
+        if: ${{ !cancelled() && env.TRUNK_API_TOKEN_AVAILABLE == 'true' }}
+        continue-on-error: true
+        uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2
+        env:
+          TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
+        with:
+          junit-paths: target/nextest/ci/junit.xml
+          org-slug: agentty
+          previous-step-outcome: ${{ steps.source-tests.outcome }}
+          token: ${{ secrets.TRUNK_API_TOKEN }}
 
   validate:
     name: Workspace checks

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -39,3 +39,5 @@ jobs:
       cargo-audit: true
       cargo-machete: true
       workspace-tests: true
+    secrets:
+      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}

--- a/.github/workflows/workspace-validation.yml
+++ b/.github/workflows/workspace-validation.yml
@@ -23,6 +23,10 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      TRUNK_API_TOKEN:
+        description: Trunk organization API token used to upload test results.
+        required: false
 
 permissions:
   contents: read
@@ -34,6 +38,8 @@ jobs:
   validate:
     name: Workspace validation
     runs-on: ubuntu-latest
+    env:
+      TRUNK_API_TOKEN_AVAILABLE: ${{ secrets.TRUNK_API_TOKEN != '' }}
 
     steps:
       - name: Checkout
@@ -60,5 +66,18 @@ jobs:
         run: prek run cargo-machete --all-files --hook-stage manual
 
       - name: Full test suite
+        id: workspace-tests
         if: ${{ inputs['workspace-tests'] }}
         run: prek run test-workspace --all-files --hook-stage manual
+
+      - name: Upload workspace test results to Trunk
+        if: ${{ !cancelled() && inputs['workspace-tests'] && env.TRUNK_API_TOKEN_AVAILABLE == 'true' }}
+        continue-on-error: true
+        uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2
+        env:
+          TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
+        with:
+          junit-paths: target/nextest/ci/junit.xml
+          org-slug: agentty
+          previous-step-outcome: ${{ steps.workspace-tests.outcome }}
+          token: ${{ secrets.TRUNK_API_TOKEN }}


### PR DESCRIPTION
- Configures the CI nextest profile to emit JUnit reports without retries.
- Uploads source, workspace, and end-to-end test results when a Trunk token is available.
- Passes the optional token through reusable workflows and shares the mounted nextest report directory for uploads.
- Corrects rootless Podman ownership mapping for the writable nextest report directory.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)