### PR TITLE
Harden patch application, response parsing, and orchestration cancellation

### DIFF
--- a/crates/ag-agent/src/agent/app_server/gemini/lifecycle.rs
+++ b/crates/ag-agent/src/agent/app_server/gemini/lifecycle.rs
@@ -481,7 +481,7 @@ pub(super) fn build_image_content_block(
 pub(super) fn prompt_image_mime_type(local_image_path: &Path) -> &'static str {
     let Some(extension) = local_image_path
         .extension()
-        .and_then(|extension| extension.to_str())
+        .and_then(std::ffi::OsStr::to_str)
     else {
         return "image/png";
     };
@@ -540,6 +540,21 @@ mod tests {
         // Assert
         assert_eq!(utility_timeout, app_server_transport::TURN_TIMEOUT);
         assert_eq!(session_timeout, app_server_transport::STARTUP_TIMEOUT);
+    }
+
+    #[test]
+    fn prompt_image_mime_type_uses_file_extension() {
+        // Arrange
+        let paths = ["image.GIF", "image.jpg", "image.webp", "image"];
+
+        // Act
+        let mime_types = paths.map(Path::new).map(prompt_image_mime_type);
+
+        // Assert
+        assert_eq!(
+            mime_types,
+            ["image/gif", "image/jpeg", "image/webp", "image/png"]
+        );
     }
 
     #[tokio::test]

--- a/crates/ag-agent/src/agent/app_server/gemini/usage.rs
+++ b/crates/ag-agent/src/agent/app_server/gemini/usage.rs
@@ -100,39 +100,35 @@ fn extract_token_count_object(value: Option<&Value>) -> Option<(u64, u64)> {
 
 /// Extracts assistant text from known ACP prompt completion result shapes.
 pub(super) fn extract_prompt_result_text(result: &Value) -> Option<String> {
-    if let Some(response_text) = result.get("response").and_then(Value::as_str) {
-        return Some(response_text.to_string());
-    }
+    extract_string_field(result, "response")
+        .or_else(|| extract_string_field(result, "text"))
+        .or_else(|| extract_nonempty_content_field(result, "content"))
+        .or_else(|| result.get("message").and_then(extract_message_text))
+        .or_else(|| extract_output_text(result.get("output")?))
+}
 
-    if let Some(message_text) = result.get("text").and_then(Value::as_str) {
-        return Some(message_text.to_string());
-    }
+fn extract_string_field(value: &Value, field: &str) -> Option<String> {
+    value.get(field).and_then(Value::as_str).map(str::to_string)
+}
 
-    if let Some(content) = result.get("content")
-        && let Some(content_text) = extract_text_from_content_value(content)
-        && !content_text.is_empty()
-    {
-        return Some(content_text);
-    }
+fn extract_nonempty_content_field(value: &Value, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(extract_text_from_content_value)
+        .filter(|text| !text.is_empty())
+}
 
-    if let Some(message) = result.get("message") {
-        if let Some(message_text) = message.get("text").and_then(Value::as_str) {
-            return Some(message_text.to_string());
-        }
+fn extract_message_text(message: &Value) -> Option<String> {
+    extract_string_field(message, "text")
+        .or_else(|| extract_nonempty_content_field(message, "content"))
+}
 
-        if let Some(content) = message.get("content")
-            && let Some(content_text) = extract_text_from_content_value(content)
-            && !content_text.is_empty()
-        {
-            return Some(content_text);
-        }
-    }
-
-    let output_items = result.get("output").and_then(Value::as_array)?;
+fn extract_output_text(output: &Value) -> Option<String> {
+    let output_items = output.as_array()?;
     let mut output_text = String::new();
     for output_item in output_items {
-        if let Some(item_text) = output_item.get("text").and_then(Value::as_str) {
-            output_text.push_str(item_text);
+        if let Some(item_text) = extract_string_field(output_item, "text") {
+            output_text.push_str(&item_text);
 
             continue;
         }
@@ -155,42 +151,75 @@ pub(super) fn extract_prompt_result_text(result: &Value) -> Option<String> {
 pub(super) fn extract_text_from_content_value(content: &Value) -> Option<String> {
     match content {
         Value::String(text) => Some(text.clone()),
-        Value::Array(parts) => {
-            let mut combined_text = String::new();
-            for part in parts {
-                if let Some(part_text) = extract_text_from_content_value(part) {
-                    combined_text.push_str(&part_text);
-                }
-            }
-            if combined_text.is_empty() {
-                return None;
-            }
-
-            Some(combined_text)
-        }
-        Value::Object(_) => {
-            if let Some(text) = content.get("text").and_then(Value::as_str) {
-                return Some(text.to_string());
-            }
-
-            if let Some(parts_text) = content
-                .get("parts")
-                .and_then(extract_text_from_content_value)
-                && !parts_text.is_empty()
-            {
-                return Some(parts_text);
-            }
-
-            if let Some(nested_content_text) = content
-                .get("content")
-                .and_then(extract_text_from_content_value)
-                && !nested_content_text.is_empty()
-            {
-                return Some(nested_content_text);
-            }
-
-            None
-        }
+        Value::Array(parts) => extract_text_from_parts(parts),
+        Value::Object(_) => extract_text_from_content_object(content),
         _ => None,
+    }
+}
+
+fn extract_text_from_parts(parts: &[Value]) -> Option<String> {
+    let combined_text = parts
+        .iter()
+        .filter_map(extract_text_from_content_value)
+        .collect::<String>();
+
+    (!combined_text.is_empty()).then_some(combined_text)
+}
+
+fn extract_text_from_content_object(content: &Value) -> Option<String> {
+    extract_string_field(content, "text")
+        .or_else(|| extract_nonempty_content_field(content, "parts"))
+        .or_else(|| extract_nonempty_content_field(content, "content"))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::extract_prompt_result_text;
+
+    #[test]
+    fn prompt_result_text_flattens_nested_content_parts() {
+        // Arrange
+        let result = json!({
+            "content": {
+                "parts": [null, "First", {"content": {"text": " second"}}]
+            }
+        });
+
+        // Act
+        let text = extract_prompt_result_text(&result);
+
+        // Assert
+        assert_eq!(text.as_deref(), Some("First second"));
+    }
+
+    #[test]
+    fn prompt_result_text_reads_message_content() {
+        // Arrange
+        let result = json!({"message": {"content": ["Message text"]}});
+
+        // Act
+        let text = extract_prompt_result_text(&result);
+
+        // Assert
+        assert_eq!(text.as_deref(), Some("Message text"));
+    }
+
+    #[test]
+    fn prompt_result_text_combines_output_items() {
+        // Arrange
+        let result = json!({
+            "output": [
+                {"text": "First"},
+                {"content": {"text": " second"}}
+            ]
+        });
+
+        // Act
+        let text = extract_prompt_result_text(&result);
+
+        // Assert
+        assert_eq!(text.as_deref(), Some("First second"));
     }
 }

--- a/crates/ag-git/src/repo.rs
+++ b/crates/ag-git/src/repo.rs
@@ -598,7 +598,7 @@ fn repo_root_from_git_dir(repo_path: &Path, git_dir: &Path) -> Result<PathBuf, G
 fn repo_root_from_dot_git_dir(git_dir: &Path) -> Result<Option<PathBuf>, GitError> {
     if git_dir
         .file_name()
-        .and_then(|name| name.to_str())
+        .and_then(std::ffi::OsStr::to_str)
         .is_none_or(|name| name != ".git")
     {
         return Ok(None);

--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -120,58 +120,14 @@ impl Harness {
         schema: OutputSchema,
         turn_id: Option<LifecycleId>,
     ) -> Result<Value, TurnError> {
-        let mut request = ModelRequest::new(prompt, schema);
-        if self.lifecycle.is_enabled() {
-            request.mark_lifecycle_observed();
-        }
-        let read_allowed = self.policy.allows(Tool::Read);
-        let write_allowed = self.policy.allows(Tool::Write);
-        let mut read_tool = None;
-        let mut write_tool = None;
-        if read_allowed || write_allowed {
-            let repository_root = self
-                .repository_root
-                .as_ref()
-                .ok_or(TurnError::RepositoryRequired)?;
-            if read_allowed {
-                request = request.with_tool(ToolDefinition::read());
-                read_tool = Some(ReadTool::new(
-                    self.file_system.clone(),
-                    repository_root.clone(),
-                ));
-            }
-            if write_allowed {
-                request = request.with_tool(ToolDefinition::write());
-                write_tool = Some(WriteTool::new(
-                    self.file_system.clone(),
-                    repository_root.clone(),
-                ));
-            }
-        }
+        let (mut request, read_tool, write_tool) = self.prepare_request(prompt, schema)?;
         let mut completed_tool_calls = 0_usize;
         let mut model_request_index = 0_u64;
 
         loop {
-            let model_lifecycle =
-                self.lifecycle
-                    .start_model_request(None, model_request_index, turn_id);
-            let (response, completion) = match self
-                .model
-                .complete_with_optional_metadata(request.clone())
-                .await
-            {
-                Ok(completion) => completion,
-                Err(error) => {
-                    if let Some(model_lifecycle) = model_lifecycle {
-                        model_lifecycle.failed(error.error_type());
-                    }
-
-                    return Err(error.into());
-                }
-            };
-            if let Some(model_lifecycle) = model_lifecycle {
-                model_lifecycle.completed(completion, response.response_type());
-            }
+            let response = self
+                .complete_model_request(&request, model_request_index, turn_id)
+                .await?;
             model_request_index += 1;
 
             match response {
@@ -191,6 +147,66 @@ impl Harness {
                 }
             }
         }
+    }
+
+    fn prepare_request(
+        &self,
+        prompt: String,
+        schema: OutputSchema,
+    ) -> Result<(ModelRequest, Option<ReadTool>, Option<WriteTool>), TurnError> {
+        let mut request = ModelRequest::new(prompt, schema);
+        if self.lifecycle.is_enabled() {
+            request.mark_lifecycle_observed();
+        }
+        let read_allowed = self.policy.allows(Tool::Read);
+        let write_allowed = self.policy.allows(Tool::Write);
+        if !read_allowed && !write_allowed {
+            return Ok((request, None, None));
+        }
+        let repository_root = self
+            .repository_root
+            .as_ref()
+            .ok_or(TurnError::RepositoryRequired)?;
+        let read_tool = read_allowed.then(|| {
+            request = request.clone().with_tool(ToolDefinition::read());
+            ReadTool::new(self.file_system.clone(), repository_root.clone())
+        });
+        let write_tool = write_allowed.then(|| {
+            request = request.clone().with_tool(ToolDefinition::write());
+            WriteTool::new(self.file_system.clone(), repository_root.clone())
+        });
+
+        Ok((request, read_tool, write_tool))
+    }
+
+    async fn complete_model_request(
+        &self,
+        request: &ModelRequest,
+        model_request_index: u64,
+        turn_id: Option<LifecycleId>,
+    ) -> Result<ModelResponse, TurnError> {
+        let model_lifecycle =
+            self.lifecycle
+                .start_model_request(None, model_request_index, turn_id);
+        let (response, completion) = match self
+            .model
+            .complete_with_optional_metadata(request.clone())
+            .await
+        {
+            Ok(completion) => completion,
+            Err(error) => {
+                if let Some(model_lifecycle) = model_lifecycle {
+                    model_lifecycle.failed(error.error_type());
+                }
+
+                return Err(error.into());
+            }
+        };
+        if let Some(model_lifecycle) = model_lifecycle {
+            model_lifecycle.completed(completion, response.response_type());
+        }
+
+        Ok(response)
     }
 
     async fn execute_tool_call(

--- a/crates/ag-harness/src/write.rs
+++ b/crates/ag-harness/src/write.rs
@@ -270,6 +270,188 @@ struct UnifiedDiff {
     original_path: String,
 }
 
+#[derive(Default)]
+struct PatchTermination {
+    new_side: bool,
+    old_side: bool,
+}
+
+impl PatchTermination {
+    fn apply_marker(
+        &mut self,
+        hunk_lines: &mut [PatchLine],
+        marker_repeated: bool,
+    ) -> Result<(), WriteError> {
+        if marker_repeated {
+            return Err(patch_error("newline marker cannot be repeated"));
+        }
+        let previous = hunk_lines
+            .last_mut()
+            .ok_or_else(|| patch_error("newline marker has no preceding patch line"))?;
+        previous.text.newline = false;
+        match previous.kind {
+            PatchLineKind::Addition => self.new_side = true,
+            PatchLineKind::Context => {
+                self.old_side = true;
+                self.new_side = true;
+            }
+            PatchLineKind::Removal => self.old_side = true,
+        }
+
+        Ok(())
+    }
+
+    fn validate_line(&self, kind: PatchLineKind) -> Result<(), WriteError> {
+        if (self.old_side && kind != PatchLineKind::Addition)
+            || (self.new_side && kind != PatchLineKind::Removal)
+        {
+            return Err(patch_error(
+                "newline marker must terminate its affected file side",
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+struct HunkApplier<'a> {
+    new_side_terminated: bool,
+    output: String,
+    output_index: usize,
+    previous_original_end: Option<usize>,
+    source_index: usize,
+    source_lines: std::str::SplitInclusive<'a, char>,
+}
+
+impl<'a> HunkApplier<'a> {
+    fn new(current: &'a str) -> Self {
+        Self {
+            new_side_terminated: false,
+            output: String::with_capacity(current.len()),
+            output_index: 0,
+            previous_original_end: None,
+            source_index: 0,
+            source_lines: current.split_inclusive('\n'),
+        }
+    }
+
+    fn apply_hunk(&mut self, hunk: &Hunk) -> Result<(), WriteError> {
+        let original_index = hunk_start(hunk.old_start, hunk.old_count, "original")?;
+        let modified_index = hunk_start(hunk.new_start, hunk.new_count, "modified")?;
+        self.validate_original_range(original_index, hunk.old_count)?;
+        self.copy_source_until(original_index)?;
+        if modified_index != self.output_index {
+            return Err(patch_error(
+                "hunk modified range does not match its original range",
+            ));
+        }
+        for line in &hunk.lines {
+            self.apply_line(line)?;
+        }
+
+        Ok(())
+    }
+
+    fn finish(mut self) -> Result<String, WriteError> {
+        if self.new_side_terminated && self.source_lines.next().is_some() {
+            return Err(patch_error(
+                "newline marker must terminate its affected file side",
+            ));
+        }
+        for source_line in self.source_lines {
+            self.output.push_str(source_line);
+        }
+
+        Ok(self.output)
+    }
+
+    fn validate_original_range(
+        &mut self,
+        original_index: usize,
+        old_count: usize,
+    ) -> Result<(), WriteError> {
+        if self
+            .previous_original_end
+            .is_some_and(|end| original_index < end)
+        {
+            return Err(patch_error(
+                "hunks must use ascending, non-overlapping original ranges",
+            ));
+        }
+        self.previous_original_end = Some(
+            original_index
+                .checked_add(old_count)
+                .ok_or_else(|| patch_error("hunk original range overflowed"))?,
+        );
+
+        Ok(())
+    }
+
+    fn copy_source_until(&mut self, original_index: usize) -> Result<(), WriteError> {
+        while self.source_index < original_index {
+            if self.new_side_terminated {
+                return Err(patch_error(
+                    "newline marker must terminate its affected file side",
+                ));
+            }
+            let source_line = self
+                .source_lines
+                .next()
+                .ok_or_else(|| patch_error("hunk starts beyond the end of the target"))?;
+            self.output.push_str(source_line);
+            self.output_index += 1;
+            self.source_index += 1;
+        }
+
+        Ok(())
+    }
+
+    fn apply_line(&mut self, line: &PatchLine) -> Result<(), WriteError> {
+        match line.kind {
+            PatchLineKind::Addition => {
+                push_text_line(&mut self.output, &line.text);
+                self.output_index += 1;
+                self.new_side_terminated = !line.text.newline;
+            }
+            PatchLineKind::Context => {
+                let source_line = self.next_matching_source_line(
+                    &line.text,
+                    "hunk context does not match the target",
+                )?;
+                self.output.push_str(source_line);
+                self.output_index += 1;
+                self.source_index += 1;
+                self.new_side_terminated = !line.text.newline;
+            }
+            PatchLineKind::Removal => {
+                self.next_matching_source_line(
+                    &line.text,
+                    "hunk removal does not match the target",
+                )?;
+                self.source_index += 1;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn next_matching_source_line(
+        &mut self,
+        expected: &TextLine,
+        mismatch_error: &'static str,
+    ) -> Result<&'a str, WriteError> {
+        let source_line = self
+            .source_lines
+            .next()
+            .ok_or_else(|| patch_error(mismatch_error))?;
+        if !source_line_matches(source_line, expected) {
+            return Err(patch_error(mismatch_error));
+        }
+
+        Ok(source_line)
+    }
+}
+
 fn apply_unified_diff(
     requested_path: &str,
     current: Option<&[u8]>,
@@ -299,70 +481,12 @@ fn parse_unified_diff(patch: &str) -> Result<UnifiedDiff, WriteError> {
     let original_path = parse_header(lines.next(), "--- ")?;
     let modified_path = parse_header(lines.next(), "+++ ")?;
     let mut hunks = Vec::new();
-    let mut old_side_terminated = false;
-    let mut new_side_terminated = false;
+    let mut termination = PatchTermination::default();
     while let Some(header) = lines.next() {
         let header = strip_patch_newline(header);
         let (old_start, old_count, new_start, new_count) = parse_hunk_header(header)?;
-        let mut hunk_lines: Vec<PatchLine> = Vec::new();
-        let mut previous_line_had_marker = false;
-        while let Some(line) = lines.next_if(|line| !line.starts_with("@@ ")) {
-            let line = strip_patch_newline(line);
-            if line == "\\ No newline at end of file" {
-                if previous_line_had_marker {
-                    return Err(patch_error("newline marker cannot be repeated"));
-                }
-                let previous = hunk_lines
-                    .last_mut()
-                    .ok_or_else(|| patch_error("newline marker has no preceding patch line"))?;
-                previous.text.newline = false;
-                match previous.kind {
-                    PatchLineKind::Addition => new_side_terminated = true,
-                    PatchLineKind::Context => {
-                        old_side_terminated = true;
-                        new_side_terminated = true;
-                    }
-                    PatchLineKind::Removal => old_side_terminated = true,
-                }
-                previous_line_had_marker = true;
-                continue;
-            }
-            let (prefix, content) = line
-                .split_at_checked(1)
-                .ok_or_else(|| patch_error("hunk contains an empty patch line"))?;
-            let kind = match prefix {
-                "+" => PatchLineKind::Addition,
-                " " => PatchLineKind::Context,
-                "-" => PatchLineKind::Removal,
-                _ => return Err(patch_error("hunk line must start with space, `+`, or `-`")),
-            };
-            if (old_side_terminated && kind != PatchLineKind::Addition)
-                || (new_side_terminated && kind != PatchLineKind::Removal)
-            {
-                return Err(patch_error(
-                    "newline marker must terminate its affected file side",
-                ));
-            }
-            hunk_lines.push(PatchLine {
-                kind,
-                text: TextLine {
-                    content: content.to_string(),
-                    newline: true,
-                },
-            });
-            previous_line_had_marker = false;
-        }
-        let actual_old = hunk_lines
-            .iter()
-            .filter(|line| line.kind != PatchLineKind::Addition)
-            .count();
-        let actual_new = hunk_lines
-            .iter()
-            .filter(|line| line.kind != PatchLineKind::Removal)
-            .count();
-        if actual_old != old_count || actual_new != new_count {
-            return Err(patch_error("hunk line counts do not match its header"));
-        }
+        let hunk_lines = parse_hunk_lines(&mut lines, &mut termination)?;
+        validate_hunk_line_counts(&hunk_lines, old_count, new_count)?;
         hunks.push(Hunk {
             lines: hunk_lines,
             new_count,
@@ -380,6 +504,72 @@ fn parse_unified_diff(patch: &str) -> Result<UnifiedDiff, WriteError> {
         modified_path,
         original_path,
     })
+}
+
+fn parse_hunk_lines<'a, I>(
+    lines: &mut std::iter::Peekable<I>,
+    termination: &mut PatchTermination,
+) -> Result<Vec<PatchLine>, WriteError>
+where
+    I: Iterator<Item = &'a str>,
+{
+    let mut hunk_lines = Vec::new();
+    let mut previous_line_had_marker = false;
+    while let Some(line) = lines.next_if(|line| !line.starts_with("@@ ")) {
+        let line = strip_patch_newline(line);
+        if line == "\\ No newline at end of file" {
+            termination.apply_marker(&mut hunk_lines, previous_line_had_marker)?;
+            previous_line_had_marker = true;
+
+            continue;
+        }
+        let patch_line = parse_patch_line(line)?;
+        termination.validate_line(patch_line.kind)?;
+        hunk_lines.push(patch_line);
+        previous_line_had_marker = false;
+    }
+
+    Ok(hunk_lines)
+}
+
+fn parse_patch_line(line: &str) -> Result<PatchLine, WriteError> {
+    let (prefix, content) = line
+        .split_at_checked(1)
+        .ok_or_else(|| patch_error("hunk contains an empty patch line"))?;
+    let kind = match prefix {
+        "+" => PatchLineKind::Addition,
+        " " => PatchLineKind::Context,
+        "-" => PatchLineKind::Removal,
+        _ => return Err(patch_error("hunk line must start with space, `+`, or `-`")),
+    };
+
+    Ok(PatchLine {
+        kind,
+        text: TextLine {
+            content: content.to_string(),
+            newline: true,
+        },
+    })
+}
+
+fn validate_hunk_line_counts(
+    hunk_lines: &[PatchLine],
+    old_count: usize,
+    new_count: usize,
+) -> Result<(), WriteError> {
+    let actual_old = hunk_lines
+        .iter()
+        .filter(|line| line.kind != PatchLineKind::Addition)
+        .count();
+    let actual_new = hunk_lines
+        .iter()
+        .filter(|line| line.kind != PatchLineKind::Removal)
+        .count();
+    if actual_old != old_count || actual_new != new_count {
+        return Err(patch_error("hunk line counts do not match its header"));
+    }
+
+    Ok(())
 }
 
 fn parse_header(line: Option<&str>, prefix: &str) -> Result<String, WriteError> {
@@ -499,96 +689,22 @@ fn normalize_line_endings<'a>(
 }
 
 fn apply_hunks(current: &str, hunks: &[Hunk]) -> Result<String, WriteError> {
-    let mut source_lines = current.split_inclusive('\n');
-    let mut output = String::with_capacity(current.len());
-    let mut output_index = 0;
-    let mut source_index = 0;
-    let mut previous_original_end = None;
-    let mut new_side_terminated = false;
+    let mut applier = HunkApplier::new(current);
     for hunk in hunks {
-        let original_index = if hunk.old_count == 0 {
-            hunk.old_start
-        } else {
-            hunk.old_start
-                .checked_sub(1)
-                .ok_or_else(|| patch_error("non-empty hunk cannot start at original line zero"))?
-        };
-        let modified_index = if hunk.new_count == 0 {
-            hunk.new_start
-        } else {
-            hunk.new_start
-                .checked_sub(1)
-                .ok_or_else(|| patch_error("non-empty hunk cannot start at modified line zero"))?
-        };
-        if previous_original_end.is_some_and(|end| original_index < end) {
-            return Err(patch_error(
-                "hunks must use ascending, non-overlapping original ranges",
-            ));
-        }
-        previous_original_end = Some(
-            original_index
-                .checked_add(hunk.old_count)
-                .ok_or_else(|| patch_error("hunk original range overflowed"))?,
-        );
-        while source_index < original_index {
-            if new_side_terminated {
-                return Err(patch_error(
-                    "newline marker must terminate its affected file side",
-                ));
-            }
-            let source_line = source_lines
-                .next()
-                .ok_or_else(|| patch_error("hunk starts beyond the end of the target"))?;
-            output.push_str(source_line);
-            output_index += 1;
-            source_index += 1;
-        }
-        if modified_index != output_index {
-            return Err(patch_error(
-                "hunk modified range does not match its original range",
-            ));
-        }
-        for line in &hunk.lines {
-            match line.kind {
-                PatchLineKind::Addition => {
-                    push_text_line(&mut output, &line.text);
-                    output_index += 1;
-                    new_side_terminated = !line.text.newline;
-                }
-                PatchLineKind::Context => {
-                    let source_line = source_lines
-                        .next()
-                        .ok_or_else(|| patch_error("hunk context does not match the target"))?;
-                    if !source_line_matches(source_line, &line.text) {
-                        return Err(patch_error("hunk context does not match the target"));
-                    }
-                    output.push_str(source_line);
-                    output_index += 1;
-                    source_index += 1;
-                    new_side_terminated = !line.text.newline;
-                }
-                PatchLineKind::Removal => {
-                    let source_line = source_lines
-                        .next()
-                        .ok_or_else(|| patch_error("hunk removal does not match the target"))?;
-                    if !source_line_matches(source_line, &line.text) {
-                        return Err(patch_error("hunk removal does not match the target"));
-                    }
-                    source_index += 1;
-                }
-            }
-        }
-    }
-    if new_side_terminated && source_lines.next().is_some() {
-        return Err(patch_error(
-            "newline marker must terminate its affected file side",
-        ));
-    }
-    for source_line in source_lines {
-        output.push_str(source_line);
+        applier.apply_hunk(hunk)?;
     }
 
-    Ok(output)
+    applier.finish()
+}
+
+fn hunk_start(start: usize, count: usize, side: &str) -> Result<usize, WriteError> {
+    if count == 0 {
+        return Ok(start);
+    }
+
+    start
+        .checked_sub(1)
+        .ok_or_else(|| patch_error(format!("non-empty hunk cannot start at {side} line zero")))
 }
 
 fn source_line_matches(source: &str, expected: &TextLine) -> bool {

--- a/crates/ag-session/src/project.rs
+++ b/crates/ag-session/src/project.rs
@@ -87,7 +87,7 @@ pub fn ordered_project_items<'a>(
 #[must_use]
 pub fn project_name_from_path(path: &Path) -> String {
     path.file_name()
-        .and_then(|name| name.to_str())
+        .and_then(std::ffi::OsStr::to_str)
         .unwrap_or_default()
         .to_string()
 }

--- a/crates/ag-store/src/connection_test.rs
+++ b/crates/ag-store/src/connection_test.rs
@@ -6,7 +6,7 @@ use ag_session::{
 use sqlx::migrate::Migrator;
 use tempfile::tempdir;
 
-use super::*;
+use super::{DB_POOL_MAX_CONNECTIONS, Database, DbError, SqlitePool, SqlitePoolOptions};
 use crate::{
     NewSessionReviewCommentResolution, PersistedSessionCreation, SessionFocusedReviewRow,
     SessionOperationRow, SessionRow, SessionTurnMetadata,

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -9,7 +9,16 @@ use mockall::predicate::eq;
 use serde_json;
 use tempfile::tempdir;
 
-use super::*;
+use super::{
+    AGENTTY_WT_DIR, AgentCliInfo, AgentKind, AgentSelection, App, AppError, AppEvent,
+    AppEventBatch, AppMode, AppServices, BranchPublishTaskContext, BranchPublishTaskFailure,
+    BranchPublishTaskSession, ConfirmationViewMode, DiffReviewComments, HashMap, HashSet,
+    InputState, PromptModeSnapshot, PublishBranchAction, QuestionProgress, RealFsClient,
+    ReviewCacheEntry, ReviewRequestClient, ReviewRequestStatusUpdate, SessionId, SyncMainOutcome,
+    SyncPopupContext, SyncReviewRequestTaskResult, SyncSessionStartError, TurnAppliedState,
+    UpdateStatus, branch_push_failure, db, detected_forge_kind_from_git_push_error, forge,
+    push_session_branch, run_branch_publish_action, session, sync,
+};
 use crate::app::branch_publish::{BranchPublishActionUpdate, BranchPublishTaskSuccess};
 use crate::app::review::ReviewUpdate;
 use crate::app::session_state::SessionGitStatus;

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -21,7 +21,12 @@ use ag_protocol::{
 use tempfile::tempdir;
 use tokio::sync::{Barrier, Notify};
 
-use super::*;
+use super::{
+    AT_MENTION_INDEX_TTL, AppServices, FileEntry, SESSION_REFRESH_INTERVAL, SessionCreationKind,
+    SessionDefaults, SessionError, SessionId, SessionManager, SessionMessageKind, SessionState,
+    SessionTaskService, TurnAppliedState, remote_branch_name_from_upstream_ref, session_branch,
+    session_folder,
+};
 use crate::app::prompt_intent::ReviewCommentResolutionOutcome;
 use crate::app::review::{review_failure_message, review_loading_message};
 use crate::app::session::SessionLoadInput;

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -201,7 +201,7 @@ impl SessionManager {
         } = input;
         let project_name = working_dir
             .file_name()
-            .and_then(|name| name.to_str())
+            .and_then(std::ffi::OsStr::to_str)
             .unwrap_or_default()
             .to_string();
 

--- a/crates/agentty/src/app/session_api.rs
+++ b/crates/agentty/src/app/session_api.rs
@@ -624,74 +624,8 @@ impl App {
             .sessions
             .session_for_id(session_id)
             .is_some_and(|session| session.role == SessionRole::Orchestrator);
-        if is_orchestrator
-            && let Some(orchestration) = self
-                .services
-                .db()
-                .orchestrations()
-                .load_orchestration_for_controller(session_id)
-                .await
-                .map_err(|error| ApiSessionError::Operation(error.to_string()))?
-            && self
-                .services
-                .db()
-                .orchestrations()
-                .begin_orchestration_cancellation(orchestration.id)
-                .await
-                .map_err(|error| ApiSessionError::Operation(error.to_string()))?
-        {
-            let tasks = self
-                .services
-                .db()
-                .orchestrations()
-                .load_orchestration_tasks(orchestration.id)
-                .await
-                .map_err(|error| ApiSessionError::Operation(error.to_string()))?;
-            for task in tasks.into_iter().filter(|task| {
-                task.status
-                    .parse::<OrchestrationTaskStatus>()
-                    .is_ok_and(|status| !status.is_settled())
-            }) {
-                let child_session_id = if task.child_session_id.is_some() {
-                    task.child_session_id
-                } else {
-                    self.services
-                        .db()
-                        .orchestrations()
-                        .load_child_session_id_for_task(task.id)
-                        .await
-                        .map_err(|error| ApiSessionError::Operation(error.to_string()))?
-                };
-                if let Some(child_session_id) = child_session_id.as_deref()
-                    && !child_session_is_stopped(task.child_status.as_deref())
-                {
-                    self.sessions
-                        .cancel_managed_session(&self.services, child_session_id)
-                        .await
-                        .map_err(api_error_from_session)?;
-                }
-                self.services
-                    .db()
-                    .orchestrations()
-                    .update_orchestration_task_status(
-                        task.id,
-                        &OrchestrationTaskStatus::Canceled.to_string(),
-                        None,
-                    )
-                    .await
-                    .map_err(|error| ApiSessionError::Operation(error.to_string()))?;
-            }
-            self.services
-                .db()
-                .orchestrations()
-                .update_orchestration_status(
-                    orchestration.id,
-                    &OrchestrationStatus::Canceled.to_string(),
-                )
-                .await
-                .map_err(|error| ApiSessionError::Operation(error.to_string()))?;
-            self.sessions
-                .update_orchestration_progress(session_id, None);
+        if is_orchestrator {
+            self.cancel_api_orchestration(session_id).await?;
         }
 
         if access == SessionRuntimeAccess::Coordinator
@@ -710,6 +644,86 @@ impl App {
         self.cancel_session(session_id)
             .await
             .map_err(api_error_from_app)
+    }
+
+    async fn cancel_api_orchestration(
+        &mut self,
+        session_id: &SessionId,
+    ) -> Result<(), ApiSessionError> {
+        let Some(orchestration) = self
+            .services
+            .db()
+            .orchestrations()
+            .load_orchestration_for_controller(session_id)
+            .await
+            .map_err(|error| ApiSessionError::Operation(error.to_string()))?
+        else {
+            return Ok(());
+        };
+        let cancellation_started = self
+            .services
+            .db()
+            .orchestrations()
+            .begin_orchestration_cancellation(orchestration.id)
+            .await
+            .map_err(|error| ApiSessionError::Operation(error.to_string()))?;
+        if !cancellation_started {
+            return Ok(());
+        }
+        let tasks = self
+            .services
+            .db()
+            .orchestrations()
+            .load_orchestration_tasks(orchestration.id)
+            .await
+            .map_err(|error| ApiSessionError::Operation(error.to_string()))?;
+        for task in tasks.into_iter().filter(|task| {
+            task.status
+                .parse::<OrchestrationTaskStatus>()
+                .is_ok_and(|status| !status.is_settled())
+        }) {
+            let child_session_id = if task.child_session_id.is_some() {
+                task.child_session_id
+            } else {
+                self.services
+                    .db()
+                    .orchestrations()
+                    .load_child_session_id_for_task(task.id)
+                    .await
+                    .map_err(|error| ApiSessionError::Operation(error.to_string()))?
+            };
+            if let Some(child_session_id) = child_session_id.as_deref()
+                && !child_session_is_stopped(task.child_status.as_deref())
+            {
+                self.sessions
+                    .cancel_managed_session(&self.services, child_session_id)
+                    .await
+                    .map_err(api_error_from_session)?;
+            }
+            self.services
+                .db()
+                .orchestrations()
+                .update_orchestration_task_status(
+                    task.id,
+                    &OrchestrationTaskStatus::Canceled.to_string(),
+                    None,
+                )
+                .await
+                .map_err(|error| ApiSessionError::Operation(error.to_string()))?;
+        }
+        self.services
+            .db()
+            .orchestrations()
+            .update_orchestration_status(
+                orchestration.id,
+                &OrchestrationStatus::Canceled.to_string(),
+            )
+            .await
+            .map_err(|error| ApiSessionError::Operation(error.to_string()))?;
+        self.sessions
+            .update_orchestration_progress(session_id, None);
+
+        Ok(())
     }
 
     /// Returns the active child count displayed in orchestration cancellation
@@ -2385,6 +2399,50 @@ mod tests {
                 })
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn cancel_api_orchestration_ignores_missing_orchestration() {
+        // Arrange
+        let (mut app, _temp_dir) = crate::test_support::new_git_test_app().await;
+        let session_id = SessionId::from("missing-orchestration");
+
+        // Act
+        let result = app.cancel_api_orchestration(&session_id).await;
+
+        // Assert
+        assert_eq!(result, Ok(()));
+    }
+
+    #[tokio::test]
+    async fn cancel_api_orchestration_ignores_settled_orchestration() {
+        // Arrange
+        let (mut app, _temp_dir) = crate::test_support::new_git_test_app().await;
+        let fixture = seed_active_orchestration_child(&mut app, true).await;
+        app.services
+            .db()
+            .orchestrations()
+            .update_orchestration_status(
+                fixture.orchestration,
+                &OrchestrationStatus::Done.to_string(),
+            )
+            .await
+            .expect("orchestration should settle");
+
+        // Act
+        let result = app.cancel_api_orchestration(&fixture.controller).await;
+        let orchestration = app
+            .services
+            .db()
+            .orchestrations()
+            .load_orchestration_for_controller(&fixture.controller)
+            .await
+            .expect("orchestration should load")
+            .expect("orchestration should exist");
+
+        // Assert
+        assert_eq!(result, Ok(()));
+        assert_eq!(orchestration.status, OrchestrationStatus::Done.to_string());
     }
 
     #[tokio::test]

--- a/crates/agentty/src/infra/clipboard_image.rs
+++ b/crates/agentty/src/infra/clipboard_image.rs
@@ -261,7 +261,7 @@ fn clipboard_png_path_from_text(clipboard: &mut Clipboard) -> Result<PathBuf, Cl
 /// Returns whether a filesystem path names a PNG image.
 fn is_png_path(path: &Path) -> bool {
     path.extension()
-        .and_then(|extension| extension.to_str())
+        .and_then(std::ffi::OsStr::to_str)
         .is_some_and(|extension| extension.eq_ignore_ascii_case("png"))
 }
 

--- a/crates/agentty/src/infra/personality.rs
+++ b/crates/agentty/src/infra/personality.rs
@@ -318,7 +318,7 @@ async fn resolve_personality_definition(
         contain_personality_definition(resolved_path, canonical_workspace, &definition_path)?;
     let directory_id = agent_directory
         .file_name()
-        .and_then(|name| name.to_str())
+        .and_then(std::ffi::OsStr::to_str)
         .unwrap_or_default()
         .to_string();
 

--- a/crates/agentty/src/ui/component/help_overlay.rs
+++ b/crates/agentty/src/ui/component/help_overlay.rs
@@ -101,7 +101,6 @@ mod tests {
     use crate::presentation::help_action::HelpAction;
 
     #[test]
-
     fn test_popup_area_centers_within_area() {
         // Arrange
 
@@ -123,7 +122,6 @@ mod tests {
     }
 
     #[test]
-
     fn test_popup_area_clamps_to_area_when_small() {
         // Arrange
 
@@ -141,7 +139,6 @@ mod tests {
     }
 
     #[test]
-
     fn test_popup_area_respects_minimum_dimensions() {
         // Arrange
 

--- a/crates/testty/src/proof/gallery.rs
+++ b/crates/testty/src/proof/gallery.rs
@@ -89,14 +89,14 @@ fn collect_artifacts(dir: &Path) -> Result<Vec<Artifact>, ProofError> {
             continue;
         }
 
-        let name = match path.file_name().and_then(|name| name.to_str()) {
+        let name = match path.file_name().and_then(std::ffi::OsStr::to_str) {
             Some(name) if name != INDEX_FILE_NAME => name.to_string(),
             _ => continue,
         };
 
         let kind = path
             .extension()
-            .and_then(|extension| extension.to_str())
+            .and_then(std::ffi::OsStr::to_str)
             .map(str::to_ascii_lowercase)
             .and_then(|extension| ArtifactKind::from_extension(&extension));
 


### PR DESCRIPTION
- Validate unified-diff ranges, newline markers, and hunk application state.
- Extract prompt text from nested message, content, and output shapes.
- Centralize model request preparation and API orchestration cancellation handling.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)