### PR TITLE
Session sync remains responsive during branch operations

### DIFF
--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -5527,8 +5527,10 @@ async fn test_rebase_session_invalid_id() {
     );
 }
 
+/// Verifies session sync queues without waiting for an active branch
+/// operation, then runs after that operation releases ownership.
 #[tokio::test]
-async fn test_rebase_session_updates_session_worktree_to_base_head() {
+async fn test_rebase_session_queues_while_branch_operation_is_busy() {
     // Arrange
     let dir = tempdir().expect("failed to create temp dir");
     let mut app = new_test_app_with_git(dir.path()).await;
@@ -5592,12 +5594,28 @@ async fn test_rebase_session_updates_session_worktree_to_base_head() {
     {
         *session_status = Status::Review;
     }
+    let branch_operation_lock = Arc::clone(
+        &app.sessions
+            .session_handles_or_err(&session_id)
+            .expect("expected session handles")
+            .branch_operation_lock,
+    );
+    let existing_operation_guard = Arc::clone(&branch_operation_lock).lock_owned().await;
 
     // Act
-    let result = app.rebase_session(&session_id).await;
+    let start_result = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        app.rebase_session(&session_id),
+    )
+    .await;
 
     // Assert
-    assert!(result.is_ok(), "rebase should succeed: {:?}", result.err());
+    let result = start_result.expect("queueing sync should not wait for the branch operation");
+    assert!(result.is_ok(), "sync should queue: {:?}", result.err());
+    assert!(branch_operation_lock.try_lock().is_err());
+
+    // Act, Assert
+    drop(existing_operation_guard);
     wait_for_output_contains(&mut app, &session_id, "[Sync] Successfully synced", 200).await;
 }
 

--- a/crates/agentty/src/app/session/workflow/merge.rs
+++ b/crates/agentty/src/app/session/workflow/merge.rs
@@ -12,7 +12,7 @@ use ag_forge as forge;
 use ag_git::{self as git, GitClient};
 use ag_protocol::AgentResponseSummary;
 use askama::Template;
-use tokio::sync::mpsc;
+use tokio::sync::{OwnedMutexGuard, mpsc};
 use tracing::warn;
 
 use super::published_branch::{self, PublishedBranchAutoPushInput};
@@ -258,9 +258,9 @@ pub(super) struct RebaseCommandInput {
 /// Bundled context for finalizing one rebase task.
 struct FinalizeRebaseInput<'a> {
     app_event_tx: &'a mpsc::UnboundedSender<AppEvent>,
-    /// Serializes post-rebase publish ownership with other queued/running
-    /// branch operations for the same session.
-    branch_operation_lock: &'a Arc<tokio::sync::Mutex<()>>,
+    /// Retains branch-operation ownership through rebase finalization and any
+    /// post-rebase auto-push.
+    branch_operation_guard: OwnedMutexGuard<()>,
     clock: &'a Arc<dyn Clock>,
     db: &'a AppRepositories,
     folder: &'a Path,
@@ -279,9 +279,8 @@ struct FinalizeRebaseInput<'a> {
 /// Bundled context for starting post-rebase auto-publish.
 struct RebaseAutoPushInput<'a> {
     app_event_tx: &'a mpsc::UnboundedSender<AppEvent>,
-    /// Serializes post-rebase publish ownership with other queued/running
-    /// branch operations for the same session.
-    branch_operation_lock: &'a Arc<tokio::sync::Mutex<()>>,
+    /// Transfers branch-operation ownership from rebase to auto-push.
+    branch_operation_guard: OwnedMutexGuard<()>,
     clock: &'a Arc<dyn Clock>,
     db: &'a AppRepositories,
     folder: &'a Path,
@@ -858,7 +857,10 @@ impl SessionMergeService {
             .session_handles_or_err(session_id)
             .map(|handles| Arc::clone(&handles.branch_operation_lock))
             .map_err(|_| SessionError::HandlesNotFound)?;
-        let _branch_operation_guard = branch_operation_lock.lock_owned().await;
+        // Reserve an idle branch while the operation is persisted. An active
+        // owner already serializes execution in the worker, so the foreground
+        // event loop must never wait here.
+        let _branch_operation_guard = branch_operation_lock.try_lock_owned().ok();
 
         let command = SessionCommand::Rebase {
             base_branch,
@@ -1845,6 +1847,7 @@ impl SessionManager {
             status,
             transcript,
         } = input;
+        let branch_operation_guard = branch_operation_lock.lock_owned().await;
 
         let status_transition = StatusTransition::from_parts(
             app_event_tx.clone(),
@@ -1893,7 +1896,7 @@ impl SessionManager {
 
         Self::finalize_rebase_task(FinalizeRebaseInput {
             app_event_tx: &app_event_tx,
-            branch_operation_lock: &branch_operation_lock,
+            branch_operation_guard,
             clock: &clock,
             db: &db,
             folder: &folder,
@@ -2141,7 +2144,7 @@ impl SessionManager {
     async fn finalize_rebase_task(input: FinalizeRebaseInput<'_>) {
         let FinalizeRebaseInput {
             app_event_tx,
-            branch_operation_lock,
+            branch_operation_guard,
             clock,
             db,
             folder,
@@ -2173,7 +2176,7 @@ impl SessionManager {
 
                 Self::start_auto_push_after_rebase(RebaseAutoPushInput {
                     app_event_tx,
-                    branch_operation_lock,
+                    branch_operation_guard,
                     clock,
                     db,
                     folder,
@@ -2221,7 +2224,7 @@ impl SessionManager {
     async fn start_auto_push_after_rebase(input: RebaseAutoPushInput<'_>) {
         let RebaseAutoPushInput {
             app_event_tx,
-            branch_operation_lock,
+            branch_operation_guard,
             clock,
             db,
             folder,
@@ -2234,7 +2237,6 @@ impl SessionManager {
             transcript,
         } = input;
 
-        let branch_operation_guard = Arc::clone(branch_operation_lock).lock_owned().await;
         let published_upstream_ref = db
             .sessions()
             .load_session_published_upstream_ref(session_id)
@@ -5185,7 +5187,7 @@ mod tests {
         // Act
         SessionManager::finalize_rebase_task(FinalizeRebaseInput {
             app_event_tx: &app_event_tx,
-            branch_operation_lock: &branch_operation_lock,
+            branch_operation_guard: Arc::clone(&branch_operation_lock).lock_owned().await,
             clock: &clock,
             db: &db,
             folder: &folder,
@@ -5492,11 +5494,12 @@ mod tests {
         let git_client: Arc<dyn GitClient> = Arc::new(metadata_sync_git_client());
         let review_request_client: Arc<dyn forge::ReviewRequestClient> =
             Arc::new(metadata_sync_review_request_client(folder.clone()));
+        let branch_operation_guard = Arc::new(tokio::sync::Mutex::new(())).lock_owned().await;
 
         // Act
         SessionManager::finalize_rebase_task(FinalizeRebaseInput {
             app_event_tx: &app_event_tx,
-            branch_operation_lock: &Arc::new(tokio::sync::Mutex::new(())),
+            branch_operation_guard,
             clock: &clock,
             db: &db,
             folder: &folder,
@@ -5592,11 +5595,12 @@ mod tests {
             });
         let git_client: Arc<dyn GitClient> = Arc::new(mock_git_client);
         let review_request_client = empty_review_request_client();
+        let branch_operation_guard = Arc::new(tokio::sync::Mutex::new(())).lock_owned().await;
 
         // Act
         SessionManager::finalize_rebase_task(FinalizeRebaseInput {
             app_event_tx: &app_event_tx,
-            branch_operation_lock: &Arc::new(tokio::sync::Mutex::new(())),
+            branch_operation_guard,
             clock: &clock,
             db: &db,
             folder: &folder,
@@ -5669,11 +5673,12 @@ mod tests {
             Arc::clone(&status),
         );
         let git_client: Arc<dyn GitClient> = Arc::new(git::MockGitClient::new());
+        let branch_operation_guard = Arc::new(tokio::sync::Mutex::new(())).lock_owned().await;
 
         // Act
         SessionManager::finalize_rebase_task(FinalizeRebaseInput {
             app_event_tx: &app_event_tx,
-            branch_operation_lock: &Arc::new(tokio::sync::Mutex::new(())),
+            branch_operation_guard,
             clock: &clock,
             db: &db,
             folder: &folder,

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -4915,6 +4915,52 @@ fn test_session_output_chronology() -> E2eResult {
     Ok(())
 }
 
+/// Verify session sync queues behind an active published-branch auto-push
+/// without blocking session-view input or redraws.
+#[test]
+fn session_sync_remains_responsive_during_auto_push() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_sync_responsive_during_auto_push")
+        .with_git()
+        .with_terminal_size(120, 30)
+        .setup(seed_published_session_output_chronology)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("Enter")
+                    .wait_for_text("Enter: reply", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Type your message", 5000)
+                    .write_text("Continue after the sync")
+                    .press_key("Enter")
+                    .wait_for_text("Got it. What would you like me to do?", 30000)
+                    .wait_for_text("Auto-pushing", 10000)
+                    .press_key("r")
+                    .press_key("?")
+                    .wait_for_text("Keybindings", 3000)
+                    .capture_labeled(
+                        "responsive_during_auto_push",
+                        "Session help opens while sync waits behind auto-push",
+                    )
+                    .press_key("q")
+                    .wait_for_text("[Sync] Successfully synced", 15000)
+            },
+            |frame, report| {
+                let help_frame = common::frame_from_capture(&report.captures[0]);
+                let help_full = Region::full(help_frame.cols(), help_frame.rows());
+                assertion::assert_text_in_region(&help_frame, "Keybindings", &help_full);
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "[Sync] Successfully synced", &full);
+                assertion::assert_not_visible(frame, "active session worker is unavailable");
+            },
+        )?;
+
+    Ok(())
+}
+
 /// Verify a completed automatic branch push remains visible after its owning
 /// project is switched out while the push is running and then restored.
 #[test]

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -435,11 +435,13 @@ flowchart LR
    branch changes.
 1. If the session already tracks a published upstream branch and no chat message or sync
    operation is queued, a per-session branch-operation guard transfers to the detached
-   auto-push until it finishes. Every sync request holds the same guard through status
-   transition and operation persistence, so its rebase is observed before publish starts
-   or waits until the active publish completes. Post-rebase auto-push transfers the
-   guard again, preventing a subsequent sync from starting until that publish finishes.
-   After a successful push, linked review-request and commit metadata are resolved and
+   auto-push until it finishes. A sync request tries to reserve an idle guard while it
+   persists and queues the operation, but never waits for an existing owner on the
+   foreground event loop. The session worker acquires the guard before rebase execution,
+   so a request is observed before publish starts or waits behind an active publish
+   while the terminal remains responsive. Post-rebase auto-push retains the same guard,
+   preventing a subsequent sync from starting until that publish finishes. After a
+   successful push, linked review-request and commit metadata are resolved and
    refreshed. Agentty reads the current remote title and description after each
    successful push and sends them, the cumulative session summary, and the generated
    commit metadata through one semantic reconciliation prompt. The prompt keeps the
@@ -764,9 +766,11 @@ their triggers:
 - **Session merge task** (merge confirmation): rebase, squash merge with the session
   commit message, worktree cleanup.
 
-- **Session sync task** (view-mode `r`, stacked-parent fan-out): assisted rebase of the
-  session branch; post-merge stacked-child syncs use `git rebase --onto` with the
-  recorded parent commit as the old base.
+- **Session sync task** (view-mode `r`, stacked-parent fan-out): queues without waiting
+  for branch-operation ownership on the foreground event loop, then acquires that
+  ownership in the session worker before assisted rebase of the session branch;
+  post-merge stacked-child syncs use `git rebase --onto` with the recorded parent commit
+  as the old base.
 
 Title generation, focused review, commit-message generation, and conflict assistance
 submit owned `OneShotRequest` values through `OneShotClient`. Its production

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -266,10 +266,12 @@ only when sync resolves; while it waits, the consolidated queue shows
 the active `Rebasing...` loader starts. Agentty validates the session worktree before
 that promotion; a validation failure replaces the waiting row with a durable
 `[Sync Error]` notice without showing sync as active. Repeated `r` presses keep the
-single queued rebase instead of adding duplicates. Session sync reserves branch-publish
-ownership before it queues or starts, and retains that ownership through its post-rebase
-push. A completed turn or subsequent sync therefore cannot start a competing
-published-branch auto-push.
+single queued rebase instead of adding duplicates. Session sync tries to reserve idle
+branch-publish ownership while queueing but never waits for an active owner on the UI
+event loop. If an auto-push is already running, the session worker waits behind it while
+the terminal remains interactive. Once rebase execution acquires ownership, it retains
+that ownership through its post-rebase push. A completed turn or subsequent sync
+therefore cannot start a competing published-branch auto-push.
 
 Pressing `p` during a running turn opens the usual branch-name popup and queues
 review-request creation on that same worker. The session remains **InProgress** and


### PR DESCRIPTION
- Queues sync without waiting on the foreground event loop, then acquires and retains branch-operation ownership through rebase and post-rebase auto-push.
- Adds unit and E2E coverage for sync requests behind active branch operations while session input remains interactive.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)