### PR TITLE
Queue review requests during rebases

### DIFF
--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -1673,7 +1673,7 @@ async fn review_request_enqueue_does_not_wait_for_existing_branch_operation() {
 }
 
 #[tokio::test]
-async fn running_review_request_action_queues_on_existing_worker() {
+async fn rebasing_review_request_action_queues_on_existing_worker() {
     // Arrange
     let (mut app, _temp_dir) = crate::test_support::new_git_test_app().await;
     let session_id = app
@@ -1698,7 +1698,7 @@ async fn running_review_request_action_queues_on_existing_worker() {
         None,
     )
     .await;
-    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::InProgress);
+    crate::test_support::set_session_status_for_test(&mut app, &session_id, Status::Rebasing);
 
     // Act
     app.start_publish_branch_action(

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -1205,8 +1205,8 @@ impl SessionWorkerService {
     /// Publishes one review request inside the serialized session worker.
     ///
     /// The live status is applied at execution time so an action accepted
-    /// during `InProgress` observes the completed turn's review-ready state
-    /// instead of the enqueue-time snapshot.
+    /// during `InProgress` or `Rebasing` observes the completed work's
+    /// review-ready state instead of the enqueue-time snapshot.
     async fn run_create_review_request_command(
         context: &SessionWorkerContext,
         mut branch_publish_session: BranchPublishTaskSession,
@@ -1428,9 +1428,9 @@ impl SessionManager {
 
     /// Persists and queues review-request creation on one session worker.
     ///
-    /// Running sessions must already own a worker so stale status cannot
-    /// create a concurrent executor. Review-ready sessions lazily create a
-    /// worker and execute the action immediately.
+    /// Active turn and rebase sessions must already own a worker so stale
+    /// status cannot create a concurrent executor. Review-ready sessions
+    /// lazily create a worker and execute the action immediately.
     ///
     /// # Errors
     /// Returns an error when operation persistence or worker delivery fails.
@@ -1450,7 +1450,7 @@ impl SessionManager {
             remote_branch_name,
             response: response.clone(),
         };
-        let result = if status == Status::InProgress {
+        let result = if matches!(status, Status::InProgress | Status::Rebasing) {
             self.worker_service_mut()
                 .enqueue_existing_session_command(services, &session_id, command)
                 .await
@@ -5520,16 +5520,43 @@ mod tests {
     }
 
     /// Seeds one rebasing session with existing provider conversation ids.
-    async fn seed_existing_session_rebase_metadata(db: &AppRepositories) {
+    async fn seed_existing_session_rebase_metadata(
+        db: &AppRepositories,
+        parent_session_id: Option<&str>,
+    ) {
         let project_id = db
             .projects()
             .upsert_project("/tmp/project", Some("main".to_string()))
             .await
             .expect("failed to upsert project");
-        db.sessions()
-            .insert_session("sess1", "gpt-5.6-sol", "main", "Rebasing", project_id)
-            .await
-            .expect("failed to insert session");
+        if let Some(parent_session_id) = parent_session_id {
+            db.sessions()
+                .insert_session(
+                    parent_session_id,
+                    "gpt-5.6-sol",
+                    "main",
+                    "Review",
+                    project_id,
+                )
+                .await
+                .expect("failed to insert parent session");
+            db.sessions()
+                .insert_stacked_draft_session(
+                    "sess1",
+                    "gpt-5.6-sol",
+                    "main",
+                    "Rebasing",
+                    parent_session_id,
+                    project_id,
+                )
+                .await
+                .expect("failed to insert stacked session");
+        } else {
+            db.sessions()
+                .insert_session("sess1", "gpt-5.6-sol", "main", "Rebasing", project_id)
+                .await
+                .expect("failed to insert session");
+        }
         db.sessions()
             .update_session_provider_conversation_id("sess1", Some("thread-before".to_string()))
             .await
@@ -5664,10 +5691,59 @@ mod tests {
         mock_git_client
     }
 
+    /// Extends the successful rebase mock with a controllable stack-metadata
+    /// boundary and a terminal review-request push failure.
+    fn blocking_stack_metadata_git_client(
+        main_checkout_root: PathBuf,
+        metadata_persistence_started: Arc<tokio::sync::Notify>,
+        release_metadata_persistence: Arc<tokio::sync::Notify>,
+    ) -> MockGitClient {
+        let mut git_client = mock_successful_conflict_rebase_git_client(main_checkout_root);
+        git_client
+            .expect_ref_hash()
+            .once()
+            .withf(|_, reference| reference == "main")
+            .returning(move |_, _| {
+                let metadata_persistence_started = Arc::clone(&metadata_persistence_started);
+                let release_metadata_persistence = Arc::clone(&release_metadata_persistence);
+
+                Box::pin(async move {
+                    metadata_persistence_started.notify_one();
+                    release_metadata_persistence.notified().await;
+
+                    Ok("parent-tip".to_string())
+                })
+            });
+        git_client
+            .expect_in_progress_operation()
+            .once()
+            .returning(|_| Box::pin(async { Ok(Some(ag_git::InProgressGitOperation::Rebase)) }));
+
+        git_client
+    }
+
+    /// Builds the review-request command queued behind the controlled rebase.
+    fn queued_review_request_command(folder: PathBuf) -> SessionCommand {
+        SessionCommand::CreateReviewRequest {
+            branch_publish_session: BranchPublishTaskSession {
+                base_branch: "main".to_string(),
+                folder,
+                id: "sess1".into(),
+                published_upstream_ref: None,
+                review_request: None,
+                status: Status::Rebasing,
+            },
+            operation_id: "op-review-request".to_string(),
+            remote_branch_name: None,
+            response: None,
+        }
+    }
+
     /// Builds one worker harness for session rebase command tests.
     fn rebase_assist_worker_harness(
         base_dir: PathBuf,
         db: AppRepositories,
+        build_git_client: impl FnOnce(PathBuf) -> MockGitClient,
     ) -> RebaseAssistWorkerHarness {
         let main_checkout_root = base_dir.join("main-checkout");
         std::fs::create_dir_all(&main_checkout_root).expect("failed to create main checkout");
@@ -5691,9 +5767,7 @@ mod tests {
             db: db.clone(),
             folder: base_dir,
             fs_client: Arc::new(fs::RealFsClient),
-            git_client: Arc::new(mock_successful_conflict_rebase_git_client(
-                main_checkout_root,
-            )),
+            git_client: Arc::new(build_git_client(main_checkout_root)),
             transcript: empty_transcript(),
             personality_catalog_client: Arc::new(RealPersonalityCatalogClient),
             queued_messages: Arc::new(Mutex::new(VecDeque::new())),
@@ -5723,12 +5797,16 @@ mod tests {
         let base_dir = tempdir().expect("failed to create temp dir");
         write_rebase_conflict_file(base_dir.path());
         let db = AppRepositories::in_memory().await.expect("db should open");
-        seed_existing_session_rebase_metadata(&db).await;
+        seed_existing_session_rebase_metadata(&db, None).await;
         db.sessions()
             .update_session_permission_mode("sess1", PermissionMode::ReadOnly)
             .await
             .expect("failed to set chat permission mode");
-        let harness = rebase_assist_worker_harness(base_dir.path().to_path_buf(), db);
+        let harness = rebase_assist_worker_harness(
+            base_dir.path().to_path_buf(),
+            db,
+            mock_successful_conflict_rebase_git_client,
+        );
 
         // Act
         SessionWorkerService::run_rebase_command(
@@ -5764,6 +5842,107 @@ mod tests {
         assert!(output_text.contains("- src/lib.rs"));
         assert!(output_text.contains("Resolved conflicts inside existing session."));
         assert!(output_text.contains("[Sync] Successfully synced wt/sess1 onto main"));
+    }
+
+    #[tokio::test]
+    /// Verifies a review request queued behind rebase cannot begin after the
+    /// raw Git command but before metadata persistence and finalization end.
+    async fn test_queued_review_request_waits_for_full_rebase_finalization() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        write_rebase_conflict_file(base_dir.path());
+        let db = AppRepositories::in_memory().await.expect("db should open");
+        seed_existing_session_rebase_metadata(&db, Some("parent-session")).await;
+        db.operations()
+            .insert_session_operation("op-rebase", "sess1", REBASE_OPERATION_KIND)
+            .await
+            .expect("failed to insert rebase operation");
+        db.operations()
+            .insert_session_operation(
+                "op-review-request",
+                "sess1",
+                CREATE_REVIEW_REQUEST_OPERATION_KIND,
+            )
+            .await
+            .expect("failed to insert review-request operation");
+
+        let metadata_persistence_started = Arc::new(tokio::sync::Notify::new());
+        let release_metadata_persistence = Arc::new(tokio::sync::Notify::new());
+        let mut harness =
+            rebase_assist_worker_harness(base_dir.path().to_path_buf(), db.clone(), {
+                let metadata_persistence_started = Arc::clone(&metadata_persistence_started);
+                let release_metadata_persistence = Arc::clone(&release_metadata_persistence);
+
+                move |main_checkout_root| {
+                    blocking_stack_metadata_git_client(
+                        main_checkout_root,
+                        metadata_persistence_started,
+                        release_metadata_persistence,
+                    )
+                }
+            });
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        harness.context.app_event_tx = app_event_tx;
+        let transcript = Arc::clone(&harness.context.transcript);
+        let status = Arc::clone(&harness.status);
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        SessionWorkerService::spawn_session_worker(
+            harness.context,
+            auto_commit_one_shot_client(),
+            command_rx,
+        );
+        command_tx
+            .send(ScheduledSessionCommand::immediate(SessionCommand::Rebase {
+                base_branch: "main".to_string(),
+                operation_id: "op-rebase".to_string(),
+            }))
+            .expect("failed to queue rebase");
+        command_tx
+            .send(ScheduledSessionCommand::queued(
+                queued_review_request_command(base_dir.path().to_path_buf()),
+                0,
+            ))
+            .expect("failed to queue review request");
+
+        // Act
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            metadata_persistence_started.notified(),
+        )
+        .await
+        .expect("rebase should reach metadata persistence");
+        let events_before_release =
+            std::iter::from_fn(|| app_event_rx.try_recv().ok()).collect::<Vec<_>>();
+        release_metadata_persistence.notify_one();
+        let publish_started = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let event = app_event_rx.recv().await.expect("missing app event");
+                if matches!(event, AppEvent::BranchPublishActionStarted { .. }) {
+                    break;
+                }
+            }
+        })
+        .await;
+
+        // Assert
+        assert!(
+            events_before_release
+                .iter()
+                .all(|event| !matches!(event, AppEvent::BranchPublishActionStarted { .. }))
+        );
+        assert_eq!(*status.lock().expect("status lock"), Status::Review);
+        assert!(
+            transcript_text(&transcript).contains("[Sync] Successfully synced wt/sess1 onto main")
+        );
+        publish_started.expect("review request should start after rebase finalization");
+        assert_eq!(
+            db.sessions()
+                .get_session_stack_base_commit_hash("sess1")
+                .await
+                .expect("failed to load stack-base hash")
+                .as_deref(),
+            Some("parent-tip")
+        );
     }
 
     #[tokio::test]

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -585,7 +585,7 @@ impl Session {
     }
 
     /// Returns the review-request publish action currently available in session
-    /// view, including queueing behind an active turn.
+    /// view, including queueing behind active turn or rebase work.
     pub fn publish_pull_request_action(&self) -> Option<PublishBranchAction> {
         let is_publish_active = self
             .transient_messages
@@ -594,7 +594,8 @@ impl Session {
 
         (self.accepts_user_turns()
             && self.owns_branch_changes()
-            && (self.status.allows_review_actions() || self.status == Status::InProgress)
+            && (self.status.allows_review_actions()
+                || matches!(self.status, Status::InProgress | Status::Rebasing))
             && !is_publish_active)
             .then_some(PublishBranchAction::PublishPullRequest)
     }
@@ -2286,51 +2287,22 @@ diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1,2 @@\n-old line\n+new line\n+anot
     }
 
     #[test]
-    fn test_publish_pull_request_action_queues_for_in_progress_session() {
+    fn test_publish_pull_request_action_queues_for_active_session() {
         // Arrange
-        let session = Session {
-            base_branch: "main".to_string(),
-            created_at: 0,
-            draft_attachments: Vec::new(),
-            folder: PathBuf::new(),
-            follow_up_tasks: Vec::new(),
-            id: "session-id".into(),
-            in_progress_started_at: Some(60),
-            in_progress_total_seconds: 120,
-            is_draft: false,
-            controller_session_id: None,
-            orchestration_progress: None,
-            role: SessionRole::default(),
-            agent: AgentSelection::new(
-                crate::domain::agent::AgentKind::Antigravity,
-                AgentModel::Gemini37Flash,
-            ),
-            parent_session_id: None,
-            permission_mode: crate::domain::permission::PermissionMode::AutoEdit,
-            personality_id: None,
-            project_name: "project".to_string(),
-            prompt: String::new(),
-            queued_messages: Vec::new(),
-            reasoning_level_override: None,
-            published_upstream_ref: Some("origin/wt/session-id".to_string()),
-            questions: Vec::new(),
-            review_request: None,
-            size: SessionSize::Xs,
-            speed_mode: SpeedMode::default(),
-            stats: SessionStats::default(),
-            status: Status::InProgress,
-            summary: None,
-            title: None,
-            transcript: None,
-            updated_at: 0,
-            transient_messages: TransientMessageStore::default(),
-        };
+        let sessions = [Status::InProgress, Status::Rebasing]
+            .map(|status| SessionFixtureBuilder::new().status(status).build());
 
         // Act
-        let action = session.publish_pull_request_action();
+        let actions = sessions.map(|session| session.publish_pull_request_action());
 
         // Assert
-        assert_eq!(action, Some(PublishBranchAction::PublishPullRequest));
+        assert_eq!(
+            actions,
+            [
+                Some(PublishBranchAction::PublishPullRequest),
+                Some(PublishBranchAction::PublishPullRequest),
+            ]
+        );
     }
 
     #[test]

--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -1189,7 +1189,7 @@ mod tests {
     }
 
     #[test]
-    fn test_view_actions_rebasing_shows_queue_and_hides_open_and_stop() {
+    fn test_view_actions_rebasing_shows_queue_publish_and_hides_open_and_stop() {
         // Arrange
         let state = ViewHelpState {
             can_fork_session: ViewActionAvailability::Enabled,
@@ -1200,7 +1200,7 @@ mod tests {
             can_open_worktree: ViewActionAvailability::Enabled,
             reply_to_session: ViewActionAvailability::Enabled,
             can_start_staged_session: ViewActionAvailability::Disabled,
-            publish_pull_request_action: None,
+            publish_pull_request_action: Some(PublishBranchAction::PublishPullRequest),
             session_state: ViewSessionState::Rebasing,
         };
 
@@ -1213,6 +1213,7 @@ mod tests {
                 .iter()
                 .any(|action| { action.key == "Enter" && action.popup_label == "Queue message" })
         );
+        assert!(actions.iter().any(|action| action.key == "p"));
         assert!(!actions.iter().any(|action| action.key == "o"));
         assert!(!actions.iter().any(|action| action.key == "Ctrl+c"));
         assert!(!actions.iter().any(|action| action.key == "d"));
@@ -1715,7 +1716,7 @@ mod tests {
     }
 
     #[test]
-    fn test_view_footer_actions_rebasing_shows_queue_and_hides_open_and_stop() {
+    fn test_view_footer_actions_rebasing_shows_queue_publish_and_hides_open_and_stop() {
         // Arrange
         let state = ViewHelpState {
             can_fork_session: ViewActionAvailability::Enabled,
@@ -1726,7 +1727,7 @@ mod tests {
             can_open_worktree: ViewActionAvailability::Enabled,
             reply_to_session: ViewActionAvailability::Enabled,
             can_start_staged_session: ViewActionAvailability::Disabled,
-            publish_pull_request_action: None,
+            publish_pull_request_action: Some(PublishBranchAction::PublishPullRequest),
             session_state: ViewSessionState::Rebasing,
         };
 
@@ -1735,7 +1736,7 @@ mod tests {
 
         // Assert
         assert!(!actions.iter().any(|action| action.key == "o"));
-        assert!(!actions.iter().any(|action| action.key == "p"));
+        assert!(actions.iter().any(|action| action.key == "p"));
         assert!(!actions.iter().any(|action| action.key == "Ctrl+c"));
         assert!(
             actions

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -971,8 +971,19 @@ fn seed_session_personality(env: &BuilderEnv) -> Result<(), Box<dyn std::error::
 /// Seeds a review-ready transcript and delays its Git rebase long enough to
 /// inspect the in-progress session output ordering.
 fn seed_rebase_transcript_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    seed_rebase_transcript_session_with_delay(env, 5)
+}
+
+/// Seeds the rebase transcript fixture with a configurable pre-rebase delay.
+fn seed_rebase_transcript_session_with_delay(
+    env: &BuilderEnv,
+    delay_seconds: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
     seed_review_ready_session(env)?;
-    seed_review_worktree_with_diff(env)?;
+    seed_linked_review_worktree_with_diff(env)?;
+    std::fs::write(env.workdir.join("base-update.txt"), "new base commit\n")?;
+    run_git(&env.workdir, &["add", "base-update.txt"])?;
+    run_git(&env.workdir, &["commit", "-m", "advance base branch"])?;
 
     let runtime = common::seed_runtime()?;
     runtime.block_on(async {
@@ -1002,14 +1013,11 @@ fn seed_rebase_transcript_session(env: &BuilderEnv) -> Result<(), Box<dyn std::e
             .await
     })?;
 
-    let pre_rebase_hook = env
-        .agentty_root
-        .join("wt")
-        .join("review-s")
-        .join(".git")
-        .join("hooks")
-        .join("pre-rebase");
-    std::fs::write(&pre_rebase_hook, "#!/bin/sh\nsleep 5\n")?;
+    let pre_rebase_hook = env.workdir.join(".git").join("hooks").join("pre-rebase");
+    std::fs::write(
+        &pre_rebase_hook,
+        format!("#!/bin/sh\nsleep {delay_seconds}\n"),
+    )?;
     #[cfg(unix)]
     std::fs::set_permissions(&pre_rebase_hook, std::fs::Permissions::from_mode(0o755))?;
 
@@ -2300,6 +2308,8 @@ case "$*" in
   *"auth status"*)
     exit 0
     ;;
+esac
+case "$*" in
   *"api"*"/pulls"*)
     if [ -f "$marker_path" ]; then
       printf '%s\n' '[{"number":42}]'
@@ -4341,9 +4351,8 @@ fn session_queue_chat_messages_during_in_progress_turn() -> E2eResult {
     Ok(())
 }
 
-/// Verify `Enter` opens the composer while a session is `Rebasing` and the
-/// submitted follow-up renders below existing workflow notices as queued work
-/// without replacing the active rebase status.
+/// Verify a `Rebasing` session exposes review-request publishing and still
+/// queues submitted follow-up messages behind the active sync.
 #[test]
 fn session_queue_chat_message_during_rebase() -> E2eResult {
     // Arrange, Act, Assert
@@ -4358,6 +4367,7 @@ fn session_queue_chat_message_during_rebase() -> E2eResult {
                     .press_key("Enter")
                     .wait_for_text("Rebasing...", 5000)
                     .wait_for_text("Enter: queue message", 5000)
+                    .wait_for_text("p: PR", 5000)
                     .press_key("Enter")
                     .wait_for_text("Type your message", 5000)
                     .write_text("follow up after sync")
@@ -4373,6 +4383,7 @@ fn session_queue_chat_message_during_rebase() -> E2eResult {
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, "Rebasing...", &full);
+                assertion::assert_text_in_region(frame, "p: PR", &full);
                 assertion::assert_text_in_region(frame, "[Commit] No changes to commit.", &full);
                 assertion::assert_text_in_region(
                     frame,
@@ -4402,6 +4413,80 @@ fn session_queue_chat_message_during_rebase() -> E2eResult {
 
                 assert_eq!(sync_assist_row, commit_row + 2);
                 assert_eq!(queued_message_row, sync_assist_row + 2);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify review-request creation submitted during a live rebase stays queued
+/// until sync completes, then publishes on the same session worker.
+#[test]
+fn review_request_creation_queues_during_rebase() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("review_request_queued_during_rebase")
+        .with_git()
+        .setup(|env| {
+            seed_rebase_transcript_session_with_delay(env, 10)?;
+            install_queued_review_request_stubs(env)
+        })
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .compose(&common::open_selected_session_view())
+                    .wait_for_text("Completed answer before rebase summary.", 5000)
+                    .wait_for_text("r: sync", 5000)
+                    .press_key("r")
+                    .wait_for_text("Rebasing...", 5000)
+                    .wait_for_text("p: PR", 5000)
+                    .press_key("p")
+                    .wait_for_text("Publish Review Request", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("≡ review request — publish after this turn", 5000)
+                    .capture_labeled(
+                        "review_request_queued_during_rebase",
+                        "Review-request creation queued behind the active session sync",
+                    )
+                    .wait_for_text("[Sync] Successfully synced", 20000)
+                    .wait_for_text("Publishing review request...", 5000)
+                    .capture_labeled(
+                        "review_request_started_after_rebase",
+                        "Review-request creation starts after session sync completes",
+                    )
+                    .wait_for_text("[Review Request] Created PR", 15000)
+            },
+            |frame, report| {
+                let queued_frame = common::frame_from_capture(&report.captures[0]);
+                let queued_full = Region::full(queued_frame.cols(), queued_frame.rows());
+                assertion::assert_text_in_region(&queued_frame, "Rebasing...", &queued_full);
+                assertion::assert_text_in_region(
+                    &queued_frame,
+                    "≡ review request — publish after this turn",
+                    &queued_full,
+                );
+                assertion::assert_not_visible(&queued_frame, "Publishing review request...");
+
+                let started_frame = common::frame_from_capture(&report.captures[1]);
+                let started_full = Region::full(started_frame.cols(), started_frame.rows());
+                assertion::assert_text_in_region(
+                    &started_frame,
+                    "[Sync] Successfully synced",
+                    &started_full,
+                );
+                assertion::assert_text_in_region(
+                    &started_frame,
+                    "Publishing review request...",
+                    &started_full,
+                );
+                assertion::assert_not_visible(&started_frame, "Rebasing...");
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(
+                    frame,
+                    "[Review Request] Created PR https://github.com/agentty-xyz/agentty/pull/42",
+                    &full,
+                );
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -310,13 +310,13 @@ flowchart LR
    `session_operation` and enqueues it on the per-session worker.
 1. The worker marks the operation `running`, checks cancel flags, verifies worktree
    isolation, and delegates to `workflow/turn.rs`, queued session sync, or queued
-   review-request creation. An **InProgress** branch action can enqueue only through the
-   sender already owned by that worker; it cannot lazily create another worker. The same
-   in-memory chat queue accepts follow-up prompts while the worker is **InProgress** or
-   **Rebasing**. Follow-up prompts and queued branch actions reserve one shared
-   submission sequence, so after the active operation the worker always selects the
-   earliest item across both queues. A command received during a queued chat turn waits
-   for that turn, then runs before only the messages submitted after it.
+   review-request creation. An **InProgress** or **Rebasing** branch action can enqueue
+   only through the sender already owned by that worker; it cannot lazily create another
+   worker. The same in-memory chat queue accepts follow-up prompts while the worker is
+   **InProgress** or **Rebasing**. Follow-up prompts and queued branch actions reserve
+   one shared submission sequence, so after the active operation the worker always
+   selects the earliest item across both queues. A command received during a queued chat
+   turn waits for that turn, then runs before only the messages submitted after it.
 1. Immediately before a chat turn, the worker resolves the persisted personality ID
    through `PersonalityCatalogClient`. The catalog scans only the session worktree's
    `.agents/agents` directory. The worker compares the resolved prompt fingerprint with

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -156,9 +156,9 @@ State-specific differences:
   the running turn. Each `Ctrl+c` retracts the newest queued message; when the queue is
   empty, `Ctrl+c` stops the active turn.
 
-- **Rebasing** sessions use `Enter` to queue a follow-up message behind the active
-  session sync. Slash commands and branch actions remain unavailable until sync
-  finishes.
+- **Rebasing** sessions use `Enter` to queue a follow-up message and keep `p` available
+  to queue review-request creation behind the active session sync. Slash commands and
+  other branch actions remain unavailable until sync finishes.
 
 - Root **Review** and **AgentReview** sessions offer `F` to fork the current branch and
   copied transcript history into a new independent session; stacked children hide `F`.

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -290,6 +290,10 @@ another branch operation already owns that lock, the handler queues immediately 
 waiting and the worker serializes review-request creation behind the operation in
 progress.
 
+Pressing `p` while the session is **Rebasing** queues review-request creation on the
+same worker instead of starting another branch executor. The active sync finishes first,
+then publishing runs when the request reaches the front of the shared queue.
+
 Session output keeps workflow feedback in execution order. Commit feedback appears
 before its sync result, post-sync auto-push progress appears after that result, and
 focused-review progress remains at the tail while those branch operations finish. If a


### PR DESCRIPTION
- Keep the `p` action available during rebase work and publish through the session’s existing worker only after sync finalization completes.
- Cover the rebasing UI and serialized execution path with unit and end-to-end tests.