### PR TITLE
Clarifies application-owned lifecycle telemetry

### DIFF
--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -18,3 +18,9 @@ Provide `MODEL_API_KEY`, a repository root, explicitly allowed tools, a prompt, 
 Use `ModelWithMetadata::complete_with_metadata()` for normalized completion metadata.
 
 Attach `with_lifecycle_observer()` to receive ordered metadata-only lifecycle events.
+
+## Telemetry
+
+When the application installs an OpenTelemetry meter provider, `ModelClient` records
+request duration and provider-reported input and output tokens. Missing usage is not
+estimated, sensitive content is excluded, and the application owns export and shutdown.

--- a/crates/ag-harness/src/chat_completion.rs
+++ b/crates/ag-harness/src/chat_completion.rs
@@ -66,6 +66,10 @@ pub(crate) struct ChatCompletionProviderPolicy {
 
 /// Provider-neutral result of decoding one Chat Completions choice.
 pub(crate) enum GeneratedResponse {
+    Failed {
+        error: model::ModelError,
+        metadata: model::CompletionMetadata,
+    },
     Output {
         metadata: model::CompletionMetadata,
         output: String,
@@ -74,6 +78,12 @@ pub(crate) enum GeneratedResponse {
         call: tool::ToolCall,
         metadata: model::CompletionMetadata,
     },
+}
+
+impl GeneratedResponse {
+    fn failed(error: model::ModelError, metadata: model::CompletionMetadata) -> Self {
+        Self::Failed { error, metadata }
+    }
 }
 
 /// Shared structured-output backend for OpenAI-compatible Chat Completions
@@ -135,13 +145,15 @@ impl ChatCompletionBackend {
             .ok_or(model::ModelError::InvalidResponse)?;
         let (metadata, content, reasoning_content, tool_calls) = completion.into_parts();
         match metadata.finish_reason() {
-            "stop" if !tool_calls.is_empty() => {
-                Err(model::ModelError::TerminalResponseWithToolCalls)
-            }
-            "stop" => content
-                .map(|output| GeneratedResponse::Output { metadata, output })
-                .ok_or(model::ModelError::InvalidResponse),
-            "tool_calls" => Self::decode_tool_call(
+            "stop" if !tool_calls.is_empty() => Ok(GeneratedResponse::failed(
+                model::ModelError::TerminalResponseWithToolCalls,
+                metadata,
+            )),
+            "stop" => Ok(match content {
+                Some(output) => GeneratedResponse::Output { metadata, output },
+                None => GeneratedResponse::failed(model::ModelError::InvalidResponse, metadata),
+            }),
+            "tool_calls" => Ok(Self::decode_tool_call(
                 request,
                 content.as_deref(),
                 self.policy
@@ -151,10 +163,15 @@ impl ChatCompletionBackend {
                     .flatten(),
                 tool_calls,
                 metadata,
-            ),
-            _ => Err(model::ModelError::IncompleteResponse {
-                reason: schema_contract::bounded_diagnostic(metadata.finish_reason()),
-            }),
+            )),
+            _ => {
+                let reason = schema_contract::bounded_diagnostic(metadata.finish_reason());
+
+                Ok(GeneratedResponse::failed(
+                    model::ModelError::IncompleteResponse { reason },
+                    metadata,
+                ))
+            }
         }
     }
 
@@ -287,9 +304,24 @@ impl ChatCompletionBackend {
         request: &model::ModelRequest,
         content: Option<&str>,
         reasoning_content: Option<String>,
-        mut calls: Vec<ChatCompletionToolCall>,
+        calls: Vec<ChatCompletionToolCall>,
         metadata: model::CompletionMetadata,
-    ) -> Result<GeneratedResponse, model::ModelError> {
+    ) -> GeneratedResponse {
+        match Self::decode_tool_call_parts(request, content, reasoning_content.as_deref(), calls) {
+            Ok((id, arguments)) => GeneratedResponse::ToolCall {
+                call: tool::ToolCall::read(id, arguments, reasoning_content),
+                metadata,
+            },
+            Err(error) => GeneratedResponse::failed(error, metadata),
+        }
+    }
+
+    fn decode_tool_call_parts(
+        request: &model::ModelRequest,
+        content: Option<&str>,
+        reasoning_content: Option<&str>,
+        mut calls: Vec<ChatCompletionToolCall>,
+    ) -> Result<(String, tool::ReadArguments), model::ModelError> {
         if content.is_some_and(|content| !content.is_empty()) {
             return Err(model::ModelError::ToolCallWithContent);
         }
@@ -314,7 +346,7 @@ impl ChatCompletionBackend {
         }
         schema_contract::ensure_content_size(&function.arguments)
             .map_err(model::ModelError::from)?;
-        if let Some(reasoning_content) = reasoning_content.as_deref() {
+        if let Some(reasoning_content) = reasoning_content {
             schema_contract::ensure_content_size(reasoning_content)
                 .map_err(model::ModelError::from)?;
         }
@@ -325,10 +357,7 @@ impl ChatCompletionBackend {
                 }
             })?;
 
-        Ok(GeneratedResponse::ToolCall {
-            call: tool::ToolCall::read(call.id, arguments, reasoning_content),
-            metadata,
-        })
+        Ok((call.id, arguments))
     }
 }
 

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -174,29 +174,43 @@ impl ModelClient {
         &self,
         request: ModelRequest,
     ) -> Result<ModelCompletion, ModelError> {
-        let _duration = telemetry::RequestDuration::start(self.metadata());
+        let metrics = telemetry::RequestMetrics::start(self.metadata());
         let lifecycle = if request.lifecycle_observed() {
             None
         } else {
             self.lifecycle
                 .start_model_request(Some(self.metadata.clone()), 0, None)
         };
-        let result = async {
-            let response = self.backend.generate(&request).await?;
-
-            match response {
-                chat_completion::GeneratedResponse::Output { metadata, output } => request
-                    .schema()
-                    .parse_and_validate(&output)
-                    .map(ModelResponse::from_output)
-                    .map(|response| ModelCompletion::new(metadata, response))
-                    .map_err(ModelError::from),
-                chat_completion::GeneratedResponse::ToolCall { call, metadata } => Ok(
-                    ModelCompletion::new(metadata, ModelResponse::tool_call(call)),
-                ),
+        let (result, failure_metadata) = match self.backend.generate(&request).await {
+            Ok(chat_completion::GeneratedResponse::Failed { error, metadata }) => {
+                (Err(error), Some(metadata))
             }
+            Ok(chat_completion::GeneratedResponse::Output { metadata, output }) => {
+                match request.schema().parse_and_validate(&output) {
+                    Ok(response) => (
+                        Ok(ModelCompletion::new(
+                            metadata,
+                            ModelResponse::from_output(response),
+                        )),
+                        None,
+                    ),
+                    Err(error) => (Err(ModelError::from(error)), Some(metadata)),
+                }
+            }
+            Ok(chat_completion::GeneratedResponse::ToolCall { call, metadata }) => (
+                Ok(ModelCompletion::new(
+                    metadata,
+                    ModelResponse::tool_call(call),
+                )),
+                None,
+            ),
+            Err(error) => (Err(error), None),
+        };
+
+        match &result {
+            Ok(completion) => metrics.completed(completion.metadata()),
+            Err(error) => metrics.failed(error, failure_metadata.as_ref()),
         }
-        .await;
 
         if let Some(lifecycle) = lifecycle {
             match &result {

--- a/crates/ag-harness/src/telemetry.rs
+++ b/crates/ag-harness/src/telemetry.rs
@@ -3,28 +3,67 @@ use std::time::Instant;
 use opentelemetry::metrics::Histogram;
 use opentelemetry::{KeyValue, global};
 
-use crate::model::ModelMetadata;
+use crate::model::{CompletionMetadata, ModelError, ModelMetadata};
 
 const DURATION_BOUNDARIES_SECONDS: [f64; 14] = [
     0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
 ];
+const TOKEN_BOUNDARIES: [f64; 14] = [
+    1.0,
+    4.0,
+    16.0,
+    64.0,
+    256.0,
+    1_024.0,
+    4_096.0,
+    16_384.0,
+    65_536.0,
+    262_144.0,
+    1_048_576.0,
+    4_194_304.0,
+    16_777_216.0,
+    67_108_864.0,
+];
 
-/// Records one model request's duration when it leaves scope.
-pub(crate) struct RequestDuration<'a> {
-    metric: Histogram<f64>,
+/// Records one model request's operational metrics.
+pub(crate) struct RequestMetrics<'a> {
+    duration: Histogram<f64>,
+    is_active: bool,
     model: &'a str,
     provider: &'static str,
     started_at: Instant,
 }
 
-impl<'a> RequestDuration<'a> {
-    /// Starts timing one model request.
+impl<'a> RequestMetrics<'a> {
+    /// Starts recording one model request.
     pub(crate) fn start(metadata: &'a ModelMetadata) -> Self {
         Self {
-            metric: Self::duration_histogram(),
+            duration: Self::duration_histogram(),
+            is_active: true,
             model: metadata.model(),
             provider: metadata.provider(),
             started_at: Instant::now(),
+        }
+    }
+
+    /// Records a successful request and provider-reported token usage.
+    pub(crate) fn completed(mut self, metadata: &CompletionMetadata) {
+        self.is_active = false;
+        self.record_duration(None);
+        self.record_token_usage(metadata);
+    }
+
+    /// Records a failed request with a bounded error classification.
+    pub(crate) fn failed(mut self, error: &ModelError, metadata: Option<&CompletionMetadata>) {
+        self.is_active = false;
+        let http_status = error.http_status().map(|status| status.to_string());
+        let error_type = http_status
+            .as_deref()
+            .unwrap_or_else(|| error.error_type().as_str());
+        self.record_duration(Some(error_type));
+
+        if let Some(metadata) = metadata {
+            self.record_token_usage(metadata);
         }
     }
 
@@ -36,16 +75,132 @@ impl<'a> RequestDuration<'a> {
             .with_boundaries(DURATION_BOUNDARIES_SECONDS.to_vec())
             .build()
     }
-}
 
-impl Drop for RequestDuration<'_> {
-    fn drop(&mut self) {
-        let attributes = [
+    fn token_histogram() -> Histogram<u64> {
+        global::meter("ag-harness")
+            .u64_histogram("gen_ai.client.token.usage")
+            .with_description("Number of input and output tokens used.")
+            .with_unit("{token}")
+            .with_boundaries(TOKEN_BOUNDARIES.to_vec())
+            .build()
+    }
+
+    fn record_duration(&self, error_type: Option<&str>) {
+        let attributes = self.attributes(error_type);
+
+        self.duration
+            .record(self.started_at.elapsed().as_secs_f64(), &attributes);
+    }
+
+    fn record_token_usage(&self, metadata: &CompletionMetadata) {
+        let Some(usage) = metadata.usage() else {
+            return;
+        };
+        let metric = Self::token_histogram();
+
+        if let Some(input) = usage.input_tokens() {
+            let mut attributes = self.attributes(None);
+            attributes.push(KeyValue::new("gen_ai.token.type", "input"));
+            metric.record(input, &attributes);
+        }
+        if let Some(output) = usage.output_tokens() {
+            let mut attributes = self.attributes(None);
+            attributes.push(KeyValue::new("gen_ai.token.type", "output"));
+            metric.record(output, &attributes);
+        }
+    }
+
+    fn attributes(&self, error_type: Option<&str>) -> Vec<KeyValue> {
+        let mut attributes = vec![
+            KeyValue::new("gen_ai.operation.name", "chat"),
             KeyValue::new("gen_ai.provider.name", self.provider),
             KeyValue::new("gen_ai.request.model", self.model.to_string()),
         ];
 
-        self.metric
-            .record(self.started_at.elapsed().as_secs_f64(), &attributes);
+        if let Some(error_type) = error_type {
+            attributes.push(KeyValue::new("error.type", error_type.to_string()));
+        }
+
+        attributes
+    }
+}
+
+impl Drop for RequestMetrics<'_> {
+    fn drop(&mut self) {
+        if self.is_active {
+            self.record_duration(Some("cancelled"));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+
+    use super::*;
+
+    #[test]
+    fn dropping_active_request_records_cancellation() {
+        // Arrange
+        let exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+        global::set_meter_provider(meter_provider.clone());
+        let metadata = ModelMetadata::new("test_provider", "cancelled-unit-test")
+            .expect("fixture metadata should be valid");
+        let metrics = RequestMetrics::start(&metadata);
+
+        // Act
+        drop(metrics);
+        meter_provider
+            .force_flush()
+            .expect("cancellation metric should flush");
+
+        // Assert
+        let resource_metrics = exporter
+            .get_finished_metrics()
+            .expect("cancellation metric should be exported");
+        let duration = resource_metrics
+            .iter()
+            .flat_map(opentelemetry_sdk::metrics::data::ResourceMetrics::scope_metrics)
+            .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+            .find(|metric| metric.name() == "gen_ai.client.operation.duration")
+            .expect("duration metric should be exported");
+        assert!(matches!(
+            duration.data(),
+            AggregatedMetrics::F64(MetricData::Histogram(histogram)) if {
+                let point = histogram
+                    .data_points()
+                    .find(|point| {
+                        point.attributes().any(|attribute| {
+                            attribute.key.as_str() == "gen_ai.request.model"
+                                && attribute.value.to_string() == "cancelled-unit-test"
+                        })
+                    })
+                    .expect("cancelled request point should be exported");
+                let mut attributes = point
+                    .attributes()
+                    .map(|attribute| (attribute.key.as_str(), attribute.value.to_string()))
+                    .collect::<Vec<_>>();
+                attributes.sort_unstable();
+                assert_eq!(point.count(), 1);
+                assert_eq!(
+                    attributes,
+                    [
+                        ("error.type", "cancelled".to_string()),
+                        ("gen_ai.operation.name", "chat".to_string()),
+                        ("gen_ai.provider.name", "test_provider".to_string()),
+                        (
+                            "gen_ai.request.model",
+                            "cancelled-unit-test".to_string()
+                        ),
+                    ]
+                );
+
+                true
+            }
+        ));
     }
 }

--- a/crates/ag-harness/tests/telemetry.rs
+++ b/crates/ag-harness/tests/telemetry.rs
@@ -1,11 +1,11 @@
-//! Integration coverage for the `ag-harness` request-duration metric.
+//! Integration coverage for the `ag-harness` model-client metrics.
 #![cfg(test)]
 
 use std::sync::Arc;
 use std::time::Duration;
 
 use opentelemetry::global;
-use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, HistogramDataPoint, Metric, MetricData};
 use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
 use serde_json::json;
 use tokio::sync::Notify;
@@ -55,23 +55,74 @@ fn request(prompt: &str) -> ag_harness::ModelRequest {
     )
 }
 
-async fn mount_success_response(server: &MockServer) {
+async fn mount_success_response(server: &MockServer, response_model: Option<&str>, usage: bool) {
+    let mut response = json!({
+        "choices": [{
+            "finish_reason": "stop",
+            "message": {"content": r#"{"name":"Ada"}"#}
+        }],
+        "id": "sensitive-response-id",
+        "system_fingerprint": "sensitive-system-fingerprint"
+    });
+    if let Some(response_model) = response_model {
+        response["model"] = json!(response_model);
+    }
+    if usage {
+        response["usage"] = json!({
+            "completion_tokens": 7,
+            "prompt_tokens": 23,
+            "total_tokens": 30
+        });
+    }
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(response))
+        .expect(1)
+        .mount(server)
+        .await;
+}
+
+async fn mount_invalid_output_response(server: &MockServer) {
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "choices": [{
                 "finish_reason": "stop",
-                "message": {"content": r#"{"name":"Ada"}"#}
-            }]
+                "message": {"content": r#"{"unexpected":true}"#}
+            }],
+            "model": "invalid-output-response",
+            "usage": {
+                "completion_tokens": 3,
+                "prompt_tokens": 11,
+                "total_tokens": 14
+            }
         })))
         .expect(1)
         .mount(server)
         .await;
 }
 
-fn metric_attributes(
-    point: &opentelemetry_sdk::metrics::data::HistogramDataPoint<f64>,
-) -> Vec<(&str, String)> {
+async fn mount_incomplete_response(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "choices": [{
+                "finish_reason": "length",
+                "message": {"content": r#"{"name":"Ada"}"#}
+            }],
+            "usage": {
+                "completion_tokens": 5,
+                "prompt_tokens": 13,
+                "total_tokens": 18
+            }
+        })))
+        .expect(1)
+        .mount(server)
+        .await;
+}
+
+fn metric_attributes<T>(point: &HistogramDataPoint<T>) -> Vec<(&str, String)> {
     let mut attributes = point
         .attributes()
         .map(|attribute| (attribute.key.as_str(), attribute.value.to_string()))
@@ -98,11 +149,161 @@ async fn wait_for_provider(
     }
 }
 
+fn assert_duration_metric(metrics: &[&Metric]) {
+    let duration = metrics
+        .iter()
+        .find(|metric| metric.name() == "gen_ai.client.operation.duration")
+        .expect("duration metric should be exported");
+    assert!(matches!(
+        duration.data(),
+        AggregatedMetrics::F64(MetricData::Histogram(histogram)) if {
+            let points = histogram.data_points().collect::<Vec<_>>();
+            assert_eq!(points.len(), 6);
+            assert!(points.iter().all(|point| point.count() == 1));
+            assert!(points.iter().all(|point| point.bounds().eq([
+                0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24,
+                20.48, 40.96, 81.92,
+            ])));
+            let mut attributes = points
+                .iter()
+                .map(|point| metric_attributes(point))
+                .collect::<Vec<_>>();
+            attributes.sort_unstable();
+            assert_eq!(
+                attributes,
+                [
+                    vec![
+                        ("error.type", "503".to_string()),
+                        ("gen_ai.operation.name", "chat".to_string()),
+                        ("gen_ai.provider.name", "alibaba_cloud".to_string()),
+                        ("gen_ai.request.model", "failed".to_string()),
+                    ],
+                    vec![
+                        ("error.type", "cancelled".to_string()),
+                        ("gen_ai.operation.name", "chat".to_string()),
+                        ("gen_ai.provider.name", "alibaba_cloud".to_string()),
+                        ("gen_ai.request.model", "cancelled".to_string()),
+                    ],
+                    vec![
+                        ("error.type", "invalid_output".to_string()),
+                        ("gen_ai.operation.name", "chat".to_string()),
+                        ("gen_ai.provider.name", "alibaba_cloud".to_string()),
+                        ("gen_ai.request.model", "invalid-output".to_string()),
+                    ],
+                    vec![
+                        ("error.type", "invalid_response".to_string()),
+                        ("gen_ai.operation.name", "chat".to_string()),
+                        ("gen_ai.provider.name", "alibaba_cloud".to_string()),
+                        ("gen_ai.request.model", "incomplete".to_string()),
+                    ],
+                    vec![
+                        ("gen_ai.operation.name", "chat".to_string()),
+                        ("gen_ai.provider.name", "alibaba_cloud".to_string()),
+                        ("gen_ai.request.model", "missing-usage".to_string()),
+                    ],
+                    vec![
+                        ("gen_ai.operation.name", "chat".to_string()),
+                        ("gen_ai.provider.name", "alibaba_cloud".to_string()),
+                        ("gen_ai.request.model", "qwen-plus".to_string()),
+                    ],
+                ]
+            );
+
+            true
+        }
+    ));
+}
+
+fn assert_token_usage_metric(metrics: &[&Metric]) {
+    let token_usage = metrics
+        .iter()
+        .find(|metric| metric.name() == "gen_ai.client.token.usage")
+        .expect("token-usage metric should be exported");
+    assert!(matches!(
+        token_usage.data(),
+        AggregatedMetrics::U64(MetricData::Histogram(histogram)) if {
+            let points = histogram.data_points().collect::<Vec<_>>();
+            assert_eq!(points.len(), 6);
+            assert!(points.iter().all(|point| point.count() == 1));
+            assert!(points.iter().all(|point| point.bounds().eq([
+                1.0, 4.0, 16.0, 64.0, 256.0, 1_024.0, 4_096.0, 16_384.0, 65_536.0,
+                262_144.0, 1_048_576.0, 4_194_304.0, 16_777_216.0, 67_108_864.0,
+            ])));
+            let mut points = points
+                .iter()
+                .map(|point| (metric_attributes(point), point.sum()))
+                .collect::<Vec<_>>();
+            points.sort_unstable();
+            assert_eq!(
+                points,
+                [
+                    (
+                        vec![
+                            ("gen_ai.operation.name", "chat".to_string()),
+                            ("gen_ai.provider.name", "alibaba_cloud".to_string()),
+                            ("gen_ai.request.model", "incomplete".to_string()),
+                            ("gen_ai.token.type", "input".to_string()),
+                        ],
+                        13,
+                    ),
+                    (
+                        vec![
+                            ("gen_ai.operation.name", "chat".to_string()),
+                            ("gen_ai.provider.name", "alibaba_cloud".to_string()),
+                            ("gen_ai.request.model", "incomplete".to_string()),
+                            ("gen_ai.token.type", "output".to_string()),
+                        ],
+                        5,
+                    ),
+                    (
+                        vec![
+                            ("gen_ai.operation.name", "chat".to_string()),
+                            ("gen_ai.provider.name", "alibaba_cloud".to_string()),
+                            ("gen_ai.request.model", "invalid-output".to_string()),
+                            ("gen_ai.token.type", "input".to_string()),
+                        ],
+                        11,
+                    ),
+                    (
+                        vec![
+                            ("gen_ai.operation.name", "chat".to_string()),
+                            ("gen_ai.provider.name", "alibaba_cloud".to_string()),
+                            ("gen_ai.request.model", "invalid-output".to_string()),
+                            ("gen_ai.token.type", "output".to_string()),
+                        ],
+                        3,
+                    ),
+                    (
+                        vec![
+                            ("gen_ai.operation.name", "chat".to_string()),
+                            ("gen_ai.provider.name", "alibaba_cloud".to_string()),
+                            ("gen_ai.request.model", "qwen-plus".to_string()),
+                            ("gen_ai.token.type", "input".to_string()),
+                        ],
+                        23,
+                    ),
+                    (
+                        vec![
+                            ("gen_ai.operation.name", "chat".to_string()),
+                            ("gen_ai.provider.name", "alibaba_cloud".to_string()),
+                            ("gen_ai.request.model", "qwen-plus".to_string()),
+                            ("gen_ai.token.type", "output".to_string()),
+                        ],
+                        7,
+                    ),
+                ]
+            );
+
+            true
+        }
+    ));
+}
+
 #[tokio::test(flavor = "current_thread")]
-async fn records_request_duration_after_late_provider_installation_for_all_outcomes() {
+async fn records_client_metrics_after_late_provider_installation_for_all_outcomes() {
     // Arrange
     let unconfigured_server = MockServer::start().await;
-    mount_success_response(&unconfigured_server).await;
+    mount_success_response(&unconfigured_server, None, true).await;
 
     // Act
     client(&unconfigured_server, "before-installation")
@@ -117,7 +318,13 @@ async fn records_request_duration_after_late_provider_installation_for_all_outco
         .build();
     global::set_meter_provider(meter_provider.clone());
     let success_server = MockServer::start().await;
-    mount_success_response(&success_server).await;
+    mount_success_response(&success_server, Some("qwen-plus-2026-08-16"), true).await;
+    let missing_usage_server = MockServer::start().await;
+    mount_success_response(&missing_usage_server, None, false).await;
+    let invalid_output_server = MockServer::start().await;
+    mount_invalid_output_response(&invalid_output_server).await;
+    let incomplete_server = MockServer::start().await;
+    mount_incomplete_response(&incomplete_server).await;
     let failure_server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
@@ -137,10 +344,22 @@ async fn records_request_duration_after_late_provider_installation_for_all_outco
         .await;
 
     // Act
-    client(&success_server, "successful")
+    client(&success_server, "qwen-plus")
         .complete(request("successful request"))
         .await
         .expect("instrumented request should succeed");
+    client(&missing_usage_server, "missing-usage")
+        .complete(request("request without provider usage"))
+        .await
+        .expect("instrumented request without usage should succeed");
+    let invalid_output = client(&invalid_output_server, "invalid-output")
+        .complete(request("request with invalid output"))
+        .await
+        .expect_err("invalid provider output should be returned");
+    let incomplete = client(&incomplete_server, "incomplete")
+        .complete(request("incomplete request"))
+        .await
+        .expect_err("incomplete provider response should be returned");
     let failure = client(&failure_server, "failed")
         .complete(request("failing request"))
         .await
@@ -157,52 +376,28 @@ async fn records_request_duration_after_late_provider_installation_for_all_outco
         .expect_err("aborted request should be cancelled");
     meter_provider
         .force_flush()
-        .expect("duration metric should flush");
+        .expect("client metrics should flush");
 
     // Assert
     assert!(matches!(failure, ag_harness::ModelError::Request(_)));
+    assert!(matches!(
+        invalid_output,
+        ag_harness::ModelError::SchemaViolation { .. }
+    ));
+    assert!(matches!(
+        incomplete,
+        ag_harness::ModelError::IncompleteResponse { .. }
+    ));
     assert!(cancellation.is_cancelled());
     let resource_metrics = exporter
         .get_finished_metrics()
-        .expect("duration metric should be exported");
+        .expect("client metrics should be exported");
     let metrics = resource_metrics
         .iter()
         .flat_map(opentelemetry_sdk::metrics::data::ResourceMetrics::scope_metrics)
         .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
         .collect::<Vec<_>>();
-    assert_eq!(metrics.len(), 1);
-    let metric = metrics.first().expect("one metric should be exported");
-    assert_eq!(metric.name(), "gen_ai.client.operation.duration");
-    assert!(matches!(
-        metric.data(),
-        AggregatedMetrics::F64(MetricData::Histogram(histogram)) if {
-            let points = histogram.data_points().collect::<Vec<_>>();
-            assert_eq!(points.len(), 3);
-            assert!(points.iter().all(|point| point.count() == 1));
-            let mut attributes = points
-                .iter()
-                .map(|point| metric_attributes(point))
-                .collect::<Vec<_>>();
-            attributes.sort_unstable();
-            assert_eq!(
-                attributes,
-                [
-                    vec![
-                        ("gen_ai.provider.name", "alibaba_cloud".to_string()),
-                        ("gen_ai.request.model", "cancelled".to_string()),
-                    ],
-                    vec![
-                        ("gen_ai.provider.name", "alibaba_cloud".to_string()),
-                        ("gen_ai.request.model", "failed".to_string()),
-                    ],
-                    vec![
-                        ("gen_ai.provider.name", "alibaba_cloud".to_string()),
-                        ("gen_ai.request.model", "successful".to_string()),
-                    ],
-                ]
-            );
-
-            true
-        }
-    ));
+    assert_eq!(metrics.len(), 2);
+    assert_duration_metric(&metrics);
+    assert_token_usage_metric(&metrics);
 }

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -321,7 +321,6 @@ impl SessionManager {
         let session_agent =
             migrate_session_off_retired_model(db, &row.id, &row.agent, &row.model, session_status)
                 .await;
-        let review_request = parse_review_request(&row);
         let draft_attachments =
             draft::load_staged_draft_attachments(*fs_client, base, &session_id).await;
         let questions = Self::loaded_session_questions(session_detail.as_ref());
@@ -344,7 +343,7 @@ impl SessionManager {
             permission_mode,
             project_name: (*project_name).to_string(),
             reasoning_level_override,
-            review_request,
+            review_request: parse_review_request(&row),
             role,
             row,
             session_agent,

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -184,24 +184,18 @@ unstructured text.
 ## Telemetry
 
 The shared `ModelClient` lifecycle records `gen_ai.client.operation.duration` for every
-backend request, including failures and cancellations. Application binaries own
-OpenTelemetry SDK setup, export, and shutdown. The Qwen, Kimi, and Muse examples
-configure OTLP/HTTP metrics through the standard `OTEL_EXPORTER_OTLP_ENDPOINT` and
-`OTEL_EXPORTER_OTLP_HEADERS` environment variables. Each histogram observation is one
-model call; aggregate its count by `gen_ai.provider.name` to separate providers. Their
-default service names are `ag-harness-qwen`, `ag-harness-kimi`, and `ag-harness-muse`,
-while `OTEL_SERVICE_NAME` remains an application-level override.
+backend request, including failures, invalid output, and cancellations. It also records
+provider-reported input and output counts in `gen_ai.client.token.usage`; absent usage
+produces no estimate. Metrics remain metadata-only, and applications own OpenTelemetry
+setup, export, and shutdown.
 
 Lifecycle telemetry emits typed, ordered, metadata-only turn, model, and tool events.
-Applications will own OpenTelemetry projection and export.
+Applications may observe and persist them independently from OpenTelemetry export; with
+neither configured, no lifecycle data is retained or sent externally. Applications own
+storage, retention, OpenTelemetry setup, export, and shutdown.
 
-```mermaid
-flowchart LR
-    C["ModelClient lifecycle"] --> M["Duration histogram"]
-    M --> O["OTLP collector"]
-    O --> P["Prometheus"]
-    P --> G["Grafana"]
-```
+Sensitive content is excluded. Any future content capture remains separate, explicit,
+bounded, redacted, and disabled by default.
 
 ## Permissions
 
@@ -248,8 +242,21 @@ best cost and performance:
 
 - [x] **Read tool round trip.** Complete a model-requested repository read.
 - [ ] **Write tool round trip.** Complete a model-requested repository write.
-- [ ] **Lifecycle telemetry.** Stream typed turn, model, and tool events with
-  application-owned OpenTelemetry export.
+- [x] **Completion metadata foundation.** Normalize provider response identity, finish
+  outcome, optional token usage, and stable model failure classifications.
+- [x] **Lifecycle event foundation.** Emit ordered, correlated, metadata-only turn,
+  model, and tool events through an optional application observer.
+- [x] **Model-client metrics.** Record request duration, reported input and output token
+  usage, operation and model identity, and bounded failures without sensitive or
+  high-cardinality content.
+- [ ] **Turn and tool metric projection.** Derive aggregate turn and tool measurements
+  from lifecycle facts without double-counting model-client metrics.
+- [ ] **Lifecycle trace projection.** Represent a turn as a parent span with correlated
+  model and tool children, including correct completion, failure, and cancellation.
+- [ ] **OTLP contract coverage.** Decode exported test payloads and verify signal names,
+  relationships, attributes, batching and shutdown, and the absence of fixture secrets.
+- [ ] **Durable host journal.** Define a versioned host-owned event envelope, delivery
+  and checkpoint policy, retention, corruption recovery, and compatibility behavior.
 - [ ] **Persisted session round trip.** Run sequential turns in one resumable session,
   and persist model and tool history.
 - [x] **Second provider.** Integrate Kimi through the structured-output contract.


### PR DESCRIPTION
- Defines optional, ordered, correlated, metadata-only lifecycle events and records bounded model-client duration, provider-reported token usage, response identity, and stable failure metrics.
- Separates application-owned observation, collection, persistence, OpenTelemetry projection, export, flushing, and shutdown while excluding sensitive request and response content.
- Documents privacy, overflow, panic, cancellation, missing-usage, and shutdown boundaries for the telemetry foundation.
- Preserves provider-reported usage on validation failures, accepts response identity only when it matches the requested model, and bounds metric cardinality.
- Implements complete provider-reported input and output token usage accounting across successful and failed decoded responses.