### PR TITLE
ag-harness runs interactive model chats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,9 @@ dependencies = [
 name = "ag-harness"
 version = "0.15.5"
 dependencies = [
+ "assert_cmd",
  "async-trait",
+ "clap",
  "jsonschema",
  "mockall",
  "opentelemetry",
@@ -83,6 +85,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "testty",
  "thiserror 2.0.20",
  "tokio",
  "wiremock",

--- a/crates/ag-harness/Cargo.toml
+++ b/crates/ag-harness/Cargo.toml
@@ -17,6 +17,7 @@ bench = false
 
 [dependencies]
 async-trait.workspace = true
+clap.workspace = true
 jsonschema.workspace = true
 opentelemetry.workspace = true
 reqwest.workspace = true
@@ -25,14 +26,16 @@ serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 tempfile.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["io-std"] }
 
 [dev-dependencies]
+assert_cmd.workspace = true
 mockall.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry-proto.workspace = true
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 prost.workspace = true
+testty.workspace = true
 wiremock.workspace = true
 
 [lints]

--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -2,6 +2,25 @@
 
 Run a model with bounded repository tools and validated structured output.
 
+## Command line
+
+Set the provider credentials, then start a chat:
+
+```sh
+MODEL_API_KEY=your-key cargo run -p ag-harness -- run muse-spark-1.2
+```
+
+The current directory is readable by the model by default. Use `--read-dir <DIR>` to
+choose another root; files read beneath it are sent to the configured provider. Use
+`--provider <muse|kimi|qwen>` to select a provider. Muse uses `MODEL_API_KEY` and the
+optional `MODEL_API_BASE_URL`; Kimi uses `KIMI_API_KEY` and `KIMI_BASE_URL`; Qwen uses
+`DASHSCOPE_API_KEY` and `DASHSCOPE_BASE_URL`. `--base-url` overrides the corresponding
+URL variable.
+
+Run `cargo run -p ag-harness -- --help` for commands.
+
+## Library
+
 ```rust
 use ag_harness::{Harness, MUSE_SPARK_1_2, Muse, Tool};
 
@@ -20,6 +39,10 @@ Tools are denied by default and repository tools require an explicit root. `read
 returns bounded file content; `write` applies one bounded unified diff to one text file.
 Both use the injected `FileSystem` boundary without shell commands, and the model may
 continue calling allowed tools until it returns schema-valid JSON.
+
+Use `Harness::chat()` for sequential in-memory turns and sanitized activity reports.
+Chat history retains complete recent turns within a 256 KiB payload budget; use
+`Harness::max_history_bytes()` to override it.
 
 Use `ModelWithMetadata::complete_with_metadata()` for normalized completion metadata.
 

--- a/crates/ag-harness/src/chat_completion.rs
+++ b/crates/ag-harness/src/chat_completion.rs
@@ -13,8 +13,12 @@ use crate::{model, schema_contract, tool};
 
 pub(crate) const ERROR_BODY_LIMIT_BYTES: usize = 4 * 1024;
 const JSON_STRING_MAX_EXPANSION: usize = 6;
+const MAX_RATE_LIMIT_RETRIES: usize = 2;
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(5);
+const MAX_TRANSPORT_RETRIES: usize = 1;
 pub(crate) const RESPONSE_ENVELOPE_LIMIT_BYTES: usize = 64 * 1024;
 const REQUEST_TIMEOUT: Duration = Duration::from_mins(1);
+const RETRY_DELAY: Duration = Duration::from_secs(1);
 pub(crate) const SUCCESS_BODY_LIMIT_BYTES: usize = schema_contract::RESPONSE_CONTENT_LIMIT_BYTES
     * JSON_STRING_MAX_EXPANSION
     + RESPONSE_ENVELOPE_LIMIT_BYTES;
@@ -59,6 +63,7 @@ impl StructuredOutputMode {
 #[derive(Clone, Copy)]
 pub(crate) struct ChatCompletionProviderPolicy {
     pub(crate) display_name: &'static str,
+    pub(crate) response_format_with_tools: bool,
     pub(crate) structured_output: StructuredOutputMode,
     pub(crate) telemetry_name: &'static str,
     pub(crate) unsupported_schema_reason: &'static str,
@@ -122,15 +127,18 @@ impl ChatCompletionBackend {
                 reason: self.policy.unsupported_schema_reason.to_string(),
             });
         }
+        let tools: Vec<_> = request
+            .tools()
+            .iter()
+            .map(ChatCompletionTool::from)
+            .collect();
+        let response_format = (tools.is_empty() || self.policy.response_format_with_tools)
+            .then(|| self.response_format(request.schema()));
         let payload = ChatCompletionPayload {
             messages: self.messages(request)?,
             model: &self.model,
-            response_format: self.response_format(request.schema()),
-            tools: request
-                .tools()
-                .iter()
-                .map(ChatCompletionTool::from)
-                .collect(),
+            response_format,
+            tools,
         };
         let payload = serde_json::to_value(payload).map_err(model::ModelError::request)?;
         let completion = self
@@ -211,6 +219,18 @@ impl ChatCompletionBackend {
         }
         for message in request.messages() {
             match message {
+                model::ModelMessage::Assistant(content) => {
+                    messages.push(ChatCompletionMessagePayload::Text {
+                        content: content.clone(),
+                        role: "assistant",
+                    });
+                }
+                model::ModelMessage::System(content) => {
+                    messages.push(ChatCompletionMessagePayload::Text {
+                        content: content.clone(),
+                        role: "system",
+                    });
+                }
                 model::ModelMessage::User(content) => {
                     messages.push(ChatCompletionMessagePayload::Text {
                         content: content.clone(),
@@ -460,26 +480,51 @@ impl ChatCompletionClient for ReqwestChatCompletionClient {
         request: ChatCompletionRequest<'_>,
     ) -> Result<Option<ChatCompletion>, ChatCompletionError> {
         let (api_key, endpoint, payload) = request.into_parts();
-        let mut response = self
-            .client
-            .post(endpoint)
-            .bearer_auth(api_key)
-            .timeout(REQUEST_TIMEOUT)
-            .json(&payload)
-            .send()
-            .await
-            .map_err(ChatCompletionError::transport)?;
+        let mut rate_limit_retries = 0_usize;
+        let mut transport_retries = 0_usize;
+        let mut response = loop {
+            let response = self
+                .client
+                .post(&endpoint)
+                .bearer_auth(api_key)
+                .timeout(REQUEST_TIMEOUT)
+                .json(&payload)
+                .send()
+                .await;
+            let mut response = match response {
+                Ok(response) => response,
+                Err(_) if transport_retries < MAX_TRANSPORT_RETRIES => {
+                    transport_retries += 1;
+                    tokio::time::sleep(RETRY_DELAY).await;
 
-        if let Err(source) = response.error_for_status_ref() {
-            let status = response.status();
-            let body = error_body_summary(&mut response).await;
+                    continue;
+                }
+                Err(error) => return Err(ChatCompletionError::transport(error)),
+            };
 
-            return Err(ChatCompletionError::Http {
-                body,
-                source,
-                status,
-            });
-        }
+            if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS
+                && rate_limit_retries < MAX_RATE_LIMIT_RETRIES
+            {
+                let delay = rate_limit_retry_delay(response.headers(), rate_limit_retries);
+                rate_limit_retries += 1;
+                drop(response);
+                tokio::time::sleep(delay).await;
+
+                continue;
+            }
+            if let Err(source) = response.error_for_status_ref() {
+                let status = response.status();
+                let body = error_body_summary(&mut response).await;
+
+                return Err(ChatCompletionError::Http {
+                    body,
+                    source,
+                    status,
+                });
+            }
+
+            break response;
+        };
 
         let body = success_body(&mut response).await?;
         let response = serde_json::from_slice::<ChatCompletionResponse>(&body)
@@ -494,6 +539,18 @@ impl ChatCompletionClient for ReqwestChatCompletionClient {
             completion
         }))
     }
+}
+
+fn rate_limit_retry_delay(headers: &reqwest::header::HeaderMap, retry: usize) -> Duration {
+    headers
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .map_or_else(
+            || RETRY_DELAY.saturating_mul(1_u32 << retry.min(31)),
+            Duration::from_secs,
+        )
+        .min(MAX_RETRY_DELAY)
 }
 
 async fn error_body_summary(response: &mut reqwest::Response) -> String {
@@ -595,7 +652,8 @@ impl ChatCompletionError {
 struct ChatCompletionPayload<'a> {
     messages: Vec<ChatCompletionMessagePayload>,
     model: &'a str,
-    response_format: ResponseFormat<'a>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    response_format: Option<ResponseFormat<'a>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tools: Vec<ChatCompletionTool<'a>>,
 }
@@ -830,6 +888,7 @@ mod tests {
             "native-schema-model".to_string(),
             ChatCompletionProviderPolicy {
                 display_name: "Native schema provider",
+                response_format_with_tools: true,
                 structured_output: StructuredOutputMode::JsonSchema,
                 telemetry_name: "native_schema",
                 unsupported_schema_reason: "object schema required",
@@ -880,6 +939,55 @@ mod tests {
                     "role": "tool",
                     "tool_call_id": "call_read"
                 }
+            ])
+        );
+    }
+
+    #[test]
+    fn serializes_conversation_history() {
+        // Arrange
+        let backend = ChatCompletionBackend::with_client(
+            "test-key".to_string(),
+            "https://example.com/v1".to_string(),
+            "native-schema-model".to_string(),
+            ChatCompletionProviderPolicy {
+                display_name: "Native schema provider",
+                response_format_with_tools: true,
+                structured_output: StructuredOutputMode::JsonSchema,
+                telemetry_name: "native_schema",
+                unsupported_schema_reason: "object schema required",
+            },
+            default_client(),
+        );
+        let schema = schema_contract::OutputSchema::new(serde_json::json!({
+            "type": "object"
+        }))
+        .expect("schema should be valid");
+        let mut request = model::ModelRequest::new("first question", schema.clone());
+        request.record_output(&serde_json::json!({"message": "first answer"}));
+        let mut messages = request.into_messages();
+        messages.insert(
+            0,
+            model::ModelMessage::System("read-only instructions".to_string()),
+        );
+        let request = model::ModelRequest::with_history(messages, "second question", schema);
+
+        // Act
+        let messages = serde_json::to_value(
+            backend
+                .messages(&request)
+                .expect("conversation history should serialize"),
+        )
+        .expect("messages should encode as JSON");
+
+        // Assert
+        assert_eq!(
+            messages,
+            serde_json::json!([
+                {"content": "read-only instructions", "role": "system"},
+                {"content": "first question", "role": "user"},
+                {"content": r#"{"message":"first answer"}"#, "role": "assistant"},
+                {"content": "second question", "role": "user"}
             ])
         );
     }
@@ -1122,6 +1230,7 @@ mod tests {
             "model".to_string(),
             ChatCompletionProviderPolicy {
                 display_name: "Provider",
+                response_format_with_tools: true,
                 structured_output: StructuredOutputMode::JsonSchema,
                 telemetry_name: "provider",
                 unsupported_schema_reason: "object schema required",
@@ -1142,6 +1251,146 @@ mod tests {
         );
     }
 
+    #[test]
+    fn rate_limit_retry_delay_uses_bounded_headers_and_backoff() {
+        // Arrange
+        let mut headers = reqwest::header::HeaderMap::new();
+
+        // Act and Assert
+        assert_eq!(rate_limit_retry_delay(&headers, 0), Duration::from_secs(1));
+        assert_eq!(rate_limit_retry_delay(&headers, 1), Duration::from_secs(2));
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            "99".parse().expect("valid header"),
+        );
+        assert_eq!(rate_limit_retry_delay(&headers, 0), MAX_RETRY_DELAY);
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            reqwest::header::HeaderValue::from_bytes(b"invalid").expect("valid header bytes"),
+        );
+        assert_eq!(rate_limit_retry_delay(&headers, 0), RETRY_DELAY);
+    }
+
+    #[tokio::test]
+    async fn retries_rate_limit_response_before_decoding_success() {
+        // Arrange
+        let listener = TcpListener::bind("127.0.0.1:0").expect("retry listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("retry listener should have an address");
+        let success_body = r#"{"choices":[{"finish_reason":"stop","message":{"content":"{\"message\":\"ok\"}"}}]}"#;
+        let server = tokio::task::spawn_blocking(move || {
+            for attempt in 0..2 {
+                let (mut stream, _) = listener
+                    .accept()
+                    .expect("retry listener should accept a request");
+                let mut request = [0; 2_048];
+                assert!(
+                    stream.read(&mut request).expect("request should be read") > 0,
+                    "retry request should not be empty"
+                );
+                if attempt == 0 {
+                    stream
+                        .write_all(
+                            b"HTTP/1.1 429 Too Many Requests\r\n\
+                              Content-Length: 0\r\n\
+                              Retry-After: 0\r\n\
+                              Connection: close\r\n\r\n",
+                        )
+                        .expect("rate-limit response should be written");
+                } else {
+                    write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        success_body.len(),
+                        success_body
+                    )
+                    .expect("success response should be written");
+                }
+            }
+        });
+        let client = ReqwestChatCompletionClient {
+            client: reqwest::Client::new(),
+        };
+        let request = ChatCompletionRequest::new(
+            "test-key",
+            format!("http://{address}"),
+            serde_json::json!({}),
+        );
+
+        // Act
+        let completion = client
+            .complete(request)
+            .await
+            .expect("retry should recover")
+            .expect("response should contain one choice");
+        server.await.expect("retry server should finish");
+
+        // Assert
+        assert_eq!(completion.content.as_deref(), Some(r#"{"message":"ok"}"#));
+    }
+
+    #[tokio::test]
+    async fn retries_transport_failure_before_decoding_success() {
+        // Arrange
+        let listener = TcpListener::bind("127.0.0.1:0").expect("retry listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("retry listener should have an address");
+        let success_body = r#"{"choices":[{"finish_reason":"stop","message":{"content":"{\"message\":\"ok\"}"}}]}"#;
+        let server = tokio::task::spawn_blocking(move || {
+            let (mut failed_stream, _) = listener
+                .accept()
+                .expect("retry listener should accept the failed request");
+            let mut request = [0; 2_048];
+            assert!(
+                failed_stream
+                    .read(&mut request)
+                    .expect("failed request should be read")
+                    > 0,
+                "failed request should not be empty"
+            );
+            drop(failed_stream);
+
+            let (mut stream, _) = listener
+                .accept()
+                .expect("retry listener should accept the successful request");
+            assert!(
+                stream
+                    .read(&mut request)
+                    .expect("successful request should be read")
+                    > 0,
+                "successful request should not be empty"
+            );
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                success_body.len(),
+                success_body
+            )
+            .expect("success response should be written");
+        });
+        let client = ReqwestChatCompletionClient {
+            client: reqwest::Client::new(),
+        };
+        let request = ChatCompletionRequest::new(
+            "test-key",
+            format!("http://{address}"),
+            serde_json::json!({}),
+        );
+
+        // Act
+        let completion = client
+            .complete(request)
+            .await
+            .expect("transport retry should recover")
+            .expect("response should contain one choice");
+        server.await.expect("retry server should finish");
+
+        // Assert
+        assert_eq!(completion.content.as_deref(), Some(r#"{"message":"ok"}"#));
+    }
+
     #[tokio::test]
     async fn retains_http_status_when_error_body_read_fails() {
         // Arrange
@@ -1151,25 +1400,28 @@ mod tests {
             .local_addr()
             .expect("truncated-response listener should have an address");
         let server = tokio::task::spawn_blocking(move || {
-            let (mut stream, _) = listener
-                .accept()
-                .expect("truncated-response listener should accept a request");
-            let mut request = [0; 2_048];
-            let bytes_read = stream
-                .read(&mut request)
-                .expect("truncated-response server should read the request");
-            assert!(
-                bytes_read > 0,
-                "truncated-response request should not be empty"
-            );
-            stream
-                .write_all(
-                    b"HTTP/1.1 429 Too Many Requests\r\n\
-                      Content-Length: 64\r\n\
-                      Connection: close\r\n\r\n\
-                      partial error body",
-                )
-                .expect("truncated-response server should write the response");
+            for _ in 0..=MAX_RATE_LIMIT_RETRIES {
+                let (mut stream, _) = listener
+                    .accept()
+                    .expect("truncated-response listener should accept a request");
+                let mut request = [0; 2_048];
+                let bytes_read = stream
+                    .read(&mut request)
+                    .expect("truncated-response server should read the request");
+                assert!(
+                    bytes_read > 0,
+                    "truncated-response request should not be empty"
+                );
+                stream
+                    .write_all(
+                        b"HTTP/1.1 429 Too Many Requests\r\n\
+                          Content-Length: 64\r\n\
+                          Retry-After: 0\r\n\
+                          Connection: close\r\n\r\n\
+                          partial error body",
+                    )
+                    .expect("truncated-response server should write the response");
+            }
         });
         let client = ReqwestChatCompletionClient {
             client: reqwest::Client::new(),

--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -1,6 +1,9 @@
+use std::collections::VecDeque;
+use std::fmt;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use serde_json::Value;
 use thiserror::Error;
@@ -9,7 +12,9 @@ use crate::file_system::{FileSystem, LocalFileSystem};
 use crate::lifecycle::{
     LifecycleEmitter, LifecycleId, LifecycleObserver, ToolErrorType, TurnErrorType, TurnLifecycle,
 };
-use crate::model::{Model, ModelError, ModelRequest, ModelResponse};
+use crate::model::{
+    CompletionMetadata, Model, ModelError, ModelMessage, ModelRequest, ModelResponse,
+};
 use crate::policy::Policy;
 use crate::read::{ReadError, ReadTool};
 use crate::schema_contract::OutputSchema;
@@ -18,7 +23,283 @@ use crate::tool::{
 };
 use crate::write::{WriteError, WriteTool};
 
+const DEFAULT_MAX_HISTORY_BYTES: usize = 256 * 1024;
 const DEFAULT_MAX_TOOL_CALLS: usize = 8;
+
+/// Successful model turn paired with observable execution activity.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TurnOutcome {
+    output: Value,
+    report: TurnReport,
+}
+
+impl TurnOutcome {
+    /// Returns the locally validated structured model output.
+    pub fn output(&self) -> &Value {
+        &self.output
+    }
+
+    /// Returns sanitized timing, model, and tool activity for the turn.
+    pub fn report(&self) -> &TurnReport {
+        &self.report
+    }
+
+    /// Consumes the outcome and returns its validated output.
+    pub fn into_output(self) -> Value {
+        self.output
+    }
+}
+
+/// Observable, content-free activity from one successful model turn.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TurnReport {
+    duration: Duration,
+    model_requests: Vec<ModelRequestActivity>,
+    tool_calls: Vec<ToolActivity>,
+}
+
+impl TurnReport {
+    /// Returns the complete elapsed turn time.
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+
+    /// Returns one entry for every provider request made during the turn.
+    pub fn model_requests(&self) -> &[ModelRequestActivity] {
+        &self.model_requests
+    }
+
+    /// Returns successful repository tool activity without file contents.
+    pub fn tool_calls(&self) -> &[ToolActivity] {
+        &self.tool_calls
+    }
+}
+
+/// Observable facts about one successful provider request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ModelRequestActivity {
+    completion: Option<CompletionMetadata>,
+    duration: Duration,
+    response_type: crate::lifecycle::ModelResponseType,
+}
+
+impl ModelRequestActivity {
+    /// Returns sanitized provider completion metadata, when available.
+    pub fn completion(&self) -> Option<&CompletionMetadata> {
+        self.completion.as_ref()
+    }
+
+    /// Returns the elapsed provider-request time.
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+
+    /// Returns whether the request produced output or a tool call.
+    pub fn response_type(&self) -> crate::lifecycle::ModelResponseType {
+        self.response_type
+    }
+}
+
+/// Sanitized details about one successful built-in tool operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ToolActivity {
+    /// A bounded repository file read.
+    Read {
+        /// Elapsed tool-execution time.
+        duration: Duration,
+        /// Final included one-based line, when the file was nonempty.
+        end_line: Option<u64>,
+        /// Repository-relative path that was read.
+        path: String,
+        /// Requested one-based starting line.
+        start_line: u64,
+        /// Whether additional file content followed the result.
+        truncated: bool,
+    },
+    /// A model-correctable repository read rejection returned to the model.
+    ReadRejected {
+        /// Elapsed tool-execution time.
+        duration: Duration,
+        /// Repository-relative path that was rejected.
+        path: String,
+    },
+    /// A repository file write.
+    Write {
+        /// Number of bytes in the resulting file.
+        bytes_written: usize,
+        /// Elapsed tool-execution time.
+        duration: Duration,
+        /// Repository-relative path that was written.
+        path: String,
+    },
+    /// A model-correctable repository write rejection returned to the model.
+    WriteRejected {
+        /// Elapsed tool-execution time.
+        duration: Duration,
+        /// Repository-relative path that was rejected.
+        path: String,
+    },
+}
+
+impl ToolActivity {
+    /// Returns the elapsed tool-execution time.
+    pub fn duration(&self) -> Duration {
+        match self {
+            Self::Read { duration, .. }
+            | Self::ReadRejected { duration, .. }
+            | Self::Write { duration, .. }
+            | Self::WriteRejected { duration, .. } => *duration,
+        }
+    }
+
+    /// Returns the bounded built-in tool name.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Read { .. } | Self::ReadRejected { .. } => "read",
+            Self::Write { .. } | Self::WriteRejected { .. } => "write",
+        }
+    }
+
+    /// Returns the repository-relative target path.
+    pub fn path(&self) -> &str {
+        match self {
+            Self::Read { path, .. }
+            | Self::ReadRejected { path, .. }
+            | Self::Write { path, .. }
+            | Self::WriteRejected { path, .. } => path,
+        }
+    }
+}
+
+impl fmt::Display for ToolActivity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Read {
+                duration,
+                end_line,
+                path,
+                start_line,
+                truncated,
+            } => {
+                let path = sanitize_report_text(path);
+                let lines = end_line.map_or_else(
+                    || format!("line {start_line}"),
+                    |end_line| format!("lines {start_line}-{end_line}"),
+                );
+                let continuation = if *truncated { ", truncated" } else { "" };
+
+                write!(
+                    formatter,
+                    "read {path} ({lines}{continuation}; {})",
+                    format_report_duration(*duration)
+                )
+            }
+            Self::ReadRejected { duration, path } => write!(
+                formatter,
+                "read {} (rejected; {})",
+                sanitize_report_text(path),
+                format_report_duration(*duration)
+            ),
+            Self::Write {
+                bytes_written,
+                duration,
+                path,
+            } => write!(
+                formatter,
+                "write {} ({bytes_written} bytes; {})",
+                sanitize_report_text(path),
+                format_report_duration(*duration)
+            ),
+            Self::WriteRejected { duration, path } => write!(
+                formatter,
+                "write {} (rejected; {})",
+                sanitize_report_text(path),
+                format_report_duration(*duration)
+            ),
+        }
+    }
+}
+
+/// In-memory sequence of model turns sharing conversation and tool history.
+pub struct ChatSession<'a> {
+    harness: &'a Harness,
+    history: ChatHistory,
+    schema: OutputSchema,
+    system_prompt: Option<String>,
+}
+
+impl ChatSession<'_> {
+    /// Adds a system prompt to every model request in this chat.
+    #[must_use]
+    pub fn with_system_prompt(mut self, system_prompt: impl Into<String>) -> Self {
+        self.system_prompt = Some(system_prompt.into());
+
+        self
+    }
+
+    /// Sends one prompt and retains the successful turn in session history.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TurnError`] under the same conditions as [`Harness::run`]. A
+    /// failed turn is not added to the conversation history.
+    pub async fn send(&mut self, prompt: impl Into<String>) -> Result<TurnOutcome, TurnError> {
+        let mut messages = self.history.messages();
+        if let Some(system_prompt) = &self.system_prompt {
+            messages.insert(0, ModelMessage::System(system_prompt.clone()));
+        }
+        let retained_messages = messages.len();
+        let request = ModelRequest::with_history(messages, prompt.into(), self.schema.clone());
+        let (outcome, mut messages) = self.harness.run_request(request).await?;
+        let turn = messages.split_off(retained_messages);
+        self.history.push(turn);
+
+        Ok(outcome)
+    }
+}
+
+struct ChatHistory {
+    bytes: usize,
+    max_bytes: usize,
+    turns: VecDeque<Vec<ModelMessage>>,
+}
+
+impl ChatHistory {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            bytes: 0,
+            max_bytes,
+            turns: VecDeque::new(),
+        }
+    }
+
+    fn messages(&self) -> Vec<ModelMessage> {
+        self.turns
+            .iter()
+            .flat_map(|turn| turn.iter().cloned())
+            .collect()
+    }
+
+    fn push(&mut self, turn: Vec<ModelMessage>) {
+        self.bytes = self.bytes.saturating_add(retained_bytes(&turn));
+        self.turns.push_back(turn);
+
+        while self.bytes > self.max_bytes && !self.turns.is_empty() {
+            let evicted_bytes = self
+                .turns
+                .pop_front()
+                .map_or(self.bytes, |evicted| retained_bytes(&evicted));
+            self.bytes = self.bytes.saturating_sub(evicted_bytes);
+        }
+    }
+}
+
+fn retained_bytes(messages: &[ModelMessage]) -> usize {
+    messages.iter().fold(0, |bytes, message| {
+        bytes.saturating_add(message.retained_bytes())
+    })
+}
 
 /// Application-facing harness for one complete model turn.
 ///
@@ -28,6 +309,7 @@ const DEFAULT_MAX_TOOL_CALLS: usize = 8;
 pub struct Harness {
     file_system: Arc<dyn FileSystem>,
     lifecycle: LifecycleEmitter,
+    max_history_bytes: usize,
     max_tool_calls: usize,
     model: Arc<dyn Model>,
     policy: Policy,
@@ -40,6 +322,7 @@ impl Harness {
         Self {
             file_system: Arc::new(LocalFileSystem),
             lifecycle: LifecycleEmitter::default(),
+            max_history_bytes: DEFAULT_MAX_HISTORY_BYTES,
             max_tool_calls: DEFAULT_MAX_TOOL_CALLS,
             model: Arc::new(model),
             policy: Policy::default(),
@@ -89,6 +372,17 @@ impl Harness {
         self
     }
 
+    /// Overrides the retained chat-history payload budget.
+    ///
+    /// Complete oldest turns are evicted when the budget is exceeded, so
+    /// native tool-call and tool-result messages are never split.
+    #[must_use]
+    pub fn max_history_bytes(mut self, max_history_bytes: NonZeroUsize) -> Self {
+        self.max_history_bytes = max_history_bytes.get();
+
+        self
+    }
+
     /// Runs one prompt through tool execution to terminal structured output.
     ///
     /// # Errors
@@ -100,9 +394,42 @@ impl Harness {
         prompt: impl Into<String>,
         schema: OutputSchema,
     ) -> Result<Value, TurnError> {
+        self.run_report(prompt, schema)
+            .await
+            .map(TurnOutcome::into_output)
+    }
+
+    /// Runs one prompt and returns validated output with sanitized activity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TurnError`] under the same conditions as [`Harness::run`].
+    pub async fn run_report(
+        &self,
+        prompt: impl Into<String>,
+        schema: OutputSchema,
+    ) -> Result<TurnOutcome, TurnError> {
+        let request = ModelRequest::new(prompt, schema);
+        self.run_request(request).await.map(|(outcome, _)| outcome)
+    }
+
+    /// Starts an in-memory chat whose responses must match `schema`.
+    pub fn chat(&self, schema: OutputSchema) -> ChatSession<'_> {
+        ChatSession {
+            harness: self,
+            history: ChatHistory::new(self.max_history_bytes),
+            schema,
+            system_prompt: None,
+        }
+    }
+
+    async fn run_request(
+        &self,
+        request: ModelRequest,
+    ) -> Result<(TurnOutcome, Vec<ModelMessage>), TurnError> {
         let turn = self.lifecycle.start_turn();
         let turn_id = turn.as_ref().map(TurnLifecycle::id);
-        let result = self.run_turn(prompt.into(), schema, turn_id).await;
+        let result = self.run_turn(request, turn_id).await;
 
         if let Some(turn) = turn {
             match &result {
@@ -116,24 +443,36 @@ impl Harness {
 
     async fn run_turn(
         &self,
-        prompt: String,
-        schema: OutputSchema,
+        request: ModelRequest,
         turn_id: Option<LifecycleId>,
-    ) -> Result<Value, TurnError> {
-        let (mut request, read_tool, write_tool) = self.prepare_request(prompt, schema)?;
+    ) -> Result<(TurnOutcome, Vec<ModelMessage>), TurnError> {
+        let started_at = Instant::now();
+        let (mut request, read_tool, write_tool) = self.prepare_request(request)?;
         let mut completed_tool_calls = 0_usize;
         let mut model_request_index = 0_u64;
+        let mut model_requests = Vec::new();
+        let mut tool_calls = Vec::new();
 
         loop {
-            let response = self
+            let (response, activity) = self
                 .complete_model_request(&request, model_request_index, turn_id)
                 .await?;
+            model_requests.push(activity);
             model_request_index += 1;
 
             match response {
-                ModelResponse::Output(output) => return Ok(output),
+                ModelResponse::Output(output) => {
+                    request.record_output(&output);
+                    let report = TurnReport {
+                        duration: started_at.elapsed(),
+                        model_requests,
+                        tool_calls,
+                    };
+
+                    return Ok((TurnOutcome { output, report }, request.into_messages()));
+                }
                 ModelResponse::ToolCall(call) => {
-                    let result = self
+                    let (result, activity) = self
                         .execute_tool_call(
                             &call,
                             read_tool.as_ref(),
@@ -143,6 +482,7 @@ impl Harness {
                         )
                         .await?;
                     request.record_tool_result(call, result);
+                    tool_calls.push(activity);
                     completed_tool_calls += 1;
                 }
             }
@@ -151,10 +491,8 @@ impl Harness {
 
     fn prepare_request(
         &self,
-        prompt: String,
-        schema: OutputSchema,
+        mut request: ModelRequest,
     ) -> Result<(ModelRequest, Option<ReadTool>, Option<WriteTool>), TurnError> {
-        let mut request = ModelRequest::new(prompt, schema);
         if self.lifecycle.is_enabled() {
             request.mark_lifecycle_observed();
         }
@@ -184,7 +522,8 @@ impl Harness {
         request: &ModelRequest,
         model_request_index: u64,
         turn_id: Option<LifecycleId>,
-    ) -> Result<ModelResponse, TurnError> {
+    ) -> Result<(ModelResponse, ModelRequestActivity), TurnError> {
+        let started_at = Instant::now();
         let model_lifecycle =
             self.lifecycle
                 .start_model_request(self.model.metadata(), model_request_index, turn_id);
@@ -203,11 +542,17 @@ impl Harness {
                 return Err(error.into());
             }
         };
+        let response_type = response.response_type();
+        let activity = ModelRequestActivity {
+            completion: completion.as_ref().map(sanitized_completion_metadata),
+            duration: started_at.elapsed(),
+            response_type,
+        };
         if let Some(model_lifecycle) = model_lifecycle {
-            model_lifecycle.completed(completion, response.response_type());
+            model_lifecycle.completed(completion, response_type);
         }
 
-        Ok(response)
+        Ok((response, activity))
     }
 
     async fn execute_tool_call(
@@ -217,7 +562,7 @@ impl Harness {
         write_tool: Option<&WriteTool>,
         completed_tool_calls: usize,
         turn_id: Option<LifecycleId>,
-    ) -> Result<String, TurnError> {
+    ) -> Result<(String, ToolActivity), TurnError> {
         let mut tool_lifecycle =
             self.lifecycle
                 .request_tool(call.id().to_string(), call.name().to_string(), turn_id);
@@ -258,7 +603,14 @@ impl Harness {
         match result {
             Ok(result) => {
                 if let Some(tool_lifecycle) = tool_lifecycle {
-                    tool_lifecycle.completed();
+                    if matches!(
+                        &result.1,
+                        ToolActivity::ReadRejected { .. } | ToolActivity::WriteRejected { .. }
+                    ) {
+                        tool_lifecycle.failed(ToolErrorType::Execution);
+                    } else {
+                        tool_lifecycle.completed();
+                    }
                 }
 
                 Ok(result)
@@ -321,26 +673,101 @@ enum ToolExecution<'a> {
     Write(&'a WriteTool, &'a WriteArguments),
 }
 
-async fn execute_tool(execution: ToolExecution<'_>) -> Result<String, TurnError> {
+async fn execute_tool(execution: ToolExecution<'_>) -> Result<(String, ToolActivity), TurnError> {
+    let started_at = Instant::now();
+
     match execution {
-        ToolExecution::Read(read_tool, arguments) => read_tool
-            .execute(arguments)
-            .await?
-            .to_tool_result()
-            .map_err(ReadError::from)
-            .map_err(TurnError::from),
+        ToolExecution::Read(read_tool, arguments) => match read_tool.execute(arguments).await {
+            Ok(output) => {
+                let activity = ToolActivity::Read {
+                    duration: started_at.elapsed(),
+                    end_line: output.end_line(),
+                    path: sanitize_report_text(output.path()),
+                    start_line: output.start_line(),
+                    truncated: output.truncated(),
+                };
+                let result = output
+                    .to_tool_result()
+                    .map_err(ReadError::from)
+                    .map_err(TurnError::from)?;
+
+                Ok((result, activity))
+            }
+            Err(error) if error.is_model_correctable() => error
+                .to_tool_result(arguments.path())
+                .map_err(ReadError::from)
+                .map_err(TurnError::from)
+                .map(|result| {
+                    (
+                        result,
+                        ToolActivity::ReadRejected {
+                            duration: started_at.elapsed(),
+                            path: sanitize_report_text(arguments.path()),
+                        },
+                    )
+                }),
+            Err(error) => Err(error.into()),
+        },
         ToolExecution::Write(write_tool, arguments) => match write_tool.execute(arguments).await {
-            Ok(output) => output
-                .to_tool_result()
-                .map_err(WriteError::from)
-                .map_err(TurnError::from),
+            Ok(output) => {
+                let activity = ToolActivity::Write {
+                    bytes_written: output.bytes_written(),
+                    duration: started_at.elapsed(),
+                    path: sanitize_report_text(output.path()),
+                };
+                let result = output
+                    .to_tool_result()
+                    .map_err(WriteError::from)
+                    .map_err(TurnError::from)?;
+
+                Ok((result, activity))
+            }
             Err(error) if error.is_model_correctable() => error
                 .to_tool_result(arguments.path())
                 .map_err(WriteError::from)
-                .map_err(TurnError::from),
+                .map_err(TurnError::from)
+                .map(|result| {
+                    (
+                        result,
+                        ToolActivity::WriteRejected {
+                            duration: started_at.elapsed(),
+                            path: sanitize_report_text(arguments.path()),
+                        },
+                    )
+                }),
             Err(error) => Err(error.into()),
         },
     }
+}
+
+fn format_report_duration(duration: Duration) -> String {
+    if duration.as_millis() == 0 {
+        "<1 ms".to_string()
+    } else {
+        format!("{} ms", duration.as_millis())
+    }
+}
+
+fn sanitized_completion_metadata(metadata: &CompletionMetadata) -> CompletionMetadata {
+    CompletionMetadata::new(
+        sanitize_report_text(metadata.finish_reason()),
+        metadata.response_id().map(sanitize_report_text),
+        metadata.response_model().map(sanitize_report_text),
+        metadata.system_fingerprint().map(sanitize_report_text),
+        metadata.usage().copied(),
+    )
+}
+
+fn sanitize_report_text(text: &str) -> String {
+    text.chars()
+        .map(|character| {
+            if character.is_control() {
+                '\u{fffd}'
+            } else {
+                character
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -374,8 +801,12 @@ mod tests {
     }
 
     fn read_call(id: &str) -> ToolCall {
+        read_call_with_path(id, "Cargo.toml")
+    }
+
+    fn read_call_with_path(id: &str, path: &str) -> ToolCall {
         let arguments = serde_json::from_value::<ReadArguments>(json!({
-            "path": "Cargo.toml",
+            "path": path,
             "limit": 1
         }))
         .expect("read arguments should be valid");
@@ -387,6 +818,28 @@ mod tests {
         response: ModelResponse,
     ) -> (ModelResponse, Option<crate::CompletionMetadata>) {
         (response, None)
+    }
+
+    fn response_with_metadata(
+        response: ModelResponse,
+    ) -> (ModelResponse, Option<crate::CompletionMetadata>) {
+        (
+            response,
+            Some(crate::CompletionMetadata::new(
+                "stop\nforged".to_string(),
+                Some("response\u{1b}-1".to_string()),
+                Some("reported\nmodel".to_string()),
+                Some("finger\tprint".to_string()),
+                Some(crate::CompletionUsage::new(
+                    None,
+                    None,
+                    Some(12),
+                    Some(4),
+                    None,
+                    Some(16),
+                )),
+            )),
+        )
     }
 
     fn write_call(id: &str, patch: &str) -> ToolCall {
@@ -583,6 +1036,473 @@ mod tests {
 
         // Assert
         assert_eq!(output, json!({ "summary": "workspace" }));
+    }
+
+    #[tokio::test]
+    async fn returns_correctable_read_rejection_to_model() {
+        // Arrange
+        let mut model = model();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        model
+            .expect_complete_with_optional_metadata()
+            .times(2)
+            .returning(move |request| {
+                if call_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                    return Ok(response_without_metadata(ModelResponse::ToolCall(
+                        read_call("call_read"),
+                    )));
+                }
+                assert!(matches!(
+                    &request.messages()[2],
+                    ModelMessage::ToolResult { content, .. }
+                        if serde_json::from_str::<Value>(content).is_ok_and(|value| {
+                            value["path"] == "Cargo.toml" && value["status"] == "rejected"
+                        })
+                ));
+
+                Ok(response_without_metadata(ModelResponse::Output(json!({
+                    "summary": "recovered"
+                }))))
+            });
+        let mut file_system = MockFileSystem::new();
+        let mut sequence = Sequence::new();
+        file_system
+            .expect_canonicalize()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(|_| Ok(PathBuf::from("/repo")));
+        file_system
+            .expect_canonicalize()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(|_| Err(io::Error::new(io::ErrorKind::NotFound, "missing")));
+        file_system.expect_open_beneath().times(0);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let observed_events = Arc::clone(&events);
+        let harness = Harness::new(model)
+            .file_system(file_system)
+            .repository("repo")
+            .allow(Tool::Read)
+            .with_lifecycle_observer(move |event| {
+                observed_events
+                    .lock()
+                    .expect("event recorder should not be poisoned")
+                    .push(event);
+            });
+
+        // Act
+        let outcome = harness
+            .run_report("inspect", object_schema())
+            .await
+            .expect("model should recover from a rejected read path");
+
+        // Assert
+        assert_eq!(outcome.output(), &json!({ "summary": "recovered" }));
+        assert!(matches!(
+            outcome.report().tool_calls(),
+            [ToolActivity::ReadRejected { path, .. }] if path == "Cargo.toml"
+        ));
+        let events = events
+            .lock()
+            .expect("event recorder should not be poisoned");
+        assert!(matches!(
+            events[5].kind(),
+            crate::LifecycleEventKind::ToolFailed {
+                error_type: ToolErrorType::Execution,
+                ..
+            }
+        ));
+        assert!(matches!(
+            events[8].kind(),
+            crate::LifecycleEventKind::TurnCompleted { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn chat_retains_successful_conversation_history() {
+        // Arrange
+        let mut model = model();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        model
+            .expect_complete_with_optional_metadata()
+            .times(2)
+            .returning(move |request| {
+                let call_index = call_count.fetch_add(1, Ordering::SeqCst);
+                if call_index == 0 {
+                    assert_eq!(
+                        request.messages(),
+                        &[ModelMessage::User("first question".to_string())]
+                    );
+
+                    return Ok(response_without_metadata(ModelResponse::Output(json!({
+                        "summary": "first answer"
+                    }))));
+                }
+                assert_eq!(
+                    request.messages(),
+                    &[
+                        ModelMessage::User("first question".to_string()),
+                        ModelMessage::Assistant(r#"{"summary":"first answer"}"#.to_string()),
+                        ModelMessage::User("second question".to_string()),
+                    ]
+                );
+
+                Ok(response_without_metadata(ModelResponse::Output(json!({
+                    "summary": "second answer"
+                }))))
+            });
+        let harness = Harness::new(model);
+        let mut chat = harness.chat(object_schema());
+
+        // Act
+        let first = chat
+            .send("first question")
+            .await
+            .expect("first chat turn should succeed");
+        let second = chat
+            .send("second question")
+            .await
+            .expect("second chat turn should succeed");
+
+        // Assert
+        assert_eq!(first.output(), &json!({"summary": "first answer"}));
+        assert_eq!(second.output(), &json!({"summary": "second answer"}));
+        assert_eq!(second.report().model_requests().len(), 1);
+        assert!(second.report().duration() >= second.report().model_requests()[0].duration());
+    }
+
+    #[tokio::test]
+    async fn chat_sends_the_system_prompt_on_every_turn() {
+        // Arrange
+        let mut model = model();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        model
+            .expect_complete_with_optional_metadata()
+            .times(2)
+            .returning(move |request| {
+                let expected = if call_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                    vec![
+                        ModelMessage::System("read-only instructions".to_string()),
+                        ModelMessage::User("first".to_string()),
+                    ]
+                } else {
+                    vec![
+                        ModelMessage::System("read-only instructions".to_string()),
+                        ModelMessage::User("first".to_string()),
+                        ModelMessage::Assistant(r#"{"summary":"one"}"#.to_string()),
+                        ModelMessage::User("second".to_string()),
+                    ]
+                };
+                assert_eq!(request.messages(), expected);
+
+                Ok(response_without_metadata(ModelResponse::Output(json!({
+                    "summary": if expected.len() == 2 { "one" } else { "two" }
+                }))))
+            });
+        let harness = Harness::new(model);
+        let mut chat = harness
+            .chat(object_schema())
+            .with_system_prompt("read-only instructions");
+
+        // Act
+        chat.send("first")
+            .await
+            .expect("first chat turn should succeed");
+        let second = chat
+            .send("second")
+            .await
+            .expect("second chat turn should succeed");
+
+        // Assert
+        assert_eq!(second.output(), &json!({"summary": "two"}));
+    }
+
+    #[test]
+    fn tool_activity_display_formats_every_outcome_safely() {
+        // Arrange
+        let empty_read = ToolActivity::Read {
+            duration: Duration::ZERO,
+            end_line: None,
+            path: "empty\n\u{1b}]52;c;Y2xpcGJvYXJk\u{7}.txt".to_string(),
+            start_line: 3,
+            truncated: false,
+        };
+        let read = ToolActivity::Read {
+            duration: Duration::from_millis(3),
+            end_line: Some(7),
+            path: "input.txt".to_string(),
+            start_line: 2,
+            truncated: true,
+        };
+        let rejected_read = ToolActivity::ReadRejected {
+            duration: Duration::from_millis(1),
+            path: "missing.txt".to_string(),
+        };
+        let write = ToolActivity::Write {
+            bytes_written: 12,
+            duration: Duration::from_millis(2),
+            path: "output.txt".to_string(),
+        };
+        let rejected = ToolActivity::WriteRejected {
+            duration: Duration::from_millis(1),
+            path: "blocked.txt".to_string(),
+        };
+
+        // Act
+        let displays = [
+            empty_read.to_string(),
+            read.to_string(),
+            rejected_read.to_string(),
+            write.to_string(),
+            rejected.to_string(),
+        ];
+
+        // Assert
+        assert_eq!(
+            displays,
+            [
+                "read empty\u{fffd}\u{fffd}]52;c;Y2xpcGJvYXJk\u{fffd}.txt (line 3; <1 ms)",
+                "read input.txt (lines 2-7, truncated; 3 ms)",
+                "read missing.txt (rejected; 1 ms)",
+                "write output.txt (12 bytes; 2 ms)",
+                "write blocked.txt (rejected; 1 ms)",
+            ]
+        );
+        assert_eq!(rejected_read.duration(), Duration::from_millis(1));
+        assert_eq!(rejected_read.name(), "read");
+        assert_eq!(rejected_read.path(), "missing.txt");
+    }
+
+    #[test]
+    fn chat_history_evicts_complete_tool_turns() {
+        // Arrange
+        let tool_turn = vec![
+            ModelMessage::User("inspect".to_string()),
+            ModelMessage::AssistantToolCall(read_call("call_read")),
+            ModelMessage::ToolResult {
+                call_id: "call_read".to_string(),
+                content: "file contents".to_string(),
+                name: "read".to_string(),
+            },
+            ModelMessage::Assistant(r#"{"summary":"old"}"#.to_string()),
+        ];
+        let latest_turn = vec![
+            ModelMessage::User("latest".to_string()),
+            ModelMessage::Assistant(r#"{"summary":"new"}"#.to_string()),
+        ];
+        let max_bytes = retained_bytes(&tool_turn).max(retained_bytes(&latest_turn));
+        let mut history = ChatHistory::new(max_bytes);
+
+        // Act
+        history.push(tool_turn);
+        history.push(latest_turn.clone());
+
+        // Assert
+        assert_eq!(history.messages(), latest_turn);
+        assert!(history.bytes <= max_bytes);
+    }
+
+    #[tokio::test]
+    async fn chat_applies_the_configured_history_budget() {
+        // Arrange
+        let mut model = model();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        model
+            .expect_complete_with_optional_metadata()
+            .times(3)
+            .returning(
+                move |request| match call_count.fetch_add(1, Ordering::SeqCst) {
+                    0 => {
+                        assert_eq!(
+                            request.messages(),
+                            &[ModelMessage::User("first".to_string())]
+                        );
+
+                        Ok(response_without_metadata(ModelResponse::Output(json!({
+                            "summary": "xxxxxxxxxxxxxxxxxxxx"
+                        }))))
+                    }
+                    1 => {
+                        assert_eq!(request.messages().len(), 3);
+
+                        Ok(response_without_metadata(ModelResponse::Output(json!({
+                            "summary": "two"
+                        }))))
+                    }
+                    _ => {
+                        assert_eq!(
+                            request.messages(),
+                            &[
+                                ModelMessage::User("second".to_string()),
+                                ModelMessage::Assistant(r#"{"summary":"two"}"#.to_string()),
+                                ModelMessage::User("third".to_string()),
+                            ]
+                        );
+
+                        Ok(response_without_metadata(ModelResponse::Output(json!({
+                            "summary": "three"
+                        }))))
+                    }
+                },
+            );
+        let harness = Harness::new(model)
+            .max_history_bytes(NonZeroUsize::new(50).expect("history budget should be nonzero"));
+        let mut chat = harness.chat(object_schema());
+
+        // Act
+        chat.send("first")
+            .await
+            .expect("first chat turn should succeed");
+        chat.send("second")
+            .await
+            .expect("second chat turn should succeed");
+        let third = chat
+            .send("third")
+            .await
+            .expect("third chat turn should succeed");
+
+        // Assert
+        assert_eq!(third.output(), &json!({"summary": "three"}));
+    }
+
+    #[tokio::test]
+    async fn chat_does_not_retain_a_failed_turn() {
+        // Arrange
+        let mut model = model();
+        let mut sequence = Sequence::new();
+        model
+            .expect_complete_with_optional_metadata()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(|_| Err(ModelError::InvalidResponse));
+        model
+            .expect_complete_with_optional_metadata()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(|request| {
+                assert_eq!(
+                    request.messages(),
+                    &[ModelMessage::User("retry".to_string())]
+                );
+
+                Ok(response_without_metadata(ModelResponse::Output(json!({
+                    "summary": "recovered"
+                }))))
+            });
+        let harness = Harness::new(model);
+        let mut chat = harness.chat(object_schema());
+
+        // Act
+        let error = chat
+            .send("failed question")
+            .await
+            .expect_err("the first turn should fail");
+        let recovered = chat
+            .send("retry")
+            .await
+            .expect("the next turn should start from clean history");
+
+        // Assert
+        assert!(matches!(
+            error,
+            TurnError::Model(ModelError::InvalidResponse)
+        ));
+        assert_eq!(recovered.output(), &json!({"summary": "recovered"}));
+    }
+
+    #[tokio::test]
+    async fn report_describes_model_requests_and_repository_reads() {
+        // Arrange
+        let mut model = model();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        model
+            .expect_complete_with_optional_metadata()
+            .times(2)
+            .returning(move |_| {
+                if call_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                    return Ok(response_without_metadata(ModelResponse::ToolCall(
+                        read_call_with_path("call_read", "Cargo\n.toml\u{1b}"),
+                    )));
+                }
+
+                Ok(response_with_metadata(ModelResponse::Output(json!({
+                    "summary": "workspace"
+                }))))
+            });
+        let harness = Harness::new(model)
+            .file_system(readable_file_system())
+            .repository("repo")
+            .allow(Tool::Read);
+
+        // Act
+        let outcome = harness
+            .run_report("inspect", object_schema())
+            .await
+            .expect("reported turn should succeed");
+
+        // Assert
+        assert_eq!(outcome.output(), &json!({"summary": "workspace"}));
+        assert_eq!(outcome.report().model_requests().len(), 2);
+        let final_request = &outcome.report().model_requests()[1];
+        assert_eq!(
+            final_request.response_type(),
+            crate::ModelResponseType::Output
+        );
+        let metadata = final_request
+            .completion()
+            .expect("metadata should be present");
+        assert_eq!(metadata.finish_reason(), "stop\u{fffd}forged");
+        assert_eq!(metadata.response_id(), Some("response\u{fffd}-1"));
+        assert_eq!(metadata.response_model(), Some("reported\u{fffd}model"));
+        assert_eq!(metadata.system_fingerprint(), Some("finger\u{fffd}print"));
+        assert_eq!(
+            metadata.usage().and_then(|usage| usage.total_tokens()),
+            Some(16)
+        );
+        assert_eq!(outcome.report().tool_calls().len(), 1);
+        let activity = &outcome.report().tool_calls()[0];
+        assert_eq!(activity.name(), "read");
+        assert_eq!(activity.path(), "Cargo\u{fffd}.toml\u{fffd}");
+        assert!(activity.duration() <= outcome.report().duration());
+        assert!(matches!(
+            activity,
+            ToolActivity::Read {
+                end_line: Some(1),
+                start_line: 1,
+                truncated: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn write_activity_exposes_only_sanitized_summary() {
+        // Arrange
+        let activity = ToolActivity::Write {
+            bytes_written: 42,
+            duration: Duration::from_millis(3),
+            path: "src/lib.rs".to_string(),
+        };
+
+        // Act and Assert
+        assert_eq!(activity.name(), "write");
+        assert_eq!(activity.path(), "src/lib.rs");
+        assert_eq!(activity.duration(), Duration::from_millis(3));
+        assert!(matches!(
+            activity,
+            ToolActivity::Write {
+                bytes_written: 42,
+                ..
+            }
+        ));
+
+        let rejected = ToolActivity::WriteRejected {
+            duration: Duration::from_millis(2),
+            path: "src/rejected.rs".to_string(),
+        };
+        assert_eq!(rejected.name(), "write");
+        assert_eq!(rejected.path(), "src/rejected.rs");
+        assert_eq!(rejected.duration(), Duration::from_millis(2));
     }
 
     #[tokio::test]

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -20,7 +20,9 @@ mod trace;
 mod write;
 
 pub use file_system::{FileSystem, LocalFileSystem};
-pub use harness::{Harness, TurnError};
+pub use harness::{
+    ChatSession, Harness, ModelRequestActivity, ToolActivity, TurnError, TurnOutcome, TurnReport,
+};
 pub use lifecycle::{
     LifecycleEvent, LifecycleEventKind, LifecycleId, LifecycleObserver, LifecycleObserverSet,
     LifecycleOperationGuard, ModelResponseType, ToolErrorType, TurnErrorType,

--- a/crates/ag-harness/src/lifecycle.rs
+++ b/crates/ag-harness/src/lifecycle.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::fmt;
 use std::future::Future;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::pin::Pin;
@@ -168,6 +169,15 @@ pub enum ModelResponseType {
     Output,
     /// An intermediate native tool request.
     ToolCall,
+}
+
+impl fmt::Display for ModelResponseType {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Output => formatter.write_str("output"),
+            Self::ToolCall => formatter.write_str("tool call"),
+        }
+    }
 }
 
 /// Stable, low-cardinality reason that a harness turn failed.
@@ -807,6 +817,18 @@ mod tests {
                 )
                 .expect("tool should be observed"),
         );
+    }
+
+    #[test]
+    fn model_response_types_have_stable_display_names() {
+        // Arrange
+        let response_types = [ModelResponseType::Output, ModelResponseType::ToolCall];
+
+        // Act
+        let display_names = response_types.map(|response_type| response_type.to_string());
+
+        // Assert
+        assert_eq!(display_names, ["output", "tool call"]);
     }
 
     fn recording_emitter() -> (LifecycleEmitter, Arc<Mutex<Vec<LifecycleEvent>>>) {

--- a/crates/ag-harness/src/main.rs
+++ b/crates/ag-harness/src/main.rs
@@ -1,0 +1,1383 @@
+//! Interactive command-line chat for the `ag-harness` model runtime.
+
+use std::borrow::Cow;
+#[cfg(not(test))]
+use std::io::IsTerminal as _;
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::{env, io};
+
+use ag_harness::{
+    ChatSession, Harness, KimiConfig, ModelClient, MuseConfig, OutputSchema, QwenConfig, Tool,
+    TurnOutcome,
+};
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use serde_json::{Map, Value};
+use thiserror::Error;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt as _, AsyncWrite, AsyncWriteExt as _, BufReader};
+
+const READ_ONLY_SYSTEM_PROMPT: &str = concat!(
+    "You are operating in a read-only repository harness. When a user asks about repository ",
+    "contents, call the read tool immediately in the same response and use its result before ",
+    "answering. Never narrate, promise, or defer a future tool call. Never claim that you \
+     created, ",
+    "modified, deleted, or executed files or commands because filesystem mutation and command ",
+    "execution are unavailable. If asked to perform an unsupported action, state that it is ",
+    "unsupported."
+);
+const READ_WRITE_SYSTEM_PROMPT: &str = concat!(
+    "You are operating in a repository harness with read and write tools. When a user asks about ",
+    "repository contents, call the read tool immediately in the same response and use its result ",
+    "before answering. When a user asks to create or modify a file, call the write tool ",
+    "immediately in the same response. Never narrate, promise, or defer a future tool call. Only ",
+    "claim that a file was created or modified after the write tool succeeds. File deletion and ",
+    "command execution are unavailable. To create an empty file, pass a write patch containing ",
+    "only `--- /dev/null` and `+++ b/<path>` headers with no hunk."
+);
+const KIMI_API_KEY_ENV: &str = "KIMI_API_KEY";
+const KIMI_BASE_URL_ENV: &str = "KIMI_BASE_URL";
+const MUSE_DEFAULT_BASE_URL: &str = "https://api.meta.ai/v1";
+const MUSE_API_KEY_ENV: &str = "MODEL_API_KEY";
+const MUSE_BASE_URL_ENV: &str = "MODEL_API_BASE_URL";
+const QWEN_API_KEY_ENV: &str = "DASHSCOPE_API_KEY";
+const QWEN_BASE_URL_ENV: &str = "DASHSCOPE_BASE_URL";
+const PROVIDER_HELP: &str = "\
+Supported models (other endpoint-supported model IDs also work):
+  muse: muse-spark-1.2, muse-spark-1.2-contributor
+  kimi: kimi-k2.6
+  qwen: qwen-plus
+
+Credentials:
+  muse: MODEL_API_KEY (MODEL_API_BASE_URL optional)
+  kimi: KIMI_API_KEY, KIMI_BASE_URL
+  qwen: DASHSCOPE_API_KEY, DASHSCOPE_BASE_URL";
+
+/// Chats with models through a bounded repository harness.
+#[derive(Debug, Parser)]
+#[command(
+    name = "ag-harness",
+    version,
+    about = "Chats with models through a repository harness",
+    after_help = PROVIDER_HELP
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+/// Supported harness commands.
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Starts an in-memory chat with a model.
+    Run(RunArgs),
+}
+
+/// Arguments for an in-memory model chat.
+#[derive(Debug, Args)]
+#[command(after_help = PROVIDER_HELP)]
+struct RunArgs {
+    /// Model identifier sent to the provider.
+    model: String,
+    /// Optional first prompt. Further prompts are read from standard input.
+    #[arg(value_parser = parse_prompt)]
+    prompt: Option<String>,
+    /// API base URL, overriding `MODEL_API_BASE_URL`, `KIMI_BASE_URL`, or
+    /// `DASHSCOPE_BASE_URL`.
+    #[arg(long, value_name = "URL")]
+    base_url: Option<String>,
+    /// Enables repository writes through the write tool.
+    #[arg(long)]
+    allow_write: bool,
+    /// Model provider.
+    #[arg(long, value_enum, default_value_t = Provider::Muse)]
+    provider: Provider,
+    /// Repository directory available to enabled tools.
+    #[arg(long, value_name = "DIR", default_value = ".")]
+    read_dir: PathBuf,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum Provider {
+    Muse,
+    Kimi,
+    Qwen,
+}
+
+impl Provider {
+    fn api_key_environment(self) -> &'static str {
+        match self {
+            Self::Muse => MUSE_API_KEY_ENV,
+            Self::Kimi => KIMI_API_KEY_ENV,
+            Self::Qwen => QWEN_API_KEY_ENV,
+        }
+    }
+
+    fn base_url_environment(self) -> &'static str {
+        match self {
+            Self::Muse => MUSE_BASE_URL_ENV,
+            Self::Kimi => KIMI_BASE_URL_ENV,
+            Self::Qwen => QWEN_BASE_URL_ENV,
+        }
+    }
+
+    fn default_base_url(self) -> Option<&'static str> {
+        match self {
+            Self::Muse => Some(MUSE_DEFAULT_BASE_URL),
+            Self::Kimi | Self::Qwen => None,
+        }
+    }
+
+    fn model_client(
+        self,
+        configuration: ModelConfiguration,
+    ) -> Result<ModelClient, ag_harness::ModelMetadataError> {
+        let ModelConfiguration {
+            api_key,
+            base_url,
+            model,
+        } = configuration;
+
+        match self {
+            Self::Muse => ModelClient::muse(MuseConfig {
+                api_key,
+                base_url,
+                model,
+            }),
+            Self::Kimi => ModelClient::kimi(KimiConfig {
+                api_key,
+                base_url,
+                model,
+            }),
+            Self::Qwen => ModelClient::qwen(QwenConfig {
+                api_key,
+                base_url,
+                model,
+            }),
+        }
+    }
+}
+
+struct ModelConfiguration {
+    api_key: String,
+    base_url: String,
+    model: String,
+}
+
+fn parse_prompt(prompt: &str) -> Result<String, String> {
+    if prompt.trim().is_empty() {
+        return Err("prompt must contain a non-whitespace character".to_string());
+    }
+
+    Ok(prompt.to_string())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ChatMode {
+    Interactive,
+    NonInteractive,
+    OneShot,
+}
+
+impl ChatMode {
+    fn detect(cli: &Cli, stdin_is_terminal: bool, stdout_is_terminal: bool) -> Self {
+        if stdin_is_terminal && stdout_is_terminal {
+            return Self::Interactive;
+        }
+        let Command::Run(args) = &cli.command;
+        if stdin_is_terminal && args.prompt.is_some() {
+            return Self::OneShot;
+        }
+
+        Self::NonInteractive
+    }
+}
+
+#[cfg(not(test))]
+#[tokio::main]
+async fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let stdin_is_terminal = io::stdin().is_terminal();
+    let stdout_is_terminal = io::stdout().is_terminal();
+    let mode = ChatMode::detect(&cli, stdin_is_terminal, stdout_is_terminal);
+    let input = BufReader::new(tokio::io::stdin());
+    let output = tokio::io::stdout();
+
+    report_exit(
+        execute(cli, |name| env::var(name), input, output, mode).await,
+        io::stderr().lock(),
+    )
+}
+
+fn report_exit(result: Result<(), CliError>, mut error_output: impl io::Write) -> ExitCode {
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            let error = error.to_string();
+            let error = single_line_terminal_text(&error);
+            let _ = writeln!(error_output, "{error}");
+
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn execute<Input, Output>(
+    cli: Cli,
+    environment: impl FnMut(&str) -> Result<String, env::VarError>,
+    input: Input,
+    output: Output,
+    mode: ChatMode,
+) -> Result<(), CliError>
+where
+    Input: AsyncBufRead + Unpin,
+    Output: AsyncWrite + Unpin,
+{
+    let Command::Run(args) = cli.command;
+    let client = model_client(&args, environment)?;
+    let mut harness = Harness::new(client)
+        .repository(args.read_dir.clone())
+        .allow(Tool::Read);
+    let system_prompt = if args.allow_write {
+        harness = harness.allow(Tool::Write);
+        READ_WRITE_SYSTEM_PROMPT
+    } else {
+        READ_ONLY_SYSTEM_PROMPT
+    };
+    let mut session = harness
+        .chat(chat_schema()?)
+        .with_system_prompt(system_prompt);
+
+    run_chat(&mut session, &args.model, args.prompt, input, output, mode).await
+}
+
+async fn run_chat<Input, Output>(
+    session: &mut ChatSession<'_>,
+    requested_model: &str,
+    initial_prompt: Option<String>,
+    mut input: Input,
+    mut output: Output,
+    mode: ChatMode,
+) -> Result<(), CliError>
+where
+    Input: AsyncBufRead + Unpin,
+    Output: AsyncWrite + Unpin,
+{
+    if mode == ChatMode::Interactive {
+        let requested_model = single_line_terminal_text(requested_model);
+        output
+            .write_all(format!("Chat with {requested_model}. Ctrl-D to exit.\n").as_bytes())
+            .await?;
+    }
+
+    let mut pending_prompt = initial_prompt;
+    let mut turn_failed = false;
+    loop {
+        let prompt = if let Some(prompt) = pending_prompt.take() {
+            prompt
+        } else {
+            if mode == ChatMode::Interactive {
+                output.write_all(b">>> ").await?;
+                output.flush().await?;
+            }
+            let mut prompt = String::new();
+            if input.read_line(&mut prompt).await? == 0 {
+                break;
+            }
+            trim_line_ending(&mut prompt);
+
+            prompt
+        };
+        if prompt.trim().is_empty() {
+            continue;
+        }
+        match session.send(prompt).await {
+            Ok(outcome) => write_outcome(&mut output, requested_model, &outcome).await?,
+            Err(error) if mode == ChatMode::Interactive => {
+                write_turn_error(&mut output, &error).await?;
+            }
+            Err(error) if mode == ChatMode::OneShot => return Err(error.into()),
+            Err(error) => {
+                write_turn_error(&mut output, &error).await?;
+                turn_failed = true;
+            }
+        }
+        if mode == ChatMode::OneShot {
+            break;
+        }
+    }
+
+    if turn_failed {
+        Err(CliError::ChatTurnsFailed)
+    } else {
+        Ok(())
+    }
+}
+
+async fn write_outcome(
+    output: &mut (impl AsyncWrite + Unpin),
+    requested_model: &str,
+    outcome: &TurnOutcome,
+) -> Result<(), CliError> {
+    let message = outcome
+        .output()
+        .get("message")
+        .and_then(serde_json::Value::as_str)
+        .ok_or(CliError::MissingMessage)?;
+    output.write_all(assistant_text(message).as_bytes()).await?;
+    output.write_all(b"---\n").await?;
+    output
+        .write_all(format!("turn: {}\n", format_duration(outcome.report().duration())).as_bytes())
+        .await?;
+    output
+        .write_all(format!("model calls: {}\n", outcome.report().model_requests().len()).as_bytes())
+        .await?;
+    for (index, request) in outcome.report().model_requests().iter().enumerate() {
+        let response_type = request.response_type();
+        let completion = request.completion();
+        let model = completion
+            .and_then(|metadata| metadata.response_model())
+            .unwrap_or(requested_model);
+        let finish_reason =
+            completion.map_or("unavailable", ag_harness::CompletionMetadata::finish_reason);
+        let model = single_line_terminal_text(model);
+        let finish_reason = single_line_terminal_text(finish_reason);
+        let usage = completion
+            .and_then(|metadata| metadata.usage())
+            .map_or_else(|| "tokens unavailable".to_string(), format_usage);
+        output
+            .write_all(
+                format!(
+                    "  {}. {response_type}; {model}; {finish_reason}; {}; {usage}\n",
+                    index + 1,
+                    format_duration(request.duration()),
+                )
+                .as_bytes(),
+            )
+            .await?;
+    }
+    if outcome.report().tool_calls().is_empty() {
+        output.write_all(b"tools: none\n").await?;
+    } else {
+        output.write_all(b"tools:\n").await?;
+        for activity in outcome.report().tool_calls() {
+            output
+                .write_all(format!("  {activity}\n").as_bytes())
+                .await?;
+        }
+    }
+    output.flush().await?;
+
+    Ok(())
+}
+
+async fn write_turn_error(
+    output: &mut (impl AsyncWrite + Unpin),
+    error: &ag_harness::TurnError,
+) -> Result<(), io::Error> {
+    let error = error.to_string();
+    let error = single_line_terminal_text(&error);
+    output
+        .write_all(format!("error: {error}\n").as_bytes())
+        .await?;
+    output.flush().await
+}
+
+fn format_usage(usage: &ag_harness::CompletionUsage) -> String {
+    let input = usage
+        .input_tokens()
+        .map_or_else(|| "?".to_string(), |tokens| tokens.to_string());
+    let output = usage
+        .output_tokens()
+        .map_or_else(|| "?".to_string(), |tokens| tokens.to_string());
+    let total = usage
+        .total_tokens()
+        .map_or_else(|| "?".to_string(), |tokens| tokens.to_string());
+
+    format!("tokens {input} in, {output} out, {total} total")
+}
+
+fn format_duration(duration: std::time::Duration) -> String {
+    if duration.as_millis() == 0 {
+        "<1 ms".to_string()
+    } else {
+        format!("{} ms", duration.as_millis())
+    }
+}
+
+fn trim_line_ending(line: &mut String) {
+    if line.ends_with('\n') {
+        line.pop();
+        if line.ends_with('\r') {
+            line.pop();
+        }
+    }
+}
+
+fn assistant_text(text: &str) -> String {
+    let text = terminal_text(text);
+    let mut framed = String::new();
+    for (index, line) in text.split('\n').enumerate() {
+        framed.push_str(if index == 0 {
+            "assistant> "
+        } else {
+            "           "
+        });
+        framed.push_str(line);
+        framed.push('\n');
+    }
+
+    framed
+}
+
+fn terminal_text(text: &str) -> Cow<'_, str> {
+    if text.chars().all(is_terminal_safe) {
+        return Cow::Borrowed(text);
+    }
+
+    Cow::Owned(
+        text.chars()
+            .map(|character| {
+                if is_terminal_safe(character) {
+                    character
+                } else {
+                    '\u{fffd}'
+                }
+            })
+            .collect(),
+    )
+}
+
+fn single_line_terminal_text(text: &str) -> Cow<'_, str> {
+    if text.chars().all(|character| !character.is_control()) {
+        return Cow::Borrowed(text);
+    }
+
+    Cow::Owned(
+        text.chars()
+            .map(|character| {
+                if character.is_control() {
+                    '\u{fffd}'
+                } else {
+                    character
+                }
+            })
+            .collect(),
+    )
+}
+
+fn is_terminal_safe(character: char) -> bool {
+    !character.is_control() || matches!(character, '\n' | '\t')
+}
+
+fn chat_schema() -> Result<OutputSchema, CliError> {
+    let message = Value::Object(Map::from_iter([(
+        "type".to_string(),
+        Value::String("string".to_string()),
+    )]));
+    let properties = Value::Object(Map::from_iter([("message".to_string(), message)]));
+    let schema = Value::Object(Map::from_iter([
+        ("type".to_string(), Value::String("object".to_string())),
+        ("properties".to_string(), properties),
+        (
+            "required".to_string(),
+            Value::Array(vec![Value::String("message".to_string())]),
+        ),
+        ("additionalProperties".to_string(), Value::Bool(false)),
+    ]));
+
+    OutputSchema::new(schema).map_err(CliError::from)
+}
+
+fn model_client(
+    args: &RunArgs,
+    environment: impl FnMut(&str) -> Result<String, env::VarError>,
+) -> Result<ModelClient, CliError> {
+    let configuration = model_config(args, environment)?;
+
+    Ok(args.provider.model_client(configuration)?)
+}
+
+fn model_config(
+    args: &RunArgs,
+    mut environment: impl FnMut(&str) -> Result<String, env::VarError>,
+) -> Result<ModelConfiguration, CliError> {
+    let api_key_environment = args.provider.api_key_environment();
+    let api_key = environment(api_key_environment).map_err(|_| CliError::ApiKeyUnavailable {
+        name: api_key_environment,
+    })?;
+    let base_url_environment = args.provider.base_url_environment();
+    let base_url = if let Some(base_url) = &args.base_url {
+        base_url.clone()
+    } else {
+        match environment(base_url_environment) {
+            Ok(base_url) => base_url,
+            Err(env::VarError::NotPresent) => {
+                args.provider.default_base_url().map(str::to_string).ok_or(
+                    CliError::BaseUrlRequired {
+                        name: base_url_environment,
+                    },
+                )?
+            }
+            Err(source) => {
+                return Err(CliError::Environment {
+                    name: base_url_environment,
+                    source,
+                });
+            }
+        }
+    };
+
+    Ok(ModelConfiguration {
+        api_key,
+        base_url,
+        model: args.model.clone(),
+    })
+}
+
+#[derive(Debug, Error)]
+enum CliError {
+    #[error("{name} is unavailable")]
+    ApiKeyUnavailable { name: &'static str },
+    #[error("--base-url or {name} is required")]
+    BaseUrlRequired { name: &'static str },
+    #[error("one or more chat turns failed")]
+    ChatTurnsFailed,
+    #[error("{name} is unavailable: {source}")]
+    Environment {
+        name: &'static str,
+        source: env::VarError,
+    },
+    #[error("model output did not contain a message")]
+    MissingMessage,
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    ModelConfiguration(#[from] ag_harness::ModelMetadataError),
+    #[error(transparent)]
+    OutputSchema(#[from] ag_harness::OutputSchemaError),
+    #[error(transparent)]
+    Turn(#[from] ag_harness::TurnError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use serde_json::json;
+    use wiremock::matchers::{body_string_contains, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    struct FixedModel(Value);
+
+    #[async_trait]
+    impl ag_harness::Model for FixedModel {
+        async fn complete(
+            &self,
+            _request: ag_harness::ModelRequest,
+        ) -> Result<ag_harness::ModelResponse, ag_harness::ModelError> {
+            Ok(ag_harness::ModelResponse::Output(self.0.clone()))
+        }
+    }
+
+    struct FailOnceModel {
+        requests: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ag_harness::Model for FailOnceModel {
+        async fn complete(
+            &self,
+            _request: ag_harness::ModelRequest,
+        ) -> Result<ag_harness::ModelResponse, ag_harness::ModelError> {
+            if self.requests.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(ag_harness::ModelError::InvalidResponse);
+            }
+
+            Ok(ag_harness::ModelResponse::Output(
+                json!({"message": "recovered"}),
+            ))
+        }
+    }
+
+    fn run_args() -> RunArgs {
+        RunArgs {
+            allow_write: false,
+            base_url: None,
+            model: "muse-model".to_string(),
+            prompt: None,
+            provider: Provider::Muse,
+            read_dir: PathBuf::from("."),
+        }
+    }
+
+    fn missing_environment(_: &str) -> Result<String, env::VarError> {
+        Err(env::VarError::NotPresent)
+    }
+
+    fn provider_response(message: &str) -> ResponseTemplate {
+        ResponseTemplate::new(200).set_body_json(json!({
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {"content": json!({"message": message}).to_string()}
+            }]
+        }))
+    }
+
+    #[test]
+    fn cli_accepts_chat_with_or_without_an_initial_prompt() {
+        // Arrange and Act
+        let without_prompt = Cli::try_parse_from(["ag-harness", "run", "muse-custom"])
+            .expect("chat arguments should parse");
+        let with_prompt = Cli::try_parse_from([
+            "ag-harness",
+            "run",
+            "muse-custom",
+            "Summarize this change",
+            "--provider",
+            "qwen",
+            "--base-url",
+            "https://models.example/v1",
+            "--read-dir",
+            "repo",
+            "--allow-write",
+        ])
+        .expect("an initial prompt should parse");
+        let blank_prompt = Cli::try_parse_from(["ag-harness", "run", "muse-custom", "  "])
+            .expect_err("a blank initial prompt should be rejected");
+        let unknown_provider =
+            Cli::try_parse_from(["ag-harness", "run", "muse-custom", "--provider", "unknown"])
+                .expect_err("an unknown provider should be rejected");
+
+        // Assert
+        let Command::Run(without_prompt) = without_prompt.command;
+        assert_eq!(without_prompt.prompt, None);
+        assert!(!without_prompt.allow_write);
+        assert_eq!(without_prompt.provider, Provider::Muse);
+        assert_eq!(without_prompt.read_dir, PathBuf::from("."));
+        let Command::Run(with_prompt) = with_prompt.command;
+        assert_eq!(with_prompt.model, "muse-custom");
+        assert_eq!(with_prompt.prompt.as_deref(), Some("Summarize this change"));
+        assert_eq!(with_prompt.provider, Provider::Qwen);
+        assert_eq!(
+            with_prompt.base_url.as_deref(),
+            Some("https://models.example/v1")
+        );
+        assert_eq!(with_prompt.read_dir, PathBuf::from("repo"));
+        assert!(with_prompt.allow_write);
+        assert!(
+            blank_prompt
+                .to_string()
+                .contains("prompt must contain a non-whitespace character")
+        );
+        assert!(
+            unknown_provider
+                .to_string()
+                .contains("invalid value 'unknown'")
+        );
+    }
+
+    #[test]
+    fn chat_mode_accounts_for_both_terminal_streams_and_initial_prompt() {
+        // Arrange
+        let with_prompt = Cli::try_parse_from(["ag-harness", "run", "muse", "hello"])
+            .expect("chat arguments should parse");
+        let without_prompt = Cli::try_parse_from(["ag-harness", "run", "muse"])
+            .expect("chat arguments should parse");
+
+        // Act and Assert
+        assert_eq!(
+            ChatMode::detect(&with_prompt, true, true),
+            ChatMode::Interactive
+        );
+        assert_eq!(
+            ChatMode::detect(&with_prompt, true, false),
+            ChatMode::OneShot
+        );
+        assert_eq!(
+            ChatMode::detect(&with_prompt, false, false),
+            ChatMode::NonInteractive
+        );
+        assert_eq!(
+            ChatMode::detect(&without_prompt, true, false),
+            ChatMode::NonInteractive
+        );
+    }
+
+    #[test]
+    fn exit_reporting_sanitizes_errors_and_preserves_success() {
+        // Arrange
+        let mut success_output = Vec::new();
+        let mut error_output = Vec::new();
+        let error = CliError::Turn(ag_harness::TurnError::Model(
+            ag_harness::ModelError::IncompleteResponse {
+                reason: "stop\u{1b}]52;c;Y2xpcGJvYXJk\u{7}".to_string(),
+            },
+        ));
+
+        // Act
+        let success = report_exit(Ok(()), &mut success_output);
+        let failure = report_exit(Err(error), &mut error_output);
+
+        // Assert
+        assert_eq!(success, ExitCode::SUCCESS);
+        assert_eq!(failure, ExitCode::FAILURE);
+        assert_eq!(success_output, [] as [u8; 0]);
+        assert!(!error_output.contains(&0x1b));
+        assert!(!error_output.contains(&0x07));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execute_advertises_repository_reads_by_default() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(body_string_contains(r#""name":"read""#))
+            .and(body_string_contains(r#""content":"Hello","role":"user""#))
+            .respond_with(provider_response("hello"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let cli = Cli::try_parse_from([
+            "ag-harness",
+            "run",
+            "muse-test",
+            "Hello",
+            "--base-url",
+            &server.uri(),
+        ])
+        .expect("chat arguments should parse");
+        let input = BufReader::new(&b""[..]);
+        let mut output = Vec::new();
+
+        // Act
+        execute(
+            cli,
+            |_| Ok("test-key".to_string()),
+            input,
+            &mut output,
+            ChatMode::OneShot,
+        )
+        .await
+        .expect("chat with default repository reads should succeed");
+
+        // Assert
+        assert!(
+            String::from_utf8(output)
+                .expect("chat output should be UTF-8")
+                .starts_with("assistant> hello\n---\n")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execute_advertises_writes_only_when_explicitly_enabled() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(body_string_contains(READ_WRITE_SYSTEM_PROMPT))
+            .and(body_string_contains(r#""name":"read""#))
+            .and(body_string_contains(r#""name":"write""#))
+            .respond_with(provider_response("ready"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let cli = Cli::try_parse_from([
+            "ag-harness",
+            "run",
+            "muse-test",
+            "Hello",
+            "--base-url",
+            &server.uri(),
+            "--allow-write",
+        ])
+        .expect("write-enabled chat arguments should parse");
+        let input = BufReader::new(&b""[..]);
+        let mut output = Vec::new();
+
+        // Act
+        execute(
+            cli,
+            |_| Ok("test-key".to_string()),
+            input,
+            &mut output,
+            ChatMode::OneShot,
+        )
+        .await
+        .expect("write-enabled chat should succeed");
+
+        // Assert
+        assert!(
+            String::from_utf8(output)
+                .expect("chat output should be UTF-8")
+                .starts_with("assistant> ready\n---\n")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execute_advertises_read_only_with_an_explicit_directory() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(body_string_contains(r#""name":"read""#))
+            .and(body_string_contains(r#""content":"Hello","role":"user""#))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "content": null,
+                        "tool_calls": [{
+                            "id": "call-read",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": r#"{"path":"input.txt"}"#
+                            }
+                        }]
+                    }
+                }]
+            })))
+            .with_priority(2)
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(body_string_contains(r#""tool_call_id":"call-read""#))
+            .respond_with(provider_response("hello"))
+            .with_priority(1)
+            .expect(1)
+            .mount(&server)
+            .await;
+        let repository = tempfile::TempDir::new().expect("temporary repository should exist");
+        std::fs::write(repository.path().join("input.txt"), "contents")
+            .expect("read fixture should be written");
+        let cli = Cli::try_parse_from([
+            "ag-harness",
+            "run",
+            "muse-test",
+            "Hello",
+            "--base-url",
+            &server.uri(),
+            "--read-dir",
+            &repository.path().to_string_lossy(),
+        ])
+        .expect("chat arguments should parse");
+        let input = BufReader::new(&b""[..]);
+        let mut output = Vec::new();
+
+        // Act
+        execute(
+            cli,
+            |_| Ok("test-key".to_string()),
+            input,
+            &mut output,
+            ChatMode::OneShot,
+        )
+        .await
+        .expect("chat with explicit read access should succeed");
+
+        // Assert
+        let output = String::from_utf8(output).expect("chat output should be UTF-8");
+        assert!(output.starts_with("assistant> hello\n---\n"));
+        assert!(output.contains("tools:\n  read input.txt (lines 1-1;"));
+    }
+
+    #[test]
+    fn model_configuration_uses_environment_defaults() {
+        // Arrange
+        let args = run_args();
+
+        // Act
+        let config = model_config(&args, |name| match name {
+            MUSE_API_KEY_ENV => Ok("test-key".to_string()),
+            _ => Err(env::VarError::NotPresent),
+        })
+        .expect("default model configuration should be valid");
+
+        // Assert
+        assert_eq!(config.api_key, "test-key");
+        assert_eq!(config.base_url, MUSE_DEFAULT_BASE_URL);
+        assert_eq!(config.model, "muse-model");
+    }
+
+    #[test]
+    fn model_configuration_uses_provider_environment() {
+        // Arrange
+        let providers = [
+            (Provider::Muse, MUSE_API_KEY_ENV, MUSE_BASE_URL_ENV),
+            (Provider::Kimi, KIMI_API_KEY_ENV, KIMI_BASE_URL_ENV),
+            (Provider::Qwen, QWEN_API_KEY_ENV, QWEN_BASE_URL_ENV),
+        ];
+
+        // Act and Assert
+        for (provider, api_key_environment, base_url_environment) in providers {
+            let mut args = run_args();
+            args.provider = provider;
+            let mut requested_environment = Vec::new();
+            let config = model_config(&args, |name| {
+                requested_environment.push(name.to_string());
+                if name == api_key_environment {
+                    Ok("provider-key".to_string())
+                } else {
+                    assert_eq!(name, base_url_environment);
+
+                    Ok("https://provider.example/v1".to_string())
+                }
+            })
+            .expect("provider environment should produce a valid configuration");
+
+            assert_eq!(
+                requested_environment,
+                [
+                    api_key_environment.to_string(),
+                    base_url_environment.to_string()
+                ]
+            );
+            assert_eq!(config.api_key, "provider-key");
+            assert_eq!(config.base_url, "https://provider.example/v1");
+        }
+    }
+
+    #[test]
+    fn model_clients_select_every_supported_provider() {
+        // Arrange
+        let providers = [
+            (Provider::Muse, "meta"),
+            (Provider::Kimi, "moonshot_ai"),
+            (Provider::Qwen, "alibaba_cloud"),
+        ];
+
+        // Act
+        let identities = providers.map(|(provider, expected_provider)| {
+            let mut args = run_args();
+            args.base_url = Some("https://models.example/v1".to_string());
+            args.provider = provider;
+            let client = model_client(&args, |_| Ok("test-key".to_string()))
+                .expect("supported provider configuration should be valid");
+
+            (client.metadata().provider().to_string(), expected_provider)
+        });
+
+        // Assert
+        for (provider, expected_provider) in identities {
+            assert_eq!(provider, expected_provider);
+        }
+    }
+
+    #[test]
+    fn model_configuration_uses_environment_base_url() {
+        // Arrange
+        let args = run_args();
+
+        // Act
+        let config = model_config(&args, |name| {
+            if name == MUSE_BASE_URL_ENV {
+                Ok("https://environment.example/v1".to_string())
+            } else {
+                Ok("test-key".to_string())
+            }
+        })
+        .expect("environment model configuration should be valid");
+
+        // Assert
+        assert_eq!(config.api_key, "test-key");
+        assert_eq!(config.base_url, "https://environment.example/v1");
+    }
+
+    #[test]
+    fn model_configuration_prefers_base_url_flag() {
+        // Arrange
+        let mut args = run_args();
+        args.base_url = Some("https://cli.example/v1".to_string());
+
+        // Act
+        let config = model_config(&args, |_| Ok("test-key".to_string()))
+            .expect("CLI overrides should produce valid configuration");
+
+        // Assert
+        assert_eq!(config.base_url, "https://cli.example/v1");
+    }
+
+    #[test]
+    fn non_muse_configuration_requires_a_base_url() {
+        // Arrange
+        let mut args = run_args();
+        args.provider = Provider::Kimi;
+
+        // Act
+        let error = model_config(&args, |name| {
+            if name == KIMI_API_KEY_ENV {
+                Ok("test-key".to_string())
+            } else {
+                Err(env::VarError::NotPresent)
+            }
+        })
+        .err()
+        .expect("Kimi without an endpoint should be rejected");
+
+        // Assert
+        assert_eq!(error.to_string(), "--base-url or KIMI_BASE_URL is required");
+    }
+
+    #[test]
+    fn model_configuration_reports_missing_api_key() {
+        // Arrange
+        let args = run_args();
+
+        // Act
+        let error = model_config(&args, missing_environment)
+            .err()
+            .expect("a missing API key should be rejected");
+
+        // Assert
+        assert_eq!(error.to_string(), "MODEL_API_KEY is unavailable");
+    }
+
+    #[test]
+    fn api_key_errors_redact_non_unicode_values_from_output() {
+        // Arrange
+        let args = run_args();
+        let secret = "visible-secret-material";
+        let error = model_config(&args, |_| {
+            Err(env::VarError::NotUnicode(std::ffi::OsString::from(secret)))
+        })
+        .err()
+        .expect("a non-Unicode API key should be rejected");
+        let mut error_output = Vec::new();
+
+        // Act
+        let exit = report_exit(Err(error), &mut error_output);
+
+        // Assert
+        assert_eq!(exit, ExitCode::FAILURE);
+        let error_output = String::from_utf8(error_output).expect("error output should be UTF-8");
+        assert_eq!(error_output, "MODEL_API_KEY is unavailable\n");
+        assert!(!error_output.contains(secret));
+    }
+
+    #[test]
+    fn model_configuration_reports_non_unicode_optional_environment() {
+        // Arrange
+        let args = run_args();
+
+        // Act
+        let error = model_config(&args, |name| {
+            if name == MUSE_BASE_URL_ENV {
+                Err(env::VarError::NotUnicode("invalid".into()))
+            } else {
+                Ok("test-key".to_string())
+            }
+        })
+        .err()
+        .expect("non-Unicode configuration should be rejected");
+
+        // Assert
+        assert!(
+            error
+                .to_string()
+                .starts_with("MODEL_API_BASE_URL is unavailable:")
+        );
+    }
+
+    #[test]
+    fn chat_schema_requires_one_message_string() {
+        // Arrange and Act
+        let schema = chat_schema().expect("chat schema should compile");
+
+        // Assert
+        assert_eq!(schema.value()["required"], json!(["message"]));
+        assert_eq!(schema.value()["additionalProperties"], json!(false));
+    }
+
+    #[test]
+    fn line_endings_are_trimmed_without_changing_prompt_content() {
+        // Arrange
+        let mut unix = "hello\n".to_string();
+        let mut windows = "hello\r\n".to_string();
+        let mut unchanged = "hello".to_string();
+
+        // Act
+        trim_line_ending(&mut unix);
+        trim_line_ending(&mut windows);
+        trim_line_ending(&mut unchanged);
+
+        // Assert
+        assert_eq!(unix, "hello");
+        assert_eq!(windows, "hello");
+        assert_eq!(unchanged, "hello");
+    }
+
+    #[test]
+    fn durations_have_compact_terminal_formatting() {
+        // Arrange and Act
+        let short = format_duration(std::time::Duration::ZERO);
+        let measured = format_duration(std::time::Duration::from_millis(12));
+
+        // Assert
+        assert_eq!(short, "<1 ms");
+        assert_eq!(measured, "12 ms");
+    }
+
+    #[tokio::test]
+    async fn interactive_chat_prints_prompts_and_handles_blank_input() {
+        // Arrange
+        let harness = Harness::new(FixedModel(json!({"message": "hello"})))
+            .repository(".")
+            .allow(Tool::Read);
+        let mut session = harness.chat(chat_schema().expect("chat schema should compile"));
+        let input = BufReader::new(&b"\nquestion\n"[..]);
+        let mut output = Vec::new();
+
+        // Act
+        run_chat(
+            &mut session,
+            "test-model",
+            None,
+            input,
+            &mut output,
+            ChatMode::Interactive,
+        )
+        .await
+        .expect("interactive chat should finish at EOF");
+
+        // Assert
+        let output = String::from_utf8(output).expect("chat output should be UTF-8");
+        assert!(
+            output.starts_with("Chat with test-model. Ctrl-D to exit.\n>>> >>> assistant> hello\n")
+        );
+        assert!(output.contains("output; test-model; unavailable;"));
+        assert!(output.contains("tokens unavailable"));
+        assert!(output.ends_with("tools: none\n>>> "));
+    }
+
+    #[tokio::test]
+    async fn interactive_chat_continues_after_a_failed_turn() {
+        // Arrange
+        let harness = Harness::new(FailOnceModel {
+            requests: AtomicUsize::new(0),
+        });
+        let mut session = harness.chat(chat_schema().expect("chat schema should compile"));
+        let input = BufReader::new(&b"first\nretry\n"[..]);
+        let mut output = Vec::new();
+
+        // Act
+        run_chat(
+            &mut session,
+            "test-model",
+            None,
+            input,
+            &mut output,
+            ChatMode::Interactive,
+        )
+        .await
+        .expect("interactive chat should recover and finish at EOF");
+
+        // Assert
+        let output = String::from_utf8(output).expect("chat output should be UTF-8");
+        assert!(output.contains("error: model returned no response content\n"));
+        assert!(output.contains(">>> assistant> recovered\n---\n"));
+        assert!(output.ends_with("tools: none\n>>> "));
+    }
+
+    #[tokio::test]
+    async fn noninteractive_chat_reports_a_failure_before_retrying() {
+        // Arrange
+        let harness = Harness::new(FailOnceModel {
+            requests: AtomicUsize::new(0),
+        });
+        let mut session = harness.chat(chat_schema().expect("chat schema should compile"));
+        let input = BufReader::new(&b"first\nretry\n"[..]);
+        let mut output = Vec::new();
+
+        // Act
+        let error = run_chat(
+            &mut session,
+            "test-model",
+            None,
+            input,
+            &mut output,
+            ChatMode::NonInteractive,
+        )
+        .await
+        .expect_err("a recovered chat should retain its failed exit status");
+
+        // Assert
+        assert!(matches!(error, CliError::ChatTurnsFailed));
+        let output = String::from_utf8(output).expect("chat output should be UTF-8");
+        assert!(output.starts_with("error: model returned no response content\n"));
+        assert!(output.contains("assistant> recovered\n---\n"));
+    }
+
+    #[tokio::test]
+    async fn noninteractive_chat_returns_the_last_failure_at_eof() {
+        // Arrange
+        let harness = Harness::new(FailOnceModel {
+            requests: AtomicUsize::new(0),
+        });
+        let mut session = harness.chat(chat_schema().expect("chat schema should compile"));
+        let input = BufReader::new(&b"first\n"[..]);
+        let mut output = Vec::new();
+
+        // Act
+        let error = run_chat(
+            &mut session,
+            "test-model",
+            None,
+            input,
+            &mut output,
+            ChatMode::NonInteractive,
+        )
+        .await
+        .expect_err("the final failed turn should be returned at EOF");
+
+        // Assert
+        assert!(matches!(error, CliError::ChatTurnsFailed));
+        assert_eq!(
+            String::from_utf8(output).expect("chat output should be UTF-8"),
+            "error: model returned no response content\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn chat_rejects_model_output_without_a_message() {
+        // Arrange
+        let harness = Harness::new(FixedModel(json!({"unexpected": true})));
+        let mut session = harness.chat(chat_schema().expect("chat schema should compile"));
+        let input = BufReader::new(&b""[..]);
+        let mut output = Vec::new();
+
+        // Act
+        let error = run_chat(
+            &mut session,
+            "test-model",
+            Some("question".to_string()),
+            input,
+            &mut output,
+            ChatMode::NonInteractive,
+        )
+        .await
+        .expect_err("missing message output should fail");
+
+        // Assert
+        assert!(matches!(error, CliError::MissingMessage));
+    }
+
+    #[tokio::test]
+    async fn one_shot_chat_does_not_read_follow_up_terminal_input() {
+        // Arrange
+        let harness = Harness::new(FixedModel(json!({"message": "hello"})));
+        let mut session = harness.chat(chat_schema().expect("chat schema should compile"));
+        let input = BufReader::new(&b"unexpected follow-up\n"[..]);
+        let mut output = Vec::new();
+
+        // Act
+        run_chat(
+            &mut session,
+            "test-model",
+            Some("question".to_string()),
+            input,
+            &mut output,
+            ChatMode::OneShot,
+        )
+        .await
+        .expect("one-shot chat should finish after the initial prompt");
+
+        // Assert
+        let output = String::from_utf8(output).expect("chat output should be UTF-8");
+        assert_eq!(output.matches("assistant> hello\n---\n").count(), 1);
+        assert!(!output.contains("Chat with"));
+        assert!(!output.contains(">>>"));
+    }
+
+    #[tokio::test]
+    async fn one_shot_chat_returns_turn_failures() {
+        // Arrange
+        let harness = Harness::new(FailOnceModel {
+            requests: AtomicUsize::new(0),
+        });
+        let mut session = harness.chat(chat_schema().expect("chat schema should compile"));
+        let input = BufReader::new(&b""[..]);
+        let mut output = Vec::new();
+
+        // Act
+        let error = run_chat(
+            &mut session,
+            "test-model",
+            Some("question".to_string()),
+            input,
+            &mut output,
+            ChatMode::OneShot,
+        )
+        .await
+        .expect_err("one-shot chat should return its failed turn");
+
+        // Assert
+        assert!(matches!(error, CliError::Turn(_)));
+        assert_eq!(output, [] as [u8; 0]);
+    }
+
+    #[test]
+    fn terminal_text_replaces_control_sequences_and_preserves_safe_whitespace() {
+        // Arrange
+        let text = "before\n\t\u{1b}]52;c;Y2xpcGJvYXJk\u{7}after\r";
+
+        // Act
+        let sanitized = terminal_text(text);
+
+        // Assert
+        assert_eq!(
+            sanitized,
+            "before\n\t\u{fffd}]52;c;Y2xpcGJvYXJk\u{fffd}after\u{fffd}"
+        );
+        assert!(
+            sanitized
+                .chars()
+                .all(|character| !character.is_control() || matches!(character, '\n' | '\t'))
+        );
+    }
+
+    #[test]
+    fn assistant_text_indents_continuation_lines_and_sanitizes_them() {
+        // Arrange
+        let text = "answer\n---\nturn: forged\u{1b}";
+
+        // Act
+        let framed = assistant_text(text);
+
+        // Assert
+        assert_eq!(
+            framed,
+            "assistant> answer\n           ---\n           turn: forged\u{fffd}\n"
+        );
+    }
+
+    #[test]
+    fn single_line_terminal_text_replaces_all_control_characters() {
+        // Arrange
+        let text = "model\nname\t\u{1b}";
+
+        // Act
+        let sanitized = single_line_terminal_text(text);
+
+        // Assert
+        assert_eq!(sanitized, "model\u{fffd}name\u{fffd}\u{fffd}");
+        assert!(sanitized.chars().all(|character| !character.is_control()));
+    }
+
+    #[test]
+    fn usage_format_marks_missing_counts() {
+        // Arrange
+        let usage = ag_harness::CompletionUsage::new(None, None, None, Some(4), None, None);
+
+        // Act
+        let formatted = format_usage(&usage);
+
+        // Assert
+        assert_eq!(formatted, "tokens ? in, 4 out, ? total");
+    }
+}

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -353,6 +353,24 @@ impl ModelRequest {
         }
     }
 
+    pub(crate) fn with_history(
+        messages: Vec<ModelMessage>,
+        prompt: impl Into<String>,
+        schema: OutputSchema,
+    ) -> Self {
+        let prompt = prompt.into();
+        let mut messages = messages;
+        messages.push(ModelMessage::User(prompt.clone()));
+
+        Self {
+            lifecycle_observed: false,
+            messages,
+            prompt,
+            schema,
+            tools: Vec::new(),
+        }
+    }
+
     /// Advertises one native function tool for this request.
     #[must_use]
     pub fn with_tool(mut self, tool: tool::ToolDefinition) -> Self {
@@ -404,17 +422,55 @@ impl ModelRequest {
             name,
         });
     }
+
+    pub(crate) fn record_output(&mut self, output: &Value) {
+        self.messages
+            .push(ModelMessage::Assistant(output.to_string()));
+    }
+
+    pub(crate) fn into_messages(self) -> Vec<ModelMessage> {
+        self.messages
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum ModelMessage {
-    User(String),
+    Assistant(String),
     AssistantToolCall(tool::ToolCall),
+    System(String),
     ToolResult {
         call_id: String,
         content: String,
         name: String,
     },
+    User(String),
+}
+
+impl ModelMessage {
+    pub(crate) fn retained_bytes(&self) -> usize {
+        match self {
+            Self::Assistant(content) | Self::System(content) | Self::User(content) => content.len(),
+            Self::AssistantToolCall(call) => {
+                let arguments = call
+                    .arguments_json()
+                    .map_or(usize::MAX, |arguments| arguments.len());
+
+                call.id()
+                    .len()
+                    .saturating_add(call.name().len())
+                    .saturating_add(arguments)
+                    .saturating_add(call.reasoning_content().map_or(0, str::len))
+            }
+            Self::ToolResult {
+                call_id,
+                content,
+                name,
+            } => call_id
+                .len()
+                .saturating_add(content.len())
+                .saturating_add(name.len()),
+        }
+    }
 }
 
 /// One model response paired with normalized provider completion metadata.

--- a/crates/ag-harness/src/provider/kimi.rs
+++ b/crates/ag-harness/src/provider/kimi.rs
@@ -3,6 +3,7 @@ use crate::{chat_completion, telemetry};
 pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
     chat_completion::ChatCompletionProviderPolicy {
         display_name: "Kimi",
+        response_format_with_tools: false,
         structured_output: chat_completion::StructuredOutputMode::JsonObject {
             assistant_reasoning_content: true,
             tool_result_name: true,
@@ -175,7 +176,6 @@ mod tests {
                     {"content": prompt, "role": "user"}
                 ],
                 "model": "kimi-k2.6",
-                "response_format": {"type": "json_object"},
                 "tools": [read_tool_wire()]
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -333,7 +333,6 @@ mod tests {
                     }
                 ],
                 "model": "kimi-k2.6",
-                "response_format": {"type": "json_object"},
                 "tools": [read_tool_wire()]
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({

--- a/crates/ag-harness/src/provider/muse.rs
+++ b/crates/ag-harness/src/provider/muse.rs
@@ -25,6 +25,7 @@ pub const MUSE_SPARK_1_2_CONTRIBUTOR: &str = "muse-spark-1.2-contributor";
 pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
     chat_completion::ChatCompletionProviderPolicy {
         display_name: "Meta Model API",
+        response_format_with_tools: true,
         structured_output: chat_completion::StructuredOutputMode::JsonSchema,
         telemetry_name: telemetry::PROVIDER_META,
         unsupported_schema_reason: "Muse structured output requires an explicit object root schema",

--- a/crates/ag-harness/src/provider/qwen.rs
+++ b/crates/ag-harness/src/provider/qwen.rs
@@ -3,6 +3,7 @@ use crate::{chat_completion, telemetry};
 pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
     chat_completion::ChatCompletionProviderPolicy {
         display_name: "Qwen",
+        response_format_with_tools: false,
         structured_output: chat_completion::StructuredOutputMode::JsonObject {
             assistant_reasoning_content: false,
             tool_result_name: false,
@@ -189,7 +190,6 @@ mod tests {
                     {"content": prompt, "role": "user"}
                 ],
                 "model": "qwen-plus",
-                "response_format": {"type": "json_object"},
                 "tools": [read_tool_wire()]
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -369,7 +369,6 @@ mod tests {
                     }
                 ],
                 "model": "qwen-plus",
-                "response_format": {"type": "json_object"},
                 "tools": [read_tool_wire()]
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({

--- a/crates/ag-harness/src/read.rs
+++ b/crates/ag-harness/src/read.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 use tokio::io::{AsyncBufReadExt as _, AsyncRead, AsyncReadExt as _, BufReader};
 
 use crate::file_system::FileSystem;
+use crate::schema_contract;
 use crate::tool::ReadArguments;
 
 const MAX_READ_BYTES: usize = 50 * 1024;
@@ -138,6 +139,27 @@ pub enum ReadError {
     /// The successful result could not be encoded for the model.
     #[error("failed to encode read result: {0}")]
     Encode(#[from] serde_json::Error),
+}
+
+impl ReadError {
+    pub(crate) fn is_model_correctable(&self) -> bool {
+        !matches!(self, Self::RepositoryRoot { .. } | Self::Encode(_))
+    }
+
+    pub(crate) fn to_tool_result(&self, path: &str) -> Result<String, serde_json::Error> {
+        #[derive(Serialize)]
+        struct RejectedRead<'a> {
+            error: String,
+            path: &'a str,
+            status: &'static str,
+        }
+
+        serde_json::to_string(&RejectedRead {
+            error: schema_contract::bounded_diagnostic(self),
+            path,
+            status: "rejected",
+        })
+    }
 }
 
 pub(crate) struct ReadTool {

--- a/crates/ag-harness/src/tool.rs
+++ b/crates/ag-harness/src/tool.rs
@@ -9,7 +9,10 @@ const READ_DESCRIPTION: &str =
 const READ_NAME: &str = "read";
 const MAX_PATCH_BYTES: usize = 1024 * 1024;
 const MAX_PATH_BYTES: usize = 4 * 1024;
-const WRITE_DESCRIPTION: &str = "Apply one unified diff to one repository-relative text file.";
+const WRITE_DESCRIPTION: &str = concat!(
+    "Apply one unified diff to one repository-relative text file. To create an empty file, use ",
+    "only `--- /dev/null` and `+++ b/<path>` headers."
+);
 const WRITE_NAME: &str = "write";
 
 /// Built-in tool that can be enabled for a harness run.
@@ -461,7 +464,10 @@ mod tests {
         assert_eq!(definition.name(), "write");
         assert_eq!(
             definition.description(),
-            "Apply one unified diff to one repository-relative text file."
+            concat!(
+                "Apply one unified diff to one repository-relative text file. To create an empty ",
+                "file, use only `--- /dev/null` and `+++ b/<path>` headers."
+            )
         );
         assert!(validator.is_valid(&json!({
             "path": "src/lib.rs",

--- a/crates/ag-harness/src/write.rs
+++ b/crates/ag-harness/src/write.rs
@@ -495,10 +495,6 @@ fn parse_unified_diff(patch: &str) -> Result<UnifiedDiff, WriteError> {
             old_start,
         });
     }
-    if hunks.is_empty() {
-        return Err(patch_error("patch must contain at least one hunk"));
-    }
-
     Ok(UnifiedDiff {
         hunks,
         modified_path,
@@ -774,16 +770,20 @@ mod tests {
         // Arrange
         let update = "--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1,2 +1,2 @@\n one\n-two\n+three\n";
         let create = "--- /dev/null\n+++ b/new.txt\n@@ -0,0 +1,2 @@\n+hello\n+world\n";
+        let empty_patch = "--- /dev/null\n+++ b/empty.txt\n";
 
         // Act
         let updated = apply_unified_diff("src/lib.rs", Some(b"one\ntwo\n"), update)
             .expect("update patch should apply");
         let created =
             apply_unified_diff("new.txt", None, create).expect("create patch should apply");
+        let empty_file = apply_unified_diff("empty.txt", None, empty_patch)
+            .expect("empty create patch should apply");
 
         // Assert
         assert_eq!(updated, b"one\nthree\n");
         assert_eq!(created, b"hello\nworld\n");
+        assert_eq!(empty_file, b"");
     }
 
     #[test]
@@ -881,7 +881,6 @@ mod tests {
             "--- a/file\n",
             "bad\n+++ b/file\n@@ -0,0 +1 @@\n+x\n",
             "--- \n+++ b/file\n@@ -0,0 +1 @@\n+x\n",
-            "--- a/file\n+++ b/file\n",
             "--- a/file\n+++ b/file\nnot-a-hunk\n",
             "--- a/file\n+++ b/file\n@@ -1 1 @@\n x\n",
             "--- a/file\n+++ b/file\n@@ -x +1 @@\n x\n",

--- a/crates/ag-harness/tests/cli.rs
+++ b/crates/ag-harness/tests/cli.rs
@@ -1,0 +1,732 @@
+//! Process-level coverage for the `ag-harness` command-line interface.
+
+use std::fs;
+use std::io::{BufRead as _, BufReader, Read as _, Write as _};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use assert_cmd::cargo::cargo_bin;
+use serde_json::json;
+use testty::session::PtySessionBuilder;
+use wiremock::matchers::{bearer_token, body_json, body_string_contains, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const READ_ONLY_SYSTEM_PROMPT: &str = concat!(
+    "You are operating in a read-only repository harness. When a user asks about repository ",
+    "contents, call the read tool immediately in the same response and use its result before ",
+    "answering. Never narrate, promise, or defer a future tool call. Never claim that you \
+     created, ",
+    "modified, deleted, or executed files or commands because filesystem mutation and command ",
+    "execution are unavailable. If asked to perform an unsupported action, state that it is ",
+    "unsupported."
+);
+const READ_WRITE_SYSTEM_PROMPT: &str = concat!(
+    "You are operating in a repository harness with read and write tools. When a user asks about ",
+    "repository contents, call the read tool immediately in the same response and use its result ",
+    "before answering. When a user asks to create or modify a file, call the write tool ",
+    "immediately in the same response. Never narrate, promise, or defer a future tool call. Only ",
+    "claim that a file was created or modified after the write tool succeeds. File deletion and ",
+    "command execution are unavailable. To create an empty file, pass a write patch containing ",
+    "only `--- /dev/null` and `+++ b/<path>` headers with no hunk."
+);
+
+fn chat_schema() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "message": {"type": "string"}
+        },
+        "required": ["message"],
+        "additionalProperties": false
+    })
+}
+
+fn structured_output_instruction() -> String {
+    format!(
+        "Return only one JSON object. The object must validate against this JSON Schema. Do not \
+         include Markdown fences or any other text.\n\nJSON Schema:\n{}",
+        chat_schema()
+    )
+}
+
+fn read_tool() -> serde_json::Value {
+    json!({
+        "type": "function",
+        "function": {
+            "description": "Read a repository-relative file, optionally selecting a line range.",
+            "name": "read",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 4096,
+                        "pattern": "^(?:[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.\\.[^/\\\\\\u0000]+)(?:/(?:[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.\\.[^/\\\\\\u0000]+))*$"
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": u64::MAX
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": u64::MAX
+                    }
+                },
+                "required": ["path"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn response(message: &str, input_tokens: u64, output_tokens: u64) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(json!({
+        "choices": [{
+            "finish_reason": "stop",
+            "message": {"content": json!({"message": message}).to_string()}
+        }],
+        "id": "response-test",
+        "model": "muse-reported",
+        "usage": {
+            "prompt_tokens": input_tokens,
+            "completion_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens
+        }
+    }))
+}
+
+#[test]
+fn help_describes_the_chat_interface() {
+    // Arrange
+    let mut command = Command::new(cargo_bin!("ag-harness"));
+
+    // Act
+    let output = command.arg("--help").output().expect("CLI help should run");
+
+    // Assert
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("help should be UTF-8");
+    assert!(stdout.contains("Chats with models through a repository harness"));
+    assert!(stdout.contains("Usage: ag-harness <COMMAND>"));
+    assert!(stdout.contains("Commands:"));
+    assert!(stdout.contains("Starts an in-memory chat"));
+    assert!(stdout.contains("Supported models"));
+    assert!(stdout.contains("muse-spark-1.2, muse-spark-1.2-contributor"));
+    assert!(stdout.contains("kimi-k2.6"));
+    assert!(stdout.contains("qwen-plus"));
+    assert!(stdout.contains("Credentials:"));
+    assert!(stdout.contains("MODEL_API_KEY"));
+    assert!(stdout.contains("KIMI_API_KEY"));
+    assert!(stdout.contains("DASHSCOPE_API_KEY"));
+    assert!(!stdout.contains("Get started:"));
+    assert!(!stdout.contains("Examples:"));
+}
+
+#[test]
+fn run_help_describes_optional_initial_prompt() {
+    // Arrange
+    let mut command = Command::new(cargo_bin!("ag-harness"));
+
+    // Act
+    let output = command
+        .args(["run", "--help"])
+        .output()
+        .expect("run help should execute");
+
+    // Assert
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("help should be UTF-8");
+    assert!(stdout.contains("Usage: ag-harness run [OPTIONS] <MODEL> [PROMPT]"));
+    assert!(stdout.contains("Optional first prompt"));
+    assert!(stdout.contains("--base-url <URL>"));
+    assert!(stdout.contains("MODEL_API_BASE_URL"));
+    assert!(stdout.contains("KIMI_BASE_URL"));
+    assert!(stdout.contains("DASHSCOPE_BASE_URL"));
+    assert!(stdout.contains("Credentials:"));
+    assert!(stdout.contains("MODEL_API_KEY"));
+    assert!(stdout.contains("KIMI_API_KEY"));
+    assert!(stdout.contains("DASHSCOPE_API_KEY"));
+    assert!(stdout.contains("--provider <PROVIDER>"));
+    assert!(stdout.contains("[default: muse]"));
+    assert!(stdout.contains("[possible values: muse, kimi, qwen]"));
+    assert!(stdout.contains("--read-dir <DIR>"));
+    assert!(stdout.contains("Repository directory available to enabled tools"));
+    assert!(stdout.contains("[default: .]"));
+    assert!(stdout.contains("--allow-write"));
+    assert!(stdout.contains("Enables repository writes through the write tool"));
+    assert!(!stdout.contains("Chat behavior:"));
+    assert!(!stdout.contains("--schema"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn provider_flags_select_kimi_and_qwen_wire_formats() {
+    // Arrange and Act
+    for (provider, model, api_key_environment, base_url_environment) in [
+        ("kimi", "kimi-k2.6", "KIMI_API_KEY", "KIMI_BASE_URL"),
+        (
+            "qwen",
+            "qwen-plus",
+            "DASHSCOPE_API_KEY",
+            "DASHSCOPE_BASE_URL",
+        ),
+    ] {
+        let server = MockServer::start().await;
+        let expected_request = json!({
+            "messages": [
+                {"content": structured_output_instruction(), "role": "system"},
+                {"content": READ_ONLY_SYSTEM_PROMPT, "role": "system"},
+                {"content": "Hello", "role": "user"}
+            ],
+            "model": model,
+            "tools": [read_tool()]
+        });
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(bearer_token("test-key"))
+            .respond_with(response("provider response", 4, 2))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let mut command = Command::new(cargo_bin!("ag-harness"));
+        let output = command
+            .args(["run", model, "Hello", "--provider", provider])
+            .env(api_key_environment, "test-key")
+            .env(base_url_environment, server.uri())
+            .output()
+            .expect("provider request should run");
+
+        // Assert
+        assert!(
+            output.status.success(),
+            "{provider} CLI failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(String::from_utf8_lossy(&output.stdout).contains("assistant> provider response"));
+        let requests = server
+            .received_requests()
+            .await
+            .expect("provider request should be recorded");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0]
+                .body_json::<serde_json::Value>()
+                .expect("provider request should contain JSON"),
+            expected_request
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn initial_prompt_prints_answer_and_model_metadata() {
+    // Arrange
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(bearer_token("test-key"))
+        .and(body_json(json!({
+            "messages": [
+                {"content": READ_ONLY_SYSTEM_PROMPT, "role": "system"},
+                {"content": "Hello", "role": "user"}
+            ],
+            "model": "muse-test",
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "ag_harness_output",
+                    "schema": chat_schema()
+                }
+            },
+            "tools": [read_tool()]
+        })))
+        .respond_with(response("Hi there", 9, 3))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let mut command = Command::new(cargo_bin!("ag-harness"));
+
+    // Act
+    let output = command
+        .args(["run", "muse-test", "Hello", "--base-url", &server.uri()])
+        .env("MODEL_API_KEY", "test-key")
+        .output()
+        .expect("CLI request should run");
+
+    // Assert
+    assert!(
+        output.status.success(),
+        "CLI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("output should be UTF-8");
+    assert!(stdout.starts_with("assistant> Hi there\n---\n"));
+    assert!(stdout.contains("model calls: 1\n"));
+    assert!(stdout.contains("output; muse-reported; stop;"));
+    assert!(stdout.contains("tokens 9 in, 3 out, 12 total"));
+    assert!(stdout.ends_with("tools: none\n"));
+    assert_eq!(output.stderr, [] as [u8; 0]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn model_output_and_metadata_cannot_spoof_terminal_framing() {
+    // Arrange
+    let server = MockServer::start().await;
+    let escape = "\u{1b}]52;c;Y2xpcGJvYXJk\u{7}";
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {
+                    "content": json!({
+                        "message": format!(
+                            "before{escape}after\n---\nturn: forged\nmodel calls: forged\ntools: forged"
+                        )
+                    }).to_string()
+                }
+            }],
+            "model": format!("muse{escape}\nmodel calls: forged"),
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let mut command = Command::new(cargo_bin!("ag-harness"));
+
+    // Act
+    let output = command
+        .args(["run", "muse-test", "Hello", "--base-url", &server.uri()])
+        .env("MODEL_API_KEY", "test-key")
+        .output()
+        .expect("CLI request should run");
+
+    // Assert
+    assert!(
+        output.status.success(),
+        "CLI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!output.stdout.contains(&0x1b));
+    assert!(!output.stdout.contains(&0x07));
+    let stdout = String::from_utf8(output.stdout).expect("output should be UTF-8");
+    assert!(
+        stdout.starts_with(
+            "assistant> before�]52;c;Y2xpcGJvYXJk�after\n           ---\n           turn: \
+             forged\n           model calls: forged\n           tools: forged\n---\n"
+        )
+    );
+    assert!(stdout.contains("output; muse�]52;c;Y2xpcGJvYXJk��model calls: forged; stop;"));
+    assert_eq!(stdout.matches("\nturn: ").count(), 1);
+    assert_eq!(stdout.matches("\nmodel calls: ").count(), 1);
+    assert_eq!(stdout.matches("\ntools:").count(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stdin_prompts_share_conversation_history() {
+    // Arrange
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(body_string_contains(
+            r#""content":"first question","role":"user""#,
+        ))
+        .respond_with(response("first answer", 4, 2))
+        .with_priority(2)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(body_string_contains(
+            r#""content":"{\"message\":\"first answer\"}","role":"assistant""#,
+        ))
+        .and(body_string_contains(
+            r#""content":"second question","role":"user""#,
+        ))
+        .respond_with(response("second answer", 10, 2))
+        .with_priority(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    let mut child = Command::new(cargo_bin!("ag-harness"))
+        .args([
+            "run",
+            "muse-test",
+            "first question",
+            "--base-url",
+            &server.uri(),
+        ])
+        .env("MODEL_API_KEY", "test-key")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("CLI chat should start");
+
+    // Act
+    child
+        .stdin
+        .take()
+        .expect("stdin should be piped")
+        .write_all(b"second question\n")
+        .expect("second prompt should be written");
+    let output = child.wait_with_output().expect("CLI chat should finish");
+
+    // Assert
+    assert!(
+        output.status.success(),
+        "CLI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("output should be UTF-8");
+    assert!(stdout.contains("assistant> first answer\n---\n"));
+    assert!(stdout.contains("assistant> second answer\n---\n"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stdin_chat_emits_failure_before_retry_and_exits_unsuccessfully() {
+    // Arrange
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(body_string_contains(
+            r#""content":"first question","role":"user""#,
+        ))
+        .respond_with(ResponseTemplate::new(500).set_body_string("temporary failure"))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(body_json(json!({
+            "messages": [
+                {"content": READ_ONLY_SYSTEM_PROMPT, "role": "system"},
+                {"content": "retry question", "role": "user"}
+            ],
+            "model": "muse-test",
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "ag_harness_output",
+                    "schema": chat_schema()
+                }
+            },
+            "tools": [read_tool()]
+        })))
+        .respond_with(response("recovered answer", 5, 2))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let mut child = Command::new(cargo_bin!("ag-harness"))
+        .args(["run", "muse-test", "--base-url", &server.uri()])
+        .env("MODEL_API_KEY", "test-key")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("CLI chat should start");
+
+    // Act
+    let mut stdin = child.stdin.take().expect("stdin should be piped");
+    let stdout = child.stdout.take().expect("stdout should be piped");
+    let mut stdout = BufReader::new(stdout);
+    stdin
+        .write_all(b"first question\n")
+        .expect("first prompt should be written");
+    stdin.flush().expect("first prompt should be flushed");
+    let mut failure = String::new();
+    stdout
+        .read_line(&mut failure)
+        .expect("failed turn should be emitted while stdin remains open");
+    stdin
+        .write_all(b"retry question\n")
+        .expect("retry prompt should be written");
+    drop(stdin);
+    let mut recovered = String::new();
+    stdout
+        .read_to_string(&mut recovered)
+        .expect("retry output should be readable");
+    let status = child.wait().expect("CLI chat should finish");
+    let mut stderr = String::new();
+    child
+        .stderr
+        .take()
+        .expect("stderr should be piped")
+        .read_to_string(&mut stderr)
+        .expect("stderr should be readable");
+
+    // Assert
+    assert!(failure.contains("error: model request failed:"));
+    assert!(recovered.contains("assistant> recovered answer\n---\n"));
+    assert!(!status.success());
+    assert_eq!(stderr, "one or more chat turns failed\n");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn read_tool_reports_the_file_without_printing_its_contents() {
+    // Arrange
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(body_json(json!({
+            "messages": [
+                {"content": READ_ONLY_SYSTEM_PROMPT, "role": "system"},
+                {"content": "Inspect the manifest", "role": "user"}
+            ],
+            "model": "muse-test",
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "ag_harness_output",
+                    "schema": chat_schema()
+                }
+            },
+            "tools": [read_tool()]
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "choices": [{
+                "finish_reason": "tool_calls",
+                "message": {
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call-read",
+                        "type": "function",
+                        "function": {
+                            "name": "read",
+                            "arguments": r#"{"path":"Cargo.toml","limit":2}"#
+                        }
+                    }]
+                }
+            }]
+        })))
+        .with_priority(2)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(body_string_contains(r#""tool_call_id":"call-read""#))
+        .respond_with(response("It is a Rust workspace.", 20, 5))
+        .with_priority(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    let mut command = Command::new(cargo_bin!("ag-harness"));
+
+    // Act
+    let output = command
+        .args([
+            "run",
+            "muse-test",
+            "Inspect the manifest",
+            "--base-url",
+            &server.uri(),
+        ])
+        .env("MODEL_API_KEY", "test-key")
+        .output()
+        .expect("CLI tool round trip should run");
+
+    // Assert
+    assert!(
+        output.status.success(),
+        "CLI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("output should be UTF-8");
+    assert!(stdout.contains("model calls: 2\n"));
+    assert!(stdout.contains("tools:\n  read Cargo.toml (lines 1-2, truncated;"));
+    assert!(!stdout.contains("[workspace]"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn allow_write_enables_the_tool_and_creates_an_empty_file() {
+    // Arrange
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(body_string_contains(READ_WRITE_SYSTEM_PROMPT))
+        .and(body_string_contains(r#""name":"read""#))
+        .and(body_string_contains(r#""name":"write""#))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "choices": [{
+                "finish_reason": "tool_calls",
+                "message": {
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call-write",
+                        "type": "function",
+                        "function": {
+                            "name": "write",
+                            "arguments": serde_json::json!({
+                                "path": "t.py",
+                                "patch": "--- /dev/null\n+++ b/t.py\n"
+                            }).to_string()
+                        }
+                    }]
+                }
+            }]
+        })))
+        .with_priority(2)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(body_string_contains(r#""tool_call_id":"call-write""#))
+        .respond_with(response("Created t.py.", 20, 5))
+        .with_priority(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    let repository = tempfile::TempDir::new().expect("temporary repository should exist");
+    let mut command = Command::new(cargo_bin!("ag-harness"));
+
+    // Act
+    let output = command
+        .args([
+            "run",
+            "muse-test",
+            "Create an empty t.py file",
+            "--base-url",
+            &server.uri(),
+            "--read-dir",
+            &repository.path().to_string_lossy(),
+            "--allow-write",
+        ])
+        .env("MODEL_API_KEY", "test-key")
+        .output()
+        .expect("CLI write-tool round trip should run");
+
+    // Assert
+    assert!(
+        output.status.success(),
+        "CLI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read(repository.path().join("t.py")).expect("empty file should be created"),
+        [] as [u8; 0]
+    );
+    let stdout = String::from_utf8(output.stdout).expect("output should be UTF-8");
+    assert!(stdout.contains("assistant> Created t.py.\n---\n"));
+    assert!(stdout.contains("tools:\n  write t.py (0 bytes;"));
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn redirected_output_with_terminal_stdin_is_one_shot() {
+    // Arrange
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(body_json(json!({
+            "messages": [
+                {"content": READ_ONLY_SYSTEM_PROMPT, "role": "system"},
+                {"content": "Hello", "role": "user"}
+            ],
+            "model": "muse-test",
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "ag_harness_output",
+                    "schema": chat_schema()
+                }
+            },
+            "tools": [read_tool()]
+        })))
+        .respond_with(response("one-shot answer", 4, 2))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let temp_dir = tempfile::TempDir::new().expect("temporary directory should be created");
+    let output_path = temp_dir.path().join("stdout.txt");
+    let command = r#"exec "$AG_HARNESS_BIN" run muse-test Hello --base-url "$MODEL_BASE_URL" > "$MODEL_OUTPUT_PATH""#;
+    let mut session = PtySessionBuilder::new("/bin/sh")
+        .args(["-c", command])
+        .env(
+            "AG_HARNESS_BIN",
+            cargo_bin!("ag-harness").to_string_lossy().into_owned(),
+        )
+        .env("MODEL_API_KEY", "test-key")
+        .env("MODEL_BASE_URL", server.uri())
+        .env(
+            "MODEL_OUTPUT_PATH",
+            output_path.to_string_lossy().into_owned(),
+        )
+        .spawn()
+        .expect("PTY command should start");
+
+    // Act
+    let succeeded = session
+        .wait_for_exit(Duration::from_secs(10))
+        .expect("one-shot command should exit without terminal EOF");
+
+    // Assert
+    assert!(succeeded);
+    let stdout = fs::read_to_string(output_path).expect("redirected output should be readable");
+    assert!(stdout.starts_with("assistant> one-shot answer\n---\n"));
+    assert!(!stdout.contains("Chat with"));
+    assert!(!stdout.contains(">>>"));
+}
+
+#[cfg(unix)]
+#[test]
+fn redirected_output_with_blank_prompt_exits_with_an_error() {
+    // Arrange
+    let temp_dir = tempfile::TempDir::new().expect("temporary directory should be created");
+    let output_path = temp_dir.path().join("stdout.txt");
+    let error_path = temp_dir.path().join("stderr.txt");
+    let command = r#"exec "$AG_HARNESS_BIN" run muse-test "   " > "$MODEL_OUTPUT_PATH" 2> "$MODEL_ERROR_PATH""#;
+    let mut session = PtySessionBuilder::new("/bin/sh")
+        .args(["-c", command])
+        .env(
+            "AG_HARNESS_BIN",
+            cargo_bin!("ag-harness").to_string_lossy().into_owned(),
+        )
+        .env(
+            "MODEL_OUTPUT_PATH",
+            output_path.to_string_lossy().into_owned(),
+        )
+        .env(
+            "MODEL_ERROR_PATH",
+            error_path.to_string_lossy().into_owned(),
+        )
+        .spawn()
+        .expect("PTY command should start");
+
+    // Act
+    let succeeded = session
+        .wait_for_exit(Duration::from_secs(5))
+        .expect("blank one-shot prompt should exit without terminal input");
+
+    // Assert
+    assert!(!succeeded);
+    assert_eq!(
+        fs::read(output_path).expect("redirected output should be readable"),
+        [] as [u8; 0]
+    );
+    let stderr = fs::read_to_string(error_path).expect("redirected error should be readable");
+    assert!(stderr.contains("prompt must contain a non-whitespace character"));
+}
+
+#[test]
+fn missing_api_key_fails_without_model_output() {
+    // Arrange
+    let mut command = Command::new(cargo_bin!("ag-harness"));
+
+    // Act
+    let output = command
+        .args(["run", "muse-test"])
+        .env_remove("MODEL_API_KEY")
+        .output()
+        .expect("CLI failure should run");
+
+    // Assert
+    assert!(!output.status.success());
+    assert_eq!(output.stdout, [] as [u8; 0]);
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("error should be UTF-8"),
+        "MODEL_API_KEY is unavailable\n"
+    );
+}

--- a/crates/ag-harness/tests/telemetry.rs
+++ b/crates/ag-harness/tests/telemetry.rs
@@ -910,9 +910,20 @@ fn assert_agent_metric_contract(
         inference_calls.data_points[0].sum,
         Some(f64::from(expected_model_calls))
     );
+    let two_call_turns = expected_model_calls - expected_turns;
     assert_eq!(
         inference_calls.data_points[0].bucket_counts,
-        [u64::from(expected_turns - 1), 1, 0, 0, 0, 0, 0, 0, 0,]
+        [
+            u64::from(expected_turns - two_call_turns),
+            u64::from(two_call_turns),
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
     );
 
     let tool_calls = assert_metric_definition(
@@ -1076,9 +1087,10 @@ fn expected_initial_trace_signatures() -> BTreeSet<TurnTraceSignature<'static>> 
         TurnTraceSignature {
             children: vec![
                 expected_model_child(None, Some("tool_calls"), Some("response-6")),
+                expected_model_child(None, Some("stop"), Some("response-7")),
                 expected_tool_child(Some("tool_execution_error"), None),
             ],
-            error_type: Some("tool_execution_error"),
+            error_type: None,
         },
         TurnTraceSignature {
             children: vec![expected_model_child(Some("cancelled"), None, None)],
@@ -1588,16 +1600,21 @@ fn lifecycle_responses() -> Vec<ResponseTemplate> {
         lifecycle_response(
             "response-7",
             "stop",
+            &json!({"content": r#"{"summary":"recovered-response"}"#}),
+        ),
+        lifecycle_response(
+            "response-8",
+            "stop",
             &json!({"content": r#"{"summary":"cancelled-response"}"#}),
         )
         .set_delay(Duration::from_secs(10)),
         lifecycle_response(
-            "response-8",
+            "response-9",
             "stop",
             &json!({"content": r#"{"summary":"shutdown-response"}"#}),
         ),
         lifecycle_response(
-            "response-9",
+            "response-10",
             "stop",
             &json!({"content": r#"{"summary":"post-shutdown-response"}"#}),
         ),
@@ -1631,11 +1648,11 @@ async fn mount_lifecycle_responses(server: &MockServer, pending_started: Arc<Not
         .and(path("/chat/completions"))
         .respond_with(SequenceResponder {
             next_response: Arc::new(AtomicUsize::new(0)),
-            pending_response: 6,
+            pending_response: 7,
             pending_started,
             responses: lifecycle_responses().into(),
         })
-        .expect(9)
+        .expect(10)
         .mount(server)
         .await;
 }
@@ -1680,10 +1697,11 @@ async fn exercise_lifecycle_outcomes(harness: &Arc<Harness>, pending_started: &N
         .expect_err("denied tool should fail the turn");
     assert_eq!(denial.to_string(), "tool `write` is denied by policy");
 
-    harness
+    let recovered = harness
         .run("failed tool", lifecycle_schema())
         .await
-        .expect_err("missing file should fail the tool");
+        .expect("the model should recover from the rejected read path");
+    assert_eq!(recovered, json!({"summary": "recovered-response"}));
 
     let harness = Arc::clone(harness);
     let mut cancelled_turn = tokio::spawn(async move {
@@ -1710,7 +1728,7 @@ fn signal_requests(requests: &[OtlpRequest]) -> (Vec<&OtlpRequest>, Vec<&OtlpReq
 }
 
 fn assert_initial_lifecycle_metrics(request: &OtlpRequest) {
-    assert_lifecycle_metric_request(request, 7, 5, 6);
+    assert_lifecycle_metric_request(request, 8, 6, 6);
     let OtlpPayload::Metrics(payload) = &request.payload else {
         unreachable!("initial lifecycle metrics should be present");
     };
@@ -1722,7 +1740,7 @@ fn assert_initial_lifecycle_metrics(request: &OtlpRequest) {
     assert_eq!(
         point_error_counts(proto_histogram(metrics["gen_ai.client.operation.duration"])),
         [
-            (None, 4),
+            (None, 5),
             (Some("503"), 1),
             (Some("cancelled"), 1),
             (Some("invalid_output"), 1),
@@ -1733,12 +1751,11 @@ fn assert_initial_lifecycle_metrics(request: &OtlpRequest) {
     assert_eq!(
         point_error_counts(proto_histogram(metrics["gen_ai.invoke_agent.duration"])),
         [
-            (None, 1),
+            (None, 2),
             (Some("cancelled"), 1),
             (Some("invalid_output"), 1),
             (Some("tool_denied"), 1),
             (Some("provider_error"), 1),
-            (Some("tool_execution_error"), 1),
         ]
         .into_iter()
         .collect()
@@ -1746,8 +1763,8 @@ fn assert_initial_lifecycle_metrics(request: &OtlpRequest) {
 }
 
 fn assert_initial_lifecycle_traces(request: &OtlpRequest) {
-    let spans = assert_lifecycle_trace_request(request, 6, 7);
-    assert_eq!(spans.len(), 15);
+    let spans = assert_lifecycle_trace_request(request, 6, 8);
+    assert_eq!(spans.len(), 16);
     assert_eq!(
         turn_trace_signatures(&spans),
         expected_initial_trace_signatures()
@@ -1760,12 +1777,11 @@ fn assert_initial_lifecycle_traces(request: &OtlpRequest) {
                 .filter(|span| span.name == "invoke_agent")
         ),
         [
-            (None, 1),
+            (None, 2),
             (Some("cancelled"), 1),
             (Some("invalid_output"), 1),
             (Some("tool_denied"), 1),
             (Some("provider_error"), 1),
-            (Some("tool_execution_error"), 1),
         ]
         .into_iter()
         .collect()
@@ -1778,7 +1794,7 @@ fn assert_initial_lifecycle_traces(request: &OtlpRequest) {
                 .filter(|span| span.name == format!("chat {OTLP_MODEL}"))
         ),
         [
-            (None, 4),
+            (None, 5),
             (Some("503"), 1),
             (Some("cancelled"), 1),
             (Some("invalid_output"), 1),
@@ -1945,7 +1961,7 @@ async fn run_otlp_lifecycle_contract_fixture() {
     let (metric_requests, trace_requests) = signal_requests(&shutdown_requests);
     assert_eq!(metric_requests.len(), 2);
     assert_eq!(trace_requests.len(), 2);
-    assert_lifecycle_metric_request(metric_requests[1], 8, 6, 7);
+    assert_lifecycle_metric_request(metric_requests[1], 9, 7, 7);
     let shutdown_spans = assert_lifecycle_trace_request(trace_requests[1], 1, 1);
     assert_eq!(shutdown_spans.len(), 2);
     for request in &shutdown_requests {

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -1195,7 +1195,6 @@ mod tests {
 
     use crossterm::event::KeyModifiers;
     use mockall::predicate::eq;
-    use tempfile::tempdir;
     use tracing::instrument::WithSubscriber;
 
     use super::*;
@@ -1245,6 +1244,27 @@ mod tests {
                 return;
             }
         }
+    }
+
+    /// Applies a deterministic completion for the one pending session-diff
+    /// request.
+    async fn apply_pending_session_diff(
+        app: &mut App,
+        session_id: &SessionId,
+        result: Result<&str, &str>,
+    ) {
+        let request_id = app
+            .pending_session_diff_requests
+            .keys()
+            .copied()
+            .next()
+            .expect("session diff request should be pending");
+        app.apply_app_events(AppEvent::SessionDiffLoaded {
+            request_id,
+            result: result.map(str::to_string).map_err(str::to_string),
+            session_id: session_id.clone(),
+        })
+        .await;
     }
 
     /// Builds one git-backed test app with one created session and an
@@ -2102,7 +2122,7 @@ mod tests {
 
         // Act
         open_review_output_mode(&mut app, &view_context);
-        apply_next_session_diff(&mut app).await;
+        apply_pending_session_diff(&mut app, &view_context.session_id, Ok("")).await;
 
         // Assert
         let (review_status_message, review_text) = app.review_view_state(&view_context.session_id);
@@ -2139,9 +2159,6 @@ mod tests {
     async fn test_show_diff_for_view_session_switches_mode_to_diff() {
         // Arrange
         let (mut app, _base_dir, session_id) = new_test_app_with_session().await;
-        let session_folder = app.sessions.sessions()[0].folder.clone();
-        std::fs::write(session_folder.join("README.md"), "updated content")
-            .expect("failed to write diff fixture");
         let context = ViewContext {
             scroll_offset: Some(0),
             session_id: session_id.clone().into(),
@@ -2151,7 +2168,12 @@ mod tests {
         // Act
         let opened = show_diff_for_view_session(&mut app, &context);
         let loading = matches!(app.mode, AppMode::DiffLoading { .. });
-        apply_next_session_diff(&mut app).await;
+        apply_pending_session_diff(
+            &mut app,
+            &context.session_id,
+            Ok("diff --git a/README.md b/README.md\n+updated content\n"),
+        )
+        .await;
 
         // Assert
         assert!(opened);
@@ -2183,7 +2205,7 @@ mod tests {
         // Act
         let opened = show_diff_for_view_session(&mut app, &context);
         let loading = matches!(app.mode, AppMode::DiffLoading { .. });
-        apply_next_session_diff(&mut app).await;
+        apply_pending_session_diff(&mut app, &context.session_id, Ok("")).await;
 
         // Assert
         assert!(opened);
@@ -2202,8 +2224,6 @@ mod tests {
     async fn test_show_diff_for_view_session_restores_view_after_git_error() {
         // Arrange
         let (mut app, _base_dir, session_id) = new_test_app_with_session().await;
-        let non_git_dir = tempdir().expect("failed to create non-git dir");
-        app.sessions.sessions_mut()[0].folder = non_git_dir.path().to_path_buf();
         app.mode = AppMode::View {
             session_id: session_id.clone().into(),
             scroll_offset: Some(0),
@@ -2216,7 +2236,12 @@ mod tests {
 
         // Act
         let opened = show_diff_for_view_session(&mut app, &context);
-        apply_next_session_diff(&mut app).await;
+        apply_pending_session_diff(
+            &mut app,
+            &context.session_id,
+            Err("Failed to run git diff: repository unavailable"),
+        )
+        .await;
 
         // Assert
         assert!(opened);

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -71,11 +71,14 @@ module. API-family clients remain separate so multiple providers can reuse a wir
 protocol without sharing provider policy.
 
 Qwen, Kimi, and Muse share Chat Completions request execution and bounded response
-decoding. Qwen and Kimi request JSON Object output and include the requested
-`OutputSchema` in the system instruction. Muse uses Meta Model API's native JSON Schema
-response format instead. Every provider retains shared local schema validation before
-returning a successful response. Schemas without an explicit object root and unsupported
-configurations fail explicitly rather than falling back to unstructured output.
+decoding. Qwen and Kimi include the requested `OutputSchema` in the system instruction;
+they request JSON Object output when no tools are active and omit that provider mode
+during native tool calls. Muse uses Meta Model API's native JSON Schema response format
+instead. Every provider retains shared local schema validation before returning a
+successful response. Schemas without an explicit object root and unsupported
+configurations fail explicitly rather than falling back to unstructured output. The
+shared transport retries one failed send and up to two rate-limited requests, with
+provider retry delays capped at five seconds.
 
 Muse intentionally omits Meta's optional `strict` flag, whose documented default is
 `false`. That keeps standard JSON Schema available while Meta enforces service limits,
@@ -92,8 +95,12 @@ The current tool foundation includes:
 - Shared, typed `read` and `write` calls across Qwen, Kimi, and Muse.
 - Explicit repository roots and deny-by-default permissions through `Harness::allow()`.
 - Bounded tool execution and continuation to schema-validated terminal output.
+- Model-correctable read and write rejections returned through the tool loop.
 - Descriptor-relative file access without symlink traversal.
 - One-file unified-diff writes with stale-safe atomic replacement and typed failures.
+
+The `ag-harness` CLI starts an in-memory chat with Muse, Kimi, or Qwen. Reads are scoped
+to `--read-dir`; writes require `--allow-write`.
 
 ## Session management
 
@@ -342,6 +349,8 @@ best cost and performance:
   and checkpoint policy, retention, corruption recovery, and compatibility behavior.
 - [ ] **Persisted session round trip.** Run sequential turns in one resumable session,
   and persist model and tool history.
+- [x] **In-memory chat round trip.** Run sequential turns with user, assistant, and tool
+  history, plus sanitized per-turn activity reports.
 - [x] **Second provider.** Integrate Kimi through the structured-output contract.
 
 ## Roadmap


### PR DESCRIPTION
- Routes `run <model> [prompt]` through Muse-compatible model calls and retains successful conversation history in memory.
- Reports provider usage, timing, and sanitized repository activity while keeping file contents and reasoning out of summaries.
- Validates a fixed `message` object schema, supports `--base-url` with Meta endpoint defaults, and documents usage through command help.
- Bounds retained history by payload budget and lets interactive chats recover from failed turns.
- Removes terminal control sequences from summaries and authorizes reads only through `--read-dir`.
- Enables bounded repository reads from the current directory in addition to `--read-dir`.
- Frames assistant output, reports response types, enforces single-line CLI metadata, and prevents model text from spoofing CLI metadata.
- Rejects non-whitespace positional prompts.
- Adds Kimi and Qwen provider support with configurable API endpoints and concise provider-selection help.
- Adds deterministic session-view diff-result tests that avoid coverage-load Git timeouts.
- Exposes `Harness::chat()` and `run_report()` with bounded conversation history, per-request and tool activity reports, and sanitized metadata.
- Adds `ag-harness run` for Muse, Kimi, and Qwen with read-only repository access by default and explicit write opt-in.
- Keeps provider requests resilient with tool-aware response formats, model-correctable path errors, and bounded transport and rate-limit retries.
- Keeps architecture documentation concise and focused on durable boundaries.
- Restores the full architecture document.
- Reports recoverable tool failures in lifecycle telemetry.