### PR TITLE
Release 0.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,38 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.15.5] - 2026-08-22
+
+### Added
+
+- ag-harness: expose lifecycle observer fan-out and GenAI metrics for agent duration,
+  model and tool calls, executed-tool duration, and stable turn outcomes.
+
 ### Changed
 
+- agentty: show the active agent, model, reasoning level, and speed mode while focused
+  reviews are loading.
+- agentty: align changed-line focus with the selected file explorer row and review
+  comment sidebar.
 - ag-agent: require Antigravity CLI 1.1.18 and retain native long-context sessions
   through its persistent NDJSON transport.
+- ag-harness: standardize GenAI telemetry metadata against the pinned OpenTelemetry
+  semantic convention revision.
+- release: bump workspace crate metadata and lockfile package versions to `0.15.5`.
 
 ### Fixed
 
 - ag-agent: normalize Antigravity's string-valued summary fallback before strict
   protocol parsing instead of failing the turn in native schema validation.
+- ag-agent: preserve sandboxed plan mode for read-only Gemini sessions while keeping
+  utility prompts on standard ACP startup.
+- ag-harness: harden unified-diff validation, nested response parsing, request
+  preparation, and orchestration cancellation.
+
+### Contributors
+
+- @andagaev
+- @minev-dev
 
 ## [v0.15.4] - 2026-08-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "image",
  "mockall",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "mockall",
  "serde",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "mockall",
  "rustix",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "ag-harness"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "async-trait",
  "jsonschema",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "askama",
  "schemars 1.2.2",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "ag-session"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "ag-agent",
  "ag-forge",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ag-store"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "ag-agent",
  "ag-session",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "clap",
  "tempfile",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "base64 0.23.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.15.4"
+version = "0.15.5"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -16,15 +16,15 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.15.4" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.15.4" }
-ag-forge = { path = "crates/ag-forge", version = "0.15.4" }
-ag-git = { path = "crates/ag-git", version = "0.15.4" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.15.4" }
-ag-session = { path = "crates/ag-session", version = "0.15.4" }
-ag-store = { path = "crates/ag-store", version = "0.15.4" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.15.4" }
-testty = { path = "crates/testty", version = "0.15.4" }
+ag-agent = { path = "crates/ag-agent", version = "0.15.5" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.15.5" }
+ag-forge = { path = "crates/ag-forge", version = "0.15.5" }
+ag-git = { path = "crates/ag-git", version = "0.15.5" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.15.5" }
+ag-session = { path = "crates/ag-session", version = "0.15.5" }
+ag-store = { path = "crates/ag-store", version = "0.15.5" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.15.5" }
+testty = { path = "crates/testty", version = "0.15.5" }
 async-trait = "0.1"
 agent-client-protocol = "2.0.0"
 assert_cmd = "2"


### PR DESCRIPTION
- Record the 0.15.5 changelog and contributor entries.
- Bump workspace crate metadata and lockfile package versions to 0.15.5.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)