### PR TITLE
Release version 0.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.15.6] - 2026-08-24
+
+### Added
+
+- ag-harness: export lifecycle events as OpenTelemetry GenAI spans with contract
+  coverage for metric and trace payloads, hierarchy, outcomes, and shutdown behavior.
+- ag-harness-cli: run interactive Muse, Kimi, and Qwen chats with bounded repository
+  access, retained conversation history, and sanitized activity summaries.
+- agentty: support whole-file Diff comments alongside line and range comments.
+
+### Changed
+
+- agentty: submit completed Diff comments with `s` from either pane.
+- agentty: queue review requests during rebases and publish them after synchronization
+  finalizes.
+- ag-harness: move the command-line application into the dedicated `ag-harness-cli`
+  crate and register live provider checks as opt-in end-to-end tests.
+- agentty: remove persisted session summaries from the protocol, storage, rendering, and
+  orchestration flows in favor of assistant answers and session transcripts.
+- release: bump workspace crate metadata and lockfile package versions to `0.15.6`.
+
+### Contributors
+
+- @andagaev
+- @minev-dev
+
 ## [v0.15.5] - 2026-08-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "image",
  "mockall",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "mockall",
  "serde",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "mockall",
  "rustix",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "ag-harness"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "async-trait",
  "jsonschema",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "ag-harness-cli"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "ag-harness",
  "assert_cmd",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "askama",
  "schemars 1.2.2",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "ag-session"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "ag-agent",
  "ag-forge",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "ag-store"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "ag-agent",
  "ag-session",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "clap",
  "tempfile",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -4454,7 +4454,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "base64 0.23.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.15.5"
+version = "0.15.6"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -16,16 +16,16 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.15.5" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.15.5" }
-ag-forge = { path = "crates/ag-forge", version = "0.15.5" }
-ag-git = { path = "crates/ag-git", version = "0.15.5" }
-ag-harness = { path = "crates/ag-harness", version = "0.15.5" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.15.5" }
-ag-session = { path = "crates/ag-session", version = "0.15.5" }
-ag-store = { path = "crates/ag-store", version = "0.15.5" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.15.5" }
-testty = { path = "crates/testty", version = "0.15.5" }
+ag-agent = { path = "crates/ag-agent", version = "0.15.6" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.15.6" }
+ag-forge = { path = "crates/ag-forge", version = "0.15.6" }
+ag-git = { path = "crates/ag-git", version = "0.15.6" }
+ag-harness = { path = "crates/ag-harness", version = "0.15.6" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.15.6" }
+ag-session = { path = "crates/ag-session", version = "0.15.6" }
+ag-store = { path = "crates/ag-store", version = "0.15.6" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.15.6" }
+testty = { path = "crates/testty", version = "0.15.6" }
 async-trait = "0.1"
 agent-client-protocol = "2.0.0"
 assert_cmd = "2"


### PR DESCRIPTION
- Add OpenTelemetry GenAI spans, interactive provider chats, and whole-file review comments.
- Queue review requests during rebases and publish them after synchronization completes.
- Move the harness CLI into its dedicated crate, remove persisted session summaries, and update release metadata.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)