### PR TITLE
Diff panes expose comment submission

### DIFF
--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -869,6 +869,13 @@ pub(crate) enum DiffLineCommentFooterState {
     },
 }
 
+impl DiffLineCommentFooterState {
+    /// Returns whether completed diff comments are ready for submission.
+    fn can_submit(self) -> bool {
+        matches!(self, Self::Ready { comment_count } if comment_count > 0)
+    }
+}
+
 /// Returns compact diff footer actions for the page-level hint line.
 pub(crate) fn diff_footer_actions(context: DiffFooterContext) -> Vec<HelpAction> {
     if matches!(
@@ -893,7 +900,14 @@ pub(crate) fn diff_footer_actions(context: DiffFooterContext) -> Vec<HelpAction>
         ];
     }
 
+    let can_submit_line_comments = context.line_comment_state.can_submit();
     let mut actions = vec![HelpAction::new("back", "q/Esc", "Back to session")];
+    if can_submit_line_comments
+        && !(context.sidebar_focus == DiffSidebarFocus::Files
+            && context.focus == DiffFocus::Content)
+    {
+        actions.push(diff_comment_submit_action());
+    }
     match context.sidebar_focus {
         DiffSidebarFocus::Files if context.focus == DiffFocus::Files => {
             actions.push(HelpAction::new("select file", "j/k", "Select file"));
@@ -932,15 +946,8 @@ pub(crate) fn diff_footer_actions(context: DiffFooterContext) -> Vec<HelpAction>
                     "Edit the selected line's or inline comment's feedback",
                 ));
             }
-            if matches!(
-                context.line_comment_state,
-                DiffLineCommentFooterState::Ready { comment_count } if comment_count > 0
-            ) {
-                actions.push(HelpAction::new(
-                    "submit comments",
-                    "s",
-                    "Submit all diff comments",
-                ));
+            if can_submit_line_comments {
+                actions.push(diff_comment_submit_action());
             }
         }
         DiffSidebarFocus::Comments => {
@@ -973,6 +980,11 @@ pub(crate) fn diff_footer_actions(context: DiffFooterContext) -> Vec<HelpAction>
     actions.push(HelpAction::new("help", "?", "Help"));
 
     actions
+}
+
+/// Builds the shared diff-comment submission action for every Diff pane.
+fn diff_comment_submit_action() -> HelpAction {
+    HelpAction::new("submit comments", "s", "Submit all diff comments")
 }
 
 /// Returns list-mode actions shared by all tabs.
@@ -2263,6 +2275,29 @@ mod tests {
     }
 
     #[test]
+    fn test_diff_file_footer_exposes_completed_comment_submission() {
+        // Arrange, Act
+        let file_footer_keys = diff_footer_actions(DiffFooterContext {
+            file_comment: DiffFileCommentAvailability::Available,
+            can_mark_selected: false,
+            can_submit: false,
+            focus: DiffFocus::Files,
+            has_review_comments: true,
+            line_comment_state: DiffLineCommentFooterState::Ready { comment_count: 2 },
+            sidebar_focus: DiffSidebarFocus::Files,
+        })
+        .iter()
+        .map(|action| action.key)
+        .collect::<Vec<_>>();
+
+        // Assert
+        assert_eq!(
+            file_footer_keys,
+            ["q/Esc", "s", "j/k", "Enter/l", "p", "Shift+C", "c", "?"]
+        );
+    }
+
+    #[test]
     fn test_read_only_diff_hides_inline_comment_actions() {
         // Arrange, Act
         let help_labels = diff_actions(false)
@@ -2339,7 +2374,7 @@ mod tests {
             can_submit: true,
             focus: DiffFocus::Files,
             has_review_comments: true,
-            line_comment_state: DiffLineCommentFooterState::Ready { comment_count: 0 },
+            line_comment_state: DiffLineCommentFooterState::Ready { comment_count: 2 },
             sidebar_focus: DiffSidebarFocus::Comments,
         });
         let comment_keys = actions.iter().map(|action| action.key).collect::<Vec<_>>();
@@ -2347,7 +2382,7 @@ mod tests {
         // Assert
         assert_eq!(
             comment_keys,
-            ["q", "j/k", "Space", "Enter", "f/Esc", "Up/Down", "?"]
+            ["q", "s", "j/k", "Space", "Enter", "f/Esc", "Up/Down", "?"]
         );
     }
 }

--- a/crates/agentty/src/runtime/key_handler.rs
+++ b/crates/agentty/src/runtime/key_handler.rs
@@ -90,6 +90,7 @@ where
                 review_comments: Some(review_comments),
                 ..
             } if review_comments.sidebar_focus == DiffSidebarFocus::Comments
+                && !mode::diff::should_submit_line_comments(app, key)
                 && !matches!(key.code, KeyCode::Char('?' | 'q')) =>
             {
                 handle_review_comment_key(app, presentation, terminal, key).await
@@ -935,7 +936,7 @@ mod tests {
     use crate::presentation::app_mode::{
         ConfirmationViewMode, DiffFocus, DiffLineCommentAnchor, DiffLineCommentTarget,
         DiffLineComments, DiffLineSide, DiffPreview, DiffRestoreTarget, DiffReviewComments,
-        PromptModeSnapshot,
+        DiffSidebarFocus, PromptModeSnapshot,
     };
     use crate::presentation::prompt::{
         PromptAttachmentState, PromptHistoryState, PromptSlashState,
@@ -1827,11 +1828,14 @@ mod tests {
         app.mode = AppMode::Diff {
             diff: "diff --git a/src/main.rs b/src/main.rs\n+review();\n".to_string(),
             file_explorer_selected_index: 1,
-            focus: DiffFocus::Content,
+            focus: DiffFocus::Files,
             line_comments,
             selected_diff_line_index: 0,
             preview: DiffPreview::default(),
-            review_comments: None,
+            review_comments: Some(DiffReviewComments {
+                sidebar_focus: DiffSidebarFocus::Comments,
+                ..DiffReviewComments::loading(1)
+            }),
             restore: Some(Box::new(DiffRestoreTarget::Prompt(PromptModeSnapshot {
                 at_mention_state: None,
                 attachment_state: PromptAttachmentState::default(),

--- a/crates/agentty/src/runtime/mode/diff.rs
+++ b/crates/agentty/src/runtime/mode/diff.rs
@@ -268,18 +268,12 @@ fn handle_navigation_key(
 
 /// Returns whether `s` requests submission of all completed diff comments.
 pub(crate) fn should_submit_line_comments(app: &App, key: KeyEvent) -> bool {
-    let AppMode::Diff {
-        focus,
-        line_comments,
-        ..
-    } = &app.mode
-    else {
+    let AppMode::Diff { line_comments, .. } = &app.mode else {
         return false;
     };
 
     can_reply_with_line_comments(app)
         && is_plain_char_key(key, 's')
-        && *focus == DiffFocus::Content
         && !line_comments.is_editing()
         && !line_comments.is_selecting()
         && !line_comments.comments.is_empty()

--- a/crates/agentty/src/ui/page/diff.rs
+++ b/crates/agentty/src/ui/page/diff.rs
@@ -2416,6 +2416,55 @@ mod tests {
     }
 
     #[test]
+    fn test_diff_page_shows_comment_submission_in_file_window() {
+        // Arrange
+        let diff = "diff --git a/main.rs b/main.rs\n@@ -0,0 +1 @@\n+review();";
+        let mut line_comments = DiffLineComments::default();
+        line_comments.start_editing_target(DiffLineCommentTarget::single(DiffLineCommentAnchor {
+            content: "review();".to_string(),
+            line: 1,
+            path: "main.rs".to_string(),
+            side: DiffLineSide::New,
+        }));
+        line_comments
+            .editing_input_mut()
+            .expect("line comment should be editable")
+            .insert_text("Explain this call");
+        line_comments.finish_editing();
+        let session = session_fixture();
+        let diff_layout_cache = DiffLayoutCache::default();
+        let markdown_render_cache = markdown::MarkdownRenderCache::default();
+        let mut page = DiffPage::new(DiffPageInput {
+            can_comment: true,
+            diff,
+            diff_layout_cache: &diff_layout_cache,
+            file_explorer_selected_index: 0,
+            focus: DiffFocus::Files,
+            line_comments: &line_comments,
+            markdown_render_cache: &markdown_render_cache,
+            preview: test_diff_preview(),
+            review_comments: None,
+            scroll_offset: 0,
+            selected_diff_line_index: 0,
+            session: &session,
+            sidebar_focus: DiffSidebarFocus::Files,
+        });
+        let backend = ratatui::backend::TestBackend::new(100, 14);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+
+        // Act
+        terminal
+            .draw(|frame| page.render(frame, frame.area()))
+            .expect("failed to render diff page");
+
+        // Assert
+        assert!(
+            buffer_text(terminal.backend().buffer()).contains("s: submit comments"),
+            "completed comments should be submittable while Files owns focus"
+        );
+    }
+
+    #[test]
     fn test_inline_comment_highlighting_distinguishes_active_and_completed_rows() {
         // Arrange
         let comment = DiffLineComment {

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -7856,6 +7856,8 @@ fn test_diff_line_comments() -> E2eResult {
                         "Multiple comments remain visible inside the diff",
                     )
                     .viewing_pause_ms(1500)
+                    .press_key("Esc")
+                    .wait_for_text("s: submit comments", 3000)
                     .press_key("s")
                     .wait_for_text("File comments:", 5000)
                     .wait_for_text("src/main.rs: Review the whole file.", 5000)

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -284,7 +284,7 @@ visible. `Esc`, `Left`, `h`, or `f` returns focus to the file tree when no visua
 selection is active. Linked review requests add a Comments section below Files; `c`
 focuses Comments while the file tree is focused, and `f` returns to Files. The Comments
 section keeps its own `Enter` action for submitting marked review threads. Press `s` to
-submit every file, line, and range comment together in the next turn.
+submit every file, line, and range comment together in the next turn from any Diff pane.
 
 | Key                   | Action                                         |
 | --------------------- | ---------------------------------------------- |

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -238,25 +238,25 @@ Finishing empty text removes the comment and its source highlight. Completed com
 keep a distinct inset background, and the active editor uses the stronger selection
 highlight. The linked review-request Comments section retains its separate `Enter`
 action for submitting marked review threads. Press `s` to submit every finished file,
-line, or range comment together as the next session turn. The submitted prompt uses one
-compact row per comment: file feedback carries its repository-relative path, while
-inline feedback also carries its old or new side and line or range. The batch keeps
-draft instructions or image attachments that were present before opening the diff.
-Selected deleted rows also include their captured pre-change source text because that
-context is absent from the current worktree. Diff comment editing and submission are
-available only when the session can accept a reply. Read-only diffs such as `Merged`
-sessions keep line navigation but omit the comment actions from the footer and help
-overlay. With no visual selection active, press `Esc`, `Left`, `h`, or `f` to return to
-the file tree. Select a changed markdown file and press `p` to render its complete
-post-change worktree content, including supported Mermaid diagrams. Preview remains
-active across file navigation; non-markdown selections keep showing raw diff lines, and
-files that are deleted, binary, too large, or unreadable show a concise notice. Press
-`p` again to restore the patch view. Pressing `q` returns to the sessions list and saves
-the complete composer; reopening the session restores the typed draft with input focus.
-Pressing `Tab` again returns focus to the composer. The same focus toggle, `d` diff
-preview, and `q` preservation flow are available while answering clarification
-questions. Long transcripts show a slim scrollbar on the right side of the output panel
-to indicate the current position.
+line, or range comment together as the next session turn from any Diff pane. The
+submitted prompt uses one compact row per comment: file feedback carries its
+repository-relative path, while inline feedback also carries its old or new side and
+line or range. The batch keeps draft instructions or image attachments that were present
+before opening the diff. Selected deleted rows also include their captured pre-change
+source text because that context is absent from the current worktree. Diff comment
+editing and submission are available only when the session can accept a reply. Read-only
+diffs such as `Merged` sessions keep line navigation but omit the comment actions from
+the footer and help overlay. With no visual selection active, press `Esc`, `Left`, `h`,
+or `f` to return to the file tree. Select a changed markdown file and press `p` to
+render its complete post-change worktree content, including supported Mermaid diagrams.
+Preview remains active across file navigation; non-markdown selections keep showing raw
+diff lines, and files that are deleted, binary, too large, or unreadable show a concise
+notice. Press `p` again to restore the patch view. Pressing `q` returns to the sessions
+list and saves the complete composer; reopening the session restores the typed draft
+with input focus. Pressing `Tab` again returns focus to the composer. The same focus
+toggle, `d` diff preview, and `q` preservation flow are available while answering
+clarification questions. Long transcripts show a slim scrollbar on the right side of the
+output panel to indicate the current position.
 
 Pressing `r` during a running turn queues session sync on the same session worker. The
 session stays **InProgress** while the active turn runs, then moves to **Rebasing** when


### PR DESCRIPTION
- Allow completed line comments to submit with `s` regardless of Diff pane focus.
- Align footer actions, key handling, end-to-end coverage, and user documentation with the expanded submission flow.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)