### PR TITLE
Expand Dependabot coverage to pre-commit updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,20 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+    assignees:
+      - "minev-dev"
+      - "andagaev"
+    groups:
+      version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
   - package-ecosystem: "rust-toolchain"
     directory: "/"
     schedule:
@@ -55,6 +69,5 @@ updates:
     groups:
       version-updates:
         applies-to: version-updates
-        update-types:
-          - "patch"
-          - "minor"
+        patterns:
+          - "*"


### PR DESCRIPTION
- Adds daily pre-commit dependency updates with a seven-day cooldown and shared assignees.
- Allows the Rust toolchain update group to include all update types.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)