### PR TITLE
Automatic focused reviews survive project switches

### DIFF
--- a/crates/ag-store/.sqlx/query-085477e92c76cdfb56690a7dca2047ed8c6f93c16c05bfb64769098abed00e25.json
+++ b/crates/ag-store/.sqlx/query-085477e92c76cdfb56690a7dca2047ed8c6f93c16c05bfb64769098abed00e25.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\nUPDATE session\nSET focused_review_status = 'Pending',\n    focused_review_diff_hash = NULL,\n    focused_review_text = NULL,\n    updated_at = ?\nWHERE id = ?\n  AND status IN ('InProgress', 'Review', 'AgentReview')\n  AND (role IS NULL OR role <> 'Orchestrator')\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "085477e92c76cdfb56690a7dca2047ed8c6f93c16c05bfb64769098abed00e25"
+}

--- a/crates/ag-store/.sqlx/query-b62be92f9a43528967211cfcedaae5d445b0a6eedb3d70491367784c6166873d.json
+++ b/crates/ag-store/.sqlx/query-b62be92f9a43528967211cfcedaae5d445b0a6eedb3d70491367784c6166873d.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\nSELECT id\nFROM session\nWHERE project_id = ?\n  AND focused_review_status = 'Pending'\n  AND status IN ('Review', 'AgentReview')\n  AND (role IS NULL OR role <> 'Orchestrator')\nORDER BY updated_at DESC, id\n",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session",
+            "name": "id"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "b62be92f9a43528967211cfcedaae5d445b0a6eedb3d70491367784c6166873d"
+}

--- a/crates/ag-store/src/connection_test.rs
+++ b/crates/ag-store/src/connection_test.rs
@@ -7,7 +7,10 @@ use sqlx::migrate::Migrator;
 use tempfile::tempdir;
 
 use super::*;
-use crate::{SessionFocusedReviewRow, SessionOperationRow, SessionRow, SessionTurnMetadata};
+use crate::{
+    PersistedSessionCreation, SessionFocusedReviewRow, SessionOperationRow, SessionRow,
+    SessionTurnMetadata,
+};
 
 /// Builds one deterministic persisted review-request fixture for DB tests.
 fn review_request_fixture() -> ReviewRequest {
@@ -2957,6 +2960,88 @@ async fn test_update_session_focused_review_clears_persisted_review() {
         .expect("failed to load focused reviews");
 
     // Assert
+    assert_eq!(focused_reviews, [] as [crate::SessionFocusedReviewRow; 0]);
+}
+
+#[tokio::test]
+async fn test_defer_session_focused_review_requires_eligible_existing_session() {
+    // Arrange
+    let database = Database::open_in_memory()
+        .await
+        .expect("failed to open in-memory db");
+    let project_id = database
+        .projects()
+        .upsert_project("/tmp/project", Some("main".to_string()))
+        .await
+        .expect("failed to insert project");
+    database
+        .sessions()
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Review", project_id)
+        .await
+        .expect("failed to insert session");
+    database
+        .sessions()
+        .update_session_focused_review(
+            "session-a",
+            Some(ag_session::FocusedReviewStatus::Ready),
+            Some("42".to_string()),
+            Some("## Review\nOutdated".to_string()),
+        )
+        .await
+        .expect("failed to seed focused review");
+    database
+        .sessions()
+        .insert_session_with_agent(PersistedSessionCreation {
+            agent: "codex",
+            base_branch: "main",
+            id: "orchestrator",
+            is_draft: false,
+            model: "gpt-5.6-sol",
+            orchestration_task_id: None,
+            parent_session_id: None,
+            permission_mode: ag_session::PermissionMode::AutoEdit,
+            personality_id: None,
+            project_id,
+            reasoning_level: ReasoningLevel::default(),
+            role: Some("Orchestrator"),
+            speed_mode: SpeedMode::Normal,
+            status: "Review",
+        })
+        .await
+        .expect("failed to insert orchestrator session");
+
+    // Act
+    let deferred = database
+        .sessions()
+        .defer_session_focused_review("session-a")
+        .await
+        .expect("failed to defer focused review");
+    let missing_deferred = database
+        .sessions()
+        .defer_session_focused_review("missing-session")
+        .await
+        .expect("failed to check missing session");
+    let orchestrator_deferred = database
+        .sessions()
+        .defer_session_focused_review("orchestrator")
+        .await
+        .expect("failed to check orchestrator session");
+    let pending_session_ids = database
+        .sessions()
+        .load_pending_focused_review_session_ids(project_id)
+        .await
+        .expect("failed to load pending focused reviews");
+    let focused_reviews = database
+        .sessions()
+        .load_session_focused_reviews_for_project(project_id)
+        .await
+        .expect("failed to load focused reviews");
+
+    // Assert
+    assert!(deferred);
+    assert!(!missing_deferred);
+    assert!(!orchestrator_deferred);
+    assert_eq!(pending_session_ids, ["session-a"]);
     assert_eq!(focused_reviews, [] as [crate::SessionFocusedReviewRow; 0]);
 }
 

--- a/crates/ag-store/src/session.rs
+++ b/crates/ag-store/src/session.rs
@@ -290,6 +290,10 @@ pub trait SessionRepository: Send + Sync {
     /// Sets `project_id` for sessions that do not yet reference a project.
     async fn backfill_session_project(&self, project_id: i64) -> Result<(), DbError>;
 
+    /// Persists an automatic focused-review trigger when the session still
+    /// exists and is eligible for a worker review.
+    async fn defer_session_focused_review(&self, id: &str) -> Result<bool, DbError>;
+
     /// Deletes a session row by identifier.
     async fn delete_session(&self, id: &str) -> Result<(), DbError>;
 
@@ -411,6 +415,13 @@ pub trait SessionRepository: Send + Sync {
     /// Loads parentless review-ready sessions that still need their recorded
     /// stack-base commit replayed onto their current base branch.
     async fn load_pending_stack_restack_session_ids(
+        &self,
+        project_id: i64,
+    ) -> Result<Vec<String>, DbError>;
+
+    /// Loads eligible worker sessions with a durable automatic focused-review
+    /// trigger for one project.
+    async fn load_pending_focused_review_session_ids(
         &self,
         project_id: i64,
     ) -> Result<Vec<String>, DbError>;
@@ -1081,6 +1092,28 @@ WHERE project_id IS NULL
         Ok(())
     }
 
+    async fn defer_session_focused_review(&self, id: &str) -> Result<bool, DbError> {
+        let now = self.now();
+        let result = sqlx::query!(
+            r#"
+UPDATE session
+SET focused_review_status = 'Pending',
+    focused_review_diff_hash = NULL,
+    focused_review_text = NULL,
+    updated_at = ?
+WHERE id = ?
+  AND status IN ('InProgress', 'Review', 'AgentReview')
+  AND (role IS NULL OR role <> 'Orchestrator')
+"#,
+            now,
+            id
+        )
+        .execute(&self.0)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
     async fn delete_session(&self, id: &str) -> Result<(), DbError> {
         let now = self.now();
         let mut transaction = self.0.begin().await?;
@@ -1699,6 +1732,28 @@ WHERE project_id = ?
   AND status IN ('Review', 'AgentReview')
 ORDER BY updated_at ASC, id ASC
 ",
+            project_id
+        )
+        .fetch_all(&self.0)
+        .await?;
+
+        Ok(session_ids)
+    }
+
+    async fn load_pending_focused_review_session_ids(
+        &self,
+        project_id: i64,
+    ) -> Result<Vec<String>, DbError> {
+        let session_ids = sqlx::query_scalar!(
+            r#"
+SELECT id
+FROM session
+WHERE project_id = ?
+  AND focused_review_status = 'Pending'
+  AND status IN ('Review', 'AgentReview')
+  AND (role IS NULL OR role <> 'Orchestrator')
+ORDER BY updated_at DESC, id
+"#,
             project_id
         )
         .fetch_all(&self.0)

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -190,6 +190,11 @@ pub(crate) enum AppEvent {
         error: String,
         session_id: SessionId,
     },
+    /// Retries one automatic focused-review deferral write after a transient
+    /// persistence failure.
+    DeferredAutoReviewPersistenceRetry {
+        retry: crate::app::session_diff::DeferredAutoReviewPersistenceRetry,
+    },
     /// Retries one focused-review persistence write that failed while its
     /// cache generation remains current.
     FocusedReviewPersistenceRetry {
@@ -252,6 +257,8 @@ pub(super) struct AppEventBatch {
     pub(super) branch_publish_action_updates: Vec<BranchPublishActionUpdate>,
     pub(super) branch_publish_resolved_session_ids: HashSet<SessionId>,
     pub(super) branch_publish_started_session_ids: HashSet<SessionId>,
+    pub(super) deferred_auto_review_persistence_retries:
+        Vec<crate::app::session_diff::DeferredAutoReviewPersistenceRetry>,
     pub(super) diff_preview_updates: Vec<DiffPreviewUpdate>,
     pub(super) focused_review_persistence_retries: Vec<FocusedReviewPersistenceRetry>,
     pub(super) git_status_update: Option<GitStatusBatchUpdate>,
@@ -299,6 +306,9 @@ enum AppEventEffect {
     ReloadProjects,
     RefreshGitStatus,
     ApplyReviewUpdates(HashMap<SessionId, ReviewUpdate>),
+    PersistDeferredAutoReviewTriggers(
+        Vec<crate::app::session_diff::DeferredAutoReviewPersistenceRetry>,
+    ),
     PersistFocusedReviewUpdates(Vec<FocusedReviewPersistenceRetry>),
 }
 
@@ -413,6 +423,11 @@ impl AppEventBatch {
             .then(|| AppEventEffect::ApplyReviewUpdates(std::mem::take(&mut self.review_updates)))
             .into_iter()
             .collect::<Vec<_>>();
+        if !self.deferred_auto_review_persistence_retries.is_empty() {
+            after_snapshot_effects.push(AppEventEffect::PersistDeferredAutoReviewTriggers(
+                std::mem::take(&mut self.deferred_auto_review_persistence_retries),
+            ));
+        }
         if !self.focused_review_persistence_retries.is_empty() {
             after_snapshot_effects.push(AppEventEffect::PersistFocusedReviewUpdates(
                 std::mem::take(&mut self.focused_review_persistence_retries),
@@ -494,6 +509,7 @@ impl AppEventBatch {
             | AppEvent::SessionQueuedSyncResolved { .. }
             | AppEvent::ReviewPrepared { .. }
             | AppEvent::ReviewPreparationFailed { .. }
+            | AppEvent::DeferredAutoReviewPersistenceRetry { .. }
             | AppEvent::FocusedReviewPersistenceRetry { .. }
             | AppEvent::SessionUpdated { .. }
             | AppEvent::AgentResponseReceived { .. }
@@ -582,6 +598,7 @@ impl AppEventBatch {
             | AppEvent::SessionQueuedSyncResolved { .. }
             | AppEvent::ReviewPrepared { .. }
             | AppEvent::ReviewPreparationFailed { .. }
+            | AppEvent::DeferredAutoReviewPersistenceRetry { .. }
             | AppEvent::FocusedReviewPersistenceRetry { .. }
             | AppEvent::SessionUpdated { .. }
             | AppEvent::AgentResponseReceived { .. }
@@ -648,6 +665,9 @@ impl AppEventBatch {
                 error,
                 session_id,
             } => self.collect_review_preparation_failed(diff_hash, error, session_id),
+            AppEvent::DeferredAutoReviewPersistenceRetry { retry } => {
+                self.deferred_auto_review_persistence_retries.push(retry);
+            }
             AppEvent::FocusedReviewPersistenceRetry { retry } => {
                 self.focused_review_persistence_retries.push(retry);
             }
@@ -985,6 +1005,8 @@ impl App {
             &mut event_batch.session_review_comment_snapshots,
         ));
         let completed_turn_session_ids = event_batch.applied_turns.keys().cloned().collect();
+        let completed_review_session_ids =
+            Self::completed_review_session_ids(&event_batch.applied_turns);
         self.supersede_review_diff_loads(&completed_turn_session_ids);
         for session_diff_update in std::mem::take(&mut event_batch.session_diff_updates) {
             self.apply_session_diff_update(session_diff_update).await;
@@ -1029,8 +1051,9 @@ impl App {
             .await;
         let mut auto_review_session_ids =
             self.sessions_entering_review(&event_batch.session_ids, &previous_session_states);
-        auto_review_session_ids.extend(completed_turn_session_ids);
-        self.start_auto_review_diff_loads(&auto_review_session_ids);
+        auto_review_session_ids.extend(completed_review_session_ids);
+        self.start_or_defer_auto_reviews(&auto_review_session_ids)
+            .await;
         app::review::hydrate_review_transients(
             &self.review_cache,
             self.sessions.state_mut(),
@@ -1050,6 +1073,18 @@ impl App {
         if should_mark_dirty {
             self.mark_dirty();
         }
+    }
+
+    /// Returns completed turns eligible to trigger an automatic focused
+    /// review rather than clarification-question input.
+    fn completed_review_session_ids(
+        applied_turns: &HashMap<SessionId, TurnAppliedState>,
+    ) -> HashSet<SessionId> {
+        applied_turns
+            .iter()
+            .filter(|(_, turn_applied_state)| turn_applied_state.questions.is_empty())
+            .map(|(session_id, _)| session_id.clone())
+            .collect()
     }
 
     /// Applies queued worker actions that started or otherwise resolved.
@@ -1244,6 +1279,9 @@ impl App {
                     );
                     self.persist_focused_review_updates(focused_review_persistence)
                         .await;
+                }
+                AppEventEffect::PersistDeferredAutoReviewTriggers(retries) => {
+                    self.persist_deferred_auto_review_retries(retries).await;
                 }
                 AppEventEffect::PersistFocusedReviewUpdates(persistence_updates) => {
                     self.persist_focused_review_retries(persistence_updates)
@@ -1885,6 +1923,53 @@ impl App {
     /// Starts focused review generation for sessions that just entered review.
     pub(super) fn auto_start_reviews(&mut self, session_ids: &HashSet<SessionId>) {
         self.start_auto_review_diff_loads(session_ids);
+    }
+
+    /// Starts automatic reviews for loaded sessions and retains triggers for
+    /// sessions whose owning project is currently inactive.
+    async fn start_or_defer_auto_reviews(&mut self, session_ids: &HashSet<SessionId>) {
+        let mut loaded_session_ids = HashSet::new();
+
+        for session_id in session_ids {
+            let loaded_status = self
+                .sessions
+                .session_for_id(session_id)
+                .map(|session| session.status);
+            if loaded_status == Some(Status::InProgress) {
+                self.defer_auto_review_session(session_id).await;
+
+                continue;
+            }
+            if loaded_status.is_some() {
+                self.deferred_auto_review_session_ids.remove(session_id);
+                loaded_session_ids.insert(session_id.clone());
+
+                continue;
+            }
+
+            self.defer_auto_review_session(session_id).await;
+        }
+
+        self.start_auto_review_diff_loads(&loaded_session_ids);
+    }
+
+    /// Consumes deferred automatic-review triggers whose sessions were
+    /// restored by the latest project switch.
+    pub(super) fn resume_deferred_auto_reviews(&mut self, persisted_session_ids: Vec<String>) {
+        self.deferred_auto_review_session_ids
+            .extend(persisted_session_ids.into_iter().map(SessionId::from));
+        let loaded_session_ids = self
+            .deferred_auto_review_session_ids
+            .iter()
+            .filter(|session_id| self.sessions.session_for_id(session_id).is_some())
+            .cloned()
+            .collect::<HashSet<_>>();
+
+        for session_id in &loaded_session_ids {
+            self.deferred_auto_review_session_ids.remove(session_id);
+        }
+
+        self.start_auto_review_diff_loads(&loaded_session_ids);
     }
 
     /// Applies one completed branch-publish action to the session chat.
@@ -3006,6 +3091,142 @@ mod tests {
             [] as [crate::app::core::events::AppEventEffect; 0]
         );
         assert!(reduction_plan.changes_observable_state);
+    }
+
+    #[tokio::test]
+    async fn completed_turn_defers_auto_review_when_project_is_inactive() {
+        // Arrange
+        let (mut app, base_dir) = crate::test_support::new_test_app().await;
+        let session_id = SessionId::from("inactive-completed-session");
+        let inactive_project_path = base_dir.path().join("inactive-project");
+        let inactive_project_id = app
+            .services
+            .db()
+            .projects()
+            .upsert_project(&inactive_project_path.to_string_lossy(), None)
+            .await
+            .expect("failed to insert inactive project");
+        app.services
+            .db()
+            .sessions()
+            .insert_session(
+                session_id.as_str(),
+                "gpt-5.6-sol",
+                "main",
+                "Review",
+                inactive_project_id,
+            )
+            .await
+            .expect("failed to insert inactive session");
+        let turn_applied_state = TurnAppliedState {
+            follow_up_tasks: Vec::new(),
+            questions: Vec::new(),
+            summary: None,
+            token_usage_delta: crate::domain::session::SessionStats::default(),
+        };
+
+        // Act
+        app.apply_app_events(AppEvent::AgentResponseReceived {
+            session_id: session_id.clone(),
+            turn_applied_state,
+        })
+        .await;
+
+        // Assert
+        assert_eq!(
+            app.deferred_auto_review_session_ids,
+            HashSet::from([session_id.clone()])
+        );
+        assert_eq!(
+            app.services
+                .db()
+                .sessions()
+                .load_pending_focused_review_session_ids(inactive_project_id)
+                .await
+                .expect("failed to load deferred review"),
+            [session_id.as_str()]
+        );
+    }
+
+    #[tokio::test]
+    async fn late_completed_turn_for_deleted_session_is_not_deferred() {
+        // Arrange
+        let (mut app, base_dir) = crate::test_support::new_test_app().await;
+        let session_id = SessionId::from("deleted-completed-session");
+        let inactive_project_path = base_dir.path().join("inactive-project");
+        let inactive_project_id = app
+            .services
+            .db()
+            .projects()
+            .upsert_project(&inactive_project_path.to_string_lossy(), None)
+            .await
+            .expect("failed to insert inactive project");
+        app.services
+            .db()
+            .sessions()
+            .insert_session(
+                session_id.as_str(),
+                "gpt-5.6-sol",
+                "main",
+                "Review",
+                inactive_project_id,
+            )
+            .await
+            .expect("failed to insert inactive session");
+        app.services
+            .db()
+            .sessions()
+            .delete_session(session_id.as_str())
+            .await
+            .expect("failed to delete inactive session");
+        let turn_applied_state = TurnAppliedState {
+            follow_up_tasks: Vec::new(),
+            questions: Vec::new(),
+            summary: None,
+            token_usage_delta: crate::domain::session::SessionStats::default(),
+        };
+
+        // Act
+        app.apply_app_events(AppEvent::AgentResponseReceived {
+            session_id,
+            turn_applied_state,
+        })
+        .await;
+
+        // Assert
+        assert!(app.deferred_auto_review_session_ids.is_empty());
+        assert!(
+            app.services
+                .db()
+                .sessions()
+                .load_pending_focused_review_session_ids(inactive_project_id)
+                .await
+                .expect("failed to load deferred reviews")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn completed_turn_with_questions_is_not_deferred() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let session_id = SessionId::from("inactive-question-session");
+        let turn_applied_state = TurnAppliedState {
+            follow_up_tasks: Vec::new(),
+            questions: vec![crate::domain::question::QuestionItem::new("Which project?")],
+            summary: None,
+            token_usage_delta: crate::domain::session::SessionStats::default(),
+        };
+
+        // Act
+        app.apply_app_events(AppEvent::AgentResponseReceived {
+            session_id,
+            turn_applied_state,
+        })
+        .await;
+
+        // Assert
+        assert!(app.deferred_auto_review_session_ids.is_empty());
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -168,6 +168,7 @@ impl App {
                 crate::presentation::settings::SettingsPresentationState::default(),
             tabs: crate::app::tab::TabManager::new(initial_tab),
             prompt_progress: std::collections::HashMap::new(),
+            deferred_auto_review_session_ids: std::collections::HashSet::new(),
             pending_focused_review_persistence: std::collections::HashMap::new(),
             pending_session_diff_requests: std::collections::HashMap::new(),
             projects,
@@ -192,8 +193,8 @@ impl App {
         Ok(app)
     }
 
-    /// Loads focused-review cache state and the managed reviews that must be
-    /// regenerated during startup recovery.
+    /// Loads focused-review cache state and reviews that must be regenerated
+    /// during startup recovery.
     async fn load_startup_focused_reviews(
         repositories: &AppRepositories,
         active_project_id: i64,
@@ -207,16 +208,15 @@ impl App {
         AppError,
     > {
         let review_cache = Self::load_focused_review_cache(repositories, active_project_id).await;
-        let recoverable_session_ids = repositories
-            .orchestrations()
-            .load_recoverable_focused_review_session_ids(active_project_id)
-            .await?;
+        let recoverable_session_ids =
+            Self::load_recoverable_focused_review_session_ids(repositories, active_project_id)
+                .await?;
         review::hydrate_review_transients(&review_cache, sessions.state_mut(), review_model);
 
         Ok((review_cache, recoverable_session_ids))
     }
 
-    /// Restarts focused review for durable managed tasks whose persistence was
+    /// Restarts focused review for durable triggers whose persistence was
     /// interrupted before a terminal review result was stored.
     pub(super) fn recover_startup_focused_reviews(&mut self, session_ids: Vec<String>) {
         let session_ids = session_ids
@@ -225,6 +225,28 @@ impl App {
             .collect();
 
         self.auto_start_reviews(&session_ids);
+    }
+
+    /// Loads durable automatic-review triggers for eligible worker and
+    /// managed sessions in one project.
+    pub(super) async fn load_recoverable_focused_review_session_ids(
+        repositories: &AppRepositories,
+        project_id: i64,
+    ) -> Result<Vec<String>, AppError> {
+        let mut session_ids = repositories
+            .sessions()
+            .load_pending_focused_review_session_ids(project_id)
+            .await?;
+        session_ids.extend(
+            repositories
+                .orchestrations()
+                .load_recoverable_focused_review_session_ids(project_id)
+                .await?,
+        );
+        session_ids.sort_unstable();
+        session_ids.dedup();
+
+        Ok(session_ids)
     }
 
     /// Loads active-project settings from the feature-scoped dependencies.

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -273,6 +273,9 @@ pub struct App {
     /// switches, is hydrated after restart, and is ready when the user presses
     /// `f`.
     pub(crate) review_cache: HashMap<SessionId, ReviewCacheEntry>,
+    /// Retains automatic focused-review triggers for completed sessions whose
+    /// owning project is not currently loaded.
+    pub(crate) deferred_auto_review_session_ids: HashSet<SessionId>,
     /// Retains focused-review cache generations until their durable writes
     /// settle so project-scoped refreshes cannot discard off-project output.
     pub(crate) pending_focused_review_persistence: HashMap<SessionId, FocusedReviewPersistence>,
@@ -456,6 +459,9 @@ impl App {
             .ok_or_else(|| {
                 AppError::Workflow(format!("Project with id `{project_id}` was not found"))
             })?;
+        let recoverable_focused_review_session_ids =
+            Self::load_recoverable_focused_review_session_ids(self.services.db(), project.id)
+                .await?;
         let git_branch = self
             .services
             .git_client()
@@ -520,6 +526,7 @@ impl App {
         }
         self.reload_projects().await;
         self.refresh_sessions_now().await;
+        self.resume_deferred_auto_reviews(recoverable_focused_review_session_ids);
 
         Ok(())
     }
@@ -1149,6 +1156,7 @@ impl App {
         if let Some(session_id) = session_id {
             app::at_mention_task::clear_pending_load(&session_id);
             self.discard_prompt_progress(&session_id).await;
+            self.discard_deleted_session_diff_state(&session_id);
             self.review_cache.remove(&session_id);
         }
 
@@ -1168,6 +1176,7 @@ impl App {
         if let Some(session_id) = session_id {
             app::at_mention_task::clear_pending_load(&session_id);
             self.discard_prompt_progress(&session_id).await;
+            self.discard_deleted_session_diff_state(&session_id);
             self.review_cache.remove(&session_id);
         }
 

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -104,6 +104,29 @@ async fn test_app_viewing_reconcile_session(
     app
 }
 
+/// Seeds one materialized session row for project-switching tests.
+async fn seed_materialized_session(
+    database: &AppRepositories,
+    base_path: &Path,
+    project_id: i64,
+    session_id: &str,
+    status: Status,
+) {
+    database
+        .sessions()
+        .insert_session(
+            session_id,
+            AgentModel::Gpt56Sol.as_str(),
+            "main",
+            &status.to_string(),
+            project_id,
+        )
+        .await
+        .expect("failed to insert materialized session");
+    fs::create_dir_all(session::session_folder(base_path, session_id).join(SESSION_DATA_DIR))
+        .expect("failed to create materialized session data dir");
+}
+
 /// Seeds one review-ready session and its persisted focused review.
 async fn seed_persisted_review_session(
     database: &AppRepositories,
@@ -113,19 +136,7 @@ async fn seed_persisted_review_session(
     diff_hash: &str,
     review_text: &str,
 ) {
-    database
-        .sessions()
-        .insert_session(
-            session_id,
-            AgentModel::Gpt56Sol.as_str(),
-            "main",
-            &Status::Review.to_string(),
-            project_id,
-        )
-        .await
-        .expect("failed to insert review session");
-    fs::create_dir_all(session::session_folder(base_path, session_id).join(SESSION_DATA_DIR))
-        .expect("failed to create review session data dir");
+    seed_materialized_session(database, base_path, project_id, session_id, Status::Review).await;
     database
         .sessions()
         .update_session_focused_review(
@@ -529,6 +540,8 @@ async fn test_switch_project_restores_project_scoped_focused_reviews() {
         loading_session_id.into(),
         ReviewCacheEntry::Loading { diff_hash: 21 },
     );
+    app.deferred_auto_review_session_ids
+        .insert(loading_session_id.into());
     insert_test_ready_review(&mut app, "inactive-review");
 
     // Act
@@ -545,6 +558,7 @@ async fn test_switch_project_restores_project_scoped_focused_reviews() {
         app.review_cache.get(loading_session_id),
         Some(ReviewCacheEntry::Loading { diff_hash: 21 })
     ));
+    assert!(app.deferred_auto_review_session_ids.is_empty());
     assert!(!app.review_cache.contains_key("inactive-review"));
     assert_eq!(
         app.sessions
@@ -564,6 +578,182 @@ async fn test_switch_project_restores_project_scoped_focused_reviews() {
             .map(|message| &message.body),
         Some(TransientMessageBody::Loading(_))
     ));
+}
+
+#[tokio::test]
+async fn test_switch_project_recovers_persisted_deferred_review_after_restart() {
+    // Arrange
+    let base_dir = tempdir().expect("failed to create temp dir");
+    let second_project_dir = tempdir().expect("failed to create second temp dir");
+    let base_path = base_dir.path().to_path_buf();
+    let database = AppRepositories::in_memory().await.expect("db should open");
+    let first_project_id = database
+        .projects()
+        .upsert_project(&base_path.to_string_lossy(), None)
+        .await
+        .expect("failed to insert first project");
+    let second_project_id = database
+        .projects()
+        .upsert_project(&second_project_dir.path().to_string_lossy(), None)
+        .await
+        .expect("failed to insert second project");
+    let session_id = "pending-review";
+    database
+        .sessions()
+        .insert_session(
+            session_id,
+            "gpt-5.6-sol",
+            "main",
+            "Review",
+            second_project_id,
+        )
+        .await
+        .expect("failed to insert pending review session");
+    fs::create_dir_all(session::session_folder(&base_path, session_id).join(SESSION_DATA_DIR))
+        .expect("failed to create pending review session data dir");
+    assert!(
+        database
+            .sessions()
+            .defer_session_focused_review(session_id)
+            .await
+            .expect("failed to persist deferred review")
+    );
+    database
+        .settings()
+        .set_active_project_id(first_project_id)
+        .await
+        .expect("failed to persist initial active project");
+    let mut app = App::new_with_clients(
+        base_path.clone(),
+        base_path,
+        None,
+        database,
+        crate::test_support::test_app_clients(),
+    )
+    .await
+    .expect("failed to build app");
+    let mut mock_git_client = ag_git::MockGitClient::new();
+    mock_git_client
+        .expect_detect_git_info()
+        .times(3)
+        .returning(|_| Box::pin(async { None }));
+    mock_git_client
+        .expect_diff()
+        .once()
+        .returning(|_, _| Box::pin(std::future::pending()));
+    install_mock_git_client(&mut app, mock_git_client);
+
+    // Act
+    app.switch_project(second_project_id)
+        .await
+        .expect("failed to switch project");
+
+    // Assert
+    assert!(app.deferred_auto_review_session_ids.is_empty());
+    assert_eq!(app.pending_session_diff_requests.len(), 1);
+}
+
+#[tokio::test]
+async fn test_switch_immediately_after_response_recovers_in_progress_review() {
+    // Arrange
+    let base_dir = tempdir().expect("failed to create temp dir");
+    let second_project_dir = tempdir().expect("failed to create second temp dir");
+    let base_path = base_dir.path().to_path_buf();
+    let database = AppRepositories::in_memory().await.expect("db should open");
+    let first_project_id = database
+        .projects()
+        .upsert_project(&base_path.to_string_lossy(), None)
+        .await
+        .expect("failed to insert first project");
+    let second_project_id = database
+        .projects()
+        .upsert_project(&second_project_dir.path().to_string_lossy(), None)
+        .await
+        .expect("failed to insert second project");
+    let session_id = "in-progress-completed-review";
+    seed_materialized_session(
+        &database,
+        &base_path,
+        first_project_id,
+        session_id,
+        Status::Review,
+    )
+    .await;
+    database
+        .settings()
+        .set_active_project_id(first_project_id)
+        .await
+        .expect("failed to persist initial active project");
+    let repositories = database.clone();
+    let mut app = App::new_with_clients(
+        base_path.clone(),
+        base_path,
+        None,
+        database,
+        crate::test_support::test_app_clients(),
+    )
+    .await
+    .expect("failed to build app");
+    crate::test_support::set_session_status_for_test(&mut app, session_id, Status::InProgress);
+    repositories
+        .sessions()
+        .update_session_status_with_timing_at(session_id, "InProgress", 0)
+        .await
+        .expect("failed to persist in-progress status");
+    let mut mock_git_client = ag_git::MockGitClient::new();
+    mock_git_client
+        .expect_detect_git_info()
+        .times(6)
+        .returning(|_| Box::pin(async { None }));
+    mock_git_client
+        .expect_diff()
+        .once()
+        .returning(|_, _| Box::pin(std::future::pending()));
+    install_mock_git_client(&mut app, mock_git_client);
+
+    // Act
+    app.apply_app_events(AppEvent::AgentResponseReceived {
+        session_id: session_id.into(),
+        turn_applied_state: test_turn_applied_state(
+            Vec::new(),
+            Vec::new(),
+            None,
+            SessionStats::default(),
+        ),
+    })
+    .await;
+    let deferred_before_switch = app.deferred_auto_review_session_ids.clone();
+    app.switch_project(second_project_id)
+        .await
+        .expect("failed to switch away from completed session");
+    repositories
+        .sessions()
+        .update_session_status_with_timing_at(session_id, "Review", 1)
+        .await
+        .expect("failed to persist final review status");
+    crate::test_support::set_session_status_for_test(&mut app, session_id, Status::Review);
+    app.apply_app_events(AppEvent::SessionUpdated {
+        session_id: session_id.into(),
+        version: 1,
+    })
+    .await;
+    let pending_after_status_transition = repositories
+        .sessions()
+        .load_pending_focused_review_session_ids(first_project_id)
+        .await
+        .expect("failed to load deferred review after status transition");
+    app.switch_project(first_project_id)
+        .await
+        .expect("failed to restore completed session project");
+
+    // Assert
+    assert_eq!(
+        deferred_before_switch,
+        HashSet::from([SessionId::from(session_id)])
+    );
+    assert_eq!(pending_after_status_transition, [session_id]);
+    assert!(app.deferred_auto_review_session_ids.is_empty());
+    assert_eq!(app.pending_session_diff_requests.len(), 1);
 }
 
 #[tokio::test]

--- a/crates/agentty/src/app/service.rs
+++ b/crates/agentty/src/app/service.rs
@@ -335,6 +335,7 @@ fn app_event_label(event: &AppEvent) -> &'static str {
         AppEvent::SessionQueuedSyncResolved { .. } => "SessionQueuedSyncResolved",
         AppEvent::ReviewPrepared { .. } => "ReviewPrepared",
         AppEvent::ReviewPreparationFailed { .. } => "ReviewPreparationFailed",
+        AppEvent::DeferredAutoReviewPersistenceRetry { .. } => "DeferredAutoReviewPersistenceRetry",
         AppEvent::FocusedReviewPersistenceRetry { .. } => "FocusedReviewPersistenceRetry",
         AppEvent::SessionUpdated { .. } => "SessionUpdated",
         AppEvent::AgentResponseReceived { .. } => "AgentResponseReceived",
@@ -425,6 +426,23 @@ mod tests {
 
         // Assert
         assert_eq!(label, "FocusedReviewPersistenceRetry");
+    }
+
+    #[test]
+    fn app_event_label_names_deferred_auto_review_persistence_retries() {
+        // Arrange
+        let event = AppEvent::DeferredAutoReviewPersistenceRetry {
+            retry: crate::app::session_diff::DeferredAutoReviewPersistenceRetry {
+                attempt: 1,
+                session_id: "session-id".into(),
+            },
+        };
+
+        // Act
+        let label = app_event_label(&event);
+
+        // Assert
+        assert_eq!(label, "DeferredAutoReviewPersistenceRetry");
     }
 
     #[test]

--- a/crates/agentty/src/app/session_diff.rs
+++ b/crates/agentty/src/app/session_diff.rs
@@ -3,6 +3,8 @@
 use std::collections::HashSet;
 use std::collections::hash_map::Entry;
 
+use tracing::warn;
+
 use crate::app::App;
 use crate::app::review::{self, FocusedReviewPersistence, ReviewCacheEntry};
 use crate::app::task::{SessionDiffTaskInput, SessionDiffTaskSource, TaskService};
@@ -12,9 +14,41 @@ use crate::domain::transient_message::{
     TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
     TransientMessageSlot,
 };
+use crate::infra::db::DbError;
 use crate::presentation::app_mode::{
     AppMode, DiffFocus, DiffLineComments, DiffPreview, DiffRestoreTarget, DiffSidebarFocus,
 };
+
+/// Maximum number of delayed persistence attempts after an automatic-review
+/// deferral write fails.
+const MAX_DEFERRED_AUTO_REVIEW_PERSISTENCE_RETRIES: u8 = 3;
+
+/// One delayed automatic-review deferral persistence attempt.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct DeferredAutoReviewPersistenceRetry {
+    /// One-based delayed retry number.
+    pub(crate) attempt: u8,
+    /// Session whose automatic focused review remains deferred.
+    pub(crate) session_id: SessionId,
+}
+
+impl DeferredAutoReviewPersistenceRetry {
+    /// Wraps one initial write before any delayed retries have run.
+    fn initial(session_id: SessionId) -> Self {
+        Self {
+            attempt: 0,
+            session_id,
+        }
+    }
+
+    /// Returns the next bounded retry, or `None` after the retry limit.
+    fn next(self) -> Option<Self> {
+        (self.attempt < MAX_DEFERRED_AUTO_REVIEW_PERSISTENCE_RETRIES).then(|| Self {
+            attempt: self.attempt.saturating_add(1),
+            session_id: self.session_id,
+        })
+    }
+}
 
 /// Completed session-diff task ready for stale-safe reducer application.
 pub(crate) struct SessionDiffUpdate {
@@ -122,6 +156,100 @@ impl App {
             },
             |restore| restore.into_mode(),
         );
+    }
+
+    /// Discards every diff continuation and deferred automatic-review trigger
+    /// owned by a deleted session so detached task completions remain stale.
+    pub(crate) fn discard_deleted_session_diff_state(&mut self, session_id: &SessionId) {
+        self.pending_session_diff_requests
+            .retain(|_, request| request.session_id != *session_id);
+        self.deferred_auto_review_session_ids.remove(session_id);
+    }
+
+    /// Persists and retains an automatic-review trigger for an eligible
+    /// session that cannot start its review yet.
+    pub(super) async fn defer_auto_review_session(&mut self, session_id: &SessionId) {
+        self.persist_deferred_auto_review(DeferredAutoReviewPersistenceRetry::initial(
+            session_id.clone(),
+        ))
+        .await;
+    }
+
+    /// Retries current automatic-review deferral writes after their bounded
+    /// backoff delay.
+    pub(super) async fn persist_deferred_auto_review_retries(
+        &mut self,
+        retries: Vec<DeferredAutoReviewPersistenceRetry>,
+    ) {
+        for retry in retries {
+            if self
+                .deferred_auto_review_session_ids
+                .contains(&retry.session_id)
+            {
+                self.persist_deferred_auto_review(retry).await;
+            }
+        }
+    }
+
+    /// Applies one automatic-review deferral persistence attempt.
+    async fn persist_deferred_auto_review(&mut self, retry: DeferredAutoReviewPersistenceRetry) {
+        let result = self
+            .services
+            .db()
+            .sessions()
+            .defer_session_focused_review(retry.session_id.as_str())
+            .await;
+        Self::handle_deferred_auto_review_persistence_result(
+            &mut self.deferred_auto_review_session_ids,
+            self.services.event_sender(),
+            retry,
+            result,
+        );
+    }
+
+    /// Retains failed triggers and schedules their next bounded persistence
+    /// attempt through the foreground event reducer.
+    fn handle_deferred_auto_review_persistence_result(
+        deferred_session_ids: &mut HashSet<SessionId>,
+        app_event_tx: tokio::sync::mpsc::UnboundedSender<crate::app::AppEvent>,
+        retry: DeferredAutoReviewPersistenceRetry,
+        result: Result<bool, DbError>,
+    ) -> bool {
+        let session_id = retry.session_id.clone();
+        match result {
+            Ok(true) => {
+                deferred_session_ids.insert(session_id);
+
+                false
+            }
+            Ok(false) => {
+                deferred_session_ids.remove(&session_id);
+
+                false
+            }
+            Err(error) => {
+                deferred_session_ids.insert(session_id.clone());
+                let Some(retry) = retry.next() else {
+                    warn!(
+                        session_id = %session_id,
+                        error = %error,
+                        "deferred automatic focused-review persistence retries exhausted; \
+                         retaining the in-memory trigger"
+                    );
+
+                    return false;
+                };
+                warn!(
+                    session_id = %session_id,
+                    retry_attempt = retry.attempt,
+                    %error,
+                    "failed to persist deferred automatic focused review; scheduling retry"
+                );
+                TaskService::spawn_deferred_auto_review_persistence_retry(app_event_tx, retry);
+
+                true
+            }
+        }
     }
 
     /// Starts one manual focused-review diff load unless that session already
@@ -486,6 +614,9 @@ impl App {
     ) {
         let session_id = update.session_id;
         let Some(session) = self.sessions.session_for_id(&session_id) else {
+            if !is_manual {
+                self.defer_auto_review_session(&session_id).await;
+            }
             if cached_diff_hash.is_none() {
                 self.review_cache.remove(&session_id);
             }
@@ -531,6 +662,12 @@ impl App {
                     review::REVIEW_NO_DIFF_MESSAGE.to_string(),
                 );
             } else if cached_diff_hash.is_none() {
+                let _ = self
+                    .services
+                    .db()
+                    .sessions()
+                    .update_session_focused_review(&session_id, None, None, None)
+                    .await;
                 self.clear_review_output(&session_id);
             }
             review::restore_session_review_status(self.sessions.state_mut(), &session_id);
@@ -844,6 +981,236 @@ mod tests {
         // Assert
         assert!(app.pending_session_diff_requests.is_empty());
         assert!(!app.review_cache.contains_key(&session_id));
+    }
+
+    #[tokio::test]
+    async fn automatic_review_diff_completion_after_project_switch_survives_restart() {
+        // Arrange
+        let (mut app, base_dir) = crate::test_support::new_test_app().await;
+        let repositories = app.services.db().clone();
+        let session_id = SessionId::from("inactive-review-diff");
+        let inactive_project_path = base_dir.path().join("inactive-project");
+        let inactive_project_id = repositories
+            .projects()
+            .upsert_project(&inactive_project_path.to_string_lossy(), None)
+            .await
+            .expect("failed to insert inactive project");
+        repositories
+            .sessions()
+            .insert_session(
+                session_id.as_str(),
+                "gpt-5.6-sol",
+                "main",
+                "Review",
+                inactive_project_id,
+            )
+            .await
+            .expect("failed to insert inactive review session");
+        let update = SessionDiffUpdate {
+            request_id: 1,
+            result: Ok("diff --git a/file b/file".to_string()),
+            session_id: session_id.clone(),
+        };
+
+        // Act
+        app.apply_review_diff_update(update, None, false).await;
+        let deferred_in_memory = app.deferred_auto_review_session_ids.clone();
+        drop(app);
+        let recoverable_session_ids = repositories
+            .sessions()
+            .load_pending_focused_review_session_ids(inactive_project_id)
+            .await
+            .expect("failed to recover deferred review after restart");
+
+        // Assert
+        assert_eq!(deferred_in_memory, HashSet::from([session_id.clone()]));
+        assert_eq!(recoverable_session_ids, [session_id.as_str()]);
+    }
+
+    #[tokio::test]
+    async fn transient_deferred_auto_review_persistence_failure_retains_and_retries_trigger() {
+        // Arrange
+        let (mut app, base_dir) = crate::test_support::new_test_app().await;
+        let session_id = SessionId::from("retry-deferred-review");
+        let inactive_project_path = base_dir.path().join("inactive-project");
+        let inactive_project_id = app
+            .services
+            .db()
+            .projects()
+            .upsert_project(&inactive_project_path.to_string_lossy(), None)
+            .await
+            .expect("failed to insert inactive project");
+        app.services
+            .db()
+            .sessions()
+            .insert_session(
+                session_id.as_str(),
+                "gpt-5.6-sol",
+                "main",
+                "Review",
+                inactive_project_id,
+            )
+            .await
+            .expect("failed to insert inactive review session");
+        let (retry_tx, mut retry_rx) = tokio::sync::mpsc::unbounded_channel();
+        let retry_scheduled = App::handle_deferred_auto_review_persistence_result(
+            &mut app.deferred_auto_review_session_ids,
+            retry_tx,
+            DeferredAutoReviewPersistenceRetry::initial(session_id.clone()),
+            Err(DbError::Query(sqlx::Error::PoolClosed)),
+        );
+
+        // Act
+        let retry_event = tokio::time::timeout(std::time::Duration::from_secs(1), retry_rx.recv())
+            .await
+            .expect("timed out waiting for deferred review persistence retry")
+            .expect("deferred review persistence failure should requeue an event");
+        app.apply_app_events(retry_event).await;
+        let recoverable_session_ids = app
+            .services
+            .db()
+            .sessions()
+            .load_pending_focused_review_session_ids(inactive_project_id)
+            .await
+            .expect("failed to load retried deferred review");
+        app.services
+            .db()
+            .sessions()
+            .update_session_focused_review(session_id.as_str(), None, None, None)
+            .await
+            .expect("failed to clear retried deferred review");
+        app.deferred_auto_review_session_ids.remove(&session_id);
+        app.apply_app_events(crate::app::AppEvent::DeferredAutoReviewPersistenceRetry {
+            retry: DeferredAutoReviewPersistenceRetry {
+                attempt: 2,
+                session_id: session_id.clone(),
+            },
+        })
+        .await;
+        let stale_retry_session_ids = app
+            .services
+            .db()
+            .sessions()
+            .load_pending_focused_review_session_ids(inactive_project_id)
+            .await
+            .expect("failed to check stale deferred review retry");
+        let (exhausted_tx, mut exhausted_rx) = tokio::sync::mpsc::unbounded_channel();
+        let exhausted_retry_scheduled = App::handle_deferred_auto_review_persistence_result(
+            &mut app.deferred_auto_review_session_ids,
+            exhausted_tx,
+            DeferredAutoReviewPersistenceRetry {
+                attempt: MAX_DEFERRED_AUTO_REVIEW_PERSISTENCE_RETRIES,
+                session_id: session_id.clone(),
+            },
+            Err(DbError::Query(sqlx::Error::PoolClosed)),
+        );
+        let exhausted_event = exhausted_rx.recv().await;
+
+        // Assert
+        assert!(retry_scheduled);
+        assert!(!exhausted_retry_scheduled);
+        assert_eq!(exhausted_event, None);
+        assert!(app.deferred_auto_review_session_ids.contains(&session_id));
+        assert_eq!(recoverable_session_ids, [session_id.as_str()]);
+        assert!(stale_retry_session_ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn automatic_empty_review_diff_clears_durable_trigger() {
+        // Arrange
+        let (mut app, _base_dir, session_id) = review_app().await;
+        app.services
+            .db()
+            .sessions()
+            .update_session_status_with_timing_at(session_id.as_str(), "Review", 1)
+            .await
+            .expect("failed to persist review status");
+        assert!(
+            app.services
+                .db()
+                .sessions()
+                .defer_session_focused_review(session_id.as_str())
+                .await
+                .expect("failed to persist deferred review")
+        );
+        let project_id = app.projects.active_project_id();
+        let update = SessionDiffUpdate {
+            request_id: 1,
+            result: Ok(String::new()),
+            session_id: session_id.clone(),
+        };
+
+        // Act
+        app.apply_review_diff_update(update, None, false).await;
+
+        // Assert
+        assert!(
+            app.services
+                .db()
+                .sessions()
+                .load_pending_focused_review_session_ids(project_id)
+                .await
+                .expect("failed to load pending reviews")
+                .is_empty()
+        );
+        assert!(!app.review_cache.contains_key(&session_id));
+    }
+
+    #[tokio::test]
+    async fn deleting_session_discards_pending_review_diff_and_late_completion() {
+        // Arrange
+        let (mut app, _base_dir, session_id) = review_app().await;
+        let request_id = 42;
+        app.pending_session_diff_requests.insert(
+            request_id,
+            PendingSessionDiffRequest {
+                purpose: SessionDiffPurpose::Review {
+                    cached_diff_hash: None,
+                    is_manual: false,
+                },
+                session_id: session_id.clone(),
+            },
+        );
+        app.deferred_auto_review_session_ids
+            .insert(session_id.clone());
+
+        // Act
+        app.delete_selected_session().await;
+        app.apply_session_diff_update(SessionDiffUpdate {
+            request_id,
+            result: Ok("late diff".to_string()),
+            session_id: session_id.clone(),
+        })
+        .await;
+
+        // Assert
+        assert!(app.pending_session_diff_requests.is_empty());
+        assert!(!app.deferred_auto_review_session_ids.contains(&session_id));
+    }
+
+    #[tokio::test]
+    async fn deferred_cleanup_deletion_discards_pending_review_diff_state() {
+        // Arrange
+        let (mut app, _base_dir, session_id) = review_app().await;
+        app.pending_session_diff_requests.insert(
+            42,
+            PendingSessionDiffRequest {
+                purpose: SessionDiffPurpose::Review {
+                    cached_diff_hash: None,
+                    is_manual: false,
+                },
+                session_id: session_id.clone(),
+            },
+        );
+        app.deferred_auto_review_session_ids
+            .insert(session_id.clone());
+
+        // Act
+        app.delete_selected_session_deferred_cleanup().await;
+
+        // Assert
+        assert!(app.pending_session_diff_requests.is_empty());
+        assert!(!app.deferred_auto_review_session_ids.contains(&session_id));
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/task.rs
+++ b/crates/agentty/src/app/task.rs
@@ -19,6 +19,7 @@ use tracing::warn;
 
 use crate::app::error::AppError;
 use crate::app::review::FocusedReviewPersistenceRetry;
+use crate::app::session_diff::DeferredAutoReviewPersistenceRetry;
 use crate::app::{AppEvent, UpdateStatus, at_mention_task};
 use crate::domain::agent::{AgentCliInfo, AgentKind, AgentSelection, ReasoningLevel};
 use crate::domain::file_entry::FileEntry;
@@ -416,6 +417,20 @@ impl TaskService {
 
             // Fire-and-forget: receiver may be dropped during shutdown.
             let _ = app_event_tx.send(AppEvent::FocusedReviewPersistenceRetry { retry });
+        });
+    }
+
+    /// Requeues one failed automatic-review deferral write after a bounded
+    /// delay so transient database errors cannot drop the trigger.
+    pub(crate) fn spawn_deferred_auto_review_persistence_retry(
+        app_event_tx: mpsc::UnboundedSender<AppEvent>,
+        retry: DeferredAutoReviewPersistenceRetry,
+    ) {
+        tokio::spawn(async move {
+            tokio::time::sleep(Self::focused_review_persistence_retry_delay(retry.attempt)).await;
+
+            // Fire-and-forget: receiver may be dropped during shutdown.
+            let _ = app_event_tx.send(AppEvent::DeferredAutoReviewPersistenceRetry { retry });
         });
     }
 

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -2048,6 +2048,57 @@ const QUEUED_REVIEW_FOLLOW_UP_ANSWER: &str = "Queued review follow-up completed 
 /// run as detached one-shot commands alongside session turns, so they need a
 /// response that no scenario assertion looks for.
 const QUEUED_FIFO_UTILITY_ANSWER: &str = "Queued FIFO helper response";
+/// Focused-review result emitted after a turn completes in an inactive project.
+const DEFERRED_PROJECT_REVIEW_TEXT: &str = "Deferred project completion received focused review.";
+
+/// Installs a delayed session turn plus a distinct focused-review response so
+/// project-switching scenarios can prove the automatic review ran.
+fn install_deferred_project_review_claude_stub(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let claude_path = env.stub_bin.join("claude");
+    let script = format!(
+        r###"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
+prompt=$(cat)
+case "$prompt" in
+  *"Review the Git diff for display in a terminal UI."*)
+    result='{{\"answer\":\"## Review\\n\\n### Project Impact\\n\\n- {DEFERRED_PROJECT_REVIEW_TEXT}\\n\\n### Suggestions\\n\\n- None.\",\"questions\":[],\"summary\":null}}'
+    ;;
+  *"Generate a concise, commit-style title"*)
+    result='{{\"answer\":\"Cross-project focused review\",\"questions\":[],\"summary\":null}}'
+    ;;
+  *"Generate the canonical session commit message"*)
+    result='{{\"answer\":\"test: exercise cross-project review\",\"questions\":[],\"summary\":null}}'
+    ;;
+  *)
+    sleep 3
+    printf 'review me\n' > deferred-project-review.txt
+    result='{{\"answer\":\"Completed work while another project was active.\",\"questions\":[],\"summary\":null}}'
+    ;;
+esac
+printf '%s\n' '{{"type":"system","subtype":"init"}}'
+printf '%s\n' "{{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"$result\",\"usage\":{{\"input_tokens\":5,\"output_tokens\":9}}}}"
+"###,
+    );
+
+    std::fs::write(&claude_path, script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o755))?;
+
+    seed_project_settings(
+        env,
+        &[
+            ("DefaultSmartAgent", "claude"),
+            ("DefaultSmartModel", "claude-haiku-4-5-20251001"),
+            ("DefaultFastAgent", "claude"),
+            ("DefaultFastModel", "claude-haiku-4-5-20251001"),
+            ("DefaultReviewAgent", "claude"),
+            ("DefaultReviewModel", "claude-haiku-4-5-20251001"),
+        ],
+    )
+}
 
 /// Installs a delayed Claude turn so the scenario can queue sync while the
 /// worker is still active, optionally forcing its later validation to fail.
@@ -4397,6 +4448,53 @@ fn session_queued_action_survives_project_switching() -> E2eResult {
                 assertion::assert_text_in_region(frame, "[Sync] Successfully synced", &full);
                 assertion::assert_text_in_region(frame, "Enter: reply", &full);
                 assertion::assert_not_visible(frame, "≡ sync —");
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify a turn that finishes while another project is active starts and
+/// displays focused review after its owning project is restored.
+#[test]
+fn completed_session_review_survives_project_switching() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("completed_session_review_survives_project_switching")
+        .with_git()
+        .setup(|env| {
+            install_deferred_project_review_claude_stub(env)?;
+            common::seed_second_project(env)
+        })
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::create_session_with_prompt_and_return_to_list(
+                        "Finish while I view another project",
+                    ))
+                    .press_key("p")
+                    .wait_for_text("Switch project", 5000)
+                    .press_key("j")
+                    .press_key("Enter")
+                    .wait_for_text("Project: zeta-project", 5000)
+                    .sleep_ms(6000)
+                    .press_key("p")
+                    .wait_for_text("Switch project", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Project: test-project", 5000)
+                    .press_key("j")
+                    .press_key("Enter")
+                    .wait_for_text(DEFERRED_PROJECT_REVIEW_TEXT, 30000)
+                    .capture_labeled(
+                        "restored_review",
+                        "Focused review after inactive-project completion",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, DEFERRED_PROJECT_REVIEW_TEXT, &full);
+                assertion::assert_text_in_region(frame, "Suggestions", &full);
+                assertion::assert_not_visible(frame, "Reviewing changes with");
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -467,6 +467,17 @@ flowchart LR
    changes durable and loaded availability to unknown, since external edits can make a
    previously empty diff stale. A durable invalidation failure prevents the tmux window
    from opening, so restart cannot restore a stale empty state after external edits.
+   When a turn completes while another project is active, the foreground reducer
+   atomically marks the existing worker session's focused review as pending. A late
+   completion event for a deleted session therefore cannot recreate an orphaned trigger.
+   The same marker is written when the response arrives before the loaded session's
+   final `Review` transition. Transient write failures retain the in-memory trigger and
+   retry through the event reducer with bounded backoff. Startup and project switching
+   reload pending triggers for the active project after its session snapshots reload. A
+   diff preparation result that lands while its project is inactive persists and
+   requeues the same trigger, and an automatic review with no diff clears the durable
+   marker, so switching projects or restarting cannot drop or endlessly replay the
+   review.
 
 ### Operation Lifecycle and Recovery
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -302,18 +302,20 @@ trigger this automatic review. Press `f` to append the cached review into the se
 output, or to see a loading message while generation is still running. The appended
 review stays visible across diff mode, question mode, session switching, project
 switching, and background session metadata refreshes, and is cleared when you submit the
-next prompt. When both are visible, `Change Summary` appears before `Review`. Focused
-review includes the saved user and agent chat history for context. It uses inspection-
-only context: it may read files, search, inspect git history, and browse when needed,
-but it recommends verification commands instead of running checks itself. The review
-treats explicit decisions, accepted tradeoffs, and explanations in the chat as
-constraints, and only reopens a resolved suggestion when the current diff contradicts
-the resolution or inspection finds a new significant risk. `Project Impact` renders
-concise bullets directly beneath its heading. `Suggestions` uses the same compact
-spacing and formats its bullets as `[Severity]: Issue details`, using `[High]` or
-`[Medium]` when follow-up work is needed. Empty `Suggestions` output does not offer the
-`/apply` action. A turn stopped with `Ctrl+c` does not start a focused review
-automatically; press `f` for a manual one.
+next prompt. If a turn finishes while another project is active, returning to the
+session's project resumes its automatic focused review, including after Agentty
+restarts. Deleted sessions do not retain pending reviews. When both are visible,
+`Change Summary` appears before `Review`. Focused review includes the saved user and
+agent chat history for context. It uses inspection-only context: it may read files,
+search, inspect git history, and browse when needed, but it recommends verification
+commands instead of running checks itself. The review treats explicit decisions,
+accepted tradeoffs, and explanations in the chat as constraints, and only reopens a
+resolved suggestion when the current diff contradicts the resolution or inspection finds
+a new significant risk. `Project Impact` renders concise bullets directly beneath its
+heading. `Suggestions` uses the same compact spacing and formats its bullets as
+`[Severity]: Issue details`, using `[High]` or `[Medium]` when follow-up work is needed.
+Empty `Suggestions` output does not offer the `/apply` action. A turn stopped with
+`Ctrl+c` does not start a focused review automatically; press `f` for a manual one.
 
 ### Session Output Markdown
 


### PR DESCRIPTION
- Persist pending worker-session review triggers and recover them after restart or project reload.
- Retain triggers across transient persistence failures, stale diff completions, and in-progress status transitions while discarding deleted-session state.
- Cover cross-project completion, restart recovery, retry handling, and stale-result cleanup with unit and E2E tests.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)