### PR TITLE
Diff view supports l for focusing selected changes

### DIFF
--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -762,9 +762,9 @@ pub(crate) fn diff_actions(can_comment: bool) -> Vec<HelpAction> {
         HelpAction::new("select item", "j/k", "Select file or comment"),
         HelpAction::new(
             if can_comment { "open/comment" } else { "open" },
-            "Enter",
+            "Enter/l",
             if can_comment {
-                "Open selected file or edit selected changed line"
+                "Open selected file with Enter/l or edit selected changed line with Enter"
             } else {
                 "Open selected file"
             },
@@ -867,7 +867,7 @@ pub(crate) fn diff_footer_actions(context: DiffFooterContext) -> Vec<HelpAction>
             actions.push(HelpAction::new("select file", "j/k", "Select file"));
             actions.push(HelpAction::new(
                 "open",
-                "Enter",
+                "Enter/l",
                 "Focus the selected file's changed lines",
             ));
             actions.push(HelpAction::new("preview", "p", "Toggle markdown preview"));
@@ -2174,7 +2174,7 @@ mod tests {
             [
                 "q",
                 "j/k",
-                "Enter",
+                "Enter/l",
                 "f/Esc/Left",
                 "c",
                 "p",
@@ -2187,7 +2187,7 @@ mod tests {
                 "?"
             ]
         );
-        assert_eq!(file_footer_keys, ["q/Esc", "j/k", "Enter", "p", "c", "?"]);
+        assert_eq!(file_footer_keys, ["q/Esc", "j/k", "Enter/l", "p", "c", "?"]);
     }
 
     #[test]

--- a/crates/agentty/src/runtime/mode/diff.rs
+++ b/crates/agentty/src/runtime/mode/diff.rs
@@ -623,7 +623,10 @@ fn apply_navigation_key(
                 return true;
             }
         }
-        KeyCode::Enter if *navigation.focus == DiffFocus::Files => {
+        KeyCode::Enter | KeyCode::Char('l')
+            if *navigation.focus == DiffFocus::Files
+                && (key.code == KeyCode::Enter || is_plain_char_key(key, 'l')) =>
+        {
             let mut content_navigation = navigation.content_navigation();
             focus_selected_file_changes(&mut content_navigation, content_area, render_cache_store);
         }
@@ -1416,45 +1419,46 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_enter_from_files_focuses_first_changed_line() {
+    async fn test_handle_enter_and_l_from_files_focus_first_changed_line() {
         // Arrange
         let (mut app, _base_dir) = crate::test_support::new_test_app().await;
-        app.mode = AppMode::Diff {
-            diff: scrollable_diff_fixture(),
-            file_explorer_selected_index: 1,
-            focus: DiffFocus::Files,
-            line_comments: DiffLineComments::default(),
-            preview: DiffPreview::default(),
-            review_comments: None,
-            restore: None,
-            scroll_cache: None,
-            scroll_offset: 0,
-            selected_diff_line_index: 7,
-            session_id: "session-id".into(),
-        };
 
-        // Act
-        let event_result = handle(
-            &mut app,
-            TEST_TERMINAL_SIZE,
-            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
-        );
+        // Act, Assert
+        for key_code in [KeyCode::Enter, KeyCode::Char('l')] {
+            app.mode = AppMode::Diff {
+                diff: scrollable_diff_fixture(),
+                file_explorer_selected_index: 1,
+                focus: DiffFocus::Files,
+                line_comments: DiffLineComments::default(),
+                preview: DiffPreview::default(),
+                review_comments: None,
+                restore: None,
+                scroll_cache: None,
+                scroll_offset: 0,
+                selected_diff_line_index: 7,
+                session_id: "session-id".into(),
+            };
+            let event_result = handle(
+                &mut app,
+                TEST_TERMINAL_SIZE,
+                KeyEvent::new(key_code, KeyModifiers::NONE),
+            );
 
-        // Assert
-        assert!(matches!(event_result, EventResult::Continue));
-        assert!(matches!(
-            app.mode,
-            AppMode::Diff {
-                focus: DiffFocus::Content,
-                line_comments: DiffLineComments {
-                    editing_index: None,
-                    ref comments,
+            assert!(matches!(event_result, EventResult::Continue));
+            assert!(matches!(
+                app.mode,
+                AppMode::Diff {
+                    focus: DiffFocus::Content,
+                    line_comments: DiffLineComments {
+                        editing_index: None,
+                        ref comments,
+                        ..
+                    },
+                    selected_diff_line_index: 0,
                     ..
-                },
-                selected_diff_line_index: 0,
-                ..
-            } if comments.is_empty()
-        ));
+                } if comments.is_empty()
+            ));
+        }
     }
 
     #[tokio::test]
@@ -1502,7 +1506,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_enter_focuses_visible_markdown_preview() {
+    async fn test_handle_l_focuses_visible_markdown_preview() {
         // Arrange
         let (mut app, _base_dir) = crate::test_support::new_test_app().await;
         app.mode = diff_mode_fixture(
@@ -1520,7 +1524,7 @@ mod tests {
         handle(
             &mut app,
             TEST_TERMINAL_SIZE,
-            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE),
         );
 
         // Assert

--- a/crates/agentty/src/ui/page/diff.rs
+++ b/crates/agentty/src/ui/page/diff.rs
@@ -2659,6 +2659,7 @@ mod tests {
         assert!(text.contains("(+1 -0) Diff — Diff Session"));
         assert_eq!(text.matches("+1/-0").count(), 2);
         assert!(text.contains("j/k: select file"));
+        assert!(text.contains("Enter/l: open"));
         assert!(text.contains("?: help"));
         assert!(foreground_symbol_cell_count(buffer, "┌") >= 2);
     }

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -6960,7 +6960,7 @@ fn test_merged_review_request_waits_for_manual_sync() -> E2eResult {
                     .press_key("d")
                     .wait_for_text("main.rs", 5000)
                     .press_key("j")
-                    .wait_for_text("Enter: open", 5000)
+                    .wait_for_text("Enter/l: open", 5000)
                     .press_key("Enter")
                     .wait_for_text("Esc/Left: files", 5000)
                     .press_key("Enter")
@@ -7317,7 +7317,7 @@ fn test_slow_diff_loading_remains_cancelable() -> E2eResult {
 }
 
 /// Verify that the right-hand patch scrolls while Files remains focused, then
-/// `Enter` moves focus into changed-line navigation.
+/// `l` moves focus into changed-line navigation like `Enter`.
 #[test]
 fn test_diff_changed_line_navigation() -> E2eResult {
     // Arrange, Act, Assert
@@ -7342,7 +7342,7 @@ fn test_diff_changed_line_navigation() -> E2eResult {
                         "diff_file_scroll",
                         "Selected file scrolled without leaving Files focus",
                     )
-                    .press_key("Enter")
+                    .press_key("l")
                     .wait_for_text("Esc/Left: files", 5000);
                 let scenario = (0..70).fold(scenario, |scenario, _| scenario.press_key("Down"));
 
@@ -7411,7 +7411,7 @@ fn test_diff_line_comments() -> E2eResult {
                     .wait_for_text("main.rs", 5000)
                     .press_key("j")
                     .wait_for_stable_frame(200, 3000)
-                    .wait_for_text("Enter: open", 5000)
+                    .wait_for_text("Enter/l: open", 5000)
                     .press_key(ENTER_KEY)
                     .wait_for_text("Enter: comment", 5000)
                     .press_key(ENTER_KEY)

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -271,10 +271,10 @@ comments are read-only.
 
 Pressing `d` from session view opens Diff mode focused on Files with the right panel
 showing the git diff. While Files remains focused, use `Shift+j` / `Shift+k` or `Up` /
-`Down` to scroll the selected file without moving focus. Press `Enter` on a file to
-focus its changes, then press `Enter` again to edit the selected changed line inline.
-After finishing with `Enter` or `Esc`, use `j` / `k` or the arrow keys to move the line
-cursor and press `Enter` to edit the selected line. Press `Shift+V` to start a visual
+`Down` to scroll the selected file without moving focus. Press `Enter` or `l` on a file
+to focus its changes, then press `Enter` to edit the selected changed line inline. After
+finishing with `Enter` or `Esc`, use `j` / `k` or the arrow keys to move the line cursor
+and press `Enter` to edit the selected line. Press `Shift+V` to start a visual
 changed-row selection, extend it with the same navigation keys, then press `Enter` to
 comment on the range or `Esc` to cancel the selection. The range stays highlighted while
 its inline editor is open and after the comment is finished, so the comment's source
@@ -292,6 +292,7 @@ Press `s` to submit every inline diff comment together in the next turn.
 | `Shift+j` / `Shift+k` | Scroll selected file, or select a changed line         |
 | `Shift+V`             | Start visual changed-row selection                     |
 | `Enter`               | Focus a file, or edit/finish a comment                 |
+| `l`                   | Focus the selected file's changes                      |
 | `Up` / `Down`         | Scroll selected file, select a line, or scroll preview |
 | `Left` / `h` / `f`    | Return to Files                                        |
 | `p`                   | Toggle markdown preview                                |

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -220,8 +220,8 @@ background; press `q` or `Esc` on **Loading diff...** to return immediately whil
 large repository is still being inspected.
 
 Inside diff view, `Shift+j` / `Shift+k` and `Up` / `Down` scroll the selected file while
-Files remains focused. Press `Enter` on a file to move focus from the file tree to its
-patch, then press `Enter` again to open an inline editor beneath the selected added or
+Files remains focused. Press `Enter` or `l` on a file to move focus from the file tree
+to its patch, then press `Enter` to open an inline editor beneath the selected added or
 removed line. Type the feedback, then press `Enter` or `Esc` to finish without leaving
 Diff mode. Use `j` / `k` or the arrow keys to move through changed lines while Agentty
 keeps the cursor visible, and press `Enter` on any selected line to add or edit its


### PR DESCRIPTION
- Keeps Enter for editing selected changed lines.
- Aligns help text, tests, and documentation with the new keybinding.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)