### PR TITLE
Keep diff loading recoverable after worktree cleanup

### DIFF
--- a/crates/ag-git/src/error.rs
+++ b/crates/ag-git/src/error.rs
@@ -28,6 +28,13 @@ pub enum GitError {
     #[error("{0}")]
     OutputParse(String),
 
+    /// The requested repository or worktree is no longer available.
+    #[error("{detail}")]
+    RepositoryUnavailable {
+        /// Original repository-discovery failure detail.
+        detail: String,
+    },
+
     /// A filesystem or process-spawn operation failed.
     #[error("{0}")]
     Io(#[from] std::io::Error),
@@ -108,6 +115,20 @@ mod tests {
             matches!(error, GitError::OutputParse(ref message) if message == "unexpected rev-parse output")
         );
         assert_eq!(error.to_string(), "unexpected rev-parse output");
+    }
+
+    #[test]
+    fn repository_unavailable_display_shows_original_detail() {
+        // Arrange
+        let error = GitError::RepositoryUnavailable {
+            detail: "git rev-parse: not a git repository".to_string(),
+        };
+
+        // Act
+        let display = error.to_string();
+
+        // Assert
+        assert_eq!(display, "git rev-parse: not a git repository");
     }
 
     #[test]

--- a/crates/ag-git/src/sync.rs
+++ b/crates/ag-git/src/sync.rs
@@ -327,37 +327,47 @@ async fn diff_output(
     name_only: bool,
 ) -> Result<String, GitError> {
     spawn_blocking(move || -> Result<String, GitError> {
-        let index_path = run_git_command_sync(
-            &repo_path,
-            &["rev-parse", "--git-path", "index"],
-            "Git index path resolution failed",
-        )?;
+        let index_path = resolve_diff_index_path(&repo_path)?;
         let index_path = PathBuf::from(index_path.trim());
         let index_path = if index_path.is_absolute() {
             index_path
         } else {
             repo_path.join(index_path)
         };
-        let temporary_index = copy_git_index_to_temp(&index_path)?;
+
+        diff_output_after_index_resolution(&repo_path, &base_branch, name_only, &index_path)
+    })
+    .await?
+}
+
+/// Generates diff output after the real index path has been resolved.
+fn diff_output_after_index_resolution(
+    repo_path: &Path,
+    base_branch: &str,
+    name_only: bool,
+    index_path: &Path,
+) -> Result<String, GitError> {
+    let result = (|| -> Result<String, GitError> {
+        let temporary_index = copy_git_index_to_temp(index_path)?;
 
         run_git_command_with_index_sync(
-            &repo_path,
+            repo_path,
             &["add", "-A", "--intent-to-add"],
             &temporary_index,
             "Git add --intent-to-add failed",
         )?;
 
         let merge_base_output =
-            run_git_command_output_sync(&repo_path, &["merge-base", "HEAD", &base_branch])?;
+            run_git_command_output_sync(repo_path, &["merge-base", "HEAD", base_branch])?;
 
         let diff_target = if merge_base_output.status.success() {
             resolve_diff_target(
-                &repo_path,
-                &base_branch,
+                repo_path,
+                base_branch,
                 String::from_utf8_lossy(&merge_base_output.stdout).trim(),
             )?
         } else {
-            base_branch
+            base_branch.to_string()
         };
 
         let args = if name_only {
@@ -366,9 +376,51 @@ async fn diff_output(
             vec!["diff", diff_target.as_str()]
         };
 
-        run_git_command_with_index_sync(&repo_path, &args, &temporary_index, "Git diff failed")
-    })
-    .await?
+        run_git_command_with_index_sync(repo_path, &args, &temporary_index, "Git diff failed")
+    })();
+
+    result.map_err(|error| classify_diff_repository_error(repo_path, error))
+}
+
+/// Resolves the real index path and classifies a reclaimed repository.
+fn resolve_diff_index_path(repo_path: &Path) -> Result<String, GitError> {
+    run_git_command_sync(
+        repo_path,
+        &["rev-parse", "--git-path", "index"],
+        "Git index path resolution failed",
+    )
+    .map_err(|error| classify_diff_repository_error(repo_path, error))
+}
+
+/// Preserves ordinary Git failures while typing unavailable repository paths.
+fn classify_diff_repository_error(repo_path: &Path, error: GitError) -> GitError {
+    if !diff_repository_is_unavailable(repo_path) {
+        return error;
+    }
+
+    GitError::RepositoryUnavailable {
+        detail: error.to_string(),
+    }
+}
+
+/// Probes repository discovery without interpreting localized Git output.
+fn diff_repository_is_unavailable(repo_path: &Path) -> bool {
+    if !repo_path.is_dir() {
+        return true;
+    }
+
+    diff_repository_probe_is_unavailable(run_git_command_output_sync(
+        repo_path,
+        &["rev-parse", "--git-dir"],
+    ))
+}
+
+/// Treats only a completed, unsuccessful discovery probe as unavailable.
+fn diff_repository_probe_is_unavailable(probe: Result<Output, GitError>) -> bool {
+    match probe {
+        Ok(output) => !output.status.success(),
+        Err(_) => false,
+    }
 }
 
 /// Reads one repository-relative worktree file with a fixed memory bound.
@@ -1713,6 +1765,151 @@ mod tests {
         );
         assert_eq!(cached_diff_after, cached_diff_before);
         assert_eq!(status_after, status_before);
+    }
+
+    #[tokio::test]
+    async fn diff_reports_repository_unavailable_outside_git_repository() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+
+        // Act
+        let result = diff(temp_dir.path().to_path_buf(), "main".to_string()).await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(GitError::RepositoryUnavailable { detail })
+                if detail.to_ascii_lowercase().contains("not a git repository")
+        ));
+    }
+
+    #[test]
+    fn diff_reports_repository_unavailable_when_removed_after_index_resolution() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let preserved_index_dir = tempdir().expect("failed to create preserved index dir");
+        setup_test_git_repo(temp_dir.path());
+        let index_path =
+            resolve_diff_index_path(temp_dir.path()).expect("index path should resolve");
+        let index_path = PathBuf::from(index_path.trim());
+        let index_path = temp_dir.path().join(index_path);
+        let preserved_index_path = preserved_index_dir.path().join("index");
+        fs::copy(index_path, &preserved_index_path).expect("index copy should succeed");
+        fs::remove_dir_all(temp_dir.path()).expect("worktree removal should succeed");
+
+        // Act
+        let result = diff_output_after_index_resolution(
+            temp_dir.path(),
+            "main",
+            false,
+            &preserved_index_path,
+        );
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(GitError::RepositoryUnavailable { detail })
+                if detail.contains("git add -A --intent-to-add")
+        ));
+    }
+
+    #[tokio::test]
+    async fn diff_preserves_invalid_base_reference_error() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        setup_test_git_repo(temp_dir.path());
+
+        // Act
+        let result = diff(
+            temp_dir.path().to_path_buf(),
+            "missing-base-reference".to_string(),
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(GitError::CommandFailed { command, stderr })
+                if command == "git diff missing-base-reference"
+                    && stderr.contains("Git diff failed")
+        ));
+    }
+
+    #[test]
+    fn diff_repository_error_classification_preserves_unrelated_failures() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        setup_test_git_repo(temp_dir.path());
+        let error = GitError::CommandFailed {
+            command: "git rev-parse --git-path index".to_string(),
+            stderr: "fatal: ambiguous argument".to_string(),
+        };
+
+        // Act
+        let classified = classify_diff_repository_error(temp_dir.path(), error);
+
+        // Assert
+        assert!(matches!(
+            classified,
+            GitError::CommandFailed { command, stderr }
+                if command == "git rev-parse --git-path index"
+                    && stderr == "fatal: ambiguous argument"
+        ));
+    }
+
+    #[test]
+    fn diff_repository_error_classification_ignores_localized_diagnostic() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let error = GitError::CommandFailed {
+            command: "git rev-parse --git-path index".to_string(),
+            stderr: "fatal: kein Git-Repository".to_string(),
+        };
+
+        // Act
+        let classified = classify_diff_repository_error(temp_dir.path(), error);
+
+        // Assert
+        assert!(matches!(
+            classified,
+            GitError::RepositoryUnavailable { detail }
+                if detail == "git rev-parse --git-path index: fatal: kein Git-Repository"
+        ));
+    }
+
+    #[test]
+    fn diff_repository_probe_preserves_spawn_failure() {
+        // Arrange
+        let probe = Err(GitError::CommandFailed {
+            command: "git rev-parse --git-dir".to_string(),
+            stderr: "git executable unavailable".to_string(),
+        });
+
+        // Act
+        let unavailable = diff_repository_probe_is_unavailable(probe);
+
+        // Assert
+        assert!(!unavailable);
+    }
+
+    #[test]
+    fn diff_repository_error_classification_types_missing_directory() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let missing_path = temp_dir.path().join("removed-worktree");
+        let error = GitError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "worktree removed",
+        ));
+
+        // Act
+        let classified = classify_diff_repository_error(&missing_path, error);
+
+        // Assert
+        assert!(matches!(
+            classified,
+            GitError::RepositoryUnavailable { detail } if detail == "worktree removed"
+        ));
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/session_diff.rs
+++ b/crates/agentty/src/app/session_diff.rs
@@ -323,6 +323,8 @@ impl App {
             }
         } else {
             SessionDiffTaskSource::Worktree {
+                archived_fallback: (session.is_managed() && session.status == Status::Merging)
+                    .then(|| self.services.db().clone()),
                 base_branch: session.base_branch.clone(),
                 git_client: self.services.git_client(),
             }
@@ -424,7 +426,25 @@ impl App {
             return;
         }
 
-        let diff = update.result.unwrap_or_else(|error| error);
+        let diff = match update.result {
+            Ok(diff) => diff,
+            Err(error) => {
+                self.mode = restore.map_or_else(
+                    || AppMode::View {
+                        scroll_offset: fallback_view_scroll_offset,
+                        session_id: session_id.clone(),
+                    },
+                    |restore| restore.into_mode(),
+                );
+                self.sessions.append_workflow_notice(
+                    &session_id,
+                    crate::domain::transcript_notice::TranscriptNotice::Error
+                        .format_line(format!("Unable to load diff: {error}")),
+                );
+
+                return;
+            }
+        };
         if diff.trim().is_empty() && !allow_empty {
             self.mode = restore.map_or_else(
                 || AppMode::View {
@@ -537,8 +557,13 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::input::InputState;
     use crate::domain::session::{
         ForgeKind, ReviewRequest, ReviewRequestState, ReviewRequestSummary,
+    };
+    use crate::presentation::app_mode::PromptModeSnapshot;
+    use crate::presentation::prompt::{
+        PromptAttachmentState, PromptHistoryState, PromptSlashState,
     };
 
     /// Builds one Git-backed review session for diff-request state tests.
@@ -693,6 +718,47 @@ mod tests {
                 }),
                 ..
             }
+        ));
+    }
+
+    #[tokio::test]
+    async fn open_diff_failure_restores_prompt_snapshot() {
+        // Arrange
+        let (mut app, _base_dir, session_id) = review_app().await;
+        let restore = DiffRestoreTarget::Prompt(PromptModeSnapshot {
+            at_mention_state: None,
+            attachment_state: PromptAttachmentState::default(),
+            history_state: PromptHistoryState::default(),
+            input: InputState::with_text("preserved draft".to_string()),
+            scroll_offset: Some(5),
+            session_id: session_id.clone(),
+            slash_state: PromptSlashState::default(),
+        });
+        assert!(app.start_diff_view_load(
+            &session_id,
+            Some(restore),
+            DiffSidebarFocus::Files,
+            false,
+        ));
+        let request_id = loading_request_id(&app).expect("diff loading mode should have a request");
+
+        // Act
+        app.apply_session_diff_update(SessionDiffUpdate {
+            request_id,
+            result: Err("worktree unavailable".to_string()),
+            session_id: session_id.clone(),
+        })
+        .await;
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Prompt {
+                input,
+                scroll_offset: Some(5),
+                session_id: restored_session_id,
+                ..
+            } if input.text() == "preserved draft" && restored_session_id == &session_id
         ));
     }
 

--- a/crates/agentty/src/app/task.rs
+++ b/crates/agentty/src/app/task.rs
@@ -61,6 +61,9 @@ pub(super) enum SessionDiffTaskSource {
     },
     /// Compute a live worktree diff against the session base branch.
     Worktree {
+        /// Archived diff used when managed merge cleanup wins the live-load
+        /// race.
+        archived_fallback: Option<crate::infra::db::AppRepositories>,
         base_branch: String,
         git_client: Arc<dyn GitClient>,
     },
@@ -113,12 +116,28 @@ impl TaskService {
                     .map(Option::unwrap_or_default)
                     .map_err(|error| format!("Failed to load archived diff: {error}")),
                 SessionDiffTaskSource::Worktree {
+                    archived_fallback,
                     base_branch,
                     git_client,
-                } => git_client
-                    .diff(input.folder, base_branch)
-                    .await
-                    .map_err(|error| format!("Failed to run git diff: {error}")),
+                } => match git_client.diff(input.folder, base_branch).await {
+                    Ok(diff) => Ok(diff),
+                    Err(error @ ag_git::GitError::RepositoryUnavailable { .. }) => {
+                        let archived_diff_result = if let Some(repositories) = archived_fallback {
+                            repositories
+                                .sessions()
+                                .load_session_archived_diff(&input.session_id)
+                                .await
+                                .map_err(|error| format!("Failed to load archived diff: {error}"))
+                        } else {
+                            Ok(None)
+                        };
+
+                        archived_diff_result.and_then(|archived_diff| {
+                            archived_diff.ok_or_else(|| format!("Failed to run git diff: {error}"))
+                        })
+                    }
+                    Err(error) => Err(format!("Failed to run git diff: {error}")),
+                },
             };
             let _ = input.app_event_tx.send(AppEvent::SessionDiffLoaded {
                 request_id,
@@ -635,6 +654,208 @@ mod tests {
         fn available_agent_clis(&self) -> Vec<AgentCliInfo> {
             std::panic::resume_unwind(Box::new("version probe failed".to_string()));
         }
+    }
+
+    /// Seeds one archived session diff for background diff fallback tests.
+    async fn archived_diff_repositories(
+        archived_diff: Option<&str>,
+    ) -> crate::infra::db::AppRepositories {
+        let repositories = crate::infra::db::AppRepositories::in_memory()
+            .await
+            .expect("in-memory repositories should open");
+        let project_id = repositories
+            .projects()
+            .upsert_project("/tmp/session-diff-project", None)
+            .await
+            .expect("project fixture should persist");
+        repositories
+            .sessions()
+            .insert_session("session-id", "gpt-5.6-sol", "main", "Merging", project_id)
+            .await
+            .expect("session fixture should persist");
+        repositories
+            .sessions()
+            .update_session_archived_diff(
+                "session-id",
+                archived_diff.map(std::string::ToString::to_string),
+            )
+            .await
+            .expect("archived diff fixture should persist");
+
+        repositories
+    }
+
+    #[tokio::test]
+    async fn session_diff_task_falls_back_to_archived_managed_merge_diff() {
+        // Arrange
+        let archived_diff = "diff --git a/file.rs b/file.rs\n+archived\n";
+        let repositories = archived_diff_repositories(Some(archived_diff)).await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_diff().once().returning(|_, _| {
+            Box::pin(async {
+                Err(ag_git::GitError::RepositoryUnavailable {
+                    detail: "worktree removed".to_string(),
+                })
+            })
+        });
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let input = SessionDiffTaskInput {
+            app_event_tx,
+            folder: PathBuf::from("/tmp/removed-worktree"),
+            session_id: "session-id".into(),
+            source: SessionDiffTaskSource::Worktree {
+                archived_fallback: Some(repositories),
+                base_branch: "main".to_string(),
+                git_client: Arc::new(git_client),
+            },
+        };
+
+        // Act
+        let request_id = TaskService::spawn_session_diff_task(input);
+        let app_event = tokio::time::timeout(Duration::from_secs(1), app_event_rx.recv())
+            .await
+            .expect("timed out waiting for session diff event")
+            .expect("session diff task should emit one event");
+
+        // Assert
+        assert!(matches!(
+            app_event,
+            AppEvent::SessionDiffLoaded {
+                request_id: event_request_id,
+                result: Ok(diff),
+                ref session_id,
+            } if event_request_id == request_id
+                && diff == archived_diff
+                && session_id == "session-id"
+        ));
+    }
+
+    #[tokio::test]
+    async fn session_diff_task_preserves_git_error_without_archived_fallback() {
+        // Arrange
+        let repositories = archived_diff_repositories(None).await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_diff().once().returning(|_, _| {
+            Box::pin(async {
+                Err(ag_git::GitError::RepositoryUnavailable {
+                    detail: "worktree removed".to_string(),
+                })
+            })
+        });
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let input = SessionDiffTaskInput {
+            app_event_tx,
+            folder: PathBuf::from("/tmp/removed-worktree"),
+            session_id: "session-id".into(),
+            source: SessionDiffTaskSource::Worktree {
+                archived_fallback: Some(repositories),
+                base_branch: "main".to_string(),
+                git_client: Arc::new(git_client),
+            },
+        };
+
+        // Act
+        TaskService::spawn_session_diff_task(input);
+        let app_event = tokio::time::timeout(Duration::from_secs(1), app_event_rx.recv())
+            .await
+            .expect("timed out waiting for session diff event")
+            .expect("session diff task should emit one event");
+
+        // Assert
+        assert!(matches!(
+            app_event,
+            AppEvent::SessionDiffLoaded {
+                result: Err(error),
+                ..
+            } if error == "Failed to run git diff: worktree removed"
+        ));
+    }
+
+    #[tokio::test]
+    async fn session_diff_task_propagates_archived_diff_database_failure() {
+        // Arrange
+        let (repositories, pool) = crate::infra::db::AppRepositories::in_memory_with_pool()
+            .await
+            .expect("in-memory repositories should open");
+        pool.close().await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_diff().once().returning(|_, _| {
+            Box::pin(async {
+                Err(ag_git::GitError::RepositoryUnavailable {
+                    detail: "worktree removed".to_string(),
+                })
+            })
+        });
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let input = SessionDiffTaskInput {
+            app_event_tx,
+            folder: PathBuf::from("/tmp/removed-worktree"),
+            session_id: "session-id".into(),
+            source: SessionDiffTaskSource::Worktree {
+                archived_fallback: Some(repositories),
+                base_branch: "main".to_string(),
+                git_client: Arc::new(git_client),
+            },
+        };
+
+        // Act
+        TaskService::spawn_session_diff_task(input);
+        let app_event = tokio::time::timeout(Duration::from_secs(1), app_event_rx.recv())
+            .await
+            .expect("timed out waiting for session diff event")
+            .expect("session diff task should emit one event");
+
+        // Assert
+        assert!(matches!(
+            app_event,
+            AppEvent::SessionDiffLoaded {
+                result: Err(error),
+                ..
+            } if error.starts_with("Failed to load archived diff:")
+                && !error.contains("worktree removed")
+        ));
+    }
+
+    #[tokio::test]
+    async fn session_diff_task_does_not_archive_fallback_for_unrelated_git_error() {
+        // Arrange
+        let repositories = archived_diff_repositories(Some("stale archived diff")).await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_diff().once().returning(|_, _| {
+            Box::pin(async {
+                Err(ag_git::GitError::CommandTimedOut {
+                    command: "git diff main".to_string(),
+                    timeout: Duration::from_secs(30),
+                })
+            })
+        });
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let input = SessionDiffTaskInput {
+            app_event_tx,
+            folder: PathBuf::from("/tmp/live-worktree"),
+            session_id: "session-id".into(),
+            source: SessionDiffTaskSource::Worktree {
+                archived_fallback: Some(repositories),
+                base_branch: "main".to_string(),
+                git_client: Arc::new(git_client),
+            },
+        };
+
+        // Act
+        TaskService::spawn_session_diff_task(input);
+        let app_event = tokio::time::timeout(Duration::from_secs(1), app_event_rx.recv())
+            .await
+            .expect("timed out waiting for session diff event")
+            .expect("session diff task should emit one event");
+
+        // Assert
+        assert!(matches!(
+            app_event,
+            AppEvent::SessionDiffLoaded {
+                result: Err(error),
+                ..
+            } if error == "Failed to run git diff: git diff main timed out after 30s"
+        ));
     }
 
     #[tokio::test]

--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -1303,7 +1303,7 @@ mod tests {
     async fn apply_next_session_diff(app: &mut App) {
         loop {
             let event =
-                tokio::time::timeout(std::time::Duration::from_secs(1), app.next_app_event())
+                tokio::time::timeout(std::time::Duration::from_secs(10), app.next_app_event())
                     .await
                     .expect("session diff event should arrive")
                     .expect("app event channel should remain open");

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -2199,11 +2199,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_show_diff_for_view_session_uses_error_message_outside_git_repo() {
+    async fn test_show_diff_for_view_session_restores_view_after_git_error() {
         // Arrange
         let (mut app, _base_dir, session_id) = new_test_app_with_session().await;
         let non_git_dir = tempdir().expect("failed to create non-git dir");
         app.sessions.sessions_mut()[0].folder = non_git_dir.path().to_path_buf();
+        app.mode = AppMode::View {
+            session_id: session_id.clone().into(),
+            scroll_offset: Some(0),
+        };
         let context = ViewContext {
             scroll_offset: Some(0),
             session_id: session_id.clone().into(),
@@ -2218,13 +2222,23 @@ mod tests {
         assert!(opened);
         assert!(matches!(
             app.mode,
-            AppMode::Diff {
+            AppMode::View {
                 ref session_id,
-                ref diff,
-                scroll_offset: 0,
+                scroll_offset: Some(0),
                 ..
-            } if session_id == &context.session_id && diff.contains("Failed to run git diff:")
+            } if session_id == &context.session_id
         ));
+        let workflow_notice = app.sessions.sessions()[0]
+            .transient_messages
+            .get(crate::domain::transient_message::TransientMessageSlot::WorkflowNotice)
+            .expect("diff load failure should be visible in the restored session view");
+        assert!(workflow_notice.body.text().contains("Unable to load diff:"));
+        assert!(
+            workflow_notice
+                .body
+                .text()
+                .contains("Failed to run git diff:")
+        );
     }
 
     /// Verifies a stale view index cannot start a background diff load.
@@ -2324,7 +2338,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn managed_done_session_surfaces_archived_diff_load_failure() {
+    async fn managed_done_session_restores_view_after_archived_diff_load_failure() {
         // Arrange
         let (mut app, _base_dir, pool) = crate::test_support::new_git_test_app_with_pool().await;
         let session_id = app
@@ -2334,6 +2348,10 @@ mod tests {
         let session = &mut app.sessions.sessions_mut()[0];
         session.role = SessionRole::OrchestrationWorker;
         session.status = Status::Done;
+        app.mode = AppMode::View {
+            session_id: session_id.clone().into(),
+            scroll_offset: Some(0),
+        };
         let context = ViewContext {
             scroll_offset: Some(0),
             session_id: session_id.into(),
@@ -2351,8 +2369,22 @@ mod tests {
         assert!(opened);
         assert!(matches!(
             app.mode,
-            AppMode::Diff { ref diff, .. } if diff.starts_with("Failed to load archived diff:")
+            AppMode::View {
+                ref session_id,
+                scroll_offset: Some(0),
+                ..
+            } if session_id == &context.session_id
         ));
+        let workflow_notice = app.sessions.sessions()[0]
+            .transient_messages
+            .get(crate::domain::transient_message::TransientMessageSlot::WorkflowNotice)
+            .expect("archived diff load failure should be visible in the restored view");
+        assert!(
+            workflow_notice
+                .body
+                .text()
+                .contains("Failed to load archived diff:")
+        );
     }
 
     #[tokio::test]

--- a/crates/agentty/src/ui/component/file_explorer.rs
+++ b/crates/agentty/src/ui/component/file_explorer.rs
@@ -15,6 +15,7 @@ const DIFF_GIT_FILE_HEADER_PREFIX: &str = "diff --git";
 const DIFF_GIT_FALLBACK_PREFIX: &str = "diff --git ";
 const FILE_EXPLORER_HORIZONTAL_BORDER_WIDTH: u16 = 2;
 const FILE_EXPLORER_TITLE: &str = " Files ";
+const LOADING_LABEL: &str = "Loading...";
 const NO_FILES_LABEL: &str = "No files";
 const PATH_SEGMENT_SEPARATOR: char = '/';
 const FOLDER_SUFFIX: &str = "/";
@@ -95,6 +96,19 @@ impl FileExplorer {
         Self {
             file_list_lines: Arc::from(file_list_lines),
             is_focused: true,
+            preserved_suffix_span_count: 0,
+            selected_index: 0,
+        }
+    }
+
+    /// Creates a non-selectable loading placeholder for the diff sidebar.
+    pub(crate) fn loading() -> Self {
+        Self {
+            file_list_lines: Arc::from([Line::from(Span::styled(
+                LOADING_LABEL,
+                Style::default().fg(style::palette::text_subtle()),
+            ))]),
+            is_focused: false,
             preserved_suffix_span_count: 0,
             selected_index: 0,
         }
@@ -459,6 +473,29 @@ mod tests {
         let border_cell = &buffer.content()[0];
         assert_eq!(border_cell.symbol(), "┌");
         assert_eq!(border_cell.fg, style::palette::border());
+    }
+
+    #[test]
+    fn loading_renders_explicit_placeholder_without_empty_state() {
+        // Arrange
+        let backend = ratatui::backend::TestBackend::new(40, 10);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+
+        // Act
+        terminal
+            .draw(|frame| FileExplorer::loading().render(frame, frame.area()))
+            .expect("failed to draw loading file explorer");
+
+        // Assert
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect::<String>();
+        assert!(text.contains(LOADING_LABEL));
+        assert!(!text.contains(NO_FILES_LABEL));
     }
 
     #[test]

--- a/crates/agentty/src/ui/page/diff.rs
+++ b/crates/agentty/src/ui/page/diff.rs
@@ -959,6 +959,7 @@ pub struct DiffPage<'a> {
     pub session: &'a Session,
     /// Sidebar section currently controlling the right pane.
     pub sidebar_focus: DiffSidebarFocus,
+    is_loading: bool,
 }
 
 /// Borrowed inputs required to construct a [`DiffPage`] for one frame.
@@ -1025,7 +1026,16 @@ impl<'a> DiffPage<'a> {
             selected_diff_line_index,
             session,
             sidebar_focus,
+            is_loading: false,
         }
+    }
+
+    /// Marks this page as a pending diff load with an explicit sidebar
+    /// placeholder.
+    pub(crate) fn loading(mut self) -> Self {
+        self.is_loading = true;
+
+        self
     }
 
     /// Renders the right-side diff panel with line-number gutters and
@@ -1462,12 +1472,12 @@ pub(crate) fn diff_changed_line_layout(
     diff_layout_cache.resolved_layout(&content, line_comments, selected_file_index, diff_area)
 }
 
-impl Page for DiffPage<'_> {
-    fn render(&mut self, f: &mut Frame, area: Rect) {
-        let areas = diff_util::diff_page_areas(area);
-        let content = self.diff_layout_cache.content(self.diff);
-        let sidebar_areas =
-            diff_util::diff_sidebar_areas(areas.file_list_area, self.review_comments.is_some());
+impl DiffPage<'_> {
+    /// Builds the Files sidebar for either a pending or completed diff load.
+    fn file_explorer(&self, content: &DiffContentSnapshot) -> FileExplorer {
+        if self.is_loading {
+            return FileExplorer::loading();
+        }
 
         FileExplorer::from_cached_lines(
             content.file_list_lines(),
@@ -1475,7 +1485,18 @@ impl Page for DiffPage<'_> {
         )
         .selected_index(self.file_explorer_selected_index)
         .focused(self.sidebar_focus == DiffSidebarFocus::Files && self.focus == DiffFocus::Files)
-        .render(f, sidebar_areas.file_list_area);
+    }
+}
+
+impl Page for DiffPage<'_> {
+    fn render(&mut self, f: &mut Frame, area: Rect) {
+        let areas = diff_util::diff_page_areas(area);
+        let content = self.diff_layout_cache.content(self.diff);
+        let sidebar_areas =
+            diff_util::diff_sidebar_areas(areas.file_list_area, self.review_comments.is_some());
+
+        self.file_explorer(&content)
+            .render(f, sidebar_areas.file_list_area);
 
         let review_comment_page = self.review_comments.map(|review_comments| {
             let rows = review_comments

--- a/crates/agentty/src/ui/router.rs
+++ b/crates/agentty/src/ui/router.rs
@@ -414,6 +414,7 @@ fn render_surface(
                     diff: "Loading diff...",
                     file_explorer_selected_index: 0,
                     focus: DiffFocus::Files,
+                    is_loading: true,
                     line_comments: &DiffLineComments::default(),
                     preview: &preview,
                     review_comments: None,
@@ -446,6 +447,7 @@ fn render_surface(
                 diff,
                 file_explorer_selected_index,
                 focus,
+                is_loading: false,
                 line_comments,
                 preview,
                 review_comments,
@@ -625,6 +627,7 @@ struct DiffSurfaceInput<'a> {
     diff: &'a str,
     file_explorer_selected_index: usize,
     focus: DiffFocus,
+    is_loading: bool,
     line_comments: &'a DiffLineComments,
     preview: &'a DiffPreview,
     review_comments: Option<&'a DiffReviewComments>,
@@ -650,7 +653,7 @@ fn render_diff_surface(
         return;
     };
 
-    page::diff::DiffPage::new(page::diff::DiffPageInput {
+    let mut page = page::diff::DiffPage::new(page::diff::DiffPageInput {
         can_comment: allows_diff_line_comment_reply(session, sessions, input.restore),
         diff: input.diff,
         diff_layout_cache: resources.diff_layout_cache,
@@ -664,8 +667,12 @@ fn render_diff_surface(
         selected_diff_line_index: input.selected_diff_line_index,
         session,
         sidebar_focus: input.sidebar_focus,
-    })
-    .render(f, area);
+    });
+    if input.is_loading {
+        page.loading().render(f, area);
+    } else {
+        page.render(f, area);
+    }
 }
 
 /// Renders the session chat page for all session-chat modes.
@@ -1215,6 +1222,7 @@ mod tests {
         assert!(diff_loading_is_diff);
         assert!(comments_text.contains("Comment — Router Session"));
         assert!(loading_text.contains("Loading diff..."));
+        assert!(!loading_text.contains("No files"));
     }
 
     #[test]
@@ -1693,6 +1701,7 @@ mod tests {
                         diff: "",
                         file_explorer_selected_index: 0,
                         focus: DiffFocus::Files,
+                        is_loading: false,
                         line_comments: &DiffLineComments::default(),
                         selected_diff_line_index: 0,
                         preview: &DiffPreview::default(),
@@ -1747,6 +1756,7 @@ mod tests {
                         diff: "",
                         file_explorer_selected_index: 0,
                         focus: DiffFocus::Files,
+                        is_loading: false,
                         line_comments: &DiffLineComments::default(),
                         selected_diff_line_index: 0,
                         preview: &DiffPreview::default(),
@@ -1806,6 +1816,7 @@ mod tests {
                         diff: "",
                         file_explorer_selected_index: 0,
                         focus: DiffFocus::Files,
+                        is_loading: false,
                         line_comments: &DiffLineComments::default(),
                         selected_diff_line_index: 0,
                         preview: &DiffPreview::default(),

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -2586,15 +2586,15 @@ fn seed_clean_review_session_with_worktree_edit(env: &BuilderEnv) -> E2eResult {
     install_worktree_edit_tmux_stub(env)
 }
 
-/// Seeds a review diff whose external driver stays busy long enough to prove
-/// that the TUI renders and accepts cancellation before Git completes.
+/// Seeds a failing review diff whose external driver stays busy long enough
+/// to prove that the TUI accepts cancellation before Git completes.
 fn seed_slow_review_diff(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     seed_review_ready_session(env)?;
     seed_review_worktree_with_diff(env)?;
 
     let session_worktree = env.agentty_root.join("wt").join("review-s");
     let slow_diff_driver = session_worktree.join("slow-diff.sh");
-    std::fs::write(&slow_diff_driver, "#!/bin/sh\nsleep 3\nexit 0\n")?;
+    std::fs::write(&slow_diff_driver, "#!/bin/sh\nsleep 3\nexit 1\n")?;
     #[cfg(unix)]
     std::fs::set_permissions(&slow_diff_driver, std::fs::Permissions::from_mode(0o755))?;
     let slow_diff_driver = slow_diff_driver
@@ -7431,15 +7431,24 @@ fn test_slow_diff_loading_remains_cancelable() -> E2eResult {
                         "diff_loading_canceled",
                         "Cancel returns before the slow Git diff completes",
                     )
+                    .press_key("d")
+                    .wait_for_text("Unable to load diff:", 5000)
+                    .capture_labeled(
+                        "diff_loading_failed",
+                        "Git failure returns to the session with a diagnostic",
+                    )
             },
             |frame, report| {
                 let loading_frame = common::frame_from_capture(&report.captures[0]);
                 let loading_full = Region::full(loading_frame.cols(), loading_frame.rows());
                 assertion::assert_text_in_region(&loading_frame, "Loading diff...", &loading_full);
+                assertion::assert_not_visible(&loading_frame, "No files");
 
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "Review-ready session shortcuts", &full);
+                assertion::assert_text_in_region(frame, "Unable to load diff:", &full);
                 assertion::assert_not_visible(frame, "Loading diff...");
+                assertion::assert_not_visible(frame, "No files");
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -820,19 +820,24 @@ orchestration paths:
   all tracked cleanup tasks before canceling unfinished work. Session view also loads
   comments on demand for its linked review request: `AppMode::DiffLoading` renders a
   cancelable page while the full diff loads, then `AppMode::Diff` renders its Files and
-  Comments sidebar immediately with a comment-loading state. `TaskService` resolves the
-  session worktree remote through the injected git/forge boundaries, falls back to the
-  persisted review-request URL after terminal-session worktree cleanup, and uses the
-  matching `AppEvent` to update only the still-open Diff workspace or its help overlay.
-  Inline code context is derived from the already loaded current diff. From a
-  reply-capable session, `a` marks an actionable thread to address, `d` marks it to
-  deny, and `Enter` renders every marked thread plus its requested action into one
-  `TurnPrompt`; outdated threads include an explicit stale-anchor marker. The selected
-  forge thread IDs are recorded in turn metadata. Post-turn handling accepts
-  deduplicated outcomes with an allowlisted ID and nonblank reply. After auto-commit and
-  a successful published-branch push, the worker posts every accepted reply and resolves
-  only outcomes reported as `fixed` through `ReviewRequestClient`; `no_change_needed`
-  outcomes remain open, and failed pushes never mutate forge thread state.
+  Comments sidebar immediately with a comment-loading state. The loading surface uses an
+  explicit Files placeholder instead of parsing its status text as an empty diff. A
+  failed interactive load restores its source mode with a transient workflow notice;
+  during managed merge cleanup, `TaskService` falls back from a repository-unavailable
+  live diff to the archived diff already persisted for that session. Other Git failures
+  remain visible diagnostics. `TaskService` resolves the session worktree remote through
+  the injected git/forge boundaries, falls back to the persisted review-request URL
+  after terminal-session worktree cleanup, and uses the matching `AppEvent` to update
+  only the still-open Diff workspace or its help overlay. Inline code context is derived
+  from the already loaded current diff. From a reply-capable session, `a` marks an
+  actionable thread to address, `d` marks it to deny, and `Enter` renders every marked
+  thread plus its requested action into one `TurnPrompt`; outdated threads include an
+  explicit stale-anchor marker. The selected forge thread IDs are recorded in turn
+  metadata. Post-turn handling accepts deduplicated outcomes with an allowlisted ID and
+  nonblank reply. After auto-commit and a successful published-branch push, the worker
+  posts every accepted reply and resolves only outcomes reported as `fixed` through
+  `ReviewRequestClient`; `no_change_needed` outcomes remain open, and failed pushes
+  never mutate forge thread state.
 
 ## Persistence and Recovery Boundaries
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -217,8 +217,10 @@ diff output. Leaving the preview returns to the composer with the draft intact. 
 opening the writable session worktree, Agentty clears a known-empty result in memory and
 durable storage because external edits may follow. If durable invalidation fails, the
 worktree stays closed; otherwise `d` becomes available and reloads the diff. Full diffs
-load in the background; press `q` or `Esc` on **Loading diff...** to return immediately
-while a large repository is still being inspected.
+load in the background, with **Loading...** in Files until changed paths are available.
+Press `q` or `Esc` on **Loading diff...** to return immediately while a large repository
+is still being inspected. A failed load returns to the session and shows its diagnostic
+there instead of opening an empty Diff workspace.
 
 Inside diff view, `Shift+j` / `Shift+k` and `Up` / `Down` scroll the selected file while
 Files remains focused. Press `Enter` or `l` on a file to move focus from the file tree


### PR DESCRIPTION
- Show an explicit Files loading placeholder while background diffs load.
- Restore the originating session view with a workflow notice when interactive diff loading fails.
- Fall back to archived managed-session diffs after merge cleanup removes the live worktree.
- Distinguish unavailable worktrees, unrelated Git failures, and archived-diff persistence failures while retaining correct recovery behavior.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)