### PR TITLE
Gives Codex auto-edit full command access

### DIFF
--- a/crates/ag-agent/src/agent/app_server/codex/client.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/client.rs
@@ -1195,9 +1195,9 @@ mod tests {
     }
 
     #[test]
-    /// Verifies Codex thread startup asks the app-server to avoid interactive
-    /// approval prompts during Agentty-managed turns.
-    fn build_thread_start_payload_uses_never_approval_policy() {
+    /// Verifies Codex auto-edit starts with the same effective unrestricted
+    /// command access as Claude auto-edit and avoids interactive approvals.
+    fn build_thread_start_payload_uses_unrestricted_auto_edit_policy() {
         // Arrange
         let folder = tempdir().expect("temporary folder should be created");
 
@@ -1218,6 +1218,13 @@ mod tests {
                 .and_then(|params| params.get("approvalPolicy"))
                 .and_then(Value::as_str),
             Some("never")
+        );
+        assert_eq!(
+            payload
+                .get("params")
+                .and_then(|params| params.get("sandbox"))
+                .and_then(Value::as_str),
+            Some("danger-full-access")
         );
     }
 

--- a/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/lifecycle.rs
@@ -769,7 +769,7 @@ pub(super) fn build_turn_start_payload(input: &CodexTurnStartPayloadInput<'_>) -
             "input": build_turn_input_items(&input.prompt),
             "cwd": input.folder.to_string_lossy(),
             "approvalPolicy": policy::approval_policy(input.permission_mode),
-            "sandboxPolicy": policy::turn_sandbox_policy(input.permission_mode, input.folder),
+            "sandboxPolicy": policy::turn_sandbox_policy(input.permission_mode),
             "model": input.model,
             "serviceTier": input.speed_mode.codex_service_tier(),
             "effort": input.reasoning_level.codex(),
@@ -1164,7 +1164,7 @@ mod tests {
     }
 
     #[test]
-    fn build_turn_start_payload_allows_worktree_agents_edits() {
+    fn build_turn_start_payload_uses_full_access_for_auto_edit() {
         // Arrange
         let folder = PathBuf::from("/tmp/agentty-codex-turn-start");
 
@@ -1187,11 +1187,7 @@ mod tests {
         assert_eq!(
             sandbox_policy,
             &serde_json::json!({
-                "type": "workspaceWrite",
-                "networkAccess": true,
-                "writableRoots": [
-                    folder.join(".agents").to_string_lossy(),
-                ],
+                "type": "dangerFullAccess",
             })
         );
         assert_eq!(

--- a/crates/ag-agent/src/agent/app_server/codex/policy.rs
+++ b/crates/ag-agent/src/agent/app_server/codex/policy.rs
@@ -27,17 +27,17 @@ pub(super) struct PermissionModePolicy {
 /// Codex app-server policy for Agentty's non-interactive auto-edit mode.
 ///
 /// The `never` approval policy keeps normal turns from blocking on user
-/// approvals, while the workspace-write sandbox still constrains filesystem
-/// writes to the session worktree and its explicit `.agents` root.
+/// approvals. Full access matches the effective Claude auto-edit policy, which
+/// permits Bash commands to retry outside Claude's sandbox when required.
 const AUTO_EDIT_POLICY: PermissionModePolicy = PermissionModePolicy {
     approval_policy: "never",
     legacy_pre_action_decision: "approved",
     legacy_pre_action_rejection_decision: "denied",
     pre_action_decision: "accept",
     pre_action_rejection_decision: "reject",
-    thread_sandbox_mode: "workspace-write",
+    thread_sandbox_mode: "danger-full-access",
     turn_network_access: true,
-    turn_sandbox_type: "workspaceWrite",
+    turn_sandbox_type: "dangerFullAccess",
     web_search_mode: "live",
 };
 
@@ -57,14 +57,6 @@ const READ_ONLY_POLICY: PermissionModePolicy = PermissionModePolicy {
     turn_sandbox_type: "readOnly",
     web_search_mode: "live",
 };
-
-/// Repository metadata directory that remains editable during Codex turns.
-///
-/// Codex protects this path by default even when it lives under the writable
-/// worktree. Listing it as an exact writable root reopens only this
-/// worktree-local directory while preserving the read-only `.git` and
-/// `.codex` boundaries.
-const EDITABLE_WORKTREE_METADATA_PATH: &str = ".agents";
 
 /// Pre-action approval request categories understood by Agentty.
 enum PreActionApprovalKind {
@@ -139,25 +131,18 @@ pub(super) fn thread_sandbox_mode(permission_mode: PermissionMode) -> &'static s
     permission_mode_policy(permission_mode).thread_sandbox_mode
 }
 
-/// Returns the turn-level sandbox policy object for one session worktree.
-pub(super) fn turn_sandbox_policy(permission_mode: PermissionMode, session_folder: &Path) -> Value {
+/// Returns the turn-level sandbox policy object for one permission mode.
+pub(super) fn turn_sandbox_policy(permission_mode: PermissionMode) -> Value {
     let policy = permission_mode_policy(permission_mode);
-    if permission_mode.is_read_only() {
+    if !permission_mode.is_read_only() {
         return serde_json::json!({
             "type": policy.turn_sandbox_type,
-            "networkAccess": policy.turn_network_access,
         });
     }
-
-    let writable_root = session_folder
-        .join(EDITABLE_WORKTREE_METADATA_PATH)
-        .to_string_lossy()
-        .into_owned();
 
     serde_json::json!({
         "type": policy.turn_sandbox_type,
         "networkAccess": policy.turn_network_access,
-        "writableRoots": [writable_root],
     })
 }
 
@@ -241,10 +226,10 @@ pub(super) fn build_server_request_response(
 
 /// Returns the scoped decision for one Codex pre-action request.
 ///
-/// Agentty runs Codex in auto-edit mode with a workspace-write sandbox policy,
-/// so command approvals are accepted when Codex still emits a pre-action
-/// request. File-change approvals remain path-scoped and only pass when every
-/// declared path stays inside the session worktree.
+/// Agentty runs Codex in auto-edit mode with full access, so command approvals
+/// are accepted when Codex still emits a pre-action request. File-change
+/// approvals remain path-scoped and only pass when every declared path stays
+/// inside the session worktree.
 fn scoped_pre_action_decision(
     response_value: &Value,
     permission_mode: PermissionMode,

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -72,6 +72,10 @@ const SECOND_QUESTION_TEXT: &str = "Which tests should be added?";
 /// Clarification question emitted by the delayed stub while help is open.
 const RECONCILE_QUESTION_TEXT: &str = "Should I add a regression test?";
 
+/// Visible confirmation emitted only when Codex receives unrestricted Auto
+/// Edit policies at both app-server request boundaries.
+const CODEX_AUTO_EDIT_POLICY_CONFIRMED_TEXT: &str = "Codex Auto Edit unrestricted policy applied.";
+
 /// Draft text typed into the composer by the chat-focus toggle test.
 const PROMPT_FOCUS_DRAFT_TEXT: &str = "Draft kept while reading chat";
 
@@ -713,6 +717,71 @@ done
         &[
             ("DefaultReviewAgent", "codex"),
             ("DefaultReviewModel", "gpt-5.6-sol"),
+        ],
+    )
+}
+
+/// Installs a Codex app-server stub that verifies Auto Edit policy payloads.
+fn seed_codex_auto_edit_policy_project(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    let codex_path = env.stub_bin.join("codex");
+    let script = r#"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'codex-cli 0.146.0\n'; exit 0; fi
+
+extract_id() {
+    printf '%s\n' "$1" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p'
+}
+
+thread_policy_matches=false
+while IFS= read -r request; do
+    case "$request" in
+        *'"method":"initialize"'*)
+            request_id=$(extract_id "$request")
+            printf '{"id":"%s","result":{}}\n' "$request_id"
+            ;;
+        *'"method":"thread/start"'*)
+            case "$request" in
+                *'"approvalPolicy":"never"'*'"sandbox":"danger-full-access"'*)
+                    thread_policy_matches=true
+                    ;;
+            esac
+            request_id=$(extract_id "$request")
+            printf '{"id":"%s","result":{"thread":{"id":"policy-thread"}}}\n' "$request_id"
+            ;;
+        *'"method":"turn/start"'*)
+            answer='Codex policy test title.'
+            case "$request" in
+                *'Generate a concise, commit-style title'*)
+                    ;;
+                *'Verify Codex Auto Edit permissions'*)
+                    answer='Codex Auto Edit policy mismatch.'
+                    case "$request" in
+                        *'"approvalPolicy":"never"'*'"sandboxPolicy":{"type":"dangerFullAccess"}'*)
+                            if [ "$thread_policy_matches" = true ]; then
+                                answer='Codex Auto Edit unrestricted policy applied.'
+                            fi
+                            ;;
+                    esac
+                    ;;
+            esac
+            request_id=$(extract_id "$request")
+            printf '{"id":"%s","result":{"turn":{"id":"policy-turn"}}}\n' "$request_id"
+            printf '%s\n' '{"method":"turn/started","params":{"turn":{"id":"policy-turn"}}}'
+            printf '{"method":"item/completed","params":{"threadId":"policy-thread","turnId":"policy-turn","item":{"type":"agentMessage","id":"policy-answer","text":"{\\"answer\\":\\"%s\\",\\"questions\\":[],\\"review_comment_outcomes\\":[],\\"subtasks\\":[],\\"summary\\":null,\\"verification_verdicts\\":[]}","phase":"final_answer"}}}\n' "$answer"
+            printf '%s\n' '{"method":"turn/completed","params":{"threadId":"policy-thread","turn":{"id":"policy-turn","status":"completed","items":[]}}}'
+            ;;
+    esac
+done
+"#;
+    std::fs::write(&codex_path, script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&codex_path, std::fs::Permissions::from_mode(0o755))?;
+
+    seed_project_settings(
+        env,
+        &[
+            ("DefaultSmartAgent", "codex"),
+            ("DefaultSmartModel", "gpt-5.6-sol"),
         ],
     )
 }
@@ -8698,6 +8767,45 @@ fn session_permission_mode_selection() -> E2eResult {
 
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "· Normal · Read Only", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify a submitted Codex Auto Edit turn receives unrestricted app-server
+/// policies and completes visibly through the real session runtime boundary.
+#[test]
+fn codex_auto_edit_uses_unrestricted_app_server_policy() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("codex_auto_edit_unrestricted_policy")
+        .with_git()
+        .setup(seed_codex_auto_edit_policy_project)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .wait_for_text("Regular", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("· Normal · Auto Edit", 5000)
+                    .write_text("Verify Codex Auto Edit permissions")
+                    .press_key("Enter")
+                    .wait_for_text(CODEX_AUTO_EDIT_POLICY_CONFIRMED_TEXT, 30000)
+                    .capture_labeled(
+                        "codex_auto_edit_unrestricted_policy",
+                        "Codex completes with unrestricted Auto Edit permissions",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(
+                    frame,
+                    CODEX_AUTO_EDIT_POLICY_CONFIRMED_TEXT,
+                    &full,
+                );
+                assertion::assert_not_visible(frame, "Codex Auto Edit policy mismatch.");
             },
         )?;
 

--- a/docs/site/content/docs/agents/backends.md
+++ b/docs/site/content/docs/agents/backends.md
@@ -33,13 +33,15 @@ All backends accept pasted local prompt images from the Agentty composer (`Ctrl+
 `Ctrl+Shift+V`, or `Alt+V` in prompt mode) and run their turns non-interactively inside
 the session worktree.
 
-Codex can edit repository-local `.agents/` content inside that worktree, including
-project skills and instructions. Its `.git` and `.codex/` paths remain read-only during
-normal turns.
+Codex `Auto Edit` turns run with full command access so browser tests, local services,
+and other tools that cannot run inside the provider sandbox remain available. This also
+means Codex commands are not confined to the session worktree; review the session diff
+and use `Read Only` for inspection-only work.
 
 Claude turns also allow Claude Code's `WebSearch` and `WebFetch` tools, so prompts that
 need current external information can use the web without an interactive permission
-grant. File edits remain scoped to the session worktree.
+grant. Claude `Auto Edit` retains Claude Code's unsandboxed command fallback for tools
+that cannot run inside its sandbox.
 
 Treat fetched web content as untrusted context. Claude still has edit-capable tools
 during the turn, so keep web-backed prompts specific and review the session diff before

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -592,21 +592,21 @@ descendants it spawned.
 - Merge and `sync main` workflows require a clean target checkout before changing
   base-branch state.
 - Provider permission policies are scoped per `TurnRequest`. Ordinary Codex turns run
-  with a non-interactive approval policy and workspace-write sandbox. The Codex turn
-  policy explicitly reopens the worktree-local `.agents/` directory that Codex otherwise
-  protects while leaving `.git` and `.codex/` read-only. Agentty immediately declines
-  MCP elicitations and grants no additional permission requests so an app-server request
-  cannot leave the turn waiting for interactive input. Codex tool input requests receive
-  an empty answer set for the same reason. Claude turns receive session-scoped settings
-  that deny writes to the known main checkout, Gemini ACP requests prefer one-shot allow
-  options, and CLI-backed providers run from the session worktree process directory.
-  Researcher requests instead carry `PermissionMode::ReadOnly` through CLI and
-  app-server launch boundaries. Codex selects `readOnly` sandbox payloads and rejects
-  command or file-change approvals; Claude exposes only inspection tools in plan mode;
-  Gemini starts with sandboxed plan approval and cancels ACP permission requests; and
-  Antigravity starts in sandboxed plan mode without its permission-bypass flag. The
-  persistent runtime identity includes the permission mode, preventing an auto-edit
-  process from being reused for research.
+  with a non-interactive approval policy and `dangerFullAccess` sandbox policy so their
+  effective command permissions match Claude auto-edit, including tools that cannot run
+  inside an OS sandbox. Agentty immediately declines MCP elicitations and grants no
+  additional permission requests so an app-server request cannot leave the turn waiting
+  for interactive input. Codex tool input requests receive an empty answer set for the
+  same reason. Claude turns receive session-scoped settings that deny writes to the
+  known main checkout while retaining Claude Code's unsandboxed command fallback, Gemini
+  ACP requests prefer one-shot allow options, and CLI-backed providers run from the
+  session worktree process directory. Researcher requests instead carry
+  `PermissionMode::ReadOnly` through CLI and app-server launch boundaries. Codex selects
+  `readOnly` sandbox payloads and rejects command or file-change approvals; Claude
+  exposes only inspection tools in plan mode; Gemini starts with sandboxed plan approval
+  and cancels ACP permission requests; and Antigravity starts in sandboxed plan mode
+  without its permission-bypass flag. The persistent runtime identity includes the
+  permission mode, preventing an auto-edit process from being reused for research.
 
 ## Agent Interaction Protocol Flow
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -764,20 +764,23 @@ with `j` / `k` or `Up` / `Down`.
 
 `/apply` requires a completed focused review (`f` key). `/mode` stores a session-scoped
 permission mode for following chat turns. `Auto Edit` uses the agent's standard editing
-permissions. During those chat turns, `Read Only` prevents repository and filesystem
-writes. The composer title always shows the current permission as `Auto Edit` or
-`Read Only`, after the response speed when that provider supports speed control. In
-`Read Only`, agents do not ask for write access; when a requested change requires edits,
-they suggest switching to `Auto Edit` with `/mode`. `/model` offers only locally
-available backends; see [Agents & Models](@/docs/agents/backends.md). `/speed` is
-available for Claude and Codex sessions. The selected speed is stored with the session,
-shown after the reasoning level in the session header and beside the composer title, and
-applied to following turns. Gemini and Antigravity sessions have no speed control, so
-their header and composer omit the speed display entirely. Fast responses use the
-provider's higher-cost low-latency mode. Enabling Fast moves Claude sessions to
-`claude-opus-5` and Codex Spark sessions to `gpt-5.6-sol` without changing the project
-default model. Returning to Normal does not change the selected model. Selecting a model
-that does not support Fast resets the session to Normal before the model changes.
+permissions. Codex `Auto Edit` has full command access, including for browser tests and
+local services that cannot run inside its sandbox. Claude `Auto Edit` can likewise retry
+incompatible commands outside its sandbox. During those chat turns, `Read Only` prevents
+repository and filesystem writes. The composer title always shows the current permission
+as `Auto Edit` or `Read Only`, after the response speed when that provider supports
+speed control. In `Read Only`, agents do not ask for write access; when a requested
+change requires edits, they suggest switching to `Auto Edit` with `/mode`. `/model`
+offers only locally available backends; see
+[Agents & Models](@/docs/agents/backends.md). `/speed` is available for Claude and Codex
+sessions. The selected speed is stored with the session, shown after the reasoning level
+in the session header and beside the composer title, and applied to following turns.
+Gemini and Antigravity sessions have no speed control, so their header and composer omit
+the speed display entirely. Fast responses use the provider's higher-cost low-latency
+mode. Enabling Fast moves Claude sessions to `claude-opus-5` and Codex Spark sessions to
+`gpt-5.6-sol` without changing the project default model. Returning to Normal does not
+change the selected model. Selecting a model that does not support Fast resets the
+session to Normal before the model changes.
 
 `/personality` scans `.agents/agents/*/agent.md` in the session worktree when the picker
 opens. Agentty does not scan the global `~/.agents` directory. Each enabled definition


### PR DESCRIPTION
- Matches Claude auto-edit behavior for browser tests, local services, and other tools that cannot run inside a sandbox.
- Verifies unrestricted thread and turn policies through an end-to-end session test.
- Keeps read-only turns restricted and documents the updated permission model.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)