### PR TITLE
Keep Gemini utility prompts out of plan mode

### DIFF
--- a/crates/ag-agent/src/agent/app_server/gemini/lifecycle.rs
+++ b/crates/ag-agent/src/agent/app_server/gemini/lifecycle.rs
@@ -60,7 +60,6 @@ pub(super) async fn start_runtime(
     ),
     AppServerError,
 > {
-    let request_kind = crate::channel::AgentRequestKind::SessionStart;
     let command = agent::create_backend(AgentKind::Gemini)
         .build_command(agent::BuildCommandRequest {
             attachments: &[],
@@ -72,7 +71,7 @@ pub(super) async fn start_runtime(
             personality_prompt: None,
             prompt: "",
             reasoning_level: request.reasoning_level,
-            request_kind: &request_kind,
+            request_kind: &request.request_kind,
             speed_mode: request.speed_mode,
         })
         .map_err(|error| {

--- a/crates/ag-agent/src/agent/gemini.rs
+++ b/crates/ag-agent/src/agent/gemini.rs
@@ -17,7 +17,12 @@ impl AgentBackend for GeminiBackend {
         request: BuildCommandRequest<'request>,
     ) -> Result<Command, AgentBackendError> {
         let mut command = build_gemini_acp_command(request.folder, request.model);
-        if request.permission_mode.is_read_only() {
+        if request.permission_mode.is_read_only()
+            && !matches!(
+                request.request_kind,
+                crate::channel::AgentRequestKind::UtilityPrompt
+            )
+        {
             command.arg("--approval-mode").arg("plan").arg("--sandbox");
         }
 
@@ -36,6 +41,11 @@ mod tests {
     /// Returns a utility request kind for Gemini command construction tests.
     fn utility_request_kind() -> AgentRequestKind {
         AgentRequestKind::UtilityPrompt
+    }
+
+    /// Returns a session request kind for Gemini command construction tests.
+    fn session_request_kind() -> AgentRequestKind {
+        AgentRequestKind::SessionStart
     }
 
     #[test]
@@ -112,7 +122,7 @@ mod tests {
                 personality_prompt: None,
                 prompt: "Inspect the architecture",
                 reasoning_level: ReasoningLevel::default(),
-                request_kind: &utility_request_kind(),
+                request_kind: &session_request_kind(),
                 speed_mode: crate::model::session::SpeedMode::default(),
             },
         )
@@ -134,5 +144,40 @@ mod tests {
                 "--sandbox"
             ]
         );
+    }
+
+    #[test]
+    /// Verifies read-only Gemini utility prompts avoid the plan-mode bootstrap
+    /// while ACP permission cancellation continues to reject mutations.
+    fn test_gemini_read_only_utility_command_uses_standard_acp_mode() {
+        // Arrange
+        let temp_directory = tempdir().expect("failed to create temp dir");
+        let backend = GeminiBackend;
+
+        // Act
+        let command = AgentBackend::build_command(
+            &backend,
+            BuildCommandRequest {
+                attachments: &[],
+                folder: temp_directory.path(),
+                main_checkout_root: None,
+                replay_transcript: None,
+                model: "gemini-3.7-flash",
+                permission_mode: crate::model::permission::PermissionMode::ReadOnly,
+                personality_prompt: None,
+                prompt: "Review the supplied diff",
+                reasoning_level: ReasoningLevel::default(),
+                request_kind: &utility_request_kind(),
+                speed_mode: crate::model::session::SpeedMode::default(),
+            },
+        )
+        .expect("command should build");
+        let args = command
+            .get_args()
+            .map(|argument| argument.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        // Assert
+        assert_eq!(args, vec!["--acp", "--model", "gemini-3.7-flash"]);
     }
 }

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -82,6 +82,8 @@ const PROMPT_FOCUS_DRAFT_TEXT: &str = "Draft kept while reading chat";
 /// Focused-review output emitted when the prompt carries both the saved
 /// decision and the instruction to honor it.
 const RESOLVED_DECISION_REVIEW_TEXT: &str = "Resolved session decision honored.";
+/// Focused-review output emitted after Gemini starts without plan-mode flags.
+const GEMINI_FOCUSED_REVIEW_TEXT: &str = "Gemini focused review completed without plan mode.";
 /// Review-request notice body used by the timeline-order regression.
 const REVIEW_REQUEST_TIMELINE_NOTICE_TEXT: &str =
     "Created PR https://github.com/agentty-xyz/agentty/pull/42";
@@ -717,6 +719,59 @@ done
         &[
             ("DefaultReviewAgent", "codex"),
             ("DefaultReviewModel", "gpt-5.6-sol"),
+        ],
+    )
+}
+
+/// Seeds a Gemini focused review whose ACP stub rejects plan-mode startup.
+fn seed_gemini_focused_review_without_plan_mode(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    seed_review_ready_session(env)?;
+    seed_review_worktree_with_diff(env)?;
+
+    let gemini_path = env.stub_bin.join("gemini");
+    let script = format!(
+        r###"#!/bin/sh
+if [ "$1" = "--version" ]; then printf 'gemini 0.0.0-test\n'; exit 0; fi
+answer='{GEMINI_FOCUSED_REVIEW_TEXT}'
+for argument in "$@"; do
+    if [ "$argument" = "--approval-mode" ] || [ "$argument" = "--sandbox" ]; then
+        answer='Gemini focused review incorrectly used plan mode.'
+    fi
+done
+
+extract_id() {{
+    printf '%s\n' "$1" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p'
+}}
+
+while IFS= read -r request; do
+    case "$request" in
+        *'"method":"initialize"'*)
+            request_id=$(extract_id "$request")
+            printf '{{"jsonrpc":"2.0","id":"%s","result":{{"protocolVersion":1}}}}\n' "$request_id"
+            ;;
+        *'"method":"session/new"'*)
+            request_id=$(extract_id "$request")
+            printf '{{"jsonrpc":"2.0","id":"%s","result":{{"sessionId":"review-session"}}}}\n' "$request_id"
+            ;;
+        *'"method":"session/prompt"'*)
+            request_id=$(extract_id "$request")
+            printf '{{"jsonrpc":"2.0","id":"%s","result":{{"response":"{{\\"answer\\":\\"## Review\\n\\n### Project Impact\\n\\n- %s\\n\\n### Suggestions\\n\\n- None.\\",\\"questions\\":[],\\"summary\\":null}}","usage":{{"inputTokens":5,"outputTokens":9}}}}}}\n' "$request_id" "$answer"
+            ;;
+    esac
+done
+"###,
+    );
+    std::fs::write(&gemini_path, script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&gemini_path, std::fs::Permissions::from_mode(0o755))?;
+
+    seed_project_settings(
+        env,
+        &[
+            ("DefaultReviewAgent", "gemini"),
+            ("DefaultReviewModel", "gemini-3.1-pro-preview"),
         ],
     )
 }
@@ -8699,6 +8754,38 @@ fn focused_review_ignores_blank_completed_fallback() -> E2eResult {
                 assertion::assert_text_in_region(frame, "Final focused review result.", &full);
                 assertion::assert_text_in_region(frame, "Suggestions", &full);
                 assertion::assert_not_visible(frame, "I will inspect the current code.");
+                assertion::assert_not_visible(frame, "Reviewing changes with");
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify Gemini focused review avoids the plan-mode bootstrap.
+#[test]
+fn gemini_focused_review_avoids_plan_mode_bootstrap() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("gemini_focused_review_avoids_plan_mode_bootstrap")
+        .with_git()
+        .setup(seed_gemini_focused_review_without_plan_mode)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("Enter")
+                    .press_key("f")
+                    .wait_for_text("Suggestions", 30000)
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled(
+                        "gemini_review",
+                        "Gemini focused review completes without plan-mode startup",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, GEMINI_FOCUSED_REVIEW_TEXT, &full);
+                assertion::assert_text_in_region(frame, "Suggestions", &full);
                 assertion::assert_not_visible(frame, "Reviewing changes with");
             },
         )?;

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -769,7 +769,9 @@ their triggers:
 
 - **Focused review assist** (entering review): runs the review prompt with the diff and
   saved user/agent chat history through the provider-enforced read-only permission mode,
-  then stores the result or error.
+  then stores the result or error. Gemini utility prompts use standard ACP startup and
+  cancel every mutation permission request, avoiding plan-mode sandbox initialization;
+  persistent read-only research sessions continue to use sandboxed plan mode.
 
 - **Sync-main workflow** (list-mode `s`): pull/rebase/push of the project branch through
   the sync orchestrator, with assisted conflict resolution.


### PR DESCRIPTION
- Preserve sandboxed plan mode for persistent read-only sessions.
- Verify focused reviews use standard ACP startup.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)