### PR TITLE
Supports visual row ranges for inline diff comments

### DIFF
--- a/crates/agentty/src/presentation/app_mode.rs
+++ b/crates/agentty/src/presentation/app_mode.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use ag_forge::ReviewCommentSnapshot;
 
 use super::help_action::{
@@ -67,35 +69,122 @@ impl DiffLineCommentAnchor {
     }
 }
 
-/// One editable comment attached to a changed diff line.
+/// Ordered changed rows that share one inline comment.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DiffLineCommentTarget {
+    /// First changed row in this target.
+    first_anchor: DiffLineCommentAnchor,
+    /// Additional changed rows in visual top-to-bottom order.
+    remaining_anchors: Vec<DiffLineCommentAnchor>,
+}
+
+impl DiffLineCommentTarget {
+    /// Creates a target containing one changed row.
+    pub(crate) fn single(anchor: DiffLineCommentAnchor) -> Self {
+        Self {
+            first_anchor: anchor,
+            remaining_anchors: Vec::new(),
+        }
+    }
+
+    /// Creates a nonempty target from changed rows in visual order.
+    pub(crate) fn from_anchors(anchors: Vec<DiffLineCommentAnchor>) -> Option<Self> {
+        let mut anchors = anchors.into_iter();
+        let first_anchor = anchors.next()?;
+
+        Some(Self {
+            first_anchor,
+            remaining_anchors: anchors.collect(),
+        })
+    }
+
+    /// Returns the top changed row in this comment target.
+    pub(crate) fn first_anchor(&self) -> &DiffLineCommentAnchor {
+        &self.first_anchor
+    }
+
+    /// Returns the bottom changed row used to place the inline editor.
+    pub(crate) fn last_anchor(&self) -> &DiffLineCommentAnchor {
+        self.remaining_anchors.last().unwrap_or(&self.first_anchor)
+    }
+
+    /// Iterates through every changed row in visual order.
+    fn anchors(&self) -> impl Iterator<Item = &DiffLineCommentAnchor> {
+        std::iter::once(&self.first_anchor).chain(self.remaining_anchors.iter())
+    }
+
+    /// Builds one compact next-turn prompt line for this row target.
+    fn prompt_line(&self, comment: &str) -> String {
+        let first_anchor = &self.first_anchor;
+        if self.remaining_anchors.is_empty() {
+            return first_anchor.prompt_line(comment);
+        }
+        let last_anchor = self.last_anchor();
+        let mut location =
+            if first_anchor.path == last_anchor.path && first_anchor.side == last_anchor.side {
+                format!(
+                    "{}:{}-{} [{}]",
+                    first_anchor.path,
+                    first_anchor.line,
+                    last_anchor.line,
+                    first_anchor.side.prompt_label(),
+                )
+            } else {
+                format!(
+                    "{}:{} [{}]..{}:{} [{}]",
+                    first_anchor.path,
+                    first_anchor.line,
+                    first_anchor.side.prompt_label(),
+                    last_anchor.path,
+                    last_anchor.line,
+                    last_anchor.side.prompt_label(),
+                )
+            };
+        let deleted_source = self
+            .anchors()
+            .filter(|anchor| anchor.side == DiffLineSide::Old)
+            .map(|anchor| anchor.content.as_str())
+            .collect::<Vec<_>>();
+        if !deleted_source.is_empty() {
+            let _ = write!(location, ", deleted source={deleted_source:?}");
+        }
+
+        format!("- {location}: {}", comment.trim())
+    }
+}
+
+/// One editable comment attached to one or more changed diff rows.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DiffLineComment {
-    /// Changed source line that owns this comment.
-    pub(crate) anchor: DiffLineCommentAnchor,
     /// User-authored inline comment text.
     pub(crate) input: InputState,
+    /// Changed source rows that own this comment.
+    pub(crate) target: DiffLineCommentTarget,
 }
 
 /// Inline comments accumulated while the unified diff remains open.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DiffLineComments {
-    /// Index of the comment currently receiving text input.
-    pub(crate) editing_index: Option<usize>,
     /// Comments retained in the order in which their lines were selected.
     pub(crate) comments: Vec<DiffLineComment>,
+    /// Index of the comment currently receiving text input.
+    pub(crate) editing_index: Option<usize>,
+    /// Changed-row index where visual line selection started.
+    pub(crate) selection_anchor_index: Option<usize>,
 }
 
 impl DiffLineComments {
-    /// Starts editing the existing comment for `anchor` or inserts a new one.
-    pub(crate) fn start_editing(&mut self, anchor: DiffLineCommentAnchor) -> usize {
+    /// Starts editing the existing comment for `target` or inserts a new one,
+    /// retaining any active visual row selection until editing finishes.
+    pub(crate) fn start_editing_target(&mut self, target: DiffLineCommentTarget) -> usize {
         let editing_index = self
             .comments
             .iter()
-            .position(|comment| comment.anchor == anchor)
+            .position(|comment| comment.target == target)
             .unwrap_or_else(|| {
                 self.comments.push(DiffLineComment {
-                    anchor,
                     input: InputState::default(),
+                    target,
                 });
 
                 self.comments.len().saturating_sub(1)
@@ -105,6 +194,32 @@ impl DiffLineComments {
         editing_index
     }
 
+    /// Starts visual changed-row selection at `selected_index`.
+    pub(crate) fn start_selection(&mut self, selected_index: usize) {
+        self.selection_anchor_index.get_or_insert(selected_index);
+    }
+
+    /// Cancels visual changed-row selection.
+    pub(crate) fn cancel_selection(&mut self) {
+        self.selection_anchor_index = None;
+    }
+
+    /// Returns whether changed-row visual selection is active.
+    pub(crate) fn is_selecting(&self) -> bool {
+        self.selection_anchor_index.is_some()
+    }
+
+    /// Returns normalized inclusive bounds for the active row selection or
+    /// cursor.
+    pub(crate) fn selected_row_bounds(&self, selected_index: usize) -> (usize, usize) {
+        let anchor_index = self.selection_anchor_index.unwrap_or(selected_index);
+
+        (
+            anchor_index.min(selected_index),
+            anchor_index.max(selected_index),
+        )
+    }
+
     /// Returns the input currently receiving inline comment keystrokes.
     pub(crate) fn editing_input_mut(&mut self) -> Option<&mut InputState> {
         self.editing_index
@@ -112,11 +227,12 @@ impl DiffLineComments {
             .map(|comment| &mut comment.input)
     }
 
-    /// Finishes editing and removes a comment whose text is blank.
+    /// Finishes editing, clears visual selection, and removes blank comments.
     pub(crate) fn finish_editing(&mut self) {
         let Some(editing_index) = self.editing_index.take() else {
             return;
         };
+        self.selection_anchor_index = None;
         if self
             .comments
             .get(editing_index)
@@ -137,7 +253,7 @@ impl DiffLineComments {
             .comments
             .iter()
             .filter(|comment| !comment.input.text().trim().is_empty())
-            .map(|comment| comment.anchor.prompt_line(comment.input.text()))
+            .map(|comment| comment.target.prompt_line(comment.input.text()))
             .collect::<Vec<_>>()
             .join("\n");
         if comments.is_empty() {
@@ -892,7 +1008,7 @@ mod tests {
         let mut line_comments = DiffLineComments::default();
 
         // Act
-        line_comments.start_editing(anchor.clone());
+        line_comments.start_editing_target(DiffLineCommentTarget::single(anchor.clone()));
         line_comments
             .editing_input_mut()
             .expect("new comment should be editable")
@@ -908,7 +1024,8 @@ mod tests {
         assert!(!line_comments.is_editing());
 
         // Act — selecting the same line edits the existing comment.
-        let editing_index = line_comments.start_editing(anchor);
+        let editing_index =
+            line_comments.start_editing_target(DiffLineCommentTarget::single(anchor));
 
         // Assert
         assert_eq!(editing_index, 0);
@@ -936,15 +1053,105 @@ mod tests {
     }
 
     #[test]
+    fn test_diff_line_comment_target_formats_new_and_mixed_row_ranges() {
+        // Arrange
+        let new_target = DiffLineCommentTarget::from_anchors(vec![
+            DiffLineCommentAnchor {
+                content: "first();".to_string(),
+                line: 4,
+                path: "src/main.rs".to_string(),
+                side: DiffLineSide::New,
+            },
+            DiffLineCommentAnchor {
+                content: "second();".to_string(),
+                line: 5,
+                path: "src/main.rs".to_string(),
+                side: DiffLineSide::New,
+            },
+        ])
+        .expect("new-line range should create a target");
+        let mixed_target = DiffLineCommentTarget::from_anchors(vec![
+            DiffLineCommentAnchor {
+                content: "old();".to_string(),
+                line: 7,
+                path: "src/old.rs".to_string(),
+                side: DiffLineSide::Old,
+            },
+            DiffLineCommentAnchor {
+                content: "new();".to_string(),
+                line: 8,
+                path: "src/new.rs".to_string(),
+                side: DiffLineSide::New,
+            },
+        ])
+        .expect("mixed range should create a target");
+
+        // Act
+        let new_prompt = new_target.prompt_line("Explain this range.");
+        let mixed_prompt = mixed_target.prompt_line("Preserve the behavior.");
+        let last_anchor = mixed_target.last_anchor();
+        let empty_target = DiffLineCommentTarget::from_anchors(Vec::new());
+
+        // Assert
+        assert_eq!(new_prompt, "- src/main.rs:4-5 [new]: Explain this range.");
+        assert_eq!(
+            mixed_prompt,
+            "- src/old.rs:7 [old]..src/new.rs:8 [new], deleted source=[\"old();\"]: Preserve the \
+             behavior."
+        );
+        assert_eq!(last_anchor.content, "new();");
+        assert_eq!(empty_target, None);
+    }
+
+    #[test]
+    fn test_diff_line_comments_tracks_visual_row_selection() {
+        // Arrange
+        let mut line_comments = DiffLineComments::default();
+        let target = DiffLineCommentTarget::single(DiffLineCommentAnchor {
+            content: "selected();".to_string(),
+            line: 4,
+            path: "src/lib.rs".to_string(),
+            side: DiffLineSide::New,
+        });
+
+        // Act
+        line_comments.start_selection(3);
+        line_comments.start_selection(9);
+        let upward_bounds = line_comments.selected_row_bounds(1);
+        let downward_bounds = line_comments.selected_row_bounds(5);
+        line_comments.start_editing_target(target);
+
+        // Assert
+        assert!(line_comments.is_selecting());
+        assert!(line_comments.is_editing());
+        assert_eq!(upward_bounds, (1, 3));
+        assert_eq!(downward_bounds, (3, 5));
+
+        // Act
+        line_comments.finish_editing();
+
+        // Assert
+        assert!(!line_comments.is_selecting());
+        assert_eq!(line_comments.selected_row_bounds(5), (5, 5));
+
+        // Act
+        line_comments.start_selection(5);
+        line_comments.cancel_selection();
+
+        // Assert
+        assert!(!line_comments.is_selecting());
+    }
+
+    #[test]
     fn test_diff_line_comments_remove_blank_editor() {
         // Arrange
         let mut line_comments = DiffLineComments::default();
-        line_comments.start_editing(DiffLineCommentAnchor {
+        line_comments.start_editing_target(DiffLineCommentTarget::single(DiffLineCommentAnchor {
             content: "removed".to_string(),
             line: 3,
             path: "src/lib.rs".to_string(),
             side: DiffLineSide::Old,
-        });
+        }));
 
         // Act
         line_comments.finish_editing();

--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -780,6 +780,11 @@ pub(crate) fn diff_actions(can_comment: bool) -> Vec<HelpAction> {
     ];
     if can_comment {
         actions.push(HelpAction::new(
+            "select rows",
+            "Shift+V",
+            "Start visual changed-row selection",
+        ));
+        actions.push(HelpAction::new(
             "save comment",
             "Enter/Esc",
             "Finish the inline comment",
@@ -823,6 +828,8 @@ pub(crate) enum DiffLineCommentFooterState {
     Editing,
     /// The visible session cannot accept an inline-comment reply.
     ReadOnly,
+    /// Visual changed-row selection is active for one range comment.
+    Selecting,
     /// Diff navigation is active with this many completed comments.
     Ready {
         /// Number of inline comments ready for batch submission.
@@ -841,6 +848,17 @@ pub(crate) fn diff_footer_actions(context: DiffFooterContext) -> Vec<HelpAction>
             "Enter/Esc",
             "Finish the inline comment",
         )];
+    }
+    if matches!(
+        context.line_comment_state,
+        DiffLineCommentFooterState::Selecting
+    ) {
+        return vec![
+            HelpAction::new("back", "q", "Back to session"),
+            HelpAction::new("cancel", "Esc", "Cancel row selection"),
+            HelpAction::new("extend", "j/k", "Extend row selection"),
+            HelpAction::new("comment", "Enter", "Comment on selected rows"),
+        ];
     }
 
     let mut actions = vec![HelpAction::new("back", "q/Esc", "Back to session")];
@@ -2161,6 +2179,7 @@ mod tests {
                 "c",
                 "p",
                 "J/K/Up/Down",
+                "Shift+V",
                 "Enter/Esc",
                 "s",
                 "Space",
@@ -2236,6 +2255,25 @@ mod tests {
 
         // Assert
         assert_eq!(editing_keys, ["Enter/Esc"]);
+    }
+
+    #[test]
+    fn test_diff_content_footer_exposes_visual_row_selection_actions() {
+        // Arrange, Act
+        let selecting_keys = diff_footer_actions(DiffFooterContext {
+            can_mark_selected: false,
+            can_submit: false,
+            focus: DiffFocus::Content,
+            has_review_comments: false,
+            line_comment_state: DiffLineCommentFooterState::Selecting,
+            sidebar_focus: DiffSidebarFocus::Files,
+        })
+        .iter()
+        .map(|action| action.key)
+        .collect::<Vec<_>>();
+
+        // Assert
+        assert_eq!(selecting_keys, ["q", "Esc", "j/k", "Enter"]);
     }
 
     #[test]

--- a/crates/agentty/src/runtime/event.rs
+++ b/crates/agentty/src/runtime/event.rs
@@ -362,8 +362,8 @@ mod tests {
     use crate::domain::session::{Session, SessionRole, SessionSize, SessionStats, Status};
     use crate::domain::transient_message::TransientMessageStore;
     use crate::presentation::app_mode::{
-        AppMode, ChatFocus, DiffFocus, DiffLineCommentAnchor, DiffLineComments, DiffLineSide,
-        DiffPreview,
+        AppMode, ChatFocus, DiffFocus, DiffLineCommentAnchor, DiffLineCommentTarget,
+        DiffLineComments, DiffLineSide, DiffPreview,
     };
     use crate::presentation::prompt::{
         PromptAttachmentState, PromptHistoryState, PromptSlashState,
@@ -779,12 +779,12 @@ mod tests {
         // Arrange
         let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
         let mut line_comments = DiffLineComments::default();
-        line_comments.start_editing(DiffLineCommentAnchor {
+        line_comments.start_editing_target(DiffLineCommentTarget::single(DiffLineCommentAnchor {
             content: "review();".to_string(),
             line: 1,
             path: "src/main.rs".to_string(),
             side: DiffLineSide::New,
-        });
+        }));
         app.mode = AppMode::Diff {
             diff: "diff --git a/src/main.rs b/src/main.rs\n+review();\n".to_string(),
             file_explorer_selected_index: 1,

--- a/crates/agentty/src/runtime/key_handler.rs
+++ b/crates/agentty/src/runtime/key_handler.rs
@@ -933,8 +933,9 @@ mod tests {
     use crate::domain::session_message::SessionTranscript;
     use crate::infra::tmux::MockTmuxClient;
     use crate::presentation::app_mode::{
-        ConfirmationViewMode, DiffFocus, DiffLineCommentAnchor, DiffLineComments, DiffLineSide,
-        DiffPreview, DiffRestoreTarget, DiffReviewComments, PromptModeSnapshot,
+        ConfirmationViewMode, DiffFocus, DiffLineCommentAnchor, DiffLineCommentTarget,
+        DiffLineComments, DiffLineSide, DiffPreview, DiffRestoreTarget, DiffReviewComments,
+        PromptModeSnapshot,
     };
     use crate::presentation::prompt::{
         PromptAttachmentState, PromptHistoryState, PromptSlashState,
@@ -1812,12 +1813,12 @@ mod tests {
         app.sessions =
             crate::test_support::session_manager_with_handles(vec![session], HashMap::new()).into();
         let mut line_comments = DiffLineComments::default();
-        line_comments.start_editing(DiffLineCommentAnchor {
+        line_comments.start_editing_target(DiffLineCommentTarget::single(DiffLineCommentAnchor {
             content: "review();".to_string(),
             line: 1,
             path: "src/main.rs".to_string(),
             side: DiffLineSide::New,
-        });
+        }));
         line_comments
             .editing_input_mut()
             .expect("seeded comment should be editable")

--- a/crates/agentty/src/runtime/mode/diff.rs
+++ b/crates/agentty/src/runtime/mode/diff.rs
@@ -5,7 +5,7 @@ use crate::app::{App, AppEvent};
 use crate::domain::input::InputState;
 use crate::domain::session::SessionId;
 use crate::presentation::app_mode::{
-    AppMode, DiffFocus, DiffLineCommentAnchor, DiffLineComments, DiffPreview,
+    AppMode, DiffFocus, DiffLineCommentTarget, DiffLineComments, DiffPreview,
     DiffPreviewUnavailableReason, DiffRestoreTarget, DiffReviewComments, DiffScrollCache,
     DiffSidebarFocus, HelpContext, PromptModeSnapshot, ViewportRect,
     allows_diff_line_comment_reply,
@@ -189,7 +189,7 @@ fn handle_navigation_key(
         diff,
         mut file_explorer_selected_index,
         mut focus,
-        line_comments,
+        mut line_comments,
         mut preview,
         mut review_comments,
         restore,
@@ -208,7 +208,7 @@ fn handle_navigation_key(
         diff: &diff,
         file_explorer_selected_index: &mut file_explorer_selected_index,
         focus: &mut focus,
-        line_comments: &line_comments,
+        line_comments: &mut line_comments,
         preview: &mut preview,
         review_comments: &mut review_comments,
         scroll_cache: &mut scroll_cache,
@@ -216,14 +216,24 @@ fn handle_navigation_key(
         selected_diff_line_index: &mut selected_diff_line_index,
         session_id: &session_id,
     };
-    let line_comment_anchor = selected_line_comment_anchor(
+    let row_selection_key_handled = handle_row_selection_key(
         render_cache_store,
         key,
-        &navigation,
+        &mut navigation,
         can_reply_with_line_comments,
     );
-    let selection_changed =
-        apply_navigation_key(app, render_cache_store, content_area, key, &mut navigation);
+    let line_comment_target = (!row_selection_key_handled)
+        .then(|| {
+            selected_line_comment_target(
+                render_cache_store,
+                key,
+                &navigation,
+                can_reply_with_line_comments,
+            )
+        })
+        .flatten();
+    let selection_changed = !row_selection_key_handled
+        && apply_navigation_key(app, render_cache_store, content_area, key, &mut navigation);
 
     if selection_changed && preview.is_enabled() {
         refresh_selected_preview(
@@ -249,8 +259,8 @@ fn handle_navigation_key(
         selected_diff_line_index,
         session_id,
     };
-    if let Some(anchor) = line_comment_anchor {
-        start_line_comment_edit(app, render_cache_store, content_area, anchor);
+    if let Some(target) = line_comment_target {
+        start_line_comment_edit(app, render_cache_store, content_area, target);
     } else if should_submit_line_comments(app, key) {
         open_line_comment_prompt(app);
     }
@@ -271,16 +281,54 @@ pub(crate) fn should_submit_line_comments(app: &App, key: KeyEvent) -> bool {
         && is_plain_char_key(key, 's')
         && *focus == DiffFocus::Content
         && !line_comments.is_editing()
+        && !line_comments.is_selecting()
         && !line_comments.comments.is_empty()
 }
 
-/// Returns the selected changed line when `Enter` is pressed in the patch.
-fn selected_line_comment_anchor(
+/// Handles `Shift+V` row-selection entry and `Esc` cancellation.
+fn handle_row_selection_key(
+    render_cache_store: &RenderCacheStore,
+    key: KeyEvent,
+    navigation: &mut DiffKeyNavigation<'_>,
+    can_reply_with_line_comments: bool,
+) -> bool {
+    if navigation.line_comments.is_selecting() && key.code == KeyCode::Esc {
+        navigation.line_comments.cancel_selection();
+
+        return true;
+    }
+    let review_comments_are_focused = navigation
+        .review_comments
+        .as_ref()
+        .is_some_and(|review_comments| review_comments.sidebar_focus == DiffSidebarFocus::Comments);
+    if !can_reply_with_line_comments
+        || !is_shift_char_key(key, 'v')
+        || *navigation.focus != DiffFocus::Content
+        || review_comments_are_focused
+        || selected_preview_is_visible(
+            navigation.diff,
+            *navigation.file_explorer_selected_index,
+            render_cache_store.diff_layout_cache(),
+            navigation.preview,
+        )
+    {
+        return false;
+    }
+
+    navigation
+        .line_comments
+        .start_selection(*navigation.selected_diff_line_index);
+
+    true
+}
+
+/// Returns the selected changed rows when `Enter` is pressed in the patch.
+fn selected_line_comment_target(
     render_cache_store: &RenderCacheStore,
     key: KeyEvent,
     navigation: &DiffKeyNavigation<'_>,
     can_reply_with_line_comments: bool,
-) -> Option<DiffLineCommentAnchor> {
+) -> Option<DiffLineCommentTarget> {
     let review_comments_are_focused = navigation
         .review_comments
         .as_ref()
@@ -300,21 +348,35 @@ fn selected_line_comment_anchor(
         return None;
     }
 
-    render_cache_store
+    let content = render_cache_store
         .diff_layout_cache()
-        .content(navigation.diff)
-        .selected_changed_line(
-            *navigation.file_explorer_selected_index,
-            *navigation.selected_diff_line_index,
-        )
+        .content(navigation.diff);
+    let (start_changed_line_index, end_changed_line_index) = navigation
+        .line_comments
+        .selected_row_bounds(*navigation.selected_diff_line_index);
+    if start_changed_line_index == end_changed_line_index {
+        return content
+            .selected_changed_line(
+                *navigation.file_explorer_selected_index,
+                start_changed_line_index,
+            )
+            .map(DiffLineCommentTarget::single);
+    }
+    let anchors = content.selected_changed_lines(
+        *navigation.file_explorer_selected_index,
+        start_changed_line_index,
+        end_changed_line_index,
+    );
+
+    DiffLineCommentTarget::from_anchors(anchors)
 }
 
-/// Starts inline editing without leaving the selected changed line.
+/// Starts inline editing without leaving the selected changed rows.
 fn start_line_comment_edit(
     app: &mut App,
     render_cache_store: &RenderCacheStore,
     content_area: Rect,
-    anchor: DiffLineCommentAnchor,
+    target: DiffLineCommentTarget,
 ) {
     let AppMode::Diff {
         diff,
@@ -322,14 +384,19 @@ fn start_line_comment_edit(
         line_comments,
         scroll_cache,
         scroll_offset,
-        selected_diff_line_index,
         ..
     } = &mut app.mode
     else {
         return;
     };
 
-    line_comments.start_editing(anchor);
+    let content = render_cache_store.diff_layout_cache().content(diff);
+    let Some(comment_changed_line_index) =
+        content.changed_line_index_for_anchor(*file_explorer_selected_index, target.last_anchor())
+    else {
+        return;
+    };
+    line_comments.start_editing_target(target);
     *scroll_cache = None;
     let layout = page::diff::diff_changed_line_layout(
         diff,
@@ -338,9 +405,7 @@ fn start_line_comment_edit(
         content_area,
         render_cache_store.diff_layout_cache(),
     );
-    let Some(selected_range) = layout.changed_line_ranges.get(*selected_diff_line_index) else {
-        return;
-    };
+    let selected_range = &layout.changed_line_ranges[comment_changed_line_index];
     let viewport_height = usize::from(layout.render_layout.viewport_height);
     if viewport_height == 0 {
         *scroll_offset = 0;
@@ -500,7 +565,7 @@ struct DiffKeyNavigation<'a> {
     diff: &'a str,
     file_explorer_selected_index: &'a mut usize,
     focus: &'a mut DiffFocus,
-    line_comments: &'a DiffLineComments,
+    line_comments: &'a mut DiffLineComments,
     preview: &'a mut DiffPreview,
     review_comments: &'a mut Option<DiffReviewComments>,
     scroll_cache: &'a mut Option<DiffScrollCache>,
@@ -587,11 +652,13 @@ fn apply_navigation_key(
             );
         }
         KeyCode::Esc | KeyCode::Left if *navigation.focus == DiffFocus::Content => {
+            navigation.line_comments.cancel_selection();
             *navigation.focus = DiffFocus::Files;
         }
         KeyCode::Char(character @ ('f' | 'h'))
             if *navigation.focus == DiffFocus::Content && is_plain_char_key(key, character) =>
         {
+            navigation.line_comments.cancel_selection();
             *navigation.focus = DiffFocus::Files;
         }
         KeyCode::Char('p')
@@ -1036,7 +1103,7 @@ mod tests {
     use ratatui::layout::Rect;
 
     use super::*;
-    use crate::presentation::app_mode::DiffReviewComments;
+    use crate::presentation::app_mode::{DiffLineCommentAnchor, DiffReviewComments};
 
     const TEST_TERMINAL_SIZE: Rect = Rect::new(0, 0, 80, 12);
 
@@ -1382,6 +1449,7 @@ mod tests {
                 line_comments: DiffLineComments {
                     editing_index: None,
                     ref comments,
+                    ..
                 },
                 selected_diff_line_index: 0,
                 ..
@@ -2570,6 +2638,125 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_handle_shift_v_selects_changed_rows_for_one_comment() {
+        // Arrange
+        let (mut app, _base_dir) = preview_test_app(ag_git::MockGitClient::new()).await;
+        let diff = concat!(
+            "diff --git a/src/main.rs b/src/main.rs\n",
+            "@@ -0,0 +1,3 @@\n",
+            "+first();\n",
+            "+second();\n",
+            "+third();\n",
+        );
+        app.mode = diff_mode_fixture(diff, 1, DiffFocus::Content, DiffPreview::default());
+        let expected_target = DiffLineCommentTarget::from_anchors(vec![
+            DiffLineCommentAnchor {
+                content: "first();".to_string(),
+                line: 1,
+                path: "src/main.rs".to_string(),
+                side: crate::presentation::app_mode::DiffLineSide::New,
+            },
+            DiffLineCommentAnchor {
+                content: "second();".to_string(),
+                line: 2,
+                path: "src/main.rs".to_string(),
+                side: crate::presentation::app_mode::DiffLineSide::New,
+            },
+        ])
+        .expect("first two changed rows should create a range target");
+
+        // Act — start downward selection, then cancel without leaving content focus.
+        handle(
+            &mut app,
+            TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Char('V'), KeyModifiers::SHIFT),
+        );
+        handle(
+            &mut app,
+            TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+        );
+        handle(
+            &mut app,
+            TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+        );
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Diff {
+                focus: DiffFocus::Content,
+                line_comments,
+                selected_diff_line_index: 1,
+                ..
+            } if !line_comments.is_selecting()
+        ));
+
+        // Act — select upward from the second row and open one range editor.
+        handle(
+            &mut app,
+            TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Char('v'), KeyModifiers::SHIFT),
+        );
+        handle(
+            &mut app,
+            TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+        );
+        handle(
+            &mut app,
+            TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Diff {
+                line_comments,
+                selected_diff_line_index: 0,
+                ..
+            } if line_comments.is_editing()
+                && line_comments.is_selecting()
+                && line_comments.comments[0].target == expected_target
+        ));
+
+        // Act — completed comments cannot submit while a new range is active.
+        handle(
+            &mut app,
+            TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+        );
+        handle(
+            &mut app,
+            TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Diff { line_comments, .. }
+                if !line_comments.is_editing() && !line_comments.is_selecting()
+        ));
+
+        // Act
+        handle(
+            &mut app,
+            TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Char('V'), KeyModifiers::SHIFT),
+        );
+        let should_submit = should_submit_line_comments(
+            &app,
+            KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE),
+        );
+
+        // Assert
+        assert!(!should_submit);
+    }
+
+    #[tokio::test]
     async fn test_merged_diff_rejects_inline_comment_creation_and_submission() {
         // Arrange
         let (mut app, _base_dir) = preview_test_app(ag_git::MockGitClient::new()).await;
@@ -2581,23 +2768,31 @@ mod tests {
         handle(
             &mut app,
             TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Char('V'), KeyModifiers::SHIFT),
+        );
+        handle(
+            &mut app,
+            TEST_TERMINAL_SIZE,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
         );
 
         // Assert
         assert!(matches!(
             &app.mode,
-            AppMode::Diff { line_comments, .. } if line_comments.comments.is_empty()
+            AppMode::Diff { line_comments, .. }
+                if line_comments.comments.is_empty() && !line_comments.is_selecting()
         ));
 
         // Arrange
         if let AppMode::Diff { line_comments, .. } = &mut app.mode {
-            line_comments.start_editing(DiffLineCommentAnchor {
-                content: "review();".to_string(),
-                line: 1,
-                path: "src/main.rs".to_string(),
-                side: crate::presentation::app_mode::DiffLineSide::New,
-            });
+            line_comments.start_editing_target(DiffLineCommentTarget::single(
+                DiffLineCommentAnchor {
+                    content: "review();".to_string(),
+                    line: 1,
+                    path: "src/main.rs".to_string(),
+                    side: crate::presentation::app_mode::DiffLineSide::New,
+                },
+            ));
             line_comments
                 .editing_input_mut()
                 .expect("seeded inline comment should be editable")
@@ -2636,23 +2831,49 @@ mod tests {
         // Arrange
         let (mut app, _base_dir) = preview_test_app(ag_git::MockGitClient::new()).await;
         let diff = scrollable_diff_fixture();
-        let anchor = DiffLineCommentAnchor {
-            content: "line 39".to_string(),
-            line: 40,
-            path: "src/main.rs".to_string(),
-            side: crate::presentation::app_mode::DiffLineSide::New,
-        };
+        let render_cache_store = RenderCacheStore::default();
+        let target = DiffLineCommentTarget::single(
+            render_cache_store
+                .diff_layout_cache()
+                .content(&diff)
+                .selected_changed_line(1, 39)
+                .expect("last changed line should resolve from the diff"),
+        );
 
         // Act
         start_line_comment_edit(
             &mut app,
-            &RenderCacheStore::default(),
+            &render_cache_store,
             TEST_TERMINAL_SIZE,
-            anchor.clone(),
+            target.clone(),
         );
 
         // Assert
         assert!(matches!(app.mode, AppMode::List));
+
+        // Arrange
+        app.mode = diff_mode_fixture(&diff, 1, DiffFocus::Content, DiffPreview::default());
+        let missing_target = DiffLineCommentTarget::single(DiffLineCommentAnchor {
+            content: "missing line".to_string(),
+            line: 999,
+            path: "src/main.rs".to_string(),
+            side: crate::presentation::app_mode::DiffLineSide::New,
+        });
+
+        // Act
+        start_line_comment_edit(
+            &mut app,
+            &render_cache_store,
+            TEST_TERMINAL_SIZE,
+            missing_target,
+        );
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Diff { line_comments, .. }
+                if !line_comments.is_editing() && line_comments.comments.is_empty()
+        ));
 
         // Arrange
         app.mode = diff_mode_fixture(&diff, 1, DiffFocus::Content, DiffPreview::default());
@@ -2667,9 +2888,9 @@ mod tests {
         // Act
         start_line_comment_edit(
             &mut app,
-            &RenderCacheStore::default(),
+            &render_cache_store,
             TEST_TERMINAL_SIZE,
-            anchor.clone(),
+            target.clone(),
         );
 
         // Assert
@@ -2677,9 +2898,10 @@ mod tests {
             &app.mode,
             AppMode::Diff {
                 line_comments,
-                scroll_offset: 0,
+                scroll_offset,
+                selected_diff_line_index: usize::MAX,
                 ..
-            } if line_comments.is_editing()
+            } if line_comments.is_editing() && *scroll_offset > 0
         ));
 
         // Arrange
@@ -2688,9 +2910,9 @@ mod tests {
         // Act
         start_line_comment_edit(
             &mut app,
-            &RenderCacheStore::default(),
+            &render_cache_store,
             Rect::new(0, 0, 80, 0),
-            anchor.clone(),
+            target.clone(),
         );
 
         // Assert
@@ -2713,12 +2935,7 @@ mod tests {
         }
 
         // Act
-        start_line_comment_edit(
-            &mut app,
-            &RenderCacheStore::default(),
-            TEST_TERMINAL_SIZE,
-            anchor,
-        );
+        start_line_comment_edit(&mut app, &render_cache_store, TEST_TERMINAL_SIZE, target);
 
         // Assert
         assert!(matches!(
@@ -2823,12 +3040,14 @@ mod tests {
             ..
         } = &mut app.mode
         {
-            line_comments.start_editing(DiffLineCommentAnchor {
-                content: "review();".to_string(),
-                line: 1,
-                path: "src/main.rs".to_string(),
-                side: crate::presentation::app_mode::DiffLineSide::New,
-            });
+            line_comments.start_editing_target(DiffLineCommentTarget::single(
+                DiffLineCommentAnchor {
+                    content: "review();".to_string(),
+                    line: 1,
+                    path: "src/main.rs".to_string(),
+                    side: crate::presentation::app_mode::DiffLineSide::New,
+                },
+            ));
             line_comments
                 .editing_input_mut()
                 .expect("comment should be editable")
@@ -2902,7 +3121,7 @@ mod tests {
             path: "src/lib.rs".to_string(),
             side: crate::presentation::app_mode::DiffLineSide::Old,
         };
-        line_comments.start_editing(anchor);
+        line_comments.start_editing_target(DiffLineCommentTarget::single(anchor));
         line_comments
             .editing_input_mut()
             .expect("comment should be editable")

--- a/crates/agentty/src/ui/page/diff.rs
+++ b/crates/agentty/src/ui/page/diff.rs
@@ -206,8 +206,55 @@ impl DiffContentSnapshot {
         )
     }
 
+    /// Returns changed-line anchors within one inclusive visual selection.
+    pub(crate) fn selected_changed_lines(
+        &self,
+        selected_index: usize,
+        start_changed_line_index: usize,
+        end_changed_line_index: usize,
+    ) -> Vec<DiffLineCommentAnchor> {
+        if start_changed_line_index > end_changed_line_index {
+            return Vec::new();
+        }
+        let Some(FileTreeItem::File(fallback_path)) = self.tree_items.get(selected_index) else {
+            return Vec::new();
+        };
+        let mut anchors = Vec::new();
+        let mut current_changed_line_index = 0;
+        let mut current_paths: Option<(String, String)> = None;
+
+        for diff_line in self.selected_lines(selected_index) {
+            if diff_line.kind == DiffLineKind::FileHeader {
+                if let Some(paths) = diff_header_paths(diff_line.content) {
+                    current_paths = Some(paths);
+                }
+
+                continue;
+            }
+            let Some((side, line, path)) =
+                Self::line_comment_location(&diff_line, current_paths.as_ref(), fallback_path)
+            else {
+                continue;
+            };
+            if current_changed_line_index > end_changed_line_index {
+                break;
+            }
+            if current_changed_line_index >= start_changed_line_index {
+                anchors.push(DiffLineCommentAnchor {
+                    content: diff_line.content.to_string(),
+                    line,
+                    path: path.to_string(),
+                    side,
+                });
+            }
+            current_changed_line_index = current_changed_line_index.saturating_add(1);
+        }
+
+        anchors
+    }
+
     /// Returns the changed-line cursor index that owns `anchor`.
-    fn changed_line_index_for_anchor(
+    pub(crate) fn changed_line_index_for_anchor(
         &self,
         selected_index: usize,
         anchor: &DiffLineCommentAnchor,
@@ -479,7 +526,9 @@ pub(crate) struct DiffResolvedLayout {
 struct DiffLineCommentInsertion {
     comment: usize,
     display_row: usize,
+    end_changed_line_index: usize,
     source_end: usize,
+    start_changed_line_index: usize,
 }
 
 /// Short-lived inputs used to paint one inline-comment diff viewport.
@@ -489,7 +538,7 @@ struct DiffVisibleLineRequest<'a> {
     line_comments: &'a DiffLineComments,
     prefix_width: usize,
     scroll_offset: u16,
-    selected_range: Option<&'a Range<usize>>,
+    highlighted_ranges: &'a [Range<usize>],
     viewport_height: u16,
 }
 
@@ -563,6 +612,31 @@ impl DiffResolvedLayout {
             self.render_layout.viewport_height,
         ))
     }
+
+    /// Returns the rendered rows covered by inclusive changed-line bounds.
+    fn changed_line_selection_range(
+        &self,
+        start_changed_line_index: usize,
+        end_changed_line_index: usize,
+    ) -> Option<Range<usize>> {
+        let start_range = self.changed_line_ranges.get(start_changed_line_index)?;
+        let end_range = self.changed_line_ranges.get(end_changed_line_index)?;
+
+        Some(start_range.start..end_range.end)
+    }
+
+    /// Returns rendered source ranges owned by visible inline comments.
+    fn line_comment_highlight_ranges(&self) -> Vec<Range<usize>> {
+        self.comment_insertions
+            .iter()
+            .filter_map(|insertion| {
+                self.changed_line_selection_range(
+                    insertion.start_changed_line_index,
+                    insertion.end_changed_line_index,
+                )
+            })
+            .collect()
+    }
 }
 
 /// Resolves inline comment rows and their display positions for one file.
@@ -577,23 +651,39 @@ fn diff_line_comment_insertions(
         .iter()
         .enumerate()
         .filter_map(|(comment_index, line_comment)| {
-            let changed_line_index =
-                content.changed_line_index_for_anchor(selected_file_index, &line_comment.anchor)?;
-            let insertion_index = changed_line_ranges.get(changed_line_index)?.end;
+            let start_changed_line_index = content.changed_line_index_for_anchor(
+                selected_file_index,
+                line_comment.target.first_anchor(),
+            )?;
+            let end_changed_line_index = content.changed_line_index_for_anchor(
+                selected_file_index,
+                line_comment.target.last_anchor(),
+            )?;
+            let insertion_index = changed_line_ranges.get(end_changed_line_index)?.end;
 
-            Some((insertion_index, comment_index))
+            Some((
+                insertion_index,
+                comment_index,
+                start_changed_line_index,
+                end_changed_line_index,
+            ))
         })
         .collect::<Vec<_>>();
-    insertions.sort_unstable_by_key(|(insertion_index, _)| *insertion_index);
+    insertions.sort_unstable_by_key(|(insertion_index, ..)| *insertion_index);
 
     insertions
         .into_iter()
         .enumerate()
         .map(
-            |(preceding_comment_count, (insertion_index, comment))| DiffLineCommentInsertion {
+            |(
+                preceding_comment_count,
+                (insertion_index, comment, start_changed_line_index, end_changed_line_index),
+            )| DiffLineCommentInsertion {
                 comment,
                 display_row: insertion_index.saturating_add(preceding_comment_count),
+                end_changed_line_index,
                 source_end: insertion_index,
+                start_changed_line_index,
             },
         )
         .collect()
@@ -977,22 +1067,29 @@ impl<'a> DiffPage<'a> {
             layout.line_count,
             layout.render_layout.viewport_height,
         );
+        let mut highlighted_ranges = layout.line_comment_highlight_ranges();
         let selected_range = (self.focus == DiffFocus::Content)
             .then(|| {
+                let (start_changed_line_index, end_changed_line_index) = self
+                    .line_comments
+                    .selected_row_bounds(self.selected_diff_line_index);
+
                 layout
-                    .changed_line_ranges
-                    .get(self.selected_diff_line_index)
+                    .changed_line_selection_range(start_changed_line_index, end_changed_line_index)
             })
             .flatten();
+        if let Some(selected_range) = selected_range {
+            highlighted_ranges.push(selected_range);
+        }
         let paint_lines = Self::borrowed_visible_lines_with_comments(
             &layout.lines,
             &DiffVisibleLineRequest {
                 comment_insertions: &layout.comment_insertions,
                 content_width: layout.render_layout.content_width,
+                highlighted_ranges: &highlighted_ranges,
                 line_comments: self.line_comments,
                 prefix_width: layout.render_layout.prefix_width,
                 scroll_offset,
-                selected_range,
                 viewport_height: layout.render_layout.viewport_height,
             },
         );
@@ -1050,8 +1147,9 @@ impl<'a> DiffPage<'a> {
                 let original_index = display_row.saturating_sub(preceding_comment_count);
                 let mut paint_line = text_util::borrowed_paint_line(lines.get(original_index)?);
                 if request
-                    .selected_range
-                    .is_some_and(|range| range.contains(&display_row))
+                    .highlighted_ranges
+                    .iter()
+                    .any(|range| range.contains(&display_row))
                 {
                     paint_line.style = paint_line.style.add_modifier(Modifier::REVERSED);
                     for span in &mut paint_line.spans {
@@ -1460,6 +1558,8 @@ impl Page for DiffPage<'_> {
                     help_action::DiffLineCommentFooterState::ReadOnly
                 } else if self.line_comments.is_editing() {
                     help_action::DiffLineCommentFooterState::Editing
+                } else if self.line_comments.is_selecting() {
+                    help_action::DiffLineCommentFooterState::Selecting
                 } else {
                     help_action::DiffLineCommentFooterState::Ready {
                         comment_count: self.line_comments.comments.len(),
@@ -1560,6 +1660,7 @@ fn preview_unavailable_message(reason: &DiffPreviewUnavailableReason) -> &str {
 mod tests {
     use super::*;
     use crate::domain::theme::ColorTheme;
+    use crate::presentation::app_mode::DiffLineCommentTarget;
     use crate::test_support::SessionFixtureBuilder;
     use crate::ui::diff_util::{parse_diff_lines, selected_diff_lines};
 
@@ -1712,8 +1813,11 @@ mod tests {
         // Act
         let old_line = content.selected_changed_line(1, 0);
         let new_line = content.selected_changed_line(1, 1);
+        let selected_lines = content.selected_changed_lines(1, 0, 1);
         let missing_line = content.selected_changed_line(1, 2);
         let folder_line = content.selected_changed_line(0, 0);
+        let folder_lines = content.selected_changed_lines(0, 0, 1);
+        let reversed_lines = content.selected_changed_lines(1, 1, 0);
         let folder_anchor_index = content.changed_line_index_for_anchor(
             0,
             old_line
@@ -1751,6 +1855,25 @@ mod tests {
         );
         assert_eq!(missing_line, None);
         assert_eq!(folder_line, None);
+        assert_eq!(
+            selected_lines,
+            [
+                DiffLineCommentAnchor {
+                    content: "old line".to_string(),
+                    line: 4,
+                    path: "src/main.rs".to_string(),
+                    side: DiffLineSide::Old,
+                },
+                DiffLineCommentAnchor {
+                    content: "new line".to_string(),
+                    line: 4,
+                    path: "src/main.rs".to_string(),
+                    side: DiffLineSide::New,
+                },
+            ]
+        );
+        assert!(folder_lines.is_empty());
+        assert!(reversed_lines.is_empty());
         assert_eq!(folder_anchor_index, None);
         assert_eq!(missing_anchor_index, None);
     }
@@ -1825,12 +1948,12 @@ mod tests {
             "+review();\n",
         );
         let mut line_comments = DiffLineComments::default();
-        line_comments.start_editing(DiffLineCommentAnchor {
+        line_comments.start_editing_target(DiffLineCommentTarget::single(DiffLineCommentAnchor {
             content: "fn main() {}".to_string(),
             line: 1,
             path: "src/main.rs".to_string(),
             side: DiffLineSide::New,
-        });
+        }));
         line_comments
             .editing_input_mut()
             .expect("inline comment should be editable")
@@ -1881,16 +2004,149 @@ mod tests {
     }
 
     #[test]
+    fn test_diff_page_keeps_commented_range_highlighted_after_editing() {
+        // Arrange
+        let diff = concat!(
+            "diff --git a/src/main.rs b/src/main.rs\n",
+            "@@ -0,0 +1,2 @@\n",
+            "+fn main() {}\n",
+            "+review();\n",
+        );
+        let mut line_comments = DiffLineComments::default();
+        line_comments.start_selection(0);
+        line_comments.start_editing_target(
+            DiffLineCommentTarget::from_anchors(vec![
+                DiffLineCommentAnchor {
+                    content: "fn main() {}".to_string(),
+                    line: 1,
+                    path: "src/main.rs".to_string(),
+                    side: DiffLineSide::New,
+                },
+                DiffLineCommentAnchor {
+                    content: "review();".to_string(),
+                    line: 2,
+                    path: "src/main.rs".to_string(),
+                    side: DiffLineSide::New,
+                },
+            ])
+            .expect("two changed rows should form a comment target"),
+        );
+        line_comments
+            .editing_input_mut()
+            .expect("range comment should be editable")
+            .insert_text("Explain both lines");
+        line_comments.finish_editing();
+        let session = session_fixture();
+        let diff_layout_cache = DiffLayoutCache::default();
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+        let mut page = DiffPage::new(DiffPageInput {
+            can_comment: true,
+            diff,
+            diff_layout_cache: &diff_layout_cache,
+            file_explorer_selected_index: 1,
+            focus: DiffFocus::Files,
+            line_comments: &line_comments,
+            markdown_render_cache: &markdown_render_cache,
+            preview: test_diff_preview(),
+            review_comments: None,
+            scroll_offset: 0,
+            selected_diff_line_index: 1,
+            session: &session,
+            sidebar_focus: DiffSidebarFocus::Files,
+        });
+        let backend = ratatui::backend::TestBackend::new(100, 14);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+
+        // Act
+        terminal
+            .draw(|frame| page.render(frame, frame.area()))
+            .expect("failed to render diff page");
+
+        // Assert
+        let selected_source_row_count = terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(100)
+            .filter(|row| {
+                let row_text = row
+                    .iter()
+                    .map(ratatui::buffer::Cell::symbol)
+                    .collect::<String>();
+                (row_text.contains("fn main() {}") || row_text.contains("review();"))
+                    && row
+                        .iter()
+                        .any(|cell| cell.modifier.contains(Modifier::REVERSED))
+            })
+            .count();
+        assert_eq!(selected_source_row_count, 2);
+        assert!(
+            terminal
+                .backend()
+                .buffer()
+                .content()
+                .chunks(100)
+                .all(|row| {
+                    let row_text = row
+                        .iter()
+                        .map(ratatui::buffer::Cell::symbol)
+                        .collect::<String>();
+
+                    !row_text.contains("comment: Explain both lines")
+                        || row
+                            .iter()
+                            .all(|cell| !cell.modifier.contains(Modifier::REVERSED))
+                })
+        );
+    }
+
+    #[test]
+    fn test_diff_page_shows_visual_selection_footer() {
+        // Arrange
+        let diff = "diff --git a/main.rs b/main.rs\n@@ -0,0 +1 @@\n+review();";
+        let mut line_comments = DiffLineComments::default();
+        line_comments.start_selection(0);
+        let session = session_fixture();
+        let diff_layout_cache = DiffLayoutCache::default();
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+        let mut page = DiffPage::new(DiffPageInput {
+            can_comment: true,
+            diff,
+            diff_layout_cache: &diff_layout_cache,
+            file_explorer_selected_index: 0,
+            focus: DiffFocus::Content,
+            line_comments: &line_comments,
+            markdown_render_cache: &markdown_render_cache,
+            preview: test_diff_preview(),
+            review_comments: None,
+            scroll_offset: 0,
+            selected_diff_line_index: 0,
+            session: &session,
+            sidebar_focus: DiffSidebarFocus::Files,
+        });
+        let backend = ratatui::backend::TestBackend::new(100, 14);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+
+        // Act
+        terminal
+            .draw(|frame| page.render(frame, frame.area()))
+            .expect("failed to render diff page");
+
+        // Assert
+        assert!(buffer_text(terminal.backend().buffer()).contains("Esc: cancel"));
+    }
+
+    #[test]
     fn test_inline_comment_highlighting_distinguishes_active_and_completed_rows() {
         // Arrange
         let comment = DiffLineComment {
-            anchor: DiffLineCommentAnchor {
+            input: crate::domain::input::InputState::with_text("Explain this".to_string()),
+            target: DiffLineCommentTarget::single(DiffLineCommentAnchor {
                 content: "review();".to_string(),
                 line: 1,
                 path: "src/main.rs".to_string(),
                 side: DiffLineSide::New,
-            },
-            input: crate::domain::input::InputState::with_text("Explain this".to_string()),
+            }),
         };
 
         // Act
@@ -2125,12 +2381,69 @@ mod tests {
         let zero_height_scroll_offset = zero_height_layout
             .changed_line_scroll_offset(0, scrolled_down)
             .expect("first changed line should remain selectable without a viewport");
+        let selection_range = layout
+            .changed_line_selection_range(2, 4)
+            .expect("valid changed-line selection should resolve rendered rows");
+        let missing_selection_range = layout.changed_line_selection_range(2, usize::MAX);
 
         // Assert
         assert_eq!(layout.changed_line_count(), 40);
         assert!(scrolled_down > 0);
         assert!(scrolled_up < scrolled_down);
         assert_eq!(zero_height_scroll_offset, 0);
+        assert_eq!(
+            selection_range,
+            layout.changed_line_ranges[2].start..layout.changed_line_ranges[4].end
+        );
+        assert_eq!(missing_selection_range, None);
+    }
+
+    #[test]
+    fn test_diff_line_comment_insertions_ignore_missing_target_bounds() {
+        // Arrange
+        let diff = "diff --git a/main.rs b/main.rs\n@@ -0,0 +1 @@\n+review();";
+        let cache = DiffLayoutCache::default();
+        let content = cache.content(diff);
+        let changed_line_ranges = diff_changed_line_layout(
+            diff,
+            &DiffLineComments::default(),
+            0,
+            Rect::new(0, 0, 80, 12),
+            &cache,
+        )
+        .changed_line_ranges;
+        let valid_anchor = content
+            .selected_changed_line(0, 0)
+            .expect("fixture should contain one changed line");
+        let missing_anchor = DiffLineCommentAnchor {
+            content: "missing();".to_string(),
+            line: 999,
+            path: "main.rs".to_string(),
+            side: DiffLineSide::New,
+        };
+        let targets = [
+            DiffLineCommentTarget::from_anchors(vec![missing_anchor.clone(), valid_anchor.clone()])
+                .expect("first missing target should be nonempty"),
+            DiffLineCommentTarget::from_anchors(vec![valid_anchor, missing_anchor])
+                .expect("last missing target should be nonempty"),
+        ];
+        let mut line_comments = DiffLineComments::default();
+        for target in targets {
+            line_comments.start_editing_target(target);
+            line_comments
+                .editing_input_mut()
+                .expect("stale comment target should remain editable")
+                .insert_text("Explain this");
+            line_comments.finish_editing();
+        }
+
+        // Act
+        let insertions =
+            diff_line_comment_insertions(&content, 0, &changed_line_ranges, &line_comments);
+
+        // Assert
+        assert_eq!(line_comments.comments.len(), 2);
+        assert!(insertions.is_empty());
     }
 
     #[test]
@@ -2162,7 +2475,7 @@ mod tests {
             .selected_changed_line(0, 0)
             .expect("fixture should contain one changed line");
         let mut line_comments = DiffLineComments::default();
-        line_comments.start_editing(anchor);
+        line_comments.start_editing_target(DiffLineCommentTarget::single(anchor));
         line_comments
             .editing_input_mut()
             .expect("inline comment should be editable")

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -7267,6 +7267,77 @@ fn test_diff_line_comments() -> E2eResult {
     Ok(())
 }
 
+/// Verify that `Shift+V` selects a changed-row range for one inline comment.
+#[test]
+fn test_diff_row_selection_comments() -> E2eResult {
+    // Arrange — Ctrl+M emits Enter's carriage return consistently in PTY and VHS.
+    const ENTER_KEY: &str = "Ctrl+m";
+
+    // Act, Assert
+    FeatureTest::new("diff_row_selection_comments")
+        .with_git()
+        .setup(|env| {
+            seed_review_ready_session(env)?;
+            seed_linked_review_worktree_with_diff(env)?;
+            seed_sessions_startup_tab(env)
+        })
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::open_selected_session_view())
+                    .press_key("d")
+                    .wait_for_text("main.rs", 5000)
+                    .press_key("j")
+                    .wait_for_stable_frame(200, 3000)
+                    .press_key(ENTER_KEY)
+                    .wait_for_text("Enter: comment", 5000)
+                    .write_text("V")
+                    .wait_for_text("Esc: cancel", 5000)
+                    .press_key("j")
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled(
+                        "selected_comment_rows",
+                        "Visual line selection highlights a changed-row range",
+                    )
+                    .press_key(ENTER_KEY)
+                    .wait_for_text("comment: |", 5000)
+                    .write_text("Explain these lines.")
+                    .wait_for_text("Explain these lines.|", 3000)
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled(
+                        "editing_row_range_comment",
+                        "Selected rows stay highlighted while entering the comment",
+                    )
+                    .press_key(ENTER_KEY)
+                    .wait_for_text("comment: Explain these lines.", 3000)
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled(
+                        "row_range_comment",
+                        "The completed comment keeps its source range highlighted",
+                    )
+            },
+            |frame, report| {
+                let selection_frame = common::frame_from_capture(&report.captures[0]);
+                let selection_full = Region::full(selection_frame.cols(), selection_frame.rows());
+                assertion::assert_text_in_region(&selection_frame, "Esc: cancel", &selection_full);
+
+                let editor_frame = common::frame_from_capture(&report.captures[1]);
+                let editor_full = Region::full(editor_frame.cols(), editor_frame.rows());
+                assertion::assert_text_in_region(
+                    &editor_frame,
+                    "comment: Explain these lines.|",
+                    &editor_full,
+                );
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "comment: Explain these lines.", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
 /// Verify that `p` toggles a changed markdown file between raw diff and a
 /// rendered markdown/mermaid preview.
 #[test]

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -274,11 +274,15 @@ showing the git diff. While Files remains focused, use `Shift+j` / `Shift+k` or 
 `Down` to scroll the selected file without moving focus. Press `Enter` on a file to
 focus its changes, then press `Enter` again to edit the selected changed line inline.
 After finishing with `Enter` or `Esc`, use `j` / `k` or the arrow keys to move the line
-cursor and press `Enter` to edit the selected line. `Esc`, `Left`, `h`, or `f` returns
-focus to the file tree. Linked review requests add a Comments section below Files; `c`
-focuses Comments while the file tree is focused, and `f` returns to Files. The Comments
-section keeps its own `Enter` action for submitting marked review threads. Press `s` to
-submit every inline diff comment together in the next turn.
+cursor and press `Enter` to edit the selected line. Press `Shift+V` to start a visual
+changed-row selection, extend it with the same navigation keys, then press `Enter` to
+comment on the range or `Esc` to cancel the selection. The range stays highlighted while
+its inline editor is open and after the comment is finished, so the comment's source
+remains visible. `Esc`, `Left`, `h`, or `f` returns focus to the file tree when no
+visual selection is active. Linked review requests add a Comments section below Files;
+`c` focuses Comments while the file tree is focused, and `f` returns to Files. The
+Comments section keeps its own `Enter` action for submitting marked review threads.
+Press `s` to submit every inline diff comment together in the next turn.
 
 | Key                   | Action                                                 |
 | --------------------- | ------------------------------------------------------ |
@@ -286,6 +290,7 @@ submit every inline diff comment together in the next turn.
 | `Esc`                 | Focus Files, or leave from Files                       |
 | `j` / `k`             | Select a file or changed line                          |
 | `Shift+j` / `Shift+k` | Scroll selected file, or select a changed line         |
+| `Shift+V`             | Start visual changed-row selection                     |
 | `Enter`               | Focus a file, or edit/finish a comment                 |
 | `Up` / `Down`         | Scroll selected file, select a line, or scroll preview |
 | `Left` / `h` / `f`    | Return to Files                                        |
@@ -308,14 +313,15 @@ markdown file loads automatically, while folders and other file types continue s
 their normal diff. Deleted, binary, oversized, and unreadable markdown files show a
 short availability notice. Press `p` again to return to raw diff lines.
 
-Each line comment stays visible beneath its changed line while Diff mode remains open.
-Press `Enter` again on a commented line to edit it; clearing its text and finishing
-removes it. Completed comments use a distinct inset background, while the active editor
-uses the stronger selection highlight. `s` combines all finished comments with any draft
-text and image attachments that were present before opening the diff, then submits the
-batch as one session turn. The chat renders the batch compactly as one path, line, side,
-and comment per row. Comments on deleted lines also include the captured pre-change
-source text so the agent retains context that is absent from the worktree.
+Each comment stays visible beneath its changed line or selected range while Diff mode
+remains open. Press `Enter` again on the same line or range to edit it; clearing its
+text and finishing removes it. Completed comments use a distinct inset background, while
+the active editor uses the stronger selection highlight. `s` combines all finished
+comments with any draft text and image attachments that were present before opening the
+diff, then submits the batch as one session turn. The chat renders the batch compactly
+as one path, line or range, side, and comment per row. Comments containing deleted lines
+also include their captured pre-change source text so the agent retains context that is
+absent from the worktree.
 
 Read-only diffs, including `Merged` sessions, keep changed-line navigation but hide the
 inline comment and batch-submission shortcuts.

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -222,28 +222,32 @@ patch, then press `Enter` again to open an inline editor beneath the selected ad
 removed line. Type the feedback, then press `Enter` or `Esc` to finish without leaving
 Diff mode. Use `j` / `k` or the arrow keys to move through changed lines while Agentty
 keeps the cursor visible, and press `Enter` on any selected line to add or edit its
-comment. Finishing empty text removes the comment. Completed comments keep a distinct
-inset background, and the active editor uses the stronger selection highlight. The
-linked review-request Comments section retains its separate `Enter` action for
-submitting marked review threads. Press `s` to submit every finished line comment
-together as the next session turn. The submitted prompt uses one compact row per comment
-with its repository-relative path, old or new side, and line number, and keeps draft
-instructions or image attachments that were present before opening the diff.
-Deleted-line rows also include their captured pre-change source text because that
-context is absent from the current worktree. Inline comment editing and submission are
-available only when the session can accept a reply. Read-only diffs such as `Merged`
-sessions keep line navigation but omit the comment actions from the footer and help
-overlay. Press `Esc`, `Left`, `h`, or `f` to return to the file tree. Select a changed
-markdown file and press `p` to render its complete post-change worktree content,
-including supported Mermaid diagrams. Preview remains active across file navigation;
-non-markdown selections keep showing raw diff lines, and files that are deleted, binary,
-too large, or unreadable show a concise notice. Press `p` again to restore the patch
-view. Pressing `q` returns to the sessions list and saves the complete composer;
-reopening the session restores the typed draft with input focus. Pressing `Tab` again
-returns focus to the composer. The same focus toggle, `d` diff preview, and `q`
-preservation flow are available while answering clarification questions. Long
-transcripts show a slim scrollbar on the right side of the output panel to indicate the
-current position.
+comment. To comment on a range, press `Shift+V` on the first changed row, extend the
+visual selection with `j` / `k` or the arrow keys, then press `Enter`; `Esc` cancels the
+selection without leaving the patch. The full range stays highlighted while its inline
+editor is open and after the comment is finished, so every inline comment retains its
+visible source context. Finishing empty text removes the comment and its source
+highlight. Completed comments keep a distinct inset background, and the active editor
+uses the stronger selection highlight. The linked review-request Comments section
+retains its separate `Enter` action for submitting marked review threads. Press `s` to
+submit every finished line or range comment together as the next session turn. The
+submitted prompt uses one compact row per comment with its repository-relative path, old
+or new side, and line or range, and keeps draft instructions or image attachments that
+were present before opening the diff. Selected deleted rows also include their captured
+pre-change source text because that context is absent from the current worktree. Inline
+comment editing and submission are available only when the session can accept a reply.
+Read-only diffs such as `Merged` sessions keep line navigation but omit the comment
+actions from the footer and help overlay. With no visual selection active, press `Esc`,
+`Left`, `h`, or `f` to return to the file tree. Select a changed markdown file and press
+`p` to render its complete post-change worktree content, including supported Mermaid
+diagrams. Preview remains active across file navigation; non-markdown selections keep
+showing raw diff lines, and files that are deleted, binary, too large, or unreadable
+show a concise notice. Press `p` again to restore the patch view. Pressing `q` returns
+to the sessions list and saves the complete composer; reopening the session restores the
+typed draft with input focus. Pressing `Tab` again returns focus to the composer. The
+same focus toggle, `d` diff preview, and `q` preservation flow are available while
+answering clarification questions. Long transcripts show a slim scrollbar on the right
+side of the output panel to indicate the current position.
 
 Pressing `r` during a running turn queues session sync on the same session worker. The
 session stays **InProgress** while the active turn runs, then moves to **Rebasing** when


### PR DESCRIPTION
- Selects contiguous changed rows with `Shift+V` and keeps one inline comment attached to the selected range.
- Formats same-file ranges compactly and preserves deleted-line source context in submitted prompts.
- Keeps selected ranges highlighted through editing and completion while retaining cancellable selection and read-only restrictions.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)