### PR TITLE
Supports batched tool calls and benchmarks provider compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,12 +62,26 @@ repos:
         language: system
         files: (^|/)(Cargo\.toml|Cargo\.lock|.*\.rs)$
         pass_filenames: false
+      - id: cargo-check-ag-harness-benchmark
+        name: cargo check ag-harness benchmark
+        description: Compile-check the manual ag-harness live benchmark without executing it.
+        entry: cargo check -q --locked -p ag-harness --test benchmark
+        language: system
+        files: (^|/)(Cargo\.toml|Cargo\.lock|crates/ag-harness/(src/.*\.rs|tests/benchmark/.*\.rs))$
+        pass_filenames: false
       - id: clippy
         name: clippy
         description: Run strict clippy across all Rust targets and features, failing on warnings.
         entry: cargo clippy -q --locked --all-targets --all-features -- -D warnings
         language: system
         files: (^|/)(Cargo\.toml|Cargo\.lock|.*\.rs)$
+        pass_filenames: false
+      - id: clippy-ag-harness-benchmark
+        name: clippy ag-harness benchmark
+        description: Lint the manual ag-harness live benchmark without executing it.
+        entry: cargo clippy -q --locked -p ag-harness --test benchmark -- -D warnings
+        language: system
+        files: (^|/)(Cargo\.toml|Cargo\.lock|crates/ag-harness/(src/.*\.rs|tests/benchmark/.*\.rs))$
         pass_filenames: false
       - id: test-workspace
         name: cargo nextest workspace

--- a/crates/ag-harness/Cargo.toml
+++ b/crates/ag-harness/Cargo.toml
@@ -15,6 +15,13 @@ path = "tests/e2e/main.rs"
 test = false
 bench = false
 
+[[test]]
+name = "benchmark"
+path = "tests/benchmark/main.rs"
+test = false
+bench = false
+harness = false
+
 [dependencies]
 async-trait.workspace = true
 jsonschema.workspace = true

--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -21,7 +21,10 @@ Provide `MODEL_API_KEY`, a repository root, explicitly allowed tools, a prompt, 
 Tools are denied by default and repository tools require an explicit root. `read`
 returns bounded file content; `write` applies one bounded unified diff to one text file.
 Both use the injected `FileSystem` boundary without shell commands, and the model may
-continue calling allowed tools until it returns schema-valid JSON.
+continue calling allowed tools until it returns schema-valid JSON. When a provider
+returns multiple tool calls in one response, the harness validates the complete batch,
+executes it in provider order, and records one assistant message followed by every tool
+result.
 
 Use `Harness::chat()` for sequential in-memory turns and sanitized activity reports.
 Chat history retains complete recent turns within a 256 KiB payload budget; use
@@ -60,4 +63,5 @@ and shutdown. The emitted signals follow the pinned OpenTelemetry GenAI
 semantic-convention contract documented in the architecture guide.
 
 The companion `ag-harness-cli` package provides an interactive command-line chat powered
-by this library.
+by this library. The manual real-model compatibility benchmark and its latest recorded
+results live in `tests/benchmark/README.md`.

--- a/crates/ag-harness/src/chat_completion.rs
+++ b/crates/ag-harness/src/chat_completion.rs
@@ -13,7 +13,7 @@ use crate::{model, schema_contract, tool};
 
 pub(crate) const ERROR_BODY_LIMIT_BYTES: usize = 4 * 1024;
 const JSON_STRING_MAX_EXPANSION: usize = 6;
-const MAX_RATE_LIMIT_RETRIES: usize = 2;
+const MAX_RATE_LIMIT_RETRIES: usize = 5;
 const MAX_RETRY_DELAY: Duration = Duration::from_secs(5);
 const MAX_TRANSPORT_RETRIES: usize = 1;
 pub(crate) const RESPONSE_ENVELOPE_LIMIT_BYTES: usize = 64 * 1024;
@@ -81,6 +81,10 @@ pub(crate) enum GeneratedResponse {
     },
     ToolCall {
         call: tool::ToolCall,
+        metadata: model::CompletionMetadata,
+    },
+    ToolCalls {
+        calls: Vec<tool::ToolCall>,
         metadata: model::CompletionMetadata,
     },
 }
@@ -167,7 +171,7 @@ impl ChatCompletionBackend {
                 self.policy
                     .structured_output
                     .assistant_reasoning_content()
-                    .then_some(reasoning_content)
+                    .then_some(reasoning_content.as_deref())
                     .flatten(),
                 tool_calls,
                 metadata,
@@ -238,26 +242,10 @@ impl ChatCompletionBackend {
                     });
                 }
                 model::ModelMessage::AssistantToolCall(call) => {
-                    messages.push(ChatCompletionMessagePayload::AssistantToolCall {
-                        content: None,
-                        reasoning_content: self
-                            .policy
-                            .structured_output
-                            .assistant_reasoning_content()
-                            .then(|| call.reasoning_content().map(str::to_string))
-                            .flatten(),
-                        role: "assistant",
-                        tool_calls: vec![ChatCompletionOutgoingToolCall {
-                            function: ChatCompletionOutgoingFunctionCall {
-                                arguments: call
-                                    .arguments_json()
-                                    .map_err(model::ModelError::request)?,
-                                name: call.name().to_string(),
-                            },
-                            id: call.id().to_string(),
-                            kind: "function",
-                        }],
-                    });
+                    messages.push(self.assistant_tool_call_message(std::slice::from_ref(call))?);
+                }
+                model::ModelMessage::AssistantToolCalls(calls) => {
+                    messages.push(self.assistant_tool_call_message(calls)?);
                 }
                 model::ModelMessage::ToolResult {
                     call_id,
@@ -279,6 +267,43 @@ impl ChatCompletionBackend {
         }
 
         Ok(messages)
+    }
+
+    fn assistant_tool_call_message(
+        &self,
+        calls: &[tool::ToolCall],
+    ) -> Result<ChatCompletionMessagePayload, model::ModelError> {
+        let reasoning_content = self
+            .policy
+            .structured_output
+            .assistant_reasoning_content()
+            .then(|| {
+                calls
+                    .first()
+                    .and_then(tool::ToolCall::reasoning_content)
+                    .map(str::to_string)
+            })
+            .flatten();
+        let tool_calls = calls
+            .iter()
+            .map(|call| {
+                Ok(ChatCompletionOutgoingToolCall {
+                    function: ChatCompletionOutgoingFunctionCall {
+                        arguments: call.arguments_json().map_err(model::ModelError::request)?,
+                        name: call.name().to_string(),
+                    },
+                    id: call.id().to_string(),
+                    kind: "function",
+                })
+            })
+            .collect::<Result<_, model::ModelError>>()?;
+
+        Ok(ChatCompletionMessagePayload::AssistantToolCall {
+            content: None,
+            reasoning_content,
+            role: "assistant",
+            tool_calls,
+        })
     }
 
     fn response_format<'a>(&self, schema: &'a schema_contract::OutputSchema) -> ResponseFormat<'a> {
@@ -323,12 +348,16 @@ impl ChatCompletionBackend {
     fn decode_tool_call(
         request: &model::ModelRequest,
         content: Option<&str>,
-        reasoning_content: Option<String>,
+        reasoning_content: Option<&str>,
         calls: Vec<ChatCompletionToolCall>,
         metadata: model::CompletionMetadata,
     ) -> GeneratedResponse {
         match Self::decode_tool_call_parts(request, content, reasoning_content, calls) {
-            Ok(call) => GeneratedResponse::ToolCall { call, metadata },
+            Ok(mut calls) if calls.len() == 1 => GeneratedResponse::ToolCall {
+                call: calls.remove(0),
+                metadata,
+            },
+            Ok(calls) => GeneratedResponse::ToolCalls { calls, metadata },
             Err(error) => GeneratedResponse::failed(error, metadata),
         }
     }
@@ -336,17 +365,33 @@ impl ChatCompletionBackend {
     fn decode_tool_call_parts(
         request: &model::ModelRequest,
         content: Option<&str>,
-        reasoning_content: Option<String>,
-        mut calls: Vec<ChatCompletionToolCall>,
-    ) -> Result<tool::ToolCall, model::ModelError> {
+        reasoning_content: Option<&str>,
+        calls: Vec<ChatCompletionToolCall>,
+    ) -> Result<Vec<tool::ToolCall>, model::ModelError> {
         if content.is_some_and(|content| !content.is_empty()) {
             return Err(model::ModelError::ToolCallWithContent);
         }
-        let call = match calls.len() {
-            0 => return Err(model::ModelError::MissingToolCall),
-            1 => calls.remove(0),
-            _ => return Err(model::ModelError::MultipleToolCalls),
-        };
+        if calls.is_empty() {
+            return Err(model::ModelError::MissingToolCall);
+        }
+        let mut decoded = Vec::with_capacity(calls.len());
+        for (index, call) in calls.into_iter().enumerate() {
+            decoded.push(Self::decode_one_tool_call(
+                request,
+                call,
+                (index == 0).then_some(reasoning_content).flatten(),
+            )?);
+        }
+        model::ensure_unique_tool_call_ids(&decoded)?;
+
+        Ok(decoded)
+    }
+
+    fn decode_one_tool_call(
+        request: &model::ModelRequest,
+        call: ChatCompletionToolCall,
+        reasoning_content: Option<&str>,
+    ) -> Result<tool::ToolCall, model::ModelError> {
         if call.kind != "function" {
             return Err(model::ModelError::UnsupportedToolType {
                 kind: schema_contract::bounded_diagnostic(call.kind),
@@ -363,7 +408,7 @@ impl ChatCompletionBackend {
         }
         schema_contract::ensure_content_size(&function.arguments)
             .map_err(model::ModelError::from)?;
-        if let Some(reasoning_content) = reasoning_content.as_deref() {
+        if let Some(reasoning_content) = reasoning_content {
             schema_contract::ensure_content_size(reasoning_content)
                 .map_err(model::ModelError::from)?;
         }
@@ -373,14 +418,14 @@ impl ChatCompletionBackend {
                     reason: schema_contract::bounded_diagnostic(error),
                 })?;
 
-            tool::ToolCall::write(call.id, arguments, reasoning_content)
+            tool::ToolCall::write(call.id, arguments, reasoning_content.map(str::to_string))
         } else {
             let arguments = serde_json::from_str::<tool::ReadArguments>(&function.arguments)
                 .map_err(|error| model::ModelError::InvalidToolArguments {
                     reason: schema_contract::bounded_diagnostic(error),
                 })?;
 
-            tool::ToolCall::read(call.id, arguments, reasoning_content)
+            tool::ToolCall::read(call.id, arguments, reasoning_content.map(str::to_string))
         };
 
         Ok(call)
@@ -542,15 +587,15 @@ impl ChatCompletionClient for ReqwestChatCompletionClient {
 }
 
 fn rate_limit_retry_delay(headers: &reqwest::header::HeaderMap, retry: usize) -> Duration {
-    headers
+    let provider_delay = headers
         .get(reqwest::header::RETRY_AFTER)
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.parse::<u64>().ok())
-        .map_or_else(
-            || RETRY_DELAY.saturating_mul(1_u32 << retry.min(31)),
-            Duration::from_secs,
-        )
-        .min(MAX_RETRY_DELAY)
+        .map(Duration::from_secs)
+        .unwrap_or_default();
+    let backoff = RETRY_DELAY.saturating_mul(1_u32 << retry.min(31));
+
+    provider_delay.max(backoff).min(MAX_RETRY_DELAY)
 }
 
 async fn error_body_summary(response: &mut reqwest::Response) -> String {
@@ -870,6 +915,22 @@ mod tests {
 
     use super::*;
 
+    fn native_schema_backend() -> ChatCompletionBackend {
+        ChatCompletionBackend::with_client(
+            "test-key".to_string(),
+            "https://example.com/v1".to_string(),
+            "native-schema-model".to_string(),
+            ChatCompletionProviderPolicy {
+                display_name: "Native schema provider",
+                response_format_with_tools: true,
+                structured_output: StructuredOutputMode::JsonSchema,
+                telemetry_name: "native_schema",
+                unsupported_schema_reason: "object schema required",
+            },
+            default_client(),
+        )
+    }
+
     #[test]
     fn builds_endpoint_from_base_url() {
         // Arrange and Act
@@ -882,19 +943,7 @@ mod tests {
     #[test]
     fn serializes_tool_history_for_native_json_schema_provider() {
         // Arrange
-        let backend = ChatCompletionBackend::with_client(
-            "test-key".to_string(),
-            "https://example.com/v1".to_string(),
-            "native-schema-model".to_string(),
-            ChatCompletionProviderPolicy {
-                display_name: "Native schema provider",
-                response_format_with_tools: true,
-                structured_output: StructuredOutputMode::JsonSchema,
-                telemetry_name: "native_schema",
-                unsupported_schema_reason: "object schema required",
-            },
-            default_client(),
-        );
+        let backend = native_schema_backend();
         let schema = schema_contract::OutputSchema::new(serde_json::json!({
             "type": "object"
         }))
@@ -944,21 +993,84 @@ mod tests {
     }
 
     #[test]
+    fn serializes_batched_tool_history_for_native_json_schema_provider() {
+        // Arrange
+        let backend = native_schema_backend();
+        let schema = schema_contract::OutputSchema::new(serde_json::json!({
+            "type": "object"
+        }))
+        .expect("schema should be valid");
+        let calls = [
+            ("call_manifest", "Cargo.toml"),
+            ("call_readme", "README.md"),
+        ]
+        .into_iter()
+        .map(|(id, path)| {
+            let arguments = serde_json::from_value(serde_json::json!({ "path": path }))
+                .expect("read arguments should be valid");
+
+            tool::ToolCall::read(id.to_string(), arguments, None)
+        })
+        .collect();
+        let mut request = model::ModelRequest::new("inspect both files", schema);
+        request.record_tool_results(
+            calls,
+            vec!["manifest result".to_string(), "readme result".to_string()],
+        );
+
+        // Act
+        let messages = serde_json::to_value(
+            backend
+                .messages(&request)
+                .expect("batched tool history should serialize"),
+        )
+        .expect("messages should encode as JSON");
+
+        // Assert
+        assert_eq!(
+            messages,
+            serde_json::json!([
+                {"content": "inspect both files", "role": "user"},
+                {
+                    "content": null,
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "arguments": r#"{"path":"Cargo.toml"}"#,
+                                "name": "read"
+                            },
+                            "id": "call_manifest",
+                            "type": "function"
+                        },
+                        {
+                            "function": {
+                                "arguments": r#"{"path":"README.md"}"#,
+                                "name": "read"
+                            },
+                            "id": "call_readme",
+                            "type": "function"
+                        }
+                    ]
+                },
+                {
+                    "content": "manifest result",
+                    "role": "tool",
+                    "tool_call_id": "call_manifest"
+                },
+                {
+                    "content": "readme result",
+                    "role": "tool",
+                    "tool_call_id": "call_readme"
+                }
+            ])
+        );
+    }
+
+    #[test]
     fn serializes_conversation_history() {
         // Arrange
-        let backend = ChatCompletionBackend::with_client(
-            "test-key".to_string(),
-            "https://example.com/v1".to_string(),
-            "native-schema-model".to_string(),
-            ChatCompletionProviderPolicy {
-                display_name: "Native schema provider",
-                response_format_with_tools: true,
-                structured_output: StructuredOutputMode::JsonSchema,
-                telemetry_name: "native_schema",
-                unsupported_schema_reason: "object schema required",
-            },
-            default_client(),
-        );
+        let backend = native_schema_backend();
         let schema = schema_contract::OutputSchema::new(serde_json::json!({
             "type": "object"
         }))
@@ -1188,6 +1300,92 @@ mod tests {
     }
 
     #[test]
+    fn decodes_multiple_advertised_tool_calls() {
+        // Arrange
+        let schema = schema_contract::OutputSchema::new(serde_json::json!({
+            "type": "object"
+        }))
+        .expect("schema should be valid");
+        let request =
+            model::ModelRequest::new("inspect", schema).with_tool(tool::ToolDefinition::read());
+        let calls = ["Cargo.toml", "README.md"]
+            .into_iter()
+            .enumerate()
+            .map(|(index, path)| ChatCompletionToolCall {
+                function: serde_json::json!({
+                    "name": "read",
+                    "arguments": serde_json::json!({"path": path}).to_string()
+                }),
+                id: format!("call_{index}"),
+                kind: "function".to_string(),
+            })
+            .collect();
+
+        // Act
+        let response = ChatCompletionBackend::decode_tool_call(
+            &request,
+            None,
+            Some("reasoning"),
+            calls,
+            model::CompletionMetadata::new("tool_calls".to_string(), None, None, None, None),
+        );
+
+        // Assert
+        assert!(matches!(
+            response,
+            GeneratedResponse::ToolCalls { calls, metadata }
+                if metadata.finish_reason() == "tool_calls"
+                    && calls.len() == 2
+                    && calls[0].read_arguments().is_some_and(|arguments| {
+                        arguments.path() == "Cargo.toml"
+                    })
+                    && calls[1].read_arguments().is_some_and(|arguments| {
+                        arguments.path() == "README.md"
+                    })
+        ));
+    }
+
+    #[test]
+    fn rejects_duplicate_tool_call_ids() {
+        // Arrange
+        let schema = schema_contract::OutputSchema::new(serde_json::json!({
+            "type": "object"
+        }))
+        .expect("schema should be valid");
+        let request =
+            model::ModelRequest::new("inspect", schema).with_tool(tool::ToolDefinition::read());
+        let calls = ["Cargo.toml", "README.md"]
+            .into_iter()
+            .map(|path| ChatCompletionToolCall {
+                function: serde_json::json!({
+                    "name": "read",
+                    "arguments": serde_json::json!({"path": path}).to_string()
+                }),
+                id: "duplicate_call".to_string(),
+                kind: "function".to_string(),
+            })
+            .collect();
+
+        // Act
+        let response = ChatCompletionBackend::decode_tool_call(
+            &request,
+            None,
+            None,
+            calls,
+            model::CompletionMetadata::new("tool_calls".to_string(), None, None, None, None),
+        );
+
+        // Assert
+        assert!(matches!(
+            response,
+            GeneratedResponse::Failed {
+                error: model::ModelError::DuplicateToolCallId { id },
+                metadata,
+            } if id == "duplicate_call" && metadata.finish_reason() == "tool_calls"
+        ));
+    }
+
+    #[test]
     fn rejects_success_chunk_that_exceeds_remaining_capacity() {
         // Arrange
         let mut body = vec![0; SUCCESS_BODY_LIMIT_BYTES - 1];
@@ -1259,6 +1457,11 @@ mod tests {
         // Act and Assert
         assert_eq!(rate_limit_retry_delay(&headers, 0), Duration::from_secs(1));
         assert_eq!(rate_limit_retry_delay(&headers, 1), Duration::from_secs(2));
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            "1".parse().expect("valid header"),
+        );
+        assert_eq!(rate_limit_retry_delay(&headers, 2), Duration::from_secs(4));
         headers.insert(
             reqwest::header::RETRY_AFTER,
             "99".parse().expect("valid header"),

--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -14,6 +14,7 @@ use crate::lifecycle::{
 };
 use crate::model::{
     CompletionMetadata, Model, ModelError, ModelMessage, ModelRequest, ModelResponse,
+    ensure_unique_tool_call_ids,
 };
 use crate::policy::Policy;
 use crate::read::{ReadError, ReadTool};
@@ -484,6 +485,33 @@ impl Harness {
                     request.record_tool_result(call, result);
                     tool_calls.push(activity);
                     completed_tool_calls += 1;
+                }
+                ModelResponse::ToolCalls(calls) => {
+                    if calls.is_empty() {
+                        return Err(ModelError::MissingToolCall.into());
+                    }
+                    ensure_unique_tool_call_ids(&calls)?;
+                    if calls.len() > self.max_tool_calls.saturating_sub(completed_tool_calls) {
+                        return Err(TurnError::ToolCallLimit {
+                            limit: self.max_tool_calls,
+                        });
+                    }
+                    let mut results = Vec::with_capacity(calls.len());
+                    for call in &calls {
+                        let (result, activity) = self
+                            .execute_tool_call(
+                                call,
+                                read_tool.as_ref(),
+                                write_tool.as_ref(),
+                                completed_tool_calls,
+                                turn_id,
+                            )
+                            .await?;
+                        results.push(result);
+                        tool_calls.push(activity);
+                        completed_tool_calls += 1;
+                    }
+                    request.record_tool_results(calls, results);
                 }
             }
         }
@@ -1036,6 +1064,75 @@ mod tests {
 
         // Assert
         assert_eq!(output, json!({ "summary": "workspace" }));
+    }
+
+    #[tokio::test]
+    async fn completes_multiple_read_tools_from_one_model_response() {
+        // Arrange
+        let mut model = model();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        model
+            .expect_complete_with_optional_metadata()
+            .times(2)
+            .returning(move |request| {
+                if call_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                    return Ok(response_without_metadata(ModelResponse::ToolCalls(vec![
+                        read_call("call_one"),
+                        read_call("call_two"),
+                    ])));
+                }
+                assert!(matches!(
+                    &request.messages()[1],
+                    ModelMessage::AssistantToolCalls(calls)
+                        if calls.iter().map(ToolCall::id).collect::<Vec<_>>()
+                            == ["call_one", "call_two"]
+                ));
+                assert!(matches!(
+                    &request.messages()[2],
+                    ModelMessage::ToolResult { call_id, .. } if call_id == "call_one"
+                ));
+                assert!(matches!(
+                    &request.messages()[3],
+                    ModelMessage::ToolResult { call_id, .. } if call_id == "call_two"
+                ));
+
+                Ok(response_without_metadata(ModelResponse::Output(
+                    json!({ "summary": "workspace" }),
+                )))
+            });
+        let mut file_system = MockFileSystem::new();
+        file_system
+            .expect_canonicalize()
+            .times(4)
+            .returning(|path| {
+                if path == std::path::Path::new("repo") {
+                    Ok(PathBuf::from("/repo"))
+                } else {
+                    Ok(PathBuf::from("/repo/Cargo.toml"))
+                }
+            });
+        file_system
+            .expect_open_beneath()
+            .times(2)
+            .returning(|_, _| {
+                Ok(Box::new(Cursor::new(
+                    b"[workspace]\nmember = true\n".to_vec(),
+                )))
+            });
+        let harness = Harness::new(model)
+            .file_system(file_system)
+            .repository("repo")
+            .allow(Tool::Read);
+
+        // Act
+        let outcome = harness
+            .run_report("inspect two files", object_schema())
+            .await
+            .expect("parallel tool round trip should succeed");
+
+        // Assert
+        assert_eq!(outcome.output(), &json!({ "summary": "workspace" }));
+        assert_eq!(outcome.report().tool_calls().len(), 2);
     }
 
     #[tokio::test]
@@ -1845,6 +1942,154 @@ mod tests {
         // Assert
         assert!(matches!(&error, TurnError::ToolCallLimit { limit: 1 }));
         assert_eq!(error.error_type(), TurnErrorType::ToolCallLimit);
+    }
+
+    #[tokio::test]
+    async fn enforces_tool_call_limit_within_one_model_response() {
+        // Arrange
+        let mut model = model();
+        model
+            .expect_complete_with_optional_metadata()
+            .times(1)
+            .returning(|_| {
+                Ok(response_without_metadata(ModelResponse::ToolCalls(vec![
+                    read_call("call_one"),
+                    read_call("call_two"),
+                ])))
+            });
+        let mut file_system = MockFileSystem::new();
+        file_system.expect_canonicalize().times(0);
+        file_system.expect_open_beneath().times(0);
+        let harness = Harness::new(model)
+            .file_system(file_system)
+            .repository("repo")
+            .allow(Tool::Read)
+            .max_tool_calls(NonZeroUsize::new(1).expect("limit should be non-zero"));
+
+        // Act
+        let error = harness
+            .run("inspect", object_schema())
+            .await
+            .expect_err("second batched tool call should exceed the limit");
+
+        // Assert
+        assert!(matches!(error, TurnError::ToolCallLimit { limit: 1 }));
+    }
+
+    #[tokio::test]
+    async fn rejects_batched_writes_before_any_write_executes() {
+        // Arrange
+        let mut model = model();
+        model
+            .expect_complete_with_optional_metadata()
+            .times(1)
+            .returning(|_| {
+                Ok(response_without_metadata(ModelResponse::ToolCalls(vec![
+                    write_call(
+                        "call_one",
+                        "--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+first\n",
+                    ),
+                    write_call(
+                        "call_two",
+                        "--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+second\n",
+                    ),
+                ])))
+            });
+        let mut file_system = MockFileSystem::new();
+        file_system.expect_canonicalize().times(0);
+        file_system.expect_open_beneath().times(0);
+        file_system.expect_replace_beneath().times(0);
+        let harness = Harness::new(model)
+            .file_system(file_system)
+            .repository("repo")
+            .allow(Tool::Write)
+            .max_tool_calls(NonZeroUsize::new(1).expect("limit should be non-zero"));
+
+        // Act
+        let error = harness
+            .run("update twice", object_schema())
+            .await
+            .expect_err("oversized batch should fail before writing");
+
+        // Assert
+        assert!(matches!(&error, TurnError::ToolCallLimit { limit: 1 }));
+        assert_eq!(error.error_type(), TurnErrorType::ToolCallLimit);
+    }
+
+    #[tokio::test]
+    async fn rejects_duplicate_batched_call_ids_before_any_write_executes() {
+        // Arrange
+        let mut model = model();
+        model
+            .expect_complete_with_optional_metadata()
+            .times(1)
+            .returning(|_| {
+                Ok(response_without_metadata(ModelResponse::ToolCalls(vec![
+                    write_call(
+                        "duplicate_call",
+                        "--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+first\n",
+                    ),
+                    write_call(
+                        "duplicate_call",
+                        "--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+second\n",
+                    ),
+                ])))
+            });
+        let mut file_system = MockFileSystem::new();
+        file_system.expect_canonicalize().times(0);
+        file_system.expect_open_beneath().times(0);
+        file_system.expect_replace_beneath().times(0);
+        let harness = Harness::new(model)
+            .file_system(file_system)
+            .repository("repo")
+            .allow(Tool::Write);
+
+        // Act
+        let error = harness
+            .run("update twice", object_schema())
+            .await
+            .expect_err("duplicate call identifiers should fail before writing");
+
+        // Assert
+        assert!(matches!(
+            &error,
+            TurnError::Model(ModelError::DuplicateToolCallId { id }) if id == "duplicate_call"
+        ));
+        assert_eq!(
+            error.error_type(),
+            TurnErrorType::Model(crate::ModelErrorType::InvalidToolCall)
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_empty_tool_call_batch() {
+        // Arrange
+        let mut model = model();
+        model
+            .expect_complete_with_optional_metadata()
+            .times(1)
+            .returning(|_| {
+                Ok(response_without_metadata(ModelResponse::ToolCalls(
+                    Vec::new(),
+                )))
+            });
+        let harness = Harness::new(model);
+
+        // Act
+        let error = harness
+            .run("inspect", object_schema())
+            .await
+            .expect_err("empty tool batch should fail immediately");
+
+        // Assert
+        assert!(matches!(
+            &error,
+            TurnError::Model(ModelError::MissingToolCall)
+        ));
+        assert_eq!(
+            error.error_type(),
+            TurnErrorType::Model(crate::ModelErrorType::InvalidToolCall)
+        );
     }
 
     #[tokio::test]

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::error::Error;
 
 use async_trait::async_trait;
@@ -6,7 +7,7 @@ use thiserror::Error;
 
 use crate::lifecycle::{LifecycleEmitter, LifecycleObserver, ModelResponseType};
 use crate::provider::{self, KimiConfig, MuseConfig, QwenConfig};
-use crate::schema_contract::{OutputSchema, OutputValidationError};
+use crate::schema_contract::{OutputSchema, OutputValidationError, bounded_diagnostic};
 use crate::{chat_completion, telemetry, tool};
 
 /// Object-safe boundary for provider-neutral model requests.
@@ -225,6 +226,13 @@ impl ModelClient {
                 )),
                 None,
             ),
+            Ok(chat_completion::GeneratedResponse::ToolCalls { calls, metadata }) => (
+                Ok(ModelCompletion::new(
+                    metadata,
+                    ModelResponse::tool_calls(calls),
+                )),
+                None,
+            ),
             Err(error) => (Err(error), None),
         };
 
@@ -423,6 +431,30 @@ impl ModelRequest {
         });
     }
 
+    pub(crate) fn record_tool_results(
+        &mut self,
+        calls: Vec<tool::ToolCall>,
+        contents: Vec<String>,
+    ) {
+        debug_assert_eq!(calls.len(), contents.len());
+        let results: Vec<_> = calls
+            .iter()
+            .zip(contents)
+            .map(|(call, content)| (call.id().to_string(), call.name().to_string(), content))
+            .collect();
+        self.messages.push(ModelMessage::AssistantToolCalls(calls));
+        self.messages
+            .extend(
+                results
+                    .into_iter()
+                    .map(|(call_id, name, content)| ModelMessage::ToolResult {
+                        call_id,
+                        content,
+                        name,
+                    }),
+            );
+    }
+
     pub(crate) fn record_output(&mut self, output: &Value) {
         self.messages
             .push(ModelMessage::Assistant(output.to_string()));
@@ -437,6 +469,7 @@ impl ModelRequest {
 pub(crate) enum ModelMessage {
     Assistant(String),
     AssistantToolCall(tool::ToolCall),
+    AssistantToolCalls(Vec<tool::ToolCall>),
     System(String),
     ToolResult {
         call_id: String,
@@ -461,6 +494,17 @@ impl ModelMessage {
                     .saturating_add(arguments)
                     .saturating_add(call.reasoning_content().map_or(0, str::len))
             }
+            Self::AssistantToolCalls(calls) => calls.iter().fold(0, |bytes, call| {
+                let arguments = call
+                    .arguments_json()
+                    .map_or(usize::MAX, |arguments| arguments.len());
+
+                bytes
+                    .saturating_add(call.id().len())
+                    .saturating_add(call.name().len())
+                    .saturating_add(arguments)
+                    .saturating_add(call.reasoning_content().map_or(0, str::len))
+            }),
             Self::ToolResult {
                 call_id,
                 content,
@@ -626,6 +670,10 @@ pub enum ModelResponse {
     Output(Value),
     /// One validated native function call requiring application handling.
     ToolCall(tool::ToolCall),
+    /// Multiple validated native function calls from one model response.
+    ///
+    /// The harness rejects an empty batch as a missing tool call.
+    ToolCalls(Vec<tool::ToolCall>),
 }
 
 impl ModelResponse {
@@ -633,15 +681,24 @@ impl ModelResponse {
     pub fn output(&self) -> Option<&Value> {
         match self {
             Self::Output(output) => Some(output),
-            Self::ToolCall(_) => None,
+            Self::ToolCall(_) | Self::ToolCalls(_) => None,
         }
     }
 
     /// Returns the intermediate native function call, when present.
     pub fn call(&self) -> Option<&tool::ToolCall> {
         match self {
-            Self::Output(_) => None,
             Self::ToolCall(call) => Some(call),
+            Self::Output(_) | Self::ToolCalls(_) => None,
+        }
+    }
+
+    /// Returns every intermediate native function call in this response.
+    pub fn calls(&self) -> &[tool::ToolCall] {
+        match self {
+            Self::Output(_) => &[],
+            Self::ToolCall(call) => std::slice::from_ref(call),
+            Self::ToolCalls(calls) => calls,
         }
     }
 
@@ -653,10 +710,14 @@ impl ModelResponse {
         Self::ToolCall(call)
     }
 
+    fn tool_calls(calls: Vec<tool::ToolCall>) -> Self {
+        Self::ToolCalls(calls)
+    }
+
     pub(crate) fn response_type(&self) -> ModelResponseType {
         match self {
             Self::Output(_) => ModelResponseType::Output,
-            Self::ToolCall(_) => ModelResponseType::ToolCall,
+            Self::ToolCall(_) | Self::ToolCalls(_) => ModelResponseType::ToolCall,
         }
     }
 }
@@ -709,6 +770,12 @@ pub enum ModelError {
     /// The provider returned more than the single supported call.
     #[error("model returned multiple tool calls")]
     MultipleToolCalls,
+    /// The provider returned multiple tool calls with the same identifier.
+    #[error("model returned duplicate tool call identifier: {id}")]
+    DuplicateToolCallId {
+        /// Bounded duplicate identifier returned by the provider.
+        id: String,
+    },
     /// A tool-call response also contained terminal assistant content.
     #[error("model tool call response contained terminal content")]
     ToolCallWithContent,
@@ -824,6 +891,7 @@ impl ModelError {
             }
             Self::MissingToolCall
             | Self::MultipleToolCalls
+            | Self::DuplicateToolCallId { .. }
             | Self::ToolCallWithContent
             | Self::TerminalResponseWithToolCalls
             | Self::UnsupportedToolType { .. }
@@ -863,6 +931,19 @@ impl ModelError {
     ) -> Self {
         Self::Request(Box::new(ClassifiedRequestError { error_type, source }))
     }
+}
+
+pub(crate) fn ensure_unique_tool_call_ids(calls: &[tool::ToolCall]) -> Result<(), ModelError> {
+    let mut call_ids = HashSet::with_capacity(calls.len());
+    for call in calls {
+        if !call_ids.insert(call.id()) {
+            return Err(ModelError::DuplicateToolCallId {
+                id: bounded_diagnostic(call.id()),
+            });
+        }
+    }
+
+    Ok(())
 }
 
 impl From<OutputValidationError> for ModelError {
@@ -1058,6 +1139,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn client_returns_multiple_tool_calls() {
+        // Arrange
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_manifest",
+                                "type": "function",
+                                "function": {
+                                    "name": "read",
+                                    "arguments": r#"{"path":"Cargo.toml"}"#
+                                }
+                            },
+                            {
+                                "id": "call_readme",
+                                "type": "function",
+                                "function": {
+                                    "name": "read",
+                                    "arguments": r#"{"path":"README.md"}"#
+                                }
+                            }
+                        ]
+                    }
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = ModelClient::qwen(QwenConfig {
+            api_key: "test-key".to_string(),
+            base_url: server.uri(),
+            model: "qwen-plus".to_string(),
+        })
+        .expect("fixture configuration should be valid");
+        let request = test_request().with_tool(tool::ToolDefinition::read());
+
+        // Act
+        let completion = client
+            .complete_with_metadata(request)
+            .await
+            .expect("batched tool response should complete");
+
+        // Assert
+        assert_eq!(completion.metadata().finish_reason(), "tool_calls");
+        assert_eq!(
+            completion
+                .response()
+                .calls()
+                .iter()
+                .map(tool::ToolCall::id)
+                .collect::<Vec<_>>(),
+            ["call_manifest", "call_readme"]
+        );
+    }
+
+    #[tokio::test]
     async fn client_observes_classified_failure() {
         // Arrange
         let server = MockServer::start().await;
@@ -1207,6 +1350,74 @@ mod tests {
         // Assert
         assert_eq!(response.output(), Some(&value));
         assert!(response.call().is_none());
+        assert_eq!(response.calls(), []);
+    }
+
+    #[test]
+    fn response_exposes_multiple_tool_calls() {
+        // Arrange
+        let calls = vec![
+            tool::ToolCall::read(
+                "call_one".to_string(),
+                serde_json::from_value(json!({"path": "Cargo.toml"}))
+                    .expect("read arguments should be valid"),
+                None,
+            ),
+            tool::ToolCall::read(
+                "call_two".to_string(),
+                serde_json::from_value(json!({"path": "README.md"}))
+                    .expect("read arguments should be valid"),
+                None,
+            ),
+        ];
+
+        // Act
+        let response = ModelResponse::tool_calls(calls);
+
+        // Assert
+        assert!(response.output().is_none());
+        assert!(response.call().is_none());
+        assert_eq!(
+            response
+                .calls()
+                .iter()
+                .map(tool::ToolCall::id)
+                .collect::<Vec<_>>(),
+            ["call_one", "call_two"]
+        );
+    }
+
+    #[test]
+    fn batched_tool_message_retained_bytes_sums_each_call() {
+        // Arrange
+        let calls = vec![
+            tool::ToolCall::read(
+                "call_manifest".to_string(),
+                serde_json::from_value(json!({"path": "Cargo.toml"}))
+                    .expect("read arguments should be valid"),
+                Some("reasoning".to_string()),
+            ),
+            tool::ToolCall::read(
+                "call_readme".to_string(),
+                serde_json::from_value(json!({"path": "README.md"}))
+                    .expect("read arguments should be valid"),
+                None,
+            ),
+        ];
+        let message = ModelMessage::AssistantToolCalls(calls);
+        let expected = "call_manifest".len()
+            + "read".len()
+            + r#"{"path":"Cargo.toml"}"#.len()
+            + "reasoning".len()
+            + "call_readme".len()
+            + "read".len()
+            + r#"{"path":"README.md"}"#.len();
+
+        // Act
+        let retained_bytes = message.retained_bytes();
+
+        // Assert
+        assert_eq!(retained_bytes, expected);
     }
 
     #[test]
@@ -1276,6 +1487,7 @@ mod tests {
         let debug_output = format!("{response:?}");
 
         // Assert
+        assert_eq!(response.calls()[0].id(), "call_read");
         assert!(debug_output.contains("call_read"));
         assert!(debug_output.contains("[REDACTED]"));
         assert!(!debug_output.contains(secret_reasoning));
@@ -1420,6 +1632,21 @@ mod tests {
             ModelErrorType::InvalidToolCall.as_str(),
             "invalid_tool_call"
         );
+    }
+
+    #[test]
+    fn classifies_duplicate_tool_call_id_as_invalid_tool_call() {
+        // Arrange
+        let error = ModelError::DuplicateToolCallId {
+            id: "duplicate_call".to_string(),
+        };
+
+        // Act
+        let error_type = error.error_type();
+
+        // Assert
+        assert_eq!(error_type, ModelErrorType::InvalidToolCall);
+        assert_eq!(error.http_status(), None);
     }
 
     #[test]

--- a/crates/ag-harness/src/provider/kimi.rs
+++ b/crates/ag-harness/src/provider/kimi.rs
@@ -367,44 +367,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejects_missing_and_multiple_tool_calls() {
+    async fn rejects_missing_tool_call() {
         // Arrange
-        let messages = [
-            (json!({"content": null}), "model returned no tool call"),
-            (
-                json!({
-                    "content": null,
-                    "tool_calls": [
-                        {
-                            "id": "call_one",
-                            "type": "function",
-                            "function": {"name": "read", "arguments": r#"{"path":"Cargo.toml"}"#}
-                        },
-                        {
-                            "id": "call_two",
-                            "type": "function",
-                            "function": {"name": "read", "arguments": r#"{"path":"README.md"}"#}
-                        }
-                    ]
-                }),
-                "model returned multiple tool calls",
-            ),
-        ];
+        let server = MockServer::start().await;
+        mount_tool_response(&server, "inspect the manifest", json!({"content": null})).await;
+        let model = kimi(&server);
 
         // Act
-        let mut errors = Vec::new();
-        for (message, expected) in messages {
-            let server = MockServer::start().await;
-            mount_tool_response(&server, "inspect the manifest", message).await;
-            let error = kimi(&server)
-                .complete(read_request("inspect the manifest"))
-                .await
-                .expect_err("invalid tool-call count should fail");
-            errors.push((error.to_string(), expected));
-        }
+        let error = model
+            .complete(read_request("inspect the manifest"))
+            .await
+            .expect_err("missing tool call should fail");
 
         // Assert
-        assert!(errors.iter().all(|(error, expected)| error == expected));
+        assert_eq!(error.to_string(), "model returned no tool call");
     }
 
     #[tokio::test]

--- a/crates/ag-harness/tests/benchmark/README.md
+++ b/crates/ag-harness/tests/benchmark/README.md
@@ -1,0 +1,38 @@
+# Real-model compatibility benchmark
+
+This manual benchmark exercises `ag-harness` against every supported live provider. It
+is a small system benchmark, not an official leaderboard submission. Each case has a
+deterministic scorer: schema validation, exact tool activity, or final filesystem state.
+
+## Benchmark coverage
+
+| Public benchmark   | Applicable case           | Scope boundary                                                                                                                                                                                                                                                  |
+| ------------------ | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| JSONSchemaBench    | `structured`              | Exercises a nested object, constants, and a fixed tuple. The official 10K-schema constrained-decoding benchmark is not run because `ag-harness` intentionally accepts only explicit object-root response schemas and providers impose their own schema subsets. |
+| BFCL               | `parallel_read`           | Scores exact batched function selection and arguments. Full BFCL needs arbitrary user-defined functions, parallel execution, and categories outside the two built-in repository tools.                                                                          |
+| tau-bench          | `read_recovery`, `memory` | Scores multi-step recovery after a rejected tool and cross-turn state. Full tau-bench needs domain APIs, a stateful database, policy documents, and a simulated user.                                                                                           |
+| GAIA               | `parallel_read`           | Covers bounded local-file retrieval only. Full GAIA needs web, Python, and shell tools plus its gated validation data.                                                                                                                                          |
+| SWE-bench Verified | `write`                   | Verifies the resulting file rather than trusting the terminal answer. Full SWE-bench needs per-task repositories, dependency installation, shell execution, and test-based patch scoring.                                                                       |
+
+EleutherAI's LM Evaluation Harness, OpenAI Evals, and Inspect AI are evaluation
+frameworks rather than additional task datasets. Their model adapters and task catalogs
+are useful integration targets, but an adapter alone would not expand what this crate's
+fixed tool surface can validly measure.
+
+## Run
+
+Configure `KIMI_API_KEY`, `KIMI_BASE_URL`, `KIMI_MODEL`, `MODEL_API_KEY`,
+`DASHSCOPE_API_KEY`, and `DASHSCOPE_BASE_URL`, then run:
+
+```sh
+AG_HARNESS_BENCHMARK_REPETITIONS=2 \
+  cargo test --locked -p ag-harness --test benchmark
+```
+
+`MODEL_API_BASE_URL` and `MODEL_API_MODEL` remain optional. Every result line records
+pass/fail, wall time, successful model requests, executed tool calls, and
+provider-reported total tokens. Failed cases report zero activity because the public
+turn report is available only after a successful turn. The benchmark does not estimate
+missing tokens or cost.
+
+See `results/2026-08-23.md` for the baseline and post-change report.

--- a/crates/ag-harness/tests/benchmark/main.rs
+++ b/crates/ag-harness/tests/benchmark/main.rs
@@ -1,0 +1,382 @@
+//! Manually executed, real-model compatibility benchmark.
+
+mod summary;
+
+use std::io::Write as _;
+use std::time::{Duration, Instant};
+use std::{env, fmt};
+
+use ag_harness::{
+    Harness, KimiConfig, MUSE_SPARK_1_2, ModelClient, ModelRequestActivity, ModelResponseType,
+    MuseConfig, OutputSchema, QwenConfig, Tool, ToolActivity, TurnOutcome,
+};
+use serde_json::{Value, json};
+
+type DynError = Box<dyn std::error::Error + Send + Sync>;
+
+const MODEL_API_BASE_URL: &str = "https://api.meta.ai/v1";
+
+#[tokio::main]
+async fn main() -> Result<(), DynError> {
+    let repetitions = env::var("AG_HARNESS_BENCHMARK_REPETITIONS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(1);
+    let mut results = Vec::new();
+
+    for repetition in 1..=repetitions {
+        for provider in Provider::ALL {
+            results.push(run_case(provider, repetition, "structured", structured).await);
+            results.push(run_case(provider, repetition, "parallel_read", parallel_read).await);
+            results.push(run_case(provider, repetition, "read_recovery", read_recovery).await);
+            results.push(run_case(provider, repetition, "write", write).await);
+            results.push(run_case(provider, repetition, "memory", memory).await);
+        }
+    }
+
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    for result in &results {
+        writeln!(stdout, "{result}")?;
+    }
+    let passed = results.iter().filter(|result| result.passed).count();
+    let total = results.len();
+    writeln!(stdout, "SUMMARY passed={passed} total={total}")?;
+    stdout.flush()?;
+    summary::ensure_all_passed(passed, total)?;
+
+    Ok(())
+}
+
+async fn run_case(
+    provider: Provider,
+    repetition: usize,
+    case: &'static str,
+    run: fn(Provider) -> CaseFuture,
+) -> ResultLine {
+    let started_at = Instant::now();
+    let result = run(provider).await;
+    let (detail, measurement, passed) = match result {
+        Ok(measurement) => (None, measurement, true),
+        Err(error) => (Some(error.to_string()), CaseMeasurement::default(), false),
+    };
+
+    ResultLine {
+        case,
+        detail,
+        duration: started_at.elapsed(),
+        measurement,
+        passed,
+        provider,
+        repetition,
+    }
+}
+
+type CaseFuture = std::pin::Pin<Box<dyn Future<Output = Result<CaseMeasurement, DynError>>>>;
+
+fn structured(provider: Provider) -> CaseFuture {
+    Box::pin(async move {
+        let schema = schema(json!({
+            "type": "object",
+            "properties": {
+                "person": {
+                    "type": "object",
+                    "properties": {
+                        "active": { "type": "boolean", "const": true },
+                        "name": { "type": "string", "const": "Ada" },
+                        "score": { "type": "integer", "const": 17 }
+                    },
+                    "required": ["active", "name", "score"],
+                    "additionalProperties": false
+                },
+                "tags": {
+                    "type": "array",
+                    "prefixItems": [
+                        { "type": "string", "const": "rust" },
+                        { "type": "string", "const": "agent" }
+                    ],
+                    "items": false,
+                    "minItems": 2,
+                    "maxItems": 2
+                }
+            },
+            "required": ["person", "tags"],
+            "additionalProperties": false
+        }))?;
+        let outcome = Harness::new(provider.client()?)
+            .run_report(
+                "Extract this record exactly: Ada has score 17, is active, and has tags rust then \
+                 agent.",
+                schema,
+            )
+            .await?;
+        if outcome.output()["person"]["name"] != "Ada" {
+            return Err("structured output had the wrong name".into());
+        }
+
+        Ok(CaseMeasurement::from_outcomes([&outcome]))
+    })
+}
+
+fn parallel_read(provider: Provider) -> CaseFuture {
+    Box::pin(async move {
+        let repository = tempfile::tempdir()?;
+        std::fs::write(repository.path().join("alpha.txt"), "first=amber\n")?;
+        std::fs::write(repository.path().join("beta.txt"), "second=17\n")?;
+        let schema = exact_value_schema("code", "amber-17")?;
+        let outcome = Harness::new(provider.client()?)
+            .repository(repository.path())
+            .allow(Tool::Read)
+            .run_report(
+                "Read both alpha.txt and beta.txt. Combine their values as first-second.",
+                schema,
+            )
+            .await?;
+        let mut read_paths = match outcome.report().tool_calls() {
+            [
+                ToolActivity::Read {
+                    path: first_path, ..
+                },
+                ToolActivity::Read {
+                    path: second_path, ..
+                },
+            ] => [first_path.as_str(), second_path.as_str()],
+            activities => {
+                return Err(format!(
+                    "expected exactly two successful reads, observed activities={activities:?}"
+                )
+                .into());
+            }
+        };
+        read_paths.sort_unstable();
+        let response_types = outcome
+            .report()
+            .model_requests()
+            .iter()
+            .map(ModelRequestActivity::response_type)
+            .collect::<Vec<_>>();
+        if read_paths != ["alpha.txt", "beta.txt"]
+            || response_types != [ModelResponseType::ToolCall, ModelResponseType::Output]
+            || outcome.output()["code"] != "amber-17"
+        {
+            return Err(format!(
+                "expected one exact read batch and amber-17, observed paths={read_paths:?} \
+                 responses={response_types:?}"
+            )
+            .into());
+        }
+
+        Ok(CaseMeasurement::from_outcomes([&outcome]))
+    })
+}
+
+fn read_recovery(provider: Provider) -> CaseFuture {
+    Box::pin(async move {
+        let repository = tempfile::tempdir()?;
+        std::fs::write(repository.path().join("fallback.txt"), "code=violet-29\n")?;
+        let schema = exact_value_schema("code", "violet-29")?;
+        let outcome = Harness::new(provider.client()?)
+            .repository(repository.path())
+            .allow(Tool::Read)
+            .run_report(
+                "First read missing.txt. When that is rejected, recover by reading fallback.txt \
+                 and return its code.",
+                schema,
+            )
+            .await?;
+        let rejected = outcome
+            .report()
+            .tool_calls()
+            .iter()
+            .any(|activity| matches!(activity, ToolActivity::ReadRejected { .. }));
+        let recovered = outcome
+            .report()
+            .tool_calls()
+            .iter()
+            .any(|activity| matches!(activity, ToolActivity::Read { path, .. } if path == "fallback.txt"));
+        if !rejected || !recovered || outcome.output()["code"] != "violet-29" {
+            return Err("model did not follow the rejected-read recovery trajectory".into());
+        }
+
+        Ok(CaseMeasurement::from_outcomes([&outcome]))
+    })
+}
+
+fn write(provider: Provider) -> CaseFuture {
+    Box::pin(async move {
+        let repository = tempfile::tempdir()?;
+        let target = repository.path().join("status.txt");
+        std::fs::write(&target, "status=pending\n")?;
+        let schema = schema(json!({
+            "type": "object",
+            "properties": { "changed": { "type": "boolean", "const": true } },
+            "required": ["changed"],
+            "additionalProperties": false
+        }))?;
+        let outcome = Harness::new(provider.client()?)
+            .repository(repository.path())
+            .allow(Tool::Write)
+            .run_report(
+                "Use the write tool to change status.txt from status=pending to status=complete.",
+                schema,
+            )
+            .await?;
+        let wrote = outcome.report().tool_calls().iter().any(
+            |activity| matches!(activity, ToolActivity::Write { path, .. } if path == "status.txt"),
+        );
+        if !wrote || std::fs::read_to_string(target)? != "status=complete\n" {
+            return Err("model did not produce the verified file edit".into());
+        }
+
+        Ok(CaseMeasurement::from_outcomes([&outcome]))
+    })
+}
+
+fn memory(provider: Provider) -> CaseFuture {
+    Box::pin(async move {
+        let schema = schema(json!({
+            "type": "object",
+            "properties": {
+                "answer": { "type": "string", "enum": ["stored", "cobalt-41"] }
+            },
+            "required": ["answer"],
+            "additionalProperties": false
+        }))?;
+        let harness = Harness::new(provider.client()?);
+        let mut chat = harness.chat(schema);
+        let stored = chat
+            .send("Remember the code cobalt-41 and answer only with stored.")
+            .await?;
+        let recalled = chat
+            .send("What exact code did I ask you to remember?")
+            .await?;
+        if stored.output()["answer"] != "stored" || recalled.output()["answer"] != "cobalt-41" {
+            return Err("chat did not retain the exact code across turns".into());
+        }
+
+        Ok(CaseMeasurement::from_outcomes([&stored, &recalled]))
+    })
+}
+
+fn exact_value_schema(property: &str, value: &str) -> Result<OutputSchema, DynError> {
+    schema(json!({
+        "type": "object",
+        "properties": { property: { "type": "string", "const": value } },
+        "required": [property],
+        "additionalProperties": false
+    }))
+}
+
+fn schema(value: Value) -> Result<OutputSchema, DynError> {
+    OutputSchema::new(value).map_err(Into::into)
+}
+
+#[derive(Clone, Copy)]
+enum Provider {
+    Kimi,
+    Muse,
+    Qwen,
+}
+
+impl Provider {
+    const ALL: [Self; 3] = [Self::Kimi, Self::Muse, Self::Qwen];
+
+    fn client(self) -> Result<ModelClient, DynError> {
+        match self {
+            Self::Kimi => Ok(ModelClient::kimi(KimiConfig {
+                api_key: env::var("KIMI_API_KEY")?,
+                base_url: env::var("KIMI_BASE_URL")?,
+                model: env::var("KIMI_MODEL")?,
+            })?),
+            Self::Muse => Ok(ModelClient::muse(MuseConfig {
+                api_key: env::var("MODEL_API_KEY")?,
+                base_url: env::var("MODEL_API_BASE_URL")
+                    .unwrap_or_else(|_| MODEL_API_BASE_URL.to_string()),
+                model: env::var("MODEL_API_MODEL").unwrap_or_else(|_| MUSE_SPARK_1_2.to_string()),
+            })?),
+            Self::Qwen => Ok(ModelClient::qwen(QwenConfig {
+                api_key: env::var("DASHSCOPE_API_KEY")?,
+                base_url: env::var("DASHSCOPE_BASE_URL")?,
+                model: "qwen-plus".to_string(),
+            })?),
+        }
+    }
+}
+
+impl fmt::Display for Provider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Kimi => formatter.write_str("kimi"),
+            Self::Muse => formatter.write_str("muse"),
+            Self::Qwen => formatter.write_str("qwen"),
+        }
+    }
+}
+
+struct ResultLine {
+    case: &'static str,
+    detail: Option<String>,
+    duration: Duration,
+    measurement: CaseMeasurement,
+    passed: bool,
+    provider: Provider,
+    repetition: usize,
+}
+
+impl fmt::Display for ResultLine {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "RESULT provider={} case={} repetition={} passed={} duration_ms={} model_requests={} \
+             tool_calls={} total_tokens={}",
+            self.provider,
+            self.case,
+            self.repetition,
+            self.passed,
+            self.duration.as_millis(),
+            self.measurement.model_requests,
+            self.measurement.tool_calls,
+            self.measurement
+                .total_tokens
+                .map_or_else(|| "unknown".to_string(), |tokens| tokens.to_string())
+        )?;
+        if let Some(detail) = &self.detail {
+            write!(formatter, " detail={}", detail.replace(['\n', '\r'], " "))?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct CaseMeasurement {
+    model_requests: usize,
+    tool_calls: usize,
+    total_tokens: Option<u64>,
+}
+
+impl CaseMeasurement {
+    fn from_outcomes<'a>(outcomes: impl IntoIterator<Item = &'a TurnOutcome>) -> Self {
+        let mut measurement = Self::default();
+        let mut reported_tokens = false;
+        let mut total_tokens = 0_u64;
+
+        for outcome in outcomes {
+            measurement.model_requests += outcome.report().model_requests().len();
+            measurement.tool_calls += outcome.report().tool_calls().len();
+            for request in outcome.report().model_requests() {
+                if let Some(tokens) = request
+                    .completion()
+                    .and_then(|completion| completion.usage())
+                    .and_then(|usage| usage.total_tokens())
+                {
+                    reported_tokens = true;
+                    total_tokens = total_tokens.saturating_add(tokens);
+                }
+            }
+        }
+        measurement.total_tokens = reported_tokens.then_some(total_tokens);
+
+        measurement
+    }
+}

--- a/crates/ag-harness/tests/benchmark/results/2026-08-23.md
+++ b/crates/ag-harness/tests/benchmark/results/2026-08-23.md
@@ -1,0 +1,64 @@
+# `ag-harness` benchmark report - 2026-08-23
+
+## Configuration
+
+- Two repetitions of five cases against Kimi K2.6, Muse Spark 1.2, and Qwen Plus.
+- Thirty scored task executions in each run; multi-step cases make additional provider
+  requests.
+- Provider temperature and service tier were their API defaults.
+- The provider order was intentionally unchanged between runs, including burst pressure
+  on Kimi's three-request-per-minute organization quota.
+
+## Results
+
+| Provider  |          Baseline |           Updated | Updated median successful latency |
+| --------- | ----------------: | ----------------: | --------------------------------: |
+| Kimi      |              2/10 |              7/10 |                          8,896 ms |
+| Muse      |             10/10 |             10/10 |                          6,710 ms |
+| Qwen      |              8/10 |             10/10 |                          2,767 ms |
+| **Total** | **20/30 (66.7%)** | **27/30 (90.0%)** |                                 - |
+
+The baseline failures were four rejected multi-call responses and six Kimi HTTP 429
+responses. After the update, all four multi-call cases passed and bounded backoff
+recovered three quota-limited cases. The remaining three failures were Kimi HTTP 429
+responses; there were no task, schema, tool-argument, or verified-state failures in the
+updated run. Excluding provider throttling, the observed task pass rate moved from 20/24
+(83.3%) to 27/27 (100%).
+
+The historical `parallel_read` passes are provisional. This run's scorer verified two
+successful reads and the final value, but did not retain exact paths or prove that both
+reads came from one batched model response. The benchmark now checks both properties;
+the live cases require a future authorized rerun before those passes support batching
+claims.
+
+## Updated-run activity
+
+Activity totals include successful cases only because failed turns do not return a
+`TurnReport`.
+
+| Provider | Model requests | Tool calls | Reported tokens |
+| -------- | -------------: | ---------: | --------------: |
+| Kimi     |             13 |          6 |           7,781 |
+| Muse     |             20 |         10 |          17,841 |
+| Qwen     |             22 |         12 |           9,306 |
+
+No cost number is reported. The APIs returned token usage but not billed cost, and a
+benchmark report should not embed a pricing snapshot that will silently become stale.
+
+## Harness changes
+
+- Decode and locally validate every tool call in a provider response.
+- Preserve single-call responses while representing batched responses explicitly.
+- Execute validated batches in provider order, enforce the existing per-turn limit per
+  call, and retain the assistant batch followed by all tool results as one history
+  group.
+- Increase bounded rate-limit recovery from two to five retries and combine
+  `Retry-After` with capped exponential backoff.
+
+## Interpretation
+
+The strongest conclusion is narrow: the former rejection of standards-compliant batched
+tool calls was a harness defect, and fixing it removed every non-quota failure in this
+matrix. This run is too small for model ranking, tail-latency claims, or pass-k
+reliability estimates. Full official BFCL, tau-bench, GAIA, and SWE-bench results remain
+blocked on extensible tools and sandboxed execution rather than model credentials.

--- a/crates/ag-harness/tests/benchmark/summary.rs
+++ b/crates/ag-harness/tests/benchmark/summary.rs
@@ -1,0 +1,28 @@
+use std::error::Error;
+use std::fmt;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct BenchmarkFailure {
+    passed: usize,
+    total: usize,
+}
+
+impl fmt::Display for BenchmarkFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "benchmark failed: {} of {} cases passed",
+            self.passed, self.total
+        )
+    }
+}
+
+impl Error for BenchmarkFailure {}
+
+pub(super) fn ensure_all_passed(passed: usize, total: usize) -> Result<(), BenchmarkFailure> {
+    if passed == total {
+        Ok(())
+    } else {
+        Err(BenchmarkFailure { passed, total })
+    }
+}

--- a/crates/ag-harness/tests/benchmark_summary.rs
+++ b/crates/ag-harness/tests/benchmark_summary.rs
@@ -1,0 +1,31 @@
+//! Regression coverage for the manual benchmark's process result.
+
+#[path = "benchmark/summary.rs"]
+mod summary;
+
+#[test]
+fn accepts_complete_benchmark_summary() {
+    // Arrange
+    let passed = 30;
+    let total = 30;
+
+    // Act
+    let result = summary::ensure_all_passed(passed, total);
+
+    // Assert
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn rejects_incomplete_benchmark_summary() {
+    // Arrange
+    let passed = 29;
+    let total = 30;
+
+    // Act
+    let error = summary::ensure_all_passed(passed, total)
+        .expect_err("failed benchmark cases should produce an error exit");
+
+    // Assert
+    assert_eq!(error.to_string(), "benchmark failed: 29 of 30 cases passed");
+}

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -79,8 +79,10 @@ during native tool calls. Muse uses Meta Model API's native JSON Schema response
 instead. Every provider retains shared local schema validation before returning a
 successful response. Schemas without an explicit object root and unsupported
 configurations fail explicitly rather than falling back to unstructured output. The
-shared transport retries one failed send and up to two rate-limited requests, with
-provider retry delays capped at five seconds.
+shared transport retries one failed send and up to five rate-limited requests, with
+provider retry delays capped at five seconds. Rate-limit retries use the greater of a
+provider's whole-second `Retry-After` value and bounded exponential backoff, avoiding a
+tight retry loop when a provider understates its recovery interval.
 
 Muse intentionally omits Meta's optional `strict` flag, whose documented default is
 `false`. That keeps standard JSON Schema available while Meta enforces service limits,
@@ -95,6 +97,8 @@ training. The Muse example defaults to the standard model and accepts an explici
 The current tool foundation includes:
 
 - Shared, typed `read` and `write` calls across Qwen, Kimi, and Muse.
+- Validated multi-call responses, executed in provider order with every result retained
+  in one complete assistant/tool history group.
 - Explicit repository roots and deny-by-default permissions through `Harness::allow()`.
 - Bounded tool execution and continuation to schema-validated terminal output.
 - Model-correctable read and write rejections returned through the tool loop.
@@ -243,7 +247,8 @@ best cost and performance:
 
 ## Next iterations
 
-- [ ] **Benchmarks.** Measure task quality, latency, token and tool usage, and cost.
+- [x] **Compatibility benchmark.** Measure task quality, latency, token and tool usage
+  across the live supported providers.
 
 ## Roadmap
 


### PR DESCRIPTION
- Decodes and validates complete tool-call batches, executes them in provider order, preserves grouped assistant/tool history, and enforces per-turn limits.
- Extends rate-limit recovery to five bounded retries using the greater of provider `Retry-After` values and exponential backoff.
- Adds live-provider compatibility cases for structured output, batched reads, recovery, verified writes, and cross-turn memory with recorded baseline results.