### PR TITLE
Expose completion metadata and classify model errors

### DIFF
--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -14,3 +14,5 @@ let output = harness.run(prompt, output_schema).await?;
 
 Provide `MODEL_API_KEY`, a repository root, explicitly allowed tools, a prompt, and an
 `OutputSchema`. Expect schema-validated JSON or a typed error.
+
+Use `ModelWithMetadata::complete_with_metadata()` for normalized completion metadata.

--- a/crates/ag-harness/src/chat_completion.rs
+++ b/crates/ag-harness/src/chat_completion.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 
@@ -65,8 +66,14 @@ pub(crate) struct ChatCompletionProviderPolicy {
 
 /// Provider-neutral result of decoding one Chat Completions choice.
 pub(crate) enum GeneratedResponse {
-    Output(String),
-    ToolCall(tool::ToolCall),
+    Output {
+        metadata: model::CompletionMetadata,
+        output: String,
+    },
+    ToolCall {
+        call: tool::ToolCall,
+        metadata: model::CompletionMetadata,
+    },
 }
 
 /// Shared structured-output backend for OpenAI-compatible Chat Completions
@@ -126,13 +133,13 @@ impl ChatCompletionBackend {
             .await
             .map_err(|error| self.map_completion_error(error))?
             .ok_or(model::ModelError::InvalidResponse)?;
-        let (finish_reason, content, reasoning_content, tool_calls) = completion.into_parts();
-        match finish_reason.as_str() {
+        let (metadata, content, reasoning_content, tool_calls) = completion.into_parts();
+        match metadata.finish_reason() {
             "stop" if !tool_calls.is_empty() => {
                 Err(model::ModelError::TerminalResponseWithToolCalls)
             }
             "stop" => content
-                .map(GeneratedResponse::Output)
+                .map(|output| GeneratedResponse::Output { metadata, output })
                 .ok_or(model::ModelError::InvalidResponse),
             "tool_calls" => Self::decode_tool_call(
                 request,
@@ -143,9 +150,10 @@ impl ChatCompletionBackend {
                     .then_some(reasoning_content)
                     .flatten(),
                 tool_calls,
+                metadata,
             ),
             _ => Err(model::ModelError::IncompleteResponse {
-                reason: schema_contract::bounded_diagnostic(finish_reason),
+                reason: schema_contract::bounded_diagnostic(metadata.finish_reason()),
             }),
         }
     }
@@ -258,14 +266,20 @@ impl ChatCompletionBackend {
                 body,
                 source,
                 status,
-            } => model::ModelError::request(ProviderHttpError {
-                body,
-                provider: self.policy.display_name,
-                source,
-                status,
-            }),
+            } => {
+                model::ModelError::provider_request(self.policy.display_name, body, source, status)
+            }
+            error @ ChatCompletionError::InvalidResponse(_) => {
+                model::ModelError::classified_request(
+                    model::ModelErrorType::InvalidProviderResponse,
+                    error.into(),
+                )
+            }
             ChatCompletionError::ResponseBodyTooLarge => model::ModelError::ResponseBodyTooLarge,
-            error => model::ModelError::request(error),
+            error @ ChatCompletionError::Transport(_) => model::ModelError::classified_request(
+                model::ModelErrorType::Transport,
+                error.into(),
+            ),
         }
     }
 
@@ -274,6 +288,7 @@ impl ChatCompletionBackend {
         content: Option<&str>,
         reasoning_content: Option<String>,
         mut calls: Vec<ChatCompletionToolCall>,
+        metadata: model::CompletionMetadata,
     ) -> Result<GeneratedResponse, model::ModelError> {
         if content.is_some_and(|content| !content.is_empty()) {
             return Err(model::ModelError::ToolCallWithContent);
@@ -310,11 +325,10 @@ impl ChatCompletionBackend {
                 }
             })?;
 
-        Ok(GeneratedResponse::ToolCall(tool::ToolCall::read(
-            call.id,
-            arguments,
-            reasoning_content,
-        )))
+        Ok(GeneratedResponse::ToolCall {
+            call: tool::ToolCall::read(call.id, arguments, reasoning_content),
+            metadata,
+        })
     }
 }
 
@@ -344,7 +358,7 @@ impl<'a> ChatCompletionRequest<'a> {
 /// Provider-independent fields extracted from the first completion choice.
 pub(crate) struct ChatCompletion {
     content: Option<String>,
-    finish_reason: String,
+    metadata: model::CompletionMetadata,
     reasoning_content: Option<String>,
     tool_calls: Vec<ChatCompletionToolCall>,
 }
@@ -354,7 +368,7 @@ impl ChatCompletion {
     pub(crate) fn new(finish_reason: String, content: Option<String>) -> Self {
         Self {
             content,
-            finish_reason,
+            metadata: model::CompletionMetadata::new(finish_reason, None, None, None, None),
             reasoning_content: None,
             tool_calls: Vec::new(),
         }
@@ -364,13 +378,13 @@ impl ChatCompletion {
     fn into_parts(
         self,
     ) -> (
-        String,
+        model::CompletionMetadata,
         Option<String>,
         Option<String>,
         Vec<ChatCompletionToolCall>,
     ) {
         (
-            self.finish_reason,
+            self.metadata,
             self.content,
             self.reasoning_content,
             self.tool_calls,
@@ -436,8 +450,9 @@ impl ChatCompletionClient for ReqwestChatCompletionClient {
         let response = serde_json::from_slice::<ChatCompletionResponse>(&body)
             .map_err(ChatCompletionError::InvalidResponse)?;
 
-        Ok(response.choices.into_iter().next().map(|choice| {
+        Ok(response.into_completion().map(|(choice, metadata)| {
             let mut completion = ChatCompletion::new(choice.finish_reason, choice.message.content);
+            completion.metadata = metadata;
             completion.reasoning_content = choice.message.reasoning_content;
             completion.tool_calls = choice.message.tool_calls.unwrap_or_default();
 
@@ -541,16 +556,6 @@ impl ChatCompletionError {
     }
 }
 
-#[derive(Debug, Error)]
-#[error("{provider} returned HTTP {status}: {body}")]
-struct ProviderHttpError {
-    body: String,
-    provider: &'static str,
-    #[source]
-    source: reqwest::Error,
-    status: reqwest::StatusCode,
-}
-
 #[derive(Serialize)]
 struct ChatCompletionPayload<'a> {
     messages: Vec<ChatCompletionMessagePayload>,
@@ -641,6 +646,36 @@ struct ChatCompletionFunction<'a> {
 #[derive(Deserialize)]
 struct ChatCompletionResponse {
     choices: Vec<ChatCompletionChoice>,
+    #[serde(default, deserialize_with = "deserialize_optional")]
+    id: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional")]
+    model: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional")]
+    system_fingerprint: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional")]
+    usage: Option<ChatCompletionUsage>,
+}
+
+impl ChatCompletionResponse {
+    fn into_completion(self) -> Option<(ChatCompletionChoice, model::CompletionMetadata)> {
+        let Self {
+            choices,
+            id,
+            model: response_model,
+            system_fingerprint,
+            usage,
+        } = self;
+        let choice = choices.into_iter().next()?;
+        let metadata = model::CompletionMetadata::new(
+            choice.finish_reason.clone(),
+            id,
+            response_model,
+            system_fingerprint,
+            usage.map(model::CompletionUsage::from),
+        );
+
+        Some((choice, metadata))
+    }
 }
 
 #[derive(Deserialize)]
@@ -656,6 +691,68 @@ struct ChatCompletionMessage {
     reasoning_content: Option<String>,
     #[serde(default)]
     tool_calls: Option<Vec<ChatCompletionToolCall>>,
+}
+
+#[derive(Deserialize)]
+struct ChatCompletionUsage {
+    #[serde(default, deserialize_with = "deserialize_optional")]
+    completion_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_optional")]
+    completion_tokens_details: Option<CompletionTokenDetails>,
+    #[serde(default, deserialize_with = "deserialize_optional")]
+    prompt_cache_hit_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_optional")]
+    prompt_cache_miss_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_optional")]
+    prompt_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_optional")]
+    prompt_tokens_details: Option<PromptTokenDetails>,
+    #[serde(default, deserialize_with = "deserialize_optional")]
+    total_tokens: Option<u64>,
+}
+
+impl From<ChatCompletionUsage> for model::CompletionUsage {
+    fn from(usage: ChatCompletionUsage) -> Self {
+        Self::new(
+            usage.prompt_cache_hit_tokens.or_else(|| {
+                usage
+                    .prompt_tokens_details
+                    .as_ref()
+                    .and_then(|details| details.cached_tokens)
+            }),
+            usage.prompt_cache_miss_tokens,
+            usage.prompt_tokens,
+            usage.completion_tokens,
+            usage
+                .completion_tokens_details
+                .and_then(|details| details.reasoning_tokens),
+            usage.total_tokens,
+        )
+    }
+}
+
+#[derive(Deserialize)]
+struct CompletionTokenDetails {
+    #[serde(default, deserialize_with = "deserialize_optional")]
+    reasoning_tokens: Option<u64>,
+}
+
+#[derive(Deserialize)]
+struct PromptTokenDetails {
+    #[serde(default, deserialize_with = "deserialize_optional")]
+    cached_tokens: Option<u64>,
+}
+
+fn deserialize_optional<'de, DeserializerType, ValueType>(
+    deserializer: DeserializerType,
+) -> Result<Option<ValueType>, DeserializerType::Error>
+where
+    DeserializerType: Deserializer<'de>,
+    ValueType: DeserializeOwned,
+{
+    let value = Value::deserialize(deserializer)?;
+
+    Ok(serde_json::from_value(value).ok())
 }
 
 #[derive(Deserialize)]
@@ -753,6 +850,122 @@ mod tests {
     }
 
     #[test]
+    fn decodes_complete_metadata_from_first_choice() {
+        // Arrange
+        let response = serde_json::from_value::<ChatCompletionResponse>(serde_json::json!({
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {"content": r#"{"name":"Ada"}"#}
+                },
+                {
+                    "finish_reason": "length",
+                    "message": {"content": "ignored"}
+                }
+            ],
+            "id": "response-1",
+            "model": "provider-model",
+            "system_fingerprint": "fingerprint-1",
+            "usage": {
+                "completion_tokens": 21,
+                "completion_tokens_details": {"reasoning_tokens": 3},
+                "prompt_cache_hit_tokens": 5,
+                "prompt_cache_miss_tokens": 8,
+                "prompt_tokens": 13,
+                "prompt_tokens_details": {"cached_tokens": 99},
+                "total_tokens": 34,
+                "unknown_usage_field": 55
+            },
+            "unknown_response_field": true
+        }))
+        .expect("complete response metadata should decode");
+
+        // Act
+        let (choice, metadata) = response
+            .into_completion()
+            .expect("first completion choice should exist");
+        let usage = metadata.usage().expect("usage should be retained");
+
+        // Assert
+        assert_eq!(choice.message.content.as_deref(), Some(r#"{"name":"Ada"}"#));
+        assert_eq!(metadata.finish_reason(), "stop");
+        assert_eq!(metadata.response_id(), Some("response-1"));
+        assert_eq!(metadata.response_model(), Some("provider-model"));
+        assert_eq!(metadata.system_fingerprint(), Some("fingerprint-1"));
+        assert_eq!(usage.cache_hit_tokens(), Some(5));
+        assert_eq!(usage.cache_miss_tokens(), Some(8));
+        assert_eq!(usage.input_tokens(), Some(13));
+        assert_eq!(usage.output_tokens(), Some(21));
+        assert_eq!(usage.reasoning_tokens(), Some(3));
+        assert_eq!(usage.total_tokens(), Some(34));
+    }
+
+    #[test]
+    fn decodes_partial_usage_without_estimating_missing_counts() {
+        // Arrange
+        let response = serde_json::from_value::<ChatCompletionResponse>(serde_json::json!({
+            "choices": [{
+                "finish_reason": "tool_calls",
+                "message": {"content": null}
+            }],
+            "id": 42,
+            "model": ["unexpected"],
+            "system_fingerprint": {"unexpected": true},
+            "usage": {
+                "completion_tokens": "unknown",
+                "completion_tokens_details": {"reasoning_tokens": -1},
+                "prompt_tokens_details": {"cached_tokens": 7}
+            }
+        }))
+        .expect("partial usage should decode");
+
+        // Act
+        let (_, metadata) = response
+            .into_completion()
+            .expect("completion choice should exist");
+        let usage = metadata.usage().expect("partial usage should be retained");
+
+        // Assert
+        assert_eq!(usage.cache_hit_tokens(), Some(7));
+        assert_eq!(usage.cache_miss_tokens(), None);
+        assert_eq!(usage.input_tokens(), None);
+        assert_eq!(usage.output_tokens(), None);
+        assert_eq!(usage.reasoning_tokens(), None);
+        assert_eq!(usage.total_tokens(), None);
+        assert_eq!(metadata.response_id(), None);
+        assert_eq!(metadata.response_model(), None);
+        assert_eq!(metadata.system_fingerprint(), None);
+    }
+
+    #[test]
+    fn preserves_missing_metadata_and_empty_choices() {
+        // Arrange
+        let response = serde_json::from_value::<ChatCompletionResponse>(serde_json::json!({
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {"content": "{}"}
+            }]
+        }))
+        .expect("minimal response should decode");
+        let empty_response = serde_json::from_value::<ChatCompletionResponse>(serde_json::json!({
+            "choices": []
+        }))
+        .expect("empty choices should decode");
+
+        // Act
+        let (_, metadata) = response
+            .into_completion()
+            .expect("minimal response should retain its choice");
+
+        // Assert
+        assert_eq!(metadata.response_id(), None);
+        assert_eq!(metadata.response_model(), None);
+        assert_eq!(metadata.system_fingerprint(), None);
+        assert_eq!(metadata.usage(), None);
+        assert!(empty_response.into_completion().is_none());
+    }
+
+    #[test]
     fn rejects_success_chunk_that_exceeds_remaining_capacity() {
         // Arrange
         let mut body = vec![0; SUCCESS_BODY_LIMIT_BYTES - 1];
@@ -783,6 +996,35 @@ mod tests {
                 .expect("transport failure should retain its source")
                 .to_string(),
             "connection reset"
+        );
+    }
+
+    #[test]
+    fn normalizes_transport_error_classification() {
+        // Arrange
+        let backend = ChatCompletionBackend::with_client(
+            "test-key".to_string(),
+            "https://example.com/v1".to_string(),
+            "model".to_string(),
+            ChatCompletionProviderPolicy {
+                display_name: "Provider",
+                structured_output: StructuredOutputMode::JsonSchema,
+                telemetry_name: "provider",
+                unsupported_schema_reason: "object schema required",
+            },
+            default_client(),
+        );
+        let transport_error = ChatCompletionError::transport(io::Error::other("offline"));
+
+        // Act
+        let error = backend.map_completion_error(transport_error);
+
+        // Assert
+        assert_eq!(error.error_type(), model::ModelErrorType::Transport);
+        assert_eq!(error.http_status(), None);
+        assert_eq!(
+            error.to_string(),
+            "model request failed: Chat Completions transport failed: offline"
         );
     }
 

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -1,7 +1,7 @@
 //! Lightweight, Rust-native LLM harness for application-facing agent workflows.
 //!
-//! The crate provides a provider-neutral model client, validated structured
-//! output, and private provider backends.
+//! The crate provides a provider-neutral model client, normalized completion
+//! metadata, validated structured output, and private provider backends.
 
 mod chat_completion;
 mod file_system;
@@ -17,7 +17,9 @@ mod tool;
 pub use file_system::{FileSystem, LocalFileSystem};
 pub use harness::{Harness, TurnError};
 pub use model::{
-    Model, ModelClient, ModelError, ModelMetadata, ModelMetadataError, ModelRequest, ModelResponse,
+    CompletionMetadata, CompletionUsage, Model, ModelClient, ModelCompletion, ModelError,
+    ModelErrorType, ModelMetadata, ModelMetadataError, ModelRequest, ModelResponse,
+    ModelWithMetadata,
 };
 pub use provider::{
     KimiConfig, MUSE_SPARK_1_2, MUSE_SPARK_1_2_CONTRIBUTOR, Muse, MuseConfig, MuseError, QwenConfig,

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -24,6 +24,21 @@ pub trait Model: Send + Sync {
     async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError>;
 }
 
+/// Object-safe model extension that returns normalized completion metadata.
+#[async_trait]
+pub trait ModelWithMetadata: Model {
+    /// Completes one model request and returns normalized provider metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] when the provider request fails or its response
+    /// cannot be converted to the provider-neutral response.
+    async fn complete_with_metadata(
+        &self,
+        request: ModelRequest,
+    ) -> Result<ModelCompletion, ModelError>;
+}
+
 /// Application-facing client for provider-neutral model requests.
 ///
 /// Provider request execution remains private so every request passes through
@@ -94,18 +109,34 @@ impl ModelClient {
     /// Returns [`ModelError`] when the provider request fails or its response
     /// cannot be converted to the provider-neutral response.
     pub async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
+        self.complete_with_metadata(request)
+            .await
+            .map(ModelCompletion::into_response)
+    }
+
+    /// Completes one model request and returns normalized provider metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] when the provider request fails or its response
+    /// cannot be converted to the provider-neutral response.
+    pub async fn complete_with_metadata(
+        &self,
+        request: ModelRequest,
+    ) -> Result<ModelCompletion, ModelError> {
         let _duration = telemetry::RequestDuration::start(self.metadata());
         let response = self.backend.generate(&request).await?;
 
         match response {
-            chat_completion::GeneratedResponse::Output(output) => request
+            chat_completion::GeneratedResponse::Output { metadata, output } => request
                 .schema()
                 .parse_and_validate(&output)
                 .map(ModelResponse::from_output)
+                .map(|response| ModelCompletion::new(metadata, response))
                 .map_err(ModelError::from),
-            chat_completion::GeneratedResponse::ToolCall(call) => {
-                Ok(ModelResponse::tool_call(call))
-            }
+            chat_completion::GeneratedResponse::ToolCall { call, metadata } => Ok(
+                ModelCompletion::new(metadata, ModelResponse::tool_call(call)),
+            ),
         }
     }
 
@@ -127,6 +158,16 @@ impl ModelClient {
 impl Model for ModelClient {
     async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
         ModelClient::complete(self, request).await
+    }
+}
+
+#[async_trait]
+impl ModelWithMetadata for ModelClient {
+    async fn complete_with_metadata(
+        &self,
+        request: ModelRequest,
+    ) -> Result<ModelCompletion, ModelError> {
+        ModelClient::complete_with_metadata(self, request).await
     }
 }
 
@@ -259,6 +300,152 @@ pub(crate) enum ModelMessage {
     },
 }
 
+/// One model response paired with normalized provider completion metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ModelCompletion {
+    metadata: CompletionMetadata,
+    response: ModelResponse,
+}
+
+impl ModelCompletion {
+    /// Creates a completion from normalized metadata and a model response.
+    pub fn new(metadata: CompletionMetadata, response: ModelResponse) -> Self {
+        Self { metadata, response }
+    }
+
+    /// Returns the normalized metadata reported by the provider.
+    pub fn metadata(&self) -> &CompletionMetadata {
+        &self.metadata
+    }
+
+    /// Returns the provider-neutral model response.
+    pub fn response(&self) -> &ModelResponse {
+        &self.response
+    }
+
+    /// Consumes the completion and returns its provider-neutral response.
+    pub fn into_response(self) -> ModelResponse {
+        self.response
+    }
+}
+
+/// Provider-reported facts about one completed model request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompletionMetadata {
+    finish_reason: String,
+    response_id: Option<String>,
+    response_model: Option<String>,
+    system_fingerprint: Option<String>,
+    usage: Option<CompletionUsage>,
+}
+
+impl CompletionMetadata {
+    /// Creates normalized provider completion metadata.
+    pub fn new(
+        finish_reason: String,
+        response_id: Option<String>,
+        response_model: Option<String>,
+        system_fingerprint: Option<String>,
+        usage: Option<CompletionUsage>,
+    ) -> Self {
+        Self {
+            finish_reason,
+            response_id,
+            response_model,
+            system_fingerprint,
+            usage,
+        }
+    }
+
+    /// Returns the provider's reason that generation stopped.
+    pub fn finish_reason(&self) -> &str {
+        &self.finish_reason
+    }
+
+    /// Returns the provider-assigned response identifier, when reported.
+    pub fn response_id(&self) -> Option<&str> {
+        self.response_id.as_deref()
+    }
+
+    /// Returns the model identifier reported in the response, when present.
+    pub fn response_model(&self) -> Option<&str> {
+        self.response_model.as_deref()
+    }
+
+    /// Returns the provider's backend fingerprint, when reported.
+    pub fn system_fingerprint(&self) -> Option<&str> {
+        self.system_fingerprint.as_deref()
+    }
+
+    /// Returns provider-reported token usage, when present.
+    pub fn usage(&self) -> Option<&CompletionUsage> {
+        self.usage.as_ref()
+    }
+}
+
+/// Provider-reported token counts for one completed model request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CompletionUsage {
+    cache_hit: Option<u64>,
+    cache_miss: Option<u64>,
+    input: Option<u64>,
+    output: Option<u64>,
+    reasoning: Option<u64>,
+    total: Option<u64>,
+}
+
+impl CompletionUsage {
+    /// Creates normalized provider-reported token usage.
+    pub fn new(
+        cache_hit_tokens: Option<u64>,
+        cache_miss_tokens: Option<u64>,
+        input_tokens: Option<u64>,
+        output_tokens: Option<u64>,
+        reasoning_tokens: Option<u64>,
+        total_tokens: Option<u64>,
+    ) -> Self {
+        Self {
+            cache_hit: cache_hit_tokens,
+            cache_miss: cache_miss_tokens,
+            input: input_tokens,
+            output: output_tokens,
+            reasoning: reasoning_tokens,
+            total: total_tokens,
+        }
+    }
+
+    /// Returns input tokens served from a provider cache, when reported.
+    pub fn cache_hit_tokens(self) -> Option<u64> {
+        self.cache_hit
+    }
+
+    /// Returns input tokens that missed a provider cache, when reported.
+    pub fn cache_miss_tokens(self) -> Option<u64> {
+        self.cache_miss
+    }
+
+    /// Returns the provider-reported input token count.
+    pub fn input_tokens(self) -> Option<u64> {
+        self.input
+    }
+
+    /// Returns the provider-reported output token count.
+    pub fn output_tokens(self) -> Option<u64> {
+        self.output
+    }
+
+    /// Returns output tokens used for provider-exposed reasoning, when
+    /// reported.
+    pub fn reasoning_tokens(self) -> Option<u64> {
+        self.reasoning
+    }
+
+    /// Returns the provider-reported total token count.
+    pub fn total_tokens(self) -> Option<u64> {
+        self.total
+    }
+}
+
 /// Provider-neutral output from one model request.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ModelResponse {
@@ -368,10 +555,133 @@ pub enum ModelError {
     },
 }
 
+/// Stable, low-cardinality classification for a [`ModelError`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ModelErrorType {
+    /// Request construction or another unclassified client-side failure.
+    Request,
+    /// Network transport failed before a provider response was decoded.
+    Transport,
+    /// The provider returned an unsuccessful HTTP response.
+    Provider,
+    /// The provider returned a malformed response envelope.
+    InvalidProviderResponse,
+    /// The provider returned an unusable or incomplete successful response.
+    InvalidResponse,
+    /// The provider cannot satisfy the requested output contract.
+    UnsupportedOutput,
+    /// The response exceeded a configured safety bound.
+    ResponseTooLarge,
+    /// Terminal output failed JSON parsing or local schema validation.
+    InvalidOutput,
+    /// A native tool call was missing, malformed, or unsupported.
+    InvalidToolCall,
+}
+
+impl ModelErrorType {
+    /// Returns the stable value intended for telemetry attributes.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Request => "request_error",
+            Self::Transport => "transport_error",
+            Self::Provider => "provider_error",
+            Self::InvalidProviderResponse => "invalid_provider_response",
+            Self::InvalidResponse => "invalid_response",
+            Self::UnsupportedOutput => "unsupported_output",
+            Self::ResponseTooLarge => "response_too_large",
+            Self::InvalidOutput => "invalid_output",
+            Self::InvalidToolCall => "invalid_tool_call",
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("{source}")]
+struct ClassifiedRequestError {
+    error_type: ModelErrorType,
+    #[source]
+    source: Box<dyn Error + Send + Sync>,
+}
+
+#[derive(Debug, Error)]
+#[error("{provider} returned HTTP {status}: {body}")]
+struct ProviderRequestError {
+    body: String,
+    provider: &'static str,
+    #[source]
+    source: reqwest::Error,
+    status: reqwest::StatusCode,
+}
+
 impl ModelError {
     /// Wraps a provider transport or response-decoding failure.
     pub fn request(error: impl Error + Send + Sync + 'static) -> Self {
         Self::Request(Box::new(error))
+    }
+
+    /// Returns a stable, low-cardinality classification for this failure.
+    pub fn error_type(&self) -> ModelErrorType {
+        match self {
+            Self::Request(source) => {
+                if source.downcast_ref::<ProviderRequestError>().is_some() {
+                    ModelErrorType::Provider
+                } else {
+                    source
+                        .downcast_ref::<ClassifiedRequestError>()
+                        .map_or(ModelErrorType::Request, |error| error.error_type)
+                }
+            }
+            Self::InvalidResponse | Self::IncompleteResponse { .. } => {
+                ModelErrorType::InvalidResponse
+            }
+            Self::ResponseBodyTooLarge | Self::ResponseContentTooLarge => {
+                ModelErrorType::ResponseTooLarge
+            }
+            Self::UnsupportedOutputSchema { .. } => ModelErrorType::UnsupportedOutput,
+            Self::InvalidJson { .. } | Self::SchemaViolation { .. } => {
+                ModelErrorType::InvalidOutput
+            }
+            Self::MissingToolCall
+            | Self::MultipleToolCalls
+            | Self::ToolCallWithContent
+            | Self::TerminalResponseWithToolCalls
+            | Self::UnsupportedToolType { .. }
+            | Self::UnsupportedToolName { .. }
+            | Self::InvalidToolArguments { .. } => ModelErrorType::InvalidToolCall,
+        }
+    }
+
+    /// Returns the provider HTTP status associated with this failure, when
+    /// available.
+    pub fn http_status(&self) -> Option<u16> {
+        match self {
+            Self::Request(source) => source
+                .downcast_ref::<ProviderRequestError>()
+                .map(|error| error.status.as_u16()),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn provider_request(
+        provider: &'static str,
+        body: String,
+        source: reqwest::Error,
+        status: reqwest::StatusCode,
+    ) -> Self {
+        Self::Request(Box::new(ProviderRequestError {
+            body,
+            provider,
+            source,
+            status,
+        }))
+    }
+
+    pub(crate) fn classified_request(
+        error_type: ModelErrorType,
+        source: Box<dyn Error + Send + Sync>,
+    ) -> Self {
+        Self::Request(Box::new(ClassifiedRequestError { error_type, source }))
     }
 }
 
@@ -522,6 +832,55 @@ mod tests {
     }
 
     #[test]
+    fn completion_exposes_normalized_metadata_and_response() {
+        // Arrange
+        let usage = CompletionUsage::new(Some(5), Some(8), Some(13), Some(21), Some(3), Some(34));
+        let metadata = CompletionMetadata::new(
+            "stop".to_string(),
+            Some("response-1".to_string()),
+            Some("provider-model".to_string()),
+            Some("fingerprint-1".to_string()),
+            Some(usage),
+        );
+        let response = ModelResponse::from_output(json!({ "name": "Ada" }));
+        let completion = ModelCompletion::new(metadata, response.clone());
+
+        // Act
+        let completion_metadata = completion.metadata();
+        let completion_response = completion.response();
+
+        // Assert
+        assert_eq!(completion_metadata.finish_reason(), "stop");
+        assert_eq!(completion_metadata.response_id(), Some("response-1"));
+        assert_eq!(completion_metadata.response_model(), Some("provider-model"));
+        assert_eq!(
+            completion_metadata.system_fingerprint(),
+            Some("fingerprint-1")
+        );
+        assert_eq!(completion_metadata.usage(), Some(&usage));
+        assert_eq!(usage.cache_hit_tokens(), Some(5));
+        assert_eq!(usage.cache_miss_tokens(), Some(8));
+        assert_eq!(usage.input_tokens(), Some(13));
+        assert_eq!(usage.output_tokens(), Some(21));
+        assert_eq!(usage.reasoning_tokens(), Some(3));
+        assert_eq!(usage.total_tokens(), Some(34));
+        assert_eq!(completion_response, &response);
+        assert_eq!(completion.into_response(), response);
+    }
+
+    #[test]
+    fn completion_metadata_preserves_absent_provider_fields() {
+        // Arrange
+        let metadata = CompletionMetadata::new("stop".to_string(), None, None, None, None);
+
+        // Act and Assert
+        assert_eq!(metadata.response_id(), None);
+        assert_eq!(metadata.response_model(), None);
+        assert_eq!(metadata.system_fingerprint(), None);
+        assert_eq!(metadata.usage(), None);
+    }
+
+    #[test]
     fn response_debug_redacts_provider_reasoning() {
         // Arrange
         let secret_reasoning = "private reasoning from repository context";
@@ -575,6 +934,133 @@ mod tests {
 
         // Assert
         assert_eq!(message, "model request failed: connection refused");
+    }
+
+    #[test]
+    fn classifies_model_errors_with_stable_telemetry_values() {
+        // Arrange
+        let errors = [
+            (
+                ModelError::request(io::Error::other("request")),
+                ModelErrorType::Request,
+            ),
+            (ModelError::InvalidResponse, ModelErrorType::InvalidResponse),
+            (
+                ModelError::IncompleteResponse {
+                    reason: "length".to_string(),
+                },
+                ModelErrorType::InvalidResponse,
+            ),
+            (
+                ModelError::ResponseBodyTooLarge,
+                ModelErrorType::ResponseTooLarge,
+            ),
+            (
+                ModelError::ResponseContentTooLarge,
+                ModelErrorType::ResponseTooLarge,
+            ),
+            (
+                ModelError::UnsupportedOutputSchema {
+                    reason: "object required".to_string(),
+                },
+                ModelErrorType::UnsupportedOutput,
+            ),
+            (
+                ModelError::InvalidJson {
+                    reason: "invalid".to_string(),
+                },
+                ModelErrorType::InvalidOutput,
+            ),
+            (
+                ModelError::SchemaViolation {
+                    path: "$".to_string(),
+                    reason: "invalid".to_string(),
+                },
+                ModelErrorType::InvalidOutput,
+            ),
+            (ModelError::MissingToolCall, ModelErrorType::InvalidToolCall),
+            (
+                ModelError::MultipleToolCalls,
+                ModelErrorType::InvalidToolCall,
+            ),
+            (
+                ModelError::ToolCallWithContent,
+                ModelErrorType::InvalidToolCall,
+            ),
+            (
+                ModelError::TerminalResponseWithToolCalls,
+                ModelErrorType::InvalidToolCall,
+            ),
+            (
+                ModelError::UnsupportedToolType {
+                    kind: "custom".to_string(),
+                },
+                ModelErrorType::InvalidToolCall,
+            ),
+            (
+                ModelError::UnsupportedToolName {
+                    name: "write".to_string(),
+                },
+                ModelErrorType::InvalidToolCall,
+            ),
+            (
+                ModelError::InvalidToolArguments {
+                    reason: "invalid".to_string(),
+                },
+                ModelErrorType::InvalidToolCall,
+            ),
+        ];
+
+        // Act
+        let classifications =
+            errors.map(|(error, expected)| (error.error_type(), expected, error.http_status()));
+
+        // Assert
+        assert!(
+            classifications
+                .into_iter()
+                .all(|(actual, expected, status)| actual == expected && status.is_none())
+        );
+        assert_eq!(ModelErrorType::Request.as_str(), "request_error");
+        assert_eq!(ModelErrorType::Transport.as_str(), "transport_error");
+        assert_eq!(ModelErrorType::Provider.as_str(), "provider_error");
+        assert_eq!(
+            ModelErrorType::InvalidProviderResponse.as_str(),
+            "invalid_provider_response"
+        );
+        assert_eq!(ModelErrorType::InvalidResponse.as_str(), "invalid_response");
+        assert_eq!(
+            ModelErrorType::UnsupportedOutput.as_str(),
+            "unsupported_output"
+        );
+        assert_eq!(
+            ModelErrorType::ResponseTooLarge.as_str(),
+            "response_too_large"
+        );
+        assert_eq!(ModelErrorType::InvalidOutput.as_str(), "invalid_output");
+        assert_eq!(
+            ModelErrorType::InvalidToolCall.as_str(),
+            "invalid_tool_call"
+        );
+    }
+
+    #[test]
+    fn classified_request_retains_source_and_type() {
+        // Arrange
+        let error = ModelError::classified_request(
+            ModelErrorType::Transport,
+            io::Error::other("connection reset").into(),
+        );
+
+        // Act
+        let source = std::error::Error::source(&error)
+            .and_then(std::error::Error::source)
+            .expect("classified request should retain its original source");
+
+        // Assert
+        assert_eq!(error.error_type(), ModelErrorType::Transport);
+        assert_eq!(error.http_status(), None);
+        assert_eq!(source.to_string(), "connection reset");
     }
 
     #[test]

--- a/crates/ag-harness/src/provider/muse.rs
+++ b/crates/ag-harness/src/provider/muse.rs
@@ -5,7 +5,8 @@ use thiserror::Error;
 
 use crate::chat_completion;
 use crate::model::{
-    Model, ModelClient, ModelError, ModelMetadataError, ModelRequest, ModelResponse,
+    Model, ModelClient, ModelCompletion, ModelError, ModelMetadataError, ModelRequest,
+    ModelResponse, ModelWithMetadata,
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.meta.ai/v1";
@@ -67,6 +68,16 @@ impl Muse {
 impl Model for Muse {
     async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
         self.client.complete(request).await
+    }
+}
+
+#[async_trait]
+impl ModelWithMetadata for Muse {
+    async fn complete_with_metadata(
+        &self,
+        request: ModelRequest,
+    ) -> Result<ModelCompletion, ModelError> {
+        self.client.complete_with_metadata(request).await
     }
 }
 
@@ -275,13 +286,17 @@ mod tests {
         let model = muse(&server);
 
         // Act
-        let response = model
-            .complete(request("extract the name"))
+        let completion = model
+            .complete_with_metadata(request("extract the name"))
             .await
             .expect("Muse request should succeed");
 
         // Assert
-        assert_eq!(response.output(), Some(&json!({ "name": "Ada" })));
+        assert_eq!(
+            completion.response().output(),
+            Some(&json!({ "name": "Ada" }))
+        );
+        assert_eq!(completion.metadata().finish_reason(), "stop");
     }
 
     #[tokio::test]

--- a/crates/ag-harness/src/provider/qwen.rs
+++ b/crates/ag-harness/src/provider/qwen.rs
@@ -216,7 +216,7 @@ mod tests {
             r#"{"name":"Ada"}"#,
         )
         .await;
-        let model = qwen(&server);
+        let model: Box<dyn model::Model> = Box::new(qwen(&server));
 
         // Act
         let response = model
@@ -226,6 +226,58 @@ mod tests {
 
         // Assert
         assert_eq!(response.output(), Some(&json!({ "name": "Ada" })));
+    }
+
+    #[tokio::test]
+    async fn completes_with_normalized_provider_metadata() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": r#"{"name":"Ada"}"#}
+                }],
+                "id": "response-1",
+                "model": "qwen-plus-2026-08-16",
+                "system_fingerprint": "fingerprint-1",
+                "usage": {
+                    "completion_tokens": 9,
+                    "completion_tokens_details": {"reasoning_tokens": 2},
+                    "prompt_tokens": 12,
+                    "prompt_tokens_details": {"cached_tokens": 4},
+                    "total_tokens": 21
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let model: Box<dyn model::ModelWithMetadata> = Box::new(qwen(&server));
+
+        // Act
+        let completion = model
+            .complete_with_metadata(request("extract the name"))
+            .await
+            .expect("Qwen completion metadata should decode");
+        let metadata = completion.metadata();
+        let usage = metadata.usage().expect("Qwen usage should be retained");
+
+        // Assert
+        assert_eq!(
+            completion.response().output(),
+            Some(&json!({ "name": "Ada" }))
+        );
+        assert_eq!(metadata.finish_reason(), "stop");
+        assert_eq!(metadata.response_id(), Some("response-1"));
+        assert_eq!(metadata.response_model(), Some("qwen-plus-2026-08-16"));
+        assert_eq!(metadata.system_fingerprint(), Some("fingerprint-1"));
+        assert_eq!(usage.input_tokens(), Some(12));
+        assert_eq!(usage.output_tokens(), Some(9));
+        assert_eq!(usage.total_tokens(), Some(21));
+        assert_eq!(usage.cache_hit_tokens(), Some(4));
+        assert_eq!(usage.cache_miss_tokens(), None);
+        assert_eq!(usage.reasoning_tokens(), Some(2));
     }
 
     #[tokio::test]
@@ -511,7 +563,7 @@ mod tests {
         // Assert
         assert!(matches!(
             output,
-            crate::chat_completion::GeneratedResponse::Output(output)
+            crate::chat_completion::GeneratedResponse::Output { output, .. }
                 if output == r#"{"name":"Ada"}"#
         ));
     }
@@ -832,6 +884,8 @@ mod tests {
             .and_then(|source| source.downcast_ref::<reqwest::Error>())
             .expect("HTTP failure should retain its reqwest source");
         assert_eq!(source.status(), Some(reqwest::StatusCode::UNAUTHORIZED));
+        assert_eq!(error.error_type(), model::ModelErrorType::Provider);
+        assert_eq!(error.http_status(), Some(401));
     }
 
     #[tokio::test]
@@ -883,5 +937,15 @@ mod tests {
 
         // Assert
         assert!(matches!(error, model::ModelError::Request(_)));
+        assert_eq!(
+            error.error_type(),
+            model::ModelErrorType::InvalidProviderResponse
+        );
+        assert_eq!(error.http_status(), None);
+        assert!(
+            error.to_string().starts_with(
+                "model request failed: Chat Completions returned an invalid response:"
+            )
+        );
     }
 }

--- a/crates/ag-harness/tests/public_api.rs
+++ b/crates/ag-harness/tests/public_api.rs
@@ -1,0 +1,101 @@
+//! External-consumer coverage for the `ag-harness` model traits.
+
+use std::error::Error;
+
+use ag_harness::{
+    CompletionMetadata, CompletionUsage, Model, ModelCompletion, ModelError, ModelRequest,
+    ModelResponse, ModelWithMetadata, OutputSchema, OutputSchemaError,
+};
+use async_trait::async_trait;
+use serde_json::json;
+
+struct ExternalModel;
+
+#[async_trait]
+impl Model for ExternalModel {
+    async fn complete(&self, _request: ModelRequest) -> Result<ModelResponse, ModelError> {
+        Ok(ModelResponse::Output(json!({ "name": "Ada" })))
+    }
+}
+
+struct ExternalMetadataModel;
+
+#[async_trait]
+impl Model for ExternalMetadataModel {
+    async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
+        self.complete_with_metadata(request)
+            .await
+            .map(ModelCompletion::into_response)
+    }
+}
+
+#[async_trait]
+impl ModelWithMetadata for ExternalMetadataModel {
+    async fn complete_with_metadata(
+        &self,
+        _request: ModelRequest,
+    ) -> Result<ModelCompletion, ModelError> {
+        let usage = CompletionUsage::new(None, None, Some(4), Some(2), None, Some(6));
+        let metadata = CompletionMetadata::new(
+            "stop".to_string(),
+            Some("external-response".to_string()),
+            Some("external-model".to_string()),
+            None,
+            Some(usage),
+        );
+
+        Ok(ModelCompletion::new(
+            metadata,
+            ModelResponse::Output(json!({ "name": "Ada" })),
+        ))
+    }
+}
+
+fn request() -> Result<ModelRequest, OutputSchemaError> {
+    Ok(ModelRequest::new(
+        "extract the name",
+        OutputSchema::new(json!({
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"]
+        }))?,
+    ))
+}
+
+#[test]
+fn external_response_only_provider_implements_model() {
+    // Arrange
+    fn assert_model<ModelType: Model>() {}
+
+    // Act and Assert
+    assert_model::<ExternalModel>();
+}
+
+#[tokio::test]
+async fn external_provider_constructs_metadata_completion_through_dynamic_dispatch()
+-> Result<(), Box<dyn Error>> {
+    // Arrange
+    let model: Box<dyn ModelWithMetadata> = Box::new(ExternalMetadataModel);
+
+    // Act
+    let completion = model.complete_with_metadata(request()?).await?;
+
+    // Assert
+    assert_eq!(
+        completion.response().output(),
+        Some(&json!({ "name": "Ada" }))
+    );
+    assert_eq!(
+        completion.metadata().response_id(),
+        Some("external-response")
+    );
+    assert_eq!(
+        completion
+            .metadata()
+            .usage()
+            .and_then(|usage| usage.total_tokens()),
+        Some(6)
+    );
+
+    Ok(())
+}

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -63,6 +63,8 @@ request's `OutputSchema`. Provider request execution remains private so applicat
 cannot bypass this lifecycle. `ModelClient` validates and retains the provider and model
 identity during construction, before any request starts.
 
+`ModelWithMetadata` adds object-safe completion metadata without changing `Model`.
+
 Provider-owned adapters and compatibility rules live under the private `provider`
 module. API-family clients remain separate so multiple providers can reuse a wire
 protocol without sharing provider policy.


### PR DESCRIPTION
- Return normalized provider completion metadata and optional token usage alongside validated model responses.
- Classify transport, provider, malformed-response, and model failures with stable telemetry values while preserving provider HTTP statuses.
- Document the metadata-bearing completion API and its absent-field behavior.