### PR TITLE
Prevent partial and duplicate review-comment updates

### DIFF
--- a/crates/ag-store/.sqlx/query-7185cd769ad458776090a306a234a78dea9a287cf6bab353362d49f7656cafd4.json
+++ b/crates/ag-store/.sqlx/query-7185cd769ad458776090a306a234a78dea9a287cf6bab353362d49f7656cafd4.json
@@ -1,0 +1,98 @@
+{
+  "db_name": "SQLite",
+  "query": "\nSELECT is_posting AS \"is_posting: bool\",\n       commit_hash,\n       reply,\n       reply_token,\n       resolution,\n       review_request_display_id,\n       thread_id\nFROM session_review_comment_resolution\nWHERE session_id = ?\nORDER BY rowid\n",
+  "describe": {
+    "columns": [
+      {
+        "name": "is_posting: bool",
+        "ordinal": 0,
+        "type_info": "Integer",
+        "origin": {
+          "Table": {
+            "table": "session_review_comment_resolution",
+            "name": "is_posting"
+          }
+        }
+      },
+      {
+        "name": "commit_hash",
+        "ordinal": 1,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_review_comment_resolution",
+            "name": "commit_hash"
+          }
+        }
+      },
+      {
+        "name": "reply",
+        "ordinal": 2,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_review_comment_resolution",
+            "name": "reply"
+          }
+        }
+      },
+      {
+        "name": "reply_token",
+        "ordinal": 3,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_review_comment_resolution",
+            "name": "reply_token"
+          }
+        }
+      },
+      {
+        "name": "resolution",
+        "ordinal": 4,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_review_comment_resolution",
+            "name": "resolution"
+          }
+        }
+      },
+      {
+        "name": "review_request_display_id",
+        "ordinal": 5,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_review_comment_resolution",
+            "name": "review_request_display_id"
+          }
+        }
+      },
+      {
+        "name": "thread_id",
+        "ordinal": 6,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_review_comment_resolution",
+            "name": "thread_id"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7185cd769ad458776090a306a234a78dea9a287cf6bab353362d49f7656cafd4"
+}

--- a/crates/ag-store/.sqlx/query-74b5cb91bc0ed909315b1c8aaedf67b13d6127c194bbad8291ed557b0ada3806.json
+++ b/crates/ag-store/.sqlx/query-74b5cb91bc0ed909315b1c8aaedf67b13d6127c194bbad8291ed557b0ada3806.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\nUPDATE session_review_comment_resolution\nSET commit_hash = ?\nWHERE session_id = ?\n  AND reply_token = ?\n  AND commit_hash IS NULL\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "74b5cb91bc0ed909315b1c8aaedf67b13d6127c194bbad8291ed557b0ada3806"
+}

--- a/crates/ag-store/.sqlx/query-a776cc784009c4691a1bba70d063f76f90a1e10f0c71c2e1d6876dcec6d3aacb.json
+++ b/crates/ag-store/.sqlx/query-a776cc784009c4691a1bba70d063f76f90a1e10f0c71c2e1d6876dcec6d3aacb.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\nUPDATE session_review_comment_resolution\nSET is_posting = 1\nWHERE session_id = ?\n  AND reply_token = ?\n  AND is_posting = 0\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "a776cc784009c4691a1bba70d063f76f90a1e10f0c71c2e1d6876dcec6d3aacb"
+}

--- a/crates/ag-store/.sqlx/query-d58ed123f8d3906ed402f35d08c77e6b6bdfdb64845075708c7d5dc8dc8db66d.json
+++ b/crates/ag-store/.sqlx/query-d58ed123f8d3906ed402f35d08c77e6b6bdfdb64845075708c7d5dc8dc8db66d.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\nINSERT INTO session_review_comment_resolution (\n    session_id,\n    commit_hash,\n    review_request_display_id,\n    thread_id,\n    reply,\n    reply_token,\n    resolution\n)\nVALUES (?, ?, ?, ?, ?, ?, ?)\nON CONFLICT(session_id, review_request_display_id, thread_id)\nDO UPDATE SET\n    commit_hash = excluded.commit_hash,\n    reply = excluded.reply,\n    reply_token = excluded.reply_token,\n    resolution = excluded.resolution,\n    is_posting = 0\nWHERE session_review_comment_resolution.commit_hash IS NULL\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 7
+    },
+    "nullable": []
+  },
+  "hash": "d58ed123f8d3906ed402f35d08c77e6b6bdfdb64845075708c7d5dc8dc8db66d"
+}

--- a/crates/ag-store/.sqlx/query-f8287f5054bd59ee47da89101f125b869a5a67fa63b73d52d3f367ce379abdaa.json
+++ b/crates/ag-store/.sqlx/query-f8287f5054bd59ee47da89101f125b869a5a67fa63b73d52d3f367ce379abdaa.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\nDELETE FROM session_review_comment_resolution\nWHERE session_id = ?\n  AND reply_token = ?\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "f8287f5054bd59ee47da89101f125b869a5a67fa63b73d52d3f367ce379abdaa"
+}

--- a/crates/ag-store/migrations/076_create_session_review_comment_resolution.sql
+++ b/crates/ag-store/migrations/076_create_session_review_comment_resolution.sql
@@ -1,0 +1,11 @@
+CREATE TABLE session_review_comment_resolution (
+    session_id TEXT NOT NULL REFERENCES session(id) ON DELETE CASCADE,
+    commit_hash TEXT,
+    review_request_display_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    reply TEXT NOT NULL,
+    reply_token TEXT NOT NULL UNIQUE,
+    resolution TEXT NOT NULL CHECK (resolution IN ('fixed', 'no_change_needed')),
+    is_posting INTEGER NOT NULL DEFAULT 0 CHECK (is_posting IN (0, 1)),
+    PRIMARY KEY (session_id, review_request_display_id, thread_id)
+);

--- a/crates/ag-store/src/connection_test.rs
+++ b/crates/ag-store/src/connection_test.rs
@@ -8,8 +8,8 @@ use tempfile::tempdir;
 
 use super::*;
 use crate::{
-    PersistedSessionCreation, SessionFocusedReviewRow, SessionOperationRow, SessionRow,
-    SessionTurnMetadata,
+    NewSessionReviewCommentResolution, PersistedSessionCreation, SessionFocusedReviewRow,
+    SessionOperationRow, SessionRow, SessionTurnMetadata,
 };
 
 /// Builds one deterministic persisted review-request fixture for DB tests.
@@ -2730,6 +2730,7 @@ async fn test_load_projects_with_stats_returns_session_counts_tokens_and_last_up
                 model: AgentModel::Gpt56Sol.as_str().to_string(),
                 provider_conversation_id: None,
                 questions_json: "[]".to_string(),
+                review_comment_resolutions: Vec::new(),
                 summary: String::new(),
                 token_usage_delta: SessionStats {
                     added_lines: 0,
@@ -2758,6 +2759,7 @@ async fn test_load_projects_with_stats_returns_session_counts_tokens_and_last_up
                 model: AgentModel::Gpt56Sol.as_str().to_string(),
                 provider_conversation_id: None,
                 questions_json: "[]".to_string(),
+                review_comment_resolutions: Vec::new(),
                 summary: String::new(),
                 token_usage_delta: SessionStats {
                     added_lines: 0,
@@ -3085,6 +3087,7 @@ async fn test_persist_session_turn_metadata_rolls_back_on_failure() {
                 model: AgentModel::Gpt56Sol.as_str().to_string(),
                 provider_conversation_id: Some("thread-123".to_string()),
                 questions_json: r#"[{"text":"Need tests?"}]"#.to_string(),
+                review_comment_resolutions: Vec::new(),
                 summary: r#"{"turn":"Updated the worker.","session":"Session state changed."}"#
                     .to_string(),
                 token_usage_delta: SessionStats {
@@ -3118,6 +3121,107 @@ async fn test_persist_session_turn_metadata_rolls_back_on_failure() {
     assert_eq!(session.input_tokens, 0);
     assert_eq!(session.output_tokens, 0);
     assert_eq!(provider_conversation_id.as_deref(), None);
+}
+
+#[tokio::test]
+/// Verifies a failed review-operation insert cannot leave a completed turn
+/// behind after the database is reopened.
+async fn test_persist_session_turn_metadata_and_review_operation_are_restart_atomic() {
+    // Arrange
+    let temp_dir = tempdir().expect("failed to create temp directory");
+    let db_path = temp_dir.path().join("agentty.db");
+    let database = Database::open(&db_path)
+        .await
+        .expect("failed to open database");
+    let project_id = database
+        .projects()
+        .upsert_project("/tmp/project", Some("main".to_string()))
+        .await
+        .expect("failed to insert project");
+    database
+        .sessions()
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Review", project_id)
+        .await
+        .expect("failed to insert session");
+    let turn_metadata = |resolution: &str| SessionTurnMetadata {
+        applied_personality_id: None,
+        applied_personality_prompt_hash: None,
+        instruction_conversation_id: None,
+        model: AgentModel::Gpt56Sol.as_str().to_string(),
+        provider_conversation_id: Some("thread-123".to_string()),
+        questions_json: r#"[{"text":"Need tests?"}]"#.to_string(),
+        review_comment_resolutions: vec![NewSessionReviewCommentResolution {
+            commit_hash: None,
+            reply: "Applied the validation.".to_string(),
+            reply_token: "token-1".to_string(),
+            resolution: resolution.to_string(),
+            review_request_display_id: "#42".to_string(),
+            thread_id: "thread-1".to_string(),
+        }],
+        summary: "Completed turn".to_string(),
+        token_usage_delta: SessionStats::default(),
+    };
+
+    // Act
+    let result = database
+        .sessions()
+        .persist_session_turn_metadata("session-a", &turn_metadata("invalid"))
+        .await;
+    database.pool().close().await;
+    let database = Database::open(&db_path)
+        .await
+        .expect("failed to reopen database");
+    let session = load_session_row(&database, "session-a").await;
+    let operations = database
+        .reviews()
+        .load_session_review_comment_resolutions("session-a")
+        .await
+        .expect("failed to load review operations");
+    let provider_conversation_id = database
+        .sessions()
+        .get_session_provider_conversation_id("session-a")
+        .await
+        .expect("failed to load provider conversation id");
+
+    // Assert
+    assert!(matches!(result, Err(DbError::Query(_))));
+    assert_eq!(session.summary, None);
+    assert_eq!(session.questions, None);
+    assert_eq!(provider_conversation_id, None);
+    assert_eq!(operations, Vec::new());
+
+    // Act
+    database
+        .sessions()
+        .persist_session_turn_metadata("session-a", &turn_metadata("fixed"))
+        .await
+        .expect("failed to persist completed turn and review operation");
+    database.pool().close().await;
+    let database = Database::open(&db_path)
+        .await
+        .expect("failed to reopen database after retry");
+    let session = load_session_row(&database, "session-a").await;
+    let operations = database
+        .reviews()
+        .load_session_review_comment_resolutions("session-a")
+        .await
+        .expect("failed to load persisted review operations");
+    let provider_conversation_id = database
+        .sessions()
+        .get_session_provider_conversation_id("session-a")
+        .await
+        .expect("failed to load provider conversation id");
+
+    // Assert
+    assert_eq!(session.summary.as_deref(), Some("Completed turn"));
+    assert_eq!(
+        session.questions.as_deref(),
+        Some(r#"[{"text":"Need tests?"}]"#)
+    );
+    assert_eq!(provider_conversation_id.as_deref(), Some("thread-123"));
+    assert_eq!(operations.len(), 1);
+    assert_eq!(operations[0].reply, "Applied the validation.");
+    assert_eq!(operations[0].resolution, "fixed");
 }
 
 #[tokio::test]

--- a/crates/ag-store/src/lib.rs
+++ b/crates/ag-store/src/lib.rs
@@ -34,7 +34,10 @@ pub(crate) use project::SqliteProjectRepository;
 pub use project::{ProjectListRow, ProjectRepository, ProjectRow};
 pub use repository::AppRepositories;
 pub(crate) use review::SqliteReviewRepository;
-pub use review::{ReviewRepository, SessionReviewRequestRow};
+pub use review::{
+    NewSessionReviewCommentResolution, ReviewRepository, SessionReviewCommentResolutionRow,
+    SessionReviewRequestRow,
+};
 pub(crate) use session::SqliteSessionRepository;
 pub use session::{
     ForkSessionSnapshot, PersistedSessionCreation, SessionAgentModelRow, SessionDetailRow,

--- a/crates/ag-store/src/repository.rs
+++ b/crates/ag-store/src/repository.rs
@@ -326,6 +326,7 @@ WHERE session_orchestration.id = ?
             model: "gpt-5.6-sol".to_string(),
             provider_conversation_id: Some("conversation-a".to_string()),
             questions_json: "[]".to_string(),
+            review_comment_resolutions: Vec::new(),
             summary: "Persisted summary".to_string(),
             token_usage_delta: SessionStats {
                 added_lines: 0,

--- a/crates/ag-store/src/review.rs
+++ b/crates/ag-store/src/review.rs
@@ -2,9 +2,45 @@
 
 use ag_session::ReviewRequest;
 use async_trait::async_trait;
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 
 use crate::DbError;
+
+/// Durable input for one review-comment resolution operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NewSessionReviewCommentResolution {
+    /// Full commit hash containing the reported fix, once auto-commit succeeds.
+    pub commit_hash: Option<String>,
+    /// Original agent-authored reply retained across retries.
+    pub reply: String,
+    /// Unguessable token embedded in the posted reply.
+    pub reply_token: String,
+    /// Persisted normalized resolution decision.
+    pub resolution: String,
+    /// Forge-native review-request identifier such as `#123` or `!123`.
+    pub review_request_display_id: String,
+    /// Forge-native review-thread identifier.
+    pub thread_id: String,
+}
+
+/// Row returned for one unfinished review-comment resolution operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SessionReviewCommentResolutionRow {
+    /// Full commit hash that must remain reachable from the pushed branch.
+    pub commit_hash: Option<String>,
+    /// Whether a forge reply attempt may already have exposed the token.
+    pub is_posting: bool,
+    /// Original agent-authored reply retained across retries.
+    pub reply: String,
+    /// Unguessable token embedded in the posted reply.
+    pub reply_token: String,
+    /// Persisted normalized resolution decision.
+    pub resolution: String,
+    /// Forge-native review-request identifier such as `#123` or `!123`.
+    pub review_request_display_id: String,
+    /// Forge-native review-thread identifier.
+    pub thread_id: String,
+}
 
 /// Row returned when loading one `session_review_request`.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -33,6 +69,37 @@ pub struct SessionReviewRequestRow {
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait ReviewRepository: Send + Sync {
+    /// Binds newly inserted operations to the commit produced for their turn.
+    async fn bind_session_review_comment_resolutions_to_commit(
+        &self,
+        id: &str,
+        resolutions: &[NewSessionReviewCommentResolution],
+        commit_hash: &str,
+    ) -> Result<(), DbError>;
+
+    /// Discards unfinished operations created with the supplied reply tokens.
+    async fn discard_session_review_comment_resolutions(
+        &self,
+        id: &str,
+        resolutions: &[NewSessionReviewCommentResolution],
+    ) -> Result<(), DbError>;
+
+    /// Inserts one atomic set of review-comment resolution operations.
+    ///
+    /// A bound operation for the same thread wins. A fresh agent turn may
+    /// replace an unbound operation left by interrupted commit binding.
+    async fn insert_session_review_comment_resolutions(
+        &self,
+        id: &str,
+        resolutions: &[NewSessionReviewCommentResolution],
+    ) -> Result<(), DbError>;
+
+    /// Loads unfinished review-comment resolution operations for a session.
+    async fn load_session_review_comment_resolutions(
+        &self,
+        id: &str,
+    ) -> Result<Vec<SessionReviewCommentResolutionRow>, DbError>;
+
     /// Loads the persisted forge review-request linkage for a session.
     async fn load_session_review_request(
         &self,
@@ -44,6 +111,20 @@ pub trait ReviewRepository: Send + Sync {
         &self,
         id: &str,
         review_request: Option<ReviewRequest>,
+    ) -> Result<(), DbError>;
+
+    /// Records that one operation is about to attempt its forge reply.
+    async fn mark_session_review_comment_resolution_posting(
+        &self,
+        id: &str,
+        reply_token: &str,
+    ) -> Result<(), DbError>;
+
+    /// Removes one operation after its requested forge effects finish.
+    async fn remove_session_review_comment_resolution(
+        &self,
+        id: &str,
+        reply_token: &str,
     ) -> Result<(), DbError>;
 }
 
@@ -58,8 +139,141 @@ impl SqliteReviewRepository {
     }
 }
 
+/// Inserts review-comment resolutions through the caller's transaction.
+pub(crate) async fn insert_review_comment_resolutions(
+    connection: &mut SqliteConnection,
+    session_id: &str,
+    resolutions: &[NewSessionReviewCommentResolution],
+) -> Result<(), DbError> {
+    for resolution in resolutions {
+        sqlx::query!(
+            r"
+INSERT INTO session_review_comment_resolution (
+    session_id,
+    commit_hash,
+    review_request_display_id,
+    thread_id,
+    reply,
+    reply_token,
+    resolution
+)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(session_id, review_request_display_id, thread_id)
+DO UPDATE SET
+    commit_hash = excluded.commit_hash,
+    reply = excluded.reply,
+    reply_token = excluded.reply_token,
+    resolution = excluded.resolution,
+    is_posting = 0
+WHERE session_review_comment_resolution.commit_hash IS NULL
+",
+            session_id,
+            resolution.commit_hash,
+            resolution.review_request_display_id,
+            resolution.thread_id,
+            resolution.reply,
+            resolution.reply_token,
+            resolution.resolution
+        )
+        .execute(&mut *connection)
+        .await?;
+    }
+
+    Ok(())
+}
+
 #[async_trait]
 impl ReviewRepository for SqliteReviewRepository {
+    async fn bind_session_review_comment_resolutions_to_commit(
+        &self,
+        id: &str,
+        resolutions: &[NewSessionReviewCommentResolution],
+        commit_hash: &str,
+    ) -> Result<(), DbError> {
+        let mut transaction = self.0.begin().await?;
+        for resolution in resolutions {
+            sqlx::query!(
+                r"
+UPDATE session_review_comment_resolution
+SET commit_hash = ?
+WHERE session_id = ?
+  AND reply_token = ?
+  AND commit_hash IS NULL
+",
+                commit_hash,
+                id,
+                resolution.reply_token
+            )
+            .execute(&mut *transaction)
+            .await?;
+        }
+        transaction.commit().await?;
+
+        Ok(())
+    }
+
+    async fn discard_session_review_comment_resolutions(
+        &self,
+        id: &str,
+        resolutions: &[NewSessionReviewCommentResolution],
+    ) -> Result<(), DbError> {
+        let mut transaction = self.0.begin().await?;
+        for resolution in resolutions {
+            sqlx::query!(
+                r"
+DELETE FROM session_review_comment_resolution
+WHERE session_id = ?
+  AND reply_token = ?
+",
+                id,
+                resolution.reply_token
+            )
+            .execute(&mut *transaction)
+            .await?;
+        }
+        transaction.commit().await?;
+
+        Ok(())
+    }
+
+    async fn insert_session_review_comment_resolutions(
+        &self,
+        id: &str,
+        resolutions: &[NewSessionReviewCommentResolution],
+    ) -> Result<(), DbError> {
+        let mut transaction = self.0.begin().await?;
+        insert_review_comment_resolutions(&mut transaction, id, resolutions).await?;
+        transaction.commit().await?;
+
+        Ok(())
+    }
+
+    async fn load_session_review_comment_resolutions(
+        &self,
+        id: &str,
+    ) -> Result<Vec<SessionReviewCommentResolutionRow>, DbError> {
+        let resolutions = sqlx::query_as!(
+            SessionReviewCommentResolutionRow,
+            r#"
+SELECT is_posting AS "is_posting: bool",
+       commit_hash,
+       reply,
+       reply_token,
+       resolution,
+       review_request_display_id,
+       thread_id
+FROM session_review_comment_resolution
+WHERE session_id = ?
+ORDER BY rowid
+"#,
+            id
+        )
+        .fetch_all(&self.0)
+        .await?;
+
+        Ok(resolutions)
+    }
+
     async fn load_session_review_request(
         &self,
         id: &str,
@@ -145,5 +359,311 @@ WHERE session_id = ?
         }
 
         Ok(())
+    }
+
+    async fn mark_session_review_comment_resolution_posting(
+        &self,
+        id: &str,
+        reply_token: &str,
+    ) -> Result<(), DbError> {
+        let update_result = sqlx::query!(
+            r"
+UPDATE session_review_comment_resolution
+SET is_posting = 1
+WHERE session_id = ?
+  AND reply_token = ?
+  AND is_posting = 0
+",
+            id,
+            reply_token
+        )
+        .execute(&self.0)
+        .await?;
+        if update_result.rows_affected() != 1 {
+            return Err(DbError::InvalidData {
+                entity: "review-comment operation",
+                reason: format!("posting update matched no pending row for token `{reply_token}`"),
+            });
+        }
+
+        Ok(())
+    }
+
+    async fn remove_session_review_comment_resolution(
+        &self,
+        id: &str,
+        reply_token: &str,
+    ) -> Result<(), DbError> {
+        let delete_result = sqlx::query!(
+            r"
+DELETE FROM session_review_comment_resolution
+WHERE session_id = ?
+  AND reply_token = ?
+",
+            id,
+            reply_token
+        )
+        .execute(&self.0)
+        .await?;
+        if delete_result.rows_affected() != 1 {
+            return Err(DbError::InvalidData {
+                entity: "review-comment operation",
+                reason: format!("delete matched no row for token `{reply_token}`"),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AppRepositories;
+
+    #[tokio::test]
+    async fn active_review_comment_operation_preserves_original_reply_across_retries() {
+        // Arrange
+        let repositories = AppRepositories::in_memory()
+            .await
+            .expect("failed to open in-memory repositories");
+        let project_id = repositories
+            .projects()
+            .upsert_project("/tmp/project", Some("main".to_string()))
+            .await
+            .expect("failed to insert project");
+        repositories
+            .sessions()
+            .insert_session("session-id", "codex", "main", "Review", project_id)
+            .await
+            .expect("failed to insert session");
+        let original = review_comment_resolution("Original reply", "token-1");
+        let regenerated = review_comment_resolution("Regenerated reply", "token-2");
+        repositories
+            .reviews()
+            .insert_session_review_comment_resolutions(
+                "session-id",
+                std::slice::from_ref(&original),
+            )
+            .await
+            .expect("failed to insert original operation");
+        repositories
+            .reviews()
+            .bind_session_review_comment_resolutions_to_commit(
+                "session-id",
+                std::slice::from_ref(&original),
+                "commit-original",
+            )
+            .await
+            .expect("failed to bind original operation");
+
+        // Act
+        repositories
+            .reviews()
+            .insert_session_review_comment_resolutions(
+                "session-id",
+                std::slice::from_ref(&regenerated),
+            )
+            .await
+            .expect("failed to ignore regenerated operation");
+        repositories
+            .reviews()
+            .bind_session_review_comment_resolutions_to_commit(
+                "session-id",
+                std::slice::from_ref(&regenerated),
+                "commit-regenerated",
+            )
+            .await
+            .expect("failed to ignore regenerated binding");
+        let active = repositories
+            .reviews()
+            .load_session_review_comment_resolutions("session-id")
+            .await
+            .expect("failed to load active operation");
+        repositories
+            .reviews()
+            .mark_session_review_comment_resolution_posting("session-id", "token-1")
+            .await
+            .expect("failed to mark original operation as posting");
+        let posting = repositories
+            .reviews()
+            .load_session_review_comment_resolutions("session-id")
+            .await
+            .expect("failed to reload posting operation");
+        repositories
+            .reviews()
+            .remove_session_review_comment_resolution("session-id", "token-1")
+            .await
+            .expect("failed to remove original operation");
+        repositories
+            .reviews()
+            .insert_session_review_comment_resolutions("session-id", &[regenerated])
+            .await
+            .expect("failed to insert later operation");
+        let replacement = repositories
+            .reviews()
+            .load_session_review_comment_resolutions("session-id")
+            .await
+            .expect("failed to load replacement operation");
+        let missing_update_error = repositories
+            .reviews()
+            .mark_session_review_comment_resolution_posting("session-id", "missing-token")
+            .await
+            .expect_err("missing operation should reject state update");
+        let missing_delete_error = repositories
+            .reviews()
+            .remove_session_review_comment_resolution("session-id", "missing-token")
+            .await
+            .expect_err("missing operation should reject deletion");
+
+        // Assert
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].reply, "Original reply");
+        assert_eq!(active[0].reply_token, "token-1");
+        assert_eq!(active[0].commit_hash.as_deref(), Some("commit-original"));
+        assert!(!active[0].is_posting);
+        assert!(posting[0].is_posting);
+        assert_eq!(replacement.len(), 1);
+        assert_eq!(replacement[0].reply, "Regenerated reply");
+        assert!(matches!(missing_update_error, DbError::InvalidData { .. }));
+        assert!(matches!(missing_delete_error, DbError::InvalidData { .. }));
+    }
+
+    #[tokio::test]
+    async fn discard_failed_retry_preserves_older_conflicting_operation() {
+        // Arrange
+        let repositories = AppRepositories::in_memory()
+            .await
+            .expect("failed to open in-memory repositories");
+        let project_id = repositories
+            .projects()
+            .upsert_project("/tmp/project", Some("main".to_string()))
+            .await
+            .expect("failed to insert project");
+        repositories
+            .sessions()
+            .insert_session("session-id", "codex", "main", "Review", project_id)
+            .await
+            .expect("failed to insert session");
+        let original = review_comment_resolution("Original reply", "token-original");
+        let regenerated = review_comment_resolution("Regenerated reply", "token-regenerated");
+        let mut unrelated = review_comment_resolution("Unrelated reply", "token-unrelated");
+        unrelated.thread_id = "thread-2".to_string();
+        let mut inserted = review_comment_resolution("Inserted reply", "token-inserted");
+        inserted.thread_id = "thread-3".to_string();
+        repositories
+            .reviews()
+            .insert_session_review_comment_resolutions(
+                "session-id",
+                &[original.clone(), unrelated.clone()],
+            )
+            .await
+            .expect("failed to insert review operations");
+        repositories
+            .reviews()
+            .bind_session_review_comment_resolutions_to_commit(
+                "session-id",
+                std::slice::from_ref(&original),
+                "commit-original",
+            )
+            .await
+            .expect("failed to bind original operation");
+        repositories
+            .reviews()
+            .insert_session_review_comment_resolutions(
+                "session-id",
+                &[regenerated.clone(), inserted.clone()],
+            )
+            .await
+            .expect("failed to insert later review operations");
+
+        // Act
+        repositories
+            .reviews()
+            .discard_session_review_comment_resolutions("session-id", &[regenerated, inserted])
+            .await
+            .expect("failed to discard newly inserted review operations");
+        let remaining = repositories
+            .reviews()
+            .load_session_review_comment_resolutions("session-id")
+            .await
+            .expect("failed to load remaining review operations");
+
+        // Assert
+        assert_eq!(remaining.len(), 2);
+        assert_eq!(remaining[0].reply_token, original.reply_token);
+        assert_eq!(remaining[0].reply, original.reply);
+        assert_eq!(remaining[1].reply_token, unrelated.reply_token);
+        assert_eq!(remaining[1].reply, unrelated.reply);
+    }
+
+    #[tokio::test]
+    async fn fresh_retry_replaces_unbound_operation() {
+        // Arrange
+        let repositories = AppRepositories::in_memory()
+            .await
+            .expect("failed to open in-memory repositories");
+        let project_id = repositories
+            .projects()
+            .upsert_project("/tmp/project", Some("main".to_string()))
+            .await
+            .expect("failed to insert project");
+        repositories
+            .sessions()
+            .insert_session("session-id", "codex", "main", "Review", project_id)
+            .await
+            .expect("failed to insert session");
+        let original = review_comment_resolution("Original reply", "token-original");
+        let regenerated = review_comment_resolution("Regenerated reply", "token-regenerated");
+        repositories
+            .reviews()
+            .insert_session_review_comment_resolutions("session-id", &[original])
+            .await
+            .expect("failed to insert unbound operation");
+
+        // Act
+        repositories
+            .reviews()
+            .insert_session_review_comment_resolutions(
+                "session-id",
+                std::slice::from_ref(&regenerated),
+            )
+            .await
+            .expect("failed to replace unbound operation");
+        repositories
+            .reviews()
+            .bind_session_review_comment_resolutions_to_commit(
+                "session-id",
+                std::slice::from_ref(&regenerated),
+                "commit-regenerated",
+            )
+            .await
+            .expect("failed to bind replacement operation");
+        let active = repositories
+            .reviews()
+            .load_session_review_comment_resolutions("session-id")
+            .await
+            .expect("failed to load replacement operation");
+
+        // Assert
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].reply, "Regenerated reply");
+        assert_eq!(active[0].reply_token, "token-regenerated");
+        assert_eq!(active[0].commit_hash.as_deref(), Some("commit-regenerated"));
+        assert!(!active[0].is_posting);
+    }
+
+    fn review_comment_resolution(
+        reply: &str,
+        reply_token: &str,
+    ) -> NewSessionReviewCommentResolution {
+        NewSessionReviewCommentResolution {
+            commit_hash: None,
+            reply: reply.to_string(),
+            reply_token: reply_token.to_string(),
+            resolution: "fixed".to_string(),
+            review_request_display_id: "#42".to_string(),
+            thread_id: "thread-1".to_string(),
+        }
     }
 }

--- a/crates/ag-store/src/session.rs
+++ b/crates/ag-store/src/session.rs
@@ -10,7 +10,9 @@ use async_trait::async_trait;
 use sqlx::SqlitePool;
 use tracing::warn;
 
-use super::review::SessionReviewRequestRow;
+use super::review::{
+    NewSessionReviewCommentResolution, SessionReviewRequestRow, insert_review_comment_resolutions,
+};
 use super::session_message::SessionMessageStore;
 use super::session_snapshot::SessionSnapshotStore;
 use super::status;
@@ -41,6 +43,8 @@ pub struct SessionTurnMetadata {
     pub provider_conversation_id: Option<String>,
     /// Serialized clarification-question payload stored on the session row.
     pub questions_json: String,
+    /// Review-comment operations committed with this completed turn.
+    pub review_comment_resolutions: Vec<NewSessionReviewCommentResolution>,
     /// Serialized structured summary payload stored on the session row.
     pub summary: String,
     /// Token-usage delta attributed to the completed turn.
@@ -2012,6 +2016,13 @@ ON CONFLICT(session_id, model) DO UPDATE SET
             .await?;
         }
 
+        insert_review_comment_resolutions(
+            &mut transaction,
+            session_id,
+            &turn_metadata.review_comment_resolutions,
+        )
+        .await?;
+
         transaction.commit().await?;
 
         Ok(())
@@ -3075,6 +3086,7 @@ WHERE id = ?
                     model: "gpt-5.6-sol".to_string(),
                     provider_conversation_id: None,
                     questions_json: "[]".to_string(),
+                    review_comment_resolutions: Vec::new(),
                     summary: String::new(),
                     token_usage_delta: SessionStats::default(),
                 },

--- a/crates/agentty/src/app/session/workflow/merge.rs
+++ b/crates/agentty/src/app/session/workflow/merge.rs
@@ -2294,7 +2294,7 @@ impl SessionManager {
             folder,
             git_client,
             published_upstream_ref,
-            review_comment_resolution: None,
+            review_request_client: Arc::clone(review_request_client),
             review_request_metadata_sync,
             session_id,
             session_update_versions: session_update_versions.clone(),

--- a/crates/agentty/src/app/session/workflow/post_turn.rs
+++ b/crates/agentty/src/app/session/workflow/post_turn.rs
@@ -8,12 +8,13 @@ use ag_agent as agent;
 use ag_agent::{AgentError, OneShotClient, TurnResult};
 use ag_forge as forge;
 use ag_git::GitClient;
-use ag_protocol::{AgentResponse, ReviewCommentOutcome};
+use ag_protocol::{AgentResponse, ReviewCommentOutcome, ReviewCommentResolution};
 use serde_json;
 use tokio::sync::mpsc;
 use tracing::warn;
+use uuid::Uuid;
 
-use super::task::SessionTranscriptMessageAppend;
+use super::task::{AutoCommitOutcome, SessionTranscriptMessageAppend};
 use super::worker::{SessionWorkerContext, TurnMetadata, has_unfinished_branch_operation};
 use super::{SessionTaskService, StatusTransition, published_branch, turn};
 use crate::app::assist::AssistContext;
@@ -25,7 +26,7 @@ use crate::domain::session::{
 };
 use crate::domain::session_message::{SessionMessageKind, SessionTranscript};
 use crate::domain::transcript_notice::TranscriptNotice;
-use crate::infra::db::{AppRepositories, SessionTurnMetadata};
+use crate::infra::db::{AppRepositories, NewSessionReviewCommentResolution, SessionTurnMetadata};
 use crate::infra::fs::FsClient;
 
 /// Personality state persisted after one successful main session turn.
@@ -177,6 +178,7 @@ impl TurnFinalizerContext {
 struct TurnPersistence<'a> {
     context: &'a PostTurnContext,
     personality: TurnPersonalityPersistence,
+    review_comment_resolutions: &'a [NewSessionReviewCommentResolution],
     session_agent: crate::domain::agent::AgentSelection,
 }
 
@@ -227,6 +229,7 @@ impl TurnPersistence<'_> {
                     model: session_model.as_str().to_string(),
                     provider_conversation_id: provider_conversation_id.map(str::to_string),
                     questions_json,
+                    review_comment_resolutions: self.review_comment_resolutions.to_vec(),
                     summary: summary.clone(),
                     token_usage_delta: token_usage_delta.clone(),
                 },
@@ -484,9 +487,16 @@ async fn apply_successful_turn_result(
         )
         .await;
     }
+    let review_comment_resolutions = prepare_review_comment_resolutions(
+        context,
+        &turn_metadata.review_comment_thread_ids,
+        &assistant_message.review_comment_outcomes,
+    )
+    .await?;
     let turn_applied_state = match (TurnPersistence {
         context,
         personality,
+        review_comment_resolutions: &review_comment_resolutions,
         session_agent: turn_metadata.session_agent,
     }
     .apply(
@@ -509,45 +519,33 @@ async fn apply_successful_turn_result(
     } else {
         Status::Question
     };
-    let review_comment_outcomes = valid_review_comment_outcomes(
-        &turn_metadata.review_comment_thread_ids,
-        &assistant_message.review_comment_outcomes,
-    );
     // Fire-and-forget: receiver may be dropped during shutdown.
     let _ = context.app_event_tx.send(AppEvent::AgentResponseReceived {
         session_id: context.session_id.clone(),
         turn_applied_state,
     });
     let owns_branch_changes = session_owns_branch_changes(&context.db, &context.session_id).await;
-    let commit_outcome = if owns_branch_changes {
-        SessionTaskService::handle_auto_commit(AssistContext {
-            app_event_tx: context.app_event_tx.clone(),
-            child_pid: Arc::clone(&context.child_pid),
-            db: context.db.clone(),
-            folder: context.folder.clone(),
-            git_client: Arc::clone(&context.git_client),
-            id: context.session_id.to_string(),
-            one_shot_client: Arc::clone(&context.one_shot_client),
-            session_agent: turn_metadata.session_agent,
-            session_update_versions: context.session_update_versions.clone(),
-            transcript: Arc::clone(&context.transcript),
-        })
-        .await
+    let (can_auto_push, review_request_commit_message) = if owns_branch_changes {
+        run_auto_commit(
+            context,
+            turn_metadata.session_agent,
+            !turn_metadata.review_comment_thread_ids.is_empty(),
+            &review_comment_resolutions,
+        )
+        .await?
     } else {
-        None
+        (true, None)
     };
-    let review_request_commit_message = commit_outcome.map(|outcome| outcome.commit_message);
     let review_request_session_summary = assistant_message
         .summary
         .as_ref()
         .map(|summary| summary.session.clone());
-    if owns_branch_changes {
+    if owns_branch_changes && can_auto_push {
         start_published_branch_auto_push(
             context,
             turn_metadata,
             review_request_commit_message,
             review_request_session_summary,
-            review_comment_outcomes,
         )
         .await;
     }
@@ -562,35 +560,255 @@ async fn apply_successful_turn_result(
     Ok(target_status)
 }
 
+/// Builds durable operations for accepted review-comment outcomes.
+async fn prepare_review_comment_resolutions(
+    context: &PostTurnContext,
+    allowed_thread_ids: &[String],
+    outcomes: &[ReviewCommentOutcome],
+) -> Result<Vec<NewSessionReviewCommentResolution>, SessionError> {
+    let validation = validate_review_comment_outcomes(allowed_thread_ids, outcomes);
+    if !validation.is_complete {
+        append_incomplete_review_comment_outcomes_notice(
+            context,
+            validation.accepted_count,
+            validation.expected_count,
+        )
+        .await;
+    }
+    if validation.outcomes.is_empty() {
+        return Ok(Vec::new());
+    }
+    let review_request = match context
+        .db
+        .reviews()
+        .load_session_review_request(&context.session_id)
+        .await
+    {
+        Ok(Some(review_request)) => review_request,
+        Ok(None) => {
+            let error = SessionError::Workflow(
+                "the session no longer has a linked review request".to_string(),
+            );
+            append_review_comment_persistence_failure_notice(context, &error.to_string()).await;
+
+            return Err(error);
+        }
+        Err(error) => {
+            append_review_comment_persistence_failure_notice(context, &error.to_string()).await;
+
+            return Err(error.into());
+        }
+    };
+
+    Ok(validation
+        .outcomes
+        .iter()
+        .map(|outcome| NewSessionReviewCommentResolution {
+            commit_hash: None,
+            reply: outcome.reply.clone(),
+            reply_token: Uuid::new_v4().to_string(),
+            resolution: match outcome.resolution {
+                ReviewCommentResolution::Fixed => "fixed",
+                ReviewCommentResolution::NoChangeNeeded => "no_change_needed",
+            }
+            .to_string(),
+            review_request_display_id: review_request.display_id.clone(),
+            thread_id: outcome.thread_id.clone(),
+        })
+        .collect())
+}
+
+/// Reports that accepted outcomes could not be made durable and therefore
+/// cannot safely drive forge mutations.
+async fn append_review_comment_persistence_failure_notice(context: &PostTurnContext, error: &str) {
+    let message = TranscriptNotice::ReviewCommentsWarning.format(format!(
+        "Could not save the review-comment operation, so this response will not post replies or \
+         resolve threads: {error}"
+    ));
+    SessionTaskService::append_workflow_notice(
+        &context.transcript,
+        &context.db,
+        &context.app_event_tx,
+        &context.session_update_versions,
+        &context.session_id,
+        &message,
+    )
+    .await;
+}
+
 async fn session_owns_branch_changes(db: &AppRepositories, session_id: &str) -> bool {
     turn::load_session_role(db, session_id)
         .await
         .owns_branch_changes()
 }
 
-/// Returns deduplicated outcomes whose thread identifiers were explicitly
-/// allowlisted for this turn and whose replies are nonblank.
-fn valid_review_comment_outcomes(
+/// Runs the automatic commit and returns whether post-commit branch effects
+/// may continue plus the optional generated commit message.
+async fn run_auto_commit(
+    context: &PostTurnContext,
+    session_agent: crate::domain::agent::AgentSelection,
+    has_review_comment_targets: bool,
+    review_comment_resolutions: &[NewSessionReviewCommentResolution],
+) -> Result<(bool, Option<String>), SessionError> {
+    let outcome = SessionTaskService::handle_auto_commit(AssistContext {
+        app_event_tx: context.app_event_tx.clone(),
+        child_pid: Arc::clone(&context.child_pid),
+        db: context.db.clone(),
+        folder: context.folder.clone(),
+        git_client: Arc::clone(&context.git_client),
+        id: context.session_id.to_string(),
+        one_shot_client: Arc::clone(&context.one_shot_client),
+        session_agent,
+        session_update_versions: context.session_update_versions.clone(),
+        transcript: Arc::clone(&context.transcript),
+    })
+    .await;
+
+    match outcome {
+        AutoCommitOutcome::Committed(outcome) => {
+            if !review_comment_resolutions.is_empty() {
+                let commit_hash = context.git_client.head_hash(context.folder.clone()).await?;
+                context
+                    .db
+                    .reviews()
+                    .bind_session_review_comment_resolutions_to_commit(
+                        &context.session_id,
+                        review_comment_resolutions,
+                        &commit_hash,
+                    )
+                    .await?;
+            }
+
+            Ok((true, Some(outcome.commit_message)))
+        }
+        AutoCommitOutcome::NoChanges => {
+            if !review_comment_resolutions.is_empty() {
+                let commit_hash = context.git_client.head_hash(context.folder.clone()).await?;
+                context
+                    .db
+                    .reviews()
+                    .bind_session_review_comment_resolutions_to_commit(
+                        &context.session_id,
+                        review_comment_resolutions,
+                        &commit_hash,
+                    )
+                    .await?;
+            }
+
+            Ok((true, None))
+        }
+        AutoCommitOutcome::Failed => {
+            context
+                .db
+                .reviews()
+                .discard_session_review_comment_resolutions(
+                    &context.session_id,
+                    review_comment_resolutions,
+                )
+                .await?;
+            if has_review_comment_targets {
+                append_review_comment_commit_failure_notice(context).await;
+            }
+
+            Ok((false, None))
+        }
+    }
+}
+
+/// Result of validating agent-reported outcomes against one turn's thread
+/// allowlist.
+struct ReviewCommentOutcomeValidation {
+    accepted_count: usize,
+    expected_count: usize,
+    is_complete: bool,
+    outcomes: Vec<ReviewCommentOutcome>,
+}
+
+/// Returns normalized outcomes only when the agent supplied exactly one valid
+/// outcome for every allowlisted thread.
+fn validate_review_comment_outcomes(
     allowed_thread_ids: &[String],
     outcomes: &[ReviewCommentOutcome],
-) -> Vec<ReviewCommentOutcome> {
+) -> ReviewCommentOutcomeValidation {
     let allowed_thread_ids = allowed_thread_ids
         .iter()
         .map(String::as_str)
         .collect::<HashSet<_>>();
     let mut accepted_thread_ids = HashSet::new();
+    let mut has_invalid_allowlisted_outcome = false;
+    let mut accepted_outcomes = Vec::new();
 
-    outcomes
-        .iter()
-        .filter(|outcome| allowed_thread_ids.contains(outcome.thread_id.as_str()))
-        .filter(|outcome| !outcome.reply.trim().is_empty())
-        .filter(|outcome| accepted_thread_ids.insert(outcome.thread_id.clone()))
-        .map(|outcome| ReviewCommentOutcome {
+    for outcome in outcomes {
+        if !allowed_thread_ids.contains(outcome.thread_id.as_str()) {
+            continue;
+        }
+        if outcome.reply.trim().is_empty() || !accepted_thread_ids.insert(outcome.thread_id.clone())
+        {
+            has_invalid_allowlisted_outcome = true;
+            continue;
+        }
+
+        accepted_outcomes.push(ReviewCommentOutcome {
             reply: outcome.reply.trim().to_string(),
             resolution: outcome.resolution,
             thread_id: outcome.thread_id.clone(),
-        })
-        .collect()
+        });
+    }
+
+    let accepted_count = accepted_outcomes.len();
+    let expected_count = allowed_thread_ids.len();
+    let is_complete = accepted_count == expected_count && !has_invalid_allowlisted_outcome;
+    if !is_complete {
+        accepted_outcomes.clear();
+    }
+
+    ReviewCommentOutcomeValidation {
+        accepted_count,
+        expected_count,
+        is_complete,
+        outcomes: accepted_outcomes,
+    }
+}
+
+/// Reports an incomplete structured response without applying a partial set of
+/// forge mutations.
+async fn append_incomplete_review_comment_outcomes_notice(
+    context: &PostTurnContext,
+    accepted_count: usize,
+    expected_count: usize,
+) {
+    let message = TranscriptNotice::ReviewCommentsWarning.format(format!(
+        "The agent returned exactly one valid outcome for {accepted_count} of {expected_count} \
+         selected review thread(s). No review replies were posted or threads resolved. Reopen \
+         review comments to retry."
+    ));
+    SessionTaskService::append_workflow_notice(
+        &context.transcript,
+        &context.db,
+        &context.app_event_tx,
+        &context.session_update_versions,
+        &context.session_id,
+        &message,
+    )
+    .await;
+}
+
+/// Reports that forge effects were withheld because pending worktree changes
+/// did not reach a commit.
+async fn append_review_comment_commit_failure_notice(context: &PostTurnContext) {
+    let message = TranscriptNotice::ReviewCommentsWarning.format(
+        "Agentty could not commit the review-comment changes, so it did not push the branch, post \
+         replies, or resolve threads. Fix the commit error, then reopen review comments to retry.",
+    );
+    SessionTaskService::append_workflow_notice(
+        &context.transcript,
+        &context.db,
+        &context.app_event_tx,
+        &context.session_update_versions,
+        &context.session_id,
+        &message,
+    )
+    .await;
 }
 
 /// Returns whether the completed session has materialized stacked children
@@ -632,7 +850,6 @@ async fn start_published_branch_auto_push(
     turn_metadata: TurnMetadata,
     review_request_commit_message: Option<String>,
     review_request_session_summary: Option<String>,
-    review_comment_outcomes: Vec<ReviewCommentOutcome>,
 ) {
     let Some(published_upstream_ref) = turn_metadata.published_upstream_ref else {
         return;
@@ -657,7 +874,6 @@ async fn start_published_branch_auto_push(
             git_client: Arc::clone(&context.git_client),
             one_shot_client: Arc::clone(&context.one_shot_client),
             published_upstream_ref,
-            review_comment_outcomes,
             review_request_client: Arc::clone(&context.review_request_client),
             review_request_commit_message,
             session_agent: turn_metadata.session_agent,
@@ -801,6 +1017,51 @@ mod tests {
         (context, status)
     }
 
+    /// Builds the narrow post-turn context used by review-operation tests.
+    fn review_operation_test_context(
+        db: AppRepositories,
+        git_client: MockGitClient,
+    ) -> PostTurnContext {
+        PostTurnContext {
+            app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
+            child_pid: Arc::new(Mutex::new(None)),
+            clock: Arc::new(crate::infra::clock::RealClock),
+            db,
+            folder: PathBuf::from("/tmp/project"),
+            git_client: Arc::new(git_client),
+            one_shot_client: Arc::new(MockOneShotClient::new()),
+            queued_messages: Arc::new(Mutex::new(VecDeque::new())),
+            review_request_client: Arc::new(forge::MockReviewRequestClient::new()),
+            session_update_versions: Arc::default(),
+            session_id: "session-id".into(),
+            transcript: Arc::new(Mutex::new(SessionTranscript::default())),
+        }
+    }
+
+    /// Links the review request fixture required to prepare durable outcomes.
+    async fn link_review_operation_test_request(db: &AppRepositories) {
+        db.reviews()
+            .update_session_review_request(
+                "session-id",
+                Some(crate::domain::session::ReviewRequest {
+                    last_refreshed_at: 100,
+                    summary: forge::ReviewRequestSummary {
+                        display_id: "#42".to_string(),
+                        forge_kind: forge::ForgeKind::GitHub,
+                        source_branch: "wt/session-id".to_string(),
+                        state: crate::domain::session::ReviewRequestState::Open,
+                        status_summary: None,
+                        target_branch: "main".to_string(),
+                        title: "Review title".to_string(),
+                        web_url: "https://github.com/agentty-xyz/agentty/pull/42".to_string(),
+                    },
+                }),
+            )
+            .await
+            .expect("failed to link review request");
+    }
+
     #[test]
     fn test_truncate_turn_error_notice_keeps_short_errors_intact() {
         // Arrange
@@ -830,7 +1091,7 @@ mod tests {
     }
 
     #[test]
-    fn test_valid_review_comment_outcomes_filters_and_normalizes_agent_output() {
+    fn test_review_comment_outcomes_require_exactly_one_valid_item_per_thread() {
         // Arrange
         let allowed_thread_ids = vec!["thread-fixed".to_string(), "thread-other".to_string()];
         let outcomes = vec![
@@ -862,11 +1123,46 @@ mod tests {
         ];
 
         // Act
-        let accepted = valid_review_comment_outcomes(&allowed_thread_ids, &outcomes);
+        let validation = validate_review_comment_outcomes(&allowed_thread_ids, &outcomes);
 
         // Assert
+        assert_eq!(validation.accepted_count, 2);
+        assert_eq!(validation.expected_count, 2);
+        assert!(!validation.is_complete);
+        assert_eq!(validation.outcomes, Vec::new());
+    }
+
+    #[test]
+    fn test_review_comment_outcomes_normalize_complete_allowlisted_response() {
+        // Arrange
+        let allowed_thread_ids = vec!["thread-fixed".to_string(), "thread-other".to_string()];
+        let outcomes = vec![
+            ReviewCommentOutcome {
+                reply: "  Applied the validation.  ".to_string(),
+                resolution: ReviewCommentResolution::Fixed,
+                thread_id: "thread-fixed".to_string(),
+            },
+            ReviewCommentOutcome {
+                reply: "No change needed.".to_string(),
+                resolution: ReviewCommentResolution::NoChangeNeeded,
+                thread_id: "thread-other".to_string(),
+            },
+            ReviewCommentOutcome {
+                reply: "Unknown thread.".to_string(),
+                resolution: ReviewCommentResolution::Fixed,
+                thread_id: "thread-unknown".to_string(),
+            },
+        ];
+
+        // Act
+        let validation = validate_review_comment_outcomes(&allowed_thread_ids, &outcomes);
+
+        // Assert
+        assert_eq!(validation.accepted_count, 2);
+        assert_eq!(validation.expected_count, 2);
+        assert!(validation.is_complete);
         assert_eq!(
-            accepted,
+            validation.outcomes,
             vec![
                 ReviewCommentOutcome {
                     reply: "Applied the validation.".to_string(),
@@ -880,6 +1176,142 @@ mod tests {
                 }
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn review_comment_operations_preserve_complete_outcomes() {
+        // Arrange
+        let db = AppRepositories::in_memory().await.expect("db should open");
+        insert_research_session(&db, "session-id").await;
+        link_review_operation_test_request(&db).await;
+        let context = review_operation_test_context(db, MockGitClient::new());
+        let thread_ids = vec!["thread-fixed".to_string(), "thread-other".to_string()];
+        let outcomes = vec![
+            ReviewCommentOutcome {
+                reply: "Applied the fix.".to_string(),
+                resolution: ReviewCommentResolution::Fixed,
+                thread_id: "thread-fixed".to_string(),
+            },
+            ReviewCommentOutcome {
+                reply: "No change is needed.".to_string(),
+                resolution: ReviewCommentResolution::NoChangeNeeded,
+                thread_id: "thread-other".to_string(),
+            },
+        ];
+
+        // Act
+        let operations = prepare_review_comment_resolutions(&context, &thread_ids, &outcomes)
+            .await
+            .expect("review operations should be prepared");
+
+        // Assert
+        assert_eq!(operations.len(), 2);
+        assert_eq!(operations[0].resolution, "fixed");
+        assert_eq!(operations[1].resolution, "no_change_needed");
+        assert!(operations.iter().all(|operation| {
+            operation.commit_hash.is_none()
+                && operation.review_request_display_id == "#42"
+                && !operation.reply_token.is_empty()
+        }));
+        assert_ne!(operations[0].reply_token, operations[1].reply_token);
+    }
+
+    #[tokio::test]
+    async fn review_comment_operations_require_a_linked_review_request() {
+        // Arrange
+        let db = AppRepositories::in_memory().await.expect("db should open");
+        insert_research_session(&db, "session-id").await;
+        let context = review_operation_test_context(db, MockGitClient::new());
+        let outcomes = vec![ReviewCommentOutcome {
+            reply: "Applied the fix.".to_string(),
+            resolution: ReviewCommentResolution::Fixed,
+            thread_id: "thread-fixed".to_string(),
+        }];
+
+        // Act
+        let error =
+            prepare_review_comment_resolutions(&context, &["thread-fixed".to_string()], &outcomes)
+                .await
+                .expect_err("a linked review request should be required");
+        let transcript = context
+            .transcript
+            .lock()
+            .expect("transcript lock should remain usable")
+            .replay_text()
+            .expect("persistence warning should be rendered");
+
+        // Assert
+        assert!(
+            error
+                .to_string()
+                .contains("the session no longer has a linked review request")
+        );
+        assert!(transcript.contains(
+            "Could not save the review-comment operation, so this response will not post replies"
+        ));
+    }
+
+    #[tokio::test]
+    async fn review_comment_operations_report_link_lookup_failures() {
+        // Arrange
+        let (db, pool) = AppRepositories::in_memory_with_pool()
+            .await
+            .expect("db should open");
+        insert_research_session(&db, "session-id").await;
+        let context = review_operation_test_context(db, MockGitClient::new());
+        let outcomes = vec![ReviewCommentOutcome {
+            reply: "Applied the fix.".to_string(),
+            resolution: ReviewCommentResolution::Fixed,
+            thread_id: "thread-fixed".to_string(),
+        }];
+        pool.close().await;
+
+        // Act
+        let error =
+            prepare_review_comment_resolutions(&context, &["thread-fixed".to_string()], &outcomes)
+                .await
+                .expect_err("review request lookup should fail");
+        let transcript = context
+            .transcript
+            .lock()
+            .expect("transcript lock should remain usable")
+            .replay_text()
+            .expect("persistence warning should be rendered");
+
+        // Assert
+        assert!(error.to_string().contains("closed pool"));
+        assert!(transcript.contains(
+            "Could not save the review-comment operation, so this response will not post replies"
+        ));
+    }
+
+    #[tokio::test]
+    async fn ordinary_commit_failures_do_not_emit_review_comment_warnings() {
+        // Arrange
+        let db = AppRepositories::in_memory().await.expect("db should open");
+        insert_research_session(&db, "session-id").await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_is_worktree_clean().once().returning(|_| {
+            Box::pin(async { Err(GitError::OutputParse("commit failed".to_string())) })
+        });
+        let context = review_operation_test_context(db, git_client);
+        let session_agent = AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol);
+
+        // Act
+        let result = run_auto_commit(&context, session_agent, false, &[])
+            .await
+            .expect("commit failure handling should remain recoverable");
+        let transcript = context
+            .transcript
+            .lock()
+            .expect("transcript lock should remain usable")
+            .replay_text()
+            .expect("commit failure should be rendered");
+
+        // Assert
+        assert_eq!(result, (false, None));
+        assert!(transcript.contains("[Commit Error] commit failed"));
+        assert!(!transcript.contains("[Review Comments Warning]"));
     }
 
     #[tokio::test]
@@ -1163,7 +1595,6 @@ mod tests {
                     },
                     None,
                     None,
-                    Vec::new(),
                 )
                 .await;
             })

--- a/crates/agentty/src/app/session/workflow/published_branch.rs
+++ b/crates/agentty/src/app/session/workflow/published_branch.rs
@@ -7,7 +7,6 @@ use std::sync::{Arc, Mutex};
 use ag_agent::OneShotClient;
 use ag_forge as forge;
 use ag_git::GitClient;
-use ag_protocol::{ReviewCommentOutcome, ReviewCommentResolution};
 use tokio::sync::{OwnedMutexGuard, mpsc};
 use uuid::Uuid;
 
@@ -22,7 +21,20 @@ use crate::domain::session::{
 };
 use crate::domain::session_message::SessionTranscript;
 use crate::domain::transcript_notice::TranscriptNotice;
-use crate::infra::db::AppRepositories;
+use crate::infra::db::{AppRepositories, SessionReviewCommentResolutionRow};
+
+/// Prefix for the per-operation marker appended to forge replies.
+const REVIEW_COMMENT_REPLY_MARKER_PREFIX: &str = "<!-- agentty review resolution:";
+
+/// Result of ensuring one durable operation has an Agentty-authored reply.
+enum ReviewCommentReplyProgress {
+    /// The durable operation proves the reply was posted.
+    Recorded,
+    /// The thread became resolved before Agentty could post its reply.
+    ThreadResolved,
+    /// Reply progress could not be proven or safely advanced.
+    Unavailable,
+}
 
 /// Owned inputs required to start one detached published-branch auto-push.
 pub(super) struct PublishedBranchAutoPushStartInput {
@@ -42,8 +54,6 @@ pub(super) struct PublishedBranchAutoPushStartInput {
     pub(super) one_shot_client: Arc<dyn OneShotClient>,
     /// Published upstream reference that provides the remote branch target.
     pub(super) published_upstream_ref: String,
-    /// Valid review-thread outcomes eligible for post-push forge updates.
-    pub(super) review_comment_outcomes: Vec<ReviewCommentOutcome>,
     /// Forge boundary used for optional linked PR/MR metadata refresh.
     pub(super) review_request_client: Arc<dyn forge::ReviewRequestClient>,
     /// Optional auto-commit message used to refresh linked PR/MR metadata.
@@ -78,12 +88,6 @@ pub(super) fn start_published_branch_auto_push(input: PublishedBranchAutoPushSta
                 },
                 review_request_client: Arc::clone(&input.review_request_client),
             });
-    let review_comment_resolution =
-        (!input.review_comment_outcomes.is_empty()).then(|| ReviewCommentResolutionInput {
-            outcomes: input.review_comment_outcomes,
-            review_request_client: Arc::clone(&input.review_request_client),
-        });
-
     let _ = input
         .app_event_tx
         .send(AppEvent::PublishedBranchSyncUpdated {
@@ -99,7 +103,7 @@ pub(super) fn start_published_branch_auto_push(input: PublishedBranchAutoPushSta
         folder: input.folder,
         git_client: input.git_client,
         published_upstream_ref: input.published_upstream_ref,
-        review_comment_resolution,
+        review_request_client: input.review_request_client,
         review_request_metadata_sync,
         session_id: input.session_id,
         session_update_versions: input.session_update_versions,
@@ -125,8 +129,8 @@ pub(super) struct PublishedBranchAutoPushInput {
     pub(super) git_client: Arc<dyn GitClient>,
     /// Published upstream reference that provides the remote branch target.
     pub(super) published_upstream_ref: String,
-    /// Optional review-thread outcomes applied only after a successful push.
-    pub(super) review_comment_resolution: Option<ReviewCommentResolutionInput>,
+    /// Forge boundary used for durable review-comment resolution operations.
+    pub(super) review_request_client: Arc<dyn forge::ReviewRequestClient>,
     /// Optional metadata sync payload used after a successful post-turn push.
     pub(super) review_request_metadata_sync: Option<ReviewRequestMetadataSyncInput>,
     /// Session id whose branch is being pushed.
@@ -161,14 +165,6 @@ pub(super) struct ReviewRequestMetadataEvaluationInput {
     pub(super) session_summary: String,
 }
 
-/// Owned dependencies for forge thread replies and resolution after push.
-pub(super) struct ReviewCommentResolutionInput {
-    /// Valid, allowlisted outcomes reported by the completed agent turn.
-    pub(super) outcomes: Vec<ReviewCommentOutcome>,
-    /// Forge boundary used to post replies and resolve review threads.
-    pub(super) review_request_client: Arc<dyn forge::ReviewRequestClient>,
-}
-
 /// Runs one detached auto-push for a previously published session branch and
 /// reports its state through the app event pipeline.
 pub(super) async fn run_published_branch_auto_push(input: PublishedBranchAutoPushInput) {
@@ -194,9 +190,7 @@ async fn run_published_branch_auto_push_task(input: PublishedBranchAutoPushInput
             if let Some(metadata_sync_input) = input.review_request_metadata_sync.as_ref() {
                 sync_linked_review_request_metadata_after_push(&input, metadata_sync_input).await;
             }
-            if let Some(resolution_input) = input.review_comment_resolution.as_ref() {
-                resolve_review_comments_after_push(&input, resolution_input).await;
-            }
+            resolve_review_comments_after_push(&input).await;
 
             let message = TranscriptNotice::BranchPush
                 .format("Auto-pushed published branch after completed turn.");
@@ -227,19 +221,40 @@ async fn run_published_branch_auto_push_task(input: PublishedBranchAutoPushInput
 
 /// Posts agent-authored replies and resolves fixed allowlisted review threads
 /// after the updated branch is visible on the forge.
-async fn resolve_review_comments_after_push(
-    input: &PublishedBranchAutoPushInput,
-    resolution_input: &ReviewCommentResolutionInput,
-) {
-    let expected_reply_count = resolution_input.outcomes.len();
-    let expected_resolution_count = resolution_input
-        .outcomes
+async fn resolve_review_comments_after_push(input: &PublishedBranchAutoPushInput) {
+    let operations = match input
+        .db
+        .reviews()
+        .load_session_review_comment_resolutions(&input.session_id)
+        .await
+    {
+        Ok(operations) if operations.is_empty() => return,
+        Ok(operations) => operations,
+        Err(error) => {
+            append_review_comment_operation_load_failure_notice(input, &error.to_string()).await;
+
+            return;
+        }
+    };
+    let Some(operations) = review_comment_operations_matching_pushed_head(input, operations).await
+    else {
+        return;
+    };
+    if operations.is_empty() {
+        return;
+    }
+    let expected_reply_count = operations.len();
+    let expected_resolution_count = operations
         .iter()
-        .filter(|outcome| outcome.resolution == ReviewCommentResolution::Fixed)
+        .filter(|operation| operation.resolution == "fixed")
         .count();
     let linked_review_request = match load_open_review_request(input).await {
         Ok(Some(linked_review_request)) => linked_review_request,
-        Ok(None) => return,
+        Ok(None) => {
+            append_missing_open_review_request_notice(input, expected_reply_count).await;
+
+            return;
+        }
         Err(error) => {
             append_review_comment_resolution_notice(
                 input,
@@ -258,6 +273,108 @@ async fn resolve_review_comments_after_push(
             return;
         }
     };
+    let operations = operations
+        .into_iter()
+        .filter(|operation| {
+            operation.review_request_display_id == linked_review_request.summary.display_id
+        })
+        .collect::<Vec<_>>();
+    if operations.is_empty() {
+        append_missing_open_review_request_notice(input, expected_reply_count).await;
+
+        return;
+    }
+    let expected_reply_count = operations.len();
+    let expected_resolution_count = operations
+        .iter()
+        .filter(|operation| operation.resolution == "fixed")
+        .count();
+    let Some(remote) =
+        review_comment_resolution_remote(input, expected_reply_count, expected_resolution_count)
+            .await
+    else {
+        return;
+    };
+    let display_id = &linked_review_request.summary.display_id;
+    let Some(live_snapshot) = live_review_comment_snapshot(
+        input,
+        &remote,
+        display_id,
+        expected_reply_count,
+        expected_resolution_count,
+    )
+    .await
+    else {
+        return;
+    };
+    let (replied_count, resolved_count) =
+        post_review_comment_operations(input, &operations, &remote, display_id, &live_snapshot)
+            .await;
+    append_review_comment_resolution_notice(
+        input,
+        replied_count,
+        expected_reply_count,
+        resolved_count,
+        expected_resolution_count,
+    )
+    .await;
+}
+
+/// Keeps only operations whose fix commit exactly matches the pushed tip.
+async fn review_comment_operations_matching_pushed_head(
+    input: &PublishedBranchAutoPushInput,
+    operations: Vec<SessionReviewCommentResolutionRow>,
+) -> Option<Vec<SessionReviewCommentResolutionRow>> {
+    let mut matching_operations = Vec::new();
+    let mut stale_operations = Vec::new();
+    let mut unbound_count = 0;
+
+    for operation in operations {
+        let Some(commit_hash) = operation.commit_hash.as_ref() else {
+            unbound_count += 1;
+
+            continue;
+        };
+        let reachability = input
+            .git_client
+            .get_ref_ahead_behind(
+                input.folder.clone(),
+                "HEAD".to_string(),
+                commit_hash.clone(),
+            )
+            .await;
+        match reachability {
+            Ok((0, 0)) => matching_operations.push(operation),
+            Ok(_) => stale_operations.push(operation),
+            Err(error) => {
+                append_review_comment_commit_verification_failure_notice(input, &error.to_string())
+                    .await;
+
+                return None;
+            }
+        }
+    }
+
+    let stale_count = stale_operations.len();
+    for operation in &stale_operations {
+        remove_review_comment_operation(input, operation).await;
+    }
+    if stale_count != 0 {
+        append_stale_review_comment_operations_notice(input, stale_count).await;
+    }
+    if unbound_count != 0 {
+        append_unbound_review_comment_operations_notice(input, unbound_count).await;
+    }
+
+    Some(matching_operations)
+}
+
+/// Resolves the authenticated forge remote used for post-push thread effects.
+async fn review_comment_resolution_remote(
+    input: &PublishedBranchAutoPushInput,
+    expected_reply_count: usize,
+    expected_resolution_count: usize,
+) -> Option<forge::ForgeRemote> {
     let repo_url = match input.git_client.repo_url(input.folder.clone()).await {
         Ok(repo_url) => repo_url,
         Err(error) => {
@@ -275,15 +392,15 @@ async fn resolve_review_comments_after_push(
                 "failed to resolve repository remote for review-thread resolution"
             );
 
-            return;
+            return None;
         }
     };
-    let remote = match resolution_input
+    match input
         .review_request_client
         .detect_remote(repo_url)
         .map(|remote| remote.with_command_working_directory(input.folder.clone()))
     {
-        Ok(remote) => remote,
+        Ok(remote) => Some(remote),
         Err(error) => {
             append_review_comment_resolution_notice(
                 input,
@@ -300,86 +417,372 @@ async fn resolve_review_comments_after_push(
                 "failed to detect forge remote for review-thread resolution"
             );
 
-            return;
+            None
         }
-    };
+    }
+}
 
-    let (replied_count, resolved_count) = post_review_comment_outcomes(
-        input,
-        resolution_input,
-        &remote,
-        &linked_review_request.summary.display_id,
-    )
-    .await;
-    append_review_comment_resolution_notice(
-        input,
-        replied_count,
-        expected_reply_count,
-        resolved_count,
-        expected_resolution_count,
-    )
-    .await;
+/// Refreshes live thread state so retries can skip already-posted replies and
+/// avoid mutating threads that disappeared after selection.
+async fn live_review_comment_snapshot(
+    input: &PublishedBranchAutoPushInput,
+    remote: &forge::ForgeRemote,
+    display_id: &str,
+    expected_reply_count: usize,
+    expected_resolution_count: usize,
+) -> Option<forge::ReviewCommentSnapshot> {
+    match input
+        .review_request_client
+        .fetch_review_comment_snapshot(remote.clone(), display_id.to_string())
+        .await
+    {
+        Ok(live_snapshot) => Some(live_snapshot),
+        Err(error) => {
+            append_review_comment_resolution_notice(
+                input,
+                0,
+                expected_reply_count,
+                0,
+                expected_resolution_count,
+            )
+            .await;
+            let error_detail = error.detail_message();
+            tracing::warn!(
+                session_id = %input.session_id,
+                error = %error_detail,
+                "failed to refresh review threads before applying outcomes"
+            );
+
+            None
+        }
+    }
 }
 
 /// Posts each accepted reply and resolves only fixed outcomes.
-async fn post_review_comment_outcomes(
+async fn post_review_comment_operations(
     input: &PublishedBranchAutoPushInput,
-    resolution_input: &ReviewCommentResolutionInput,
+    operations: &[SessionReviewCommentResolutionRow],
     remote: &forge::ForgeRemote,
     display_id: &str,
+    live_snapshot: &forge::ReviewCommentSnapshot,
 ) -> (usize, usize) {
     let mut replied_count = 0;
     let mut resolved_count = 0;
 
-    for outcome in &resolution_input.outcomes {
-        let reply_result = resolution_input
-            .review_request_client
-            .reply_to_thread(
-                remote.clone(),
-                display_id.to_string(),
-                outcome.thread_id.clone(),
-                outcome.reply.clone(),
-            )
-            .await;
-        if let Err(error) = reply_result {
-            let error_detail = error.detail_message();
-            tracing::warn!(
-                session_id = %input.session_id,
-                thread_id = %outcome.thread_id,
-                error = %error_detail,
-                "failed to reply to review thread"
-            );
-
-            continue;
-        }
-        replied_count += 1;
-        if outcome.resolution == ReviewCommentResolution::NoChangeNeeded {
-            continue;
-        }
-
-        let resolve_result = resolution_input
-            .review_request_client
-            .resolve_thread(
-                remote.clone(),
-                display_id.to_string(),
-                outcome.thread_id.clone(),
-            )
-            .await;
-        match resolve_result {
-            Ok(()) => resolved_count += 1,
-            Err(error) => {
-                let error_detail = error.detail_message();
-                tracing::warn!(
-                    session_id = %input.session_id,
-                    thread_id = %outcome.thread_id,
-                    error = %error_detail,
-                    "failed to resolve replied review thread"
-                );
-            }
-        }
+    for operation in operations {
+        let (operation_replied_count, operation_resolved_count) =
+            apply_review_comment_operation(input, operation, remote, display_id, live_snapshot)
+                .await;
+        replied_count += operation_replied_count;
+        resolved_count += operation_resolved_count;
     }
 
     (replied_count, resolved_count)
+}
+
+/// Applies one persisted reply and optional fixed-thread resolution.
+async fn apply_review_comment_operation(
+    input: &PublishedBranchAutoPushInput,
+    operation: &SessionReviewCommentResolutionRow,
+    remote: &forge::ForgeRemote,
+    display_id: &str,
+    live_snapshot: &forge::ReviewCommentSnapshot,
+) -> (usize, usize) {
+    let Some(thread_index) = live_snapshot
+        .threads
+        .iter()
+        .position(|thread| thread.id == operation.thread_id)
+    else {
+        tracing::warn!(
+            session_id = %input.session_id,
+            thread_id = %operation.thread_id,
+            "allowlisted review thread disappeared before outcome application"
+        );
+
+        return (0, 0);
+    };
+    let is_fixed = operation.resolution == "fixed";
+    match ensure_review_comment_reply(
+        input,
+        operation,
+        remote,
+        display_id,
+        live_snapshot,
+        thread_index,
+    )
+    .await
+    {
+        ReviewCommentReplyProgress::Recorded => {}
+        ReviewCommentReplyProgress::ThreadResolved => {
+            remove_review_comment_operation(input, operation).await;
+
+            return (0, usize::from(is_fixed));
+        }
+        ReviewCommentReplyProgress::Unavailable => return (0, 0),
+    }
+    let resolved_count = complete_review_comment_operation(
+        input,
+        operation,
+        remote,
+        display_id,
+        live_snapshot.threads[thread_index].is_resolved,
+        is_fixed,
+    )
+    .await;
+
+    (1, resolved_count)
+}
+
+/// Ensures one reply is posted or recoverably recognized from a prior try.
+async fn ensure_review_comment_reply(
+    input: &PublishedBranchAutoPushInput,
+    operation: &SessionReviewCommentResolutionRow,
+    remote: &forge::ForgeRemote,
+    display_id: &str,
+    live_snapshot: &forge::ReviewCommentSnapshot,
+    thread_index: usize,
+) -> ReviewCommentReplyProgress {
+    let reply_body = review_comment_reply_body(&operation.reply, &operation.reply_token);
+    if operation.is_posting
+        && live_snapshot.threads[thread_index]
+            .comments
+            .iter()
+            .any(|comment| comment.body == reply_body)
+    {
+        return ReviewCommentReplyProgress::Recorded;
+    }
+    if live_snapshot.threads[thread_index].is_resolved {
+        tracing::warn!(
+            session_id = %input.session_id,
+            thread_id = %operation.thread_id,
+            "review thread was resolved before its agent reply could be posted"
+        );
+
+        return ReviewCommentReplyProgress::ThreadResolved;
+    }
+    if !operation.is_posting && !mark_review_comment_operation_posting(input, operation).await {
+        return ReviewCommentReplyProgress::Unavailable;
+    }
+    let reply_result = input
+        .review_request_client
+        .reply_to_thread(
+            remote.clone(),
+            display_id.to_string(),
+            operation.thread_id.clone(),
+            reply_body,
+        )
+        .await;
+    if let Err(error) = reply_result {
+        let error_detail = error.detail_message();
+        tracing::warn!(
+            session_id = %input.session_id,
+            thread_id = %operation.thread_id,
+            error = %error_detail,
+            "failed to reply to review thread"
+        );
+
+        return ReviewCommentReplyProgress::Unavailable;
+    }
+    ReviewCommentReplyProgress::Recorded
+}
+
+/// Completes a replied operation, resolving the forge thread when requested.
+async fn complete_review_comment_operation(
+    input: &PublishedBranchAutoPushInput,
+    operation: &SessionReviewCommentResolutionRow,
+    remote: &forge::ForgeRemote,
+    display_id: &str,
+    is_thread_resolved: bool,
+    is_fixed: bool,
+) -> usize {
+    if !is_fixed {
+        remove_review_comment_operation(input, operation).await;
+
+        return 0;
+    }
+    if is_thread_resolved {
+        remove_review_comment_operation(input, operation).await;
+
+        return 1;
+    }
+    let resolve_result = input
+        .review_request_client
+        .resolve_thread(
+            remote.clone(),
+            display_id.to_string(),
+            operation.thread_id.clone(),
+        )
+        .await;
+    match resolve_result {
+        Ok(()) => {
+            remove_review_comment_operation(input, operation).await;
+
+            1
+        }
+        Err(error) => {
+            let error_detail = error.detail_message();
+            tracing::warn!(
+                session_id = %input.session_id,
+                thread_id = %operation.thread_id,
+                error = %error_detail,
+                "failed to resolve replied review thread"
+            );
+
+            0
+        }
+    }
+}
+
+/// Records that one operation may expose its reply token to the forge.
+async fn mark_review_comment_operation_posting(
+    input: &PublishedBranchAutoPushInput,
+    operation: &SessionReviewCommentResolutionRow,
+) -> bool {
+    match input
+        .db
+        .reviews()
+        .mark_session_review_comment_resolution_posting(&input.session_id, &operation.reply_token)
+        .await
+    {
+        Ok(()) => true,
+        Err(error) => {
+            tracing::warn!(
+                session_id = %input.session_id,
+                thread_id = %operation.thread_id,
+                %error,
+                "failed to persist review-comment operation progress"
+            );
+
+            false
+        }
+    }
+}
+
+/// Removes one operation after its requested forge effects finish.
+async fn remove_review_comment_operation(
+    input: &PublishedBranchAutoPushInput,
+    operation: &SessionReviewCommentResolutionRow,
+) {
+    if let Err(error) = input
+        .db
+        .reviews()
+        .remove_session_review_comment_resolution(&input.session_id, &operation.reply_token)
+        .await
+    {
+        tracing::warn!(
+            session_id = %input.session_id,
+            thread_id = %operation.thread_id,
+            %error,
+            "failed to remove completed review-comment operation"
+        );
+    }
+}
+
+/// Appends an operation-specific non-rendering identity marker to one reply.
+fn review_comment_reply_body(reply: &str, reply_token: &str) -> String {
+    format!("{reply}\n\n{REVIEW_COMMENT_REPLY_MARKER_PREFIX}{reply_token} -->")
+}
+
+/// Reports that durable review-comment work could not be loaded after push.
+async fn append_review_comment_operation_load_failure_notice(
+    input: &PublishedBranchAutoPushInput,
+    error: &str,
+) {
+    let message = TranscriptNotice::ReviewCommentsWarning.format(format!(
+        "Could not load saved review-comment operations after the branch push: {error}"
+    ));
+    SessionTaskService::append_workflow_notice(
+        &input.transcript,
+        &input.db,
+        &input.app_event_tx,
+        &input.session_update_versions,
+        &input.session_id,
+        &message,
+    )
+    .await;
+}
+
+/// Reports that commit ancestry could not be checked after a successful push.
+async fn append_review_comment_commit_verification_failure_notice(
+    input: &PublishedBranchAutoPushInput,
+    error: &str,
+) {
+    let message = TranscriptNotice::ReviewCommentsWarning.format(format!(
+        "Could not verify saved review-comment commits after the branch push: {error}. The saved \
+         operations will retry after the next successful push."
+    ));
+    SessionTaskService::append_workflow_notice(
+        &input.transcript,
+        &input.db,
+        &input.app_event_tx,
+        &input.session_update_versions,
+        &input.session_id,
+        &message,
+    )
+    .await;
+}
+
+/// Reports saved outcomes discarded after the pushed tip changed.
+async fn append_stale_review_comment_operations_notice(
+    input: &PublishedBranchAutoPushInput,
+    stale_count: usize,
+) {
+    let message = TranscriptNotice::ReviewCommentsWarning.format(format!(
+        "Discarded {stale_count} saved review thread update(s) because the pushed branch tip no \
+         longer exactly matches the reported fix commit. Reopen review comments to retry."
+    ));
+    SessionTaskService::append_workflow_notice(
+        &input.transcript,
+        &input.db,
+        &input.app_event_tx,
+        &input.session_update_versions,
+        &input.session_id,
+        &message,
+    )
+    .await;
+}
+
+/// Reports operations retained after commit binding was interrupted.
+async fn append_unbound_review_comment_operations_notice(
+    input: &PublishedBranchAutoPushInput,
+    unbound_count: usize,
+) {
+    let message = TranscriptNotice::ReviewCommentsWarning.format(format!(
+        "Kept {unbound_count} saved review thread update(s) pending because Agentty could not \
+         finish binding them to the committed revision. Reopen those comments and run a fresh \
+         agent turn to retry."
+    ));
+    SessionTaskService::append_workflow_notice(
+        &input.transcript,
+        &input.db,
+        &input.app_event_tx,
+        &input.session_update_versions,
+        &input.session_id,
+        &message,
+    )
+    .await;
+}
+
+/// Reports that the review request disappeared or became terminal between
+/// comment selection and post-push outcome application.
+async fn append_missing_open_review_request_notice(
+    input: &PublishedBranchAutoPushInput,
+    expected_reply_count: usize,
+) {
+    let message = TranscriptNotice::ReviewCommentsWarning.format(format!(
+        "Skipped {expected_reply_count} review thread update(s) because the session no longer has \
+         an open linked review request. The saved operation will retry after the link is restored \
+         and the branch is pushed again."
+    ));
+    SessionTaskService::append_workflow_notice(
+        &input.transcript,
+        &input.db,
+        &input.app_event_tx,
+        &input.session_update_versions,
+        &input.session_id,
+        &message,
+    )
+    .await;
 }
 
 /// Appends a concise durable result for post-push review-thread updates.
@@ -399,8 +802,8 @@ async fn append_review_comment_resolution_notice(
         } else {
             TranscriptNotice::ReviewCommentsWarning.format(format!(
                 "Replied to {replied_count} of {expected_reply_count} review thread(s) and \
-                 resolved {resolved_count} of {expected_resolution_count} fixed thread(s). Reopen \
-                 review comments to retry the remaining threads."
+                 resolved {resolved_count} of {expected_resolution_count} fixed thread(s). The \
+                 saved operation will retry after the next successful branch push."
             ))
         };
     SessionTaskService::append_workflow_notice(
@@ -619,10 +1022,19 @@ fn warn_review_request_metadata_sync(input: &PublishedBranchAutoPushInput, error
 
 #[cfg(test)]
 mod tests {
-    use ag_forge::MockReviewRequestClient;
+    use ag_forge::{MockReviewRequestClient, ReviewCommentAnchorSide, ReviewCommentThread};
     use ag_git::{GitError, MockGitClient};
+    use ag_protocol::{ReviewCommentOutcome, ReviewCommentResolution};
 
     use super::*;
+
+    #[derive(Clone, Copy)]
+    enum TestCommitComparison {
+        Error,
+        Matching,
+        Rewritten,
+        Unbound,
+    }
 
     #[tokio::test]
     async fn metadata_sync_reconciles_live_remote_metadata_without_persisted_baselines() {
@@ -719,6 +1131,93 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn metadata_sync_reports_link_load_failure() {
+        // Arrange
+        let (db, pool) = AppRepositories::in_memory_with_pool()
+            .await
+            .expect("db should open");
+        insert_session(&db).await;
+        link_open_review_request(&db, "#42").await;
+        let (input, transcript) = metadata_sync_test_input(db, MockGitClient::new());
+        let metadata_sync_input = metadata_sync_input(
+            Some("Generated title\n\nNew body."),
+            MockReviewRequestClient::new(),
+        );
+        pool.close().await;
+
+        // Act
+        sync_linked_review_request_metadata_after_push(&input, &metadata_sync_input).await;
+
+        // Assert
+        assert!(last_transcript_message(&transcript).contains(
+            "Failed to update linked review-request metadata: attempted to acquire a connection \
+             on a closed pool"
+        ));
+    }
+
+    #[tokio::test]
+    async fn metadata_sync_skips_missing_commit_message() {
+        // Arrange
+        let db = linked_review_request_db().await;
+        let mut git_client = MockGitClient::new();
+        git_client
+            .expect_head_commit_message()
+            .once()
+            .returning(|_| Box::pin(async { Ok(None) }));
+        let (input, transcript) = metadata_sync_test_input(db, git_client);
+        let metadata_sync_input = metadata_sync_input(None, MockReviewRequestClient::new());
+
+        // Act
+        sync_linked_review_request_metadata_after_push(&input, &metadata_sync_input).await;
+
+        // Assert
+        assert!(transcript.lock().expect("transcript lock").is_empty());
+    }
+
+    #[tokio::test]
+    async fn metadata_sync_skips_unstructured_commit_message() {
+        // Arrange
+        let db = linked_review_request_db().await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_head_commit_message().never();
+        let (input, transcript) = metadata_sync_test_input(db, git_client);
+        let metadata_sync_input =
+            metadata_sync_input(Some("\n \n"), MockReviewRequestClient::new());
+
+        // Act
+        sync_linked_review_request_metadata_after_push(&input, &metadata_sync_input).await;
+
+        // Assert
+        assert!(transcript.lock().expect("transcript lock").is_empty());
+    }
+
+    #[tokio::test]
+    async fn metadata_sync_reports_repository_remote_failure() {
+        // Arrange
+        let db = linked_review_request_db().await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_repo_url().once().returning(|_| {
+            Box::pin(async { Err(GitError::OutputParse("missing remote".to_string())) })
+        });
+        let (input, transcript) = metadata_sync_test_input(db, git_client);
+        let mut review_request_client = MockReviewRequestClient::new();
+        review_request_client.expect_detect_remote().never();
+        let metadata_sync_input =
+            metadata_sync_input(Some("Generated title\n\nNew body."), review_request_client);
+
+        // Act
+        sync_linked_review_request_metadata_after_push(&input, &metadata_sync_input).await;
+
+        // Assert
+        let message = last_transcript_message(&transcript);
+        assert!(
+            message
+                .contains("Failed to resolve repository remote for review-request metadata sync")
+        );
+        assert!(message.contains("missing remote"));
+    }
+
+    #[tokio::test]
     async fn review_comment_resolution_reports_reply_and_resolution_failures() {
         // Arrange
         let db = linked_review_request_db().await;
@@ -731,6 +1230,12 @@ mod tests {
             .expect_detect_remote()
             .once()
             .returning(|_| Ok(github_remote()));
+        review_request_client
+            .expect_fetch_review_comment_snapshot()
+            .once()
+            .returning(|_, _| {
+                Box::pin(async { Ok(review_comment_snapshot(&["reply-fails", "resolve-fails"])) })
+            });
         review_request_client
             .expect_reply_to_thread()
             .withf(|_, _, thread_id, _| thread_id == "reply-fails")
@@ -765,20 +1270,18 @@ mod tests {
             git_client,
             review_request_client,
             vec![fixed_outcome("reply-fails"), fixed_outcome("resolve-fails")],
-        );
-        let resolution_input = input
-            .review_comment_resolution
-            .as_ref()
-            .expect("resolution input should exist");
+        )
+        .await;
 
         // Act
-        resolve_review_comments_after_push(&input, resolution_input).await;
+        resolve_review_comments_after_push(&input).await;
 
         // Assert
         assert_eq!(
             last_transcript_message(&transcript),
             "[Review Comments Warning] Replied to 1 of 2 review thread(s) and resolved 0 of 2 \
-             fixed thread(s). Reopen review comments to retry the remaining threads."
+             fixed thread(s). The saved operation will retry after the next successful branch \
+             push."
         );
     }
 
@@ -796,10 +1299,21 @@ mod tests {
             .once()
             .returning(|_| Ok(github_remote()));
         review_request_client
+            .expect_fetch_review_comment_snapshot()
+            .once()
+            .returning(|_, _| {
+                Box::pin(async { Ok(review_comment_snapshot(&["no-change", "fixed"])) })
+            });
+        review_request_client
             .expect_reply_to_thread()
             .withf(|_, _, thread_id, body| {
-                (thread_id == "no-change" && body == "The current implementation is already safe.")
-                    || (thread_id == "fixed" && body == "Addressed fixed.")
+                (thread_id == "no-change"
+                    && body
+                        == "The current implementation is already safe.\n\n<!-- agentty review \
+                            resolution:token-no-change -->")
+                    || (thread_id == "fixed"
+                        && body
+                            == "Addressed fixed.\n\n<!-- agentty review resolution:token-fixed -->")
             })
             .times(2)
             .returning(|_, _, _, _| Box::pin(async { Ok(()) }));
@@ -813,19 +1327,246 @@ mod tests {
             git_client,
             review_request_client,
             vec![no_change_outcome("no-change"), fixed_outcome("fixed")],
-        );
-        let resolution_input = input
-            .review_comment_resolution
-            .as_ref()
-            .expect("resolution input should exist");
+        )
+        .await;
 
         // Act
-        resolve_review_comments_after_push(&input, resolution_input).await;
+        resolve_review_comments_after_push(&input).await;
 
         // Assert
         assert_eq!(
             last_transcript_message(&transcript),
             "[Review Comments] Replied to 2 review thread(s) and resolved 1 fixed thread(s)."
+        );
+    }
+
+    #[tokio::test]
+    async fn review_comment_resolution_reuses_matching_reply_before_retrying_resolution() {
+        // Arrange
+        let db = linked_review_request_db().await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_repo_url().once().returning(|_| {
+            Box::pin(async { Ok("https://github.com/agentty-xyz/agentty.git".to_string()) })
+        });
+        let mut live_snapshot = review_comment_snapshot(&["fixed"]);
+        live_snapshot.threads[0]
+            .comments
+            .push(forge::ReviewComment {
+                author: "agentty".to_string(),
+                body: review_comment_reply_body("Addressed fixed.", "token-fixed"),
+            });
+        let mut review_request_client = MockReviewRequestClient::new();
+        review_request_client
+            .expect_detect_remote()
+            .once()
+            .returning(|_| Ok(github_remote()));
+        review_request_client
+            .expect_fetch_review_comment_snapshot()
+            .once()
+            .return_once(|_, _| Box::pin(async move { Ok(live_snapshot) }));
+        review_request_client.expect_reply_to_thread().never();
+        review_request_client
+            .expect_resolve_thread()
+            .withf(|_, _, thread_id| thread_id == "fixed")
+            .once()
+            .returning(|_, _, _| Box::pin(async { Ok(()) }));
+        let (input, transcript) = resolution_test_input(
+            db,
+            git_client,
+            review_request_client,
+            vec![fixed_outcome("fixed")],
+        )
+        .await;
+        input
+            .db
+            .reviews()
+            .mark_session_review_comment_resolution_posting("session-id", "token-fixed")
+            .await
+            .expect("failed to persist posting state");
+
+        // Act
+        resolve_review_comments_after_push(&input).await;
+
+        // Assert
+        assert_eq!(
+            last_transcript_message(&transcript),
+            "[Review Comments] Replied to 1 review thread(s) and resolved 1 fixed thread(s)."
+        );
+    }
+
+    #[tokio::test]
+    async fn review_comment_resolution_does_not_trust_matching_reply_while_pending() {
+        // Arrange
+        let db = linked_review_request_db().await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_repo_url().once().returning(|_| {
+            Box::pin(async { Ok("https://github.com/agentty-xyz/agentty.git".to_string()) })
+        });
+        let mut live_snapshot = review_comment_snapshot(&["fixed"]);
+        live_snapshot.threads[0]
+            .comments
+            .push(forge::ReviewComment {
+                author: "collaborator".to_string(),
+                body: review_comment_reply_body("Addressed fixed.", "token-fixed"),
+            });
+        let mut review_request_client = MockReviewRequestClient::new();
+        review_request_client
+            .expect_detect_remote()
+            .once()
+            .returning(|_| Ok(github_remote()));
+        review_request_client
+            .expect_fetch_review_comment_snapshot()
+            .once()
+            .return_once(|_, _| Box::pin(async move { Ok(live_snapshot) }));
+        review_request_client
+            .expect_reply_to_thread()
+            .once()
+            .returning(|_, _, _, _| Box::pin(async { Ok(()) }));
+        review_request_client
+            .expect_resolve_thread()
+            .once()
+            .returning(|_, _, _| Box::pin(async { Ok(()) }));
+        let (input, transcript) = resolution_test_input(
+            db,
+            git_client,
+            review_request_client,
+            vec![fixed_outcome("fixed")],
+        )
+        .await;
+
+        // Act
+        resolve_review_comments_after_push(&input).await;
+
+        // Assert
+        assert_eq!(
+            last_transcript_message(&transcript),
+            "[Review Comments] Replied to 1 review thread(s) and resolved 1 fixed thread(s)."
+        );
+    }
+
+    #[tokio::test]
+    async fn review_comment_resolution_reports_disappeared_live_thread() {
+        // Arrange
+        let db = linked_review_request_db().await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_repo_url().once().returning(|_| {
+            Box::pin(async { Ok("https://github.com/agentty-xyz/agentty.git".to_string()) })
+        });
+        let mut review_request_client = MockReviewRequestClient::new();
+        review_request_client
+            .expect_detect_remote()
+            .once()
+            .returning(|_| Ok(github_remote()));
+        review_request_client
+            .expect_fetch_review_comment_snapshot()
+            .once()
+            .returning(|_, _| Box::pin(async { Ok(forge::ReviewCommentSnapshot::default()) }));
+        review_request_client.expect_reply_to_thread().never();
+        review_request_client.expect_resolve_thread().never();
+        let (input, transcript) = resolution_test_input(
+            db,
+            git_client,
+            review_request_client,
+            vec![fixed_outcome("missing")],
+        )
+        .await;
+
+        // Act
+        resolve_review_comments_after_push(&input).await;
+
+        // Assert
+        assert_eq!(
+            last_transcript_message(&transcript),
+            "[Review Comments Warning] Replied to 0 of 1 review thread(s) and resolved 0 of 1 \
+             fixed thread(s). The saved operation will retry after the next successful branch \
+             push."
+        );
+    }
+
+    #[tokio::test]
+    async fn review_comment_resolution_reports_live_snapshot_failure() {
+        // Arrange
+        let db = linked_review_request_db().await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_repo_url().once().returning(|_| {
+            Box::pin(async { Ok("https://github.com/agentty-xyz/agentty.git".to_string()) })
+        });
+        let mut review_request_client = MockReviewRequestClient::new();
+        review_request_client
+            .expect_detect_remote()
+            .once()
+            .returning(|_| Ok(github_remote()));
+        review_request_client
+            .expect_fetch_review_comment_snapshot()
+            .once()
+            .returning(|_, _| {
+                Box::pin(async {
+                    Err(forge::ReviewRequestError::OperationFailed {
+                        forge_kind: forge::ForgeKind::GitHub,
+                        message: "snapshot unavailable".to_string(),
+                    })
+                })
+            });
+        review_request_client.expect_reply_to_thread().never();
+        review_request_client.expect_resolve_thread().never();
+        let (input, transcript) = resolution_test_input(
+            db,
+            git_client,
+            review_request_client,
+            vec![fixed_outcome("fixed")],
+        )
+        .await;
+
+        // Act
+        resolve_review_comments_after_push(&input).await;
+
+        // Assert
+        assert_eq!(
+            last_transcript_message(&transcript),
+            "[Review Comments Warning] Replied to 0 of 1 review thread(s) and resolved 0 of 1 \
+             fixed thread(s). The saved operation will retry after the next successful branch \
+             push."
+        );
+    }
+
+    #[tokio::test]
+    async fn review_comment_resolution_does_not_reply_to_concurrently_resolved_thread() {
+        // Arrange
+        let db = linked_review_request_db().await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_repo_url().once().returning(|_| {
+            Box::pin(async { Ok("https://github.com/agentty-xyz/agentty.git".to_string()) })
+        });
+        let mut live_snapshot = review_comment_snapshot(&["fixed"]);
+        live_snapshot.threads[0].is_resolved = true;
+        let mut review_request_client = MockReviewRequestClient::new();
+        review_request_client
+            .expect_detect_remote()
+            .once()
+            .returning(|_| Ok(github_remote()));
+        review_request_client
+            .expect_fetch_review_comment_snapshot()
+            .once()
+            .return_once(|_, _| Box::pin(async move { Ok(live_snapshot) }));
+        review_request_client.expect_reply_to_thread().never();
+        review_request_client.expect_resolve_thread().never();
+        let (input, transcript) = resolution_test_input(
+            db,
+            git_client,
+            review_request_client,
+            vec![fixed_outcome("fixed")],
+        )
+        .await;
+
+        // Act
+        resolve_review_comments_after_push(&input).await;
+
+        // Assert
+        assert_eq!(
+            last_transcript_message(&transcript),
+            "[Review Comments Warning] Replied to 0 of 1 review thread(s) and resolved 1 of 1 \
+             fixed thread(s). The saved operation will retry after the next successful branch \
+             push."
         );
     }
 
@@ -847,20 +1588,18 @@ mod tests {
             git_client,
             MockReviewRequestClient::new(),
             vec![fixed_outcome("thread-1")],
-        );
-        let resolution_input = input
-            .review_comment_resolution
-            .as_ref()
-            .expect("resolution input should exist");
+        )
+        .await;
 
         // Act
-        resolve_review_comments_after_push(&input, resolution_input).await;
+        resolve_review_comments_after_push(&input).await;
 
         // Assert
         assert_eq!(
             last_transcript_message(&transcript),
             "[Review Comments Warning] Replied to 0 of 1 review thread(s) and resolved 0 of 1 \
-             fixed thread(s). Reopen review comments to retry the remaining threads."
+             fixed thread(s). The saved operation will retry after the next successful branch \
+             push."
         );
     }
 
@@ -883,20 +1622,18 @@ mod tests {
             git_client,
             review_request_client,
             vec![fixed_outcome("thread-1")],
-        );
-        let resolution_input = input
-            .review_comment_resolution
-            .as_ref()
-            .expect("resolution input should exist");
+        )
+        .await;
 
         // Act
-        resolve_review_comments_after_push(&input, resolution_input).await;
+        resolve_review_comments_after_push(&input).await;
 
         // Assert
         assert_eq!(
             last_transcript_message(&transcript),
             "[Review Comments Warning] Replied to 0 of 1 review thread(s) and resolved 0 of 1 \
-             fixed thread(s). Reopen review comments to retry the remaining threads."
+             fixed thread(s). The saved operation will retry after the next successful branch \
+             push."
         );
     }
 
@@ -912,27 +1649,28 @@ mod tests {
             git_client,
             MockReviewRequestClient::new(),
             vec![fixed_outcome("thread-1")],
-        );
-        let resolution_input = input
-            .review_comment_resolution
-            .as_ref()
-            .expect("resolution input should exist");
+        )
+        .await;
 
         // Act
-        resolve_review_comments_after_push(&input, resolution_input).await;
+        resolve_review_comments_after_push(&input).await;
 
         // Assert
-        assert!(transcript.lock().expect("transcript lock").is_empty());
+        assert_eq!(
+            last_transcript_message(&transcript),
+            "[Review Comments Warning] Skipped 1 review thread update(s) because the session no \
+             longer has an open linked review request. The saved operation will retry after the \
+             link is restored and the branch is pushed again."
+        );
     }
 
     #[tokio::test]
-    async fn review_comment_resolution_reports_linked_review_load_failure() {
+    async fn review_comment_resolution_reports_operation_load_failure() {
         // Arrange
         let (db, pool) = AppRepositories::in_memory_with_pool()
             .await
             .expect("db should open");
         insert_session(&db).await;
-        pool.close().await;
         let mut git_client = MockGitClient::new();
         git_client.expect_repo_url().never();
         let (input, transcript) = resolution_test_input(
@@ -940,29 +1678,393 @@ mod tests {
             git_client,
             MockReviewRequestClient::new(),
             vec![fixed_outcome("thread-1")],
-        );
-        let resolution_input = input
-            .review_comment_resolution
-            .as_ref()
-            .expect("resolution input should exist");
+        )
+        .await;
+        pool.close().await;
 
         // Act
-        resolve_review_comments_after_push(&input, resolution_input).await;
+        resolve_review_comments_after_push(&input).await;
+
+        // Assert
+        assert_eq!(
+            last_transcript_message(&transcript),
+            "[Review Comments Warning] Could not load saved review-comment operations after the \
+             branch push: attempted to acquire a connection on a closed pool"
+        );
+    }
+
+    #[tokio::test]
+    async fn review_comment_resolution_reports_posting_progress_failure() {
+        // Arrange
+        let (db, pool) = AppRepositories::in_memory_with_pool()
+            .await
+            .expect("db should open");
+        insert_session(&db).await;
+        link_open_review_request(&db, "#42").await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_repo_url().once().returning(|_| {
+            Box::pin(async { Ok("https://github.com/agentty-xyz/agentty.git".to_string()) })
+        });
+        let mut review_request_client = MockReviewRequestClient::new();
+        review_request_client
+            .expect_detect_remote()
+            .once()
+            .returning(|_| Ok(github_remote()));
+        review_request_client
+            .expect_fetch_review_comment_snapshot()
+            .once()
+            .return_once(move |_, _| {
+                Box::pin(async move {
+                    pool.close().await;
+
+                    Ok(review_comment_snapshot(&["fixed"]))
+                })
+            });
+        review_request_client.expect_reply_to_thread().never();
+        review_request_client.expect_resolve_thread().never();
+        let (input, transcript) = resolution_test_input(
+            db,
+            git_client,
+            review_request_client,
+            vec![fixed_outcome("fixed")],
+        )
+        .await;
+
+        // Act
+        resolve_review_comments_after_push(&input).await;
 
         // Assert
         assert_eq!(
             last_transcript_message(&transcript),
             "[Review Comments Warning] Replied to 0 of 1 review thread(s) and resolved 0 of 1 \
-             fixed thread(s). Reopen review comments to retry the remaining threads."
+             fixed thread(s). The saved operation will retry after the next successful branch \
+             push."
+        );
+    }
+
+    #[tokio::test]
+    async fn review_comment_resolution_counts_replied_thread_resolved_during_retry() {
+        // Arrange
+        let (db, pool) = AppRepositories::in_memory_with_pool()
+            .await
+            .expect("db should open");
+        insert_session(&db).await;
+        link_open_review_request(&db, "#42").await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_repo_url().once().returning(|_| {
+            Box::pin(async { Ok("https://github.com/agentty-xyz/agentty.git".to_string()) })
+        });
+        let mut live_snapshot = review_comment_snapshot(&["fixed"]);
+        live_snapshot.threads[0].is_resolved = true;
+        live_snapshot.threads[0]
+            .comments
+            .push(forge::ReviewComment {
+                author: "agentty".to_string(),
+                body: review_comment_reply_body("Addressed fixed.", "token-fixed"),
+            });
+        let mut review_request_client = MockReviewRequestClient::new();
+        review_request_client
+            .expect_detect_remote()
+            .once()
+            .returning(|_| Ok(github_remote()));
+        review_request_client
+            .expect_fetch_review_comment_snapshot()
+            .once()
+            .return_once(move |_, _| {
+                Box::pin(async move {
+                    pool.close().await;
+
+                    Ok(live_snapshot)
+                })
+            });
+        review_request_client.expect_reply_to_thread().never();
+        review_request_client.expect_resolve_thread().never();
+        let (input, transcript) = resolution_test_input(
+            db,
+            git_client,
+            review_request_client,
+            vec![fixed_outcome("fixed")],
+        )
+        .await;
+        input
+            .db
+            .reviews()
+            .mark_session_review_comment_resolution_posting("session-id", "token-fixed")
+            .await
+            .expect("failed to persist posting state");
+
+        // Act
+        resolve_review_comments_after_push(&input).await;
+
+        // Assert
+        assert_eq!(
+            last_transcript_message(&transcript),
+            "[Review Comments] Replied to 1 review thread(s) and resolved 1 fixed thread(s)."
+        );
+    }
+
+    #[tokio::test]
+    async fn review_comment_resolution_reports_link_load_failure() {
+        // Arrange
+        let (db, pool) = AppRepositories::in_memory_with_pool()
+            .await
+            .expect("db should open");
+        insert_session(&db).await;
+        db.reviews()
+            .update_session_review_request("session-id", Some(open_review_request("#42")))
+            .await
+            .expect("failed to link review request");
+        persist_resolution_test_operations(&db, vec![fixed_outcome("thread-1")], Some("commit-1"))
+            .await;
+        let mut git_client = MockGitClient::new();
+        git_client
+            .expect_get_ref_ahead_behind()
+            .once()
+            .return_once(move |_, _, _| {
+                Box::pin(async move {
+                    pool.close().await;
+
+                    Ok((0, 0))
+                })
+            });
+        git_client.expect_repo_url().never();
+        let (input, transcript) =
+            persisted_resolution_test_input(db, git_client, MockReviewRequestClient::new());
+
+        // Act
+        resolve_review_comments_after_push(&input).await;
+
+        // Assert
+        assert_eq!(
+            last_transcript_message(&transcript),
+            "[Review Comments Warning] Replied to 0 of 1 review thread(s) and resolved 0 of 1 \
+             fixed thread(s). The saved operation will retry after the next successful branch \
+             push."
+        );
+    }
+
+    #[tokio::test]
+    async fn review_comment_resolution_rejects_operations_for_an_old_review_request() {
+        // Arrange
+        let db = linked_review_request_db().await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_repo_url().never();
+        let (input, transcript) = resolution_test_input(
+            db.clone(),
+            git_client,
+            MockReviewRequestClient::new(),
+            vec![fixed_outcome("thread-1")],
+        )
+        .await;
+        db.reviews()
+            .update_session_review_request("session-id", Some(open_review_request("#43")))
+            .await
+            .expect("failed to replace linked review request");
+
+        // Act
+        resolve_review_comments_after_push(&input).await;
+        let operations = db
+            .reviews()
+            .load_session_review_comment_resolutions("session-id")
+            .await
+            .expect("failed to load retained review operation");
+
+        // Assert
+        assert_eq!(operations.len(), 1);
+        assert_eq!(
+            last_transcript_message(&transcript),
+            "[Review Comments Warning] Skipped 1 review thread update(s) because the session no \
+             longer has an open linked review request. The saved operation will retry after the \
+             link is restored and the branch is pushed again."
+        );
+    }
+
+    #[tokio::test]
+    async fn review_comment_resolution_discards_fix_commit_removed_by_rebase() {
+        // Arrange
+        let db = linked_review_request_db().await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_repo_url().never();
+        let (input, transcript) = resolution_test_input_with_commit_reachability(
+            db.clone(),
+            git_client,
+            MockReviewRequestClient::new(),
+            vec![fixed_outcome("thread-1")],
+            TestCommitComparison::Rewritten,
+        )
+        .await;
+
+        // Act
+        resolve_review_comments_after_push(&input).await;
+        let operations = db
+            .reviews()
+            .load_session_review_comment_resolutions("session-id")
+            .await
+            .expect("failed to load discarded review operation");
+
+        // Assert
+        assert_eq!(operations, Vec::new());
+        assert_eq!(
+            last_transcript_message(&transcript),
+            "[Review Comments Warning] Discarded 1 saved review thread update(s) because the \
+             pushed branch tip no longer exactly matches the reported fix commit. Reopen review \
+             comments to retry."
+        );
+    }
+
+    #[tokio::test]
+    async fn review_comment_resolution_retains_unbound_operation_for_fresh_retry() {
+        // Arrange
+        let db = linked_review_request_db().await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_get_ref_ahead_behind().never();
+        git_client.expect_repo_url().never();
+        let (input, transcript) = resolution_test_input_with_commit_reachability(
+            db.clone(),
+            git_client,
+            MockReviewRequestClient::new(),
+            vec![fixed_outcome("thread-1")],
+            TestCommitComparison::Unbound,
+        )
+        .await;
+
+        // Act
+        resolve_review_comments_after_push(&input).await;
+        let operations = db
+            .reviews()
+            .load_session_review_comment_resolutions("session-id")
+            .await
+            .expect("failed to load retained review operation");
+
+        // Assert
+        assert_eq!(operations.len(), 1);
+        assert!(operations[0].commit_hash.is_none());
+        assert_eq!(
+            last_transcript_message(&transcript),
+            "[Review Comments Warning] Kept 1 saved review thread update(s) pending because \
+             Agentty could not finish binding them to the committed revision. Reopen those \
+             comments and run a fresh agent turn to retry."
+        );
+    }
+
+    #[tokio::test]
+    async fn review_comment_resolution_retries_when_commit_check_fails() {
+        // Arrange
+        let db = linked_review_request_db().await;
+        let mut git_client = MockGitClient::new();
+        git_client.expect_repo_url().never();
+        let (input, transcript) = resolution_test_input_with_commit_reachability(
+            db.clone(),
+            git_client,
+            MockReviewRequestClient::new(),
+            vec![fixed_outcome("thread-1")],
+            TestCommitComparison::Error,
+        )
+        .await;
+
+        // Act
+        resolve_review_comments_after_push(&input).await;
+        let operations = db
+            .reviews()
+            .load_session_review_comment_resolutions("session-id")
+            .await
+            .expect("failed to load retained review operation");
+
+        // Assert
+        assert_eq!(operations.len(), 1);
+        assert_eq!(
+            last_transcript_message(&transcript),
+            "[Review Comments Warning] Could not verify saved review-comment commits after the \
+             branch push: commit lookup failed. The saved operations will retry after the next \
+             successful push."
         );
     }
 
     /// Builds one detached-push input for direct review-resolution tests.
-    fn resolution_test_input(
+    async fn resolution_test_input(
         db: AppRepositories,
         git_client: MockGitClient,
         review_request_client: MockReviewRequestClient,
         outcomes: Vec<ReviewCommentOutcome>,
+    ) -> (PublishedBranchAutoPushInput, Arc<Mutex<SessionTranscript>>) {
+        resolution_test_input_with_commit_reachability(
+            db,
+            git_client,
+            review_request_client,
+            outcomes,
+            TestCommitComparison::Matching,
+        )
+        .await
+    }
+
+    /// Builds one resolution input with a deterministic commit comparison.
+    async fn resolution_test_input_with_commit_reachability(
+        db: AppRepositories,
+        mut git_client: MockGitClient,
+        review_request_client: MockReviewRequestClient,
+        outcomes: Vec<ReviewCommentOutcome>,
+        commit_comparison: TestCommitComparison,
+    ) -> (PublishedBranchAutoPushInput, Arc<Mutex<SessionTranscript>>) {
+        if !matches!(commit_comparison, TestCommitComparison::Unbound) {
+            git_client
+                .expect_get_ref_ahead_behind()
+                .returning(move |_, left_ref, right_ref| {
+                    assert_eq!(left_ref, "HEAD");
+                    assert_eq!(right_ref, "commit-1");
+
+                    Box::pin(async move {
+                        match commit_comparison {
+                            TestCommitComparison::Error => {
+                                Err(GitError::OutputParse("commit lookup failed".to_string()))
+                            }
+                            TestCommitComparison::Matching => Ok((0, 0)),
+                            TestCommitComparison::Rewritten => Ok((1, 1)),
+                            TestCommitComparison::Unbound => unreachable!(),
+                        }
+                    })
+                });
+        }
+        let commit_hash =
+            (!matches!(commit_comparison, TestCommitComparison::Unbound)).then_some("commit-1");
+        persist_resolution_test_operations(&db, outcomes, commit_hash).await;
+
+        persisted_resolution_test_input(db, git_client, review_request_client)
+    }
+
+    /// Persists deterministic review operations for direct resolution tests.
+    async fn persist_resolution_test_operations(
+        db: &AppRepositories,
+        outcomes: Vec<ReviewCommentOutcome>,
+        commit_hash: Option<&str>,
+    ) {
+        let resolutions = outcomes
+            .into_iter()
+            .map(
+                |outcome| crate::infra::db::NewSessionReviewCommentResolution {
+                    commit_hash: commit_hash.map(str::to_string),
+                    reply: outcome.reply,
+                    reply_token: format!("token-{}", outcome.thread_id),
+                    resolution: match outcome.resolution {
+                        ReviewCommentResolution::Fixed => "fixed",
+                        ReviewCommentResolution::NoChangeNeeded => "no_change_needed",
+                    }
+                    .to_string(),
+                    review_request_display_id: "#42".to_string(),
+                    thread_id: outcome.thread_id,
+                },
+            )
+            .collect::<Vec<_>>();
+        db.reviews()
+            .insert_session_review_comment_resolutions("session-id", &resolutions)
+            .await
+            .expect("failed to persist review-comment resolutions");
+    }
+
+    /// Builds one resolution input after its durable operations are present.
+    fn persisted_resolution_test_input(
+        db: AppRepositories,
+        git_client: MockGitClient,
+        review_request_client: MockReviewRequestClient,
     ) -> (PublishedBranchAutoPushInput, Arc<Mutex<SessionTranscript>>) {
         let transcript = Arc::new(Mutex::new(SessionTranscript::default()));
         let input = PublishedBranchAutoPushInput {
@@ -971,10 +2073,7 @@ mod tests {
             folder: PathBuf::from("/tmp/project"),
             git_client: Arc::new(git_client),
             published_upstream_ref: "origin/wt/session-id".to_string(),
-            review_comment_resolution: Some(ReviewCommentResolutionInput {
-                outcomes,
-                review_request_client: Arc::new(review_request_client),
-            }),
+            review_request_client: Arc::new(review_request_client),
             review_request_metadata_sync: None,
             session_id: "session-id".into(),
             session_update_versions: Arc::default(),
@@ -997,7 +2096,7 @@ mod tests {
             folder: PathBuf::from("/tmp/project"),
             git_client: Arc::new(git_client),
             published_upstream_ref: "origin/wt/session-id".to_string(),
-            review_comment_resolution: None,
+            review_request_client: Arc::new(MockReviewRequestClient::new()),
             review_request_metadata_sync: None,
             session_id: "session-id".into(),
             session_update_versions: Arc::default(),
@@ -1006,6 +2105,26 @@ mod tests {
         };
 
         (input, transcript)
+    }
+
+    /// Builds metadata-sync dependencies with deterministic provider mocks.
+    fn metadata_sync_input(
+        commit_message: Option<&str>,
+        review_request_client: MockReviewRequestClient,
+    ) -> ReviewRequestMetadataSyncInput {
+        ReviewRequestMetadataSyncInput {
+            clock: Arc::new(crate::infra::clock::RealClock),
+            commit_message: commit_message.map(str::to_string),
+            evaluation: ReviewRequestMetadataEvaluationInput {
+                one_shot_client: Arc::new(ag_agent::MockOneShotClient::new()),
+                session_agent: AgentSelection::new(
+                    crate::domain::agent::AgentKind::Codex,
+                    crate::domain::agent::AgentModel::Gpt56Sol,
+                ),
+                session_summary: "Session summary".to_string(),
+            },
+            review_request_client: Arc::new(review_request_client),
+        }
     }
 
     /// Builds one fixed outcome accepted by the post-turn allowlist.
@@ -1026,31 +2145,62 @@ mod tests {
         }
     }
 
+    /// Builds one live unresolved forge snapshot for outcome-application
+    /// tests.
+    fn review_comment_snapshot(thread_ids: &[&str]) -> forge::ReviewCommentSnapshot {
+        forge::ReviewCommentSnapshot {
+            pr_level_comments: Vec::new(),
+            threads: thread_ids
+                .iter()
+                .map(|thread_id| ReviewCommentThread {
+                    anchor_side: ReviewCommentAnchorSide::New,
+                    comments: Vec::new(),
+                    id: (*thread_id).to_string(),
+                    is_outdated: Some(false),
+                    is_resolved: false,
+                    line: Some(1),
+                    path: "src/lib.rs".to_string(),
+                    start_line: None,
+                })
+                .collect(),
+        }
+    }
+
     /// Inserts one session linked to an open GitHub pull request.
     async fn linked_review_request_db() -> AppRepositories {
         let db = AppRepositories::in_memory().await.expect("db should open");
         insert_session(&db).await;
-        db.reviews()
-            .update_session_review_request(
-                "session-id",
-                Some(ReviewRequest {
-                    last_refreshed_at: 100,
-                    summary: forge::ReviewRequestSummary {
-                        display_id: "#42".to_string(),
-                        forge_kind: forge::ForgeKind::GitHub,
-                        source_branch: "wt/session-id".to_string(),
-                        state: ReviewRequestState::Open,
-                        status_summary: None,
-                        target_branch: "main".to_string(),
-                        title: "Review title".to_string(),
-                        web_url: "https://github.com/agentty-xyz/agentty/pull/42".to_string(),
-                    },
-                }),
-            )
-            .await
-            .expect("failed to link review request");
+        link_open_review_request(&db, "#42").await;
 
         db
+    }
+
+    /// Links one open review request to the resolution-test session.
+    async fn link_open_review_request(db: &AppRepositories, display_id: &str) {
+        db.reviews()
+            .update_session_review_request("session-id", Some(open_review_request(display_id)))
+            .await
+            .expect("failed to link review request");
+    }
+
+    /// Builds one open linked review request fixture.
+    fn open_review_request(display_id: &str) -> ReviewRequest {
+        ReviewRequest {
+            last_refreshed_at: 100,
+            summary: forge::ReviewRequestSummary {
+                display_id: display_id.to_string(),
+                forge_kind: forge::ForgeKind::GitHub,
+                source_branch: "wt/session-id".to_string(),
+                state: ReviewRequestState::Open,
+                status_summary: None,
+                target_branch: "main".to_string(),
+                title: "Review title".to_string(),
+                web_url: format!(
+                    "https://github.com/agentty-xyz/agentty/pull/{}",
+                    display_id.trim_start_matches('#')
+                ),
+            },
+        }
     }
 
     /// Inserts the session row required by review and transcript stores.

--- a/crates/agentty/src/app/session/workflow/task.rs
+++ b/crates/agentty/src/app/session/workflow/task.rs
@@ -175,6 +175,20 @@ pub(crate) struct SessionCommitOutcome {
     pub(crate) commit_message: String,
 }
 
+/// Terminal result of the automatic session-commit phase.
+///
+/// Callers must distinguish a clean worktree from a failed commit so a push of
+/// the previous `HEAD` cannot be mistaken for delivery of the agent's latest
+/// changes.
+pub(crate) enum AutoCommitOutcome {
+    /// Pending worktree changes were committed successfully.
+    Committed(SessionCommitOutcome),
+    /// The worktree contained no changes to commit.
+    NoChanges,
+    /// Agentty could not commit the pending worktree changes.
+    Failed,
+}
+
 /// Inputs needed to execute an agent-assisted edit task.
 pub(crate) struct RunAgentAssistTaskInput {
     /// App event sender used for progress and status updates.
@@ -338,9 +352,7 @@ impl SessionTaskService {
     /// also request an immediate git-status refresh so footer ahead/behind
     /// counts do not wait for the background poller. The active loader shows a
     /// dedicated committing label for the full auto-commit phase.
-    pub(in crate::app) async fn handle_auto_commit(
-        context: AssistContext,
-    ) -> Option<SessionCommitOutcome> {
+    pub(in crate::app) async fn handle_auto_commit(context: AssistContext) -> AutoCommitOutcome {
         Self::set_session_progress(
             &context.app_event_tx,
             &context.id,
@@ -363,13 +375,13 @@ impl SessionTaskService {
                 Self::emit_session_workflow_notice(&context.app_event_tx, &context.id, message);
                 Self::request_git_status_refresh(&context.app_event_tx);
 
-                Some(outcome)
+                AutoCommitOutcome::Committed(outcome)
             }
             Ok(None) => {
                 let message = TranscriptNotice::Commit.format_line("No changes to commit.");
                 Self::emit_session_workflow_notice(&context.app_event_tx, &context.id, message);
 
-                None
+                AutoCommitOutcome::NoChanges
             }
             Err(commit_error) => {
                 let message = TranscriptNotice::CommitError.format(&commit_error);
@@ -383,7 +395,7 @@ impl SessionTaskService {
                 )
                 .await;
 
-                None
+                AutoCommitOutcome::Failed
             }
         };
 
@@ -2682,7 +2694,7 @@ mod tests {
         };
 
         // Act
-        SessionTaskService::handle_auto_commit(context).await;
+        let outcome = SessionTaskService::handle_auto_commit(context).await;
 
         // Assert
         let output_text = transcript
@@ -2691,6 +2703,7 @@ mod tests {
             .and_then(|buffer| buffer.replay_text())
             .unwrap_or_default();
         assert!(output_text.contains("[Commit Error] commit failed"));
+        assert!(matches!(outcome, AutoCommitOutcome::Failed));
     }
 
     #[tokio::test]
@@ -2803,7 +2816,7 @@ mod tests {
         let outcome = SessionTaskService::handle_auto_commit(context).await;
 
         // Assert
-        assert!(outcome.is_some());
+        assert!(matches!(outcome, AutoCommitOutcome::Committed(_)));
         let output_text = transcript
             .lock()
             .ok()
@@ -2903,7 +2916,7 @@ mod tests {
         };
 
         // Act
-        SessionTaskService::handle_auto_commit(context).await;
+        let outcome = SessionTaskService::handle_auto_commit(context).await;
 
         // Assert
         let output_text = transcript
@@ -2929,6 +2942,7 @@ mod tests {
             progress_message: None,
             session_id: "session-id".into(),
         }));
+        assert!(matches!(outcome, AutoCommitOutcome::NoChanges));
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -23,6 +23,8 @@ use uuid::Uuid;
 use super::merge::{
     ExistingSessionRebaseAssistClient, RebaseAssistFuture, RebaseAssistMode, RebaseCommandInput,
 };
+#[cfg(test)]
+use super::published_branch;
 use super::task::SessionTranscriptMessageAppend;
 use super::{SessionTaskService, isolation, session_folder, turn};
 use crate::app::branch_publish::{
@@ -3304,6 +3306,7 @@ mod tests {
                     model: AgentModel::Gemini37Flash.as_str().to_string(),
                     provider_conversation_id: None,
                     questions_json: "[]".to_string(),
+                    review_comment_resolutions: Vec::new(),
                     summary: String::new(),
                     token_usage_delta: SessionStats::default(),
                 },
@@ -3982,9 +3985,82 @@ mod tests {
             .returning(|_| Box::pin(async { Ok(()) }));
     }
 
-    /// Returns one git client mock that produces a successful auto-commit
-    /// outcome.
-    fn auto_commit_git_client(commit_message: &str, sequence: &mut Sequence) -> MockGitClient {
+    /// Proves a later successful push performs no review-thread effects.
+    async fn assert_later_push_skips_review_operations(context: &SessionWorkerContext) {
+        let mut git_client = MockGitClient::new();
+        expect_safe_auto_push_state(&mut git_client);
+        git_client
+            .expect_push_current_branch_to_remote_branch()
+            .once()
+            .returning(|_, _| Box::pin(async { Ok("origin/wt/session-id".to_string()) }));
+        git_client.expect_repo_url().never();
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+
+        published_branch::run_published_branch_auto_push(
+            published_branch::PublishedBranchAutoPushInput {
+                app_event_tx,
+                db: context.db.clone(),
+                folder: context.folder.clone(),
+                git_client: Arc::new(git_client),
+                published_upstream_ref: "origin/wt/session-id".to_string(),
+                review_request_client: Arc::new(forge::MockReviewRequestClient::new()),
+                review_request_metadata_sync: None,
+                session_id: context.session_id.clone(),
+                session_update_versions: context.session_update_versions.clone(),
+                sync_operation_id: "later-push".to_string(),
+                transcript: Arc::clone(&context.transcript),
+            },
+        )
+        .await;
+        let event = app_event_rx
+            .recv()
+            .await
+            .expect("later push should report completion");
+
+        assert!(matches!(
+            event,
+            AppEvent::PublishedBranchSyncUpdated {
+                sync_status: PublishedBranchSyncStatus::Succeeded,
+                ..
+            }
+        ));
+    }
+
+    /// Pushes a descendant commit that has reverted the reported fix.
+    async fn push_descendant_that_reverted_fix(context: &SessionWorkerContext) {
+        let mut git_client = MockGitClient::new();
+        expect_safe_auto_push_state(&mut git_client);
+        git_client
+            .expect_push_current_branch_to_remote_branch()
+            .once()
+            .returning(|_, _| Box::pin(async { Ok("origin/wt/session-id".to_string()) }));
+        git_client
+            .expect_get_ref_ahead_behind()
+            .once()
+            .withf(|_, left_ref, right_ref| left_ref == "HEAD" && right_ref == "fix-commit")
+            .returning(|_, _, _| Box::pin(async { Ok((1, 0)) }));
+        git_client.expect_repo_url().never();
+
+        published_branch::run_published_branch_auto_push(
+            published_branch::PublishedBranchAutoPushInput {
+                app_event_tx: context.app_event_tx.clone(),
+                db: context.db.clone(),
+                folder: context.folder.clone(),
+                git_client: Arc::new(git_client),
+                published_upstream_ref: "origin/wt/session-id".to_string(),
+                review_request_client: Arc::new(forge::MockReviewRequestClient::new()),
+                review_request_metadata_sync: None,
+                session_id: context.session_id.clone(),
+                session_update_versions: context.session_update_versions.clone(),
+                sync_operation_id: "push-after-revert".to_string(),
+                transcript: Arc::clone(&context.transcript),
+            },
+        )
+        .await;
+    }
+
+    /// Returns one git client mock through a successful dirty-worktree commit.
+    fn dirty_auto_commit_git_client(commit_message: &str) -> MockGitClient {
         let mut mock_git_client = MockGitClient::new();
         expect_pre_commit_hook_ready(&mut mock_git_client);
         mock_git_client
@@ -4019,6 +4095,14 @@ mod tests {
             .expect_head_short_hash()
             .once()
             .returning(|_| Box::pin(async { Ok("abc1234".to_string()) }));
+
+        mock_git_client
+    }
+
+    /// Returns one git client mock that produces a successful auto-commit
+    /// outcome.
+    fn auto_commit_git_client(commit_message: &str, sequence: &mut Sequence) -> MockGitClient {
+        let mut mock_git_client = dirty_auto_commit_git_client(commit_message);
         expect_safe_auto_push_state(&mut mock_git_client);
         mock_git_client
             .expect_push_current_branch_to_remote_branch()
@@ -4047,12 +4131,22 @@ mod tests {
             .expect_is_worktree_clean()
             .once()
             .returning(|_| Box::pin(async { Ok(true) }));
+        mock_git_client
+            .expect_head_hash()
+            .once()
+            .in_sequence(sequence)
+            .returning(|_| Box::pin(async { Ok("commit-1".to_string()) }));
         expect_safe_auto_push_state(&mut mock_git_client);
         mock_git_client
             .expect_push_current_branch_to_remote_branch()
             .once()
             .in_sequence(sequence)
             .returning(|_, _| Box::pin(async { Ok("origin/wt/session-id".to_string()) }));
+        mock_git_client
+            .expect_get_ref_ahead_behind()
+            .once()
+            .in_sequence(sequence)
+            .returning(|_, _, _| Box::pin(async { Ok((0, 0)) }));
         mock_git_client
             .expect_repo_url()
             .once()
@@ -4077,6 +4171,27 @@ mod tests {
             .in_sequence(sequence)
             .returning(|_| Ok(github_forge_remote()));
         review_request_client
+            .expect_fetch_review_comment_snapshot()
+            .once()
+            .in_sequence(sequence)
+            .returning(|_, _| {
+                Box::pin(async {
+                    Ok(forge::ReviewCommentSnapshot {
+                        pr_level_comments: Vec::new(),
+                        threads: vec![forge::ReviewCommentThread {
+                            anchor_side: forge::ReviewCommentAnchorSide::New,
+                            comments: Vec::new(),
+                            id: "thread-42".to_string(),
+                            is_outdated: Some(false),
+                            is_resolved: false,
+                            line: Some(1),
+                            path: "src/lib.rs".to_string(),
+                            start_line: None,
+                        }],
+                    })
+                })
+            });
+        review_request_client
             .expect_reply_to_thread()
             .once()
             .in_sequence(sequence)
@@ -4084,7 +4199,10 @@ mod tests {
                 remote.command_working_directory.as_deref() == Some(folder.as_path())
                     && display_id == "#42"
                     && thread_id == "thread-42"
-                    && body == "Added the missing validation."
+                    && body.starts_with(
+                        "Added the missing validation.\n\n<!-- agentty review resolution:",
+                    )
+                    && body.ends_with(" -->")
             })
             .returning(|_, _, _, _| Box::pin(async { Ok(()) }));
         review_request_client
@@ -4100,40 +4218,7 @@ mod tests {
     /// Returns one git client mock that commits successfully but fails the
     /// follow-up auto-push.
     fn auto_commit_git_client_with_push_failure(commit_message: &str) -> MockGitClient {
-        let mut mock_git_client = MockGitClient::new();
-        expect_pre_commit_hook_ready(&mut mock_git_client);
-        mock_git_client
-            .expect_is_worktree_clean()
-            .once()
-            .returning(|_| Box::pin(async { Ok(false) }));
-        mock_git_client
-            .expect_diff()
-            .once()
-            .returning(|_, _| Box::pin(async { Ok("diff --git a/a.rs b/a.rs".to_string()) }));
-        mock_git_client
-            .expect_has_commits_since()
-            .once()
-            .returning(|_, _| Box::pin(async { Ok(true) }));
-        mock_git_client
-            .expect_head_commit_message()
-            .once()
-            .returning({
-                let commit_message = commit_message.to_string();
-
-                move |_| {
-                    let commit_message = commit_message.clone();
-
-                    Box::pin(async move { Ok(Some(commit_message)) })
-                }
-            });
-        mock_git_client
-            .expect_commit_all_preserving_single_commit()
-            .once()
-            .returning(|_, _, _, _, _| Box::pin(async { Ok(()) }));
-        mock_git_client
-            .expect_head_short_hash()
-            .once()
-            .returning(|_| Box::pin(async { Ok("abc1234".to_string()) }));
+        let mut mock_git_client = dirty_auto_commit_git_client(commit_message);
         expect_safe_auto_push_state(&mut mock_git_client);
         mock_git_client
             .expect_push_current_branch_to_remote_branch()
@@ -4232,6 +4317,28 @@ mod tests {
                 answer: answer.to_string(),
                 questions: Vec::new(),
                 review_comment_outcomes: Vec::new(),
+                subtasks: Vec::new(),
+                verification_verdicts: Vec::new(),
+                summary: None,
+            },
+            context_reset: false,
+            input_tokens: 0,
+            output_tokens: 0,
+            provider_conversation_id: None,
+        }
+    }
+
+    /// Returns one completed turn that reports a fixed review thread.
+    fn fixed_review_turn_result() -> TurnResult {
+        TurnResult {
+            assistant_message: AgentResponse {
+                answer: "Implemented the change.".to_string(),
+                questions: Vec::new(),
+                review_comment_outcomes: vec![ReviewCommentOutcome {
+                    reply: "Added the missing validation.".to_string(),
+                    resolution: ReviewCommentResolution::Fixed,
+                    thread_id: "thread-42".to_string(),
+                }],
                 subtasks: Vec::new(),
                 verification_verdicts: Vec::new(),
                 summary: None,
@@ -4379,24 +4486,7 @@ mod tests {
             session_agent,
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
-        let turn_result = TurnResult {
-            assistant_message: AgentResponse {
-                answer: "Implemented the change.".to_string(),
-                questions: Vec::new(),
-                review_comment_outcomes: vec![ReviewCommentOutcome {
-                    reply: "Added the missing validation.".to_string(),
-                    resolution: ReviewCommentResolution::Fixed,
-                    thread_id: "thread-42".to_string(),
-                }],
-                subtasks: Vec::new(),
-                verification_verdicts: Vec::new(),
-                summary: None,
-            },
-            context_reset: false,
-            input_tokens: 0,
-            output_tokens: 0,
-            provider_conversation_id: None,
-        };
+        let turn_result = fixed_review_turn_result();
 
         // Act
         let status = apply_worker_turn_result(
@@ -4433,13 +4523,373 @@ mod tests {
             .expect("resolution notice should be appended")
             .content
             .clone();
+        let unfinished_operations = context
+            .db
+            .reviews()
+            .load_session_review_comment_resolutions("sess1")
+            .await
+            .expect("failed to load completed review-comment operations");
 
         // Assert
         assert_eq!(status, Status::Review);
+        assert_eq!(unfinished_operations, Vec::new());
         assert_eq!(
             notice.trim(),
             "[Review Comments] Replied to 1 review thread(s) and resolved 1 fixed thread(s)."
         );
+    }
+
+    #[tokio::test]
+    async fn test_failed_push_discards_review_fix_undone_by_descendant() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let db = AppRepositories::in_memory().await.expect("db should open");
+        insert_in_progress_session_with_review_request(&db).await;
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash);
+        let mut git_client = auto_commit_git_client_with_push_failure("Fix the review comment");
+        git_client
+            .expect_head_hash()
+            .once()
+            .returning(|_| Box::pin(async { Ok("fix-commit".to_string()) }));
+        let transcript = empty_transcript();
+        let context = SessionWorkerContext {
+            app_event_tx,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
+            cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
+            channel: Arc::new(MockAgentChannel::new()),
+            child_pid: Arc::new(Mutex::new(None)),
+            clock: Arc::new(crate::infra::clock::RealClock),
+            db: db.clone(),
+            folder: base_dir.path().join("sess1"),
+            fs_client: Arc::new(fs::MockFsClient::new()),
+            git_client: Arc::new(git_client),
+            transcript: Arc::clone(&transcript),
+            personality_catalog_client: Arc::new(RealPersonalityCatalogClient),
+            queued_messages: Arc::new(Mutex::new(VecDeque::new())),
+            review_request_client: Arc::new(forge::MockReviewRequestClient::new()),
+            session_update_versions: Arc::default(),
+            session_id: "sess1".into(),
+            session_agent,
+            status: Arc::new(Mutex::new(Status::InProgress)),
+        };
+        let turn_result = fixed_review_turn_result();
+
+        // Act
+        apply_worker_turn_result(
+            &context,
+            TurnMetadata {
+                published_upstream_ref: Some("origin/wt/session-id".to_string()),
+                review_comment_thread_ids: vec!["thread-42".to_string()],
+                session_agent,
+            },
+            Ok(turn_result),
+        )
+        .await
+        .expect("turn result should succeed");
+        let first_push_events = tokio::time::timeout(Duration::from_secs(1), async {
+            let mut sync_events = Vec::new();
+            while sync_events.len() < 2 {
+                let event = app_event_rx.recv().await.expect("missing app event");
+                if let AppEvent::PublishedBranchSyncUpdated { sync_status, .. } = event {
+                    sync_events.push(sync_status);
+                }
+            }
+
+            sync_events
+        })
+        .await
+        .expect("timed out waiting for failed push");
+        let pending_operations = db
+            .reviews()
+            .load_session_review_comment_resolutions("sess1")
+            .await
+            .expect("failed to load pending review operation");
+        push_descendant_that_reverted_fix(&context).await;
+        let remaining_operations = db
+            .reviews()
+            .load_session_review_comment_resolutions("sess1")
+            .await
+            .expect("failed to load discarded review operation");
+        let notice = transcript
+            .lock()
+            .expect("transcript lock should be available")
+            .messages()
+            .last()
+            .expect("stale-operation notice should be appended")
+            .content
+            .clone();
+
+        // Assert
+        assert_eq!(
+            first_push_events,
+            vec![
+                PublishedBranchSyncStatus::InProgress,
+                PublishedBranchSyncStatus::Failed,
+            ]
+        );
+        assert_eq!(pending_operations.len(), 1);
+        assert_eq!(
+            pending_operations[0].commit_hash.as_deref(),
+            Some("fix-commit")
+        );
+        assert_eq!(remaining_operations, Vec::new());
+        assert_eq!(
+            notice.trim(),
+            "[Review Comments Warning] Discarded 1 saved review thread update(s) because the \
+             pushed branch tip no longer exactly matches the reported fix commit. Reopen review \
+             comments to retry."
+        );
+    }
+
+    #[tokio::test]
+    async fn test_commit_binding_failure_retains_review_operation_for_fresh_retry() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let db = AppRepositories::in_memory().await.expect("db should open");
+        insert_in_progress_session_with_review_request(&db).await;
+        let (app_event_tx, _) = mpsc::unbounded_channel();
+        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash);
+        let mut git_client = dirty_auto_commit_git_client("Fix the review comment");
+        git_client.expect_head_hash().once().returning(|_| {
+            Box::pin(async {
+                Err(ag_git::GitError::OutputParse(
+                    "commit binding interrupted".to_string(),
+                ))
+            })
+        });
+        git_client
+            .expect_push_current_branch_to_remote_branch()
+            .never();
+        let context = SessionWorkerContext {
+            app_event_tx,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
+            cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
+            channel: Arc::new(MockAgentChannel::new()),
+            child_pid: Arc::new(Mutex::new(None)),
+            clock: Arc::new(crate::infra::clock::RealClock),
+            db: db.clone(),
+            folder: base_dir.path().join("sess1"),
+            fs_client: Arc::new(fs::MockFsClient::new()),
+            git_client: Arc::new(git_client),
+            transcript: empty_transcript(),
+            personality_catalog_client: Arc::new(RealPersonalityCatalogClient),
+            queued_messages: Arc::new(Mutex::new(VecDeque::new())),
+            review_request_client: Arc::new(forge::MockReviewRequestClient::new()),
+            session_update_versions: Arc::default(),
+            session_id: "sess1".into(),
+            session_agent,
+            status: Arc::new(Mutex::new(Status::InProgress)),
+        };
+
+        // Act
+        let error = apply_worker_turn_result(
+            &context,
+            TurnMetadata {
+                published_upstream_ref: Some("origin/wt/session-id".to_string()),
+                review_comment_thread_ids: vec!["thread-42".to_string()],
+                session_agent,
+            },
+            Ok(fixed_review_turn_result()),
+        )
+        .await
+        .expect_err("commit binding should fail");
+        let pending_operations = db
+            .reviews()
+            .load_session_review_comment_resolutions("sess1")
+            .await
+            .expect("failed to load binding-pending review operation");
+
+        // Assert
+        assert!(error.to_string().contains("commit binding interrupted"));
+        assert_eq!(pending_operations.len(), 1);
+        assert!(pending_operations[0].commit_hash.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_commit_failure_discards_review_operations_before_later_push() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let db = AppRepositories::in_memory().await.expect("db should open");
+        insert_in_progress_session_with_review_request(&db).await;
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash);
+        let mut git_client = MockGitClient::new();
+        git_client.expect_is_worktree_clean().once().returning(|_| {
+            Box::pin(async { Err(ag_git::GitError::OutputParse("commit failed".to_string())) })
+        });
+        git_client
+            .expect_push_current_branch_to_remote_branch()
+            .never();
+        let mut review_request_client = forge::MockReviewRequestClient::new();
+        review_request_client.expect_detect_remote().never();
+        review_request_client
+            .expect_fetch_review_comment_snapshot()
+            .never();
+        review_request_client.expect_reply_to_thread().never();
+        review_request_client.expect_resolve_thread().never();
+        let transcript = empty_transcript();
+        let context = SessionWorkerContext {
+            app_event_tx,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
+            cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
+            channel: Arc::new(MockAgentChannel::new()),
+            child_pid: Arc::new(Mutex::new(None)),
+            clock: Arc::new(crate::infra::clock::RealClock),
+            db,
+            folder: base_dir.path().join("sess1"),
+            fs_client: Arc::new(fs::MockFsClient::new()),
+            git_client: Arc::new(git_client),
+            transcript: Arc::clone(&transcript),
+            personality_catalog_client: Arc::new(RealPersonalityCatalogClient),
+            queued_messages: Arc::new(Mutex::new(VecDeque::new())),
+            review_request_client: Arc::new(review_request_client),
+            session_update_versions: Arc::default(),
+            session_id: "sess1".into(),
+            session_agent,
+            status: Arc::new(Mutex::new(Status::InProgress)),
+        };
+        let turn_result = TurnResult {
+            assistant_message: AgentResponse {
+                answer: "Implemented the change.".to_string(),
+                questions: Vec::new(),
+                review_comment_outcomes: vec![ReviewCommentOutcome {
+                    reply: "Added the missing validation.".to_string(),
+                    resolution: ReviewCommentResolution::Fixed,
+                    thread_id: "thread-42".to_string(),
+                }],
+                subtasks: Vec::new(),
+                verification_verdicts: Vec::new(),
+                summary: None,
+            },
+            context_reset: false,
+            input_tokens: 0,
+            output_tokens: 0,
+            provider_conversation_id: None,
+        };
+
+        // Act
+        let status = apply_worker_turn_result(
+            &context,
+            TurnMetadata {
+                published_upstream_ref: Some("origin/wt/session-id".to_string()),
+                review_comment_thread_ids: vec!["thread-42".to_string()],
+                session_agent,
+            },
+            Ok(turn_result),
+        )
+        .await
+        .expect("turn result should succeed");
+        let events = std::iter::from_fn(|| app_event_rx.try_recv().ok()).collect::<Vec<_>>();
+        let transcript_text = transcript
+            .lock()
+            .expect("transcript lock should be available")
+            .replay_text()
+            .expect("commit failure notices should be persisted");
+        let unfinished_operations = context
+            .db
+            .reviews()
+            .load_session_review_comment_resolutions("sess1")
+            .await
+            .expect("failed to load discarded review-comment operation");
+
+        // Act
+        assert_later_push_skips_review_operations(&context).await;
+
+        // Assert
+        assert_eq!(status, Status::Review);
+        assert_eq!(unfinished_operations, Vec::new());
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, AppEvent::PublishedBranchSyncUpdated { .. }))
+        );
+        assert!(transcript_text.contains("[Commit Error] commit failed"));
+        assert!(transcript_text.contains(
+            "could not commit the review-comment changes, so it did not push the branch"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_apply_turn_result_rejects_incomplete_review_comment_outcome_batch() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let db = AppRepositories::in_memory().await.expect("db should open");
+        insert_in_progress_session_with_review_request(&db).await;
+        let session_agent = AgentSelection::new(AgentKind::Antigravity, AgentModel::Gemini37Flash);
+        let mut git_client = MockGitClient::new();
+        git_client
+            .expect_is_worktree_clean()
+            .once()
+            .returning(|_| Box::pin(async { Ok(true) }));
+        git_client
+            .expect_push_current_branch_to_remote_branch()
+            .never();
+        let transcript = empty_transcript();
+        let context = SessionWorkerContext {
+            app_event_tx: mpsc::unbounded_channel().0,
+            branch_operation_lock: Arc::new(tokio::sync::Mutex::new(())),
+            cancel_token: Arc::new(Mutex::new(CancellationToken::new())),
+            channel: Arc::new(MockAgentChannel::new()),
+            child_pid: Arc::new(Mutex::new(None)),
+            clock: Arc::new(crate::infra::clock::RealClock),
+            db,
+            folder: base_dir.path().join("sess1"),
+            fs_client: Arc::new(fs::MockFsClient::new()),
+            git_client: Arc::new(git_client),
+            transcript: Arc::clone(&transcript),
+            personality_catalog_client: Arc::new(RealPersonalityCatalogClient),
+            queued_messages: Arc::new(Mutex::new(VecDeque::new())),
+            review_request_client: Arc::new(forge::MockReviewRequestClient::new()),
+            session_update_versions: Arc::default(),
+            session_id: "sess1".into(),
+            session_agent,
+            status: Arc::new(Mutex::new(Status::InProgress)),
+        };
+        let turn_result = TurnResult {
+            assistant_message: AgentResponse {
+                answer: "Implemented one change.".to_string(),
+                questions: Vec::new(),
+                review_comment_outcomes: vec![ReviewCommentOutcome {
+                    reply: "Added the first validation.".to_string(),
+                    resolution: ReviewCommentResolution::Fixed,
+                    thread_id: "thread-1".to_string(),
+                }],
+                subtasks: Vec::new(),
+                verification_verdicts: Vec::new(),
+                summary: None,
+            },
+            context_reset: false,
+            input_tokens: 0,
+            output_tokens: 0,
+            provider_conversation_id: None,
+        };
+
+        // Act
+        let status = apply_worker_turn_result(
+            &context,
+            TurnMetadata {
+                published_upstream_ref: None,
+                review_comment_thread_ids: vec!["thread-1".to_string(), "thread-2".to_string()],
+                session_agent,
+            },
+            Ok(turn_result),
+        )
+        .await
+        .expect("turn result should succeed");
+        let transcript_text = transcript
+            .lock()
+            .expect("transcript lock should be available")
+            .replay_text()
+            .expect("validation warning should be persisted");
+
+        // Assert
+        assert_eq!(status, Status::Review);
+        assert!(
+            transcript_text
+                .contains("exactly one valid outcome for 1 of 2 selected review thread(s)")
+        );
+        assert!(transcript_text.contains("No review replies were posted or threads resolved"));
     }
 
     #[tokio::test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -2936,6 +2936,31 @@ printf '%s\n' '{"type":"result","subtype":"success","result":"{\"answer\":\"Proc
     Ok(())
 }
 
+/// Seeds a two-thread review batch whose agent response omits one required
+/// outcome so the UI can prove partial forge updates are rejected visibly.
+fn seed_incomplete_review_comment_outcomes(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    seed_review_comment_agent_resolution(env)?;
+
+    let claude_path = env.stub_bin.join("claude");
+    std::fs::write(
+        &claude_path,
+        r#"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
+cat > /dev/null 2>&1
+printf '%s\n' '{"type":"system","subtype":"init"}'
+printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Processed only one selected review thread."}]}}'
+printf '%s\n' '{"type":"result","subtype":"success","result":"{\"answer\":\"Processed only one selected review thread.\",\"questions\":[],\"review_comment_outcomes\":[{\"reply\":\"Added the explanation.\",\"resolution\":\"fixed\",\"thread_id\":\"thread-inline\"}],\"summary\":null}","usage":{"input_tokens":5,"output_tokens":9}}'
+"#,
+    )?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o755))?;
+
+    Ok(())
+}
+
 /// Seeds a merged GitHub review response and delays runtime worktree removal
 /// so the feature scenario can prove terminal rendering stays responsive.
 fn seed_slow_merged_review_request_status(
@@ -7674,6 +7699,7 @@ fn test_diff_line_comments() -> E2eResult {
                     .wait_for_text("Enter: reply", 5000)
                     .wait_for_text("[Commit] No changes to commit.", 5000)
                     .wait_for_text("No review findings.", 5000)
+                    .write_text("G")
                     .wait_for_stable_frame(1000, 5000)
                     .viewing_pause_ms(1500)
                     .capture_labeled(
@@ -8221,6 +8247,56 @@ fn session_review_comment_agent_resolution() -> E2eResult {
                 );
                 assertion::assert_not_visible(frame, "Thread ID: thread-inline");
                 assertion::assert_not_visible(frame, "Requested action:");
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify an incomplete structured outcome batch produces a visible warning
+/// and does not silently apply only the reported thread.
+#[test]
+fn test_review_comment_incomplete_outcomes() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("review_comment_incomplete_outcomes")
+        .with_git()
+        .with_terminal_size(160, 60)
+        .setup(seed_incomplete_review_comment_outcomes)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .compose(&common::open_selected_session_view())
+                    .press_key("d")
+                    .wait_for_text("c: comments", 5000)
+                    .press_key("c")
+                    .wait_for_text("Space: select", 5000)
+                    .press_key("Space")
+                    .press_key("j")
+                    .press_key("Space")
+                    .wait_for_text("Selected 2", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Processed only one selected review thread.", 10000)
+                    .wait_for_text("exactly one valid outcome for 1 of 2", 10000)
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(
+                    frame,
+                    "exactly one valid outcome for 1 of 2",
+                    &full,
+                );
+                assertion::assert_text_in_region(
+                    frame,
+                    "No review replies were posted or threads",
+                    &full,
+                );
+                assertion::assert_text_in_region(
+                    frame,
+                    "resolved. Reopen review comments to retry",
+                    &full,
+                );
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -840,15 +840,28 @@ orchestration paths:
   the injected git/forge boundaries, falls back to the persisted review-request URL
   after terminal-session worktree cleanup, and uses the matching `AppEvent` to update
   only the still-open Diff workspace or its help overlay. Inline code context is derived
-  from the already loaded current diff. From a reply-capable session, `a` marks an
-  actionable thread to address, `d` marks it to deny, and `Enter` renders every marked
-  thread plus its requested action into one `TurnPrompt`; outdated threads include an
-  explicit stale-anchor marker. The selected forge thread IDs are recorded in turn
-  metadata. Post-turn handling accepts deduplicated outcomes with an allowlisted ID and
-  nonblank reply. After auto-commit and a successful published-branch push, the worker
-  posts every accepted reply and resolves only outcomes reported as `fixed` through
-  `ReviewRequestClient`; `no_change_needed` outcomes remain open, and failed pushes
-  never mutate forge thread state.
+  from the already loaded current diff. From a reply-capable session, `Space` toggles an
+  actionable thread in the evaluation batch, and `Enter` renders every selected thread
+  into one `TurnPrompt`; outdated threads include an explicit stale-anchor marker. The
+  selected forge thread IDs are recorded in turn metadata. Post-turn handling requires
+  exactly one allowlisted, nonblank outcome per selected thread and rejects an
+  incomplete or duplicated batch before any forge mutation. Accepted outcomes, their
+  original replies, and random per-thread reply tokens commit in the same SQLite
+  transaction as the completed-turn metadata before auto-commit starts. A failed
+  auto-commit prevents the published-branch push and discards the selected batch before
+  a later turn can push unrelated changes. Successful auto-commit binds each newly
+  inserted operation to the full fix commit SHA. After every successful push, the worker
+  requires that commit to exactly match pushed `HEAD`; later descendants and rewritten
+  commits are discarded before forge access. An operation whose commit binding was
+  interrupted remains pending and is replaceable by a fresh agent turn, while a bound
+  operation continues to retain its original reply. Immediately before a forge reply,
+  the worker marks the durable operation as posting. Recovery trusts a matching
+  tokenized reply only when that flag is set, which closes the reply-success/crash
+  window without treating a collaborator-authored imitation as Agentty's audit reply.
+  The row is deleted after the requested forge effects finish. Bound operations retain
+  the first accepted reply when a later agent turn reports a different one. The worker
+  resolves only `fixed` operations through `ReviewRequestClient`; `no_change_needed`
+  operations remain open, and failed commits or pushes never mutate forge thread state.
 
 ## Persistence and Recovery Boundaries
 
@@ -857,6 +870,12 @@ runtime flow:
 
 - DB opens with SQLite WAL and `foreign_keys = ON`, then embedded migrations run at
   startup.
+- Review-comment resolution operations are durable, session-owned rows committed with
+  their completed-turn metadata and later bound to the successful fix commit. A pre-post
+  flag and unguessable reply token make post-push forge effects resumable across process
+  shutdown without relying on in-memory agent output, while exact pushed-tip matching
+  rejects outcomes after any later commit. Binding-pending rows remain durable until a
+  fresh review turn replaces them.
 - Session snapshots in memory are authoritative for rendering; DB is authoritative for
   restart recovery.
 - Shared session handles provide low-latency updates between DB reloads.

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -631,15 +631,31 @@ can retry without reporting a false terminal cancellation.
   done and why whether or not a change was needed. Press `f` to return to the Files
   section without leaving Diff mode.
 - Agent-driven review-comment turns report one structured outcome for each submitted
-  inline thread. After Agentty commits the work and successfully pushes an already
-  published branch, it posts the agent's concise reply for every valid allowlisted
-  outcome and resolves only threads reported as `fixed`. Threads reported as
-  `no_change_needed` receive their explanatory reply but remain open. Unknown thread
-  IDs, blank replies, and resolved threads are ignored. Unresolved outdated threads
-  remain actionable through their forge thread ID while their stale line anchor is
-  omitted from current diff context. Reply or resolution failures produce a
-  `[Review Comments Warning]` transcript notice and do not block the successful branch
-  push.
+  inline thread. Agentty rejects the whole outcome batch when an allowlisted thread is
+  missing, duplicated, or has a blank reply, so a malformed agent response cannot apply
+  only part of the selected work. After Agentty commits the work and successfully pushes
+  an already published branch, it refreshes the live threads, posts the agent's concise
+  reply for every valid allowlisted outcome, and resolves only threads reported as
+  `fixed`. Threads reported as `no_change_needed` receive their explanatory reply but
+  remain open. Unknown thread IDs are ignored. Unresolved outdated threads remain
+  actionable through their forge thread ID while their stale line anchor is omitted from
+  current diff context. Agentty saves each operation's original reply and random marker
+  token in the same database transaction that completes the agent turn, so restart
+  recovery cannot observe one without the other. It flags the operation immediately
+  before posting and deletes it after completion, so a later successful branch push
+  resumes saved work and reuses a reply that reached the forge before an interruption
+  instead of posting it twice. A new agent response cannot replace a bound unfinished
+  operation's saved reply, and an unrelated comment that copies Agentty's old static
+  marker is not accepted as its audit reply. Commit, reply, resolution, and
+  missing-open-review failures produce a `[Review Comments Warning]` transcript notice.
+  A commit failure discards that review batch, so a later unrelated push cannot apply
+  its stale outcomes; reopen the comments to retry. A push failure keeps a successfully
+  committed batch for the next push attempt. Before applying that batch, Agentty
+  verifies the pushed tip still exactly matches its saved fix commit. Any later commit,
+  including a revert, causes Agentty to discard the saved outcomes and require a fresh
+  review batch. If shutdown or persistence failure interrupts commit binding, Agentty
+  keeps the unbound batch pending, reports that a fresh agent turn is required, and lets
+  that turn replace only the unbound operation.
 
 <a id="usage-review-request-prerequisites"></a> Publishing needs regular Git
 authentication (credential helper or PAT for HTTPS remotes, SSH key for SSH remotes)


### PR DESCRIPTION
- Persist complete review outcomes atomically with turn metadata and bind them to successful fix commits.
- Resume reply and resolution operations safely across crashes and push retries using durable tokens and posting state.
- Reject incomplete batches and discard operations whose commits fail, become stale, or are no longer reachable.
- Add complete coverable production-line coverage and a deterministic diff-line-comments feature capture.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)