### PR TITLE
Projects lifecycle events into OpenTelemetry GenAI spans

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,10 @@ mockall = "0.15"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", default-features = false }
 objc2-foundation = { version = "0.3", default-features = false }
-opentelemetry = { version = "0.32", default-features = false, features = ["metrics"] }
-opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "metrics", "reqwest-blocking-client"] }
+opentelemetry = { version = "0.32", default-features = false, features = ["metrics", "trace"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "metrics", "reqwest-blocking-client", "trace"] }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic-messages", "metrics", "trace"] }
-opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["metrics", "trace"] }
 percent-encoding = "2"
 portable-pty = "0.9"
 prost = "0.14"

--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -29,11 +29,26 @@ project standard agent and client-side tool metrics. Use `LifecycleObserverSet` 
 the same stream to multiple observers, such as metrics, traces, and a host-owned
 journal.
 
+`LifecycleTraceObserver` projects that stream to OpenTelemetry GenAI spans. Install a
+tracer provider in the application before starting an operation, then attach the
+observer to a client or harness:
+
+```rust
+use ag_harness::LifecycleTraceObserver;
+
+let harness = Harness::new(model)
+    .with_lifecycle_observer(LifecycleTraceObserver::new());
+```
+
 ## Telemetry
 
 When the application installs an OpenTelemetry meter provider, `ModelClient` records
 request duration and provider-reported input and output tokens. `LifecycleMetrics`
 projects end-to-end harness-turn duration, per-turn model and tool call counts, and
-executed-tool duration. Missing usage is not estimated, sensitive content is excluded,
-and the application owns export and shutdown. The emitted instruments follow the pinned
-OpenTelemetry GenAI semantic-convention contract documented in the architecture guide.
+executed-tool duration. The trace observer emits correlated `invoke_agent`,
+`chat {model}`, and `execute_tool {tool}` spans. It propagates each model and tool
+context while the corresponding asynchronous operation is polled, so provider,
+HTTP-client, and tool instrumentation becomes a child of the projected span. Missing
+usage is not estimated, sensitive content is excluded, and the application owns export
+and shutdown. The emitted signals follow the pinned OpenTelemetry GenAI
+semantic-convention contract documented in the architecture guide.

--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -187,16 +187,17 @@ impl Harness {
     ) -> Result<ModelResponse, TurnError> {
         let model_lifecycle =
             self.lifecycle
-                .start_model_request(None, model_request_index, turn_id);
-        let (response, completion) = match self
-            .model
-            .complete_with_optional_metadata(request.clone())
-            .await
-        {
+                .start_model_request(self.model.metadata(), model_request_index, turn_id);
+        let operation = self.model.complete_with_optional_metadata(request.clone());
+        let completion = match model_lifecycle.as_ref() {
+            Some(model_lifecycle) => model_lifecycle.scope(operation).await,
+            None => operation.await,
+        };
+        let (response, completion) = match completion {
             Ok(completion) => completion,
             Err(error) => {
                 if let Some(model_lifecycle) = model_lifecycle {
-                    model_lifecycle.failed(error.error_type());
+                    model_lifecycle.failed(error.error_type(), error.http_status());
                 }
 
                 return Err(error.into());
@@ -217,9 +218,9 @@ impl Harness {
         completed_tool_calls: usize,
         turn_id: Option<LifecycleId>,
     ) -> Result<String, TurnError> {
-        let mut tool_lifecycle = self
-            .lifecycle
-            .request_tool(call.name().to_string(), turn_id);
+        let mut tool_lifecycle =
+            self.lifecycle
+                .request_tool(call.id().to_string(), call.name().to_string(), turn_id);
         let execution = match call.arguments() {
             ToolCallArguments::Read(arguments) => {
                 read_tool.map(|tool| ToolExecution::Read(tool, arguments))
@@ -249,7 +250,12 @@ impl Harness {
         if let Some(tool_lifecycle) = tool_lifecycle.as_mut() {
             tool_lifecycle.started();
         }
-        match execute_tool(execution).await {
+        let operation = execute_tool(execution);
+        let result = match tool_lifecycle.as_ref() {
+            Some(tool_lifecycle) => tool_lifecycle.scope(operation).await,
+            None => operation.await,
+        };
+        match result {
             Ok(result) => {
                 if let Some(tool_lifecycle) = tool_lifecycle {
                     tool_lifecycle.completed();
@@ -348,7 +354,14 @@ mod tests {
 
     use super::*;
     use crate::file_system::MockFileSystem;
-    use crate::model::{MockModel, ModelMessage};
+    use crate::model::ModelMessage;
+
+    fn model() -> crate::model::MockModel {
+        let mut model = crate::model::MockModel::new();
+        model.expect_metadata().return_const(None);
+
+        model
+    }
 
     fn object_schema() -> OutputSchema {
         OutputSchema::new(json!({
@@ -462,10 +475,13 @@ mod tests {
         assert!(matches!(
             events[3].kind(),
             crate::LifecycleEventKind::ToolRequested {
+                provider_call_id,
                 tool_name,
                 turn_id: event_turn_id,
                 ..
-            } if tool_name == "read" && *event_turn_id == turn_id
+            } if provider_call_id == "provider-call-id"
+                && tool_name == "read"
+                && *event_turn_id == turn_id
         ));
         assert!(matches!(
             events[4].kind(),
@@ -514,7 +530,7 @@ mod tests {
     #[tokio::test]
     async fn completes_read_tool_round_trip() {
         // Arrange
-        let mut model = MockModel::new();
+        let mut model = model();
         let call_count = Arc::new(AtomicUsize::new(0));
         model
             .expect_complete_with_optional_metadata()
@@ -572,7 +588,7 @@ mod tests {
     #[tokio::test]
     async fn emits_correlated_lifecycle_for_read_tool_round_trip() {
         // Arrange
-        let mut model = MockModel::new();
+        let mut model = model();
         let call_count = Arc::new(AtomicUsize::new(0));
         model
             .expect_complete_with_optional_metadata()
@@ -624,14 +640,13 @@ mod tests {
         assert_read_tool_lifecycle(&events);
         let event_debug = format!("{events:?}");
         assert!(!event_debug.contains("sensitive prompt"));
-        assert!(!event_debug.contains("provider-call-id"));
         assert!(!event_debug.contains("[workspace]"));
     }
 
     #[tokio::test]
     async fn requires_repository_when_read_is_allowed() {
         // Arrange
-        let mut model = MockModel::new();
+        let mut model = model();
         model.expect_complete_with_optional_metadata().times(0);
         let harness = Harness::new(model)
             .allow(Tool::Read)
@@ -652,7 +667,7 @@ mod tests {
     async fn completes_write_tool_round_trip() {
         // Arrange
         let patch = "--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
-        let mut model = MockModel::new();
+        let mut model = model();
         let call_count = Arc::new(AtomicUsize::new(0));
         model
             .expect_complete_with_optional_metadata()
@@ -722,7 +737,7 @@ mod tests {
     #[tokio::test]
     async fn returns_correctable_write_rejection_to_model() {
         // Arrange
-        let mut model = MockModel::new();
+        let mut model = model();
         let call_count = Arc::new(AtomicUsize::new(0));
         model
             .expect_complete_with_optional_metadata()
@@ -772,7 +787,7 @@ mod tests {
     #[tokio::test]
     async fn returns_terminal_write_boundary_failure() {
         // Arrange
-        let mut model = MockModel::new();
+        let mut model = model();
         model
             .expect_complete_with_optional_metadata()
             .times(1)
@@ -811,7 +826,7 @@ mod tests {
     #[tokio::test]
     async fn rejects_write_call_when_policy_denies_write() {
         // Arrange
-        let mut model = MockModel::new();
+        let mut model = model();
         model
             .expect_complete_with_optional_metadata()
             .times(1)
@@ -849,7 +864,7 @@ mod tests {
     #[tokio::test]
     async fn rejects_tool_call_when_policy_denies_read() {
         // Arrange
-        let mut model = MockModel::new();
+        let mut model = model();
         model
             .expect_complete_with_optional_metadata()
             .times(1)
@@ -885,7 +900,7 @@ mod tests {
     #[tokio::test]
     async fn enforces_tool_call_limit() {
         // Arrange
-        let mut model = MockModel::new();
+        let mut model = model();
         model
             .expect_complete_with_optional_metadata()
             .times(2)
@@ -915,7 +930,7 @@ mod tests {
     #[tokio::test]
     async fn returns_typed_read_failure() {
         // Arrange
-        let mut model = MockModel::new();
+        let mut model = model();
         model
             .expect_complete_with_optional_metadata()
             .times(1)
@@ -952,7 +967,7 @@ mod tests {
     #[tokio::test]
     async fn returns_typed_model_failure() {
         // Arrange
-        let mut model = MockModel::new();
+        let mut model = model();
         model
             .expect_complete_with_optional_metadata()
             .times(1)

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -16,13 +16,14 @@ mod read;
 mod schema_contract;
 mod telemetry;
 mod tool;
+mod trace;
 mod write;
 
 pub use file_system::{FileSystem, LocalFileSystem};
 pub use harness::{Harness, TurnError};
 pub use lifecycle::{
     LifecycleEvent, LifecycleEventKind, LifecycleId, LifecycleObserver, LifecycleObserverSet,
-    ModelResponseType, ToolErrorType, TurnErrorType,
+    LifecycleOperationGuard, ModelResponseType, ToolErrorType, TurnErrorType,
 };
 pub use model::{
     CompletionMetadata, CompletionUsage, Model, ModelClient, ModelCompletion, ModelError,
@@ -36,4 +37,5 @@ pub use read::{ReadError, ReadOutput};
 pub use schema_contract::{OutputSchema, OutputSchemaError};
 pub use telemetry::LifecycleMetrics;
 pub use tool::{ReadArguments, Tool, ToolCall, ToolCallArguments, ToolDefinition, WriteArguments};
+pub use trace::LifecycleTraceObserver;
 pub use write::{WriteError, WriteOutput};

--- a/crates/ag-harness/src/lifecycle.rs
+++ b/crates/ag-harness/src/lifecycle.rs
@@ -1,7 +1,10 @@
 use std::collections::VecDeque;
+use std::future::Future;
 use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, PoisonError};
+use std::task::{Context as TaskContext, Poll};
 use std::thread::{self, ThreadId};
 use std::time::{Duration, Instant};
 
@@ -92,6 +95,8 @@ pub enum LifecycleEventKind {
         duration: Duration,
         /// Stable failure classification.
         error_type: ModelErrorType,
+        /// Provider HTTP status used as `error.type`, when available.
+        http_status: Option<u16>,
         /// Identifier shared by this request's lifecycle events.
         model_call_id: LifecycleId,
         /// Owning turn, or `None` for a standalone model request.
@@ -108,6 +113,8 @@ pub enum LifecycleEventKind {
     },
     /// The model requested one tool operation.
     ToolRequested {
+        /// Provider-assigned identifier for this tool call.
+        provider_call_id: String,
         /// Identifier shared by this tool operation's lifecycle events.
         tool_call_id: LifecycleId,
         /// Bounded built-in tool name.
@@ -225,7 +232,20 @@ impl ToolErrorType {
 pub trait LifecycleObserver: Send + Sync {
     /// Receives one event before the operation continues.
     fn observe(&self, event: LifecycleEvent);
+
+    /// Enters ambient state for one poll of the identified operation.
+    #[doc(hidden)]
+    fn enter_operation(
+        &self,
+        _operation_id: LifecycleId,
+    ) -> Option<Box<dyn LifecycleOperationGuard>> {
+        None
+    }
 }
+
+/// Guard for ambient state installed while an operation future is polled.
+#[doc(hidden)]
+pub trait LifecycleOperationGuard {}
 
 impl<Observe> LifecycleObserver for Observe
 where
@@ -305,6 +325,60 @@ impl LifecycleObserver for LifecycleObserverSet {
             event = next_event;
         }
     }
+
+    fn enter_operation(
+        &self,
+        operation_id: LifecycleId,
+    ) -> Option<Box<dyn LifecycleOperationGuard>> {
+        let guards = self
+            .observers
+            .iter()
+            .filter_map(|observer| {
+                catch_unwind(AssertUnwindSafe(|| observer.enter_operation(operation_id)))
+                    .ok()
+                    .flatten()
+            })
+            .collect::<Vec<_>>();
+        (!guards.is_empty()).then(|| {
+            Box::new(LifecycleOperationGuardSet { guards }) as Box<dyn LifecycleOperationGuard>
+        })
+    }
+}
+
+struct LifecycleOperationGuardSet {
+    guards: Vec<Box<dyn LifecycleOperationGuard>>,
+}
+
+impl LifecycleOperationGuard for LifecycleOperationGuardSet {}
+
+impl Drop for LifecycleOperationGuardSet {
+    fn drop(&mut self) {
+        while let Some(guard) = self.guards.pop() {
+            drop_operation_guard(guard);
+        }
+    }
+}
+
+struct IsolatedLifecycleOperationGuard {
+    guard: Option<Box<dyn LifecycleOperationGuard>>,
+}
+
+impl IsolatedLifecycleOperationGuard {
+    fn new(guard: Option<Box<dyn LifecycleOperationGuard>>) -> Self {
+        Self { guard }
+    }
+}
+
+impl Drop for IsolatedLifecycleOperationGuard {
+    fn drop(&mut self) {
+        if let Some(guard) = self.guard.take() {
+            drop_operation_guard(guard);
+        }
+    }
+}
+
+fn drop_operation_guard(guard: Box<dyn LifecycleOperationGuard>) {
+    let _ = catch_unwind(AssertUnwindSafe(|| drop(guard)));
 }
 
 #[derive(Default)]
@@ -370,12 +444,14 @@ impl LifecycleEmitter {
 
     pub(crate) fn request_tool(
         &self,
+        provider_call_id: String,
         tool_name: String,
         turn_id: Option<LifecycleId>,
     ) -> Option<ToolLifecycle> {
         let turn_id = turn_id?;
         let tool_call_id = self.next_id()?;
         self.emit(LifecycleEventKind::ToolRequested {
+            provider_call_id,
             tool_call_id,
             tool_name,
             turn_id,
@@ -407,6 +483,44 @@ impl LifecycleEmitter {
         };
 
         let _ = catch_unwind(AssertUnwindSafe(|| state.observer.observe(event)));
+    }
+
+    fn scope<F>(&self, operation_id: LifecycleId, future: F) -> LifecycleOperation<F>
+    where
+        F: Future,
+    {
+        LifecycleOperation {
+            future: Box::pin(future),
+            observer: self.state.as_ref().map(|state| Arc::clone(&state.observer)),
+            operation_id,
+        }
+    }
+}
+
+struct LifecycleOperation<F> {
+    future: Pin<Box<F>>,
+    observer: Option<Arc<dyn LifecycleObserver>>,
+    operation_id: LifecycleId,
+}
+
+impl<F> Future for LifecycleOperation<F>
+where
+    F: Future,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, task_context: &mut TaskContext<'_>) -> Poll<Self::Output> {
+        let operation = self.get_mut();
+        let guard = operation.observer.as_ref().and_then(|observer| {
+            catch_unwind(AssertUnwindSafe(|| {
+                observer.enter_operation(operation.operation_id)
+            }))
+            .ok()
+            .flatten()
+        });
+        let _guard = IsolatedLifecycleOperationGuard::new(guard);
+
+        operation.future.as_mut().poll(task_context)
     }
 }
 
@@ -533,6 +647,13 @@ pub(crate) struct ModelRequestLifecycle {
 }
 
 impl ModelRequestLifecycle {
+    pub(crate) fn scope<F>(&self, future: F) -> impl Future<Output = F::Output>
+    where
+        F: Future,
+    {
+        self.emitter.scope(self.model_call_id, future)
+    }
+
     pub(crate) fn completed(
         mut self,
         completion: Option<CompletionMetadata>,
@@ -549,11 +670,12 @@ impl ModelRequestLifecycle {
             });
     }
 
-    pub(crate) fn failed(mut self, error_type: ModelErrorType) {
+    pub(crate) fn failed(mut self, error_type: ModelErrorType, http_status: Option<u16>) {
         self.active = false;
         self.emitter.emit(LifecycleEventKind::ModelRequestFailed {
             duration: self.started_at.elapsed(),
             error_type,
+            http_status,
             model_call_id: self.model_call_id,
             turn_id: self.turn_id,
         });
@@ -582,6 +704,13 @@ pub(crate) struct ToolLifecycle {
 }
 
 impl ToolLifecycle {
+    pub(crate) fn scope<F>(&self, future: F) -> impl Future<Output = F::Output>
+    where
+        F: Future,
+    {
+        self.emitter.scope(self.tool_call_id, future)
+    }
+
     pub(crate) fn started(&mut self) {
         self.emitter.emit(LifecycleEventKind::ToolStarted {
             tool_call_id: self.tool_call_id,
@@ -634,12 +763,50 @@ impl Drop for ToolLifecycle {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::sync::{Barrier, Mutex, mpsc};
 
     use super::*;
 
     fn completion_metadata() -> CompletionMetadata {
         CompletionMetadata::new("stop".to_string(), None, None, None, None)
+    }
+
+    fn emit_tool_terminal_events(emitter: &LifecycleEmitter, turn_id: LifecycleId) {
+        let mut completed_tool = emitter
+            .request_tool(
+                "provider-completed".to_string(),
+                "read".to_string(),
+                Some(turn_id),
+            )
+            .expect("tool should be observed");
+        completed_tool.started();
+        completed_tool.completed();
+        emitter
+            .request_tool(
+                "provider-denied".to_string(),
+                "read".to_string(),
+                Some(turn_id),
+            )
+            .expect("tool should be observed")
+            .denied();
+        emitter
+            .request_tool(
+                "provider-failed".to_string(),
+                "read".to_string(),
+                Some(turn_id),
+            )
+            .expect("tool should be observed")
+            .failed(ToolErrorType::CallLimit);
+        drop(
+            emitter
+                .request_tool(
+                    "provider-cancelled".to_string(),
+                    "read".to_string(),
+                    Some(turn_id),
+                )
+                .expect("tool should be observed"),
+        );
     }
 
     fn recording_emitter() -> (LifecycleEmitter, Arc<Mutex<Vec<LifecycleEvent>>>) {
@@ -653,6 +820,129 @@ mod tests {
         });
 
         (emitter, events)
+    }
+
+    struct CountingOperationGuard {
+        active_scopes: Arc<AtomicUsize>,
+        panics_on_drop: bool,
+    }
+
+    impl LifecycleOperationGuard for CountingOperationGuard {}
+
+    impl Drop for CountingOperationGuard {
+        fn drop(&mut self) {
+            self.active_scopes.fetch_sub(1, AtomicOrdering::SeqCst);
+            if self.panics_on_drop {
+                std::panic::resume_unwind(Box::new("operation guard drop failed"));
+            }
+        }
+    }
+
+    struct ScopeObserver {
+        active_scopes: Arc<AtomicUsize>,
+        panics_on_drop: bool,
+        panics_on_enter: bool,
+    }
+
+    impl LifecycleObserver for ScopeObserver {
+        fn observe(&self, _event: LifecycleEvent) {}
+
+        fn enter_operation(
+            &self,
+            _operation_id: LifecycleId,
+        ) -> Option<Box<dyn LifecycleOperationGuard>> {
+            if self.panics_on_enter {
+                std::panic::resume_unwind(Box::new("operation scope failed"));
+            }
+            self.active_scopes.fetch_add(1, AtomicOrdering::SeqCst);
+
+            Some(Box::new(CountingOperationGuard {
+                active_scopes: Arc::clone(&self.active_scopes),
+                panics_on_drop: self.panics_on_drop,
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn observer_set_composes_operation_scopes_and_isolates_all_panics() {
+        // Arrange
+        let active_scopes = Arc::new(AtomicUsize::new(0));
+        let observers = LifecycleObserverSet::new(ScopeObserver {
+            active_scopes: Arc::clone(&active_scopes),
+            panics_on_drop: false,
+            panics_on_enter: true,
+        })
+        .with_observer(ScopeObserver {
+            active_scopes: Arc::clone(&active_scopes),
+            panics_on_drop: false,
+            panics_on_enter: false,
+        })
+        .with_observer(ScopeObserver {
+            active_scopes: Arc::clone(&active_scopes),
+            panics_on_drop: true,
+            panics_on_enter: false,
+        });
+        let emitter = LifecycleEmitter::new(observers);
+        let request = emitter
+            .start_model_request(None, 0, None)
+            .expect("model request should be observed");
+
+        // Act
+        let active_during_operation = request
+            .scope(async {
+                tokio::task::yield_now().await;
+
+                active_scopes.load(AtomicOrdering::SeqCst)
+            })
+            .await;
+
+        // Assert
+        assert_eq!(active_during_operation, 2);
+        assert_eq!(active_scopes.load(AtomicOrdering::SeqCst), 0);
+        request.completed(None, ModelResponseType::Output);
+    }
+
+    #[tokio::test]
+    async fn direct_operation_scope_panic_does_not_change_control_flow() {
+        // Arrange
+        let active_scopes = Arc::new(AtomicUsize::new(0));
+        let emitter = LifecycleEmitter::new(ScopeObserver {
+            active_scopes,
+            panics_on_drop: false,
+            panics_on_enter: true,
+        });
+        let request = emitter
+            .start_model_request(None, 0, None)
+            .expect("model request should be observed");
+
+        // Act
+        let output = request.scope(async { 42 }).await;
+
+        // Assert
+        assert_eq!(output, 42);
+        request.completed(None, ModelResponseType::Output);
+    }
+
+    #[tokio::test]
+    async fn direct_operation_guard_drop_panic_does_not_change_control_flow() {
+        // Arrange
+        let active_scopes = Arc::new(AtomicUsize::new(0));
+        let emitter = LifecycleEmitter::new(ScopeObserver {
+            active_scopes: Arc::clone(&active_scopes),
+            panics_on_drop: true,
+            panics_on_enter: false,
+        });
+        let request = emitter
+            .start_model_request(None, 0, None)
+            .expect("model request should be observed");
+
+        // Act
+        let output = request.scope(async { 42 }).await;
+
+        // Assert
+        assert_eq!(output, 42);
+        assert_eq!(active_scopes.load(AtomicOrdering::SeqCst), 0);
+        request.completed(None, ModelResponseType::Output);
     }
 
     #[test]
@@ -757,30 +1047,13 @@ mod tests {
         emitter
             .start_model_request(None, 1, Some(turn_id))
             .expect("model request should be observed")
-            .failed(ModelErrorType::Provider);
+            .failed(ModelErrorType::Provider, Some(503));
         drop(
             emitter
                 .start_model_request(None, 2, Some(turn_id))
                 .expect("model request should be observed"),
         );
-        let mut completed_tool = emitter
-            .request_tool("read".to_string(), Some(turn_id))
-            .expect("tool should be observed");
-        completed_tool.started();
-        completed_tool.completed();
-        emitter
-            .request_tool("read".to_string(), Some(turn_id))
-            .expect("tool should be observed")
-            .denied();
-        emitter
-            .request_tool("read".to_string(), Some(turn_id))
-            .expect("tool should be observed")
-            .failed(ToolErrorType::CallLimit);
-        drop(
-            emitter
-                .request_tool("read".to_string(), Some(turn_id))
-                .expect("tool should be observed"),
-        );
+        emit_tool_terminal_events(&emitter, turn_id);
 
         // Assert
         let events = events
@@ -846,7 +1119,7 @@ mod tests {
         // Act
         let turn = emitter.start_turn();
         let model_request = emitter.start_model_request(None, 0, None);
-        let tool = emitter.request_tool("read".to_string(), None);
+        let tool = emitter.request_tool("provider-call".to_string(), "read".to_string(), None);
         emitter.emit(LifecycleEventKind::TurnStarted {
             turn_id: LifecycleId(0),
         });
@@ -985,7 +1258,11 @@ mod tests {
         });
         let turn_id = LifecycleId(0);
         let mut tool = emitter
-            .request_tool("read".to_string(), Some(turn_id))
+            .request_tool(
+                "provider-call".to_string(),
+                "read".to_string(),
+                Some(turn_id),
+            )
             .expect("tool should be observed");
 
         // Act

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -16,6 +16,12 @@ use crate::{chat_completion, telemetry, tool};
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait Model: Send + Sync {
+    /// Returns the configured model identity when the implementation exposes
+    /// it.
+    fn metadata(&self) -> Option<ModelMetadata> {
+        None
+    }
+
     /// Completes one model request.
     ///
     /// # Errors
@@ -46,6 +52,12 @@ pub trait Model: Send + Sync {
 /// Object-safe model boundary that guarantees normalized completion metadata.
 #[async_trait]
 pub trait ModelWithMetadata: Send + Sync {
+    /// Returns the configured model identity when the implementation exposes
+    /// it.
+    fn metadata(&self) -> Option<ModelMetadata> {
+        None
+    }
+
     /// Completes one model request and returns normalized provider metadata.
     ///
     /// # Errors
@@ -63,6 +75,10 @@ impl<ModelType> Model for ModelType
 where
     ModelType: ModelWithMetadata + ?Sized,
 {
+    fn metadata(&self) -> Option<ModelMetadata> {
+        ModelWithMetadata::metadata(self)
+    }
+
     async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
         self.complete_with_metadata(request)
             .await
@@ -181,7 +197,12 @@ impl ModelClient {
             self.lifecycle
                 .start_model_request(Some(self.metadata.clone()), 0, None)
         };
-        let (result, failure_metadata) = match self.backend.generate(&request).await {
+        let operation = self.backend.generate(&request);
+        let generated = match lifecycle.as_ref() {
+            Some(lifecycle) => lifecycle.scope(operation).await,
+            None => operation.await,
+        };
+        let (result, failure_metadata) = match generated {
             Ok(chat_completion::GeneratedResponse::Failed { error, metadata }) => {
                 (Err(error), Some(metadata))
             }
@@ -218,7 +239,7 @@ impl ModelClient {
                     Some(completion.metadata.clone()),
                     completion.response.response_type(),
                 ),
-                Err(error) => lifecycle.failed(error.error_type()),
+                Err(error) => lifecycle.failed(error.error_type(), error.http_status()),
             }
         }
 
@@ -245,6 +266,10 @@ impl ModelClient {
 
 #[async_trait]
 impl ModelWithMetadata for ModelClient {
+    fn metadata(&self) -> Option<ModelMetadata> {
+        Some(self.metadata.clone())
+    }
+
     async fn complete_with_metadata(
         &self,
         request: ModelRequest,
@@ -851,12 +876,14 @@ mod tests {
         let model = ResponseOnlyModel;
 
         // Act
+        let model_metadata = Model::metadata(&model);
         let (response, metadata) = model
             .complete_with_optional_metadata(test_request())
             .await
             .expect("response-only model should complete");
 
         // Assert
+        assert!(model_metadata.is_none());
         assert_eq!(response.output(), Some(&json!({ "name": "Ada" })));
         assert!(metadata.is_none());
     }
@@ -867,6 +894,7 @@ mod tests {
         let model = MetadataModel;
 
         // Act
+        let model_metadata = ModelWithMetadata::metadata(&model);
         let response = Model::complete(&model, test_request())
             .await
             .expect("metadata model should complete through Model");
@@ -876,6 +904,7 @@ mod tests {
                 .expect("metadata model should expose optional metadata");
 
         // Assert
+        assert!(model_metadata.is_none());
         assert_eq!(response.output(), Some(&json!({ "name": "Ada" })));
         assert_eq!(optional_response.output(), Some(&json!({ "name": "Ada" })));
         assert_eq!(
@@ -896,6 +925,8 @@ mod tests {
 
         // Act
         let metadata = client.metadata();
+        let trait_metadata = ModelWithMetadata::metadata(&client)
+            .expect("model client should expose configured metadata through the trait");
 
         // Assert
         assert_eq!(metadata.provider(), "alibaba_cloud");
@@ -904,6 +935,7 @@ mod tests {
             metadata,
             &ModelMetadata::new("alibaba_cloud", "qwen-plus").expect("metadata should be valid")
         );
+        assert_eq!(&trait_metadata, metadata);
     }
 
     #[tokio::test]
@@ -1012,6 +1044,7 @@ mod tests {
             events[1].kind(),
             crate::LifecycleEventKind::ModelRequestFailed {
                 error_type: ModelErrorType::Provider,
+                http_status: Some(503),
                 ..
             }
         ));

--- a/crates/ag-harness/src/provider/muse.rs
+++ b/crates/ag-harness/src/provider/muse.rs
@@ -5,7 +5,8 @@ use thiserror::Error;
 
 use crate::lifecycle::LifecycleObserver;
 use crate::model::{
-    ModelClient, ModelCompletion, ModelError, ModelMetadataError, ModelRequest, ModelWithMetadata,
+    ModelClient, ModelCompletion, ModelError, ModelMetadata, ModelMetadataError, ModelRequest,
+    ModelWithMetadata,
 };
 use crate::{chat_completion, telemetry};
 
@@ -73,6 +74,10 @@ impl Muse {
 
 #[async_trait]
 impl ModelWithMetadata for Muse {
+    fn metadata(&self) -> Option<ModelMetadata> {
+        Some(self.client.metadata().clone())
+    }
+
     async fn complete_with_metadata(
         &self,
         request: ModelRequest,
@@ -191,10 +196,12 @@ mod tests {
         // Arrange and Act
         let muse = Muse::from_environment(MUSE_SPARK_1_2, default_environment)
             .expect("fixture environment should be valid");
+        let metadata = ModelWithMetadata::metadata(&muse)
+            .expect("Muse should expose its configured model identity");
 
         // Assert
-        assert_eq!(muse.client.metadata().provider(), "meta");
-        assert_eq!(muse.client.metadata().model(), MUSE_SPARK_1_2);
+        assert_eq!(metadata.provider(), "meta");
+        assert_eq!(metadata.model(), MUSE_SPARK_1_2);
     }
 
     #[test]

--- a/crates/ag-harness/src/telemetry.rs
+++ b/crates/ag-harness/src/telemetry.rs
@@ -9,12 +9,23 @@ use crate::lifecycle::{LifecycleEvent, LifecycleEventKind, LifecycleId, Lifecycl
 use crate::model::{CompletionMetadata, ModelError, ModelMetadata};
 
 pub(crate) const ATTRIBUTE_ERROR_TYPE: &str = "error.type";
-pub(crate) const ATTRIBUTE_TOOL_NAME: &str = "gen_ai.tool.name";
-pub(crate) const ATTRIBUTE_TOOL_TYPE: &str = "gen_ai.tool.type";
+pub(crate) const ATTRIBUTE_OUTPUT_TYPE: &str = "gen_ai.output.type";
 pub(crate) const ATTRIBUTE_OPERATION_NAME: &str = "gen_ai.operation.name";
 pub(crate) const ATTRIBUTE_PROVIDER_NAME: &str = "gen_ai.provider.name";
 pub(crate) const ATTRIBUTE_REQUEST_MODEL: &str = "gen_ai.request.model";
+pub(crate) const ATTRIBUTE_RESPONSE_FINISH_REASONS: &str = "gen_ai.response.finish_reasons";
+pub(crate) const ATTRIBUTE_RESPONSE_ID: &str = "gen_ai.response.id";
+pub(crate) const ATTRIBUTE_RESPONSE_MODEL: &str = "gen_ai.response.model";
 pub(crate) const ATTRIBUTE_TOKEN_TYPE: &str = "gen_ai.token.type";
+pub(crate) const ATTRIBUTE_TOOL_CALL_ID: &str = "gen_ai.tool.call.id";
+pub(crate) const ATTRIBUTE_TOOL_NAME: &str = "gen_ai.tool.name";
+pub(crate) const ATTRIBUTE_TOOL_TYPE: &str = "gen_ai.tool.type";
+pub(crate) const ATTRIBUTE_USAGE_CACHE_READ_INPUT_TOKENS: &str =
+    "gen_ai.usage.cache_read.input_tokens";
+pub(crate) const ATTRIBUTE_USAGE_INPUT_TOKENS: &str = "gen_ai.usage.input_tokens";
+pub(crate) const ATTRIBUTE_USAGE_OUTPUT_TOKENS: &str = "gen_ai.usage.output_tokens";
+pub(crate) const ATTRIBUTE_USAGE_REASONING_OUTPUT_TOKENS: &str =
+    "gen_ai.usage.reasoning.output_tokens";
 pub(crate) const DURATION_BOUNDARIES_SECONDS: [f64; 14] = [
     0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
 ];
@@ -22,10 +33,6 @@ pub(crate) const DURATION_DESCRIPTION: &str = "GenAI operation duration.";
 pub(crate) const DURATION_METRIC: &str = "gen_ai.client.operation.duration";
 pub(crate) const DURATION_UNIT: &str = "s";
 pub(crate) const ERROR_CANCELLED: &str = "cancelled";
-pub(crate) const ERROR_REPOSITORY_REQUIRED: &str = "repository_required";
-pub(crate) const ERROR_TOOL_CALL_LIMIT: &str = "tool_call_limit";
-pub(crate) const ERROR_TOOL_DENIED: &str = "tool_denied";
-pub(crate) const ERROR_TOOL_EXECUTION: &str = "tool_execution_error";
 pub(crate) const ERROR_INVALID_OUTPUT: &str = "invalid_output";
 pub(crate) const ERROR_INVALID_PROVIDER_RESPONSE: &str = "invalid_provider_response";
 pub(crate) const ERROR_INVALID_RESPONSE: &str = "invalid_response";
@@ -34,9 +41,16 @@ pub(crate) const ERROR_PROVIDER: &str = "provider_error";
 pub(crate) const ERROR_REQUEST: &str = "request_error";
 pub(crate) const ERROR_RESPONSE_TOO_LARGE: &str = "response_too_large";
 pub(crate) const ERROR_TRANSPORT: &str = "transport_error";
+pub(crate) const ERROR_TOOL_CALL_LIMIT: &str = "tool_call_limit";
+pub(crate) const ERROR_TOOL_DENIED: &str = "tool_denied";
+pub(crate) const ERROR_TOOL_EXECUTION: &str = "tool_execution_error";
+pub(crate) const ERROR_REPOSITORY_REQUIRED: &str = "repository_required";
 pub(crate) const ERROR_UNSUPPORTED_OUTPUT: &str = "unsupported_output";
 pub(crate) const INSTRUMENTATION_SCOPE: &str = "ag-harness";
 pub(crate) const OPERATION_CHAT: &str = "chat";
+pub(crate) const OPERATION_EXECUTE_TOOL: &str = "execute_tool";
+pub(crate) const OPERATION_INVOKE_AGENT: &str = "invoke_agent";
+pub(crate) const OUTPUT_JSON: &str = "json";
 pub(crate) const PROVIDER_ALIBABA_CLOUD: &str = "alibaba_cloud";
 pub(crate) const PROVIDER_META: &str = "meta";
 pub(crate) const PROVIDER_MOONSHOT_AI: &str = "moonshot_ai";
@@ -80,7 +94,7 @@ const AGENT_TOOL_CALLS_METRIC: &str = "gen_ai.invoke_agent.tool_calls";
 const AGENT_TOOL_CALLS_UNIT: &str = "{tool_call}";
 const TOOL_DURATION_DESCRIPTION: &str = "The duration of a single tool execution.";
 const TOOL_DURATION_METRIC: &str = "gen_ai.execute_tool.duration";
-const TOOL_TYPE_FUNCTION: &str = "function";
+pub(crate) const TOOL_TYPE_FUNCTION: &str = "function";
 
 /// OpenTelemetry metric projection over ordered harness lifecycle events.
 ///
@@ -211,6 +225,7 @@ impl LifecycleMetricState {
                 tool_call_id,
                 tool_name,
                 turn_id,
+                ..
             } => {
                 if let Some(turn) = self.turns.get_mut(turn_id) {
                     turn.tool_calls += 1;
@@ -479,14 +494,22 @@ mod tests {
         lifecycle
             .start_model_request(None, 0, Some(denied_turn_id))
             .expect("observer should start a model request")
-            .failed(crate::model::ModelErrorType::InvalidOutput);
+            .failed(crate::model::ModelErrorType::InvalidOutput, None);
         let mut completed_tool = lifecycle
-            .request_tool("read".to_string(), Some(denied_turn_id))
+            .request_tool(
+                "completed-call".to_string(),
+                "read".to_string(),
+                Some(denied_turn_id),
+            )
             .expect("observer should request a tool");
         completed_tool.started();
         completed_tool.completed();
         lifecycle
-            .request_tool("write".to_string(), Some(denied_turn_id))
+            .request_tool(
+                "denied-call".to_string(),
+                "write".to_string(),
+                Some(denied_turn_id),
+            )
             .expect("observer should request a denied tool")
             .denied();
         denied_turn.failed(crate::lifecycle::TurnErrorType::ToolDenied);
@@ -496,7 +519,11 @@ mod tests {
             .expect("observer should start a turn");
         let failed_turn_id = failed_turn.id();
         let mut failed_tool = lifecycle
-            .request_tool("read".to_string(), Some(failed_turn_id))
+            .request_tool(
+                "failed-call".to_string(),
+                "read".to_string(),
+                Some(failed_turn_id),
+            )
             .expect("observer should request a tool");
         failed_tool.started();
         failed_tool.failed(crate::lifecycle::ToolErrorType::Execution);
@@ -512,7 +539,11 @@ mod tests {
                 .expect("observer should start a model request"),
         );
         let mut cancelled_tool = lifecycle
-            .request_tool("write".to_string(), Some(cancelled_turn_id))
+            .request_tool(
+                "cancelled-call".to_string(),
+                "write".to_string(),
+                Some(cancelled_turn_id),
+            )
             .expect("observer should request a tool");
         cancelled_tool.started();
         drop(cancelled_tool);
@@ -523,7 +554,11 @@ mod tests {
             .expect("observer should start a turn");
         let limited_turn_id = limited_turn.id();
         lifecycle
-            .request_tool("read".to_string(), Some(limited_turn_id))
+            .request_tool(
+                "limited-call".to_string(),
+                "read".to_string(),
+                Some(limited_turn_id),
+            )
             .expect("observer should request a limited tool")
             .failed(crate::lifecycle::ToolErrorType::CallLimit);
         limited_turn.failed(crate::lifecycle::TurnErrorType::ToolCallLimit);

--- a/crates/ag-harness/src/trace.rs
+++ b/crates/ag-harness/src/trace.rs
@@ -1,0 +1,1054 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, PoisonError};
+
+use opentelemetry::trace::{SpanKind, Status, TraceContextExt, Tracer};
+use opentelemetry::{Array, Context, KeyValue, StringValue, Value, global};
+
+use crate::lifecycle::{
+    LifecycleEvent, LifecycleEventKind, LifecycleId, LifecycleObserver, LifecycleOperationGuard,
+};
+use crate::model::{CompletionMetadata, ModelMetadata};
+use crate::telemetry;
+
+const TOOL_CALL_ID_ATTRIBUTE_LIMIT_BYTES: usize = 128;
+
+/// Projects one ordered harness lifecycle stream to OpenTelemetry `GenAI`
+/// spans.
+///
+/// Install an OpenTelemetry tracer provider before operations start, then
+/// attach one observer to a [`crate::Harness`] or [`crate::ModelClient`].
+/// Applications retain ownership of exporter configuration, flushing, and
+/// shutdown.
+pub struct LifecycleTraceObserver {
+    state: Mutex<TraceState>,
+}
+
+impl LifecycleTraceObserver {
+    /// Creates an empty lifecycle trace projection.
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(TraceState::default()),
+        }
+    }
+}
+
+impl Default for LifecycleTraceObserver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LifecycleObserver for LifecycleTraceObserver {
+    fn observe(&self, event: LifecycleEvent) {
+        self.state
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .observe(event.kind());
+    }
+
+    fn enter_operation(
+        &self,
+        operation_id: LifecycleId,
+    ) -> Option<Box<dyn LifecycleOperationGuard>> {
+        let context = self
+            .state
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .operation_context(operation_id)?;
+
+        Some(Box::new(TraceOperationGuard {
+            _guard: context.attach(),
+        }))
+    }
+}
+
+struct TraceOperationGuard {
+    _guard: opentelemetry::ContextGuard,
+}
+
+impl LifecycleOperationGuard for TraceOperationGuard {}
+
+#[derive(Default)]
+struct TraceState {
+    model_spans: HashMap<LifecycleId, Context>,
+    pending_tools: HashMap<LifecycleId, PendingTool>,
+    tool_spans: HashMap<LifecycleId, Context>,
+    turn_spans: HashMap<LifecycleId, Context>,
+}
+
+impl TraceState {
+    fn operation_context(&self, operation_id: LifecycleId) -> Option<Context> {
+        self.model_spans
+            .get(&operation_id)
+            .or_else(|| self.tool_spans.get(&operation_id))
+            .cloned()
+    }
+
+    fn observe(&mut self, event: &LifecycleEventKind) {
+        match event {
+            LifecycleEventKind::TurnStarted { turn_id } => self.start_turn(*turn_id),
+            LifecycleEventKind::TurnCompleted { turn_id, .. } => {
+                finish_span(self.turn_spans.remove(turn_id), None, Vec::new());
+            }
+            LifecycleEventKind::TurnFailed {
+                error_type,
+                turn_id,
+                ..
+            } => {
+                finish_span(
+                    self.turn_spans.remove(turn_id),
+                    Some(error_type.as_str().to_string()),
+                    Vec::new(),
+                );
+            }
+            LifecycleEventKind::ModelRequestStarted {
+                model,
+                model_call_id,
+                turn_id,
+                ..
+            } => self.start_model(*model_call_id, model.as_ref(), *turn_id),
+            LifecycleEventKind::ModelRequestCompleted {
+                completion,
+                model_call_id,
+                ..
+            } => finish_span(
+                self.model_spans.remove(model_call_id),
+                None,
+                completion_attributes(completion.as_ref()),
+            ),
+            LifecycleEventKind::ModelRequestFailed {
+                error_type,
+                http_status,
+                model_call_id,
+                ..
+            } => finish_span(
+                self.model_spans.remove(model_call_id),
+                Some(http_status.map_or_else(
+                    || error_type.as_str().to_string(),
+                    |status| status.to_string(),
+                )),
+                Vec::new(),
+            ),
+            LifecycleEventKind::ModelRequestCancelled { model_call_id, .. } => finish_span(
+                self.model_spans.remove(model_call_id),
+                Some(telemetry::ERROR_CANCELLED.to_string()),
+                Vec::new(),
+            ),
+            LifecycleEventKind::ToolRequested {
+                provider_call_id,
+                tool_call_id,
+                tool_name,
+                turn_id,
+            } => {
+                self.pending_tools.insert(
+                    *tool_call_id,
+                    PendingTool {
+                        name: tool_name.clone(),
+                        provider_call_id: provider_call_id.clone(),
+                        turn_id: *turn_id,
+                    },
+                );
+            }
+            LifecycleEventKind::ToolStarted {
+                tool_call_id,
+                turn_id,
+            } => self.start_tool(*tool_call_id, *turn_id),
+            LifecycleEventKind::ToolCompleted { tool_call_id, .. } => {
+                finish_span(self.tool_spans.remove(tool_call_id), None, Vec::new());
+            }
+            LifecycleEventKind::ToolDenied { tool_call_id, .. } => {
+                self.pending_tools.remove(tool_call_id);
+            }
+            LifecycleEventKind::ToolFailed {
+                error_type,
+                tool_call_id,
+                ..
+            } => {
+                self.pending_tools.remove(tool_call_id);
+                finish_span(
+                    self.tool_spans.remove(tool_call_id),
+                    Some(error_type.as_str().to_string()),
+                    Vec::new(),
+                );
+            }
+        }
+    }
+
+    fn start_turn(&mut self, turn_id: LifecycleId) {
+        let context = start_span(
+            telemetry::OPERATION_INVOKE_AGENT,
+            SpanKind::Internal,
+            vec![
+                KeyValue::new(
+                    telemetry::ATTRIBUTE_OPERATION_NAME,
+                    telemetry::OPERATION_INVOKE_AGENT,
+                ),
+                KeyValue::new(telemetry::ATTRIBUTE_OUTPUT_TYPE, telemetry::OUTPUT_JSON),
+            ],
+            None,
+        );
+        self.turn_spans.insert(turn_id, context);
+    }
+
+    fn start_model(
+        &mut self,
+        model_call_id: LifecycleId,
+        model: Option<&ModelMetadata>,
+        turn_id: Option<LifecycleId>,
+    ) {
+        let Some(model) = model else {
+            return;
+        };
+        let name = format!("{} {}", telemetry::OPERATION_CHAT, model.model());
+        let attributes = vec![
+            KeyValue::new(
+                telemetry::ATTRIBUTE_OPERATION_NAME,
+                telemetry::OPERATION_CHAT,
+            ),
+            KeyValue::new(telemetry::ATTRIBUTE_PROVIDER_NAME, model.provider()),
+            KeyValue::new(
+                telemetry::ATTRIBUTE_REQUEST_MODEL,
+                model.model().to_string(),
+            ),
+            KeyValue::new(telemetry::ATTRIBUTE_OUTPUT_TYPE, telemetry::OUTPUT_JSON),
+        ];
+        let context = match turn_id {
+            Some(turn_id) => {
+                let Some(parent) = self.turn_spans.get(&turn_id) else {
+                    return;
+                };
+                start_span(name, SpanKind::Client, attributes, Some(parent))
+            }
+            None => start_span(name, SpanKind::Client, attributes, None),
+        };
+        self.model_spans.insert(model_call_id, context);
+    }
+
+    fn start_tool(&mut self, tool_call_id: LifecycleId, turn_id: LifecycleId) {
+        let Some(tool) = self.pending_tools.remove(&tool_call_id) else {
+            return;
+        };
+        debug_assert_eq!(tool.turn_id, turn_id);
+        let name = format!("{} {}", telemetry::OPERATION_EXECUTE_TOOL, tool.name);
+        let mut attributes = vec![
+            KeyValue::new(
+                telemetry::ATTRIBUTE_OPERATION_NAME,
+                telemetry::OPERATION_EXECUTE_TOOL,
+            ),
+            KeyValue::new(telemetry::ATTRIBUTE_TOOL_NAME, tool.name),
+            KeyValue::new(
+                telemetry::ATTRIBUTE_TOOL_TYPE,
+                telemetry::TOOL_TYPE_FUNCTION,
+            ),
+        ];
+        if tool.provider_call_id.len() <= TOOL_CALL_ID_ATTRIBUTE_LIMIT_BYTES {
+            attributes.push(KeyValue::new(
+                telemetry::ATTRIBUTE_TOOL_CALL_ID,
+                tool.provider_call_id,
+            ));
+        }
+        let Some(parent) = self.turn_spans.get(&turn_id) else {
+            return;
+        };
+        let context = start_span(name, SpanKind::Internal, attributes, Some(parent));
+        self.tool_spans.insert(tool_call_id, context);
+    }
+}
+
+struct PendingTool {
+    name: String,
+    provider_call_id: String,
+    turn_id: LifecycleId,
+}
+
+fn start_span(
+    name: impl Into<std::borrow::Cow<'static, str>>,
+    kind: SpanKind,
+    attributes: Vec<KeyValue>,
+    parent: Option<&Context>,
+) -> Context {
+    let tracer = global::tracer(telemetry::INSTRUMENTATION_SCOPE);
+    let builder = tracer
+        .span_builder(name)
+        .with_kind(kind)
+        .with_attributes(attributes);
+    let parent = parent.cloned().unwrap_or_else(Context::current);
+    let span = builder.start_with_context(&tracer, &parent);
+
+    parent.with_span(span)
+}
+
+fn finish_span(context: Option<Context>, error_type: Option<String>, attributes: Vec<KeyValue>) {
+    let Some(context) = context else {
+        return;
+    };
+    let span = context.span();
+    span.set_attributes(attributes);
+    if let Some(error_type) = error_type {
+        span.set_attribute(KeyValue::new(telemetry::ATTRIBUTE_ERROR_TYPE, error_type));
+        span.set_status(Status::error(""));
+    }
+    span.end();
+}
+
+fn completion_attributes(completion: Option<&CompletionMetadata>) -> Vec<KeyValue> {
+    let Some(completion) = completion else {
+        return Vec::new();
+    };
+    let mut attributes = vec![KeyValue::new(
+        telemetry::ATTRIBUTE_RESPONSE_FINISH_REASONS,
+        Value::Array(Array::String(vec![StringValue::from(
+            completion.finish_reason().to_string(),
+        )])),
+    )];
+    if let Some(response_id) = completion.response_id() {
+        attributes.push(KeyValue::new(
+            telemetry::ATTRIBUTE_RESPONSE_ID,
+            response_id.to_string(),
+        ));
+    }
+    if let Some(response_model) = completion.response_model() {
+        attributes.push(KeyValue::new(
+            telemetry::ATTRIBUTE_RESPONSE_MODEL,
+            response_model.to_string(),
+        ));
+    }
+    if let Some(usage) = completion.usage() {
+        push_token_attribute(
+            &mut attributes,
+            telemetry::ATTRIBUTE_USAGE_CACHE_READ_INPUT_TOKENS,
+            usage.cache_hit_tokens(),
+        );
+        push_token_attribute(
+            &mut attributes,
+            telemetry::ATTRIBUTE_USAGE_INPUT_TOKENS,
+            usage.input_tokens(),
+        );
+        push_token_attribute(
+            &mut attributes,
+            telemetry::ATTRIBUTE_USAGE_OUTPUT_TOKENS,
+            usage.output_tokens(),
+        );
+        push_token_attribute(
+            &mut attributes,
+            telemetry::ATTRIBUTE_USAGE_REASONING_OUTPUT_TOKENS,
+            usage.reasoning_tokens(),
+        );
+    }
+
+    attributes
+}
+
+fn push_token_attribute(attributes: &mut Vec<KeyValue>, key: &'static str, value: Option<u64>) {
+    let Some(value) = value.and_then(|value| i64::try_from(value).ok()) else {
+        return;
+    };
+    attributes.push(KeyValue::new(key, value));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::io::Cursor;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    use async_trait::async_trait;
+    use opentelemetry::baggage::BaggageExt as _;
+    use opentelemetry::global;
+    use opentelemetry::trace::{FutureExt as _, Span as _, SpanId, SpanKind, Status};
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
+    use serde_json::json;
+    use tokio::sync::Mutex as TestMutex;
+
+    use super::*;
+    use crate::file_system::MockFileSystem;
+    use crate::harness::Harness;
+    use crate::lifecycle::{LifecycleEmitter, ToolErrorType, TurnErrorType};
+    use crate::model::{
+        CompletionUsage, Model, ModelError, ModelErrorType, ModelRequest, ModelResponse,
+    };
+    use crate::schema_contract::OutputSchema;
+    use crate::tool::{ReadArguments, Tool, ToolCall};
+
+    static TRACE_PROVIDER_LOCK: TestMutex<()> = TestMutex::const_new(());
+
+    struct NestedSpanModel {
+        call_count: AtomicUsize,
+        observed_baggage: Arc<StdMutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl Model for NestedSpanModel {
+        fn metadata(&self) -> Option<ModelMetadata> {
+            Some(
+                ModelMetadata::new("test_provider", "nested-model")
+                    .expect("fixture metadata should be valid"),
+            )
+        }
+
+        async fn complete(&self, _request: ModelRequest) -> Result<ModelResponse, ModelError> {
+            record_baggage(&self.observed_baggage);
+            nested_span("mock.model.child");
+            if self.call_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                let arguments = serde_json::from_value::<ReadArguments>(json!({
+                    "path": "Cargo.toml",
+                    "limit": 1
+                }))
+                .expect("read arguments should be valid");
+
+                return Ok(ModelResponse::ToolCall(ToolCall::read(
+                    "mock-call".to_string(),
+                    arguments,
+                    None,
+                )));
+            }
+
+            Ok(ModelResponse::Output(json!({ "summary": "workspace" })))
+        }
+    }
+
+    fn nested_span(name: &'static str) {
+        let tracer = global::tracer("ag-harness-test");
+        let mut span = tracer.start(name);
+        span.end();
+    }
+
+    fn record_baggage(observed_baggage: &StdMutex<Vec<String>>) {
+        let baggage_value = Context::current()
+            .baggage()
+            .get("workflow.id")
+            .expect("application baggage should be propagated")
+            .to_string();
+        observed_baggage
+            .lock()
+            .expect("baggage recorder should not be poisoned")
+            .push(baggage_value);
+    }
+
+    fn attributes(span: &SpanData) -> BTreeMap<&str, String> {
+        span.attributes
+            .iter()
+            .map(|attribute| (attribute.key.as_str(), attribute.value.to_string()))
+            .collect()
+    }
+
+    fn find_span<'a>(spans: &'a [SpanData], name: &str, error_type: Option<&str>) -> &'a SpanData {
+        spans
+            .iter()
+            .find(|span| {
+                span.name == name
+                    && attributes(span)
+                        .get(telemetry::ATTRIBUTE_ERROR_TYPE)
+                        .map(String::as_str)
+                        == error_type
+            })
+            .expect("expected span should be exported")
+    }
+
+    fn full_completion() -> CompletionMetadata {
+        CompletionMetadata::new(
+            "stop".to_string(),
+            Some("response-id".to_string()),
+            Some("response-model".to_string()),
+            Some("unexported-fingerprint".to_string()),
+            Some(CompletionUsage::new(
+                Some(2),
+                Some(3),
+                Some(5),
+                Some(8),
+                Some(1),
+                Some(13),
+            )),
+        )
+    }
+
+    fn project_successes(emitter: &LifecycleEmitter, metadata: &ModelMetadata) {
+        let successful_turn = emitter.start_turn().expect("observer should enable turns");
+        let successful_turn_id = successful_turn.id();
+        emitter
+            .start_model_request(Some(metadata.clone()), 0, Some(successful_turn_id))
+            .expect("observer should enable model calls")
+            .completed(Some(full_completion()), crate::ModelResponseType::ToolCall);
+        let mut successful_tool = emitter
+            .request_tool(
+                "successful-call".to_string(),
+                "read".to_string(),
+                Some(successful_turn_id),
+            )
+            .expect("turn should enable tools");
+        successful_tool.started();
+        successful_tool.completed();
+        successful_turn.completed();
+
+        let first_interleaved_turn = emitter.start_turn().expect("observer should enable turns");
+        let first_interleaved_turn_id = first_interleaved_turn.id();
+        let second_interleaved_turn = emitter.start_turn().expect("observer should enable turns");
+        let second_interleaved_turn_id = second_interleaved_turn.id();
+        emitter
+            .start_model_request(
+                Some(
+                    ModelMetadata::new("test_provider", "interleaved-one")
+                        .expect("fixture metadata should be valid"),
+                ),
+                0,
+                Some(first_interleaved_turn_id),
+            )
+            .expect("observer should enable model calls")
+            .completed(None, crate::ModelResponseType::ToolCall);
+        emitter
+            .start_model_request(
+                Some(
+                    ModelMetadata::new("test_provider", "interleaved-two")
+                        .expect("fixture metadata should be valid"),
+                ),
+                0,
+                Some(second_interleaved_turn_id),
+            )
+            .expect("observer should enable model calls")
+            .completed(None, crate::ModelResponseType::ToolCall);
+        let mut first_interleaved_tool = emitter
+            .request_tool(
+                "first-call".to_string(),
+                "first".to_string(),
+                Some(first_interleaved_turn_id),
+            )
+            .expect("turn should enable tools");
+        first_interleaved_tool.started();
+        let mut second_interleaved_tool = emitter
+            .request_tool(
+                "second-call".to_string(),
+                "second".to_string(),
+                Some(second_interleaved_turn_id),
+            )
+            .expect("turn should enable tools");
+        second_interleaved_tool.started();
+        second_interleaved_tool.completed();
+        first_interleaved_tool.completed();
+        second_interleaved_turn.completed();
+        first_interleaved_turn.completed();
+    }
+
+    fn project_failures(emitter: &LifecycleEmitter, metadata: &ModelMetadata) {
+        let failed_turn = emitter.start_turn().expect("observer should enable turns");
+        let failed_turn_id = failed_turn.id();
+        emitter
+            .start_model_request(Some(metadata.clone()), 0, Some(failed_turn_id))
+            .expect("observer should enable model calls")
+            .failed(ModelErrorType::Transport, None);
+        failed_turn.failed(TurnErrorType::Model(ModelErrorType::Transport));
+
+        emitter
+            .start_model_request(Some(metadata.clone()), 0, None)
+            .expect("observer should enable standalone calls");
+        emitter
+            .start_model_request(Some(metadata.clone()), 0, None)
+            .expect("observer should enable standalone calls")
+            .failed(ModelErrorType::Provider, Some(429));
+
+        let denied_turn = emitter.start_turn().expect("observer should enable turns");
+        let denied_turn_id = denied_turn.id();
+        emitter
+            .request_tool(
+                "denied-call".to_string(),
+                "write".to_string(),
+                Some(denied_turn_id),
+            )
+            .expect("turn should enable tools")
+            .denied();
+        denied_turn.failed(TurnErrorType::ToolDenied);
+
+        let tool_failure_turn = emitter.start_turn().expect("observer should enable turns");
+        let tool_failure_turn_id = tool_failure_turn.id();
+        let mut failed_tool = emitter
+            .request_tool(
+                "failed-call".to_string(),
+                "read".to_string(),
+                Some(tool_failure_turn_id),
+            )
+            .expect("turn should enable tools");
+        failed_tool.started();
+        failed_tool.failed(ToolErrorType::Execution);
+        tool_failure_turn.failed(TurnErrorType::Tool);
+
+        let cancelled_turn = emitter.start_turn().expect("observer should enable turns");
+        drop(cancelled_turn);
+
+        emitter
+            .start_model_request(Some(metadata.clone()), 0, None)
+            .expect("observer should enable standalone calls")
+            .completed(None, crate::ModelResponseType::Output);
+        emitter
+            .start_model_request(None, 0, None)
+            .expect("observer should enable unknown model calls")
+            .completed(None, crate::ModelResponseType::Output);
+
+        let limited_turn = emitter.start_turn().expect("observer should enable turns");
+        let limited_turn_id = limited_turn.id();
+        emitter
+            .request_tool(
+                "limited-call".to_string(),
+                "read".to_string(),
+                Some(limited_turn_id),
+            )
+            .expect("turn should enable tools")
+            .failed(ToolErrorType::CallLimit);
+        limited_turn.failed(TurnErrorType::ToolCallLimit);
+
+        let cancelled_tool_turn = emitter.start_turn().expect("observer should enable turns");
+        let cancelled_tool_turn_id = cancelled_tool_turn.id();
+        let mut cancelled_tool = emitter
+            .request_tool(
+                "cancelled-call".to_string(),
+                "write".to_string(),
+                Some(cancelled_tool_turn_id),
+            )
+            .expect("turn should enable tools");
+        cancelled_tool.started();
+        drop(cancelled_tool);
+        cancelled_tool_turn.failed(TurnErrorType::Tool);
+    }
+
+    fn project_optional_metadata(emitter: &LifecycleEmitter, metadata: ModelMetadata) {
+        emitter
+            .start_model_request(Some(metadata), 0, None)
+            .expect("observer should enable standalone calls")
+            .completed(
+                Some(CompletionMetadata::new(
+                    "stop".to_string(),
+                    None,
+                    None,
+                    None,
+                    Some(CompletionUsage::new(
+                        None,
+                        None,
+                        Some(u64::MAX),
+                        None,
+                        None,
+                        None,
+                    )),
+                )),
+                crate::ModelResponseType::Output,
+            );
+    }
+
+    fn assert_success_spans(spans: &[SpanData]) {
+        assert!(spans.iter().all(|span| {
+            span.instrumentation_scope.name() == telemetry::INSTRUMENTATION_SCOPE
+                && span.end_time >= span.start_time
+                && !format!("{span:?}").contains("unexported-fingerprint")
+        }));
+
+        let successful_agent = find_span(spans, "invoke_agent", None);
+        assert_eq!(successful_agent.span_kind, SpanKind::Internal);
+        assert_eq!(successful_agent.status, Status::Unset);
+        assert_eq!(
+            attributes(successful_agent),
+            BTreeMap::from([
+                (
+                    telemetry::ATTRIBUTE_OPERATION_NAME,
+                    "invoke_agent".to_string()
+                ),
+                (telemetry::ATTRIBUTE_OUTPUT_TYPE, "json".to_string()),
+            ])
+        );
+        let successful_model = find_span(spans, "chat test-model", None);
+        assert_eq!(successful_model.span_kind, SpanKind::Client);
+        assert_eq!(
+            successful_model.parent_span_id,
+            successful_agent.span_context.span_id()
+        );
+        let model_attributes = attributes(successful_model);
+        assert_eq!(
+            model_attributes.get(telemetry::ATTRIBUTE_PROVIDER_NAME),
+            Some(&"test_provider".to_string())
+        );
+        assert_eq!(
+            model_attributes.get(telemetry::ATTRIBUTE_RESPONSE_FINISH_REASONS),
+            Some(&"[\"stop\"]".to_string())
+        );
+        assert_eq!(
+            model_attributes.get(telemetry::ATTRIBUTE_RESPONSE_ID),
+            Some(&"response-id".to_string())
+        );
+        assert_eq!(
+            model_attributes.get(telemetry::ATTRIBUTE_RESPONSE_MODEL),
+            Some(&"response-model".to_string())
+        );
+        assert_eq!(
+            model_attributes.get(telemetry::ATTRIBUTE_USAGE_CACHE_READ_INPUT_TOKENS),
+            Some(&"2".to_string())
+        );
+        assert_eq!(
+            model_attributes.get(telemetry::ATTRIBUTE_USAGE_INPUT_TOKENS),
+            Some(&"5".to_string())
+        );
+        assert_eq!(
+            model_attributes.get(telemetry::ATTRIBUTE_USAGE_OUTPUT_TOKENS),
+            Some(&"8".to_string())
+        );
+        assert_eq!(
+            model_attributes.get(telemetry::ATTRIBUTE_USAGE_REASONING_OUTPUT_TOKENS),
+            Some(&"1".to_string())
+        );
+        let successful_tool = find_span(spans, "execute_tool read", None);
+        assert_eq!(successful_tool.span_kind, SpanKind::Internal);
+        assert_eq!(
+            successful_tool.parent_span_id,
+            successful_agent.span_context.span_id()
+        );
+        assert_eq!(
+            attributes(successful_tool),
+            BTreeMap::from([
+                (
+                    telemetry::ATTRIBUTE_OPERATION_NAME,
+                    "execute_tool".to_string()
+                ),
+                (
+                    telemetry::ATTRIBUTE_TOOL_CALL_ID,
+                    "successful-call".to_string()
+                ),
+                (telemetry::ATTRIBUTE_TOOL_NAME, "read".to_string()),
+                (telemetry::ATTRIBUTE_TOOL_TYPE, "function".to_string()),
+            ])
+        );
+    }
+
+    fn assert_interleaved_spans(spans: &[SpanData]) {
+        let first_interleaved_model = find_span(spans, "chat interleaved-one", None);
+        let second_interleaved_model = find_span(spans, "chat interleaved-two", None);
+        let first_interleaved_tool = find_span(spans, "execute_tool first", None);
+        let second_interleaved_tool = find_span(spans, "execute_tool second", None);
+        assert_eq!(
+            first_interleaved_model.parent_span_id,
+            first_interleaved_tool.parent_span_id
+        );
+        assert_eq!(
+            second_interleaved_model.parent_span_id,
+            second_interleaved_tool.parent_span_id
+        );
+        assert_ne!(
+            first_interleaved_model.parent_span_id,
+            second_interleaved_model.parent_span_id
+        );
+        assert!(
+            spans
+                .iter()
+                .filter(|span| span.name == "invoke_agent")
+                .any(|span| span.span_context.span_id() == first_interleaved_model.parent_span_id)
+        );
+        assert!(
+            spans
+                .iter()
+                .filter(|span| span.name == "invoke_agent")
+                .any(|span| span.span_context.span_id() == second_interleaved_model.parent_span_id)
+        );
+    }
+
+    fn assert_failure_spans(spans: &[SpanData]) {
+        let failed_model = find_span(spans, "chat test-model", Some("transport_error"));
+        assert_eq!(failed_model.status, Status::error(""));
+        find_span(spans, "chat test-model", Some("429"));
+        let standalone_cancelled =
+            find_span(spans, "chat test-model", Some(telemetry::ERROR_CANCELLED));
+        assert_eq!(standalone_cancelled.parent_span_id, SpanId::INVALID);
+        let denied_agent = find_span(spans, "invoke_agent", Some("tool_denied"));
+        assert_eq!(denied_agent.status, Status::error(""));
+        assert!(!spans.iter().any(|span| {
+            span.name == "execute_tool write"
+                && !attributes(span).contains_key(telemetry::ATTRIBUTE_ERROR_TYPE)
+        }));
+        let failed_tool = find_span(spans, "execute_tool read", Some("tool_execution_error"));
+        assert_eq!(failed_tool.status, Status::error(""));
+        find_span(spans, "invoke_agent", Some("cancelled"));
+        find_span(spans, "invoke_agent", Some("tool_call_limit"));
+        find_span(spans, "execute_tool write", Some("cancelled"));
+    }
+
+    fn assert_optional_metadata(spans: &[SpanData]) {
+        let oversized_usage = spans
+            .iter()
+            .find(|span| {
+                span.name == "chat test-model"
+                    && attributes(span).contains_key(telemetry::ATTRIBUTE_RESPONSE_FINISH_REASONS)
+                    && !attributes(span).contains_key(telemetry::ATTRIBUTE_RESPONSE_ID)
+            })
+            .expect("completion without optional identity should be exported");
+        assert!(!attributes(oversized_usage).contains_key(telemetry::ATTRIBUTE_USAGE_INPUT_TOKENS));
+    }
+
+    #[tokio::test]
+    async fn projects_correlated_semantic_spans_for_every_lifecycle_outcome() {
+        // Arrange
+        let _trace_provider_guard = TRACE_PROVIDER_LOCK.lock().await;
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        global::set_tracer_provider(provider.clone());
+        let emitter = LifecycleEmitter::new(LifecycleTraceObserver::default());
+        let metadata = ModelMetadata::new("test_provider", "test-model")
+            .expect("fixture metadata should be valid");
+
+        // Act
+        project_successes(&emitter, &metadata);
+        project_failures(&emitter, &metadata);
+        project_optional_metadata(&emitter, metadata);
+        provider
+            .force_flush()
+            .expect("finished spans should flush to memory");
+        let spans = exporter
+            .get_finished_spans()
+            .expect("finished spans should be readable");
+
+        // Assert
+        assert_eq!(spans.len(), 22);
+        assert_success_spans(&spans);
+        assert_interleaved_spans(&spans);
+        assert_failure_spans(&spans);
+        assert_optional_metadata(&spans);
+
+        provider.shutdown().expect("test provider should shut down");
+    }
+
+    #[tokio::test]
+    async fn propagates_model_and_tool_contexts_to_nested_spans() {
+        // Arrange
+        let _trace_provider_guard = TRACE_PROVIDER_LOCK.lock().await;
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        global::set_tracer_provider(provider.clone());
+        let schema = OutputSchema::new(json!({
+            "type": "object",
+            "properties": { "summary": { "type": "string" } },
+            "required": ["summary"],
+            "additionalProperties": false
+        }))
+        .expect("schema should be valid");
+        let observed_baggage = Arc::new(StdMutex::new(Vec::new()));
+        let mut file_system = MockFileSystem::new();
+        file_system.expect_canonicalize().returning(|path| {
+            Ok(if path == Path::new("repo") {
+                PathBuf::from("/repo")
+            } else {
+                path.to_path_buf()
+            })
+        });
+        let tool_baggage = Arc::clone(&observed_baggage);
+        file_system
+            .expect_open_beneath()
+            .once()
+            .return_once(move |_, _| {
+                record_baggage(&tool_baggage);
+                nested_span("mock.tool.child");
+
+                Ok(Box::new(Cursor::new(b"[workspace]\n".to_vec())))
+            });
+        file_system.expect_replace_beneath().never();
+        let harness = Harness::new(NestedSpanModel {
+            call_count: AtomicUsize::new(0),
+            observed_baggage: Arc::clone(&observed_baggage),
+        })
+        .file_system(file_system)
+        .repository("repo")
+        .allow(Tool::Read)
+        .with_lifecycle_observer(LifecycleTraceObserver::new());
+
+        // Act
+        let application_context =
+            Context::current().with_baggage([KeyValue::new("workflow.id", "workflow-42")]);
+        let output = harness
+            .run("inspect the manifest", schema)
+            .with_context(application_context)
+            .await
+            .expect("mock tool round trip should succeed");
+        provider
+            .force_flush()
+            .expect("finished spans should flush to memory");
+        let spans = exporter
+            .get_finished_spans()
+            .expect("finished spans should be readable");
+
+        // Assert
+        assert_eq!(output, json!({ "summary": "workspace" }));
+        let model_span_ids = spans
+            .iter()
+            .filter(|span| span.name == "chat nested-model")
+            .map(|span| span.span_context.span_id())
+            .collect::<Vec<_>>();
+        let nested_model_parents = spans
+            .iter()
+            .filter(|span| span.name == "mock.model.child")
+            .map(|span| span.parent_span_id)
+            .collect::<Vec<_>>();
+        assert_eq!(model_span_ids.len(), 2);
+        assert_eq!(nested_model_parents.len(), 2);
+        assert!(
+            nested_model_parents
+                .iter()
+                .all(|parent| model_span_ids.contains(parent))
+        );
+        assert!(
+            model_span_ids
+                .iter()
+                .all(|span_id| nested_model_parents.contains(span_id))
+        );
+        let tool_span = find_span(&spans, "execute_tool read", None);
+        let nested_tool = find_span(&spans, "mock.tool.child", None);
+        assert_eq!(nested_tool.parent_span_id, tool_span.span_context.span_id());
+        assert_eq!(
+            attributes(tool_span).get(telemetry::ATTRIBUTE_TOOL_CALL_ID),
+            Some(&"mock-call".to_string())
+        );
+        assert_eq!(
+            *observed_baggage
+                .lock()
+                .expect("baggage recorder should not be poisoned"),
+            vec!["workflow-42", "workflow-42", "workflow-42"]
+        );
+
+        provider.shutdown().expect("test provider should shut down");
+    }
+
+    #[tokio::test]
+    async fn omits_oversized_tool_call_id_attribute() {
+        // Arrange
+        let _trace_provider_guard = TRACE_PROVIDER_LOCK.lock().await;
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        global::set_tracer_provider(provider.clone());
+        let emitter = LifecycleEmitter::new(LifecycleTraceObserver::new());
+        let turn = emitter.start_turn().expect("observer should enable turns");
+        let turn_id = turn.id();
+
+        // Act
+        let mut tool = emitter
+            .request_tool(
+                "x".repeat(TOOL_CALL_ID_ATTRIBUTE_LIMIT_BYTES + 1),
+                "read".to_string(),
+                Some(turn_id),
+            )
+            .expect("turn should enable tools");
+        tool.started();
+        tool.completed();
+        turn.completed();
+        provider
+            .force_flush()
+            .expect("finished spans should flush to memory");
+        let spans = exporter
+            .get_finished_spans()
+            .expect("finished spans should be readable");
+
+        // Assert
+        let tool_span = find_span(&spans, "execute_tool read", None);
+        assert!(!attributes(tool_span).contains_key(telemetry::ATTRIBUTE_TOOL_CALL_ID));
+
+        provider.shutdown().expect("test provider should shut down");
+    }
+
+    #[test]
+    fn lifecycle_error_types_are_bounded_and_documentable() {
+        // Arrange
+        let turn_errors = [
+            TurnErrorType::Cancelled,
+            TurnErrorType::Model(ModelErrorType::InvalidOutput),
+            TurnErrorType::Tool,
+            TurnErrorType::ToolDenied,
+            TurnErrorType::ToolCallLimit,
+            TurnErrorType::RepositoryRequired,
+        ];
+        let tool_errors = [
+            ToolErrorType::Cancelled,
+            ToolErrorType::CallLimit,
+            ToolErrorType::Execution,
+        ];
+
+        // Act
+        let turn_values = turn_errors.map(TurnErrorType::as_str);
+        let tool_values = tool_errors.map(ToolErrorType::as_str);
+
+        // Assert
+        assert_eq!(
+            turn_values,
+            [
+                "cancelled",
+                "invalid_output",
+                "tool_execution_error",
+                "tool_denied",
+                "tool_call_limit",
+                "repository_required",
+            ]
+        );
+        assert_eq!(
+            tool_values,
+            ["cancelled", "tool_call_limit", "tool_execution_error"]
+        );
+    }
+
+    #[tokio::test]
+    async fn trace_observer_recovers_after_its_state_mutex_is_poisoned() {
+        // Arrange
+        let _trace_provider_guard = TRACE_PROVIDER_LOCK.lock().await;
+        let observer = LifecycleTraceObserver::new();
+        let _ = std::panic::catch_unwind(|| {
+            let _state = observer
+                .state
+                .lock()
+                .expect("fresh observer state should lock");
+            std::panic::resume_unwind(Box::new("poison trace observer state"));
+        });
+        let emitter = LifecycleEmitter::new(observer);
+
+        // Act
+        let turn = emitter.start_turn().expect("observer should recover");
+        turn.completed();
+
+        // Assert
+        assert!(emitter.is_enabled());
+    }
+
+    #[test]
+    fn missing_correlations_do_not_create_partial_spans() {
+        // Arrange
+        let mut state = TraceState::default();
+        let emitter = LifecycleEmitter::new(|_event: LifecycleEvent| {});
+        let missing_turn = emitter.start_turn().expect("observer should enable turns");
+        let missing_id = missing_turn.id();
+        missing_turn.completed();
+        state.pending_tools.insert(
+            missing_id,
+            PendingTool {
+                name: "read".to_string(),
+                provider_call_id: "missing-call".to_string(),
+                turn_id: missing_id,
+            },
+        );
+        let metadata = ModelMetadata::new("test_provider", "missing-parent")
+            .expect("fixture metadata should be valid");
+
+        // Act
+        state.start_tool(missing_id, missing_id);
+        state.start_tool(missing_id, missing_id);
+        state.start_model(missing_id, Some(&metadata), Some(missing_id));
+        finish_span(
+            None,
+            Some(telemetry::ERROR_TOOL_EXECUTION.to_string()),
+            Vec::new(),
+        );
+        let absent_tool = LifecycleEmitter::default().request_tool(
+            "absent-call".to_string(),
+            "read".to_string(),
+            None,
+        );
+
+        // Assert
+        assert!(state.tool_spans.is_empty());
+        assert!(state.model_spans.is_empty());
+        assert!(absent_tool.is_none());
+    }
+}

--- a/crates/ag-harness/tests/lifecycle.rs
+++ b/crates/ag-harness/tests/lifecycle.rs
@@ -203,6 +203,7 @@ async fn observes_one_terminal_event_for_success_failure_and_cancellation() {
         failure_events[1].kind(),
         LifecycleEventKind::ModelRequestFailed {
             error_type: ModelErrorType::Provider,
+            http_status: Some(503),
             turn_id: None,
             ..
         }
@@ -256,10 +257,10 @@ async fn harness_owns_model_events_without_duplicate_model_observation() {
     assert!(matches!(
         harness_events[1].kind(),
         LifecycleEventKind::ModelRequestStarted {
-            model: None,
+            model: Some(model),
             turn_id: Some(_),
             ..
-        }
+        } if model.provider() == "alibaba_cloud" && model.model() == "harness-model"
     ));
     assert!(matches!(
         harness_events[2].kind(),

--- a/crates/ag-harness/tests/public_api.rs
+++ b/crates/ag-harness/tests/public_api.rs
@@ -5,8 +5,8 @@ use std::sync::{Arc, Mutex};
 
 use ag_harness::{
     CompletionMetadata, CompletionUsage, Harness, LifecycleEventKind, LifecycleMetrics,
-    LifecycleObserverSet, Model, ModelCompletion, ModelError, ModelRequest, ModelResponse,
-    ModelWithMetadata, OutputSchema, OutputSchemaError,
+    LifecycleObserverSet, LifecycleTraceObserver, Model, ModelCompletion, ModelError,
+    ModelMetadata, ModelRequest, ModelResponse, ModelWithMetadata, OutputSchema, OutputSchemaError,
 };
 use async_trait::async_trait;
 use serde_json::json;
@@ -24,6 +24,10 @@ struct ExternalMetadataModel;
 
 #[async_trait]
 impl ModelWithMetadata for ExternalMetadataModel {
+    fn metadata(&self) -> Option<ModelMetadata> {
+        ModelMetadata::new("external_provider", "external-model").ok()
+    }
+
     async fn complete_with_metadata(
         &self,
         _request: ModelRequest,
@@ -42,6 +46,17 @@ impl ModelWithMetadata for ExternalMetadataModel {
             ModelResponse::Output(json!({ "name": "Ada" })),
         ))
     }
+}
+
+fn assert_observer<Observer: ag_harness::LifecycleObserver>(_observer: Observer) {}
+
+#[test]
+fn external_consumer_constructs_lifecycle_trace_observer() {
+    // Arrange & Act
+    let observer = LifecycleTraceObserver::new();
+
+    // Assert
+    assert_observer(observer);
 }
 
 fn request() -> Result<ModelRequest, OutputSchemaError> {
@@ -80,10 +95,15 @@ async fn external_provider_constructs_metadata_completion_through_dynamic_dispat
     let model: Box<dyn ModelWithMetadata> = Box::new(ExternalMetadataModel);
 
     // Act
+    let configured_metadata = model
+        .metadata()
+        .expect("external provider should expose configured identity");
     let completion = model.complete_with_metadata(request()?).await?;
 
     // Assert
     assert_model::<ExternalMetadataModel>();
+    assert_eq!(configured_metadata.provider(), "external_provider");
+    assert_eq!(configured_metadata.model(), "external-model");
     assert_eq!(
         completion.response().output(),
         Some(&json!({ "name": "Ada" }))
@@ -125,6 +145,13 @@ async fn external_metadata_provider_reaches_harness_lifecycle() -> Result<(), Bo
     let events = events
         .lock()
         .expect("event recorder should not be poisoned");
+    assert!(events.iter().any(|event| matches!(
+        event.kind(),
+        LifecycleEventKind::ModelRequestStarted {
+            model: Some(model),
+            ..
+        } if model.provider() == "external_provider" && model.model() == "external-model"
+    )));
     assert!(events.iter().any(|event| matches!(
         event.kind(),
         LifecycleEventKind::ModelRequestCompleted {

--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -4272,6 +4272,12 @@ mod tests {
                 text: "## Review\n### Suggestions\n- Fix the typo.".to_string(),
             },
         );
+        let mut mock_git_client = ag_git::MockGitClient::new();
+        mock_git_client
+            .expect_diff()
+            .once()
+            .returning(|_, _| Box::pin(async { Ok("current diff".to_string()) }));
+        install_mock_git_client(&mut app, mock_git_client);
         let prompt_context = prompt_context(&mut app).expect("expected prompt context");
 
         // Act

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -233,6 +233,10 @@ per turn, but records tool duration only after `ToolStarted`. Executions include
 `gen_ai.tool.name` and `gen_ai.tool.type=function`; unavailable agent identity and
 dynamic model identity are omitted.
 
+`LifecycleTraceObserver` projects each turn to an `invoke_agent` span with correlated
+`chat {model}` and `execute_tool {tool_name}` children. It propagates operation context
+to nested instrumentation and exports only standard, metadata-only GenAI attributes.
+
 The provider registry contains one standard value and two documented custom values:
 
 | Provider | `gen_ai.provider.name` | Registry status                                                            |
@@ -324,7 +328,7 @@ best cost and performance:
   high-cardinality content.
 - [x] **Turn and tool metric projection.** Derive aggregate turn and tool measurements
   from lifecycle facts without double-counting model-client metrics.
-- [ ] **Lifecycle trace projection.** Represent a turn as a parent span with correlated
+- [x] **Lifecycle trace projection.** Represent a turn as a parent span with correlated
   model and tool children, including correct completion, failure, and cancellation.
 - [ ] **OTLP contract coverage.** Decode exported test payloads and verify signal names,
   relationships, attributes, batching and shutdown, and the absence of fixture secrets.


### PR DESCRIPTION
- Correlates turns, model requests, and executed tools with provider metadata, completion usage, HTTP status, and bounded errors.
- Propagates model and tool span context across asynchronous operations for nested instrumentation.
- Exposes and documents `LifecycleTraceObserver` with span hierarchy and public API coverage.
- Makes the `/apply` diff-hash mismatch test independent of subprocess timing.
- Adds complete line coverage for the two GenAI tracing files flagged by Codecov.