### PR TITLE
Extends Gemini utility prompt bootstrap deadlines

### DIFF
--- a/crates/ag-agent/src/agent/app_server/gemini/lifecycle.rs
+++ b/crates/ag-agent/src/agent/app_server/gemini/lifecycle.rs
@@ -109,7 +109,9 @@ pub(super) async fn start_runtime_with_built_command(
         request.permission_mode,
     );
 
-    match bootstrap_runtime_session(&mut transport, state.folder.as_path()).await {
+    let bootstrap_timeout = bootstrap_response_timeout(&request.request_kind);
+    match bootstrap_runtime_session(&mut transport, state.folder.as_path(), bootstrap_timeout).await
+    {
         Ok(session_id) => {
             state.session_id = session_id;
 
@@ -129,21 +131,42 @@ pub(super) async fn start_runtime_with_built_command(
 pub(super) async fn bootstrap_runtime_session<Transport: AppServerRuntimeTransport>(
     transport: &mut Transport,
     folder: &Path,
+    response_timeout: std::time::Duration,
 ) -> Result<String, AppServerError> {
-    initialize_runtime(transport).await?;
+    initialize_runtime(transport, response_timeout).await?;
 
-    start_session(transport, folder).await
+    start_session(transport, folder, response_timeout).await
+}
+
+/// Selects a long-running bootstrap deadline for isolated utility prompts.
+///
+/// Gemini initializes plan-mode tools and creates a fresh ACP session before
+/// one-shot focused review can submit its prompt. Normal persistent sessions
+/// retain the bounded startup timeout so unrelated configuration failures are
+/// still reported promptly.
+fn bootstrap_response_timeout(
+    request_kind: &crate::channel::AgentRequestKind,
+) -> std::time::Duration {
+    if matches!(
+        request_kind,
+        crate::channel::AgentRequestKind::UtilityPrompt
+    ) {
+        app_server_transport::TURN_TIMEOUT
+    } else {
+        app_server_transport::STARTUP_TIMEOUT
+    }
 }
 
 /// Sends the ACP initialize handshake.
 pub(super) async fn initialize_runtime<Transport: AppServerRuntimeTransport>(
     transport: &mut Transport,
+    response_timeout: std::time::Duration,
 ) -> Result<(), AppServerError> {
     let initialization_request_id = format!("init-{}", uuid::Uuid::new_v4());
     let initialization_request = build_initialize_request_payload(&initialization_request_id)?;
     transport.write_json_line(initialization_request).await?;
     let initialize_response_line = transport
-        .wait_for_response_line(initialization_request_id)
+        .wait_for_response_line_with_timeout(initialization_request_id, response_timeout)
         .await?;
     let initialize_response =
         serde_json::from_str::<Value>(&initialize_response_line).map_err(|error| {
@@ -235,6 +258,7 @@ pub(super) fn parse_json_rpc_result<T: serde::de::DeserializeOwned>(
 pub(super) async fn start_session<Transport: AppServerRuntimeTransport>(
     transport: &mut Transport,
     folder: &Path,
+    response_timeout: std::time::Duration,
 ) -> Result<String, AppServerError> {
     let session_new_id = format!("session-new-{}", uuid::Uuid::new_v4());
     let session_new_payload = build_json_rpc_request_payload(
@@ -243,7 +267,9 @@ pub(super) async fn start_session<Transport: AppServerRuntimeTransport>(
         NewSessionRequest::new(folder.to_path_buf()),
     )?;
     transport.write_json_line(session_new_payload).await?;
-    let response_line = transport.wait_for_response_line(session_new_id).await?;
+    let response_line = transport
+        .wait_for_response_line_with_timeout(session_new_id, response_timeout)
+        .await?;
     let response_value = serde_json::from_str::<Value>(&response_line).map_err(|error| {
         AppServerError::Provider(format!(
             "Failed to parse session/new response JSON: {error}"
@@ -501,6 +527,21 @@ mod tests {
         }
     }
 
+    #[test]
+    fn utility_prompts_receive_long_running_bootstrap_timeout() {
+        // Arrange
+        let utility_request_kind = crate::channel::AgentRequestKind::UtilityPrompt;
+        let session_request_kind = crate::channel::AgentRequestKind::SessionStart;
+
+        // Act
+        let utility_timeout = bootstrap_response_timeout(&utility_request_kind);
+        let session_timeout = bootstrap_response_timeout(&session_request_kind);
+
+        // Assert
+        assert_eq!(utility_timeout, app_server_transport::TURN_TIMEOUT);
+        assert_eq!(session_timeout, app_server_transport::STARTUP_TIMEOUT);
+    }
+
     #[tokio::test]
     async fn start_runtime_reports_spawn_error_for_missing_folder() {
         // Arrange
@@ -537,6 +578,186 @@ mod tests {
         assert!(
             error.to_string().contains("initialize"),
             "unexpected bootstrap error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bootstrap_runtime_session_propagates_long_running_response_timeout() {
+        // Arrange
+        let folder = tempdir().expect("create session folder");
+        let mut transport = MockAppServerRuntimeTransport::new();
+        transport
+            .expect_write_json_line()
+            .times(3)
+            .returning(|_| Box::pin(async { Ok(()) }));
+        transport
+            .expect_wait_for_response_line_with_timeout()
+            .times(2)
+            .withf(|_, response_timeout| *response_timeout == app_server_transport::TURN_TIMEOUT)
+            .returning(|response_id, _| {
+                let response = if response_id.starts_with("init-") {
+                    let result = InitializeResponse::new(ProtocolVersion::LATEST);
+
+                    serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": response_id,
+                        "result": result,
+                    })
+                } else {
+                    let result = NewSessionResponse::new("gemini-review-session");
+
+                    serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": response_id,
+                        "result": result,
+                    })
+                };
+
+                Box::pin(async move { Ok(response.to_string()) })
+            });
+
+        // Act
+        let session_id = bootstrap_runtime_session(
+            &mut transport,
+            folder.path(),
+            app_server_transport::TURN_TIMEOUT,
+        )
+        .await;
+
+        // Assert
+        assert_eq!(
+            session_id.expect("Gemini bootstrap should accept the long-running timeout"),
+            "gemini-review-session"
+        );
+    }
+
+    #[tokio::test]
+    async fn initialize_runtime_uses_long_running_response_timeout() {
+        // Arrange
+        let request_id = Arc::new(Mutex::new(None));
+        let mut transport = MockAppServerRuntimeTransport::new();
+        let mut sequence = Sequence::new();
+        transport
+            .expect_write_json_line()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .withf(|payload| {
+                payload.get("method").and_then(Value::as_str) == Some(AGENT_METHOD_NAMES.initialize)
+            })
+            .returning({
+                let request_id = Arc::clone(&request_id);
+
+                move |payload| {
+                    *request_id
+                        .lock()
+                        .expect("initialize id lock should remain usable") = payload
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string);
+
+                    Box::pin(async { Ok(()) })
+                }
+            });
+        transport
+            .expect_wait_for_response_line_with_timeout()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .withf(|_, response_timeout| *response_timeout == app_server_transport::TURN_TIMEOUT)
+            .returning(move |_, _| {
+                let response_id = request_id
+                    .lock()
+                    .expect("initialize id lock should remain usable")
+                    .clone()
+                    .expect("initialize id should be captured");
+                let response = InitializeResponse::new(ProtocolVersion::LATEST);
+
+                Box::pin(async move {
+                    Ok(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": response_id,
+                        "result": response,
+                    })
+                    .to_string())
+                })
+            });
+        transport
+            .expect_write_json_line()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .withf(|payload| payload.get("method").and_then(Value::as_str) == Some("initialized"))
+            .return_once(|_| Box::pin(async { Ok(()) }));
+
+        // Act
+        let result = initialize_runtime(&mut transport, app_server_transport::TURN_TIMEOUT).await;
+
+        // Assert
+        result.expect("Gemini initialization should accept the long-running timeout");
+    }
+
+    #[tokio::test]
+    async fn start_session_uses_long_running_response_timeout() {
+        // Arrange
+        let folder = tempdir().expect("create session folder");
+        let request_id = Arc::new(Mutex::new(None));
+        let mut transport = MockAppServerRuntimeTransport::new();
+        let mut sequence = Sequence::new();
+        transport
+            .expect_write_json_line()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .withf(|payload| {
+                payload.get("method").and_then(Value::as_str)
+                    == Some(AGENT_METHOD_NAMES.session_new)
+            })
+            .returning({
+                let request_id = Arc::clone(&request_id);
+
+                move |payload| {
+                    *request_id
+                        .lock()
+                        .expect("session/new id lock should remain usable") = payload
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string);
+
+                    Box::pin(async { Ok(()) })
+                }
+            });
+        transport
+            .expect_wait_for_response_line_with_timeout()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .withf(|_, response_timeout| *response_timeout == app_server_transport::TURN_TIMEOUT)
+            .returning(move |_, _| {
+                let response_id = request_id
+                    .lock()
+                    .expect("session/new id lock should remain usable")
+                    .clone()
+                    .expect("session/new id should be captured");
+                let response = NewSessionResponse::new("gemini-review-session");
+
+                Box::pin(async move {
+                    Ok(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": response_id,
+                        "result": response,
+                    })
+                    .to_string())
+                })
+            });
+
+        // Act
+        let session_id = start_session(
+            &mut transport,
+            folder.path(),
+            app_server_transport::TURN_TIMEOUT,
+        )
+        .await;
+
+        // Assert
+        assert_eq!(
+            session_id.expect("Gemini session creation should accept the long-running timeout"),
+            "gemini-review-session"
         );
     }
 

--- a/crates/ag-agent/src/agent/app_server/stdio_transport.rs
+++ b/crates/ag-agent/src/agent/app_server/stdio_transport.rs
@@ -6,6 +6,7 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::time::Duration;
 
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, BufReader, Lines};
@@ -33,6 +34,13 @@ pub(crate) trait AppServerRuntimeTransport: Send {
     fn wait_for_response_line(
         &mut self,
         response_id: String,
+    ) -> AppServerTransportFuture<'_, Result<String, AppServerTransportError>>;
+
+    /// Waits for one matching response using a provider-selected timeout.
+    fn wait_for_response_line_with_timeout(
+        &mut self,
+        response_id: String,
+        response_timeout: Duration,
     ) -> AppServerTransportFuture<'_, Result<String, AppServerTransportError>>;
 
     /// Reads the next raw stdout line from the runtime.
@@ -102,6 +110,22 @@ impl AppServerRuntimeTransport for AppServerStdioTransport {
         })
     }
 
+    /// Waits for one matching response line using an explicit deadline.
+    fn wait_for_response_line_with_timeout(
+        &mut self,
+        response_id: String,
+        response_timeout: Duration,
+    ) -> AppServerTransportFuture<'_, Result<String, AppServerTransportError>> {
+        Box::pin(async move {
+            app_server_transport::wait_for_response_line_with_timeout(
+                &mut self.stdout_lines,
+                &response_id,
+                response_timeout,
+            )
+            .await
+        })
+    }
+
     /// Reads one raw JSON line from runtime stdout.
     fn next_stdout(
         &mut self,
@@ -117,5 +141,47 @@ impl AppServerRuntimeTransport for AppServerStdioTransport {
                     source,
                 })
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn explicit_response_timeout_round_trips_matching_line() {
+        // Arrange
+        let command = std::process::Command::new("cat");
+        let (mut child, stdin, stdout) =
+            app_server_transport::spawn_runtime_command(command, "cat")
+                .expect("`cat` transport fixture should spawn");
+        let mut transport = AppServerStdioTransport::new(
+            stdin,
+            stdout,
+            "test stdin is unavailable",
+            "failed reading test stdout",
+        );
+        let payload = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "response-1",
+            "result": {},
+        });
+        transport
+            .write_json_line(payload.clone())
+            .await
+            .expect("fixture request should be written");
+
+        // Act
+        let response_line = transport
+            .wait_for_response_line_with_timeout("response-1".to_string(), Duration::from_secs(1))
+            .await;
+
+        // Assert
+        assert_eq!(
+            response_line.expect("matching response should arrive"),
+            payload.to_string()
+        );
+        transport.close_stdin();
+        app_server_transport::shutdown_child(&mut child).await;
     }
 }

--- a/crates/ag-agent/src/app_server_transport.rs
+++ b/crates/ag-agent/src/app_server_transport.rs
@@ -144,7 +144,24 @@ pub(crate) async fn wait_for_response_line<R>(
 where
     R: tokio::io::AsyncRead + Unpin,
 {
-    tokio::time::timeout(STARTUP_TIMEOUT, async {
+    wait_for_response_line_with_timeout(stdout_lines, response_id, STARTUP_TIMEOUT).await
+}
+
+/// Reads stdout lines until a matching response arrives or `response_timeout`
+/// elapses.
+///
+/// Provider lifecycles whose documented bootstrap work includes long-running
+/// initialization may select a wider deadline without weakening the default
+/// startup bound for every app-server request.
+pub(crate) async fn wait_for_response_line_with_timeout<R>(
+    stdout_lines: &mut Lines<BufReader<R>>,
+    response_id: &str,
+    response_timeout: Duration,
+) -> Result<String, AppServerTransportError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    tokio::time::timeout(response_timeout, async {
         loop {
             let stdout_line = stdout_lines
                 .next_line()
@@ -166,7 +183,7 @@ where
     .await
     .map_err(|_| AppServerTransportError::Timeout {
         response_id: response_id.to_string(),
-        timeout_seconds: STARTUP_TIMEOUT.as_secs(),
+        timeout_seconds: response_timeout.as_secs(),
     })?
 }
 
@@ -442,6 +459,29 @@ mod tests {
             "expected ProcessTerminated, got: {response_result:?}"
         );
         writer_task.await.expect("writer task should finish");
+    }
+
+    /// Verifies provider-selected response deadlines are preserved in timeout
+    /// diagnostics instead of falling back to the shared startup window.
+    #[tokio::test]
+    async fn wait_for_response_line_with_timeout_uses_selected_deadline() {
+        // Arrange
+        let (reader, _writer) = tokio::io::duplex(256);
+        let mut stdout_lines = BufReader::new(reader).lines();
+        let response_timeout = Duration::from_millis(1);
+
+        // Act
+        let response_result =
+            wait_for_response_line_with_timeout(&mut stdout_lines, "req-1", response_timeout).await;
+
+        // Assert
+        assert!(matches!(
+            response_result,
+            Err(AppServerTransportError::Timeout {
+                ref response_id,
+                timeout_seconds: 0,
+            }) if response_id == "req-1"
+        ));
     }
 
     #[test]

--- a/crates/agentty/src/app/task.rs
+++ b/crates/agentty/src/app/task.rs
@@ -1076,8 +1076,8 @@ mod tests {
     }
 
     #[tokio::test]
-    /// Ensures the detached review-assist task emits the completed review
-    /// through the app event channel.
+    /// Ensures a detached Gemini review-assist task uses the utility-prompt
+    /// route and emits the completed review through the app event channel.
     async fn spawn_review_assist_task_with_client_emits_completed_review() {
         // Arrange
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
@@ -1086,8 +1086,12 @@ mod tests {
             .expect_submit()
             .times(1)
             .returning(|request| {
-                assert_eq!(request.agent_kind, AgentKind::Claude);
+                assert_eq!(request.agent_kind, AgentKind::Gemini);
                 assert_eq!(request.permission_mode, ag_agent::PermissionMode::ReadOnly);
+                assert!(matches!(
+                    request.request_kind,
+                    ag_agent::AgentRequestKind::UtilityPrompt
+                ));
                 assert_eq!(request.reasoning_level, ReasoningLevel::XHigh);
                 assert_eq!(request.speed_mode, crate::domain::agent::SpeedMode::Fast);
                 assert!(
@@ -1106,7 +1110,7 @@ mod tests {
             diff_hash: 42,
             reasoning_level: ReasoningLevel::XHigh,
             review_diff: "diff --git a/src/lib.rs b/src/lib.rs".to_string(),
-            review_selection: AgentSelection::new(AgentKind::Claude, AgentModel::ClaudeSonnet5),
+            review_selection: AgentSelection::new(AgentKind::Gemini, AgentModel::Gemini31Pro),
             session_chat_history: None,
             session_folder: PathBuf::from("/tmp/review-assist"),
             session_id: "session-42".into(),


### PR DESCRIPTION
- Uses the longer turn timeout for utility prompt initialization and session creation while preserving the bounded startup timeout for regular sessions.
- Propagates provider-selected deadlines through stdio transport and timeout diagnostics.
- Routes detached review assistance through Gemini utility prompts.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)