### PR TITLE
Formats session timers with readable unit spacing

### DIFF
--- a/crates/ag-tui-text/src/text_util.rs
+++ b/crates/ag-tui-text/src/text_util.rs
@@ -325,7 +325,7 @@ pub fn format_token_count(count: u64) -> String {
     count.to_string()
 }
 
-/// Formats elapsed seconds as a compact `1h1m1s` label.
+/// Formats elapsed seconds as a compact `1h 1m 1s` label.
 ///
 /// Hours and minutes are omitted when their value is zero, but seconds are
 /// always rendered so live timers never lose sub-minute visibility.
@@ -341,11 +341,11 @@ pub fn format_duration_compact(duration_seconds: i64) -> String {
     let mut label = String::new();
 
     if hour_count > 0 {
-        let _ = write!(label, "{hour_count}h");
+        let _ = write!(label, "{hour_count}h ");
     }
 
     if minute_count > 0 {
-        let _ = write!(label, "{minute_count}m");
+        let _ = write!(label, "{minute_count}m ");
     }
 
     let _ = write!(label, "{second_count}s");
@@ -598,11 +598,11 @@ mod tests {
         // Assert
         assert_eq!(zero, "0s");
         assert_eq!(less_than_one_minute, "59s");
-        assert_eq!(one_minute, "1m0s");
-        assert_eq!(two_minutes, "2m0s");
-        assert_eq!(one_hour, "1h0s");
-        assert_eq!(one_hour_one_minute_one_second, "1h1m1s");
-        assert_eq!(one_day_one_hour_one_minute_one_second, "25h1m1s");
+        assert_eq!(one_minute, "1m 0s");
+        assert_eq!(two_minutes, "2m 0s");
+        assert_eq!(one_hour, "1h 0s");
+        assert_eq!(one_hour_one_minute_one_second, "1h 1m 1s");
+        assert_eq!(one_day_one_hour_one_minute_one_second, "25h 1m 1s");
     }
 
     #[test]

--- a/crates/agentty/src/ui/layout.rs
+++ b/crates/agentty/src/ui/layout.rs
@@ -522,7 +522,7 @@ mod tests {
         // Assert
         assert_eq!(header_lines.len(), 2);
         assert!(header_lines[0].to_string().contains("..."));
-        assert!(header_lines[1].to_string().contains("Timer: 1h1m0s"));
+        assert!(header_lines[1].to_string().contains("Timer: 1h 1m 0s"));
     }
 
     #[test]
@@ -568,7 +568,7 @@ mod tests {
             early_metadata.find("Model: gpt-5.6-sol") < early_metadata.find("Reasoning: high"),
             "model should appear before reasoning in metadata text"
         );
-        assert!(later_metadata.contains("Timer: 1h1m0s"));
+        assert!(later_metadata.contains("Timer: 1h 1m 0s"));
     }
 
     #[test]
@@ -585,7 +585,7 @@ mod tests {
 
         // Assert
         assert_eq!(earlier_metadata, later_metadata);
-        assert!(earlier_metadata.contains("Timer: 1h1m0s"));
+        assert!(earlier_metadata.contains("Timer: 1h 1m 0s"));
     }
 
     #[test]

--- a/crates/agentty/src/ui/page/session_list.rs
+++ b/crates/agentty/src/ui/page/session_list.rs
@@ -1286,7 +1286,7 @@ mod tests {
             crate::test_support::titled_session_fixture("done-1", Status::Done);
         archived_session.in_progress_total_seconds = 3_661;
         let sessions = vec![active_session, archived_session];
-        let expected_width = u16::try_from("1h1m1s".chars().count()).unwrap_or(u16::MAX);
+        let expected_width = u16::try_from("1h 1m 1s".chars().count()).unwrap_or(u16::MAX);
         let rows = prepared_session_rows(&sessions, ReasoningLevel::default(), None, 160);
 
         // Act
@@ -1428,7 +1428,7 @@ mod tests {
 
         // Assert
         let text = buffer_text(terminal.backend().buffer());
-        assert!(text.contains("2m0s"));
+        assert!(text.contains("2m 0s"));
     }
 
     #[test]
@@ -1457,7 +1457,7 @@ mod tests {
 
         // Assert
         let text = buffer_text(terminal.backend().buffer());
-        assert!(text.contains("2m5s"));
+        assert!(text.contains("2m 5s"));
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1240,7 +1240,7 @@ fn seed_child_worktree_for_onto_rebase(
     Ok(parent_tip)
 }
 
-/// Seeds one review-ready session with a persisted reasoning level.
+/// Seeds one review-ready session with a persisted reasoning level and timer.
 fn seed_session_with_reasoning_level(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     seed_review_ready_session(env)?;
 
@@ -1251,6 +1251,14 @@ fn seed_session_with_reasoning_level(env: &BuilderEnv) -> Result<(), Box<dyn std
         database
             .sessions()
             .update_session_reasoning_level("review-shortcut-0001", ReasoningLevel::Medium)
+            .await?;
+        database
+            .sessions()
+            .update_session_status_with_timing_at("review-shortcut-0001", "InProgress", 0)
+            .await?;
+        database
+            .sessions()
+            .update_session_status_with_timing_at("review-shortcut-0001", "Review", 125)
             .await
     })?;
 
@@ -3457,8 +3465,7 @@ fn test_session_pre_commit_hook_warning() -> E2eResult {
     Ok(())
 }
 
-/// Verify that the Sessions tab model column includes the effective reasoning
-/// level next to the model name.
+/// Verify that the Sessions tab separates timer units and shows reasoning.
 #[test]
 fn session_list_model_reasoning_level() -> E2eResult {
     // Arrange, Act, Assert
@@ -3471,14 +3478,16 @@ fn session_list_model_reasoning_level() -> E2eResult {
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::switch_to_tab("Sessions"))
                     .wait_for_text("gpt-5.6-sol [medium]", 5000)
+                    .wait_for_text("2m 5s", 5000)
                     .capture_labeled(
                         "model_reasoning",
-                        "Session row model column with reasoning level",
+                        "Session row with readable model and timer details",
                     )
             },
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "gpt-5.6-sol [medium]", &full);
+                assertion::assert_text_in_region(frame, "2m 5s", &full);
             },
         )?;
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -22,13 +22,13 @@ tabs. Press `Tab` to move forward or `Shift+Tab` to move backward:
   versions are listed here too.
 - **Sessions**: List, create, and manage agent sessions for the active project. Rows
   show a size marker prefix (for example `[XL]`), the current `agent/model` with its
-  reasoning level, and a live active-work `Timer` column. The list shows only populated
-  merge queue, active, and archive groups, with a session count in each group heading.
-  Archive rows use subdued text so completed work is visually distinct from current
-  sessions. When there are no sessions, it prompts you to press `a` to start one. Press
-  `p` to open a project switcher popup that lists registered projects in
-  most-recently-opened order and switches the active project without leaving the
-  Sessions view.
+  reasoning level, and a live active-work `Timer` column whose time units are separated
+  for readability (for example, `11m 23s`). The list shows only populated merge queue,
+  active, and archive groups, with a session count in each group heading. Archive rows
+  use subdued text so completed work is visually distinct from current sessions. When
+  there are no sessions, it prompts you to press `a` to start one. Press `p` to open a
+  project switcher popup that lists registered projects in most-recently-opened order
+  and switches the active project without leaving the Sessions view.
 - **Settings**: Configure the color theme, orchestrator parallelism, automatic approval
   for read-only research waves, per-role smart/fast/review model and reasoning defaults,
   the optional `Last used model as default` mode, the session commit coauthor trailer,


### PR DESCRIPTION
- Separates displayed hours, minutes, and seconds with spaces.
- Seeds persisted timer state so Sessions coverage verifies the readable timer format.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)