### PR TITLE
Session work survives project switches

### DIFF
--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -1911,8 +1911,17 @@ impl App {
                         review_request_creation.as_ref(),
                     )
                 ));
-                self.sessions
-                    .finish_branch_publish(&session_id, result_message);
+                if let Some(persistent_notice) = self
+                    .sessions
+                    .finish_branch_publish(&session_id, result_message)
+                {
+                    SessionTaskService::persist_workflow_notice(
+                        self.services.db(),
+                        &session_id,
+                        &persistent_notice,
+                    )
+                    .await;
+                }
             }
             Ok(BranchPublishTaskSuccess::PullRequestPublished {
                 review_request,
@@ -1942,8 +1951,17 @@ impl App {
                     "**{}**\n\n{}",
                     failure.title, failure.message
                 ));
-                self.sessions
-                    .finish_branch_publish(&session_id, result_message);
+                if let Some(persistent_notice) = self
+                    .sessions
+                    .finish_branch_publish(&session_id, result_message)
+                {
+                    SessionTaskService::persist_workflow_notice(
+                        self.services.db(),
+                        &session_id,
+                        &persistent_notice,
+                    )
+                    .await;
+                }
             }
         }
     }

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -1313,12 +1313,14 @@ impl App {
                 )
                 .await;
             match enqueue_result {
-                Err(error) => self.sessions.finish_branch_publish(
-                    session_id,
-                    TransientMessageBody::Markdown(format!(
-                        "**Review request publish failed**\n\n{error}"
-                    )),
-                ),
+                Err(error) => {
+                    let _ = self.sessions.finish_branch_publish(
+                        session_id,
+                        TransientMessageBody::Markdown(format!(
+                            "**Review request publish failed**\n\n{error}"
+                        )),
+                    );
+                }
                 Ok(Some(queued_order)) => self.sessions.queue_branch_publish(
                     session_id,
                     queued_order,

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -1900,6 +1900,95 @@ async fn apply_app_events_branch_publish_action_sets_inline_success() {
 }
 
 #[tokio::test]
+async fn apply_branch_publish_action_persists_result_for_unloaded_project() {
+    // Arrange
+    let session_folder = tempdir().expect("failed to create temp dir");
+    let mut app = new_test_app_with_selected_session(
+        session_folder.path().to_path_buf(),
+        "",
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    persist_selected_session(&app).await;
+    app.sessions
+        .session_handles_mut()
+        .insert("session-1".into(), SessionHandles::new(Status::Review));
+    app.sessions.state_mut().replace_sessions(Vec::new());
+
+    // Act
+    app.apply_branch_publish_action_update(BranchPublishActionUpdate {
+        result: Ok(BranchPublishTaskSuccess::Pushed {
+            branch_name: "wt/session-1".to_string(),
+            review_request_creation: None,
+            upstream_reference: "origin/wt/session-1".to_string(),
+        }),
+        session_id: "session-1".into(),
+    })
+    .await;
+
+    // Assert
+    let persisted_messages = app
+        .services
+        .db()
+        .sessions()
+        .load_session_messages("session-1")
+        .await
+        .expect("failed to load persisted session messages");
+    assert_eq!(persisted_messages.len(), 1);
+    assert_eq!(
+        persisted_messages[0].kind,
+        SessionMessageKind::WorkflowNotice.as_str()
+    );
+    assert!(persisted_messages[0].content.contains("Branch pushed"));
+    assert!(
+        persisted_messages[0]
+            .content
+            .contains("Pushed session branch `wt/session-1`.")
+    );
+    {
+        let live_transcript = app
+            .sessions
+            .session_handles()
+            .get("session-1")
+            .expect("session handles should remain loaded")
+            .transcript
+            .lock()
+            .expect("session transcript lock should succeed");
+        assert_eq!(
+            live_transcript
+                .messages()
+                .last()
+                .map(|message| message.content.as_str()),
+            Some(persisted_messages[0].content.as_str())
+        );
+    }
+
+    // Act
+    app.apply_branch_publish_action_update(BranchPublishActionUpdate {
+        result: Err(BranchPublishTaskFailure::failed(
+            PublishBranchAction::PublishPullRequest,
+            "remote rejected".to_string(),
+        )),
+        session_id: "session-1".into(),
+    })
+    .await;
+
+    // Assert
+    let persisted_messages = app
+        .services
+        .db()
+        .sessions()
+        .load_session_messages("session-1")
+        .await
+        .expect("failed to load persisted session messages");
+    assert_eq!(persisted_messages.len(), 2);
+    assert_eq!(
+        persisted_messages[1].content,
+        "**Review request publish failed**\n\nremote rejected"
+    );
+}
+
+#[tokio::test]
 async fn apply_branch_publish_action_update_persists_pull_request_notice() {
     // Arrange
     let session_folder = tempdir().expect("failed to create temp dir");
@@ -1999,6 +2088,55 @@ async fn apply_branch_publish_action_update_persists_pull_request_notice() {
             .first()
             .and_then(|session| session.review_request.clone()),
         Some(review_request)
+    );
+}
+
+#[tokio::test]
+async fn apply_branch_publish_action_persists_review_request_for_unloaded_project() {
+    // Arrange
+    let session_folder = tempdir().expect("failed to create temp dir");
+    let mut app = new_test_app_with_selected_session(
+        session_folder.path().to_path_buf(),
+        "",
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    persist_selected_session(&app).await;
+    app.sessions
+        .session_handles_mut()
+        .insert("session-1".into(), SessionHandles::new(Status::Review));
+    app.sessions.state_mut().replace_sessions(Vec::new());
+    let review_request = crate::domain::session::ReviewRequest {
+        last_refreshed_at: 55,
+        summary: crate::domain::session::ReviewRequestSummary {
+            web_url: "https://github.com/agentty-xyz/agentty/pull/42".to_string(),
+            ..test_review_request_summary("#42", ReviewRequestState::Open)
+        },
+    };
+
+    // Act
+    app.apply_branch_publish_action_update(BranchPublishActionUpdate {
+        result: Ok(BranchPublishTaskSuccess::PullRequestPublished {
+            branch_name: "wt/session-1".to_string(),
+            review_request,
+            upstream_reference: "origin/wt/session-1".to_string(),
+        }),
+        session_id: "session-1".into(),
+    })
+    .await;
+
+    // Assert
+    let persisted_messages = app
+        .services
+        .db()
+        .sessions()
+        .load_session_messages("session-1")
+        .await
+        .expect("failed to load persisted session messages");
+    assert_eq!(persisted_messages.len(), 1);
+    assert_eq!(
+        persisted_messages[0].content,
+        "\n[Review Request] Created PR https://github.com/agentty-xyz/agentty/pull/42\n"
     );
 }
 
@@ -4159,6 +4297,83 @@ async fn apply_app_events_preserves_completed_published_branch_sync_updates() {
             })
             .count(),
         1
+    );
+}
+
+#[tokio::test]
+/// Verifies terminal auto-push notices are persisted while their project
+/// snapshot is unloaded, so both outcomes survive a later reload.
+async fn apply_published_branch_sync_persists_notices_for_unloaded_project() {
+    // Arrange
+    let session_folder = tempdir().expect("failed to create temp dir");
+    let mut app = new_test_app_with_selected_session(
+        session_folder.path().to_path_buf(),
+        "",
+        Arc::new(MockTmuxClient::new()),
+    )
+    .await;
+    persist_selected_session(&app).await;
+    app.sessions
+        .session_handles_mut()
+        .insert("session-1".into(), SessionHandles::new(Status::Review));
+    app.apply_app_events(AppEvent::PublishedBranchSyncUpdated {
+        persistent_notice: None,
+        session_id: "session-1".into(),
+        sync_operation_id: "sync-success".to_string(),
+        sync_status: PublishedBranchSyncStatus::InProgress,
+    })
+    .await;
+    app.sessions.state_mut().replace_sessions(Vec::new());
+
+    // Act
+    app.apply_app_events(AppEvent::PublishedBranchSyncUpdated {
+        persistent_notice: Some(
+            "[Branch Push] Auto-pushed published branch after completed turn.".to_string(),
+        ),
+        session_id: "session-1".into(),
+        sync_operation_id: "sync-success".to_string(),
+        sync_status: PublishedBranchSyncStatus::Succeeded,
+    })
+    .await;
+    app.apply_app_events(AppEvent::PublishedBranchSyncUpdated {
+        persistent_notice: None,
+        session_id: "session-1".into(),
+        sync_operation_id: "sync-failure".to_string(),
+        sync_status: PublishedBranchSyncStatus::InProgress,
+    })
+    .await;
+    app.apply_app_events(AppEvent::PublishedBranchSyncUpdated {
+        persistent_notice: Some("[Branch Push Error] Remote rejected the push.".to_string()),
+        session_id: "session-1".into(),
+        sync_operation_id: "sync-failure".to_string(),
+        sync_status: PublishedBranchSyncStatus::Failed,
+    })
+    .await;
+
+    // Assert
+    let persisted_messages = app
+        .services
+        .db()
+        .sessions()
+        .load_session_messages("session-1")
+        .await
+        .expect("failed to load persisted session messages");
+    assert_eq!(persisted_messages.len(), 2);
+    assert_eq!(
+        persisted_messages
+            .iter()
+            .map(|message| (message.kind.as_str(), message.content.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                SessionMessageKind::WorkflowNotice.as_str(),
+                "[Branch Push] Auto-pushed published branch after completed turn.",
+            ),
+            (
+                SessionMessageKind::WorkflowNotice.as_str(),
+                "[Branch Push Error] Remote rejected the push.",
+            ),
+        ]
     );
 }
 

--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -642,9 +642,17 @@ impl SessionManager {
     }
 
     /// Replaces manual branch-publish progress with its inline final result.
-    pub(crate) fn finish_branch_publish(&mut self, session_id: &str, body: TransientMessageBody) {
+    ///
+    /// When the owning project is not loaded, appends the result to the live
+    /// transcript instead and returns it for durable persistence.
+    pub(crate) fn finish_branch_publish(
+        &mut self,
+        session_id: &str,
+        body: TransientMessageBody,
+    ) -> Option<String> {
         self.state
             .resolve_queued_action(session_id, TransientMessageSlot::BranchPublish);
+        let persistent_notice = body.text().to_string();
         if let Some(session) = self
             .state
             .sessions
@@ -658,7 +666,12 @@ impl SessionManager {
                 slot: TransientMessageSlot::BranchPublish,
                 turn_position: session.latest_user_prompt_position(),
             });
+
+            return None;
         }
+
+        self.append_workflow_notice_to_handle(session_id, &persistent_notice)
+            .then_some(persistent_notice)
     }
 
     /// Promotes completed review-request creation into durable transcript
@@ -681,7 +694,7 @@ impl SessionManager {
             .iter_mut()
             .find(|session| session.id == session_id)
         else {
-            return false;
+            return appended_to_handle;
         };
         if !appended_to_handle {
             session
@@ -782,7 +795,7 @@ impl SessionManager {
             .iter_mut()
             .find(|session| session.id == session_id)
         else {
-            return false;
+            return appended_to_handle;
         };
         if !appended_to_handle && let Some(persistent_notice) = persistent_notice {
             session

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -966,6 +966,106 @@ fn test_finish_review_request_publish_keeps_loading_review_at_tail() {
 }
 
 #[test]
+fn test_finish_branch_publish_promotes_result_when_project_snapshot_is_unloaded() {
+    // Arrange
+    let mut session_manager = test_session_manager("session-id", None);
+    session_manager.state_mut().replace_sessions(Vec::new());
+
+    // Act
+    let persistent_notice = session_manager.finish_branch_publish(
+        "session-id",
+        TransientMessageBody::Markdown("**Branch push failed**\n\nRemote rejected".to_string()),
+    );
+
+    // Assert
+    assert_eq!(
+        persistent_notice.as_deref(),
+        Some("**Branch push failed**\n\nRemote rejected")
+    );
+    let transcript = session_manager
+        .state()
+        .handle("session-id")
+        .expect("session handles should remain loaded")
+        .transcript
+        .lock()
+        .expect("session transcript lock should succeed");
+    let notice = transcript
+        .messages()
+        .last()
+        .expect("branch publish result should be promoted to the transcript");
+    assert_eq!(notice.kind, SessionMessageKind::WorkflowNotice);
+    assert_eq!(notice.content, "**Branch push failed**\n\nRemote rejected");
+}
+
+#[test]
+fn test_finish_review_request_publish_reports_unloaded_handle_update() {
+    // Arrange
+    let mut session_manager = test_session_manager("session-id", None);
+    session_manager.state_mut().replace_sessions(Vec::new());
+
+    // Act
+    let finished = session_manager.finish_review_request_publish(
+        "session-id",
+        "[Review Request] Created PR https://example.test/pull/42",
+    );
+
+    // Assert
+    assert!(finished);
+    let transcript = session_manager
+        .state()
+        .handle("session-id")
+        .expect("session handles should remain loaded")
+        .transcript
+        .lock()
+        .expect("session transcript lock should succeed");
+    assert_eq!(
+        transcript
+            .messages()
+            .last()
+            .map(|message| (message.kind, message.content.as_str())),
+        Some((
+            SessionMessageKind::WorkflowNotice,
+            "[Review Request] Created PR https://example.test/pull/42",
+        ))
+    );
+}
+
+#[test]
+fn test_finish_published_branch_sync_reports_unloaded_handle_update() {
+    // Arrange
+    let mut session_manager = test_session_manager("session-id", None);
+    session_manager.start_published_branch_sync("session-id", "sync-id".to_string());
+    session_manager.state_mut().replace_sessions(Vec::new());
+
+    // Act
+    let finished = session_manager.finish_published_branch_sync(
+        "session-id",
+        "sync-id",
+        Some("[Branch Push] Auto-pushed published branch after completed turn."),
+    );
+
+    // Assert
+    assert!(finished);
+    let transcript = session_manager
+        .state()
+        .handle("session-id")
+        .expect("session handles should remain loaded")
+        .transcript
+        .lock()
+        .expect("session transcript lock should succeed");
+    assert_eq!(
+        transcript
+            .messages()
+            .last()
+            .map(|message| (message.kind, message.content.as_str())),
+        Some((
+            SessionMessageKind::WorkflowNotice,
+            "[Branch Push] Auto-pushed published branch after completed turn.",
+        ))
+    );
+}
+
+#[test]
 fn test_update_orchestration_progress_replaces_and_clears_board_snapshot() {
     // Arrange
     let mut session_manager = test_session_manager("controller", None);

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -19,7 +19,7 @@ use crate::domain::session::{
     SessionStats, Status, activity_day_key_with_offset,
 };
 use crate::domain::session_message::{SessionMessage, SessionMessageKind, SessionTranscript};
-use crate::domain::transient_message::TransientMessageStore;
+use crate::domain::transient_message::{TransientMessage, TransientMessageStore};
 use crate::infra::clock::Clock;
 use crate::infra::db::{
     AppRepositories, DbError, SessionDetailRow, SessionListRow, SessionMessageRow,
@@ -77,7 +77,7 @@ struct LoadedSessionInput {
     session_agent: AgentSelection,
     session_id: SessionId,
     session_prompt: String,
-    session_queued_actions: Vec<crate::domain::transient_message::TransientMessage>,
+    session_queued_actions: Vec<TransientMessage>,
     session_queued_messages: Vec<QueuedMessage>,
     session_questions: Vec<QuestionItem>,
     session_summary: Option<String>,
@@ -329,13 +329,8 @@ impl SessionManager {
             .as_deref()
             .and_then(|value| value.parse::<ReasoningLevel>().ok());
         let speed_mode = row.speed_mode.parse::<SpeedMode>().unwrap_or_default();
-        let existing_handles = handles.get(&session_id);
-        let session_queued_messages = existing_handles
-            .map(SessionHandles::queued_message_snapshot)
-            .unwrap_or_default();
-        let session_queued_actions = existing_handles
-            .map(SessionHandles::queued_action_snapshot)
-            .unwrap_or_default();
+        let (session_queued_messages, session_queued_actions) =
+            Self::loaded_queue_snapshots(handles.get(&session_id));
         let (role, orchestration_metadata) =
             Self::loaded_orchestration_metadata(&row, orchestration_metadata);
         sessions.push(Self::build_loaded_session(LoadedSessionInput {
@@ -403,6 +398,19 @@ impl SessionManager {
         session_detail
             .and_then(|detail| detail.questions.as_deref())
             .and_then(parse_questions_json)
+            .unwrap_or_default()
+    }
+
+    fn loaded_queue_snapshots(
+        handles: Option<&SessionHandles>,
+    ) -> (Vec<QueuedMessage>, Vec<TransientMessage>) {
+        handles
+            .map(|handles| {
+                (
+                    handles.queued_message_snapshot(),
+                    handles.queued_action_snapshot(),
+                )
+            })
             .unwrap_or_default()
     }
 

--- a/crates/agentty/src/app/session/workflow/refresh.rs
+++ b/crates/agentty/src/app/session/workflow/refresh.rs
@@ -170,8 +170,6 @@ impl SessionManager {
             .retain_follow_up_task_positions(&active_session_ids);
         self.state.retain_session_branch_names(&active_session_ids);
         self.state.retain_session_git_statuses(&active_session_ids);
-        self.worker_service_mut()
-            .retain_active_workers(&active_session_ids);
 
         if let Some((sessions_row_count, sessions_updated_at_max)) = sessions_metadata {
             self.state.row_count = sessions_row_count;

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -808,12 +808,6 @@ impl SessionWorkerService {
         self.workers.remove(session_id);
     }
 
-    /// Drops worker queues for sessions no longer present in the active list.
-    pub(super) fn retain_active_workers(&mut self, active_session_ids: &HashSet<SessionId>) {
-        self.workers
-            .retain(|session_id, _| active_session_ids.contains(session_id));
-    }
-
     /// Returns an existing session worker sender or creates one lazily.
     fn ensure_session_worker(
         &mut self,
@@ -1491,15 +1485,13 @@ impl SessionManager {
     ) {
         let terminal_session_ids = updated_session_ids
             .iter()
-            .filter_map(|session_id| {
-                self.sessions()
-                    .iter()
-                    .find(|session| session.id == *session_id)
-                    .and_then(|session| {
-                        matches!(session.status, Status::Done | Status::Canceled)
-                            .then(|| session.id.clone())
-                    })
+            .filter(|session_id| {
+                self.state
+                    .handle(session_id)
+                    .and_then(|handles| handles.status.lock().ok().map(|status| *status))
+                    .is_some_and(|status| matches!(status, Status::Done | Status::Canceled))
             })
+            .cloned()
             .collect::<Vec<_>>();
 
         for session_id in terminal_session_ids {

--- a/crates/agentty/src/app/session_api.rs
+++ b/crates/agentty/src/app/session_api.rs
@@ -277,12 +277,14 @@ impl App {
             )
             .await;
         match enqueue_result {
-            Err(error) => self.sessions.finish_branch_publish(
-                &session_id,
-                crate::domain::transient_message::TransientMessageBody::Markdown(format!(
-                    "**Review request publish failed**\n\n{error}"
-                )),
-            ),
+            Err(error) => {
+                let _ = self.sessions.finish_branch_publish(
+                    &session_id,
+                    crate::domain::transient_message::TransientMessageBody::Markdown(format!(
+                        "**Review request publish failed**\n\n{error}"
+                    )),
+                );
+            }
             Ok(Some(queued_order)) => self.sessions.queue_branch_publish(
                 &session_id,
                 queued_order,

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -4246,15 +4246,15 @@ fn session_running_turn_shows_sync_shortcut() -> E2eResult {
     Ok(())
 }
 
-/// Verify a queued session action remains visible after switching away from
-/// its owning project and back while the active turn is still running.
+/// Verify a running session remains controllable and completes work queued
+/// after switching away from its owning project and back.
 #[test]
 fn session_queued_action_survives_project_switching() -> E2eResult {
     // Arrange, Act, Assert
     FeatureTest::new("session_queued_action_survives_project_switching")
         .with_git()
         .setup(|env| {
-            install_delayed_sync_claude_stub(env, false, 30)?;
+            install_delayed_sync_claude_stub(env, false, 10)?;
             common::seed_second_project(env)
         })
         .run(
@@ -4267,9 +4267,7 @@ fn session_queued_action_survives_project_switching() -> E2eResult {
                     .write_text("Keep queued sync visible")
                     .wait_for_text("Keep queued sync visible", 3000)
                     .press_key("Enter")
-                    .wait_for_text("r: sync", 5000)
-                    .press_key("r")
-                    .wait_for_text("rebase onto the base branch after this turn", 5000)
+                    .wait_for_text("Ctrl+c: stop", 5000)
                     .press_key("q")
                     .wait_for_text("new session", 5000)
                     .press_key("p")
@@ -4284,20 +4282,37 @@ fn session_queued_action_survives_project_switching() -> E2eResult {
                     .press_key("j")
                     .press_key("Enter")
                     .wait_for_text("Keep queued sync visible", 5000)
+                    .wait_for_text("r: sync", 5000)
+                    .press_key("r")
+                    .wait_for_text("rebase onto the base branch after this turn", 5000)
                     .capture_labeled(
                         "restored_queued_action",
-                        "Queued sync restored after project switching",
+                        "Running session accepts work after project switching",
                     )
+                    .wait_for_text(QUEUED_SYNC_TURN_ANSWER, 30000)
+                    .wait_for_text("[Sync] Successfully synced", 10000)
+                    .wait_for_text("Enter: reply", 5000)
             },
-            |frame, _report| {
-                let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(frame, "Keep queued sync visible", &full);
+            |frame, report| {
+                let queued_frame = common::frame_from_capture(&report.captures[0]);
+                let queued_full = Region::full(queued_frame.cols(), queued_frame.rows());
                 assertion::assert_text_in_region(
-                    frame,
+                    &queued_frame,
                     "≡ sync — rebase onto the base branch after this turn",
-                    &full,
+                    &queued_full,
                 );
-                assertion::assert_text_in_region(frame, "Ctrl+c: stop", &full);
+                assertion::assert_text_in_region(&queued_frame, "Ctrl+c: stop", &queued_full);
+                assertion::assert_text_in_region(
+                    &queued_frame,
+                    "Keep queued sync visible",
+                    &queued_full,
+                );
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, QUEUED_SYNC_TURN_ANSWER, &full);
+                assertion::assert_text_in_region(frame, "[Sync] Successfully synced", &full);
+                assertion::assert_text_in_region(frame, "Enter: reply", &full);
+                assertion::assert_not_visible(frame, "≡ sync —");
             },
         )?;
 
@@ -4810,6 +4825,60 @@ fn test_session_output_chronology() -> E2eResult {
 
                 assert!(sync_row < commit_row);
                 assert!(commit_row < auto_push_row);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify a completed automatic branch push remains visible after its owning
+/// project is switched out while the push is running and then restored.
+#[test]
+fn published_branch_push_survives_project_switching() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("published_branch_push_survives_project_switching")
+        .with_git()
+        .setup(|env| {
+            seed_published_session_output_chronology(env)?;
+            common::seed_second_project(env)
+        })
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .press_key("Enter")
+                    .wait_for_text("Enter: reply", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Type your message", 5000)
+                    .write_text("Continue after the sync")
+                    .press_key("Enter")
+                    .wait_for_text("Got it. What would you like me to do?", 30000)
+                    .wait_for_text("Auto-pushing", 10000)
+                    .wait_for_text("Enter: reply", 5000)
+                    .compose(&common::return_to_session_list())
+                    .press_key("p")
+                    .wait_for_text("Switch project", 5000)
+                    .press_key("j")
+                    .press_key("Enter")
+                    .wait_for_text("Project: zeta-project", 5000)
+                    .sleep_ms(9000)
+                    .press_key("p")
+                    .wait_for_text("Switch project", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Project: test-project", 5000)
+                    .press_key("j")
+                    .press_key("Enter")
+                    .wait_for_text("[Branch Push]", 5000)
+                    .wait_for_text("Auto-pushed published branch after completed turn.", 5000)
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "[Branch Push]", &full);
+                assertion::assert_text_in_region(
+                    frame,
+                    "Auto-pushed published branch after completed turn.",
+                    &full,
+                );
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -131,11 +131,11 @@ channels:
 - **Turn event stream** (`TurnEvent`): `AgentChannel` implementations stream transient
   loader-thought and PID updates to the session turn consumer while the final transcript
   waits for the completed turn result.
-- **Session handles** (`SessionHandles`): shared `Arc<Mutex<...>>` transcript, status,
-  PID, queued-message state, and queued workflow-action rows. Handles are the single
-  source of truth for live session data; the reducer re-projects them into render
-  snapshots on `SessionUpdated` and project-scoped reloads without losing queue
-  visualization.
+- **Session runtime** (`SessionWorkerService` and `SessionHandles`): process-wide worker
+  senders plus shared `Arc<Mutex<...>>` transcript, status, PID, queued-message state,
+  and queued workflow-action rows. Project-scoped reloads replace only render snapshots;
+  workers and handles remain available until their sessions terminate. The reducer
+  re-projects live handles on `SessionUpdated` and project switches.
 
 ## App Event Reducer
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -202,8 +202,10 @@ and removes its queued row without entering **Rebasing**. A queued review-reques
 is canceled the same way: its waiting row disappears and `p` becomes available again
 without starting publish work. **Rebasing** keeps cancellation unavailable while still
 accepting queued messages. The chat queue is in-memory only and is discarded if
-`agentty` restarts. Switching projects within the same Agentty process preserves queued
-messages and workflow-action rows until their session worker starts or resolves them.
+`agentty` restarts. Switching projects within the same Agentty process preserves running
+workers, queued messages, and workflow-action rows. Returning to the project can queue
+more work on the same worker, and workflow results completed in the background remain
+available in the session transcript.
 
 While the composer is open, `Tab` moves focus to the chat transcript above it so the
 conversation can be scrolled with `j` / `k`, `g` / `G`, and `Ctrl+D` / `Ctrl+U` without


### PR DESCRIPTION
- Keeps session workers and handles alive across project-scoped reloads so running sessions can accept queued work after switching projects.
- Promotes branch-publish and review-request results into live transcripts and persists them when the owning project snapshot is unloaded.
- Persists automatic branch-sync results when the owning project snapshot is unloaded.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)