### PR TITLE
Inline right-arrow math renders as Unicode

### DIFF
--- a/crates/ag-tui-text/src/markdown.rs
+++ b/crates/ag-tui-text/src/markdown.rs
@@ -1491,12 +1491,13 @@ fn character_display_width(character: char) -> usize {
     UnicodeWidthChar::width(character).unwrap_or(0)
 }
 
-/// Parses inline markdown markers (`**bold**`, `*italic*`, `` `code` ``) into
-/// styled spans.
+/// Parses inline markdown markers (`**bold**`, `*italic*`, `` `code` ``) and
+/// supported dollar-delimited math symbols into styled spans.
 ///
 /// Text outside markers inherits `base_style`. Bold adds `Modifier::BOLD`,
 /// italic adds `Modifier::ITALIC`, and backtick-delimited code uses the
-/// dedicated inline-code style.
+/// dedicated inline-code style. Supported math commands render as terminal-
+/// friendly Unicode symbols, while unsupported expressions remain literal.
 pub fn parse_inline_spans(content: &str, base_style: Style) -> Vec<Span<'static>> {
     let characters: Vec<char> = content.chars().collect();
     let mut spans = Vec::new();
@@ -1504,6 +1505,19 @@ pub fn parse_inline_spans(content: &str, base_style: Style) -> Vec<Span<'static>
     let mut index = 0;
 
     while index < characters.len() {
+        if characters[index] == '$' && characters.get(index + 1) == Some(&'$') {
+            let Some(end_index) = find_matching_double_dollar(&characters, index + 2) else {
+                literal.extend(characters[index..].iter());
+
+                break;
+            };
+
+            literal.extend(characters[index..end_index + 2].iter());
+            index = end_index + 2;
+
+            continue;
+        }
+
         if characters[index] == '`'
             && let Some(end_index) = find_matching_backtick(&characters, index + 1)
             && end_index > index + 1
@@ -1525,7 +1539,7 @@ pub fn parse_inline_spans(content: &str, base_style: Style) -> Vec<Span<'static>
             flush_literal_span(&mut spans, &mut literal, base_style);
             let bold_content: String = characters[index + 2..end_index].iter().collect();
             spans.push(Span::styled(
-                bold_content,
+                render_inline_math_symbols(&bold_content),
                 base_style.add_modifier(Modifier::BOLD),
             ));
             index = end_index + 2;
@@ -1540,7 +1554,7 @@ pub fn parse_inline_spans(content: &str, base_style: Style) -> Vec<Span<'static>
             flush_literal_span(&mut spans, &mut literal, base_style);
             let italic_content: String = characters[index + 1..end_index].iter().collect();
             spans.push(Span::styled(
-                italic_content,
+                render_inline_math_symbols(&italic_content),
                 base_style.add_modifier(Modifier::ITALIC),
             ));
             index = end_index + 1;
@@ -1557,12 +1571,70 @@ pub fn parse_inline_spans(content: &str, base_style: Style) -> Vec<Span<'static>
     spans
 }
 
+/// Finds the opening index of a closing `$$` delimiter.
+fn find_matching_double_dollar(characters: &[char], start_index: usize) -> Option<usize> {
+    characters[start_index..]
+        .windows(2)
+        .position(|window| window == ['$', '$'])
+        .map(|relative_index| relative_index + start_index)
+}
+
+/// Converts supported inline math while preserving display-math delimiters.
+fn render_inline_math_symbols(content: &str) -> String {
+    let mut rendered = String::with_capacity(content.len());
+    let mut remaining = content;
+
+    while let Some(character) = remaining.chars().next() {
+        if let Some((inline_code, suffix)) = split_delimited_prefix(remaining, "`") {
+            rendered.push_str(inline_code);
+            remaining = suffix;
+
+            continue;
+        }
+
+        if let Some((display_math, suffix)) = split_delimited_prefix(remaining, "$$") {
+            rendered.push_str(display_math);
+            remaining = suffix;
+
+            continue;
+        }
+
+        if remaining.starts_with("$$") {
+            rendered.push_str(remaining);
+
+            break;
+        }
+
+        if let Some(suffix) = remaining.strip_prefix(r"$\rightarrow$") {
+            rendered.push('→');
+            remaining = suffix;
+
+            continue;
+        }
+
+        rendered.push(character);
+        remaining = &remaining[character.len_utf8()..];
+    }
+
+    rendered
+}
+
+/// Splits one complete delimited prefix from its trailing content.
+fn split_delimited_prefix<'a>(content: &'a str, delimiter: &str) -> Option<(&'a str, &'a str)> {
+    let delimited_content = content.strip_prefix(delimiter)?;
+    let closing_index = delimited_content.find(delimiter)?;
+    let expression_end = delimiter.len() + closing_index + delimiter.len();
+
+    Some(content.split_at(expression_end))
+}
+
 fn flush_literal_span(spans: &mut Vec<Span<'static>>, literal: &mut String, style: Style) {
     if literal.is_empty() {
         return;
     }
 
-    spans.push(Span::styled(std::mem::take(literal), style));
+    let content = render_inline_math_symbols(&std::mem::take(literal));
+    spans.push(Span::styled(content, style));
 }
 
 fn parse_heading(raw_line: &str) -> Option<(usize, &str)> {
@@ -2169,6 +2241,188 @@ mod tests {
                 .iter()
                 .any(|span| span.content.as_ref() == "code" && span.style == inline_code_style())
         );
+    }
+
+    #[test]
+    fn test_render_markdown_renders_inline_right_arrow_math_symbol() {
+        // Arrange
+        let input = r"Move $\rightarrow$ forward.";
+
+        // Act
+        let lines = render_markdown(input, 80);
+
+        // Assert
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].to_string(), "Move → forward.");
+    }
+
+    #[test]
+    fn test_render_markdown_renders_inline_right_arrow_math_inside_bold() {
+        // Arrange
+        let input = r"Move **$\rightarrow$** forward.";
+
+        // Act
+        let lines = render_markdown(input, 80);
+        let arrow_span = lines[0]
+            .spans
+            .iter()
+            .find(|span| span.content.as_ref() == "→")
+            .expect("right arrow should render");
+
+        // Assert
+        assert!(arrow_span.style.add_modifier.contains(Modifier::BOLD));
+        assert_eq!(lines[0].to_string(), "Move → forward.");
+    }
+
+    #[test]
+    fn test_render_markdown_renders_inline_right_arrow_math_inside_italic() {
+        // Arrange
+        let input = r"Move *$\rightarrow$* forward.";
+
+        // Act
+        let lines = render_markdown(input, 80);
+        let arrow_span = lines[0]
+            .spans
+            .iter()
+            .find(|span| span.content.as_ref() == "→")
+            .expect("right arrow should render");
+
+        // Assert
+        assert!(arrow_span.style.add_modifier.contains(Modifier::ITALIC));
+        assert_eq!(lines[0].to_string(), "Move → forward.");
+    }
+
+    #[test]
+    fn test_render_markdown_preserves_unsupported_inline_math() {
+        // Arrange
+        let input =
+            r"Keep $x + y$, unmatched $\rightarrow literal, and $$text $\rightarrow$ literal.";
+
+        // Act
+        let lines = render_markdown(input, 120);
+
+        // Assert
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].to_string(), input);
+    }
+
+    #[test]
+    fn test_render_markdown_preserves_display_math() {
+        // Arrange
+        let input = r"Keep $$text $\rightarrow$ text$$ literal.";
+
+        // Act
+        let lines = render_markdown(input, 80);
+
+        // Assert
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].to_string(), input);
+    }
+
+    #[test]
+    fn test_render_markdown_preserves_bold_syntax_inside_display_math() {
+        // Arrange
+        let input = r"Keep $$text **$\rightarrow$** text$$ literal.";
+
+        // Act
+        let lines = render_markdown(input, 80);
+
+        // Assert
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].to_string(), input);
+    }
+
+    #[test]
+    fn test_render_markdown_preserves_italic_syntax_inside_display_math() {
+        // Arrange
+        let input = r"Keep $$text *$\rightarrow$* text$$ literal.";
+
+        // Act
+        let lines = render_markdown(input, 80);
+
+        // Assert
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].to_string(), input);
+    }
+
+    #[test]
+    fn test_render_markdown_preserves_display_math_inside_bold() {
+        // Arrange
+        let input = r"Keep **$$text $\rightarrow$ text$$** literal.";
+
+        // Act
+        let lines = render_markdown(input, 80);
+        let math_text = lines[0]
+            .spans
+            .iter()
+            .filter(|span| span.style.add_modifier.contains(Modifier::BOLD))
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+
+        // Assert
+        assert_eq!(math_text, r"$$text $\rightarrow$ text$$");
+        assert_eq!(
+            lines[0].to_string(),
+            r"Keep $$text $\rightarrow$ text$$ literal."
+        );
+    }
+
+    #[test]
+    fn test_render_markdown_preserves_display_math_inside_italic() {
+        // Arrange
+        let input = r"Keep *$$text $\rightarrow$ text$$* literal.";
+
+        // Act
+        let lines = render_markdown(input, 80);
+        let math_text = lines[0]
+            .spans
+            .iter()
+            .filter(|span| span.style.add_modifier.contains(Modifier::ITALIC))
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+
+        // Assert
+        assert_eq!(math_text, r"$$text $\rightarrow$ text$$");
+        assert_eq!(
+            lines[0].to_string(),
+            r"Keep $$text $\rightarrow$ text$$ literal."
+        );
+    }
+
+    #[test]
+    fn test_render_markdown_preserves_inline_code_inside_bold() {
+        // Arrange
+        let input = r"Keep **`$\rightarrow$`** literal.";
+
+        // Act
+        let lines = render_markdown(input, 80);
+        let code_span = lines[0]
+            .spans
+            .iter()
+            .find(|span| span.content.as_ref() == r"`$\rightarrow$`")
+            .expect("inline code should remain literal");
+
+        // Assert
+        assert!(code_span.style.add_modifier.contains(Modifier::BOLD));
+        assert_eq!(lines[0].to_string(), r"Keep `$\rightarrow$` literal.");
+    }
+
+    #[test]
+    fn test_render_markdown_preserves_inline_code_inside_italic() {
+        // Arrange
+        let input = r"Keep *`$\rightarrow$`* literal.";
+
+        // Act
+        let lines = render_markdown(input, 80);
+        let code_span = lines[0]
+            .spans
+            .iter()
+            .find(|span| span.content.as_ref() == r"`$\rightarrow$`")
+            .expect("inline code should remain literal");
+
+        // Assert
+        assert!(code_span.style.add_modifier.contains(Modifier::ITALIC));
+        assert_eq!(lines[0].to_string(), r"Keep `$\rightarrow$` literal.");
     }
 
     #[test]

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -323,11 +323,7 @@ impl SessionManager {
         let review_request = parse_review_request(&row);
         let draft_attachments =
             draft::load_staged_draft_attachments(*fs_client, base, &session_id).await;
-        let questions = session_detail
-            .as_ref()
-            .and_then(|detail| detail.questions.as_deref())
-            .and_then(parse_questions_json)
-            .unwrap_or_default();
+        let questions = Self::loaded_session_questions(session_detail.as_ref());
         let reasoning_level_override = row
             .reasoning_level_override
             .as_deref()
@@ -401,6 +397,13 @@ impl SessionManager {
             };
 
         (session_detail, session_status, session_transcript)
+    }
+
+    fn loaded_session_questions(session_detail: Option<&SessionDetailRow>) -> Vec<QuestionItem> {
+        session_detail
+            .and_then(|detail| detail.questions.as_deref())
+            .and_then(parse_questions_json)
+            .unwrap_or_default()
     }
 
     fn loaded_orchestration_metadata(

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -322,6 +322,36 @@ fn seed_session_with_inline_markdown_punctuation(
     Ok(())
 }
 
+/// Seeds one review-ready session whose transcript contains inline right-arrow
+/// math syntax.
+fn seed_session_with_inline_math(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    common::seed_session(
+        env,
+        SessionSeed::regular("inline-math-0001", "claude-opus-5", "main", "Review")
+            .with_title("Inline math output"),
+    )?;
+
+    let runtime = common::seed_runtime()?;
+
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        database
+            .sessions()
+            .append_session_message(
+                "inline-math-0001",
+                SessionMessageKind::AssistantAnswer,
+                r"Continue $\rightarrow$, then **$\rightarrow$** and *$\rightarrow$*.
+Display $$text **$\rightarrow$** and *$\rightarrow$* text$$ literally.
+Code **`$\rightarrow$`** and *`$\rightarrow$`* literally.",
+            )
+            .await
+    })?;
+
+    std::fs::create_dir_all(env.agentty_root.join("wt").join("inline-m"))?;
+
+    Ok(())
+}
+
 /// Seeds one review-ready session whose transcript contains mermaid flowchart,
 /// entity-relationship, and sequence fenced blocks. The flowchart includes an
 /// extended shape, an `&` fan-out, and bidirectional arrows, while the sequence
@@ -3862,6 +3892,50 @@ fn session_view_inline_markdown_punctuation_spacing() -> E2eResult {
                 );
                 assertion::assert_not_visible(frame, "( session_messages_from_rows )");
                 assertion::assert_not_visible(frame, "[ Image #1 ]");
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that inline right-arrow math syntax renders as a Unicode arrow in
+/// session chat.
+#[test]
+fn session_view_inline_right_arrow_math() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_inline_right_arrow_math")
+        .setup(seed_session_with_inline_math)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("Enter")
+                    .wait_for_text("Continue →, then → and →.", 5000)
+                    .wait_for_text(
+                        r"Display $$text **$\rightarrow$** and *$\rightarrow$* text$$ literally.",
+                        5000,
+                    )
+                    .wait_for_text(r"Code `$\rightarrow$` and `$\rightarrow$` literally.", 5000)
+                    .capture_labeled(
+                        "inline_right_arrow_math",
+                        "Session view with rendered inline right-arrow math",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Continue →, then → and →.", &full);
+                assertion::assert_text_in_region(
+                    frame,
+                    r"Display $$text **$\rightarrow$** and *$\rightarrow$* text$$ literally.",
+                    &full,
+                );
+                assertion::assert_text_in_region(
+                    frame,
+                    r"Code `$\rightarrow$` and `$\rightarrow$` literally.",
+                    &full,
+                );
+                assertion::assert_not_visible(frame, r"Continue $\rightarrow$");
             },
         )?;
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -313,10 +313,12 @@ automatically; press `f` for a manual one.
 Session output renders common Markdown blocks in agent answers and persisted user
 messages, including headings, lists, block quotes, code fences, and pipe tables. Tables
 are aligned to the output panel width so compact comparison data stays readable in the
-terminal transcript. Leading horizontal whitespace in pasted prompts is preserved after
-submission, including nested indentation in multiline text. Tabs render at four-column
-tab stops. Transcript messages and workflow notices use one empty line between messages,
-regardless of padding stored with the message content.
+terminal transcript. Inline `$\rightarrow$` math renders as the Unicode `→` symbol;
+unsupported dollar-delimited expressions remain literal. Leading horizontal whitespace
+in pasted prompts is preserved after submission, including nested indentation in
+multiline text. Tabs render at four-column tab stops. Transcript messages and workflow
+notices use one empty line between messages, regardless of padding stored with the
+message content.
 
 <a id="usage-session-mermaid"></a> Complete ```` ```mermaid ```` fenced blocks in
 session output render as Unicode diagrams. Simple `graph`/`flowchart` diagrams with


### PR DESCRIPTION
- Converts `$(\\rightarrow)$` to `→` in session output, including plain, bold, and italic text.
- Preserves unsupported, unmatched, display-math, and inline-code expressions literally.