### PR TITLE
Exposes completion metadata and lifecycle events

### DIFF
--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -16,3 +16,5 @@ Provide `MODEL_API_KEY`, a repository root, explicitly allowed tools, a prompt, 
 `OutputSchema`. Expect schema-validated JSON or a typed error.
 
 Use `ModelWithMetadata::complete_with_metadata()` for normalized completion metadata.
+
+Attach `with_lifecycle_observer()` to receive ordered metadata-only lifecycle events.

--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -6,6 +6,9 @@ use serde_json::Value;
 use thiserror::Error;
 
 use crate::file_system::{FileSystem, LocalFileSystem};
+use crate::lifecycle::{
+    LifecycleEmitter, LifecycleId, LifecycleObserver, ToolErrorType, TurnErrorType, TurnLifecycle,
+};
 use crate::model::{Model, ModelError, ModelRequest, ModelResponse};
 use crate::policy::Policy;
 use crate::read::{ReadError, ReadTool};
@@ -21,6 +24,7 @@ const DEFAULT_MAX_TOOL_CALLS: usize = 8;
 /// structured output.
 pub struct Harness {
     file_system: Arc<dyn FileSystem>,
+    lifecycle: LifecycleEmitter,
     max_tool_calls: usize,
     model: Arc<dyn Model>,
     policy: Policy,
@@ -32,6 +36,7 @@ impl Harness {
     pub fn new(model: impl Model + 'static) -> Self {
         Self {
             file_system: Arc::new(LocalFileSystem),
+            lifecycle: LifecycleEmitter::default(),
             max_tool_calls: DEFAULT_MAX_TOOL_CALLS,
             model: Arc::new(model),
             policy: Policy::default(),
@@ -63,6 +68,16 @@ impl Harness {
         self
     }
 
+    /// Sends metadata-only turn, model, and tool events to `observer`.
+    ///
+    /// This observer owns model events for requests made through the harness.
+    #[must_use]
+    pub fn with_lifecycle_observer(mut self, observer: impl LifecycleObserver + 'static) -> Self {
+        self.lifecycle = LifecycleEmitter::new(observer);
+
+        self
+    }
+
     /// Overrides the maximum number of native calls allowed in one turn.
     #[must_use]
     pub fn max_tool_calls(mut self, max_tool_calls: NonZeroUsize) -> Self {
@@ -82,7 +97,30 @@ impl Harness {
         prompt: impl Into<String>,
         schema: OutputSchema,
     ) -> Result<Value, TurnError> {
+        let turn = self.lifecycle.start_turn();
+        let turn_id = turn.as_ref().map(TurnLifecycle::id);
+        let result = self.run_turn(prompt.into(), schema, turn_id).await;
+
+        if let Some(turn) = turn {
+            match &result {
+                Ok(_) => turn.completed(),
+                Err(error) => turn.failed(error.error_type()),
+            }
+        }
+
+        result
+    }
+
+    async fn run_turn(
+        &self,
+        prompt: String,
+        schema: OutputSchema,
+        turn_id: Option<LifecycleId>,
+    ) -> Result<Value, TurnError> {
         let mut request = ModelRequest::new(prompt, schema);
+        if self.lifecycle.is_enabled() {
+            request.mark_lifecycle_observed();
+        }
         let read_tool = if self.policy.allows(Tool::Read) {
             let repository_root = self
                 .repository_root
@@ -98,23 +136,72 @@ impl Harness {
             None
         };
         let mut completed_tool_calls = 0_usize;
+        let mut model_request_index = 0_u64;
 
         loop {
-            match self.model.complete(request.clone()).await? {
+            let model_lifecycle =
+                self.lifecycle
+                    .start_model_request(None, model_request_index, turn_id);
+            let (response, completion) = match self
+                .model
+                .complete_with_optional_metadata(request.clone())
+                .await
+            {
+                Ok(completion) => completion,
+                Err(error) => {
+                    if let Some(model_lifecycle) = model_lifecycle {
+                        model_lifecycle.failed(error.error_type());
+                    }
+
+                    return Err(error.into());
+                }
+            };
+            if let Some(model_lifecycle) = model_lifecycle {
+                model_lifecycle.completed(completion, response.response_type());
+            }
+            model_request_index += 1;
+
+            match response {
                 ModelResponse::Output(output) => return Ok(output),
                 ModelResponse::ToolCall(call) => {
+                    let mut tool_lifecycle = self
+                        .lifecycle
+                        .request_tool(call.name().to_string(), turn_id);
                     let Some(read_tool) = read_tool.as_ref() else {
+                        if let Some(tool_lifecycle) = tool_lifecycle {
+                            tool_lifecycle.denied();
+                        }
+
                         return Err(TurnError::ToolDenied {
                             name: call.name().to_string(),
                         });
                     };
                     if completed_tool_calls >= self.max_tool_calls {
+                        if let Some(tool_lifecycle) = tool_lifecycle {
+                            tool_lifecycle.failed(ToolErrorType::CallLimit);
+                        }
+
                         return Err(TurnError::ToolCallLimit {
                             limit: self.max_tool_calls,
                         });
                     }
-                    let output = read_tool.execute(call.arguments()).await?;
+                    if let Some(tool_lifecycle) = tool_lifecycle.as_mut() {
+                        tool_lifecycle.started();
+                    }
+                    let output = match read_tool.execute(call.arguments()).await {
+                        Ok(output) => output,
+                        Err(error) => {
+                            if let Some(tool_lifecycle) = tool_lifecycle {
+                                tool_lifecycle.failed(ToolErrorType::Execution);
+                            }
+
+                            return Err(error.into());
+                        }
+                    };
                     let result = output.to_tool_result().map_err(ReadError::from)?;
+                    if let Some(tool_lifecycle) = tool_lifecycle {
+                        tool_lifecycle.completed();
+                    }
                     request.record_tool_result(call, result);
                     completed_tool_calls += 1;
                 }
@@ -149,9 +236,23 @@ pub enum TurnError {
     },
 }
 
+impl TurnError {
+    /// Returns the stable lifecycle classification for this failure.
+    pub fn error_type(&self) -> TurnErrorType {
+        match self {
+            Self::Model(error) => TurnErrorType::Model(error.error_type()),
+            Self::ToolDenied { .. } => TurnErrorType::ToolDenied,
+            Self::Read(_) => TurnErrorType::Tool,
+            Self::RepositoryRequired => TurnErrorType::RepositoryRequired,
+            Self::ToolCallLimit { .. } => TurnErrorType::ToolCallLimit,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::{self, Cursor};
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use mockall::Sequence;
@@ -182,6 +283,12 @@ mod tests {
         ToolCall::read(id.to_string(), arguments, None)
     }
 
+    fn response_without_metadata(
+        response: ModelResponse,
+    ) -> (ModelResponse, Option<crate::CompletionMetadata>) {
+        (response, None)
+    }
+
     fn readable_file_system() -> MockFileSystem {
         let mut file_system = MockFileSystem::new();
         let mut sequence = Sequence::new();
@@ -207,42 +314,149 @@ mod tests {
         file_system
     }
 
+    fn turn_started_id(event: &crate::LifecycleEvent) -> Option<crate::LifecycleId> {
+        match event.kind() {
+            crate::LifecycleEventKind::TurnStarted { turn_id } => Some(*turn_id),
+            _ => None,
+        }
+    }
+
+    fn model_started_id(event: &crate::LifecycleEvent) -> Option<crate::LifecycleId> {
+        match event.kind() {
+            crate::LifecycleEventKind::ModelRequestStarted { model_call_id, .. } => {
+                Some(*model_call_id)
+            }
+            _ => None,
+        }
+    }
+
+    fn tool_requested_id(event: &crate::LifecycleEvent) -> Option<crate::LifecycleId> {
+        match event.kind() {
+            crate::LifecycleEventKind::ToolRequested { tool_call_id, .. } => Some(*tool_call_id),
+            _ => None,
+        }
+    }
+
+    fn assert_read_tool_lifecycle(events: &[crate::LifecycleEvent]) {
+        let turn_id = turn_started_id(&events[0]).expect("first event should start the turn");
+        let first_model_call_id =
+            model_started_id(&events[1]).expect("second event should start the model request");
+        assert!(matches!(
+            events[1].kind(),
+            crate::LifecycleEventKind::ModelRequestStarted {
+                model: None,
+                request_index: 0,
+                turn_id: Some(event_turn_id),
+                ..
+            } if *event_turn_id == turn_id
+        ));
+        assert!(matches!(
+            events[2].kind(),
+            crate::LifecycleEventKind::ModelRequestCompleted {
+                completion: None,
+                model_call_id,
+                response_type: crate::ModelResponseType::ToolCall,
+                turn_id: Some(event_turn_id),
+                ..
+            } if *model_call_id == first_model_call_id && *event_turn_id == turn_id
+        ));
+        let tool_call_id =
+            tool_requested_id(&events[3]).expect("fourth event should request the tool");
+        assert!(matches!(
+            events[3].kind(),
+            crate::LifecycleEventKind::ToolRequested {
+                tool_name,
+                turn_id: event_turn_id,
+                ..
+            } if tool_name == "read" && *event_turn_id == turn_id
+        ));
+        assert!(matches!(
+            events[4].kind(),
+            crate::LifecycleEventKind::ToolStarted {
+                tool_call_id: event_tool_call_id,
+                turn_id: event_turn_id,
+            } if *event_tool_call_id == tool_call_id && *event_turn_id == turn_id
+        ));
+        assert!(matches!(
+            events[5].kind(),
+            crate::LifecycleEventKind::ToolCompleted {
+                tool_call_id: event_tool_call_id,
+                turn_id: event_turn_id,
+                ..
+            } if *event_tool_call_id == tool_call_id && *event_turn_id == turn_id
+        ));
+        assert!(matches!(
+            events[6].kind(),
+            crate::LifecycleEventKind::ModelRequestStarted {
+                request_index: 1,
+                turn_id: Some(event_turn_id),
+                ..
+            } if *event_turn_id == turn_id
+        ));
+        assert!(matches!(
+            events[7].kind(),
+            crate::LifecycleEventKind::ModelRequestCompleted {
+                completion: None,
+                response_type: crate::ModelResponseType::Output,
+                turn_id: Some(event_turn_id),
+                ..
+            } if *event_turn_id == turn_id
+        ));
+        assert!(matches!(
+            events[8].kind(),
+            crate::LifecycleEventKind::TurnCompleted {
+                turn_id: event_turn_id,
+                ..
+            } if *event_turn_id == turn_id
+        ));
+        assert!(turn_started_id(&events[1]).is_none());
+        assert!(model_started_id(&events[0]).is_none());
+        assert!(tool_requested_id(&events[0]).is_none());
+    }
+
     #[tokio::test]
     async fn completes_read_tool_round_trip() {
         // Arrange
         let mut model = MockModel::new();
         let call_count = Arc::new(AtomicUsize::new(0));
-        model.expect_complete().times(2).returning(move |request| {
-            let call_index = call_count.fetch_add(1, Ordering::SeqCst);
-            if call_index == 0 {
-                assert_eq!(request.tools(), &[ToolDefinition::read()]);
+        model
+            .expect_complete_with_optional_metadata()
+            .times(2)
+            .returning(move |request| {
+                let call_index = call_count.fetch_add(1, Ordering::SeqCst);
+                if call_index == 0 {
+                    assert_eq!(request.tools(), &[ToolDefinition::read()]);
 
-                return Ok(ModelResponse::ToolCall(read_call("call_read")));
-            }
-            assert_eq!(request.messages().len(), 3);
-            assert!(matches!(
-                &request.messages()[0],
-                ModelMessage::User(prompt) if prompt == "inspect the manifest"
-            ));
-            assert!(matches!(
-                &request.messages()[1],
-                ModelMessage::AssistantToolCall(call) if call.id() == "call_read"
-            ));
-            assert!(matches!(
-                &request.messages()[2],
-                ModelMessage::ToolResult {
-                    call_id,
-                    content,
-                    name,
+                    return Ok(response_without_metadata(ModelResponse::ToolCall(
+                        read_call("call_read"),
+                    )));
                 }
-                    if call_id == "call_read"
-                        && name == "read"
-                        && serde_json::from_str::<Value>(content)
-                            .is_ok_and(|value| value["content"] == "[workspace]")
-            ));
+                assert_eq!(request.messages().len(), 3);
+                assert!(matches!(
+                    &request.messages()[0],
+                    ModelMessage::User(prompt) if prompt == "inspect the manifest"
+                ));
+                assert!(matches!(
+                    &request.messages()[1],
+                    ModelMessage::AssistantToolCall(call) if call.id() == "call_read"
+                ));
+                assert!(matches!(
+                    &request.messages()[2],
+                    ModelMessage::ToolResult {
+                        call_id,
+                        content,
+                        name,
+                    }
+                        if call_id == "call_read"
+                            && name == "read"
+                            && serde_json::from_str::<Value>(content)
+                                .is_ok_and(|value| value["content"] == "[workspace]")
+                ));
 
-            Ok(ModelResponse::Output(json!({ "summary": "workspace" })))
-        });
+                Ok(response_without_metadata(ModelResponse::Output(
+                    json!({ "summary": "workspace" }),
+                )))
+            });
         let harness = Harness::new(model)
             .file_system(readable_file_system())
             .repository("repo")
@@ -259,11 +473,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn emits_correlated_lifecycle_for_read_tool_round_trip() {
+        // Arrange
+        let mut model = MockModel::new();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        model
+            .expect_complete_with_optional_metadata()
+            .times(2)
+            .returning(move |request| {
+                assert!(request.lifecycle_observed());
+                if call_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                    return Ok(response_without_metadata(ModelResponse::ToolCall(
+                        read_call("provider-call-id"),
+                    )));
+                }
+
+                Ok(response_without_metadata(ModelResponse::Output(
+                    json!({ "summary": "workspace" }),
+                )))
+            });
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let observed_events = Arc::clone(&events);
+        let harness = Harness::new(model)
+            .file_system(readable_file_system())
+            .repository("repo")
+            .allow(Tool::Read)
+            .with_lifecycle_observer(move |event| {
+                observed_events
+                    .lock()
+                    .expect("event recorder should not be poisoned")
+                    .push(event);
+            });
+
+        // Act
+        let output = harness
+            .run("sensitive prompt", object_schema())
+            .await
+            .expect("tool round trip should succeed");
+
+        // Assert
+        assert_eq!(output, json!({ "summary": "workspace" }));
+        let events = events
+            .lock()
+            .expect("event recorder should not be poisoned");
+        assert_eq!(events.len(), 9);
+        assert_eq!(
+            events
+                .iter()
+                .map(crate::LifecycleEvent::sequence)
+                .collect::<Vec<_>>(),
+            (0..9).collect::<Vec<_>>()
+        );
+        assert_read_tool_lifecycle(&events);
+        let event_debug = format!("{events:?}");
+        assert!(!event_debug.contains("sensitive prompt"));
+        assert!(!event_debug.contains("provider-call-id"));
+        assert!(!event_debug.contains("[workspace]"));
+    }
+
+    #[tokio::test]
     async fn requires_repository_when_read_is_allowed() {
         // Arrange
         let mut model = MockModel::new();
-        model.expect_complete().times(0);
-        let harness = Harness::new(model).allow(Tool::Read);
+        model.expect_complete_with_optional_metadata().times(0);
+        let harness = Harness::new(model)
+            .allow(Tool::Read)
+            .with_lifecycle_observer(|_| {});
 
         // Act
         let error = harness
@@ -272,24 +547,31 @@ mod tests {
             .expect_err("read should require a repository root");
 
         // Assert
-        assert!(matches!(error, TurnError::RepositoryRequired));
+        assert!(matches!(&error, TurnError::RepositoryRequired));
+        assert_eq!(error.error_type(), TurnErrorType::RepositoryRequired);
     }
 
     #[tokio::test]
     async fn rejects_tool_call_when_policy_denies_read() {
         // Arrange
         let mut model = MockModel::new();
-        model.expect_complete().times(1).returning(|request| {
-            assert!(request.tools().is_empty());
+        model
+            .expect_complete_with_optional_metadata()
+            .times(1)
+            .returning(|request| {
+                assert!(request.tools().is_empty());
 
-            Ok(ModelResponse::ToolCall(read_call("call_denied")))
-        });
+                Ok(response_without_metadata(ModelResponse::ToolCall(
+                    read_call("call_denied"),
+                )))
+            });
         let mut file_system = MockFileSystem::new();
         file_system.expect_canonicalize().times(0);
         file_system.expect_open_beneath().times(0);
         let harness = Harness::new(model)
             .file_system(file_system)
-            .repository("repo");
+            .repository("repo")
+            .with_lifecycle_observer(|_| {});
 
         // Act
         let error = harness
@@ -299,9 +581,10 @@ mod tests {
 
         // Assert
         assert!(matches!(
-            error,
+            &error,
             TurnError::ToolDenied { name } if name == "read"
         ));
+        assert_eq!(error.error_type(), TurnErrorType::ToolDenied);
     }
 
     #[tokio::test]
@@ -309,14 +592,19 @@ mod tests {
         // Arrange
         let mut model = MockModel::new();
         model
-            .expect_complete()
+            .expect_complete_with_optional_metadata()
             .times(2)
-            .returning(|_| Ok(ModelResponse::ToolCall(read_call("call_read"))));
+            .returning(|_| {
+                Ok(response_without_metadata(ModelResponse::ToolCall(
+                    read_call("call_read"),
+                )))
+            });
         let harness = Harness::new(model)
             .file_system(readable_file_system())
             .repository("repo")
             .allow(Tool::Read)
-            .max_tool_calls(NonZeroUsize::new(1).expect("limit should be non-zero"));
+            .max_tool_calls(NonZeroUsize::new(1).expect("limit should be non-zero"))
+            .with_lifecycle_observer(|_| {});
 
         // Act
         let error = harness
@@ -325,7 +613,8 @@ mod tests {
             .expect_err("second tool call should exceed the limit");
 
         // Assert
-        assert!(matches!(error, TurnError::ToolCallLimit { limit: 1 }));
+        assert!(matches!(&error, TurnError::ToolCallLimit { limit: 1 }));
+        assert_eq!(error.error_type(), TurnErrorType::ToolCallLimit);
     }
 
     #[tokio::test]
@@ -333,9 +622,13 @@ mod tests {
         // Arrange
         let mut model = MockModel::new();
         model
-            .expect_complete()
+            .expect_complete_with_optional_metadata()
             .times(1)
-            .returning(|_| Ok(ModelResponse::ToolCall(read_call("call_read"))));
+            .returning(|_| {
+                Ok(response_without_metadata(ModelResponse::ToolCall(
+                    read_call("call_read"),
+                )))
+            });
         let mut file_system = MockFileSystem::new();
         file_system
             .expect_canonicalize()
@@ -344,7 +637,8 @@ mod tests {
         let harness = Harness::new(model)
             .file_system(file_system)
             .repository("repo")
-            .allow(Tool::Read);
+            .allow(Tool::Read)
+            .with_lifecycle_observer(|_| {});
 
         // Act
         let error = harness
@@ -354,9 +648,10 @@ mod tests {
 
         // Assert
         assert!(matches!(
-            error,
+            &error,
             TurnError::Read(ReadError::RepositoryRoot { .. })
         ));
+        assert_eq!(error.error_type(), TurnErrorType::Tool);
     }
 
     #[tokio::test]
@@ -364,7 +659,7 @@ mod tests {
         // Arrange
         let mut model = MockModel::new();
         model
-            .expect_complete()
+            .expect_complete_with_optional_metadata()
             .times(1)
             .returning(|_| Err(ModelError::request(io::Error::other("offline"))));
         let mut file_system = MockFileSystem::new();
@@ -372,7 +667,8 @@ mod tests {
         file_system.expect_open_beneath().times(0);
         let harness = Harness::new(model)
             .file_system(file_system)
-            .repository("repo");
+            .repository("repo")
+            .with_lifecycle_observer(|_| {});
 
         // Act
         let error = harness
@@ -381,6 +677,10 @@ mod tests {
             .expect_err("model failure should end the turn");
 
         // Assert
-        assert!(matches!(error, TurnError::Model(ModelError::Request(_))));
+        assert!(matches!(&error, TurnError::Model(ModelError::Request(_))));
+        assert_eq!(
+            error.error_type(),
+            TurnErrorType::Model(crate::ModelErrorType::Request)
+        );
     }
 }

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -6,6 +6,7 @@
 mod chat_completion;
 mod file_system;
 mod harness;
+mod lifecycle;
 mod model;
 mod policy;
 mod provider;
@@ -16,6 +17,10 @@ mod tool;
 
 pub use file_system::{FileSystem, LocalFileSystem};
 pub use harness::{Harness, TurnError};
+pub use lifecycle::{
+    LifecycleEvent, LifecycleEventKind, LifecycleId, LifecycleObserver, ModelResponseType,
+    ToolErrorType, TurnErrorType,
+};
 pub use model::{
     CompletionMetadata, CompletionUsage, Model, ModelClient, ModelCompletion, ModelError,
     ModelErrorType, ModelMetadata, ModelMetadataError, ModelRequest, ModelResponse,

--- a/crates/ag-harness/src/lifecycle.rs
+++ b/crates/ag-harness/src/lifecycle.rs
@@ -1,0 +1,821 @@
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex, PoisonError};
+use std::thread::{self, ThreadId};
+use std::time::{Duration, Instant};
+
+use crate::model::{CompletionMetadata, ModelErrorType, ModelMetadata};
+
+/// Stream-local identifier that correlates lifecycle events for one operation.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct LifecycleId(u64);
+
+impl LifecycleId {
+    /// Returns the stream-local numeric identifier.
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// One ordered, metadata-only harness lifecycle event.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LifecycleEvent {
+    kind: LifecycleEventKind,
+    sequence: u64,
+}
+
+impl LifecycleEvent {
+    /// Returns the event's zero-based position in its observer stream.
+    pub fn sequence(&self) -> u64 {
+        self.sequence
+    }
+
+    /// Returns the typed lifecycle fact carried by this event.
+    pub fn kind(&self) -> &LifecycleEventKind {
+        &self.kind
+    }
+}
+
+/// Typed metadata-only facts emitted while model turns execute.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum LifecycleEventKind {
+    /// A complete harness turn started.
+    TurnStarted {
+        /// Identifier shared by all events in the turn.
+        turn_id: LifecycleId,
+    },
+    /// A complete harness turn finished successfully.
+    TurnCompleted {
+        /// Elapsed turn time.
+        duration: Duration,
+        /// Identifier shared by all events in the turn.
+        turn_id: LifecycleId,
+    },
+    /// A complete harness turn failed or was cancelled.
+    TurnFailed {
+        /// Elapsed turn time.
+        duration: Duration,
+        /// Stable failure classification.
+        error_type: TurnErrorType,
+        /// Identifier shared by all events in the turn.
+        turn_id: LifecycleId,
+    },
+    /// One provider-neutral model request started.
+    ModelRequestStarted {
+        /// Identifier shared by this request's lifecycle events.
+        model_call_id: LifecycleId,
+        /// Validated provider and requested-model identity, when available.
+        model: Option<ModelMetadata>,
+        /// Zero-based model-call position within a turn.
+        request_index: u64,
+        /// Owning turn, or `None` for a standalone model request.
+        turn_id: Option<LifecycleId>,
+    },
+    /// One provider-neutral model request completed successfully.
+    ModelRequestCompleted {
+        /// Normalized provider completion metadata, when available.
+        completion: Option<CompletionMetadata>,
+        /// Elapsed model-request time.
+        duration: Duration,
+        /// Identifier shared by this request's lifecycle events.
+        model_call_id: LifecycleId,
+        /// Shape of the provider-neutral response.
+        response_type: ModelResponseType,
+        /// Owning turn, or `None` for a standalone model request.
+        turn_id: Option<LifecycleId>,
+    },
+    /// One provider-neutral model request failed.
+    ModelRequestFailed {
+        /// Elapsed model-request time.
+        duration: Duration,
+        /// Stable failure classification.
+        error_type: ModelErrorType,
+        /// Identifier shared by this request's lifecycle events.
+        model_call_id: LifecycleId,
+        /// Owning turn, or `None` for a standalone model request.
+        turn_id: Option<LifecycleId>,
+    },
+    /// One in-flight provider-neutral model request was cancelled.
+    ModelRequestCancelled {
+        /// Elapsed model-request time before cancellation.
+        duration: Duration,
+        /// Identifier shared by this request's lifecycle events.
+        model_call_id: LifecycleId,
+        /// Owning turn, or `None` for a standalone model request.
+        turn_id: Option<LifecycleId>,
+    },
+    /// The model requested one tool operation.
+    ToolRequested {
+        /// Identifier shared by this tool operation's lifecycle events.
+        tool_call_id: LifecycleId,
+        /// Bounded built-in tool name.
+        tool_name: String,
+        /// Owning turn.
+        turn_id: LifecycleId,
+    },
+    /// One allowed tool operation started execution.
+    ToolStarted {
+        /// Identifier shared by this tool operation's lifecycle events.
+        tool_call_id: LifecycleId,
+        /// Owning turn.
+        turn_id: LifecycleId,
+    },
+    /// One allowed tool operation completed successfully.
+    ToolCompleted {
+        /// Elapsed tool-execution time.
+        duration: Duration,
+        /// Identifier shared by this tool operation's lifecycle events.
+        tool_call_id: LifecycleId,
+        /// Owning turn.
+        turn_id: LifecycleId,
+    },
+    /// One requested tool was denied by policy.
+    ToolDenied {
+        /// Elapsed time before denial.
+        duration: Duration,
+        /// Identifier shared by this tool operation's lifecycle events.
+        tool_call_id: LifecycleId,
+        /// Owning turn.
+        turn_id: LifecycleId,
+    },
+    /// One requested tool failed or was cancelled.
+    ToolFailed {
+        /// Elapsed tool-execution time.
+        duration: Duration,
+        /// Stable failure classification.
+        error_type: ToolErrorType,
+        /// Identifier shared by this tool operation's lifecycle events.
+        tool_call_id: LifecycleId,
+        /// Owning turn.
+        turn_id: LifecycleId,
+    },
+}
+
+/// Shape of a successful provider-neutral model response.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ModelResponseType {
+    /// Terminal, schema-validated structured output.
+    Output,
+    /// An intermediate native tool request.
+    ToolCall,
+}
+
+/// Stable, low-cardinality reason that a harness turn failed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum TurnErrorType {
+    /// The turn future was dropped before completion.
+    Cancelled,
+    /// A model request failed.
+    Model(ModelErrorType),
+    /// A repository-scoped tool failed.
+    Tool,
+    /// A requested tool was denied by policy.
+    ToolDenied,
+    /// The turn exceeded its configured tool-call limit.
+    ToolCallLimit,
+    /// A repository-scoped tool was enabled without a repository root.
+    RepositoryRequired,
+}
+
+/// Stable, low-cardinality reason that a tool operation failed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ToolErrorType {
+    /// The turn future was dropped during tool execution.
+    Cancelled,
+    /// The configured per-turn tool-call limit was reached.
+    CallLimit,
+    /// The allowed tool failed while executing or encoding its result.
+    Execution,
+}
+
+/// Synchronous destination for ordered harness lifecycle events.
+///
+/// Callback entry follows sequence order across threads and permits same-thread
+/// reentrancy. Observer panics never change the model or turn result.
+pub trait LifecycleObserver: Send + Sync {
+    /// Receives one event before the operation continues.
+    fn observe(&self, event: LifecycleEvent);
+}
+
+impl<Observe> LifecycleObserver for Observe
+where
+    Observe: Fn(LifecycleEvent) + Send + Sync,
+{
+    fn observe(&self, event: LifecycleEvent) {
+        self(event);
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct LifecycleEmitter {
+    state: Option<Arc<LifecycleState>>,
+}
+
+impl LifecycleEmitter {
+    pub(crate) fn new(observer: impl LifecycleObserver + 'static) -> Self {
+        Self {
+            state: Some(Arc::new(LifecycleState {
+                delivery: DeliveryCoordinator::default(),
+                next_id: AtomicU64::new(0),
+                observer: Arc::new(observer),
+            })),
+        }
+    }
+
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.state.is_some()
+    }
+
+    pub(crate) fn start_turn(&self) -> Option<TurnLifecycle> {
+        let turn_id = self.next_id()?;
+        self.emit(LifecycleEventKind::TurnStarted { turn_id });
+
+        Some(TurnLifecycle {
+            active: true,
+            emitter: self.clone(),
+            started_at: Instant::now(),
+            turn_id,
+        })
+    }
+
+    pub(crate) fn start_model_request(
+        &self,
+        model: Option<ModelMetadata>,
+        request_index: u64,
+        turn_id: Option<LifecycleId>,
+    ) -> Option<ModelRequestLifecycle> {
+        let model_call_id = self.next_id()?;
+        self.emit(LifecycleEventKind::ModelRequestStarted {
+            model_call_id,
+            model,
+            request_index,
+            turn_id,
+        });
+
+        Some(ModelRequestLifecycle {
+            active: true,
+            emitter: self.clone(),
+            model_call_id,
+            started_at: Instant::now(),
+            turn_id,
+        })
+    }
+
+    pub(crate) fn request_tool(
+        &self,
+        tool_name: String,
+        turn_id: Option<LifecycleId>,
+    ) -> Option<ToolLifecycle> {
+        let turn_id = turn_id?;
+        let tool_call_id = self.next_id()?;
+        self.emit(LifecycleEventKind::ToolRequested {
+            tool_call_id,
+            tool_name,
+            turn_id,
+        });
+
+        Some(ToolLifecycle {
+            active: true,
+            emitter: self.clone(),
+            started_at: Instant::now(),
+            tool_call_id,
+            turn_id,
+        })
+    }
+
+    fn next_id(&self) -> Option<LifecycleId> {
+        self.state
+            .as_ref()
+            .map(|state| LifecycleId(state.next_id.fetch_add(1, Ordering::Relaxed)))
+    }
+
+    fn emit(&self, kind: LifecycleEventKind) {
+        let Some(state) = self.state.as_ref() else {
+            return;
+        };
+        let delivery = state.delivery.enter();
+        let event = LifecycleEvent {
+            kind,
+            sequence: delivery.sequence(),
+        };
+
+        let _ = catch_unwind(AssertUnwindSafe(|| state.observer.observe(event)));
+    }
+}
+
+struct LifecycleState {
+    delivery: DeliveryCoordinator,
+    next_id: AtomicU64,
+    observer: Arc<dyn LifecycleObserver>,
+}
+
+#[derive(Default)]
+struct DeliveryCoordinator {
+    available: Condvar,
+    state: Mutex<DeliveryState>,
+}
+
+impl DeliveryCoordinator {
+    fn enter(&self) -> DeliveryPermit<'_> {
+        let current_thread = thread::current().id();
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        state = self
+            .available
+            .wait_while(state, |state| {
+                state
+                    .owner
+                    .as_ref()
+                    .is_some_and(|owner| *owner != current_thread)
+            })
+            .unwrap_or_else(PoisonError::into_inner);
+        state.depth += 1;
+        state.owner = Some(current_thread);
+        let sequence = state.next_sequence;
+        state.next_sequence += 1;
+
+        DeliveryPermit {
+            coordinator: self,
+            sequence,
+        }
+    }
+
+    fn exit(&self) {
+        let current_thread = thread::current().id();
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        debug_assert_eq!(state.owner, Some(current_thread));
+        state.depth -= 1;
+        if state.depth == 0 {
+            state.owner = None;
+            self.available.notify_one();
+        }
+    }
+}
+
+#[derive(Default)]
+struct DeliveryState {
+    depth: usize,
+    next_sequence: u64,
+    owner: Option<ThreadId>,
+}
+
+struct DeliveryPermit<'coordinator> {
+    coordinator: &'coordinator DeliveryCoordinator,
+    sequence: u64,
+}
+
+impl DeliveryPermit<'_> {
+    fn sequence(&self) -> u64 {
+        self.sequence
+    }
+}
+
+impl Drop for DeliveryPermit<'_> {
+    fn drop(&mut self) {
+        self.coordinator.exit();
+    }
+}
+
+pub(crate) struct TurnLifecycle {
+    active: bool,
+    emitter: LifecycleEmitter,
+    started_at: Instant,
+    turn_id: LifecycleId,
+}
+
+impl TurnLifecycle {
+    pub(crate) fn id(&self) -> LifecycleId {
+        self.turn_id
+    }
+
+    pub(crate) fn completed(mut self) {
+        self.active = false;
+        self.emitter.emit(LifecycleEventKind::TurnCompleted {
+            duration: self.started_at.elapsed(),
+            turn_id: self.turn_id,
+        });
+    }
+
+    pub(crate) fn failed(mut self, error_type: TurnErrorType) {
+        self.active = false;
+        self.emitter.emit(LifecycleEventKind::TurnFailed {
+            duration: self.started_at.elapsed(),
+            error_type,
+            turn_id: self.turn_id,
+        });
+    }
+}
+
+impl Drop for TurnLifecycle {
+    fn drop(&mut self) {
+        if self.active {
+            self.emitter.emit(LifecycleEventKind::TurnFailed {
+                duration: self.started_at.elapsed(),
+                error_type: TurnErrorType::Cancelled,
+                turn_id: self.turn_id,
+            });
+        }
+    }
+}
+
+pub(crate) struct ModelRequestLifecycle {
+    active: bool,
+    emitter: LifecycleEmitter,
+    model_call_id: LifecycleId,
+    started_at: Instant,
+    turn_id: Option<LifecycleId>,
+}
+
+impl ModelRequestLifecycle {
+    pub(crate) fn completed(
+        mut self,
+        completion: Option<CompletionMetadata>,
+        response_type: ModelResponseType,
+    ) {
+        self.active = false;
+        self.emitter
+            .emit(LifecycleEventKind::ModelRequestCompleted {
+                completion,
+                duration: self.started_at.elapsed(),
+                model_call_id: self.model_call_id,
+                response_type,
+                turn_id: self.turn_id,
+            });
+    }
+
+    pub(crate) fn failed(mut self, error_type: ModelErrorType) {
+        self.active = false;
+        self.emitter.emit(LifecycleEventKind::ModelRequestFailed {
+            duration: self.started_at.elapsed(),
+            error_type,
+            model_call_id: self.model_call_id,
+            turn_id: self.turn_id,
+        });
+    }
+}
+
+impl Drop for ModelRequestLifecycle {
+    fn drop(&mut self) {
+        if self.active {
+            self.emitter
+                .emit(LifecycleEventKind::ModelRequestCancelled {
+                    duration: self.started_at.elapsed(),
+                    model_call_id: self.model_call_id,
+                    turn_id: self.turn_id,
+                });
+        }
+    }
+}
+
+pub(crate) struct ToolLifecycle {
+    active: bool,
+    emitter: LifecycleEmitter,
+    started_at: Instant,
+    tool_call_id: LifecycleId,
+    turn_id: LifecycleId,
+}
+
+impl ToolLifecycle {
+    pub(crate) fn started(&mut self) {
+        self.emitter.emit(LifecycleEventKind::ToolStarted {
+            tool_call_id: self.tool_call_id,
+            turn_id: self.turn_id,
+        });
+        self.started_at = Instant::now();
+    }
+
+    pub(crate) fn completed(mut self) {
+        self.active = false;
+        self.emitter.emit(LifecycleEventKind::ToolCompleted {
+            duration: self.started_at.elapsed(),
+            tool_call_id: self.tool_call_id,
+            turn_id: self.turn_id,
+        });
+    }
+
+    pub(crate) fn denied(mut self) {
+        self.active = false;
+        self.emitter.emit(LifecycleEventKind::ToolDenied {
+            duration: self.started_at.elapsed(),
+            tool_call_id: self.tool_call_id,
+            turn_id: self.turn_id,
+        });
+    }
+
+    pub(crate) fn failed(mut self, error_type: ToolErrorType) {
+        self.active = false;
+        self.emitter.emit(LifecycleEventKind::ToolFailed {
+            duration: self.started_at.elapsed(),
+            error_type,
+            tool_call_id: self.tool_call_id,
+            turn_id: self.turn_id,
+        });
+    }
+}
+
+impl Drop for ToolLifecycle {
+    fn drop(&mut self) {
+        if self.active {
+            self.emitter.emit(LifecycleEventKind::ToolFailed {
+                duration: self.started_at.elapsed(),
+                error_type: ToolErrorType::Cancelled,
+                tool_call_id: self.tool_call_id,
+                turn_id: self.turn_id,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Barrier, Mutex, mpsc};
+
+    use super::*;
+
+    fn completion_metadata() -> CompletionMetadata {
+        CompletionMetadata::new("stop".to_string(), None, None, None, None)
+    }
+
+    fn recording_emitter() -> (LifecycleEmitter, Arc<Mutex<Vec<LifecycleEvent>>>) {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let observed_events = Arc::clone(&events);
+        let emitter = LifecycleEmitter::new(move |event| {
+            observed_events
+                .lock()
+                .expect("event recorder should not be poisoned")
+                .push(event);
+        });
+
+        (emitter, events)
+    }
+
+    #[test]
+    fn emits_ordered_terminal_events_for_every_operation() {
+        // Arrange
+        let (emitter, events) = recording_emitter();
+        let turn_id = LifecycleId(41);
+
+        // Act
+        emitter
+            .start_turn()
+            .expect("turn should be observed")
+            .completed();
+        emitter
+            .start_turn()
+            .expect("turn should be observed")
+            .failed(TurnErrorType::RepositoryRequired);
+        drop(emitter.start_turn().expect("turn should be observed"));
+        emitter
+            .start_model_request(None, 0, Some(turn_id))
+            .expect("model request should be observed")
+            .completed(Some(completion_metadata()), ModelResponseType::Output);
+        emitter
+            .start_model_request(None, 1, Some(turn_id))
+            .expect("model request should be observed")
+            .failed(ModelErrorType::Provider);
+        drop(
+            emitter
+                .start_model_request(None, 2, Some(turn_id))
+                .expect("model request should be observed"),
+        );
+        let mut completed_tool = emitter
+            .request_tool("read".to_string(), Some(turn_id))
+            .expect("tool should be observed");
+        completed_tool.started();
+        completed_tool.completed();
+        emitter
+            .request_tool("read".to_string(), Some(turn_id))
+            .expect("tool should be observed")
+            .denied();
+        emitter
+            .request_tool("read".to_string(), Some(turn_id))
+            .expect("tool should be observed")
+            .failed(ToolErrorType::CallLimit);
+        drop(
+            emitter
+                .request_tool("read".to_string(), Some(turn_id))
+                .expect("tool should be observed"),
+        );
+
+        // Assert
+        let events = events
+            .lock()
+            .expect("event recorder should not be poisoned");
+        assert_eq!(
+            events
+                .iter()
+                .map(LifecycleEvent::sequence)
+                .collect::<Vec<_>>(),
+            (0..events.len() as u64).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            events[0].kind(),
+            &LifecycleEventKind::TurnStarted {
+                turn_id: LifecycleId(0),
+            }
+        );
+        assert!(matches!(
+            events[2].kind(),
+            LifecycleEventKind::TurnStarted { turn_id } if turn_id.get() == 1
+        ));
+        assert!(matches!(
+            events[5].kind(),
+            LifecycleEventKind::TurnFailed {
+                error_type: TurnErrorType::Cancelled,
+                ..
+            }
+        ));
+        assert!(matches!(
+            events[11].kind(),
+            LifecycleEventKind::ModelRequestCancelled { .. }
+        ));
+        assert!(matches!(
+            events[14].kind(),
+            LifecycleEventKind::ToolCompleted { .. }
+        ));
+        assert!(matches!(
+            events[16].kind(),
+            LifecycleEventKind::ToolDenied { .. }
+        ));
+        assert!(matches!(
+            events[18].kind(),
+            LifecycleEventKind::ToolFailed {
+                error_type: ToolErrorType::CallLimit,
+                ..
+            }
+        ));
+        assert!(matches!(
+            events[20].kind(),
+            LifecycleEventKind::ToolFailed {
+                error_type: ToolErrorType::Cancelled,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn disabled_emitter_allocates_no_lifecycle_state() {
+        // Arrange
+        let emitter = LifecycleEmitter::default();
+
+        // Act
+        let turn = emitter.start_turn();
+        let model_request = emitter.start_model_request(None, 0, None);
+        let tool = emitter.request_tool("read".to_string(), None);
+        emitter.emit(LifecycleEventKind::TurnStarted {
+            turn_id: LifecycleId(0),
+        });
+
+        // Assert
+        assert!(!emitter.is_enabled());
+        assert!(turn.is_none());
+        assert!(model_request.is_none());
+        assert!(tool.is_none());
+    }
+
+    #[test]
+    fn observer_panics_do_not_change_control_flow() {
+        // Arrange
+        let emitter = LifecycleEmitter::new(|_| {
+            std::panic::resume_unwind(Box::new("observer failed"));
+        });
+
+        // Act
+        let turn = emitter.start_turn().expect("turn should still start");
+        turn.completed();
+
+        // Assert
+        assert!(emitter.is_enabled());
+    }
+
+    #[test]
+    fn serializes_concurrent_observer_delivery() {
+        // Arrange
+        let release_first = Arc::new((Mutex::new(false), Condvar::new()));
+        let observer_release = Arc::clone(&release_first);
+        let (delivered, delivery) = mpsc::channel();
+        let emitter = LifecycleEmitter::new(move |event: LifecycleEvent| {
+            delivered
+                .send(event.sequence())
+                .expect("delivery receiver should remain available");
+            if event.sequence() == 0 {
+                let (released, ready) = &*observer_release;
+                let released = released.lock().unwrap_or_else(PoisonError::into_inner);
+                let _released = ready
+                    .wait_while(released, |released| !*released)
+                    .unwrap_or_else(PoisonError::into_inner);
+            }
+        });
+        let first_emitter = emitter.clone();
+        let second_emitter = emitter;
+        let second_ready = Arc::new(Barrier::new(2));
+        let thread_ready = Arc::clone(&second_ready);
+
+        // Act
+        let first = thread::spawn(move || {
+            first_emitter.emit(LifecycleEventKind::TurnStarted {
+                turn_id: LifecycleId(0),
+            });
+        });
+        assert_eq!(
+            delivery
+                .recv_timeout(Duration::from_secs(1))
+                .expect("first event should enter the observer"),
+            0
+        );
+        let second = thread::spawn(move || {
+            thread_ready.wait();
+            second_emitter.emit(LifecycleEventKind::TurnStarted {
+                turn_id: LifecycleId(1),
+            });
+        });
+        second_ready.wait();
+        let concurrent_delivery = delivery.recv_timeout(Duration::from_millis(100));
+        let (released, ready) = &*release_first;
+        *released.lock().unwrap_or_else(PoisonError::into_inner) = true;
+        ready.notify_one();
+        first.join().expect("first emitter should finish");
+        second.join().expect("second emitter should finish");
+
+        // Assert
+        assert!(concurrent_delivery.is_err());
+        assert_eq!(
+            delivery
+                .recv_timeout(Duration::from_secs(1))
+                .expect("second event should follow the first"),
+            1
+        );
+    }
+
+    #[test]
+    fn supports_reentrant_observer_delivery() {
+        // Arrange
+        let emitter_holder = Arc::new(Mutex::new(None::<LifecycleEmitter>));
+        let observer_emitter = Arc::clone(&emitter_holder);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let observer_events = Arc::clone(&events);
+        let emitter = LifecycleEmitter::new(move |event: LifecycleEvent| {
+            let sequence = event.sequence();
+            observer_events
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push(sequence);
+            if sequence == 0 {
+                observer_emitter
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .as_ref()
+                    .expect("emitter should be available to its observer")
+                    .emit(LifecycleEventKind::TurnStarted {
+                        turn_id: LifecycleId(1),
+                    });
+            }
+        });
+        *emitter_holder
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = Some(emitter.clone());
+
+        // Act
+        emitter.emit(LifecycleEventKind::TurnStarted {
+            turn_id: LifecycleId(0),
+        });
+
+        // Assert
+        assert_eq!(
+            *events.lock().unwrap_or_else(PoisonError::into_inner),
+            vec![0, 1]
+        );
+    }
+
+    #[test]
+    fn starts_tool_execution_timer_after_started_observer() {
+        // Arrange
+        let observer_time = Arc::new(Mutex::new(None));
+        let recorded_time = Arc::clone(&observer_time);
+        let emitter = LifecycleEmitter::new(move |event: LifecycleEvent| {
+            if matches!(event.kind(), LifecycleEventKind::ToolStarted { .. }) {
+                *recorded_time.lock().unwrap_or_else(PoisonError::into_inner) =
+                    Some(Instant::now());
+            }
+        });
+        let turn_id = LifecycleId(0);
+        let mut tool = emitter
+            .request_tool("read".to_string(), Some(turn_id))
+            .expect("tool should be observed");
+
+        // Act
+        tool.started();
+        let execution_started_at = tool.started_at;
+        tool.completed();
+
+        // Assert
+        let observer_time = observer_time
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .expect("started observer should record its time");
+        assert!(execution_started_at >= observer_time);
+    }
+}

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 use thiserror::Error;
 
+use crate::lifecycle::{LifecycleEmitter, LifecycleObserver, ModelResponseType};
 use crate::provider::{self, KimiConfig, MuseConfig, QwenConfig};
 use crate::schema_contract::{OutputSchema, OutputValidationError};
 use crate::{chat_completion, telemetry, tool};
@@ -22,11 +23,29 @@ pub trait Model: Send + Sync {
     /// Returns [`ModelError`] when the provider request fails or its response
     /// cannot be converted to the provider-neutral response.
     async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError>;
+
+    /// Completes one model request and returns normalized metadata when
+    /// available.
+    ///
+    /// Response-only implementations inherit a default that returns `None`.
+    /// [`ModelWithMetadata`] implementations return `Some` automatically.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] under the same conditions as [`Model::complete`].
+    async fn complete_with_optional_metadata(
+        &self,
+        request: ModelRequest,
+    ) -> Result<(ModelResponse, Option<CompletionMetadata>), ModelError> {
+        self.complete(request)
+            .await
+            .map(|response| (response, None))
+    }
 }
 
-/// Object-safe model extension that returns normalized completion metadata.
+/// Object-safe model boundary that guarantees normalized completion metadata.
 #[async_trait]
-pub trait ModelWithMetadata: Model {
+pub trait ModelWithMetadata: Send + Sync {
     /// Completes one model request and returns normalized provider metadata.
     ///
     /// # Errors
@@ -39,6 +58,28 @@ pub trait ModelWithMetadata: Model {
     ) -> Result<ModelCompletion, ModelError>;
 }
 
+#[async_trait]
+impl<ModelType> Model for ModelType
+where
+    ModelType: ModelWithMetadata + ?Sized,
+{
+    async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
+        self.complete_with_metadata(request)
+            .await
+            .map(ModelCompletion::into_response)
+    }
+
+    async fn complete_with_optional_metadata(
+        &self,
+        request: ModelRequest,
+    ) -> Result<(ModelResponse, Option<CompletionMetadata>), ModelError> {
+        let completion = self.complete_with_metadata(request).await?;
+        let ModelCompletion { metadata, response } = completion;
+
+        Ok((response, Some(metadata)))
+    }
+}
+
 /// Application-facing client for provider-neutral model requests.
 ///
 /// Provider request execution remains private so every request passes through
@@ -46,6 +87,7 @@ pub trait ModelWithMetadata: Model {
 /// validation.
 pub struct ModelClient {
     backend: chat_completion::ChatCompletionBackend,
+    lifecycle: LifecycleEmitter,
     metadata: ModelMetadata,
 }
 
@@ -101,6 +143,14 @@ impl ModelClient {
         &self.metadata
     }
 
+    /// Sends metadata-only request lifecycle events to `observer`.
+    #[must_use]
+    pub fn with_lifecycle_observer(mut self, observer: impl LifecycleObserver + 'static) -> Self {
+        self.lifecycle = LifecycleEmitter::new(observer);
+
+        self
+    }
+
     /// Completes one model request through the shared telemetry and
     /// structured-output lifecycle.
     ///
@@ -125,19 +175,40 @@ impl ModelClient {
         request: ModelRequest,
     ) -> Result<ModelCompletion, ModelError> {
         let _duration = telemetry::RequestDuration::start(self.metadata());
-        let response = self.backend.generate(&request).await?;
+        let lifecycle = if request.lifecycle_observed() {
+            None
+        } else {
+            self.lifecycle
+                .start_model_request(Some(self.metadata.clone()), 0, None)
+        };
+        let result = async {
+            let response = self.backend.generate(&request).await?;
 
-        match response {
-            chat_completion::GeneratedResponse::Output { metadata, output } => request
-                .schema()
-                .parse_and_validate(&output)
-                .map(ModelResponse::from_output)
-                .map(|response| ModelCompletion::new(metadata, response))
-                .map_err(ModelError::from),
-            chat_completion::GeneratedResponse::ToolCall { call, metadata } => Ok(
-                ModelCompletion::new(metadata, ModelResponse::tool_call(call)),
-            ),
+            match response {
+                chat_completion::GeneratedResponse::Output { metadata, output } => request
+                    .schema()
+                    .parse_and_validate(&output)
+                    .map(ModelResponse::from_output)
+                    .map(|response| ModelCompletion::new(metadata, response))
+                    .map_err(ModelError::from),
+                chat_completion::GeneratedResponse::ToolCall { call, metadata } => Ok(
+                    ModelCompletion::new(metadata, ModelResponse::tool_call(call)),
+                ),
+            }
         }
+        .await;
+
+        if let Some(lifecycle) = lifecycle {
+            match &result {
+                Ok(completion) => lifecycle.completed(
+                    Some(completion.metadata.clone()),
+                    completion.response.response_type(),
+                ),
+                Err(error) => lifecycle.failed(error.error_type()),
+            }
+        }
+
+        result
     }
 
     fn chat_completion(
@@ -150,14 +221,11 @@ impl ModelClient {
         let (provider, model) = backend.identity();
         let metadata = ModelMetadata::new(provider, model)?;
 
-        Ok(Self { backend, metadata })
-    }
-}
-
-#[async_trait]
-impl Model for ModelClient {
-    async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
-        ModelClient::complete(self, request).await
+        Ok(Self {
+            backend,
+            lifecycle: LifecycleEmitter::default(),
+            metadata,
+        })
     }
 }
 
@@ -225,6 +293,7 @@ pub enum ModelMetadataError {
 /// Provider-neutral input for one model request.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ModelRequest {
+    lifecycle_observed: bool,
     messages: Vec<ModelMessage>,
     prompt: String,
     schema: OutputSchema,
@@ -237,6 +306,7 @@ impl ModelRequest {
         let prompt = prompt.into();
 
         Self {
+            lifecycle_observed: false,
             messages: vec![ModelMessage::User(prompt.clone())],
             prompt,
             schema,
@@ -275,6 +345,14 @@ impl ModelRequest {
 
     pub(crate) fn messages(&self) -> &[ModelMessage] {
         &self.messages
+    }
+
+    pub(crate) fn lifecycle_observed(&self) -> bool {
+        self.lifecycle_observed
+    }
+
+    pub(crate) fn mark_lifecycle_observed(&mut self) {
+        self.lifecycle_observed = true;
     }
 
     pub(crate) fn record_tool_result(&mut self, call: tool::ToolCall, content: String) {
@@ -478,6 +556,13 @@ impl ModelResponse {
 
     fn tool_call(call: tool::ToolCall) -> Self {
         Self::ToolCall(call)
+    }
+
+    pub(crate) fn response_type(&self) -> ModelResponseType {
+        match self {
+            Self::Output(_) => ModelResponseType::Output,
+            Self::ToolCall(_) => ModelResponseType::ToolCall,
+        }
     }
 }
 
@@ -700,11 +785,90 @@ impl From<OutputValidationError> for ModelError {
 #[cfg(test)]
 mod tests {
     use std::io;
+    use std::sync::{Arc, Mutex};
 
     use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
     use crate::tool::{ReadArguments, ToolCall};
+
+    struct ResponseOnlyModel;
+
+    #[async_trait]
+    impl Model for ResponseOnlyModel {
+        async fn complete(&self, _request: ModelRequest) -> Result<ModelResponse, ModelError> {
+            Ok(ModelResponse::Output(json!({ "name": "Ada" })))
+        }
+    }
+
+    struct MetadataModel;
+
+    #[async_trait]
+    impl ModelWithMetadata for MetadataModel {
+        async fn complete_with_metadata(
+            &self,
+            _request: ModelRequest,
+        ) -> Result<ModelCompletion, ModelError> {
+            Ok(ModelCompletion::new(
+                CompletionMetadata::new(
+                    "stop".to_string(),
+                    Some("response-id".to_string()),
+                    None,
+                    None,
+                    None,
+                ),
+                ModelResponse::Output(json!({ "name": "Ada" })),
+            ))
+        }
+    }
+
+    fn test_request() -> ModelRequest {
+        let schema =
+            OutputSchema::new(json!({ "type": "object" })).expect("fixture schema should be valid");
+
+        ModelRequest::new("prompt", schema)
+    }
+
+    #[tokio::test]
+    async fn response_only_model_defaults_optional_metadata_to_none() {
+        // Arrange
+        let model = ResponseOnlyModel;
+
+        // Act
+        let (response, metadata) = model
+            .complete_with_optional_metadata(test_request())
+            .await
+            .expect("response-only model should complete");
+
+        // Assert
+        assert_eq!(response.output(), Some(&json!({ "name": "Ada" })));
+        assert!(metadata.is_none());
+    }
+
+    #[tokio::test]
+    async fn metadata_model_automatically_implements_model_paths() {
+        // Arrange
+        let model = MetadataModel;
+
+        // Act
+        let response = Model::complete(&model, test_request())
+            .await
+            .expect("metadata model should complete through Model");
+        let (optional_response, metadata) =
+            Model::complete_with_optional_metadata(&model, test_request())
+                .await
+                .expect("metadata model should expose optional metadata");
+
+        // Assert
+        assert_eq!(response.output(), Some(&json!({ "name": "Ada" })));
+        assert_eq!(optional_response.output(), Some(&json!({ "name": "Ada" })));
+        assert_eq!(
+            metadata.as_ref().and_then(CompletionMetadata::response_id),
+            Some("response-id")
+        );
+    }
 
     #[test]
     fn client_exposes_provider_and_model() {
@@ -726,6 +890,117 @@ mod tests {
             metadata,
             &ModelMetadata::new("alibaba_cloud", "qwen-plus").expect("metadata should be valid")
         );
+    }
+
+    #[tokio::test]
+    async fn client_observes_success_unless_request_is_already_observed() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": r#"{"name":"Ada"}"#}
+                }]
+            })))
+            .expect(2)
+            .mount(&server)
+            .await;
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let observed_events = Arc::clone(&events);
+        let client = ModelClient::qwen(QwenConfig {
+            api_key: "test-key".to_string(),
+            base_url: server.uri(),
+            model: "qwen-plus".to_string(),
+        })
+        .expect("fixture configuration should be valid")
+        .with_lifecycle_observer(move |event| {
+            observed_events
+                .lock()
+                .expect("event recorder should not be poisoned")
+                .push(event);
+        });
+        let schema = OutputSchema::new(json!({
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"]
+        }))
+        .expect("fixture schema should be valid");
+        let mut observed_request = ModelRequest::new("prompt", schema.clone());
+        observed_request.mark_lifecycle_observed();
+
+        // Act
+        client
+            .complete(ModelRequest::new("prompt", schema))
+            .await
+            .expect("request should succeed");
+        client
+            .complete(observed_request)
+            .await
+            .expect("externally observed request should succeed");
+
+        // Assert
+        let events = events
+            .lock()
+            .expect("event recorder should not be poisoned");
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0].kind(),
+            crate::LifecycleEventKind::ModelRequestStarted { .. }
+        ));
+        assert!(matches!(
+            events[1].kind(),
+            crate::LifecycleEventKind::ModelRequestCompleted { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn client_observes_classified_failure() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("offline"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let observed_events = Arc::clone(&events);
+        let client = ModelClient::qwen(QwenConfig {
+            api_key: "test-key".to_string(),
+            base_url: server.uri(),
+            model: "qwen-plus".to_string(),
+        })
+        .expect("fixture configuration should be valid")
+        .with_lifecycle_observer(move |event| {
+            observed_events
+                .lock()
+                .expect("event recorder should not be poisoned")
+                .push(event);
+        });
+        let schema =
+            OutputSchema::new(json!({ "type": "object" })).expect("fixture schema should be valid");
+
+        // Act
+        let error = client
+            .complete(ModelRequest::new("prompt", schema))
+            .await
+            .expect_err("provider failure should be returned");
+
+        // Assert
+        assert_eq!(error.error_type(), ModelErrorType::Provider);
+        let events = events
+            .lock()
+            .expect("event recorder should not be poisoned");
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[1].kind(),
+            crate::LifecycleEventKind::ModelRequestFailed {
+                error_type: ModelErrorType::Provider,
+                ..
+            }
+        ));
     }
 
     #[tokio::test]

--- a/crates/ag-harness/src/provider/muse.rs
+++ b/crates/ag-harness/src/provider/muse.rs
@@ -4,9 +4,9 @@ use async_trait::async_trait;
 use thiserror::Error;
 
 use crate::chat_completion;
+use crate::lifecycle::LifecycleObserver;
 use crate::model::{
-    Model, ModelClient, ModelCompletion, ModelError, ModelMetadataError, ModelRequest,
-    ModelResponse, ModelWithMetadata,
+    ModelClient, ModelCompletion, ModelError, ModelMetadataError, ModelRequest, ModelWithMetadata,
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.meta.ai/v1";
@@ -47,6 +47,14 @@ impl Muse {
         Self::from_environment(model, |name| env::var(name))
     }
 
+    /// Sends metadata-only request lifecycle events to `observer`.
+    #[must_use]
+    pub fn with_lifecycle_observer(mut self, observer: impl LifecycleObserver + 'static) -> Self {
+        self.client = self.client.with_lifecycle_observer(observer);
+
+        self
+    }
+
     fn from_environment(
         model: impl Into<String>,
         mut environment: impl FnMut(&str) -> Result<String, env::VarError>,
@@ -61,13 +69,6 @@ impl Muse {
         })?;
 
         Ok(Self { client })
-    }
-}
-
-#[async_trait]
-impl Model for Muse {
-    async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
-        self.client.complete(request).await
     }
 }
 
@@ -109,7 +110,8 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
-    use crate::{model, tool};
+    use crate::model::{self, CompletionMetadata, Model};
+    use crate::tool;
 
     fn person_schema_value() -> Value {
         json!({
@@ -260,6 +262,21 @@ mod tests {
         assert_eq!(error, model::ModelMetadataError::EmptyModel);
     }
 
+    #[test]
+    fn configures_lifecycle_observer() {
+        // Arrange
+        let muse = Muse::from_environment(MUSE_SPARK_1_2, default_environment)
+            .expect("fixture environment should be valid");
+
+        // Act
+        let muse = muse.with_lifecycle_observer(|_| {});
+        let metadata = muse.client.metadata();
+
+        // Assert
+        assert_eq!(metadata.provider(), "meta");
+        assert_eq!(metadata.model(), MUSE_SPARK_1_2);
+    }
+
     #[tokio::test]
     async fn completes_native_json_schema_request() {
         // Arrange
@@ -280,7 +297,7 @@ mod tests {
                     "message": {"content": r#"{"name":"Ada"}"#}
                 }]
             })))
-            .expect(1)
+            .expect(2)
             .mount(&server)
             .await;
         let model = muse(&server);
@@ -290,6 +307,10 @@ mod tests {
             .complete_with_metadata(request("extract the name"))
             .await
             .expect("Muse request should succeed");
+        let (response, optional_metadata) = model
+            .complete_with_optional_metadata(request("extract the name"))
+            .await
+            .expect("Muse request with optional metadata should succeed");
 
         // Assert
         assert_eq!(
@@ -297,6 +318,13 @@ mod tests {
             Some(&json!({ "name": "Ada" }))
         );
         assert_eq!(completion.metadata().finish_reason(), "stop");
+        assert_eq!(response.output(), Some(&json!({ "name": "Ada" })));
+        assert_eq!(
+            optional_metadata
+                .as_ref()
+                .map(CompletionMetadata::finish_reason),
+            Some("stop")
+        );
     }
 
     #[tokio::test]

--- a/crates/ag-harness/tests/lifecycle.rs
+++ b/crates/ag-harness/tests/lifecycle.rs
@@ -1,0 +1,347 @@
+//! Integration coverage for metadata-only lifecycle observation.
+#![cfg(test)]
+
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ag_harness::{
+    LifecycleEvent, LifecycleEventKind, LifecycleObserver, ModelErrorType, ModelResponseType,
+    TurnErrorType,
+};
+use serde_json::json;
+use tokio::sync::Notify;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+#[derive(Clone, Default)]
+struct EventRecorder {
+    events: Arc<Mutex<Vec<LifecycleEvent>>>,
+}
+
+impl EventRecorder {
+    fn events(&self) -> Vec<LifecycleEvent> {
+        self.events
+            .lock()
+            .expect("event recorder should not be poisoned")
+            .clone()
+    }
+}
+
+impl LifecycleObserver for EventRecorder {
+    fn observe(&self, event: LifecycleEvent) {
+        self.events
+            .lock()
+            .expect("event recorder should not be poisoned")
+            .push(event);
+    }
+}
+
+struct PendingResponse {
+    started: Arc<Notify>,
+}
+
+impl Respond for PendingResponse {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        self.started.notify_one();
+
+        ResponseTemplate::new(200)
+            .set_delay(Duration::from_secs(10))
+            .set_body_json(success_body())
+    }
+}
+
+fn success_body() -> serde_json::Value {
+    json!({
+        "id": "safe-response-id",
+        "model": "returned-model",
+        "system_fingerprint": "safe-fingerprint",
+        "usage": {
+            "completion_tokens": 2,
+            "completion_tokens_details": {"reasoning_tokens": 1},
+            "prompt_cache_hit_tokens": 1,
+            "prompt_cache_miss_tokens": 2,
+            "prompt_tokens": 3,
+            "total_tokens": 5
+        },
+        "choices": [{
+            "finish_reason": "stop",
+            "message": {"content": r#"{"name":"SECRET_OUTPUT"}"#}
+        }]
+    })
+}
+
+fn client(server: &MockServer, model: &str, recorder: EventRecorder) -> ag_harness::ModelClient {
+    ag_harness::ModelClient::qwen(ag_harness::QwenConfig {
+        api_key: "SECRET_API_KEY".to_string(),
+        base_url: server.uri(),
+        model: model.to_string(),
+    })
+    .expect("fixture configuration should be valid")
+    .with_lifecycle_observer(recorder)
+}
+
+fn request() -> ag_harness::ModelRequest {
+    ag_harness::ModelRequest::new(
+        "SECRET_PROMPT",
+        ag_harness::OutputSchema::new(json!({
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+            "additionalProperties": false
+        }))
+        .expect("fixture schema should be valid"),
+    )
+}
+
+async fn wait_for_provider<Output: Debug>(
+    started: &Notify,
+    request_task: &mut tokio::task::JoinHandle<Output>,
+) -> Result<(), String> {
+    tokio::select! {
+        () = started.notified() => Ok(()),
+        result = request_task => {
+            Err(format!("pending request completed before cancellation: {result:?}"))
+        }
+        () = tokio::time::sleep(Duration::from_secs(5)) => {
+            Err("pending request did not reach the provider before the timeout".to_string())
+        }
+    }
+}
+
+fn assert_sequence(events: &[LifecycleEvent]) {
+    assert_eq!(
+        events
+            .iter()
+            .map(LifecycleEvent::sequence)
+            .collect::<Vec<_>>(),
+        (0..events.len() as u64).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn observes_one_terminal_event_for_success_failure_and_cancellation() {
+    // Arrange
+    let success_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&success_server)
+        .await;
+    let failure_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("SECRET_FAILURE_BODY"))
+        .expect(1)
+        .mount(&failure_server)
+        .await;
+    let pending_server = MockServer::start().await;
+    let pending_started = Arc::new(Notify::new());
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(PendingResponse {
+            started: Arc::clone(&pending_started),
+        })
+        .expect(1)
+        .mount(&pending_server)
+        .await;
+    let success_events = EventRecorder::default();
+    let failure_events = EventRecorder::default();
+    let cancellation_events = EventRecorder::default();
+
+    // Act
+    client(&success_server, "successful", success_events.clone())
+        .complete(request())
+        .await
+        .expect("successful request should complete");
+    let failure = client(&failure_server, "failed", failure_events.clone())
+        .complete(request())
+        .await
+        .expect_err("provider failure should be returned");
+    let pending_client = client(&pending_server, "cancelled", cancellation_events.clone());
+    let mut pending_request = tokio::spawn(async move { pending_client.complete(request()).await });
+    wait_for_provider(&pending_started, &mut pending_request)
+        .await
+        .expect("pending request should reach the provider");
+    pending_request.abort();
+    let cancellation = pending_request
+        .await
+        .expect_err("aborted request should be cancelled");
+
+    // Assert
+    assert!(matches!(failure, ag_harness::ModelError::Request(_)));
+    assert!(cancellation.is_cancelled());
+    let success_events = success_events.events();
+    let failure_events = failure_events.events();
+    let cancellation_events = cancellation_events.events();
+    for events in [&success_events, &failure_events, &cancellation_events] {
+        assert_eq!(events.len(), 2);
+        assert_sequence(events);
+        assert!(matches!(
+            events[0].kind(),
+            LifecycleEventKind::ModelRequestStarted {
+                request_index: 0,
+                turn_id: None,
+                ..
+            }
+        ));
+    }
+    assert!(matches!(
+        success_events[1].kind(),
+        LifecycleEventKind::ModelRequestCompleted {
+            completion,
+            response_type: ModelResponseType::Output,
+            turn_id: None,
+            ..
+        } if completion.as_ref().is_some_and(|completion| {
+            completion.finish_reason() == "stop"
+                && completion.response_id() == Some("safe-response-id")
+        })
+    ));
+    assert!(matches!(
+        failure_events[1].kind(),
+        LifecycleEventKind::ModelRequestFailed {
+            error_type: ModelErrorType::Provider,
+            turn_id: None,
+            ..
+        }
+    ));
+    assert!(matches!(
+        cancellation_events[1].kind(),
+        LifecycleEventKind::ModelRequestCancelled { turn_id: None, .. }
+    ));
+    let event_debug = format!("{success_events:?}{failure_events:?}{cancellation_events:?}");
+    for secret in [
+        "SECRET_API_KEY",
+        "SECRET_PROMPT",
+        "SECRET_OUTPUT",
+        "SECRET_FAILURE_BODY",
+    ] {
+        assert!(!event_debug.contains(secret));
+    }
+}
+
+#[tokio::test]
+async fn harness_owns_model_events_without_duplicate_model_observation() {
+    // Arrange
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let model_events = EventRecorder::default();
+    let harness_events = EventRecorder::default();
+    let harness = ag_harness::Harness::new(client(&server, "harness-model", model_events.clone()))
+        .with_lifecycle_observer(harness_events.clone());
+
+    // Act
+    let output = harness
+        .run("SECRET_PROMPT", request().schema().clone())
+        .await
+        .expect("harness request should complete");
+
+    // Assert
+    assert_eq!(output, json!({"name": "SECRET_OUTPUT"}));
+    assert!(model_events.events().is_empty());
+    let harness_events = harness_events.events();
+    assert_sequence(&harness_events);
+    assert_eq!(harness_events.len(), 4);
+    assert!(matches!(
+        harness_events[0].kind(),
+        LifecycleEventKind::TurnStarted { .. }
+    ));
+    assert!(matches!(
+        harness_events[1].kind(),
+        LifecycleEventKind::ModelRequestStarted {
+            model: None,
+            turn_id: Some(_),
+            ..
+        }
+    ));
+    assert!(matches!(
+        harness_events[2].kind(),
+        LifecycleEventKind::ModelRequestCompleted {
+            completion,
+            response_type: ModelResponseType::Output,
+            turn_id: Some(_),
+            ..
+        } if completion.as_ref().is_some_and(|completion| {
+            completion.finish_reason() == "stop"
+                && completion.response_id() == Some("safe-response-id")
+                && completion.response_model() == Some("returned-model")
+                && completion.system_fingerprint() == Some("safe-fingerprint")
+                && completion.usage().is_some_and(|usage| {
+                    usage.cache_hit_tokens() == Some(1)
+                        && usage.cache_miss_tokens() == Some(2)
+                        && usage.input_tokens() == Some(3)
+                        && usage.output_tokens() == Some(2)
+                        && usage.reasoning_tokens() == Some(1)
+                        && usage.total_tokens() == Some(5)
+                })
+        })
+    ));
+    assert!(matches!(
+        harness_events[3].kind(),
+        LifecycleEventKind::TurnCompleted { .. }
+    ));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn cancelling_harness_turn_closes_model_and_turn_lifecycles_once() {
+    // Arrange
+    let server = MockServer::start().await;
+    let request_started = Arc::new(Notify::new());
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(PendingResponse {
+            started: Arc::clone(&request_started),
+        })
+        .expect(1)
+        .mount(&server)
+        .await;
+    let model_events = EventRecorder::default();
+    let harness_events = EventRecorder::default();
+    let harness = ag_harness::Harness::new(client(&server, "cancelled-turn", model_events.clone()))
+        .with_lifecycle_observer(harness_events.clone());
+
+    // Act
+    let mut turn = tokio::spawn(async move {
+        harness
+            .run("SECRET_PROMPT", request().schema().clone())
+            .await
+    });
+    wait_for_provider(&request_started, &mut turn)
+        .await
+        .expect("pending request should reach the provider");
+    turn.abort();
+    let cancellation = turn.await.expect_err("aborted turn should be cancelled");
+
+    // Assert
+    assert!(cancellation.is_cancelled());
+    assert!(model_events.events().is_empty());
+    let harness_events = harness_events.events();
+    assert_sequence(&harness_events);
+    assert_eq!(harness_events.len(), 4);
+    assert!(matches!(
+        harness_events[0].kind(),
+        LifecycleEventKind::TurnStarted { .. }
+    ));
+    assert!(matches!(
+        harness_events[1].kind(),
+        LifecycleEventKind::ModelRequestStarted { .. }
+    ));
+    assert!(matches!(
+        harness_events[2].kind(),
+        LifecycleEventKind::ModelRequestCancelled { .. }
+    ));
+    assert!(matches!(
+        harness_events[3].kind(),
+        LifecycleEventKind::TurnFailed {
+            error_type: TurnErrorType::Cancelled,
+            ..
+        }
+    ));
+}

--- a/crates/ag-harness/tests/public_api.rs
+++ b/crates/ag-harness/tests/public_api.rs
@@ -1,10 +1,11 @@
 //! External-consumer coverage for the `ag-harness` model traits.
 
 use std::error::Error;
+use std::sync::{Arc, Mutex};
 
 use ag_harness::{
-    CompletionMetadata, CompletionUsage, Model, ModelCompletion, ModelError, ModelRequest,
-    ModelResponse, ModelWithMetadata, OutputSchema, OutputSchemaError,
+    CompletionMetadata, CompletionUsage, Harness, LifecycleEventKind, Model, ModelCompletion,
+    ModelError, ModelRequest, ModelResponse, ModelWithMetadata, OutputSchema, OutputSchemaError,
 };
 use async_trait::async_trait;
 use serde_json::json;
@@ -19,15 +20,6 @@ impl Model for ExternalModel {
 }
 
 struct ExternalMetadataModel;
-
-#[async_trait]
-impl Model for ExternalMetadataModel {
-    async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
-        self.complete_with_metadata(request)
-            .await
-            .map(ModelCompletion::into_response)
-    }
-}
 
 #[async_trait]
 impl ModelWithMetadata for ExternalMetadataModel {
@@ -62,25 +54,35 @@ fn request() -> Result<ModelRequest, OutputSchemaError> {
     ))
 }
 
-#[test]
-fn external_response_only_provider_implements_model() {
+#[tokio::test]
+async fn external_response_only_provider_implements_model() -> Result<(), Box<dyn Error>> {
     // Arrange
     fn assert_model<ModelType: Model>() {}
+    let model = ExternalModel;
 
-    // Act and Assert
+    // Act
+    let (response, metadata) = model.complete_with_optional_metadata(request()?).await?;
+
+    // Assert
     assert_model::<ExternalModel>();
+    assert_eq!(response.output(), Some(&json!({ "name": "Ada" })));
+    assert!(metadata.is_none());
+
+    Ok(())
 }
 
 #[tokio::test]
 async fn external_provider_constructs_metadata_completion_through_dynamic_dispatch()
 -> Result<(), Box<dyn Error>> {
     // Arrange
+    fn assert_model<ModelType: Model>() {}
     let model: Box<dyn ModelWithMetadata> = Box::new(ExternalMetadataModel);
 
     // Act
     let completion = model.complete_with_metadata(request()?).await?;
 
     // Assert
+    assert_model::<ExternalMetadataModel>();
     assert_eq!(
         completion.response().output(),
         Some(&json!({ "name": "Ada" }))
@@ -96,6 +98,40 @@ async fn external_provider_constructs_metadata_completion_through_dynamic_dispat
             .and_then(|usage| usage.total_tokens()),
         Some(6)
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn external_metadata_provider_reaches_harness_lifecycle() -> Result<(), Box<dyn Error>> {
+    // Arrange
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let observed_events = Arc::clone(&events);
+    let harness = Harness::new(ExternalMetadataModel).with_lifecycle_observer(move |event| {
+        observed_events
+            .lock()
+            .expect("event recorder should not be poisoned")
+            .push(event);
+    });
+
+    // Act
+    let output = harness
+        .run("extract the name", request()?.schema().clone())
+        .await?;
+
+    // Assert
+    assert_eq!(output, json!({ "name": "Ada" }));
+    let events = events
+        .lock()
+        .expect("event recorder should not be poisoned");
+    assert!(events.iter().any(|event| matches!(
+        event.kind(),
+        LifecycleEventKind::ModelRequestCompleted {
+            completion: Some(metadata),
+            ..
+        } if metadata.response_id() == Some("external-response")
+            && metadata.usage().and_then(|usage| usage.total_tokens()) == Some(6)
+    )));
 
     Ok(())
 }

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -63,7 +63,8 @@ request's `OutputSchema`. Provider request execution remains private so applicat
 cannot bypass this lifecycle. `ModelClient` validates and retains the provider and model
 identity during construction, before any request starts.
 
-`ModelWithMetadata` adds object-safe completion metadata without changing `Model`.
+`ModelWithMetadata` guarantees completion metadata and automatically implements the
+optional metadata path on `Model`; response-only `Model` implementations remain valid.
 
 Provider-owned adapters and compatibility rules live under the private `provider`
 module. API-family clients remain separate so multiple providers can reuse a wire
@@ -191,11 +192,8 @@ model call; aggregate its count by `gen_ai.provider.name` to separate providers.
 default service names are `ag-harness-qwen`, `ag-harness-kimi`, and `ag-harness-muse`,
 while `OTEL_SERVICE_NAME` remains an application-level override.
 
-The planned lifecycle telemetry design will:
-
-- Emit typed, ordered turn, model, and tool lifecycle events.
-- Derive OpenTelemetry metrics and traces from those events; applications own export.
-- Keep sensitive prompts, reasoning, and tool content disabled by default.
+Lifecycle telemetry emits typed, ordered, metadata-only turn, model, and tool events.
+Applications will own OpenTelemetry projection and export.
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
- Returns normalized provider completion metadata and optional token usage alongside validated model responses, preserving absent provider fields.
- Classifies transport, provider, malformed-response, and model failures with stable telemetry values while preserving provider HTTP statuses.
- Emits ordered, metadata-only turn, model, and tool lifecycle events with correlation, cancellation coverage, serialized delivery, accurate execution durations, and panic-safe observers.
- Supports response-only model compatibility while preserving normalized provider completion metadata through Harness.
- Classifies turn and tool failures with stable telemetry values.