### PR TITLE
Diff navigation preserves the scrolled viewport when entering changed-line focus

### DIFF
--- a/crates/agentty/src/runtime/mode/diff.rs
+++ b/crates/agentty/src/runtime/mode/diff.rs
@@ -768,7 +768,7 @@ enum DiffContentDirection {
     Previous,
 }
 
-/// Moves focus into a file's preview or first added/removed line.
+/// Moves focus into a file's preview or first visible added/removed line.
 fn focus_selected_file_changes(
     navigation: &mut DiffContentNavigation<'_>,
     content_area: Rect,
@@ -800,12 +800,14 @@ fn focus_selected_file_changes(
         content_area,
         render_cache_store.diff_layout_cache(),
     );
-    if changed_line_layout.changed_line_count() == 0 {
+    let Some(selected_diff_line_index) =
+        changed_line_layout.changed_line_index_at_scroll_offset(*navigation.scroll_offset)
+    else {
         return;
-    }
+    };
 
     *navigation.focus = DiffFocus::Content;
-    *navigation.selected_diff_line_index = 0;
+    *navigation.selected_diff_line_index = selected_diff_line_index;
     *navigation.scroll_offset = changed_line_layout
         .changed_line_scroll_offset(
             *navigation.selected_diff_line_index,
@@ -1459,6 +1461,44 @@ mod tests {
                 } if comments.is_empty()
             ));
         }
+    }
+
+    #[tokio::test]
+    async fn test_handle_l_from_files_focus_preserves_scrolled_position() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+        app.mode = AppMode::Diff {
+            diff: scrollable_diff_fixture(),
+            file_explorer_selected_index: 1,
+            focus: DiffFocus::Files,
+            line_comments: DiffLineComments::default(),
+            preview: DiffPreview::default(),
+            review_comments: None,
+            restore: None,
+            scroll_cache: None,
+            scroll_offset: 20,
+            selected_diff_line_index: 0,
+            session_id: "session-id".into(),
+        };
+
+        // Act
+        let event_result = handle(
+            &mut app,
+            TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE),
+        );
+
+        // Assert
+        assert!(matches!(event_result, EventResult::Continue));
+        assert!(matches!(
+            app.mode,
+            AppMode::Diff {
+                focus: DiffFocus::Content,
+                scroll_offset: 20,
+                selected_diff_line_index,
+                ..
+            } if selected_diff_line_index > 0
+        ));
     }
 
     #[tokio::test]

--- a/crates/agentty/src/ui/page/diff.rs
+++ b/crates/agentty/src/ui/page/diff.rs
@@ -583,6 +583,17 @@ impl DiffResolvedLayout {
         self.changed_line_ranges.len()
     }
 
+    /// Returns the first changed source line intersecting or below the viewport
+    /// top.
+    pub(crate) fn changed_line_index_at_scroll_offset(&self, scroll_offset: u16) -> Option<usize> {
+        let scroll_offset = usize::from(scroll_offset);
+
+        self.changed_line_ranges
+            .iter()
+            .position(|range| range.end > scroll_offset)
+            .or_else(|| self.changed_line_ranges.len().checked_sub(1))
+    }
+
     /// Returns the scroll offset that keeps one changed source line visible.
     pub(crate) fn changed_line_scroll_offset(
         &self,
@@ -2394,6 +2405,9 @@ mod tests {
         let scrolled_down = layout
             .changed_line_scroll_offset(20, 0)
             .expect("selected changed line should have a rendered range");
+        let first_visible_changed_line = layout
+            .changed_line_index_at_scroll_offset(scrolled_down)
+            .expect("scrolled viewport should contain a changed line");
         let scrolled_up = layout
             .changed_line_scroll_offset(0, scrolled_down)
             .expect("first changed line should have a rendered range");
@@ -2410,6 +2424,8 @@ mod tests {
         // Assert
         assert_eq!(layout.changed_line_count(), 40);
         assert!(scrolled_down > 0);
+        assert!(first_visible_changed_line > 0);
+        assert!(first_visible_changed_line <= 20);
         assert!(scrolled_up < scrolled_down);
         assert_eq!(zero_height_scroll_offset, 0);
         assert_eq!(
@@ -2417,6 +2433,26 @@ mod tests {
             layout.changed_line_ranges[2].start..layout.changed_line_ranges[4].end
         );
         assert_eq!(missing_selection_range, None);
+    }
+
+    #[test]
+    fn test_diff_changed_line_layout_selects_last_change_below_viewport() {
+        // Arrange
+        let diff = "diff --git a/main.rs b/main.rs\n@@ -0,0 +1 @@\n+changed\n context";
+        let cache = DiffLayoutCache::default();
+        let layout = diff_changed_line_layout(
+            diff,
+            &DiffLineComments::default(),
+            0,
+            Rect::new(0, 0, 80, 12),
+            &cache,
+        );
+
+        // Act
+        let selected_index = layout.changed_line_index_at_scroll_offset(u16::MAX);
+
+        // Assert
+        assert_eq!(selected_index, Some(0));
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -7554,7 +7554,7 @@ fn test_slow_diff_loading_remains_cancelable() -> E2eResult {
 }
 
 /// Verify that the right-hand patch scrolls while Files remains focused, then
-/// `l` moves focus into changed-line navigation like `Enter`.
+/// `l` moves focus into changed-line navigation without resetting the viewport.
 #[test]
 fn test_diff_changed_line_navigation() -> E2eResult {
     // Arrange, Act, Assert
@@ -7572,7 +7572,7 @@ fn test_diff_changed_line_navigation() -> E2eResult {
                     .press_key("j")
                     .wait_for_stable_frame(200, 3000);
                 let scenario = (0..70).fold(scenario, |scenario, _| scenario.press_key("Down"));
-                let scenario = scenario
+                scenario
                     .wait_for_text("changed line 70", 5000)
                     .wait_for_stable_frame(300, 5000)
                     .capture_labeled(
@@ -7580,16 +7580,13 @@ fn test_diff_changed_line_navigation() -> E2eResult {
                         "Selected file scrolled without leaving Files focus",
                     )
                     .press_key("l")
-                    .wait_for_text("Esc/Left: files", 5000);
-                let scenario = (0..70).fold(scenario, |scenario, _| scenario.press_key("Down"));
-
-                scenario
+                    .wait_for_text("Esc/Left: files", 5000)
                     .wait_for_text("changed line 70", 5000)
                     .wait_for_stable_frame(300, 5000)
                     .viewing_pause_ms(1500)
                     .capture_labeled(
                         "diff_changed_line_navigation",
-                        "Changed-line cursor scrolled through the selected file",
+                        "Changed-line cursor entered at the retained file position",
                     )
             },
             |frame, report| {


### PR DESCRIPTION
- Select the first visible changed line instead of resetting to the file’s first change.
- Cover retained viewport behavior in unit and E2E tests.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)