### PR TITLE
Publish harness CLI through crates.io

### DIFF
--- a/crates/ag-harness-cli/Cargo.toml
+++ b/crates/ag-harness-cli/Cargo.toml
@@ -9,6 +9,10 @@ repository.workspace = true
 homepage.workspace = true
 readme = "README.md"
 
+[package.metadata.dist]
+# Publish this package only through the crates.io workflow.
+dist = false
+
 [[bin]]
 name = "ag-harness"
 path = "src/main.rs"


### PR DESCRIPTION
- Release metadata excludes the package from dist-generated archives and installers.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)