### PR TITLE
Empty-value assertions use equality and toolchain tracks nightly-2026-08-21

### DIFF
--- a/crates/ag-git/src/merge.rs
+++ b/crates/ag-git/src/merge.rs
@@ -785,7 +785,10 @@ mod tests {
             run_git_stdout(temp_dir.path(), &["rev-parse", "HEAD"]),
             original_head
         );
-        assert!(run_git_stdout(temp_dir.path(), &["status", "--porcelain"]).is_empty());
+        assert_eq!(
+            run_git_stdout(temp_dir.path(), &["status", "--porcelain"]),
+            ""
+        );
     }
 
     #[test]

--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -559,7 +559,7 @@ mod tests {
             .expect_complete_with_optional_metadata()
             .times(1)
             .returning(|request| {
-                assert!(request.tools().is_empty());
+                assert_eq!(request.tools(), []);
 
                 Ok(response_without_metadata(ModelResponse::ToolCall(
                     read_call("call_denied"),

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -1074,7 +1074,7 @@ mod tests {
         // Assert
         assert_eq!(request.prompt(), "hello");
         assert_eq!(request.schema(), &schema);
-        assert!(request.tools().is_empty());
+        assert_eq!(request.tools(), []);
     }
 
     #[test]

--- a/crates/ag-harness/tests/lifecycle.rs
+++ b/crates/ag-harness/tests/lifecycle.rs
@@ -245,7 +245,7 @@ async fn harness_owns_model_events_without_duplicate_model_observation() {
 
     // Assert
     assert_eq!(output, json!({"name": "SECRET_OUTPUT"}));
-    assert!(model_events.events().is_empty());
+    assert_eq!(model_events.events(), [] as [ag_harness::LifecycleEvent; 0]);
     let harness_events = harness_events.events();
     assert_sequence(&harness_events);
     assert_eq!(harness_events.len(), 4);
@@ -321,7 +321,7 @@ async fn cancelling_harness_turn_closes_model_and_turn_lifecycles_once() {
 
     // Assert
     assert!(cancellation.is_cancelled());
-    assert!(model_events.events().is_empty());
+    assert_eq!(model_events.events(), [] as [ag_harness::LifecycleEvent; 0]);
     let harness_events = harness_events.events();
     assert_sequence(&harness_events);
     assert_eq!(harness_events.len(), 4);

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -3195,14 +3195,14 @@ mod tests {
 
         // Assert
         assert!(app.deferred_auto_review_session_ids.is_empty());
-        assert!(
+        assert_eq!(
             app.services
                 .db()
                 .sessions()
                 .load_pending_focused_review_session_ids(inactive_project_id)
                 .await
-                .expect("failed to load deferred reviews")
-                .is_empty()
+                .expect("failed to load deferred reviews"),
+            [] as [String; 0]
         );
     }
 

--- a/crates/agentty/src/app/orchestration.rs
+++ b/crates/agentty/src/app/orchestration.rs
@@ -5310,7 +5310,7 @@ mod tests {
             OrchestrationTaskStatus::Reported.to_string()
         );
         assert!(research.last_error.is_none());
-        assert!(backend.calls().is_empty());
+        assert_eq!(backend.calls(), [] as [String; 0]);
     }
 
     #[tokio::test]
@@ -6359,8 +6359,8 @@ mod tests {
             task.kind == OrchestrationTaskKind::Implementation.to_string()
                 && task.status == OrchestrationTaskStatus::Proposed.to_string()
         }));
-        assert!(implementation_response.subtasks.is_empty());
-        assert!(implementation_response.questions.is_empty());
+        assert_eq!(implementation_response.subtasks, []);
+        assert_eq!(implementation_response.questions, []);
     }
 
     #[tokio::test]
@@ -6431,7 +6431,7 @@ mod tests {
             "Inspect architecture and dependency boundaries"
         );
         assert!(refreshed_tasks[0].research_report.is_none());
-        assert!(correction.subtasks.is_empty());
+        assert_eq!(correction.subtasks, []);
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/prompt_intent.rs
+++ b/crates/agentty/src/app/prompt_intent.rs
@@ -1175,7 +1175,7 @@ mod tests {
                 session_id: session_id.clone(),
             }
         );
-        assert!(app.sessions.sessions()[0].queued_messages.is_empty());
+        assert_eq!(app.sessions.sessions()[0].queued_messages, []);
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -3193,7 +3193,7 @@ async fn test_enqueue_message_rejects_empty_payload() {
         .iter()
         .find(|session| session.id == session_id)
         .expect("session present");
-    assert!(session.queued_messages.is_empty());
+    assert_eq!(session.queued_messages, []);
 }
 
 #[tokio::test]

--- a/crates/agentty/src/app/session_api.rs
+++ b/crates/agentty/src/app/session_api.rs
@@ -3125,7 +3125,7 @@ mod tests {
             ApiSessionError::Operation("Session has no questions to answer".to_string())
         );
         assert_eq!(resumed_turn_kind, AgentRequestKind::SessionResume);
-        assert!(queued_messages_before_transition.is_empty());
+        assert_eq!(queued_messages_before_transition, []);
         assert_eq!(session.questions, [] as [ag_protocol::QuestionItem; 0]);
         assert_eq!(session.queued_messages, [] as [std::string::String; 0]);
         assert_eq!(clarification_answer_count(&session), 1);

--- a/crates/agentty/src/app/session_diff.rs
+++ b/crates/agentty/src/app/session_diff.rs
@@ -1112,7 +1112,7 @@ mod tests {
         assert_eq!(exhausted_event, None);
         assert!(app.deferred_auto_review_session_ids.contains(&session_id));
         assert_eq!(recoverable_session_ids, [session_id.as_str()]);
-        assert!(stale_retry_session_ids.is_empty());
+        assert_eq!(stale_retry_session_ids, [] as [String; 0]);
     }
 
     #[tokio::test]
@@ -1144,14 +1144,14 @@ mod tests {
         app.apply_review_diff_update(update, None, false).await;
 
         // Assert
-        assert!(
+        assert_eq!(
             app.services
                 .db()
                 .sessions()
                 .load_pending_focused_review_session_ids(project_id)
                 .await
-                .expect("failed to load pending reviews")
-                .is_empty()
+                .expect("failed to load pending reviews"),
+            [] as [String; 0]
         );
         assert!(!app.review_cache.contains_key(&session_id));
     }

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -1131,7 +1131,7 @@ pub(crate) mod tests {
         // Assert
         assert_eq!(queued_actions, vec![branch_publish, sync.clone()]);
         assert_eq!(after_resolve, vec![sync]);
-        assert!(handles.queued_action_snapshot().is_empty());
+        assert_eq!(handles.queued_action_snapshot(), []);
     }
 
     #[test]

--- a/crates/agentty/src/presentation/app_mode.rs
+++ b/crates/agentty/src/presentation/app_mode.rs
@@ -1158,9 +1158,9 @@ mod tests {
         line_comments.finish_editing();
 
         // Assert
-        assert!(line_comments.comments.is_empty());
+        assert_eq!(line_comments.comments, []);
         assert!(line_comments.editing_input_mut().is_none());
-        assert!(line_comments.prompt_text().is_empty());
+        assert_eq!(line_comments.prompt_text(), "");
     }
 
     #[test]

--- a/crates/agentty/src/runtime/terminal.rs
+++ b/crates/agentty/src/runtime/terminal.rs
@@ -432,7 +432,7 @@ mod tests {
         // Assert
         let _stdout = result.expect("setup should use Kitty enhancement directly");
         assert_eq!(guard.enhancement(), enhancement_fixture(true, false));
-        assert!(xterm_startup_sequence.is_empty());
+        assert_eq!(xterm_startup_sequence, "");
     }
 
     /// Verifies support-query failures fall back to the legacy key mode so TUI
@@ -657,8 +657,8 @@ mod tests {
             .expect("disable sequence should render");
 
         // Assert
-        assert!(disabled_enable_sequence.is_empty());
-        assert!(disabled_disable_sequence.is_empty());
+        assert_eq!(disabled_enable_sequence, "");
+        assert_eq!(disabled_disable_sequence, "");
         assert_eq!(enable_sequence, "\x1B[>4;1f\x1B[>4;2m");
         assert_eq!(disable_sequence, "\x1B[>4f\x1B[>4m");
     }

--- a/crates/agentty/src/ui/page/diff.rs
+++ b/crates/agentty/src/ui/page/diff.rs
@@ -1893,8 +1893,8 @@ mod tests {
                 },
             ]
         );
-        assert!(folder_lines.is_empty());
-        assert!(reversed_lines.is_empty());
+        assert_eq!(folder_lines, []);
+        assert_eq!(reversed_lines, []);
         assert_eq!(folder_anchor_index, None);
         assert_eq!(missing_anchor_index, None);
     }
@@ -2274,7 +2274,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["old first", "new first", "unchanged second"]
         );
-        assert!(missing_path_lines.is_empty());
+        assert_eq!(missing_path_lines, []);
     }
 
     #[test]
@@ -2464,7 +2464,7 @@ mod tests {
 
         // Assert
         assert_eq!(line_comments.comments.len(), 2);
-        assert!(insertions.is_empty());
+        assert_eq!(insertions, []);
     }
 
     #[test]

--- a/crates/agentty/src/ui/session_output_assembly.rs
+++ b/crates/agentty/src/ui/session_output_assembly.rs
@@ -985,7 +985,7 @@ mod tests {
 
         // Assert
         assert_eq!(loader_line_index, None);
-        assert!(lines.is_empty());
+        assert_eq!(lines, []);
     }
 
     #[test]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # Keep local and CI lint and coverage behavior reproducible.
-channel = "nightly-2026-05-28"
+channel = "nightly-2026-08-21"


### PR DESCRIPTION
- Makes empty collection and string expectations explicit across affected tests.
- Advances the pinned Rust nightly toolchain for reproducible checks.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)