### PR TITLE
Queued sync resumes after question cancellation

### DIFF
--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -14,7 +14,7 @@ use ag_agent::{
 use ag_forge as forge;
 use ag_git::GitClient;
 use ag_protocol::AgentResponse;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Notify, mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -190,12 +190,19 @@ impl ScheduledSessionCommand {
 struct SessionWorkerHandle {
     queued_work_sequence: Arc<AtomicU64>,
     sender: mpsc::UnboundedSender<ScheduledSessionCommand>,
+    wakeup: Arc<Notify>,
 }
 
 impl SessionWorkerHandle {
     /// Reserves the next submission order shared with queued chat messages.
     fn next_queued_work_order(&self) -> u64 {
         self.queued_work_sequence.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Wakes the worker so buffered work is reconsidered after an external
+    /// status transition.
+    fn wake(&self) {
+        self.wakeup.notify_one();
     }
 }
 
@@ -808,6 +815,13 @@ impl SessionWorkerService {
         self.workers.remove(session_id);
     }
 
+    /// Wakes an existing session worker after an external state transition.
+    pub(super) fn wake_session_worker(&self, session_id: &str) {
+        if let Some(worker) = self.workers.get(session_id) {
+            worker.wake();
+        }
+    }
+
     /// Returns an existing session worker sender or creates one lazily.
     fn ensure_session_worker(
         &mut self,
@@ -851,13 +865,15 @@ impl SessionWorkerService {
             transcript: Arc::clone(&runtime.transcript),
         };
         let (sender, receiver) = mpsc::unbounded_channel();
+        let wakeup = Arc::new(Notify::new());
         let worker = SessionWorkerHandle {
             queued_work_sequence: Arc::clone(&runtime.queued_work_sequence),
             sender,
+            wakeup: Arc::clone(&wakeup),
         };
         self.workers
             .insert(runtime.session_id.clone(), worker.clone());
-        Self::spawn_session_worker(context, services.one_shot_client(), receiver);
+        Self::spawn_session_worker(context, services.one_shot_client(), wakeup, receiver);
 
         worker
     }
@@ -921,6 +937,7 @@ impl SessionWorkerService {
     fn spawn_session_worker(
         context: SessionWorkerContext,
         one_shot_client: Arc<dyn OneShotClient>,
+        wakeup: Arc<Notify>,
         mut receiver: mpsc::UnboundedReceiver<ScheduledSessionCommand>,
     ) {
         tokio::spawn(async move {
@@ -931,10 +948,15 @@ impl SessionWorkerService {
                 }
 
                 let Some(work) = Self::next_scheduled_work(&context, &mut pending_commands) else {
-                    let Some(command) = receiver.recv().await else {
-                        break;
-                    };
-                    pending_commands.push_back(command);
+                    tokio::select! {
+                        command = receiver.recv() => {
+                            let Some(command) = command else {
+                                break;
+                            };
+                            pending_commands.push_back(command);
+                        }
+                        () = wakeup.notified() => {}
+                    }
 
                     continue;
                 };
@@ -1472,6 +1494,12 @@ impl SessionManager {
     /// Drops the in-memory worker sender for a session.
     pub(super) fn clear_session_worker(&mut self, session_id: &str) {
         self.worker_service_mut().clear_session_worker(session_id);
+    }
+
+    /// Wakes an existing worker so it re-evaluates buffered work against the
+    /// current session status.
+    pub(crate) fn wake_session_worker(&mut self, session_id: &str) {
+        self.worker_service_mut().wake_session_worker(session_id);
     }
 
     /// Drops worker queues for touched sessions that reached terminal status.
@@ -5709,6 +5737,7 @@ mod tests {
         SessionWorkerService::spawn_session_worker(
             harness.context,
             auto_commit_one_shot_client(),
+            Arc::new(Notify::new()),
             command_rx,
         );
         command_tx
@@ -6688,6 +6717,56 @@ mod tests {
         ));
         assert_eq!(pending_commands.len(), 1);
         assert_eq!(queue_handle.lock().expect("queue lock").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_worker_wakeup_resumes_buffered_action_after_question_cancel() {
+        // Arrange
+        let (mut context, _db, _queue_handle, _base_dir) =
+            queue_test_context(MockAgentChannel::new(), VecDeque::new(), Status::Question).await;
+        let status = Arc::clone(&context.status);
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        context.app_event_tx = app_event_tx;
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        let wakeup = Arc::new(Notify::new());
+        let mut worker_service = SessionWorkerService::new();
+        worker_service.workers.insert(
+            SessionId::from("sess1"),
+            SessionWorkerHandle {
+                queued_work_sequence: Arc::new(AtomicU64::new(0)),
+                sender: command_tx.clone(),
+                wakeup: Arc::clone(&wakeup),
+            },
+        );
+        SessionWorkerService::spawn_session_worker(
+            context,
+            auto_commit_one_shot_client(),
+            Arc::clone(&wakeup),
+            command_rx,
+        );
+        command_tx
+            .send(ScheduledSessionCommand::queued(
+                SessionCommand::Rebase {
+                    base_branch: "main".to_string(),
+                    operation_id: "already-resolved-rebase".to_string(),
+                },
+                0,
+            ))
+            .expect("failed to queue rebase");
+        tokio::task::yield_now().await;
+
+        // Act
+        *status.lock().expect("status lock") = Status::Review;
+        worker_service.wake_session_worker("sess1");
+        let resolved_event =
+            tokio::time::timeout(Duration::from_secs(1), app_event_rx.recv()).await;
+
+        // Assert
+        assert!(matches!(
+            resolved_event,
+            Ok(Some(AppEvent::SessionQueuedSyncResolved { session_id }))
+                if session_id == "sess1"
+        ));
     }
 
     #[tokio::test]

--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -802,6 +802,7 @@ async fn end_turn_no_answer(app: &mut App) {
     {
         *handle_status = Status::Review;
     }
+    app.sessions.wake_session_worker(session_id.as_str());
 
     app.services.emit_app_event(AppEvent::SessionUpdated {
         session_id: session_id.clone(),

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -72,6 +72,9 @@ const SECOND_QUESTION_TEXT: &str = "Which tests should be added?";
 /// Clarification question emitted by the delayed stub while help is open.
 const RECONCILE_QUESTION_TEXT: &str = "Should I add a regression test?";
 
+/// Clarification question emitted after session sync has already been queued.
+const QUEUED_SYNC_QUESTION_TEXT: &str = "Should I continue before syncing?";
+
 /// Visible confirmation emitted only when Codex receives unrestricted Auto
 /// Edit policies at both app-server request boundaries.
 const CODEX_AUTO_EDIT_POLICY_CONFIRMED_TEXT: &str = "Codex Auto Edit unrestricted policy applied.";
@@ -2199,6 +2202,30 @@ printf '%s\n' '{{"type":"result","subtype":"success","result":"{{\"answer\":\"{Q
     if fail_sync_validation {
         install_sync_validation_failure_git_stub(env, &validation_failure_marker)?;
     }
+
+    seed_project_settings(env, &[("DefaultSmartModel", "claude-haiku-4-5-20251001")])
+}
+
+/// Installs a delayed Claude turn that ends with a clarification question so
+/// the scenario can cancel it while sync remains queued on the worker.
+fn install_queued_sync_question_claude_stub(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let claude_path = env.stub_bin.join("claude");
+    let script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
+cat > /dev/null 2>&1
+sleep 8
+printf '%s\n' '{{"type":"system","subtype":"init"}}'
+printf '%s\n' '{{"type":"result","subtype":"success","result":"{{\"answer\":\"Need one clarification before sync.\",\"questions\":[{{\"text\":\"{QUEUED_SYNC_QUESTION_TEXT}\",\"options\":[\"Continue\"]}}]}}","usage":{{"input_tokens":5,"output_tokens":9}}}}'
+"#
+    );
+
+    std::fs::write(&claude_path, script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o755))?;
 
     seed_project_settings(env, &[("DefaultSmartModel", "claude-haiku-4-5-20251001")])
 }
@@ -4546,6 +4573,63 @@ fn session_running_turn_shows_sync_shortcut() -> E2eResult {
                     .rect
                     .row;
                 assert!(answer_row < sync_row);
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify canceling a clarification question wakes the session worker and
+/// resumes sync that was queued during the preceding active turn.
+#[test]
+fn session_queued_sync_resumes_after_question_cancel() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("session_queued_sync_resumes_after_question_cancel")
+        .with_git()
+        .setup(install_queued_sync_question_claude_stub)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("Ask before completing this turn")
+                    .wait_for_text("Ask before completing this turn", 3000)
+                    .press_key("Enter")
+                    .wait_for_text("Ctrl+c: stop", 5000)
+                    .wait_for_text("r: sync", 5000)
+                    .press_key("r")
+                    .wait_for_text("rebase onto the base branch after this turn", 5000)
+                    .wait_for_text(QUEUED_SYNC_QUESTION_TEXT, 30000)
+                    .capture_labeled(
+                        "queued_sync_waiting_on_question",
+                        "Queued sync pauses while the active turn asks a question",
+                    )
+                    .press_key("ctrl+c")
+                    .wait_for_text("[Sync] Successfully synced", 10000)
+                    .wait_for_text("Enter: reply", 5000)
+            },
+            |frame, report| {
+                let question_frame = common::frame_from_capture(&report.captures[0]);
+                let question_full = Region::full(question_frame.cols(), question_frame.rows());
+                assertion::assert_text_in_region(
+                    &question_frame,
+                    QUEUED_SYNC_QUESTION_TEXT,
+                    &question_full,
+                );
+                assertion::assert_text_in_region(
+                    &question_frame,
+                    "≡ sync — rebase onto the base branch after this turn",
+                    &question_full,
+                );
+
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "[Sync] Successfully synced", &full);
+                assertion::assert_text_in_region(frame, "Enter: reply", &full);
+                assertion::assert_not_visible(frame, QUEUED_SYNC_QUESTION_TEXT);
+                assertion::assert_not_visible(frame, "≡ sync —");
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -686,7 +686,9 @@ one structured response protocol (`answer`, `questions`, `review_comment_outcome
    answer, and submits it as a normal reply turn.
 
 Pressing `Ctrl+C` instead ends question mode immediately, restores the session to
-`Review`, and does not send the generated clarification reply.
+`Review`, and does not send the generated clarification reply. The status transition
+also wakes the session worker so branch actions that were queued before the question
+continue in their original order.
 
 ## Background Task Catalog
 


### PR DESCRIPTION
- Wake session workers when cancellation restores `Review` status

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)