### PR TITLE
Add lifecycle observer fan-out and standardize GenAI telemetry

### DIFF
--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -24,9 +24,13 @@ continue calling allowed tools until it returns schema-valid JSON.
 Use `ModelWithMetadata::complete_with_metadata()` for normalized completion metadata.
 
 Attach `with_lifecycle_observer()` to receive ordered metadata-only lifecycle events.
+Use `LifecycleObserverSet` to send the same stream to multiple observers, such as
+metrics, traces, and a host-owned journal.
 
 ## Telemetry
 
 When the application installs an OpenTelemetry meter provider, `ModelClient` records
 request duration and provider-reported input and output tokens. Missing usage is not
 estimated, sensitive content is excluded, and the application owns export and shutdown.
+The emitted instruments follow the pinned OpenTelemetry GenAI semantic-convention
+contract documented in the architecture guide.

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -21,8 +21,8 @@ mod write;
 pub use file_system::{FileSystem, LocalFileSystem};
 pub use harness::{Harness, TurnError};
 pub use lifecycle::{
-    LifecycleEvent, LifecycleEventKind, LifecycleId, LifecycleObserver, ModelResponseType,
-    ToolErrorType, TurnErrorType,
+    LifecycleEvent, LifecycleEventKind, LifecycleId, LifecycleObserver, LifecycleObserverSet,
+    ModelResponseType, ToolErrorType, TurnErrorType,
 };
 pub use model::{
     CompletionMetadata, CompletionUsage, Model, ModelClient, ModelCompletion, ModelError,

--- a/crates/ag-harness/src/lifecycle.rs
+++ b/crates/ag-harness/src/lifecycle.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, PoisonError};
@@ -208,6 +209,83 @@ where
     fn observe(&self, event: LifecycleEvent) {
         self(event);
     }
+}
+
+/// Ordered fan-out to multiple lifecycle observers.
+///
+/// Observers run in registration order. A panic in one observer does not
+/// prevent later observers from receiving the event. Same-thread reentrant
+/// events are queued until every observer receives the current event, keeping
+/// each observer's stream in sequence order.
+pub struct LifecycleObserverSet {
+    available: Condvar,
+    observers: Vec<Arc<dyn LifecycleObserver>>,
+    state: Mutex<ObserverSetState>,
+}
+
+impl LifecycleObserverSet {
+    /// Creates a fan-out containing `observer`.
+    pub fn new(observer: impl LifecycleObserver + 'static) -> Self {
+        Self {
+            available: Condvar::new(),
+            observers: vec![Arc::new(observer)],
+            state: Mutex::new(ObserverSetState::default()),
+        }
+    }
+
+    /// Appends an observer to the fan-out.
+    #[must_use]
+    pub fn with_observer(mut self, observer: impl LifecycleObserver + 'static) -> Self {
+        self.observers.push(Arc::new(observer));
+
+        self
+    }
+
+    fn deliver(&self, event: &LifecycleEvent) {
+        for observer in &self.observers {
+            let event = event.clone();
+            let _ = catch_unwind(AssertUnwindSafe(|| observer.observe(event)));
+        }
+    }
+}
+
+impl LifecycleObserver for LifecycleObserverSet {
+    fn observe(&self, event: LifecycleEvent) {
+        let current_thread = thread::current().id();
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        if state.owner == Some(current_thread) {
+            state.pending.push_back(event);
+
+            return;
+        }
+        state = self
+            .available
+            .wait_while(state, |state| state.owner.is_some())
+            .unwrap_or_else(PoisonError::into_inner);
+        state.owner = Some(current_thread);
+        drop(state);
+
+        let mut event = event;
+        loop {
+            self.deliver(&event);
+
+            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            let Some(next_event) = state.pending.pop_front() else {
+                state.owner = None;
+                self.available.notify_one();
+
+                return;
+            };
+            drop(state);
+            event = next_event;
+        }
+    }
+}
+
+#[derive(Default)]
+struct ObserverSetState {
+    owner: Option<ThreadId>,
+    pending: VecDeque<LifecycleEvent>,
 }
 
 #[derive(Clone, Default)]
@@ -550,6 +628,85 @@ mod tests {
         });
 
         (emitter, events)
+    }
+
+    #[test]
+    fn observer_set_preserves_order_during_reentrant_delivery() {
+        // Arrange
+        let emitter_holder = Arc::new(Mutex::new(None::<LifecycleEmitter>));
+        let first_emitter = Arc::clone(&emitter_holder);
+        let deliveries = Arc::new(Mutex::new(Vec::new()));
+        let first_deliveries = Arc::clone(&deliveries);
+        let second_deliveries = Arc::clone(&deliveries);
+        let observers = LifecycleObserverSet::new(move |event: LifecycleEvent| {
+            let sequence = event.sequence();
+            first_deliveries
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push((0, sequence));
+            if sequence == 0 {
+                first_emitter
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .as_ref()
+                    .expect("emitter should be available to its observer")
+                    .emit(LifecycleEventKind::TurnStarted {
+                        turn_id: LifecycleId(1),
+                    });
+            }
+        })
+        .with_observer(move |event: LifecycleEvent| {
+            second_deliveries
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push((1, event.sequence()));
+        });
+        let emitter = LifecycleEmitter::new(observers);
+        *emitter_holder
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = Some(emitter.clone());
+
+        // Act
+        emitter.emit(LifecycleEventKind::TurnStarted {
+            turn_id: LifecycleId(0),
+        });
+
+        // Assert
+        assert_eq!(
+            *deliveries.lock().unwrap_or_else(PoisonError::into_inner),
+            vec![(0, 0), (1, 0), (0, 1), (1, 1)]
+        );
+    }
+
+    #[test]
+    fn observer_set_isolates_each_observer_panic() {
+        // Arrange
+        let deliveries = Arc::new(Mutex::new(Vec::new()));
+        let recorded_deliveries = Arc::clone(&deliveries);
+        let observers = LifecycleObserverSet::new(|_| {
+            std::panic::resume_unwind(Box::new("observer failed"));
+        })
+        .with_observer(move |event: LifecycleEvent| {
+            recorded_deliveries
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push(event.sequence());
+        });
+        let emitter = LifecycleEmitter::new(observers);
+
+        // Act
+        emitter.emit(LifecycleEventKind::TurnStarted {
+            turn_id: LifecycleId(0),
+        });
+        emitter.emit(LifecycleEventKind::TurnStarted {
+            turn_id: LifecycleId(1),
+        });
+
+        // Assert
+        assert_eq!(
+            *deliveries.lock().unwrap_or_else(PoisonError::into_inner),
+            vec![0, 1]
+        );
     }
 
     #[test]

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -682,15 +682,15 @@ impl ModelErrorType {
     /// Returns the stable value intended for telemetry attributes.
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::Request => "request_error",
-            Self::Transport => "transport_error",
-            Self::Provider => "provider_error",
-            Self::InvalidProviderResponse => "invalid_provider_response",
-            Self::InvalidResponse => "invalid_response",
-            Self::UnsupportedOutput => "unsupported_output",
-            Self::ResponseTooLarge => "response_too_large",
-            Self::InvalidOutput => "invalid_output",
-            Self::InvalidToolCall => "invalid_tool_call",
+            Self::Request => telemetry::ERROR_REQUEST,
+            Self::Transport => telemetry::ERROR_TRANSPORT,
+            Self::Provider => telemetry::ERROR_PROVIDER,
+            Self::InvalidProviderResponse => telemetry::ERROR_INVALID_PROVIDER_RESPONSE,
+            Self::InvalidResponse => telemetry::ERROR_INVALID_RESPONSE,
+            Self::UnsupportedOutput => telemetry::ERROR_UNSUPPORTED_OUTPUT,
+            Self::ResponseTooLarge => telemetry::ERROR_RESPONSE_TOO_LARGE,
+            Self::InvalidOutput => telemetry::ERROR_INVALID_OUTPUT,
+            Self::InvalidToolCall => telemetry::ERROR_INVALID_TOOL_CALL,
         }
     }
 }

--- a/crates/ag-harness/src/provider/kimi.rs
+++ b/crates/ag-harness/src/provider/kimi.rs
@@ -1,6 +1,5 @@
-use crate::chat_completion;
+use crate::{chat_completion, telemetry};
 
-pub(crate) const PROVIDER_NAME: &str = "moonshot_ai";
 pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
     chat_completion::ChatCompletionProviderPolicy {
         display_name: "Kimi",
@@ -8,7 +7,7 @@ pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
             assistant_reasoning_content: true,
             tool_result_name: true,
         },
-        telemetry_name: PROVIDER_NAME,
+        telemetry_name: telemetry::PROVIDER_MOONSHOT_AI,
         unsupported_schema_reason: "Kimi JSON Object mode requires an explicit object root schema",
     };
 

--- a/crates/ag-harness/src/provider/muse.rs
+++ b/crates/ag-harness/src/provider/muse.rs
@@ -3,11 +3,11 @@ use std::env;
 use async_trait::async_trait;
 use thiserror::Error;
 
-use crate::chat_completion;
 use crate::lifecycle::LifecycleObserver;
 use crate::model::{
     ModelClient, ModelCompletion, ModelError, ModelMetadataError, ModelRequest, ModelWithMetadata,
 };
+use crate::{chat_completion, telemetry};
 
 const DEFAULT_BASE_URL: &str = "https://api.meta.ai/v1";
 const MODEL_API_BASE_URL_ENV: &str = "MODEL_API_BASE_URL";
@@ -21,12 +21,11 @@ pub const MUSE_SPARK_1_2: &str = "muse-spark-1.2";
 /// completions to train future models.
 pub const MUSE_SPARK_1_2_CONTRIBUTOR: &str = "muse-spark-1.2-contributor";
 
-pub(crate) const PROVIDER_NAME: &str = "meta";
 pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
     chat_completion::ChatCompletionProviderPolicy {
         display_name: "Meta Model API",
         structured_output: chat_completion::StructuredOutputMode::JsonSchema,
-        telemetry_name: PROVIDER_NAME,
+        telemetry_name: telemetry::PROVIDER_META,
         unsupported_schema_reason: "Muse structured output requires an explicit object root schema",
     };
 

--- a/crates/ag-harness/src/provider/qwen.rs
+++ b/crates/ag-harness/src/provider/qwen.rs
@@ -1,6 +1,5 @@
-use crate::chat_completion;
+use crate::{chat_completion, telemetry};
 
-pub(crate) const PROVIDER_NAME: &str = "alibaba_cloud";
 pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
     chat_completion::ChatCompletionProviderPolicy {
         display_name: "Qwen",
@@ -8,7 +7,7 @@ pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
             assistant_reasoning_content: false,
             tool_result_name: false,
         },
-        telemetry_name: PROVIDER_NAME,
+        telemetry_name: telemetry::PROVIDER_ALIBABA_CLOUD,
         unsupported_schema_reason: "Qwen JSON Object mode requires an explicit object root schema",
     };
 

--- a/crates/ag-harness/src/telemetry.rs
+++ b/crates/ag-harness/src/telemetry.rs
@@ -5,10 +5,33 @@ use opentelemetry::{KeyValue, global};
 
 use crate::model::{CompletionMetadata, ModelError, ModelMetadata};
 
-const DURATION_BOUNDARIES_SECONDS: [f64; 14] = [
+pub(crate) const ATTRIBUTE_ERROR_TYPE: &str = "error.type";
+pub(crate) const ATTRIBUTE_OPERATION_NAME: &str = "gen_ai.operation.name";
+pub(crate) const ATTRIBUTE_PROVIDER_NAME: &str = "gen_ai.provider.name";
+pub(crate) const ATTRIBUTE_REQUEST_MODEL: &str = "gen_ai.request.model";
+pub(crate) const ATTRIBUTE_TOKEN_TYPE: &str = "gen_ai.token.type";
+pub(crate) const DURATION_BOUNDARIES_SECONDS: [f64; 14] = [
     0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
 ];
-const TOKEN_BOUNDARIES: [f64; 14] = [
+pub(crate) const DURATION_DESCRIPTION: &str = "GenAI operation duration.";
+pub(crate) const DURATION_METRIC: &str = "gen_ai.client.operation.duration";
+pub(crate) const DURATION_UNIT: &str = "s";
+pub(crate) const ERROR_CANCELLED: &str = "cancelled";
+pub(crate) const ERROR_INVALID_OUTPUT: &str = "invalid_output";
+pub(crate) const ERROR_INVALID_PROVIDER_RESPONSE: &str = "invalid_provider_response";
+pub(crate) const ERROR_INVALID_RESPONSE: &str = "invalid_response";
+pub(crate) const ERROR_INVALID_TOOL_CALL: &str = "invalid_tool_call";
+pub(crate) const ERROR_PROVIDER: &str = "provider_error";
+pub(crate) const ERROR_REQUEST: &str = "request_error";
+pub(crate) const ERROR_RESPONSE_TOO_LARGE: &str = "response_too_large";
+pub(crate) const ERROR_TRANSPORT: &str = "transport_error";
+pub(crate) const ERROR_UNSUPPORTED_OUTPUT: &str = "unsupported_output";
+pub(crate) const INSTRUMENTATION_SCOPE: &str = "ag-harness";
+pub(crate) const OPERATION_CHAT: &str = "chat";
+pub(crate) const PROVIDER_ALIBABA_CLOUD: &str = "alibaba_cloud";
+pub(crate) const PROVIDER_META: &str = "meta";
+pub(crate) const PROVIDER_MOONSHOT_AI: &str = "moonshot_ai";
+pub(crate) const TOKEN_BOUNDARIES: [f64; 14] = [
     1.0,
     4.0,
     16.0,
@@ -24,6 +47,11 @@ const TOKEN_BOUNDARIES: [f64; 14] = [
     16_777_216.0,
     67_108_864.0,
 ];
+pub(crate) const TOKEN_DESCRIPTION: &str = "Number of input and output tokens used.";
+pub(crate) const TOKEN_METRIC: &str = "gen_ai.client.token.usage";
+pub(crate) const TOKEN_TYPE_INPUT: &str = "input";
+pub(crate) const TOKEN_TYPE_OUTPUT: &str = "output";
+pub(crate) const TOKEN_UNIT: &str = "{token}";
 
 /// Records one model request's operational metrics.
 pub(crate) struct RequestMetrics<'a> {
@@ -68,19 +96,19 @@ impl<'a> RequestMetrics<'a> {
     }
 
     fn duration_histogram() -> Histogram<f64> {
-        global::meter("ag-harness")
-            .f64_histogram("gen_ai.client.operation.duration")
-            .with_description("GenAI operation duration.")
-            .with_unit("s")
+        global::meter(INSTRUMENTATION_SCOPE)
+            .f64_histogram(DURATION_METRIC)
+            .with_description(DURATION_DESCRIPTION)
+            .with_unit(DURATION_UNIT)
             .with_boundaries(DURATION_BOUNDARIES_SECONDS.to_vec())
             .build()
     }
 
     fn token_histogram() -> Histogram<u64> {
-        global::meter("ag-harness")
-            .u64_histogram("gen_ai.client.token.usage")
-            .with_description("Number of input and output tokens used.")
-            .with_unit("{token}")
+        global::meter(INSTRUMENTATION_SCOPE)
+            .u64_histogram(TOKEN_METRIC)
+            .with_description(TOKEN_DESCRIPTION)
+            .with_unit(TOKEN_UNIT)
             .with_boundaries(TOKEN_BOUNDARIES.to_vec())
             .build()
     }
@@ -100,25 +128,25 @@ impl<'a> RequestMetrics<'a> {
 
         if let Some(input) = usage.input_tokens() {
             let mut attributes = self.attributes(None);
-            attributes.push(KeyValue::new("gen_ai.token.type", "input"));
+            attributes.push(KeyValue::new(ATTRIBUTE_TOKEN_TYPE, TOKEN_TYPE_INPUT));
             metric.record(input, &attributes);
         }
         if let Some(output) = usage.output_tokens() {
             let mut attributes = self.attributes(None);
-            attributes.push(KeyValue::new("gen_ai.token.type", "output"));
+            attributes.push(KeyValue::new(ATTRIBUTE_TOKEN_TYPE, TOKEN_TYPE_OUTPUT));
             metric.record(output, &attributes);
         }
     }
 
     fn attributes(&self, error_type: Option<&str>) -> Vec<KeyValue> {
         let mut attributes = vec![
-            KeyValue::new("gen_ai.operation.name", "chat"),
-            KeyValue::new("gen_ai.provider.name", self.provider),
-            KeyValue::new("gen_ai.request.model", self.model.to_string()),
+            KeyValue::new(ATTRIBUTE_OPERATION_NAME, OPERATION_CHAT),
+            KeyValue::new(ATTRIBUTE_PROVIDER_NAME, self.provider),
+            KeyValue::new(ATTRIBUTE_REQUEST_MODEL, self.model.to_string()),
         ];
 
         if let Some(error_type) = error_type {
-            attributes.push(KeyValue::new("error.type", error_type.to_string()));
+            attributes.push(KeyValue::new(ATTRIBUTE_ERROR_TYPE, error_type.to_string()));
         }
 
         attributes
@@ -128,7 +156,7 @@ impl<'a> RequestMetrics<'a> {
 impl Drop for RequestMetrics<'_> {
     fn drop(&mut self) {
         if self.is_active {
-            self.record_duration(Some("cancelled"));
+            self.record_duration(Some(ERROR_CANCELLED));
         }
     }
 }

--- a/crates/ag-harness/tests/public_api.rs
+++ b/crates/ag-harness/tests/public_api.rs
@@ -4,8 +4,9 @@ use std::error::Error;
 use std::sync::{Arc, Mutex};
 
 use ag_harness::{
-    CompletionMetadata, CompletionUsage, Harness, LifecycleEventKind, Model, ModelCompletion,
-    ModelError, ModelRequest, ModelResponse, ModelWithMetadata, OutputSchema, OutputSchemaError,
+    CompletionMetadata, CompletionUsage, Harness, LifecycleEventKind, LifecycleObserverSet, Model,
+    ModelCompletion, ModelError, ModelRequest, ModelResponse, ModelWithMetadata, OutputSchema,
+    OutputSchemaError,
 };
 use async_trait::async_trait;
 use serde_json::json;
@@ -132,6 +133,46 @@ async fn external_metadata_provider_reaches_harness_lifecycle() -> Result<(), Bo
         } if metadata.response_id() == Some("external-response")
             && metadata.usage().and_then(|usage| usage.total_tokens()) == Some(6)
     )));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn external_observer_set_fans_out_lifecycle_events() -> Result<(), Box<dyn Error>> {
+    // Arrange
+    let first_events = Arc::new(Mutex::new(Vec::new()));
+    let observed_first_events = Arc::clone(&first_events);
+    let second_events = Arc::new(Mutex::new(Vec::new()));
+    let observed_second_events = Arc::clone(&second_events);
+    let observers = LifecycleObserverSet::new(move |event| {
+        observed_first_events
+            .lock()
+            .expect("first event recorder should not be poisoned")
+            .push(event);
+    })
+    .with_observer(move |event| {
+        observed_second_events
+            .lock()
+            .expect("second event recorder should not be poisoned")
+            .push(event);
+    });
+    let harness = Harness::new(ExternalMetadataModel).with_lifecycle_observer(observers);
+
+    // Act
+    let output = harness
+        .run("extract the name", request()?.schema().clone())
+        .await?;
+
+    // Assert
+    assert_eq!(output, json!({ "name": "Ada" }));
+    let first_events = first_events
+        .lock()
+        .expect("first event recorder should not be poisoned");
+    let second_events = second_events
+        .lock()
+        .expect("second event recorder should not be poisoned");
+    assert!(!first_events.is_empty());
+    assert_eq!(*first_events, *second_events);
 
     Ok(())
 }

--- a/crates/ag-harness/tests/telemetry.rs
+++ b/crates/ag-harness/tests/telemetry.rs
@@ -154,6 +154,8 @@ fn assert_duration_metric(metrics: &[&Metric]) {
         .iter()
         .find(|metric| metric.name() == "gen_ai.client.operation.duration")
         .expect("duration metric should be exported");
+    assert_eq!(duration.description(), "GenAI operation duration.");
+    assert_eq!(duration.unit(), "s");
     assert!(matches!(
         duration.data(),
         AggregatedMetrics::F64(MetricData::Histogram(histogram)) if {
@@ -219,6 +221,11 @@ fn assert_token_usage_metric(metrics: &[&Metric]) {
         .iter()
         .find(|metric| metric.name() == "gen_ai.client.token.usage")
         .expect("token-usage metric should be exported");
+    assert_eq!(
+        token_usage.description(),
+        "Number of input and output tokens used."
+    );
+    assert_eq!(token_usage.unit(), "{token}");
     assert!(matches!(
         token_usage.data(),
         AggregatedMetrics::U64(MetricData::Histogram(histogram)) if {

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -196,8 +196,69 @@ Applications may observe and persist them independently from OpenTelemetry expor
 neither configured, no lifecycle data is retained or sent externally. Applications own
 storage, retention, OpenTelemetry setup, export, and shutdown.
 
+`LifecycleObserverSet` composes projections over that one ordered stream. Observers run
+in registration order, and each callback has an independent panic boundary. Reentrant
+events wait behind the event currently being fanned out so every observer sees the same
+sequence order.
+
 Sensitive content is excluded. Any future content capture remains separate, explicit,
 bounded, redacted, and disabled by default.
+
+### OpenTelemetry semantic-convention contract
+
+`ag-harness` targets the OpenTelemetry GenAI semantic conventions at revision
+[`eaefa142a94cefe5d199d47e4a73727dfbd825df`](https://github.com/open-telemetry/semantic-conventions-genai/tree/eaefa142a94cefe5d199d47e4a73727dfbd825df).
+The conventions are Development status, so this immutable revision, rather than the
+repository's moving `main` branch, defines the compatibility contract.
+
+The current model-client projection implements these standard histograms:
+
+| Instrument                         | Unit      | Explicit bucket boundaries                    |
+| ---------------------------------- | --------- | --------------------------------------------- |
+| `gen_ai.client.operation.duration` | `s`       | `0.01` through `81.92`, doubling each step    |
+| `gen_ai.client.token.usage`        | `{token}` | `1` through `67108864`, quadrupling each step |
+
+Both instruments record the required `gen_ai.operation.name` value `chat`, the provider
+identity, and the requested model when available. Token measurements also record the
+required `gen_ai.token.type` value `input` or `output`. Failed duration measurements
+record `error.type`. Instrument names, descriptions, units, boundaries, attribute names,
+and well-known values are centralized in the telemetry module.
+
+The provider registry contains one standard value and two documented custom values:
+
+| Provider | `gen_ai.provider.name` | Registry status                                                            |
+| -------- | ---------------------- | -------------------------------------------------------------------------- |
+| Kimi     | `moonshot_ai`          | OpenTelemetry well-known value                                             |
+| Muse     | `meta`                 | Custom value; no OpenTelemetry value identifies Meta Model API             |
+| Qwen     | `alibaba_cloud`        | Custom value; no OpenTelemetry value identifies Alibaba Cloud Model Studio |
+
+Model request failures use this bounded `error.type` vocabulary:
+
+| Value                       | Meaning                                                 |
+| --------------------------- | ------------------------------------------------------- |
+| HTTP status code            | Provider returned that valid HTTP error status          |
+| `cancelled`                 | The request future was dropped before completion        |
+| `request_error`             | Request construction or an unclassified client failure  |
+| `transport_error`           | Transport failed before a provider response was decoded |
+| `provider_error`            | Provider failure without an available HTTP status       |
+| `invalid_provider_response` | Provider response envelope was malformed                |
+| `invalid_response`          | Successful response was incomplete or unusable          |
+| `unsupported_output`        | Provider could not satisfy the output contract          |
+| `response_too_large`        | Response exceeded a configured safety bound             |
+| `invalid_output`            | Output failed JSON parsing or schema validation         |
+| `invalid_tool_call`         | Tool call was missing, malformed, or unsupported        |
+
+Messages, prompts, system instructions, tool arguments, tool results, response bodies,
+repository content, and internal lifecycle identifiers are never projected to
+OpenTelemetry. Opt-in content attributes and events remain disabled even when the
+semantic conventions define them.
+
+Upgrading the pinned revision requires an explicit conformance change. That change must
+review the source models and generated metric, span, and event documents; update the
+pin, central constants, provider and error registries, contract tests, and this
+architecture page together; and preserve the metadata-only policy. When the pinned
+revision has no applicable convention, the fact remains an internal `LifecycleEvent`
+instead of being exported under an invented standard-looking name.
 
 ## Permissions
 


### PR DESCRIPTION
- Expose ordered `LifecycleObserverSet` delivery with reentrant sequencing and observer panic isolation.
- Centralize provider, error, instrument, attribute, unit, description, and boundary values against the pinned OpenTelemetry GenAI revision.
- Document the metadata-only lifecycle and telemetry contract and verify public fan-out and metric metadata.