### PR TITLE
Model catalog centralizes provider configuration

### DIFF
--- a/crates/ag-harness-cli/README.md
+++ b/crates/ag-harness-cli/README.md
@@ -15,4 +15,9 @@ provider. Muse uses `MODEL_API_KEY` and the optional `MODEL_API_BASE_URL`; Kimi 
 `KIMI_API_KEY` and `KIMI_BASE_URL`; Qwen uses `DASHSCOPE_API_KEY` and
 `DASHSCOPE_BASE_URL`. `--base-url` overrides the corresponding URL variable.
 
+Provider names, known model identifiers, credential variables, and endpoint defaults
+come from `ag-harness`. The CLI owns argument parsing, application prompts, terminal
+interaction, and output formatting, so extending the library catalog does not require a
+matching CLI provider branch.
+
 Run `cargo run -p ag-harness-cli -- --help` for commands.

--- a/crates/ag-harness-cli/src/main.rs
+++ b/crates/ag-harness-cli/src/main.rs
@@ -8,10 +8,11 @@ use std::process::ExitCode;
 use std::{env, io};
 
 use ag_harness::{
-    ChatSession, Harness, KimiConfig, ModelClient, MuseConfig, OutputSchema, QwenConfig, Tool,
-    TurnOutcome,
+    ChatSession, Harness, ModelConfiguration, ModelConfigurationError, ModelProvider, OutputSchema,
+    Tool, TurnOutcome,
 };
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::builder::{PossibleValuesParser, TypedValueParser};
+use clap::{Args, Parser, Subcommand};
 use serde_json::{Map, Value};
 use thiserror::Error;
 use tokio::io::{AsyncBufRead, AsyncBufReadExt as _, AsyncWrite, AsyncWriteExt as _, BufReader};
@@ -31,26 +32,8 @@ const READ_WRITE_SYSTEM_PROMPT: &str = concat!(
     "before answering. When a user asks to create or modify a file, call the write tool ",
     "immediately in the same response. Never narrate, promise, or defer a future tool call. Only ",
     "claim that a file was created or modified after the write tool succeeds. File deletion and ",
-    "command execution are unavailable. To create an empty file, pass a write patch containing ",
-    "only `--- /dev/null` and `+++ b/<path>` headers with no hunk."
+    "command execution are unavailable."
 );
-const KIMI_API_KEY_ENV: &str = "KIMI_API_KEY";
-const KIMI_BASE_URL_ENV: &str = "KIMI_BASE_URL";
-const MUSE_DEFAULT_BASE_URL: &str = "https://api.meta.ai/v1";
-const MUSE_API_KEY_ENV: &str = "MODEL_API_KEY";
-const MUSE_BASE_URL_ENV: &str = "MODEL_API_BASE_URL";
-const QWEN_API_KEY_ENV: &str = "DASHSCOPE_API_KEY";
-const QWEN_BASE_URL_ENV: &str = "DASHSCOPE_BASE_URL";
-const PROVIDER_HELP: &str = "\
-Supported models (other endpoint-supported model IDs also work):
-  muse: muse-spark-1.2, muse-spark-1.2-contributor
-  kimi: kimi-k2.6
-  qwen: qwen-plus
-
-Credentials:
-  muse: MODEL_API_KEY (MODEL_API_BASE_URL optional)
-  kimi: KIMI_API_KEY, KIMI_BASE_URL
-  qwen: DASHSCOPE_API_KEY, DASHSCOPE_BASE_URL";
 
 /// Chats with models through a bounded repository harness.
 #[derive(Debug, Parser)]
@@ -58,7 +41,7 @@ Credentials:
     name = "ag-harness",
     version,
     about = "Chats with models through a repository harness",
-    after_help = PROVIDER_HELP
+    after_help = provider_help()
 )]
 struct Cli {
     #[command(subcommand)]
@@ -74,93 +57,69 @@ enum Command {
 
 /// Arguments for an in-memory model chat.
 #[derive(Debug, Args)]
-#[command(after_help = PROVIDER_HELP)]
+#[command(after_help = provider_help())]
 struct RunArgs {
     /// Model identifier sent to the provider.
     model: String,
     /// Optional first prompt. Further prompts are read from standard input.
     #[arg(value_parser = parse_prompt)]
     prompt: Option<String>,
-    /// API base URL, overriding `MODEL_API_BASE_URL`, `KIMI_BASE_URL`, or
-    /// `DASHSCOPE_BASE_URL`.
+    /// API base URL, overriding the provider-specific environment variable.
     #[arg(long, value_name = "URL")]
     base_url: Option<String>,
     /// Enables repository writes through the write tool.
     #[arg(long)]
     allow_write: bool,
     /// Model provider.
-    #[arg(long, value_enum, default_value_t = Provider::Muse)]
-    provider: Provider,
+    #[arg(
+        long,
+        default_value_t = ModelProvider::Muse,
+        value_parser = model_provider_parser()
+    )]
+    provider: ModelProvider,
     /// Repository directory available to enabled tools.
     #[arg(long, value_name = "DIR", default_value = ".")]
     read_dir: PathBuf,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
-enum Provider {
-    Muse,
-    Kimi,
-    Qwen,
+fn model_provider_parser() -> impl TypedValueParser<Value = ModelProvider> {
+    PossibleValuesParser::new(
+        ModelProvider::all()
+            .iter()
+            .map(|provider| provider.as_str()),
+    )
+    .try_map(|provider| provider.parse::<ModelProvider>())
 }
 
-impl Provider {
-    fn api_key_environment(self) -> &'static str {
-        match self {
-            Self::Muse => MUSE_API_KEY_ENV,
-            Self::Kimi => KIMI_API_KEY_ENV,
-            Self::Qwen => QWEN_API_KEY_ENV,
-        }
+fn provider_help() -> String {
+    let mut help =
+        String::from("Supported models (other endpoint-supported model IDs also work):\n");
+    for provider in ModelProvider::all() {
+        help.push_str("  ");
+        help.push_str(provider.as_str());
+        help.push_str(": ");
+        help.push_str(&provider.known_models().join(", "));
+        help.push('\n');
     }
-
-    fn base_url_environment(self) -> &'static str {
-        match self {
-            Self::Muse => MUSE_BASE_URL_ENV,
-            Self::Kimi => KIMI_BASE_URL_ENV,
-            Self::Qwen => QWEN_BASE_URL_ENV,
+    help.push_str("\nCredentials:\n");
+    for provider in ModelProvider::all() {
+        help.push_str("  ");
+        help.push_str(provider.as_str());
+        help.push_str(": ");
+        help.push_str(provider.api_key_environment());
+        if provider.default_base_url().is_some() {
+            help.push_str(" (");
+            help.push_str(provider.base_url_environment());
+            help.push_str(" optional)");
+        } else {
+            help.push_str(", ");
+            help.push_str(provider.base_url_environment());
         }
+        help.push('\n');
     }
+    help.pop();
 
-    fn default_base_url(self) -> Option<&'static str> {
-        match self {
-            Self::Muse => Some(MUSE_DEFAULT_BASE_URL),
-            Self::Kimi | Self::Qwen => None,
-        }
-    }
-
-    fn model_client(
-        self,
-        configuration: ModelConfiguration,
-    ) -> Result<ModelClient, ag_harness::ModelMetadataError> {
-        let ModelConfiguration {
-            api_key,
-            base_url,
-            model,
-        } = configuration;
-
-        match self {
-            Self::Muse => ModelClient::muse(MuseConfig {
-                api_key,
-                base_url,
-                model,
-            }),
-            Self::Kimi => ModelClient::kimi(KimiConfig {
-                api_key,
-                base_url,
-                model,
-            }),
-            Self::Qwen => ModelClient::qwen(QwenConfig {
-                api_key,
-                base_url,
-                model,
-            }),
-        }
-    }
-}
-
-struct ModelConfiguration {
-    api_key: String,
-    base_url: String,
-    model: String,
+    help
 }
 
 fn parse_prompt(prompt: &str) -> Result<String, String> {
@@ -233,7 +192,11 @@ where
     Output: AsyncWrite + Unpin,
 {
     let Command::Run(args) = cli.command;
-    let client = model_client(&args, environment)?;
+    let mut configuration = ModelConfiguration::new(args.provider, args.model.clone());
+    if let Some(base_url) = &args.base_url {
+        configuration = configuration.base_url(base_url.clone());
+    }
+    let client = configuration.client_from_environment(environment)?;
     let mut harness = Harness::new(client)
         .repository(args.read_dir.clone())
         .allow(Tool::Read);
@@ -488,75 +451,31 @@ fn chat_schema() -> Result<OutputSchema, CliError> {
     OutputSchema::new(schema).map_err(CliError::from)
 }
 
-fn model_client(
-    args: &RunArgs,
-    environment: impl FnMut(&str) -> Result<String, env::VarError>,
-) -> Result<ModelClient, CliError> {
-    let configuration = model_config(args, environment)?;
-
-    Ok(args.provider.model_client(configuration)?)
-}
-
-fn model_config(
-    args: &RunArgs,
-    mut environment: impl FnMut(&str) -> Result<String, env::VarError>,
-) -> Result<ModelConfiguration, CliError> {
-    let api_key_environment = args.provider.api_key_environment();
-    let api_key = environment(api_key_environment).map_err(|_| CliError::ApiKeyUnavailable {
-        name: api_key_environment,
-    })?;
-    let base_url_environment = args.provider.base_url_environment();
-    let base_url = if let Some(base_url) = &args.base_url {
-        base_url.clone()
-    } else {
-        match environment(base_url_environment) {
-            Ok(base_url) => base_url,
-            Err(env::VarError::NotPresent) => {
-                args.provider.default_base_url().map(str::to_string).ok_or(
-                    CliError::BaseUrlRequired {
-                        name: base_url_environment,
-                    },
-                )?
-            }
-            Err(source) => {
-                return Err(CliError::Environment {
-                    name: base_url_environment,
-                    source,
-                });
-            }
-        }
-    };
-
-    Ok(ModelConfiguration {
-        api_key,
-        base_url,
-        model: args.model.clone(),
-    })
-}
-
 #[derive(Debug, Error)]
 enum CliError {
-    #[error("{name} is unavailable")]
-    ApiKeyUnavailable { name: &'static str },
     #[error("--base-url or {name} is required")]
     BaseUrlRequired { name: &'static str },
     #[error("one or more chat turns failed")]
     ChatTurnsFailed,
-    #[error("{name} is unavailable: {source}")]
-    Environment {
-        name: &'static str,
-        source: env::VarError,
-    },
     #[error("model output did not contain a message")]
     MissingMessage,
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error(transparent)]
-    ModelConfiguration(#[from] ag_harness::ModelMetadataError),
+    ModelConfiguration(ModelConfigurationError),
     #[error(transparent)]
     OutputSchema(#[from] ag_harness::OutputSchemaError),
     #[error(transparent)]
     Turn(#[from] ag_harness::TurnError),
+}
+
+impl From<ModelConfigurationError> for CliError {
+    fn from(error: ModelConfigurationError) -> Self {
+        match error {
+            ModelConfigurationError::BaseUrl { name } => Self::BaseUrlRequired { name },
+            error => Self::ModelConfiguration(error),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -602,21 +521,6 @@ mod tests {
         }
     }
 
-    fn run_args() -> RunArgs {
-        RunArgs {
-            allow_write: false,
-            base_url: None,
-            model: "muse-model".to_string(),
-            prompt: None,
-            provider: Provider::Muse,
-            read_dir: PathBuf::from("."),
-        }
-    }
-
-    fn missing_environment(_: &str) -> Result<String, env::VarError> {
-        Err(env::VarError::NotPresent)
-    }
-
     fn provider_response(message: &str) -> ResponseTemplate {
         ResponseTemplate::new(200).set_body_json(json!({
             "choices": [{
@@ -655,12 +559,12 @@ mod tests {
         let Command::Run(without_prompt) = without_prompt.command;
         assert_eq!(without_prompt.prompt, None);
         assert!(!without_prompt.allow_write);
-        assert_eq!(without_prompt.provider, Provider::Muse);
+        assert_eq!(without_prompt.provider, ModelProvider::Muse);
         assert_eq!(without_prompt.read_dir, PathBuf::from("."));
         let Command::Run(with_prompt) = with_prompt.command;
         assert_eq!(with_prompt.model, "muse-custom");
         assert_eq!(with_prompt.prompt.as_deref(), Some("Summarize this change"));
-        assert_eq!(with_prompt.provider, Provider::Qwen);
+        assert_eq!(with_prompt.provider, ModelProvider::Qwen);
         assert_eq!(
             with_prompt.base_url.as_deref(),
             Some("https://models.example/v1")
@@ -677,6 +581,30 @@ mod tests {
                 .to_string()
                 .contains("invalid value 'unknown'")
         );
+    }
+
+    #[test]
+    fn cli_accepts_every_catalog_provider() {
+        // Arrange and Act
+        let providers = ModelProvider::all()
+            .iter()
+            .map(|provider| {
+                Cli::try_parse_from([
+                    "ag-harness",
+                    "run",
+                    "model-id",
+                    "--provider",
+                    provider.as_str(),
+                ])
+                .expect("catalog provider should parse")
+            })
+            .collect::<Vec<_>>();
+
+        // Assert
+        for (cli, expected) in providers.into_iter().zip(ModelProvider::all()) {
+            let Command::Run(args) = cli.command;
+            assert_eq!(args.provider, *expected);
+        }
     }
 
     #[test]
@@ -888,200 +816,25 @@ mod tests {
     }
 
     #[test]
-    fn model_configuration_uses_environment_defaults() {
+    fn cli_configuration_errors_preserve_cli_specific_guidance() {
         // Arrange
-        let args = run_args();
+        let base_url = ModelConfigurationError::BaseUrl {
+            name: "KIMI_BASE_URL",
+        };
+        let api_key = ModelConfigurationError::ApiKey {
+            name: "MODEL_API_KEY",
+        };
 
         // Act
-        let config = model_config(&args, |name| match name {
-            MUSE_API_KEY_ENV => Ok("test-key".to_string()),
-            _ => Err(env::VarError::NotPresent),
-        })
-        .expect("default model configuration should be valid");
+        let base_url = CliError::from(base_url);
+        let api_key = CliError::from(api_key);
 
         // Assert
-        assert_eq!(config.api_key, "test-key");
-        assert_eq!(config.base_url, MUSE_DEFAULT_BASE_URL);
-        assert_eq!(config.model, "muse-model");
-    }
-
-    #[test]
-    fn model_configuration_uses_provider_environment() {
-        // Arrange
-        let providers = [
-            (Provider::Muse, MUSE_API_KEY_ENV, MUSE_BASE_URL_ENV),
-            (Provider::Kimi, KIMI_API_KEY_ENV, KIMI_BASE_URL_ENV),
-            (Provider::Qwen, QWEN_API_KEY_ENV, QWEN_BASE_URL_ENV),
-        ];
-
-        // Act and Assert
-        for (provider, api_key_environment, base_url_environment) in providers {
-            let mut args = run_args();
-            args.provider = provider;
-            let mut requested_environment = Vec::new();
-            let config = model_config(&args, |name| {
-                requested_environment.push(name.to_string());
-                if name == api_key_environment {
-                    Ok("provider-key".to_string())
-                } else {
-                    assert_eq!(name, base_url_environment);
-
-                    Ok("https://provider.example/v1".to_string())
-                }
-            })
-            .expect("provider environment should produce a valid configuration");
-
-            assert_eq!(
-                requested_environment,
-                [
-                    api_key_environment.to_string(),
-                    base_url_environment.to_string()
-                ]
-            );
-            assert_eq!(config.api_key, "provider-key");
-            assert_eq!(config.base_url, "https://provider.example/v1");
-        }
-    }
-
-    #[test]
-    fn model_clients_select_every_supported_provider() {
-        // Arrange
-        let providers = [
-            (Provider::Muse, "meta"),
-            (Provider::Kimi, "moonshot_ai"),
-            (Provider::Qwen, "alibaba_cloud"),
-        ];
-
-        // Act
-        let identities = providers.map(|(provider, expected_provider)| {
-            let mut args = run_args();
-            args.base_url = Some("https://models.example/v1".to_string());
-            args.provider = provider;
-            let client = model_client(&args, |_| Ok("test-key".to_string()))
-                .expect("supported provider configuration should be valid");
-
-            (client.metadata().provider().to_string(), expected_provider)
-        });
-
-        // Assert
-        for (provider, expected_provider) in identities {
-            assert_eq!(provider, expected_provider);
-        }
-    }
-
-    #[test]
-    fn model_configuration_uses_environment_base_url() {
-        // Arrange
-        let args = run_args();
-
-        // Act
-        let config = model_config(&args, |name| {
-            if name == MUSE_BASE_URL_ENV {
-                Ok("https://environment.example/v1".to_string())
-            } else {
-                Ok("test-key".to_string())
-            }
-        })
-        .expect("environment model configuration should be valid");
-
-        // Assert
-        assert_eq!(config.api_key, "test-key");
-        assert_eq!(config.base_url, "https://environment.example/v1");
-    }
-
-    #[test]
-    fn model_configuration_prefers_base_url_flag() {
-        // Arrange
-        let mut args = run_args();
-        args.base_url = Some("https://cli.example/v1".to_string());
-
-        // Act
-        let config = model_config(&args, |_| Ok("test-key".to_string()))
-            .expect("CLI overrides should produce valid configuration");
-
-        // Assert
-        assert_eq!(config.base_url, "https://cli.example/v1");
-    }
-
-    #[test]
-    fn non_muse_configuration_requires_a_base_url() {
-        // Arrange
-        let mut args = run_args();
-        args.provider = Provider::Kimi;
-
-        // Act
-        let error = model_config(&args, |name| {
-            if name == KIMI_API_KEY_ENV {
-                Ok("test-key".to_string())
-            } else {
-                Err(env::VarError::NotPresent)
-            }
-        })
-        .err()
-        .expect("Kimi without an endpoint should be rejected");
-
-        // Assert
-        assert_eq!(error.to_string(), "--base-url or KIMI_BASE_URL is required");
-    }
-
-    #[test]
-    fn model_configuration_reports_missing_api_key() {
-        // Arrange
-        let args = run_args();
-
-        // Act
-        let error = model_config(&args, missing_environment)
-            .err()
-            .expect("a missing API key should be rejected");
-
-        // Assert
-        assert_eq!(error.to_string(), "MODEL_API_KEY is unavailable");
-    }
-
-    #[test]
-    fn api_key_errors_redact_non_unicode_values_from_output() {
-        // Arrange
-        let args = run_args();
-        let secret = "visible-secret-material";
-        let error = model_config(&args, |_| {
-            Err(env::VarError::NotUnicode(std::ffi::OsString::from(secret)))
-        })
-        .err()
-        .expect("a non-Unicode API key should be rejected");
-        let mut error_output = Vec::new();
-
-        // Act
-        let exit = report_exit(Err(error), &mut error_output);
-
-        // Assert
-        assert_eq!(exit, ExitCode::FAILURE);
-        let error_output = String::from_utf8(error_output).expect("error output should be UTF-8");
-        assert_eq!(error_output, "MODEL_API_KEY is unavailable\n");
-        assert!(!error_output.contains(secret));
-    }
-
-    #[test]
-    fn model_configuration_reports_non_unicode_optional_environment() {
-        // Arrange
-        let args = run_args();
-
-        // Act
-        let error = model_config(&args, |name| {
-            if name == MUSE_BASE_URL_ENV {
-                Err(env::VarError::NotUnicode("invalid".into()))
-            } else {
-                Ok("test-key".to_string())
-            }
-        })
-        .err()
-        .expect("non-Unicode configuration should be rejected");
-
-        // Assert
-        assert!(
-            error
-                .to_string()
-                .starts_with("MODEL_API_BASE_URL is unavailable:")
+        assert_eq!(
+            base_url.to_string(),
+            "--base-url or KIMI_BASE_URL is required"
         );
+        assert_eq!(api_key.to_string(), "MODEL_API_KEY is unavailable");
     }
 
     #[test]

--- a/crates/ag-harness-cli/tests/cli.rs
+++ b/crates/ag-harness-cli/tests/cli.rs
@@ -5,6 +5,7 @@ use std::io::{BufRead as _, BufReader, Read as _, Write as _};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
+use ag_harness::ModelProvider;
 use assert_cmd::cargo::cargo_bin;
 use serde_json::json;
 use testty::session::PtySessionBuilder;
@@ -26,8 +27,7 @@ const READ_WRITE_SYSTEM_PROMPT: &str = concat!(
     "before answering. When a user asks to create or modify a file, call the write tool ",
     "immediately in the same response. Never narrate, promise, or defer a future tool call. Only ",
     "claim that a file was created or modified after the write tool succeeds. File deletion and ",
-    "command execution are unavailable. To create an empty file, pass a write patch containing ",
-    "only `--- /dev/null` and `+++ b/<path>` headers with no hunk."
+    "command execution are unavailable."
 );
 
 fn chat_schema() -> serde_json::Value {
@@ -114,13 +114,16 @@ fn help_describes_the_chat_interface() {
     assert!(stdout.contains("Commands:"));
     assert!(stdout.contains("Starts an in-memory chat"));
     assert!(stdout.contains("Supported models"));
-    assert!(stdout.contains("muse-spark-1.2, muse-spark-1.2-contributor"));
-    assert!(stdout.contains("kimi-k2.6"));
-    assert!(stdout.contains("qwen-plus"));
+    for provider in ModelProvider::all() {
+        assert!(stdout.contains(provider.as_str()));
+        for model in provider.known_models() {
+            assert!(stdout.contains(model));
+        }
+    }
     assert!(stdout.contains("Credentials:"));
-    assert!(stdout.contains("MODEL_API_KEY"));
-    assert!(stdout.contains("KIMI_API_KEY"));
-    assert!(stdout.contains("DASHSCOPE_API_KEY"));
+    for provider in ModelProvider::all() {
+        assert!(stdout.contains(provider.api_key_environment()));
+    }
     assert!(!stdout.contains("Get started:"));
     assert!(!stdout.contains("Examples:"));
 }
@@ -142,16 +145,21 @@ fn run_help_describes_optional_initial_prompt() {
     assert!(stdout.contains("Usage: ag-harness run [OPTIONS] <MODEL> [PROMPT]"));
     assert!(stdout.contains("Optional first prompt"));
     assert!(stdout.contains("--base-url <URL>"));
-    assert!(stdout.contains("MODEL_API_BASE_URL"));
-    assert!(stdout.contains("KIMI_BASE_URL"));
-    assert!(stdout.contains("DASHSCOPE_BASE_URL"));
+    for provider in ModelProvider::all() {
+        assert!(stdout.contains(provider.base_url_environment()));
+    }
     assert!(stdout.contains("Credentials:"));
-    assert!(stdout.contains("MODEL_API_KEY"));
-    assert!(stdout.contains("KIMI_API_KEY"));
-    assert!(stdout.contains("DASHSCOPE_API_KEY"));
+    for provider in ModelProvider::all() {
+        assert!(stdout.contains(provider.api_key_environment()));
+    }
     assert!(stdout.contains("--provider <PROVIDER>"));
     assert!(stdout.contains("[default: muse]"));
-    assert!(stdout.contains("[possible values: muse, kimi, qwen]"));
+    let provider_values = ModelProvider::all()
+        .iter()
+        .map(|provider| provider.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    assert!(stdout.contains(&format!("[possible values: {provider_values}]")));
     assert!(stdout.contains("--read-dir <DIR>"));
     assert!(stdout.contains("Repository directory available to enabled tools"));
     assert!(stdout.contains("[default: .]"));
@@ -164,15 +172,8 @@ fn run_help_describes_optional_initial_prompt() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn provider_flags_select_kimi_and_qwen_wire_formats() {
     // Arrange and Act
-    for (provider, model, api_key_environment, base_url_environment) in [
-        ("kimi", "kimi-k2.6", "KIMI_API_KEY", "KIMI_BASE_URL"),
-        (
-            "qwen",
-            "qwen-plus",
-            "DASHSCOPE_API_KEY",
-            "DASHSCOPE_BASE_URL",
-        ),
-    ] {
+    for provider in [ModelProvider::Kimi, ModelProvider::Qwen] {
+        let model = provider.known_models()[0];
         let server = MockServer::start().await;
         let expected_request = json!({
             "messages": [
@@ -192,9 +193,9 @@ async fn provider_flags_select_kimi_and_qwen_wire_formats() {
             .await;
         let mut command = Command::new(cargo_bin!("ag-harness"));
         let output = command
-            .args(["run", model, "Hello", "--provider", provider])
-            .env(api_key_environment, "test-key")
-            .env(base_url_environment, server.uri())
+            .args(["run", model, "Hello", "--provider", provider.as_str()])
+            .env(provider.api_key_environment(), "test-key")
+            .env(provider.base_url_environment(), server.uri())
             .output()
             .expect("provider request should run");
 

--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -32,6 +32,11 @@ Chat history retains complete recent turns within a 256 KiB payload budget; use
 
 Use `ModelWithMetadata::complete_with_metadata()` for normalized completion metadata.
 
+Use `ModelProvider` and `ModelConfiguration` to discover built-in providers and
+construct a provider client from its standard environment variables. The catalog owns
+known model identifiers, credential variables, endpoint variables, and provider defaults
+so applications do not need provider-specific construction branches.
+
 Attach `with_lifecycle_observer()` to receive ordered metadata-only lifecycle events.
 After installing an OpenTelemetry meter provider, attach `LifecycleMetrics::new()` to
 project standard agent and client-side tool metrics. Use `LifecycleObserverSet` to send

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -33,7 +33,9 @@ pub use model::{
     ModelWithMetadata,
 };
 pub use provider::{
-    KimiConfig, MUSE_SPARK_1_2, MUSE_SPARK_1_2_CONTRIBUTOR, Muse, MuseConfig, MuseError, QwenConfig,
+    KIMI_K2_6, KimiConfig, MUSE_SPARK_1_2, MUSE_SPARK_1_2_CONTRIBUTOR, ModelConfiguration,
+    ModelConfigurationError, ModelProvider, ModelProviderParseError, Muse, MuseConfig, QWEN_PLUS,
+    QwenConfig,
 };
 pub use read::{ReadError, ReadOutput};
 pub use schema_contract::{OutputSchema, OutputSchemaError};

--- a/crates/ag-harness/src/provider.rs
+++ b/crates/ag-harness/src/provider.rs
@@ -1,12 +1,16 @@
 //! Provider-specific model adapters.
 
+mod catalog;
 mod kimi;
 mod muse;
 mod qwen;
 
-pub use kimi::KimiConfig;
+pub use catalog::{
+    ModelConfiguration, ModelConfigurationError, ModelProvider, ModelProviderParseError,
+};
 pub(crate) use kimi::POLICY as KIMI_POLICY;
+pub use kimi::{KIMI_K2_6, KimiConfig};
 pub(crate) use muse::POLICY as MUSE_POLICY;
-pub use muse::{MUSE_SPARK_1_2, MUSE_SPARK_1_2_CONTRIBUTOR, Muse, MuseConfig, MuseError};
+pub use muse::{MUSE_SPARK_1_2, MUSE_SPARK_1_2_CONTRIBUTOR, Muse, MuseConfig};
 pub(crate) use qwen::POLICY as QWEN_POLICY;
-pub use qwen::QwenConfig;
+pub use qwen::{QWEN_PLUS, QwenConfig};

--- a/crates/ag-harness/src/provider/catalog.rs
+++ b/crates/ag-harness/src/provider/catalog.rs
@@ -1,0 +1,452 @@
+use std::str::FromStr;
+use std::{env, fmt};
+
+use thiserror::Error;
+
+use super::{kimi, muse, qwen};
+use crate::model::{ModelClient, ModelMetadataError};
+
+/// Provider supported by the built-in model client catalog.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ModelProvider {
+    /// Moonshot AI's Kimi API.
+    Kimi,
+    /// Meta's Model API for Muse models.
+    Muse,
+    /// Alibaba Cloud Model Studio's Qwen API.
+    Qwen,
+}
+
+impl ModelProvider {
+    const ALL: [Self; 3] = [Self::Muse, Self::Kimi, Self::Qwen];
+
+    /// Returns every built-in provider in display order.
+    pub fn all() -> &'static [Self] {
+        &Self::ALL
+    }
+
+    /// Returns the stable identifier for this provider.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Kimi => "kimi",
+            Self::Muse => "muse",
+            Self::Qwen => "qwen",
+        }
+    }
+
+    /// Returns representative model identifiers known to this provider.
+    pub const fn known_models(self) -> &'static [&'static str] {
+        match self {
+            Self::Kimi => &[kimi::KIMI_K2_6],
+            Self::Muse => &[muse::MUSE_SPARK_1_2, muse::MUSE_SPARK_1_2_CONTRIBUTOR],
+            Self::Qwen => &[qwen::QWEN_PLUS],
+        }
+    }
+
+    /// Returns the environment variable containing the provider API key.
+    pub const fn api_key_environment(self) -> &'static str {
+        match self {
+            Self::Kimi => kimi::KIMI_API_KEY_ENV,
+            Self::Muse => muse::MODEL_API_KEY_ENV,
+            Self::Qwen => qwen::DASHSCOPE_API_KEY_ENV,
+        }
+    }
+
+    /// Returns the environment variable containing the provider base URL.
+    pub const fn base_url_environment(self) -> &'static str {
+        match self {
+            Self::Kimi => kimi::KIMI_BASE_URL_ENV,
+            Self::Muse => muse::MODEL_API_BASE_URL_ENV,
+            Self::Qwen => qwen::DASHSCOPE_BASE_URL_ENV,
+        }
+    }
+
+    /// Returns the built-in base URL used when the environment has no override.
+    pub const fn default_base_url(self) -> Option<&'static str> {
+        match self {
+            Self::Muse => Some(muse::DEFAULT_BASE_URL),
+            Self::Kimi | Self::Qwen => None,
+        }
+    }
+
+    fn client(
+        self,
+        api_key: String,
+        base_url: String,
+        model: String,
+    ) -> Result<ModelClient, ModelMetadataError> {
+        match self {
+            Self::Kimi => ModelClient::kimi(kimi::KimiConfig {
+                api_key,
+                base_url,
+                model,
+            }),
+            Self::Muse => ModelClient::muse(muse::MuseConfig {
+                api_key,
+                base_url,
+                model,
+            }),
+            Self::Qwen => ModelClient::qwen(qwen::QwenConfig {
+                api_key,
+                base_url,
+                model,
+            }),
+        }
+    }
+}
+
+impl fmt::Display for ModelProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ModelProvider {
+    type Err = ModelProviderParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::all()
+            .iter()
+            .copied()
+            .find(|provider| provider.as_str() == value)
+            .ok_or_else(|| ModelProviderParseError {
+                value: value.to_string(),
+            })
+    }
+}
+
+/// Unsupported built-in model provider identifier.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+#[error("unsupported model provider `{value}`")]
+pub struct ModelProviderParseError {
+    value: String,
+}
+
+/// Provider-neutral configuration used to construct a built-in model client.
+pub struct ModelConfiguration {
+    base_url: Option<String>,
+    model: String,
+    provider: ModelProvider,
+}
+
+impl ModelConfiguration {
+    /// Creates configuration for `model` served by `provider`.
+    pub fn new(provider: ModelProvider, model: impl Into<String>) -> Self {
+        Self {
+            base_url: None,
+            model: model.into(),
+            provider,
+        }
+    }
+
+    /// Overrides the provider base URL and its environment variable.
+    #[must_use]
+    pub fn base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = Some(base_url.into());
+
+        self
+    }
+
+    /// Constructs the configured client through an injected environment lookup.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelConfigurationError`] when credentials, an endpoint, or
+    /// the model identifier are unavailable or invalid.
+    pub fn client_from_environment(
+        self,
+        mut environment: impl FnMut(&str) -> Result<String, env::VarError>,
+    ) -> Result<ModelClient, ModelConfigurationError> {
+        let api_key_environment = self.provider.api_key_environment();
+        let api_key =
+            environment(api_key_environment).map_err(|_| ModelConfigurationError::ApiKey {
+                name: api_key_environment,
+            })?;
+        let base_url_environment = self.provider.base_url_environment();
+        let base_url = if let Some(base_url) = self.base_url {
+            base_url
+        } else {
+            match environment(base_url_environment) {
+                Ok(base_url) => base_url,
+                Err(env::VarError::NotPresent) => {
+                    self.provider.default_base_url().map(str::to_string).ok_or(
+                        ModelConfigurationError::BaseUrl {
+                            name: base_url_environment,
+                        },
+                    )?
+                }
+                Err(source) => {
+                    return Err(ModelConfigurationError::Environment {
+                        name: base_url_environment,
+                        source,
+                    });
+                }
+            }
+        };
+
+        self.provider
+            .client(api_key, base_url, self.model)
+            .map_err(ModelConfigurationError::from)
+    }
+}
+
+/// Failure returned while configuring a built-in model client.
+#[derive(Debug, Error)]
+pub enum ModelConfigurationError {
+    /// The provider API key is missing or is not valid Unicode.
+    #[error("{name} is unavailable")]
+    ApiKey {
+        /// Environment variable that could not be read.
+        name: &'static str,
+    },
+    /// Neither a base URL override nor a provider default is available.
+    #[error("no explicit base URL was provided and {name} is unavailable")]
+    BaseUrl {
+        /// Provider base-URL environment variable.
+        name: &'static str,
+    },
+    /// An optional provider environment variable is not valid Unicode.
+    #[error("{name} is unavailable: {source}")]
+    Environment {
+        /// Environment variable that could not be read.
+        name: &'static str,
+        /// Environment lookup failure.
+        source: env::VarError,
+    },
+    /// The selected model identifier is invalid.
+    #[error(transparent)]
+    Metadata(#[from] ModelMetadataError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn missing_environment(_: &str) -> Result<String, env::VarError> {
+        Err(env::VarError::NotPresent)
+    }
+
+    #[test]
+    fn catalog_exposes_every_provider_and_known_model() {
+        // Arrange and Act
+        let providers = ModelProvider::all();
+
+        // Assert
+        assert_eq!(
+            providers,
+            &[
+                ModelProvider::Muse,
+                ModelProvider::Kimi,
+                ModelProvider::Qwen
+            ]
+        );
+        assert_eq!(
+            ModelProvider::Muse.known_models(),
+            &["muse-spark-1.2", "muse-spark-1.2-contributor"]
+        );
+        assert_eq!(ModelProvider::Kimi.known_models(), &["kimi-k2.6"]);
+        assert_eq!(ModelProvider::Qwen.known_models(), &["qwen-plus"]);
+        assert_eq!(
+            ModelProvider::Muse.default_base_url(),
+            Some("https://api.meta.ai/v1")
+        );
+        assert_eq!(ModelProvider::Kimi.default_base_url(), None);
+        assert_eq!(ModelProvider::Qwen.default_base_url(), None);
+    }
+
+    #[test]
+    fn provider_identifiers_round_trip_and_display() {
+        // Arrange and Act
+        let parsed = ModelProvider::all()
+            .iter()
+            .map(|provider| provider.as_str().parse())
+            .collect::<Result<Vec<ModelProvider>, _>>()
+            .expect("catalog provider identifiers should parse");
+        let displayed = ModelProvider::all()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+
+        // Assert
+        assert_eq!(parsed, ModelProvider::all());
+        assert_eq!(displayed, ["muse", "kimi", "qwen"]);
+        assert_eq!(
+            "unknown".parse::<ModelProvider>(),
+            Err(ModelProviderParseError {
+                value: "unknown".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn configuration_uses_provider_environment() {
+        // Arrange and Act
+        for provider in ModelProvider::all() {
+            let mut requested_environment = Vec::new();
+            let client = ModelConfiguration::new(*provider, provider.known_models()[0])
+                .client_from_environment(|name| {
+                    requested_environment.push(name.to_string());
+                    if name == provider.api_key_environment() {
+                        Ok("provider-key".to_string())
+                    } else {
+                        assert_eq!(name, provider.base_url_environment());
+
+                        Ok("https://provider.example/v1".to_string())
+                    }
+                })
+                .expect("provider environment should produce a valid client");
+
+            // Assert
+            assert_eq!(
+                requested_environment,
+                [
+                    provider.api_key_environment().to_string(),
+                    provider.base_url_environment().to_string()
+                ]
+            );
+            assert_eq!(client.metadata().model(), provider.known_models()[0]);
+        }
+    }
+
+    #[test]
+    fn configuration_uses_default_and_explicit_base_urls() {
+        // Arrange
+        let default = ModelConfiguration::new(ModelProvider::Muse, muse::MUSE_SPARK_1_2);
+        let explicit = ModelConfiguration::new(ModelProvider::Muse, muse::MUSE_SPARK_1_2)
+            .base_url("https://cli.example/v1");
+
+        // Act
+        let default = default
+            .client_from_environment(|name| {
+                if name == muse::MODEL_API_KEY_ENV {
+                    Ok("test-key".to_string())
+                } else {
+                    Err(env::VarError::NotPresent)
+                }
+            })
+            .expect("Muse default endpoint should be valid");
+        let explicit = explicit
+            .client_from_environment(|_| Ok("test-key".to_string()))
+            .expect("explicit endpoint should be valid");
+
+        // Assert
+        assert_eq!(default.metadata().provider(), "meta");
+        assert_eq!(explicit.metadata().provider(), "meta");
+    }
+
+    #[test]
+    fn configuration_requires_non_default_base_url() {
+        // Arrange
+        let configuration = ModelConfiguration::new(ModelProvider::Kimi, kimi::KIMI_K2_6);
+
+        // Act
+        let error = configuration
+            .client_from_environment(|name| {
+                if name == kimi::KIMI_API_KEY_ENV {
+                    Ok("test-key".to_string())
+                } else {
+                    Err(env::VarError::NotPresent)
+                }
+            })
+            .err()
+            .expect("Kimi without an endpoint should be rejected");
+
+        // Assert
+        assert!(matches!(
+            error,
+            ModelConfigurationError::BaseUrl {
+                name: kimi::KIMI_BASE_URL_ENV
+            }
+        ));
+        assert_eq!(
+            error.to_string(),
+            "no explicit base URL was provided and KIMI_BASE_URL is unavailable"
+        );
+    }
+
+    #[test]
+    fn configuration_redacts_api_key_lookup_failures() {
+        // Arrange
+        let secret = "visible-secret-material";
+        let configuration = ModelConfiguration::new(ModelProvider::Muse, muse::MUSE_SPARK_1_2);
+
+        // Act
+        let error = configuration
+            .client_from_environment(|_| {
+                Err(env::VarError::NotUnicode(std::ffi::OsString::from(secret)))
+            })
+            .err()
+            .expect("invalid API key environment should be rejected");
+        let message = error.to_string();
+
+        // Assert
+        assert_eq!(message, "MODEL_API_KEY is unavailable");
+        assert!(!message.contains(secret));
+    }
+
+    #[test]
+    fn configuration_reports_optional_environment_failures() {
+        // Arrange
+        let configuration = ModelConfiguration::new(ModelProvider::Muse, muse::MUSE_SPARK_1_2);
+
+        // Act
+        let error = configuration
+            .client_from_environment(|name| {
+                if name == muse::MODEL_API_BASE_URL_ENV {
+                    Err(env::VarError::NotUnicode("invalid".into()))
+                } else {
+                    Ok("test-key".to_string())
+                }
+            })
+            .err()
+            .expect("invalid optional environment should be rejected");
+
+        // Assert
+        assert!(matches!(
+            error,
+            ModelConfigurationError::Environment {
+                name: muse::MODEL_API_BASE_URL_ENV,
+                source: env::VarError::NotUnicode(_)
+            }
+        ));
+    }
+
+    #[test]
+    fn configuration_reports_missing_api_key() {
+        // Arrange
+        let configuration = ModelConfiguration::new(ModelProvider::Muse, muse::MUSE_SPARK_1_2);
+
+        // Act
+        let error = configuration
+            .client_from_environment(missing_environment)
+            .err()
+            .expect("missing API key should be rejected");
+
+        // Assert
+        assert!(matches!(
+            error,
+            ModelConfigurationError::ApiKey {
+                name: muse::MODEL_API_KEY_ENV
+            }
+        ));
+    }
+
+    #[test]
+    fn configuration_rejects_an_empty_model() {
+        // Arrange
+        let configuration = ModelConfiguration::new(ModelProvider::Muse, "  ")
+            .base_url("https://models.example/v1");
+
+        // Act
+        let error = configuration
+            .client_from_environment(|_| Ok("test-key".to_string()))
+            .err()
+            .expect("empty model should be rejected");
+
+        // Assert
+        assert!(matches!(
+            error,
+            ModelConfigurationError::Metadata(ModelMetadataError::EmptyModel)
+        ));
+    }
+}

--- a/crates/ag-harness/src/provider/kimi.rs
+++ b/crates/ag-harness/src/provider/kimi.rs
@@ -1,5 +1,11 @@
 use crate::{chat_completion, telemetry};
 
+pub(crate) const KIMI_API_KEY_ENV: &str = "KIMI_API_KEY";
+pub(crate) const KIMI_BASE_URL_ENV: &str = "KIMI_BASE_URL";
+
+/// Kimi K2.6 model identifier.
+pub const KIMI_K2_6: &str = "kimi-k2.6";
+
 pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
     chat_completion::ChatCompletionProviderPolicy {
         display_name: "Kimi",

--- a/crates/ag-harness/src/provider/muse.rs
+++ b/crates/ag-harness/src/provider/muse.rs
@@ -1,18 +1,17 @@
 use std::env;
 
 use async_trait::async_trait;
-use thiserror::Error;
 
+use super::catalog::{ModelConfiguration, ModelConfigurationError, ModelProvider};
 use crate::lifecycle::LifecycleObserver;
 use crate::model::{
-    ModelClient, ModelCompletion, ModelError, ModelMetadata, ModelMetadataError, ModelRequest,
-    ModelWithMetadata,
+    ModelClient, ModelCompletion, ModelError, ModelMetadata, ModelRequest, ModelWithMetadata,
 };
 use crate::{chat_completion, telemetry};
 
-const DEFAULT_BASE_URL: &str = "https://api.meta.ai/v1";
-const MODEL_API_BASE_URL_ENV: &str = "MODEL_API_BASE_URL";
-const MODEL_API_KEY_ENV: &str = "MODEL_API_KEY";
+pub(crate) const DEFAULT_BASE_URL: &str = "https://api.meta.ai/v1";
+pub(crate) const MODEL_API_BASE_URL_ENV: &str = "MODEL_API_BASE_URL";
+pub(crate) const MODEL_API_KEY_ENV: &str = "MODEL_API_KEY";
 
 /// Standard Muse Spark 1.2 model whose prompts and completions are not used
 /// to train Meta models.
@@ -42,9 +41,9 @@ impl Muse {
     ///
     /// # Errors
     ///
-    /// Returns [`MuseError`] when `MODEL_API_KEY` is unavailable or `model` is
-    /// empty.
-    pub fn from_env(model: impl Into<String>) -> Result<Self, MuseError> {
+    /// Returns [`ModelConfigurationError`] when the provider environment or
+    /// model identifier is invalid.
+    pub fn from_env(model: impl Into<String>) -> Result<Self, ModelConfigurationError> {
         Self::from_environment(model, |name| env::var(name))
     }
 
@@ -58,16 +57,10 @@ impl Muse {
 
     fn from_environment(
         model: impl Into<String>,
-        mut environment: impl FnMut(&str) -> Result<String, env::VarError>,
-    ) -> Result<Self, MuseError> {
-        let api_key = environment(MODEL_API_KEY_ENV).map_err(MuseError::ApiKey)?;
-        let base_url =
-            environment(MODEL_API_BASE_URL_ENV).unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
-        let client = ModelClient::muse(MuseConfig {
-            api_key,
-            base_url,
-            model: model.into(),
-        })?;
+        environment: impl FnMut(&str) -> Result<String, env::VarError>,
+    ) -> Result<Self, ModelConfigurationError> {
+        let client = ModelConfiguration::new(ModelProvider::Muse, model)
+            .client_from_environment(environment)?;
 
         Ok(Self { client })
     }
@@ -87,17 +80,6 @@ impl ModelWithMetadata for Muse {
     }
 }
 
-/// Failure returned while configuring Muse from the environment.
-#[derive(Debug, Error)]
-pub enum MuseError {
-    /// `MODEL_API_KEY` is missing or is not valid Unicode.
-    #[error("MODEL_API_KEY is unavailable: {0}")]
-    ApiKey(#[source] env::VarError),
-    /// The selected model identifier is invalid.
-    #[error(transparent)]
-    Metadata(#[from] ModelMetadataError),
-}
-
 /// Configuration for a Muse model served through Meta's Model API.
 pub struct MuseConfig {
     /// API key sent as a bearer token.
@@ -110,6 +92,8 @@ pub struct MuseConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::process::Command;
+
     use serde_json::{Value, json};
     use wiremock::matchers::{bearer_token, body_json, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -206,6 +190,45 @@ mod tests {
     }
 
     #[test]
+    fn environment_configuration_from_env_runs_in_isolated_process() {
+        // Arrange
+        let test_executable = env::current_exe().expect("test executable should be available");
+
+        // Act
+        let output = Command::new(test_executable)
+            .args([
+                "--ignored",
+                "--exact",
+                "provider::muse::tests::environment_configuration_from_env_subprocess",
+            ])
+            .env(MODEL_API_KEY_ENV, "test-key")
+            .env(MODEL_API_BASE_URL_ENV, "https://models.example/v1")
+            .output()
+            .expect("isolated environment test should run");
+        let standard_error = String::from_utf8_lossy(&output.stderr);
+
+        // Assert
+        assert!(
+            output.status.success(),
+            "isolated environment test failed: {standard_error}"
+        );
+    }
+
+    #[test]
+    #[ignore = "run by environment_configuration_from_env_runs_in_isolated_process"]
+    fn environment_configuration_from_env_subprocess() {
+        // Arrange and Act
+        let muse = Muse::from_env(MUSE_SPARK_1_2)
+            .expect("isolated process environment should configure Muse");
+        let metadata = ModelWithMetadata::metadata(&muse)
+            .expect("Muse should expose its configured model identity");
+
+        // Assert
+        assert_eq!(metadata.provider(), "meta");
+        assert_eq!(metadata.model(), MUSE_SPARK_1_2);
+    }
+
+    #[test]
     fn environment_configuration_requires_api_key() {
         // Arrange and Act
         let error = Muse::from_environment(MUSE_SPARK_1_2, |_| Err(env::VarError::NotPresent))
@@ -215,7 +238,32 @@ mod tests {
         // Assert
         assert!(matches!(
             error,
-            MuseError::ApiKey(env::VarError::NotPresent)
+            ModelConfigurationError::ApiKey {
+                name: MODEL_API_KEY_ENV
+            }
+        ));
+    }
+
+    #[test]
+    fn environment_configuration_rejects_non_unicode_base_url() {
+        // Arrange and Act
+        let error = Muse::from_environment(MUSE_SPARK_1_2, |name| {
+            if name == MODEL_API_KEY_ENV {
+                Ok("test-key".to_string())
+            } else {
+                Err(env::VarError::NotUnicode("invalid".into()))
+            }
+        })
+        .err()
+        .expect("invalid base URL environment should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            ModelConfigurationError::Environment {
+                name: MODEL_API_BASE_URL_ENV,
+                source: env::VarError::NotUnicode(_)
+            }
         ));
     }
 
@@ -229,7 +277,7 @@ mod tests {
         // Assert
         assert!(matches!(
             error,
-            MuseError::Metadata(ModelMetadataError::EmptyModel)
+            ModelConfigurationError::Metadata(model::ModelMetadataError::EmptyModel)
         ));
     }
 

--- a/crates/ag-harness/src/provider/qwen.rs
+++ b/crates/ag-harness/src/provider/qwen.rs
@@ -1,5 +1,11 @@
 use crate::{chat_completion, telemetry};
 
+pub(crate) const DASHSCOPE_API_KEY_ENV: &str = "DASHSCOPE_API_KEY";
+pub(crate) const DASHSCOPE_BASE_URL_ENV: &str = "DASHSCOPE_BASE_URL";
+
+/// Qwen Plus model identifier.
+pub const QWEN_PLUS: &str = "qwen-plus";
+
 pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
     chat_completion::ChatCompletionProviderPolicy {
         display_name: "Qwen",

--- a/crates/ag-harness/tests/public_api.rs
+++ b/crates/ag-harness/tests/public_api.rs
@@ -5,8 +5,9 @@ use std::sync::{Arc, Mutex};
 
 use ag_harness::{
     CompletionMetadata, CompletionUsage, Harness, LifecycleEventKind, LifecycleMetrics,
-    LifecycleObserverSet, LifecycleTraceObserver, Model, ModelCompletion, ModelError,
-    ModelMetadata, ModelRequest, ModelResponse, ModelWithMetadata, OutputSchema, OutputSchemaError,
+    LifecycleObserverSet, LifecycleTraceObserver, Model, ModelCompletion, ModelConfiguration,
+    ModelError, ModelMetadata, ModelProvider, ModelRequest, ModelResponse, ModelWithMetadata,
+    OutputSchema, OutputSchemaError,
 };
 use async_trait::async_trait;
 use serde_json::json;
@@ -49,6 +50,26 @@ impl ModelWithMetadata for ExternalMetadataModel {
 }
 
 fn assert_observer<Observer: ag_harness::LifecycleObserver>(_observer: Observer) {}
+
+#[test]
+fn external_consumer_configures_every_catalog_provider() {
+    // Arrange and Act
+    let clients = ModelProvider::all()
+        .iter()
+        .map(|provider| {
+            ModelConfiguration::new(*provider, provider.known_models()[0])
+                .base_url("https://models.example/v1")
+                .client_from_environment(|_| Ok("test-key".to_string()))
+                .expect("catalog provider should construct a client")
+        })
+        .collect::<Vec<_>>();
+
+    // Assert
+    assert_eq!(clients.len(), ModelProvider::all().len());
+    for (client, provider) in clients.iter().zip(ModelProvider::all()) {
+        assert_eq!(client.metadata().model(), provider.known_models()[0]);
+    }
+}
 
 #[test]
 fn external_consumer_constructs_lifecycle_trace_observer() {

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -72,6 +72,12 @@ Provider-owned adapters and compatibility rules live under the private `provider
 module. API-family clients remain separate so multiple providers can reuse a wire
 protocol without sharing provider policy.
 
+The public `ModelProvider` catalog and `ModelConfiguration` builder are the single
+source of truth for built-in provider identifiers, representative model IDs, credential
+and endpoint environment variables, endpoint defaults, and client construction.
+Applications consume that catalog generically instead of matching on each provider.
+Application-owned prompts remain outside the catalog and model runtime.
+
 Qwen, Kimi, and Muse share Chat Completions request execution and bounded response
 decoding. Qwen and Kimi include the requested `OutputSchema` in the system instruction;
 they request JSON Object output when no tools are active and omit that provider mode
@@ -107,7 +113,9 @@ The current tool foundation includes:
 
 The `ag-harness-cli` package ships the `ag-harness` command, which starts an in-memory
 chat with Muse, Kimi, or Qwen. Reads are scoped to `--read-dir`; writes require
-`--allow-write`.
+`--allow-write`. It derives provider parsing and help text from the library catalog
+while retaining command-line defaults, application prompts, terminal interaction, and
+output formatting.
 
 ## Session management
 

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -30,14 +30,16 @@ For file-level detail, read the module docstrings directly.
   metadata, commit/diff/push/pull sync, merge-conflict preflights, rebase/conflict
   handling, and squash-merge workflows behind the `GitClient` boundary.
 - `crates/ag-harness/`: Application-facing LLM harness crate with the provider-neutral
-  object-safe `Model` boundary, its `ModelClient` implementation, private Qwen, Kimi,
-  and Muse policies, a shared Chat Completions backend with JSON Object and JSON Schema
-  modes, backend-neutral request-duration telemetry, and a deny-by-default `Harness`
-  loop that executes bounded repository reads and stale-safe patch writes through an
-  injectable `FileSystem`. Application binaries own telemetry setup.
+  object-safe `Model` boundary, its `ModelClient` implementation, the built-in provider
+  catalog and environment-backed configuration, private Qwen, Kimi, and Muse policies, a
+  shared Chat Completions backend with JSON Object and JSON Schema modes,
+  backend-neutral request-duration telemetry, and a deny-by-default `Harness` loop that
+  executes bounded repository reads and stale-safe patch writes through an injectable
+  `FileSystem`. Application binaries own prompts and telemetry setup.
 - `crates/ag-harness-cli/`: Interactive `ag-harness` command-line application and its
-  process-level tests. It composes the `ag-harness` library with provider configuration,
-  bounded repository permissions, terminal-safe output, and in-memory chat handling.
+  process-level tests. It derives provider parsing and help from `ag-harness`, then owns
+  command-line defaults, application prompts, bounded repository permission selection,
+  terminal-safe output, and in-memory chat input handling.
 - `crates/ag-protocol/`: Shared structured response protocol library crate with
   transport-neutral response models, schema generation, parser diagnostics, protocol
   prompt envelopes, repair prompts, review-comment outcomes, and turn prompt payload


### PR DESCRIPTION
- Exposes built-in provider identifiers, known models, environment variables, endpoint defaults, and client construction through `ag-harness`.
- Derives CLI provider parsing and help text from the shared catalog while retaining application interaction and output ownership.
- Documents and tests generic catalog consumption across all built-in providers.
- Adds isolated process-environment coverage for `Muse::from_env()`.