### PR TITLE
Changed-line focus aligns with selected file rows

### DIFF
--- a/crates/agentty/src/runtime/mode/diff.rs
+++ b/crates/agentty/src/runtime/mode/diff.rs
@@ -587,6 +587,7 @@ impl DiffKeyNavigation<'_> {
             focus: self.focus,
             line_comments: self.line_comments,
             preview: self.preview,
+            review_comments_are_visible: self.review_comments.is_some(),
             scroll_cache: self.scroll_cache,
             scroll_offset: self.scroll_offset,
             selected_diff_line_index: self.selected_diff_line_index,
@@ -761,6 +762,7 @@ struct DiffContentNavigation<'a> {
     focus: &'a mut DiffFocus,
     line_comments: &'a mut DiffLineComments,
     preview: &'a DiffPreview,
+    review_comments_are_visible: bool,
     scroll_cache: &'a mut Option<DiffScrollCache>,
     scroll_offset: &'a mut u16,
     selected_diff_line_index: &'a mut usize,
@@ -806,8 +808,19 @@ fn focus_selected_file_changes(
         content_area,
         render_cache_store.diff_layout_cache(),
     );
-    let Some(selected_diff_line_index) =
-        changed_line_layout.changed_line_index_at_scroll_offset(*navigation.scroll_offset)
+    let page_areas = diff_util::diff_page_areas(content_area);
+    let sidebar_areas = diff_util::diff_sidebar_areas(
+        page_areas.file_list_area,
+        navigation.review_comments_are_visible,
+    );
+    let selected_visual_row = FileExplorer::selected_visual_row(
+        navigation.file_explorer_selected_index,
+        content.item_count(),
+        sidebar_areas.file_list_area,
+    )
+    .unwrap_or_default();
+    let Some(selected_diff_line_index) = changed_line_layout
+        .changed_line_index_at_visual_row(*navigation.scroll_offset, selected_visual_row)
     else {
         return;
     };
@@ -1188,6 +1201,24 @@ mod tests {
         )
     }
 
+    /// Returns eight file rows whose last file starts changing at line 33.
+    fn aligned_file_diff_fixture() -> String {
+        let preceding_files = ('a'..='g')
+            .map(|file_name| {
+                format!("diff --git a/{file_name}.rs b/{file_name}.rs\n@@ -0,0 +1 @@\n+seed")
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let selected_file_lines = (33..=42)
+            .map(|line_number| format!("+line {line_number}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        format!(
+            "{preceding_files}\ndiff --git a/h.rs b/h.rs\n@@ -0,0 +33,10 @@\n{selected_file_lines}"
+        )
+    }
+
     /// Builds a diff-mode snapshot for focused navigation tests.
     fn diff_mode_fixture(
         diff: &str,
@@ -1494,6 +1525,49 @@ mod tests {
                 } if comments.is_empty()
             ));
         }
+    }
+
+    #[tokio::test]
+    async fn test_handle_l_focuses_changed_line_aligned_with_selected_file_row() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+        let diff = aligned_file_diff_fixture();
+        app.mode = AppMode::Diff {
+            diff: diff.clone(),
+            file_explorer_selected_index: 7,
+            focus: DiffFocus::Files,
+            line_comments: DiffLineComments::default(),
+            preview: DiffPreview::default(),
+            review_comments: None,
+            restore: None,
+            scroll_cache: None,
+            scroll_offset: 2,
+            selected_diff_line_index: 0,
+            session_id: "session-id".into(),
+        };
+        let content_area = Rect::new(0, 0, 80, 20);
+
+        // Act
+        handle(
+            &mut app,
+            content_area,
+            KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE),
+        );
+
+        // Assert
+        assert!(matches!(
+            app.mode,
+            AppMode::Diff {
+                focus: DiffFocus::Content,
+                selected_diff_line_index: 7,
+                ..
+            }
+        ));
+        let selected_anchor = page::diff::DiffLayoutCache::default()
+            .content(&diff)
+            .selected_changed_line(7, 7)
+            .expect("aligned changed line should resolve");
+        assert_eq!(selected_anchor.line, 40);
     }
 
     #[tokio::test]

--- a/crates/agentty/src/ui/component/file_explorer.rs
+++ b/crates/agentty/src/ui/component/file_explorer.rs
@@ -176,6 +176,29 @@ impl FileExplorer {
         }
     }
 
+    /// Returns the selected item's row inside the bordered list viewport.
+    ///
+    /// The explorer creates a fresh [`ListState`] for every render. Ratatui
+    /// therefore starts at offset zero and, when necessary, scrolls just far
+    /// enough to keep the selected one-line item visible at the bottom.
+    pub(crate) fn selected_visual_row(
+        selected_index: usize,
+        item_count: usize,
+        area: Rect,
+    ) -> Option<u16> {
+        if item_count == 0 {
+            return None;
+        }
+        let viewport_height = Block::default().borders(Borders::ALL).inner(area).height;
+        if viewport_height == 0 {
+            return None;
+        }
+        let selected_index = Self::normalize_selected_index(selected_index, item_count);
+        let last_visual_row = usize::from(viewport_height.saturating_sub(1));
+
+        u16::try_from(selected_index.min(last_visual_row)).ok()
+    }
+
     /// Returns the number of items (files and folders) in the explorer list.
     pub fn count_items(parsed_lines: &[DiffLine<'_>]) -> usize {
         let (lines, _) = Self::file_tree(parsed_lines);
@@ -582,6 +605,28 @@ mod tests {
             .iter()
             .map(|span| span.content.to_string())
             .collect()
+    }
+
+    #[test]
+    fn test_selected_visual_row_matches_fresh_list_state_scrolling() {
+        // Arrange
+        let tall_area = Rect::new(0, 0, 20, 12);
+        let short_area = Rect::new(0, 0, 20, 5);
+        let flat_area = Rect::new(0, 0, 20, 2);
+
+        // Act
+        let visible_row = FileExplorer::selected_visual_row(7, 10, tall_area);
+        let scrolled_row = FileExplorer::selected_visual_row(7, 10, short_area);
+        let clamped_row = FileExplorer::selected_visual_row(usize::MAX, 2, tall_area);
+        let empty_row = FileExplorer::selected_visual_row(0, 0, tall_area);
+        let flat_row = FileExplorer::selected_visual_row(0, 1, flat_area);
+
+        // Assert
+        assert_eq!(visible_row, Some(7));
+        assert_eq!(scrolled_row, Some(2));
+        assert_eq!(clamped_row, Some(1));
+        assert_eq!(empty_row, None);
+        assert_eq!(flat_row, None);
     }
 
     #[test]

--- a/crates/agentty/src/ui/page/diff.rs
+++ b/crates/agentty/src/ui/page/diff.rs
@@ -603,14 +603,18 @@ impl DiffResolvedLayout {
         self.adjacent_content_selection(selected_changed_line_index, selected_comment_index, false)
     }
 
-    /// Returns the first changed source line intersecting or below the viewport
-    /// top.
-    pub(crate) fn changed_line_index_at_scroll_offset(&self, scroll_offset: u16) -> Option<usize> {
-        let scroll_offset = usize::from(scroll_offset);
+    /// Returns the first changed source line intersecting or below one visual
+    /// row in the current viewport.
+    pub(crate) fn changed_line_index_at_visual_row(
+        &self,
+        scroll_offset: u16,
+        visual_row: u16,
+    ) -> Option<usize> {
+        let target_row = usize::from(scroll_offset).saturating_add(usize::from(visual_row));
 
         self.changed_line_ranges
             .iter()
-            .position(|range| range.end > scroll_offset)
+            .position(|range| range.end > target_row)
             .or_else(|| self.changed_line_ranges.len().checked_sub(1))
     }
 
@@ -2572,8 +2576,11 @@ mod tests {
             .changed_line_scroll_offset(20, 0)
             .expect("selected changed line should have a rendered range");
         let first_visible_changed_line = layout
-            .changed_line_index_at_scroll_offset(scrolled_down)
+            .changed_line_index_at_visual_row(scrolled_down, 0)
             .expect("scrolled viewport should contain a changed line");
+        let aligned_changed_line = layout
+            .changed_line_index_at_visual_row(scrolled_down, 3)
+            .expect("aligned viewport row should contain a changed line");
         let scrolled_up = layout
             .changed_line_scroll_offset(0, scrolled_down)
             .expect("first changed line should have a rendered range");
@@ -2592,6 +2599,7 @@ mod tests {
         assert!(scrolled_down > 0);
         assert!(first_visible_changed_line > 0);
         assert!(first_visible_changed_line <= 20);
+        assert!(aligned_changed_line > first_visible_changed_line);
         assert!(scrolled_up < scrolled_down);
         assert_eq!(zero_height_scroll_offset, 0);
         assert_eq!(
@@ -2615,7 +2623,7 @@ mod tests {
         );
 
         // Act
-        let selected_index = layout.changed_line_index_at_scroll_offset(u16::MAX);
+        let selected_index = layout.changed_line_index_at_visual_row(u16::MAX, 0);
 
         // Assert
         assert_eq!(selected_index, Some(0));

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -7688,6 +7688,20 @@ fn test_diff_changed_line_navigation() -> E2eResult {
                 assertion::assert_text_in_region(frame, "changed line 70", &full);
                 assertion::assert_text_in_region(frame, "Esc/Left: files", &full);
                 assertion::assert_text_in_region(frame, "j/k: select row", &full);
+                let file_row = frame
+                    .find_text("src/")
+                    .first()
+                    .expect("selected file's parent folder should remain visible")
+                    .rect
+                    .row
+                    .saturating_add(1);
+                let aligned_changed_line_row = frame
+                    .find_text("changed line 65")
+                    .first()
+                    .expect("aligned changed line should remain visible")
+                    .rect
+                    .row;
+                assert_eq!(aligned_changed_line_row, file_row);
             },
         )?;
 


### PR DESCRIPTION
- Account for the file explorer’s visible row and review-comment sidebar when focusing diff changes
- Cover scrolled, clamped, and end-to-end aligned navigation behavior

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)