### PR TITLE
Project lifecycle events into GenAI metrics

### DIFF
--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -24,13 +24,16 @@ continue calling allowed tools until it returns schema-valid JSON.
 Use `ModelWithMetadata::complete_with_metadata()` for normalized completion metadata.
 
 Attach `with_lifecycle_observer()` to receive ordered metadata-only lifecycle events.
-Use `LifecycleObserverSet` to send the same stream to multiple observers, such as
-metrics, traces, and a host-owned journal.
+After installing an OpenTelemetry meter provider, attach `LifecycleMetrics::new()` to
+project standard agent and client-side tool metrics. Use `LifecycleObserverSet` to send
+the same stream to multiple observers, such as metrics, traces, and a host-owned
+journal.
 
 ## Telemetry
 
 When the application installs an OpenTelemetry meter provider, `ModelClient` records
-request duration and provider-reported input and output tokens. Missing usage is not
-estimated, sensitive content is excluded, and the application owns export and shutdown.
-The emitted instruments follow the pinned OpenTelemetry GenAI semantic-convention
-contract documented in the architecture guide.
+request duration and provider-reported input and output tokens. `LifecycleMetrics`
+projects end-to-end harness-turn duration, per-turn model and tool call counts, and
+executed-tool duration. Missing usage is not estimated, sensitive content is excluded,
+and the application owns export and shutdown. The emitted instruments follow the pinned
+OpenTelemetry GenAI semantic-convention contract documented in the architecture guide.

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -34,5 +34,6 @@ pub use provider::{
 };
 pub use read::{ReadError, ReadOutput};
 pub use schema_contract::{OutputSchema, OutputSchemaError};
+pub use telemetry::LifecycleMetrics;
 pub use tool::{ReadArguments, Tool, ToolCall, ToolCallArguments, ToolDefinition, WriteArguments};
 pub use write::{WriteError, WriteOutput};

--- a/crates/ag-harness/src/lifecycle.rs
+++ b/crates/ag-harness/src/lifecycle.rs
@@ -181,6 +181,20 @@ pub enum TurnErrorType {
     RepositoryRequired,
 }
 
+impl TurnErrorType {
+    /// Returns the stable value intended for telemetry attributes.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cancelled => crate::telemetry::ERROR_CANCELLED,
+            Self::Model(error_type) => error_type.as_str(),
+            Self::Tool => crate::telemetry::ERROR_TOOL_EXECUTION,
+            Self::ToolDenied => crate::telemetry::ERROR_TOOL_DENIED,
+            Self::ToolCallLimit => crate::telemetry::ERROR_TOOL_CALL_LIMIT,
+            Self::RepositoryRequired => crate::telemetry::ERROR_REPOSITORY_REQUIRED,
+        }
+    }
+}
+
 /// Stable, low-cardinality reason that a tool operation failed.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
@@ -191,6 +205,17 @@ pub enum ToolErrorType {
     CallLimit,
     /// The allowed tool failed while executing or encoding its result.
     Execution,
+}
+
+impl ToolErrorType {
+    /// Returns the stable value intended for telemetry attributes.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cancelled => crate::telemetry::ERROR_CANCELLED,
+            Self::CallLimit => crate::telemetry::ERROR_TOOL_CALL_LIMIT,
+            Self::Execution => crate::telemetry::ERROR_TOOL_EXECUTION,
+        }
+    }
 }
 
 /// Synchronous destination for ordered harness lifecycle events.

--- a/crates/ag-harness/src/telemetry.rs
+++ b/crates/ag-harness/src/telemetry.rs
@@ -1,11 +1,16 @@
-use std::time::Instant;
+use std::collections::HashMap;
+use std::sync::{Mutex, PoisonError};
+use std::time::{Duration, Instant};
 
 use opentelemetry::metrics::Histogram;
 use opentelemetry::{KeyValue, global};
 
+use crate::lifecycle::{LifecycleEvent, LifecycleEventKind, LifecycleId, LifecycleObserver};
 use crate::model::{CompletionMetadata, ModelError, ModelMetadata};
 
 pub(crate) const ATTRIBUTE_ERROR_TYPE: &str = "error.type";
+pub(crate) const ATTRIBUTE_TOOL_NAME: &str = "gen_ai.tool.name";
+pub(crate) const ATTRIBUTE_TOOL_TYPE: &str = "gen_ai.tool.type";
 pub(crate) const ATTRIBUTE_OPERATION_NAME: &str = "gen_ai.operation.name";
 pub(crate) const ATTRIBUTE_PROVIDER_NAME: &str = "gen_ai.provider.name";
 pub(crate) const ATTRIBUTE_REQUEST_MODEL: &str = "gen_ai.request.model";
@@ -17,6 +22,10 @@ pub(crate) const DURATION_DESCRIPTION: &str = "GenAI operation duration.";
 pub(crate) const DURATION_METRIC: &str = "gen_ai.client.operation.duration";
 pub(crate) const DURATION_UNIT: &str = "s";
 pub(crate) const ERROR_CANCELLED: &str = "cancelled";
+pub(crate) const ERROR_REPOSITORY_REQUIRED: &str = "repository_required";
+pub(crate) const ERROR_TOOL_CALL_LIMIT: &str = "tool_call_limit";
+pub(crate) const ERROR_TOOL_DENIED: &str = "tool_denied";
+pub(crate) const ERROR_TOOL_EXECUTION: &str = "tool_execution_error";
 pub(crate) const ERROR_INVALID_OUTPUT: &str = "invalid_output";
 pub(crate) const ERROR_INVALID_PROVIDER_RESPONSE: &str = "invalid_provider_response";
 pub(crate) const ERROR_INVALID_RESPONSE: &str = "invalid_response";
@@ -52,6 +61,264 @@ pub(crate) const TOKEN_METRIC: &str = "gen_ai.client.token.usage";
 pub(crate) const TOKEN_TYPE_INPUT: &str = "input";
 pub(crate) const TOKEN_TYPE_OUTPUT: &str = "output";
 pub(crate) const TOKEN_UNIT: &str = "{token}";
+const AGENT_CALL_BOUNDARIES: [f64; 8] = [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0];
+const AGENT_DURATION_BOUNDARIES_SECONDS: [f64; 13] = [
+    0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 51.2, 102.4, 204.8, 409.6,
+];
+const AGENT_DURATION_DESCRIPTION: &str = "The end-to-end duration of a single in-process agent \
+                                          invocation, from the moment the invocation starts until \
+                                          the agent emits the last chunk of its final response or \
+                                          terminates with an error.";
+const AGENT_DURATION_METRIC: &str = "gen_ai.invoke_agent.duration";
+const AGENT_INFERENCE_CALLS_DESCRIPTION: &str =
+    "The number of inference (model) calls a GenAI agent makes during a single invocation.";
+const AGENT_INFERENCE_CALLS_METRIC: &str = "gen_ai.invoke_agent.inference_calls";
+const AGENT_INFERENCE_CALLS_UNIT: &str = "{inference_call}";
+const AGENT_TOOL_CALLS_DESCRIPTION: &str =
+    "The number of tool calls a GenAI agent makes during a single invocation.";
+const AGENT_TOOL_CALLS_METRIC: &str = "gen_ai.invoke_agent.tool_calls";
+const AGENT_TOOL_CALLS_UNIT: &str = "{tool_call}";
+const TOOL_DURATION_DESCRIPTION: &str = "The duration of a single tool execution.";
+const TOOL_DURATION_METRIC: &str = "gen_ai.execute_tool.duration";
+const TOOL_TYPE_FUNCTION: &str = "function";
+
+/// OpenTelemetry metric projection over ordered harness lifecycle events.
+///
+/// Applications install an OpenTelemetry meter provider before constructing
+/// this observer and retain ownership of export, flushing, and shutdown.
+pub struct LifecycleMetrics {
+    agent_duration: Histogram<f64>,
+    agent_inference_calls: Histogram<u64>,
+    agent_tool_calls: Histogram<u64>,
+    state: Mutex<LifecycleMetricState>,
+    tool_duration: Histogram<f64>,
+}
+
+impl LifecycleMetrics {
+    /// Creates a lifecycle observer backed by the global meter provider.
+    pub fn new() -> Self {
+        let meter = global::meter(INSTRUMENTATION_SCOPE);
+
+        Self {
+            agent_duration: meter
+                .f64_histogram(AGENT_DURATION_METRIC)
+                .with_description(AGENT_DURATION_DESCRIPTION)
+                .with_unit(DURATION_UNIT)
+                .with_boundaries(AGENT_DURATION_BOUNDARIES_SECONDS.to_vec())
+                .build(),
+            agent_inference_calls: meter
+                .u64_histogram(AGENT_INFERENCE_CALLS_METRIC)
+                .with_description(AGENT_INFERENCE_CALLS_DESCRIPTION)
+                .with_unit(AGENT_INFERENCE_CALLS_UNIT)
+                .with_boundaries(AGENT_CALL_BOUNDARIES.to_vec())
+                .build(),
+            agent_tool_calls: meter
+                .u64_histogram(AGENT_TOOL_CALLS_METRIC)
+                .with_description(AGENT_TOOL_CALLS_DESCRIPTION)
+                .with_unit(AGENT_TOOL_CALLS_UNIT)
+                .with_boundaries(AGENT_CALL_BOUNDARIES.to_vec())
+                .build(),
+            state: Mutex::new(LifecycleMetricState::default()),
+            tool_duration: meter
+                .f64_histogram(TOOL_DURATION_METRIC)
+                .with_description(TOOL_DURATION_DESCRIPTION)
+                .with_unit(DURATION_UNIT)
+                .with_boundaries(DURATION_BOUNDARIES_SECONDS.to_vec())
+                .build(),
+        }
+    }
+
+    fn record(&self, measurement: MetricMeasurement) {
+        match measurement {
+            MetricMeasurement::Agent(measurement) => {
+                let duration_attributes = measurement
+                    .error_type
+                    .map(|error_type| vec![KeyValue::new(ATTRIBUTE_ERROR_TYPE, error_type)])
+                    .unwrap_or_default();
+                self.agent_duration
+                    .record(measurement.duration.as_secs_f64(), &duration_attributes);
+                self.agent_inference_calls
+                    .record(measurement.inference_calls, &[]);
+                self.agent_tool_calls.record(measurement.tool_calls, &[]);
+            }
+            MetricMeasurement::Tool(measurement) => {
+                let mut attributes = Vec::with_capacity(3);
+                if let Some(error_type) = measurement.error_type {
+                    attributes.push(KeyValue::new(ATTRIBUTE_ERROR_TYPE, error_type));
+                }
+                attributes.push(KeyValue::new(ATTRIBUTE_TOOL_NAME, measurement.name));
+                attributes.push(KeyValue::new(ATTRIBUTE_TOOL_TYPE, TOOL_TYPE_FUNCTION));
+                self.tool_duration
+                    .record(measurement.duration.as_secs_f64(), &attributes);
+            }
+        }
+    }
+}
+
+impl Default for LifecycleMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LifecycleObserver for LifecycleMetrics {
+    fn observe(&self, event: LifecycleEvent) {
+        let measurement = self
+            .state
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .observe(&event);
+        if let Some(measurement) = measurement {
+            self.record(measurement);
+        }
+    }
+}
+
+#[derive(Default)]
+struct LifecycleMetricState {
+    tools: HashMap<LifecycleId, PendingToolMeasurement>,
+    turns: HashMap<LifecycleId, PendingAgentMeasurement>,
+}
+
+impl LifecycleMetricState {
+    fn observe(&mut self, event: &LifecycleEvent) -> Option<MetricMeasurement> {
+        match event.kind() {
+            LifecycleEventKind::TurnStarted { turn_id } => {
+                self.turns
+                    .insert(*turn_id, PendingAgentMeasurement::default());
+
+                None
+            }
+            LifecycleEventKind::TurnCompleted { duration, turn_id } => {
+                self.complete_turn(*duration, None, *turn_id)
+            }
+            LifecycleEventKind::TurnFailed {
+                duration,
+                error_type,
+                turn_id,
+            } => self.complete_turn(*duration, Some(error_type.as_str()), *turn_id),
+            LifecycleEventKind::ModelRequestStarted {
+                turn_id: Some(turn_id),
+                ..
+            } => {
+                if let Some(turn) = self.turns.get_mut(turn_id) {
+                    turn.inference_calls += 1;
+                }
+
+                None
+            }
+            LifecycleEventKind::ToolRequested {
+                tool_call_id,
+                tool_name,
+                turn_id,
+            } => {
+                if let Some(turn) = self.turns.get_mut(turn_id) {
+                    turn.tool_calls += 1;
+                    self.tools.insert(
+                        *tool_call_id,
+                        PendingToolMeasurement {
+                            name: tool_name.clone(),
+                            started: false,
+                            turn_id: *turn_id,
+                        },
+                    );
+                }
+
+                None
+            }
+            LifecycleEventKind::ToolStarted { tool_call_id, .. } => {
+                if let Some(tool) = self.tools.get_mut(tool_call_id) {
+                    tool.started = true;
+                }
+
+                None
+            }
+            LifecycleEventKind::ToolCompleted {
+                duration,
+                tool_call_id,
+                ..
+            } => self.complete_tool(*duration, None, *tool_call_id),
+            LifecycleEventKind::ToolDenied { tool_call_id, .. } => {
+                self.tools.remove(tool_call_id);
+
+                None
+            }
+            LifecycleEventKind::ToolFailed {
+                duration,
+                error_type,
+                tool_call_id,
+                ..
+            } => self.complete_tool(*duration, Some(error_type.as_str()), *tool_call_id),
+            LifecycleEventKind::ModelRequestStarted { turn_id: None, .. }
+            | LifecycleEventKind::ModelRequestCompleted { .. }
+            | LifecycleEventKind::ModelRequestFailed { .. }
+            | LifecycleEventKind::ModelRequestCancelled { .. } => None,
+        }
+    }
+
+    fn complete_turn(
+        &mut self,
+        duration: Duration,
+        error_type: Option<&'static str>,
+        turn_id: LifecycleId,
+    ) -> Option<MetricMeasurement> {
+        let pending = self.turns.remove(&turn_id)?;
+        self.tools.retain(|_, tool| tool.turn_id != turn_id);
+
+        Some(MetricMeasurement::Agent(AgentMeasurement {
+            duration,
+            error_type,
+            inference_calls: pending.inference_calls,
+            tool_calls: pending.tool_calls,
+        }))
+    }
+
+    fn complete_tool(
+        &mut self,
+        duration: Duration,
+        error_type: Option<&'static str>,
+        tool_call_id: LifecycleId,
+    ) -> Option<MetricMeasurement> {
+        let pending = self.tools.remove(&tool_call_id)?;
+        pending
+            .started
+            .then_some(MetricMeasurement::Tool(ToolMeasurement {
+                duration,
+                error_type,
+                name: pending.name,
+            }))
+    }
+}
+
+struct AgentMeasurement {
+    duration: Duration,
+    error_type: Option<&'static str>,
+    inference_calls: u64,
+    tool_calls: u64,
+}
+
+enum MetricMeasurement {
+    Agent(AgentMeasurement),
+    Tool(ToolMeasurement),
+}
+
+#[derive(Default)]
+struct PendingAgentMeasurement {
+    inference_calls: u64,
+    tool_calls: u64,
+}
+
+struct PendingToolMeasurement {
+    name: String,
+    started: bool,
+    turn_id: LifecycleId,
+}
+
+struct ToolMeasurement {
+    duration: Duration,
+    error_type: Option<&'static str>,
+    name: String,
+}
 
 /// Records one model request's operational metrics.
 pub(crate) struct RequestMetrics<'a> {
@@ -163,39 +430,107 @@ impl Drop for RequestMetrics<'_> {
 
 #[cfg(test)]
 mod tests {
-    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+    use opentelemetry_sdk::metrics::data::{
+        AggregatedMetrics, HistogramDataPoint, Metric, MetricData,
+    };
     use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
 
     use super::*;
+    use crate::lifecycle::LifecycleEmitter;
 
-    #[test]
-    fn dropping_active_request_records_cancellation() {
-        // Arrange
-        let exporter = InMemoryMetricExporter::default();
-        let meter_provider = SdkMeterProvider::builder()
-            .with_periodic_exporter(exporter.clone())
-            .build();
-        global::set_meter_provider(meter_provider.clone());
-        let metadata = ModelMetadata::new("test_provider", "cancelled-unit-test")
-            .expect("fixture metadata should be valid");
-        let metrics = RequestMetrics::start(&metadata);
+    fn attributes<T>(point: &HistogramDataPoint<T>) -> Vec<(&str, String)> {
+        let mut attributes = point
+            .attributes()
+            .map(|attribute| (attribute.key.as_str(), attribute.value.to_string()))
+            .collect::<Vec<_>>();
+        attributes.sort_unstable();
 
-        // Act
-        drop(metrics);
-        meter_provider
-            .force_flush()
-            .expect("cancellation metric should flush");
+        attributes
+    }
 
-        // Assert
-        let resource_metrics = exporter
-            .get_finished_metrics()
-            .expect("cancellation metric should be exported");
-        let duration = resource_metrics
+    fn metric<'metrics>(metrics: &'metrics [&Metric], name: &str) -> &'metrics Metric {
+        metrics
             .iter()
-            .flat_map(opentelemetry_sdk::metrics::data::ResourceMetrics::scope_metrics)
-            .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
-            .find(|metric| metric.name() == "gen_ai.client.operation.duration")
-            .expect("duration metric should be exported");
+            .find(|metric| metric.name() == name)
+            .copied()
+            .expect("metric should be exported")
+    }
+
+    fn record_lifecycle_fixtures(lifecycle: &LifecycleEmitter) {
+        lifecycle
+            .start_model_request(None, 0, None)
+            .expect("observer should start a standalone model request")
+            .completed(None, crate::lifecycle::ModelResponseType::Output);
+
+        let successful_turn = lifecycle
+            .start_turn()
+            .expect("observer should start a turn");
+        let successful_turn_id = successful_turn.id();
+        lifecycle
+            .start_model_request(None, 0, Some(successful_turn_id))
+            .expect("observer should start a model request")
+            .completed(None, crate::lifecycle::ModelResponseType::Output);
+        successful_turn.completed();
+
+        let denied_turn = lifecycle
+            .start_turn()
+            .expect("observer should start a turn");
+        let denied_turn_id = denied_turn.id();
+        lifecycle
+            .start_model_request(None, 0, Some(denied_turn_id))
+            .expect("observer should start a model request")
+            .failed(crate::model::ModelErrorType::InvalidOutput);
+        let mut completed_tool = lifecycle
+            .request_tool("read".to_string(), Some(denied_turn_id))
+            .expect("observer should request a tool");
+        completed_tool.started();
+        completed_tool.completed();
+        lifecycle
+            .request_tool("write".to_string(), Some(denied_turn_id))
+            .expect("observer should request a denied tool")
+            .denied();
+        denied_turn.failed(crate::lifecycle::TurnErrorType::ToolDenied);
+
+        let failed_turn = lifecycle
+            .start_turn()
+            .expect("observer should start a turn");
+        let failed_turn_id = failed_turn.id();
+        let mut failed_tool = lifecycle
+            .request_tool("read".to_string(), Some(failed_turn_id))
+            .expect("observer should request a tool");
+        failed_tool.started();
+        failed_tool.failed(crate::lifecycle::ToolErrorType::Execution);
+        failed_turn.failed(crate::lifecycle::TurnErrorType::Tool);
+
+        let cancelled_turn = lifecycle
+            .start_turn()
+            .expect("observer should start a turn");
+        let cancelled_turn_id = cancelled_turn.id();
+        drop(
+            lifecycle
+                .start_model_request(None, 0, Some(cancelled_turn_id))
+                .expect("observer should start a model request"),
+        );
+        let mut cancelled_tool = lifecycle
+            .request_tool("write".to_string(), Some(cancelled_turn_id))
+            .expect("observer should request a tool");
+        cancelled_tool.started();
+        drop(cancelled_tool);
+        drop(cancelled_turn);
+
+        let limited_turn = lifecycle
+            .start_turn()
+            .expect("observer should start a turn");
+        let limited_turn_id = limited_turn.id();
+        lifecycle
+            .request_tool("read".to_string(), Some(limited_turn_id))
+            .expect("observer should request a limited tool")
+            .failed(crate::lifecycle::ToolErrorType::CallLimit);
+        limited_turn.failed(crate::lifecycle::TurnErrorType::ToolCallLimit);
+    }
+
+    fn assert_request_duration(metrics: &[&Metric]) {
+        let duration = metric(metrics, DURATION_METRIC);
         assert!(matches!(
             duration.data(),
             AggregatedMetrics::F64(MetricData::Histogram(histogram)) if {
@@ -230,5 +565,161 @@ mod tests {
                 true
             }
         ));
+    }
+
+    fn assert_agent_duration(metrics: &[&Metric]) {
+        let agent_duration = metric(metrics, AGENT_DURATION_METRIC);
+        assert_eq!(agent_duration.description(), AGENT_DURATION_DESCRIPTION);
+        assert_eq!(agent_duration.unit(), DURATION_UNIT);
+        assert!(matches!(
+            agent_duration.data(),
+            AggregatedMetrics::F64(MetricData::Histogram(histogram)) if {
+                let points = histogram.data_points().collect::<Vec<_>>();
+                assert_eq!(points.len(), 5);
+                assert!(points.iter().all(|point| point.count() == 1));
+                assert!(points.iter().all(|point| point.bounds().eq(
+                    AGENT_DURATION_BOUNDARIES_SECONDS
+                )));
+                let mut attributes = points
+                    .iter()
+                    .map(|point| attributes(point))
+                    .collect::<Vec<_>>();
+                attributes.sort_unstable();
+                assert_eq!(
+                    attributes,
+                    [
+                        vec![],
+                        vec![("error.type", "cancelled".to_string())],
+                        vec![("error.type", "tool_call_limit".to_string())],
+                        vec![("error.type", "tool_denied".to_string())],
+                        vec![("error.type", "tool_execution_error".to_string())],
+                    ]
+                );
+
+                true
+            }
+        ));
+    }
+
+    fn assert_call_histogram(metric: &Metric, description: &str, expected_sum: u64, unit: &str) {
+        assert_eq!(metric.description(), description);
+        assert_eq!(metric.unit(), unit);
+        assert!(matches!(
+            metric.data(),
+            AggregatedMetrics::U64(MetricData::Histogram(histogram)) if {
+                let point = histogram
+                    .data_points()
+                    .next()
+                    .expect("call-count point should be exported");
+                assert_eq!(point.count(), 5);
+                assert_eq!(point.sum(), expected_sum);
+                assert!(point.bounds().eq(AGENT_CALL_BOUNDARIES));
+                assert_eq!(attributes(point), []);
+
+                true
+            }
+        ));
+    }
+
+    fn assert_agent_calls(metrics: &[&Metric]) {
+        let inference_calls = metric(metrics, AGENT_INFERENCE_CALLS_METRIC);
+        assert_call_histogram(
+            inference_calls,
+            AGENT_INFERENCE_CALLS_DESCRIPTION,
+            3,
+            AGENT_INFERENCE_CALLS_UNIT,
+        );
+        let tool_calls = metric(metrics, AGENT_TOOL_CALLS_METRIC);
+        assert_call_histogram(
+            tool_calls,
+            AGENT_TOOL_CALLS_DESCRIPTION,
+            5,
+            AGENT_TOOL_CALLS_UNIT,
+        );
+    }
+
+    fn assert_tool_duration(metrics: &[&Metric]) {
+        let tool_duration = metric(metrics, TOOL_DURATION_METRIC);
+        assert_eq!(tool_duration.description(), TOOL_DURATION_DESCRIPTION);
+        assert_eq!(tool_duration.unit(), DURATION_UNIT);
+        assert!(matches!(
+            tool_duration.data(),
+            AggregatedMetrics::F64(MetricData::Histogram(histogram)) if {
+                let points = histogram.data_points().collect::<Vec<_>>();
+                assert_eq!(points.len(), 3);
+                assert!(points.iter().all(|point| point.count() == 1));
+                assert!(points.iter().all(|point| point.bounds().eq(
+                    DURATION_BOUNDARIES_SECONDS
+                )));
+                let mut attributes = points
+                    .iter()
+                    .map(|point| attributes(point))
+                    .collect::<Vec<_>>();
+                attributes.sort_unstable();
+                assert_eq!(
+                    attributes,
+                    [
+                        vec![
+                            ("error.type", "cancelled".to_string()),
+                            ("gen_ai.tool.name", "write".to_string()),
+                            ("gen_ai.tool.type", "function".to_string()),
+                        ],
+                        vec![
+                            ("error.type", "tool_execution_error".to_string()),
+                            ("gen_ai.tool.name", "read".to_string()),
+                            ("gen_ai.tool.type", "function".to_string()),
+                        ],
+                        vec![
+                            ("gen_ai.tool.name", "read".to_string()),
+                            ("gen_ai.tool.type", "function".to_string()),
+                        ],
+                    ]
+                );
+
+                true
+            }
+        ));
+    }
+
+    #[test]
+    fn records_model_agent_and_tool_metric_contracts() {
+        // Arrange
+        let exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+        global::set_meter_provider(meter_provider.clone());
+        let metadata = ModelMetadata::new("test_provider", "cancelled-unit-test")
+            .expect("fixture metadata should be valid");
+        let request_metrics = RequestMetrics::start(&metadata);
+        let lifecycle = LifecycleEmitter::new(LifecycleMetrics::default());
+
+        // Act
+        drop(request_metrics);
+        record_lifecycle_fixtures(&lifecycle);
+        meter_provider.force_flush().expect("metrics should flush");
+
+        // Assert
+        let resource_metrics = exporter
+            .get_finished_metrics()
+            .expect("metrics should be exported");
+        let metrics = resource_metrics
+            .iter()
+            .flat_map(opentelemetry_sdk::metrics::data::ResourceMetrics::scope_metrics)
+            .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+            .collect::<Vec<_>>();
+        assert_eq!(metrics.len(), 5);
+        assert_eq!(
+            crate::lifecycle::TurnErrorType::Model(crate::model::ModelErrorType::Request).as_str(),
+            ERROR_REQUEST
+        );
+        assert_eq!(
+            crate::lifecycle::TurnErrorType::RepositoryRequired.as_str(),
+            ERROR_REPOSITORY_REQUIRED
+        );
+        assert_request_duration(&metrics);
+        assert_agent_duration(&metrics);
+        assert_agent_calls(&metrics);
+        assert_tool_duration(&metrics);
     }
 }

--- a/crates/ag-harness/tests/public_api.rs
+++ b/crates/ag-harness/tests/public_api.rs
@@ -4,9 +4,9 @@ use std::error::Error;
 use std::sync::{Arc, Mutex};
 
 use ag_harness::{
-    CompletionMetadata, CompletionUsage, Harness, LifecycleEventKind, LifecycleObserverSet, Model,
-    ModelCompletion, ModelError, ModelRequest, ModelResponse, ModelWithMetadata, OutputSchema,
-    OutputSchemaError,
+    CompletionMetadata, CompletionUsage, Harness, LifecycleEventKind, LifecycleMetrics,
+    LifecycleObserverSet, Model, ModelCompletion, ModelError, ModelRequest, ModelResponse,
+    ModelWithMetadata, OutputSchema, OutputSchemaError,
 };
 use async_trait::async_trait;
 use serde_json::json;
@@ -155,7 +155,8 @@ async fn external_observer_set_fans_out_lifecycle_events() -> Result<(), Box<dyn
             .lock()
             .expect("second event recorder should not be poisoned")
             .push(event);
-    });
+    })
+    .with_observer(LifecycleMetrics::new());
     let harness = Harness::new(ExternalMetadataModel).with_lifecycle_observer(observers);
 
     // Act

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -211,18 +211,27 @@ bounded, redacted, and disabled by default.
 The conventions are Development status, so this immutable revision, rather than the
 repository's moving `main` branch, defines the compatibility contract.
 
-The current model-client projection implements these standard histograms:
+The current projections implement these standard histograms:
 
-| Instrument                         | Unit      | Explicit bucket boundaries                    |
-| ---------------------------------- | --------- | --------------------------------------------- |
-| `gen_ai.client.operation.duration` | `s`       | `0.01` through `81.92`, doubling each step    |
-| `gen_ai.client.token.usage`        | `{token}` | `1` through `67108864`, quadrupling each step |
+| Instrument                            | Unit               | Explicit bucket boundaries                    |
+| ------------------------------------- | ------------------ | --------------------------------------------- |
+| `gen_ai.client.operation.duration`    | `s`                | `0.01` through `81.92`, doubling each step    |
+| `gen_ai.client.token.usage`           | `{token}`          | `1` through `67108864`, quadrupling each step |
+| `gen_ai.invoke_agent.duration`        | `s`                | `0.1` through `409.6`, doubling each step     |
+| `gen_ai.invoke_agent.inference_calls` | `{inference_call}` | `1` through `128`, doubling each step         |
+| `gen_ai.invoke_agent.tool_calls`      | `{tool_call}`      | `1` through `128`, doubling each step         |
+| `gen_ai.execute_tool.duration`        | `s`                | `0.01` through `81.92`, doubling each step    |
 
-Both instruments record the required `gen_ai.operation.name` value `chat`, the provider
-identity, and the requested model when available. Token measurements also record the
-required `gen_ai.token.type` value `input` or `output`. Failed duration measurements
-record `error.type`. Instrument names, descriptions, units, boundaries, attribute names,
-and well-known values are centralized in the telemetry module.
+Both model-client instruments record the required `gen_ai.operation.name` value `chat`,
+the provider identity, and the requested model when available. Token measurements also
+record the required `gen_ai.token.type` value `input` or `output`. Failed duration
+measurements record `error.type`. Instrument names, descriptions, units, boundaries,
+attribute names, and well-known values are centralized in the telemetry module.
+
+`LifecycleMetrics` counts started model requests and requested client-side tools once
+per turn, but records tool duration only after `ToolStarted`. Executions include
+`gen_ai.tool.name` and `gen_ai.tool.type=function`; unavailable agent identity and
+dynamic model identity are omitted.
 
 The provider registry contains one standard value and two documented custom values:
 
@@ -247,6 +256,9 @@ Model request failures use this bounded `error.type` vocabulary:
 | `response_too_large`        | Response exceeded a configured safety bound             |
 | `invalid_output`            | Output failed JSON parsing or schema validation         |
 | `invalid_tool_call`         | Tool call was missing, malformed, or unsupported        |
+
+Turn and tool projections additionally use `cancelled`, `tool_execution_error`,
+`tool_denied`, `tool_call_limit`, and `repository_required`.
 
 Messages, prompts, system instructions, tool arguments, tool results, response bodies,
 repository content, and internal lifecycle identifiers are never projected to
@@ -310,7 +322,7 @@ best cost and performance:
 - [x] **Model-client metrics.** Record request duration, reported input and output token
   usage, operation and model identity, and bounded failures without sensitive or
   high-cardinality content.
-- [ ] **Turn and tool metric projection.** Derive aggregate turn and tool measurements
+- [x] **Turn and tool metric projection.** Derive aggregate turn and tool measurements
   from lifecycle facts without double-counting model-client metrics.
 - [ ] **Lifecycle trace projection.** Represent a turn as a parent span with correlated
   model and tool children, including correct completion, failure, and cancellation.


### PR DESCRIPTION
- Exposes `LifecycleMetrics` for agent duration, model and tool call counts, and executed-tool duration.
- Maps turn and tool outcomes to stable bounded telemetry attributes and verifies the metric contract.
- Documents the lifecycle metric projection and public usage.