### PR TITLE
Queued workflow actions survive project switches

### DIFF
--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -548,6 +548,8 @@ impl SessionManager {
 
     /// Shows one manual branch-publish action as an inline session-chat task.
     pub(crate) fn start_branch_publish(&mut self, session_id: &str, loading_label: String) {
+        self.state
+            .resolve_queued_action(session_id, TransientMessageSlot::BranchPublish);
         if let Some(session) = self
             .state
             .sessions
@@ -571,45 +573,37 @@ impl SessionManager {
         order: u64,
         queued_label: String,
     ) {
-        if let Some(session) = self
+        let turn_position = self
             .state
-            .sessions
-            .iter_mut()
-            .find(|session| session.id == session_id)
-        {
-            session.transient_messages.upsert(TransientMessage {
+            .session_for_id(session_id)
+            .and_then(Session::latest_user_prompt_position);
+        self.state.upsert_queued_action(
+            session_id,
+            TransientMessage {
                 anchor: TransientMessageAnchor::Tail,
                 body: TransientMessageBody::Queued(QueuedAction::new(order, queued_label)),
                 lifecycle: TransientMessageLifecycle::UntilResolved,
                 slot: TransientMessageSlot::BranchPublish,
-                turn_position: session.latest_user_prompt_position(),
-            });
-        }
+                turn_position,
+            },
+        );
     }
 
     /// Removes a queued review-request row that resolved without starting.
     pub(crate) fn resolve_queued_branch_publish(&mut self, session_id: &str) {
-        if let Some(session) = self
-            .state
-            .sessions
-            .iter_mut()
-            .find(|session| session.id == session_id)
-        {
-            session
-                .transient_messages
-                .retract(TransientMessageSlot::BranchPublish);
-        }
+        self.state
+            .resolve_queued_action(session_id, TransientMessageSlot::BranchPublish);
     }
 
     /// Shows one session sync waiting behind the active turn.
     pub(crate) fn queue_session_sync(&mut self, session_id: &str, order: u64) {
-        if let Some(session) = self
+        let turn_position = self
             .state
-            .sessions
-            .iter_mut()
-            .find(|session| session.id == session_id)
-        {
-            session.transient_messages.upsert(TransientMessage {
+            .session_for_id(session_id)
+            .and_then(Session::latest_user_prompt_position);
+        self.state.upsert_queued_action(
+            session_id,
+            TransientMessage {
                 anchor: TransientMessageAnchor::Tail,
                 body: TransientMessageBody::Queued(QueuedAction::new(
                     order,
@@ -617,27 +611,21 @@ impl SessionManager {
                 )),
                 lifecycle: TransientMessageLifecycle::UntilResolved,
                 slot: TransientMessageSlot::SyncQueue,
-                turn_position: session.latest_user_prompt_position(),
-            });
-        }
+                turn_position,
+            },
+        );
     }
 
     /// Removes a queued-sync row after its worker command resolves or starts.
     pub(crate) fn resolve_queued_session_sync(&mut self, session_id: &str) {
-        if let Some(session) = self
-            .state
-            .sessions
-            .iter_mut()
-            .find(|session| session.id == session_id)
-        {
-            session
-                .transient_messages
-                .retract(TransientMessageSlot::SyncQueue);
-        }
+        self.state
+            .resolve_queued_action(session_id, TransientMessageSlot::SyncQueue);
     }
 
     /// Replaces manual branch-publish progress with its inline final result.
     pub(crate) fn finish_branch_publish(&mut self, session_id: &str, body: TransientMessageBody) {
+        self.state
+            .resolve_queued_action(session_id, TransientMessageSlot::BranchPublish);
         if let Some(session) = self
             .state
             .sessions
@@ -661,6 +649,8 @@ impl SessionManager {
         session_id: &str,
         persistent_notice: &str,
     ) -> bool {
+        self.state
+            .resolve_queued_action(session_id, TransientMessageSlot::BranchPublish);
         let appended_to_handle =
             self.append_workflow_notice_to_handle(session_id, persistent_notice);
         if appended_to_handle {

--- a/crates/agentty/src/app/session/state.rs
+++ b/crates/agentty/src/app/session/state.rs
@@ -5,6 +5,7 @@ use std::time::{Instant, SystemTime};
 use crate::app::session::{Clock, SESSION_REFRESH_INTERVAL};
 use crate::domain::selection::SelectionState;
 use crate::domain::session::{Session, SessionDiffStats, SessionHandles, SessionId, Status};
+use crate::domain::transient_message::{TransientMessage, TransientMessageSlot};
 
 /// Cached ahead/behind snapshots for one session branch.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -244,6 +245,30 @@ impl SessionState {
         session.reconcile_status_transition(previous_status);
     }
 
+    /// Mirrors one queued workflow row into live handles and the active render
+    /// snapshot when that project is currently loaded.
+    pub(crate) fn upsert_queued_action(&mut self, session_id: &str, message: TransientMessage) {
+        if let Some(session_handles) = self.runtime.handle(session_id) {
+            session_handles.upsert_queued_action(message.clone());
+        }
+
+        if let Some(session) = self.session_mut_for_id(session_id) {
+            session.transient_messages.upsert(message);
+        }
+    }
+
+    /// Removes one queued workflow row from live handles and the active
+    /// render snapshot when that project is currently loaded.
+    pub(crate) fn resolve_queued_action(&mut self, session_id: &str, slot: TransientMessageSlot) {
+        if let Some(session_handles) = self.runtime.handle(session_id) {
+            session_handles.resolve_queued_action(slot);
+        }
+
+        if let Some(session) = self.session_mut_for_id(session_id) {
+            session.transient_messages.retract(slot);
+        }
+    }
+
     /// Copies current values from runtime handles into plain `Session` fields.
     ///
     /// The runtime uses targeted `sync_session_from_handle()` calls for
@@ -449,6 +474,9 @@ impl SessionState {
         }
 
         session.queued_messages = session_handles.queued_message_snapshot();
+        for queued_action in session_handles.queued_action_snapshot() {
+            session.transient_messages.upsert(queued_action);
+        }
     }
 
     /// Advances the selected follow-up task for one session in the requested

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -3420,6 +3420,7 @@ impl SessionManager {
         if let Ok(mut queued_messages) = handles.queued_messages.lock() {
             queued_messages.clear();
         }
+        handles.clear_queued_actions();
 
         match handles.cancel_token.lock() {
             Ok(cancel_token) => cancel_token.cancel(),

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -74,6 +74,7 @@ struct LoadedSessionInput {
     session_agent: AgentSelection,
     session_id: SessionId,
     session_prompt: String,
+    session_queued_actions: Vec<crate::domain::transient_message::TransientMessage>,
     session_queued_messages: Vec<QueuedMessage>,
     session_questions: Vec<QuestionItem>,
     session_summary: Option<String>,
@@ -325,9 +326,12 @@ impl SessionManager {
             .as_deref()
             .and_then(|value| value.parse::<ReasoningLevel>().ok());
         let speed_mode = row.speed_mode.parse::<SpeedMode>().unwrap_or_default();
-        let session_queued_messages = handles
-            .get(&session_id)
+        let existing_handles = handles.get(&session_id);
+        let session_queued_messages = existing_handles
             .map(SessionHandles::queued_message_snapshot)
+            .unwrap_or_default();
+        let session_queued_actions = existing_handles
+            .map(SessionHandles::queued_action_snapshot)
             .unwrap_or_default();
         let (role, orchestration_metadata) =
             Self::loaded_orchestration_metadata(&row, orchestration_metadata);
@@ -349,6 +353,7 @@ impl SessionManager {
                 .as_ref()
                 .map(|detail| detail.prompt.clone())
                 .unwrap_or_default(),
+            session_queued_actions,
             session_queued_messages,
             session_questions: questions,
             session_summary: session_detail.and_then(|detail| detail.summary),
@@ -467,6 +472,9 @@ impl SessionManager {
             updated_at: input.row.updated_at,
             transient_messages: TransientMessageStore::default(),
         };
+        for queued_action in input.session_queued_actions {
+            session.transient_messages.upsert(queued_action);
+        }
         session.hydrate_summary_transient();
 
         session
@@ -715,6 +723,10 @@ mod tests {
 
     use super::*;
     use crate::domain::session::{ForgeKind, ReviewRequestState, ReviewRequestSummary};
+    use crate::domain::transient_message::{
+        QueuedAction, TransientMessage, TransientMessageAnchor, TransientMessageBody,
+        TransientMessageLifecycle, TransientMessageSlot,
+    };
     use crate::infra::clock::RealClock;
     use crate::infra::db::SessionReviewRequestRow;
     use crate::infra::fs;
@@ -950,6 +962,71 @@ mod tests {
         let handle_status = *handle.status.lock().expect("failed to lock handle status");
         assert_eq!(handle_output, assistant_replay_text(&live_output));
         assert_eq!(handle_status, live_status);
+    }
+
+    /// Ensures project-scoped reloads reconstruct queued workflow rows from
+    /// the live session handles that still own their worker commands.
+    #[tokio::test]
+    async fn test_load_sessions_restores_queued_actions_from_live_handles() {
+        // Arrange
+        let db = AppRepositories::in_memory().await.expect("db should open");
+        let project_id = db
+            .projects()
+            .upsert_project("/tmp/test", None)
+            .await
+            .expect("failed to upsert project");
+        let session_id = SessionId::from("queued-session");
+        db.sessions()
+            .insert_session(
+                &session_id,
+                "gemini-3.7-flash",
+                "main",
+                "InProgress",
+                project_id,
+            )
+            .await
+            .expect("failed to insert session");
+        let base_path = Path::new("/virtual/session-base");
+        let mock_fs_client =
+            create_folder_lookup_mock(vec![session_folder(base_path, &session_id)]);
+        let handles = SessionHandles::new(Status::InProgress);
+        handles.upsert_queued_action(TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Queued(QueuedAction::new(
+                3,
+                "sync after this turn".to_string(),
+            )),
+            lifecycle: TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::SyncQueue,
+            turn_position: Some(0),
+        });
+        let mut handles_by_session = HashMap::from([(session_id.clone(), handles)]);
+
+        // Act
+        let (sessions, _, _) = SessionManager::load_sessions_with_fs_client(
+            SessionLoadInput {
+                active_project_id: project_id,
+                active_session_id: Some(&session_id),
+                base: base_path,
+                clock: &RealClock,
+                db: &db,
+                fs_client: &mock_fs_client,
+                working_dir: Path::new("/tmp/test"),
+            },
+            &mut handles_by_session,
+        )
+        .await;
+
+        // Assert
+        let queued_action = sessions[0]
+            .transient_messages
+            .get(TransientMessageSlot::SyncQueue)
+            .expect("queued sync should be restored");
+        assert!(matches!(
+            &queued_action.body,
+            TransientMessageBody::Queued(action)
+                if action.order == 3 && action.text == "sync after this turn"
+        ));
     }
 
     /// Ensures reload caches worktree availability alongside loaded session

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -894,6 +894,8 @@ pub struct SessionHandles {
     pub status: Arc<Mutex<Status>>,
     /// Shared typed transcript snapshot mirrored to the render layer.
     pub transcript: Arc<Mutex<SessionTranscript>>,
+    /// Queued workflow rows that must survive active-project snapshot reloads.
+    queued_actions: Arc<Mutex<TransientMessageStore>>,
     /// Whether [`Self::transcript`] contains the complete persisted history.
     ///
     /// Lazy session-list handles start unhydrated so background workflow
@@ -908,6 +910,7 @@ impl SessionHandles {
             branch_operation_lock: Arc::new(AsyncMutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             child_pid: Arc::new(Mutex::new(None)),
+            queued_actions: Arc::new(Mutex::new(TransientMessageStore::default())),
             queued_messages: Arc::new(Mutex::new(VecDeque::new())),
             queued_work_sequence: Arc::new(AtomicU64::new(0)),
             status: Arc::new(Mutex::new(status)),
@@ -922,6 +925,7 @@ impl SessionHandles {
             branch_operation_lock: Arc::new(AsyncMutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             child_pid: Arc::new(Mutex::new(None)),
+            queued_actions: Arc::new(Mutex::new(TransientMessageStore::default())),
             queued_messages: Arc::new(Mutex::new(VecDeque::new())),
             queued_work_sequence: Arc::new(AtomicU64::new(0)),
             status: Arc::new(Mutex::new(status)),
@@ -936,6 +940,7 @@ impl SessionHandles {
             branch_operation_lock: Arc::new(AsyncMutex::new(())),
             cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
             child_pid: Arc::new(Mutex::new(None)),
+            queued_actions: Arc::new(Mutex::new(TransientMessageStore::default())),
             queued_messages: Arc::new(Mutex::new(VecDeque::new())),
             queued_work_sequence: Arc::new(AtomicU64::new(0)),
             status: Arc::new(Mutex::new(status)),
@@ -980,6 +985,36 @@ impl SessionHandles {
         self.queued_messages
             .lock()
             .map(|guard| guard.iter().cloned().collect::<Vec<_>>())
+            .unwrap_or_default()
+    }
+
+    /// Stores one queued workflow row beside the worker-owned queue state.
+    pub(crate) fn upsert_queued_action(&self, message: TransientMessage) {
+        debug_assert!(matches!(&message.body, TransientMessageBody::Queued(_)));
+        if let Ok(mut queued_actions) = self.queued_actions.lock() {
+            queued_actions.upsert(message);
+        }
+    }
+
+    /// Removes one queued workflow row after its command starts or resolves.
+    pub(crate) fn resolve_queued_action(&self, slot: TransientMessageSlot) {
+        if let Ok(mut queued_actions) = self.queued_actions.lock() {
+            queued_actions.retract(slot);
+        }
+    }
+
+    /// Removes all queued workflow rows during terminal cancellation.
+    pub(crate) fn clear_queued_actions(&self) {
+        if let Ok(mut queued_actions) = self.queued_actions.lock() {
+            *queued_actions = TransientMessageStore::default();
+        }
+    }
+
+    /// Returns queued workflow rows in their stable display order.
+    pub(crate) fn queued_action_snapshot(&self) -> Vec<TransientMessage> {
+        self.queued_actions
+            .lock()
+            .map(|queued_actions| queued_actions.messages().to_vec())
             .unwrap_or_default()
     }
 
@@ -1059,6 +1094,42 @@ pub(crate) mod tests {
 
         // Assert
         assert_eq!(snapshot, None);
+    }
+
+    #[test]
+    fn queued_action_snapshot_tracks_updates_and_clear() {
+        // Arrange
+        let handles = SessionHandles::new(Status::InProgress);
+        let branch_publish = TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Queued(QueuedAction::new(
+                1,
+                "publish after turn".to_string(),
+            )),
+            lifecycle: TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::BranchPublish,
+            turn_position: Some(0),
+        };
+        let sync = TransientMessage {
+            anchor: TransientMessageAnchor::Tail,
+            body: TransientMessageBody::Queued(QueuedAction::new(2, "sync after turn".to_string())),
+            lifecycle: TransientMessageLifecycle::UntilResolved,
+            slot: TransientMessageSlot::SyncQueue,
+            turn_position: Some(0),
+        };
+
+        // Act
+        handles.upsert_queued_action(branch_publish.clone());
+        handles.upsert_queued_action(sync.clone());
+        let queued_actions = handles.queued_action_snapshot();
+        handles.resolve_queued_action(TransientMessageSlot::BranchPublish);
+        let after_resolve = handles.queued_action_snapshot();
+        handles.clear_queued_actions();
+
+        // Assert
+        assert_eq!(queued_actions, vec![branch_publish, sync.clone()]);
+        assert_eq!(after_resolve, vec![sync]);
+        assert!(handles.queued_action_snapshot().is_empty());
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1940,6 +1940,7 @@ const QUEUED_FIFO_UTILITY_ANSWER: &str = "Queued FIFO helper response";
 fn install_delayed_sync_claude_stub(
     env: &BuilderEnv,
     fail_sync_validation: bool,
+    delay_seconds: u64,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let claude_path = env.stub_bin.join("claude");
     let validation_failure_marker = env.stub_bin.join("queued-sync-validation-failure");
@@ -1953,7 +1954,7 @@ fn install_delayed_sync_claude_stub(
 if [ "$1" = "update" ]; then exit 0; fi
 if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
 cat > /dev/null 2>&1
-sleep 10
+sleep {delay_seconds}
 {mark_validation_failure}printf '%s\n' '{{"type":"system","subtype":"init"}}'
 printf '%s\n' '{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"{QUEUED_SYNC_TURN_ANSWER}"}}]}}}}'
 printf '%s\n' '{{"type":"result","subtype":"success","result":"{{\"answer\":\"{QUEUED_SYNC_TURN_ANSWER}\",\"questions\":[],\"summary\":null}}","usage":{{"input_tokens":5,"output_tokens":9}}}}'
@@ -4093,7 +4094,7 @@ fn session_running_turn_shows_sync_shortcut() -> E2eResult {
     // Arrange, Act, Assert
     FeatureTest::new("session_running_sync_shortcut")
         .with_git()
-        .setup(|env| install_delayed_sync_claude_stub(env, false))
+        .setup(|env| install_delayed_sync_claude_stub(env, false, 10))
         .run(
             |scenario| {
                 scenario
@@ -4171,6 +4172,64 @@ fn session_running_turn_shows_sync_shortcut() -> E2eResult {
     Ok(())
 }
 
+/// Verify a queued session action remains visible after switching away from
+/// its owning project and back while the active turn is still running.
+#[test]
+fn session_queued_action_survives_project_switching() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_queued_action_survives_project_switching")
+        .with_git()
+        .setup(|env| {
+            install_delayed_sync_claude_stub(env, false, 30)?;
+            common::seed_second_project(env)
+        })
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .press_key("a")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("Keep queued sync visible")
+                    .wait_for_text("Keep queued sync visible", 3000)
+                    .press_key("Enter")
+                    .wait_for_text("r: sync", 5000)
+                    .press_key("r")
+                    .wait_for_text("rebase onto the base branch after this turn", 5000)
+                    .press_key("q")
+                    .wait_for_text("new session", 5000)
+                    .press_key("p")
+                    .wait_for_text("Switch project", 5000)
+                    .press_key("j")
+                    .press_key("Enter")
+                    .wait_for_text("Project: zeta-project", 5000)
+                    .press_key("p")
+                    .wait_for_text("Switch project", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Project: test-project", 5000)
+                    .press_key("j")
+                    .press_key("Enter")
+                    .wait_for_text("Keep queued sync visible", 5000)
+                    .capture_labeled(
+                        "restored_queued_action",
+                        "Queued sync restored after project switching",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Keep queued sync visible", &full);
+                assertion::assert_text_in_region(
+                    frame,
+                    "≡ sync — rebase onto the base branch after this turn",
+                    &full,
+                );
+                assertion::assert_text_in_region(frame, "Ctrl+c: stop", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
 /// Verify stopping an active turn also removes its canceled queued-sync row
 /// without promoting the skipped command to active rebase work.
 #[test]
@@ -4178,7 +4237,7 @@ fn session_queued_sync_clears_when_turn_is_cancelled() -> E2eResult {
     // Arrange, Act, Assert
     FeatureTest::new("session_queued_sync_cancelled_with_turn")
         .with_git()
-        .setup(|env| install_delayed_sync_claude_stub(env, false))
+        .setup(|env| install_delayed_sync_claude_stub(env, false, 10))
         .run(
             |scenario| {
                 scenario
@@ -4241,7 +4300,7 @@ fn session_queued_sync_validation_failure_is_visible() -> E2eResult {
     // Arrange, Act, Assert
     FeatureTest::new("session_queued_sync_validation_failure")
         .with_git()
-        .setup(|env| install_delayed_sync_claude_stub(env, true))
+        .setup(|env| install_delayed_sync_claude_stub(env, true, 10))
         .run(
             |scenario| {
                 scenario

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -132,9 +132,10 @@ channels:
   loader-thought and PID updates to the session turn consumer while the final transcript
   waits for the completed turn result.
 - **Session handles** (`SessionHandles`): shared `Arc<Mutex<...>>` transcript, status,
-  PID, and queued-message state. Handles are the single source of truth for live session
-  data; the reducer re-projects them into render snapshots on `SessionUpdated` without a
-  full DB reload.
+  PID, queued-message state, and queued workflow-action rows. Handles are the single
+  source of truth for live session data; the reducer re-projects them into render
+  snapshots on `SessionUpdated` and project-scoped reloads without losing queue
+  visualization.
 
 ## App Event Reducer
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -202,7 +202,8 @@ and removes its queued row without entering **Rebasing**. A queued review-reques
 is canceled the same way: its waiting row disappears and `p` becomes available again
 without starting publish work. **Rebasing** keeps cancellation unavailable while still
 accepting queued messages. The chat queue is in-memory only and is discarded if
-`agentty` restarts.
+`agentty` restarts. Switching projects within the same Agentty process preserves queued
+messages and workflow-action rows until their session worker starts or resolves them.
 
 While the composer is open, `Tab` moves focus to the chat transcript above it so the
 conversation can be scrolled with `j` / `k`, `g` / `G`, and `Ctrl+D` / `Ctrl+U` without


### PR DESCRIPTION
- Store queued publish and sync rows in session handles so project-scoped reloads rebuild their render state.
- Clear rows when their commands start, resolve, or cancel.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)