### PR TITLE
Custom session branches use safe remote leases

### DIFF
--- a/crates/ag-git/src/client.rs
+++ b/crates/ag-git/src/client.rs
@@ -18,10 +18,10 @@ use super::{
     has_unmerged_paths, head_commit_message, head_hash, head_short_hash, in_progress_operation,
     is_rebase_in_progress, is_worktree_clean, list_conflicted_files, list_local_commit_titles,
     list_staged_conflict_marker_files, list_upstream_commit_titles, main_checkout_working_tree,
-    main_repo_root, pull_rebase, push_current_branch, push_current_branch_to_remote_branch, rebase,
-    rebase_continue, rebase_onto_start, rebase_start, ref_hash, remote_branch_exists,
-    remove_worktree, repo_url, squash_merge, squash_merge_diff, stage_all, sync,
-    tracked_worktree_status, worktree_status,
+    main_repo_root, pull_rebase, push_current_branch, push_current_branch_to_new_remote_branch,
+    push_current_branch_to_remote_branch, rebase, rebase_continue, rebase_onto_start, rebase_start,
+    ref_hash, remote_branch_exists, remove_worktree, repo_url, squash_merge, squash_merge_diff,
+    stage_all, sync, tracked_worktree_status, worktree_status,
 };
 
 /// Boxed async result used by [`GitClient`] trait methods.
@@ -334,6 +334,17 @@ pub trait GitClient: Send + Sync {
     /// # Errors
     /// Returns an error when remote push fails.
     fn push_current_branch_to_remote_branch(
+        &self,
+        repo_path: PathBuf,
+        remote_branch_name: String,
+    ) -> GitFuture<Result<String, GitError>>;
+
+    /// Pushes the current branch to one explicit remote branch while requiring
+    /// that the remote branch does not exist.
+    ///
+    /// # Errors
+    /// Returns an error when the remote branch exists or the push fails.
+    fn push_current_branch_to_new_remote_branch(
         &self,
         repo_path: PathBuf,
         remote_branch_name: String,
@@ -689,6 +700,16 @@ impl GitClient for RealGitClient {
         })
     }
 
+    fn push_current_branch_to_new_remote_branch(
+        &self,
+        repo_path: PathBuf,
+        remote_branch_name: String,
+    ) -> GitFuture<Result<String, GitError>> {
+        Box::pin(async move {
+            push_current_branch_to_new_remote_branch(repo_path, remote_branch_name).await
+        })
+    }
+
     fn remote_branch_exists(
         &self,
         repo_path: PathBuf,
@@ -891,6 +912,36 @@ mod tests {
 
         // Assert
         assert_eq!(changed_files, vec!["new.txt".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_real_git_client_pushes_new_remote_branch() {
+        // Arrange
+        let repo_dir = tempdir().expect("failed to create temp dir");
+        let remote_dir = tempdir().expect("failed to create remote temp dir");
+        setup_test_git_repo(repo_dir.path());
+        run_git_command(remote_dir.path(), &["init", "--bare"]);
+        let remote_path = remote_dir.path().to_string_lossy().to_string();
+        run_git_command(repo_dir.path(), &["remote", "add", "origin", &remote_path]);
+        let client = RealGitClient;
+
+        // Act
+        let upstream_reference = client
+            .push_current_branch_to_new_remote_branch(
+                repo_dir.path().to_path_buf(),
+                "review/new-branch".to_string(),
+            )
+            .await
+            .expect("new remote branch push should succeed");
+        let local_head = run_git_command_stdout(repo_dir.path(), &["rev-parse", "HEAD"]);
+        let remote_head = run_git_command_stdout(
+            remote_dir.path(),
+            &["rev-parse", "refs/heads/review/new-branch"],
+        );
+
+        // Assert
+        assert_eq!(upstream_reference, "origin/review/new-branch");
+        assert_eq!(local_head, remote_head);
     }
 
     #[tokio::test]

--- a/crates/ag-git/src/lib.rs
+++ b/crates/ag-git/src/lib.rs
@@ -43,7 +43,7 @@ pub(crate) use sync::{
     diff_changed_files, fetch_remote, get_ahead_behind, get_ref_ahead_behind, has_commits_since,
     head_commit_message, head_hash, head_short_hash, is_worktree_clean, list_local_commit_titles,
     list_upstream_commit_titles, pull_rebase, push_current_branch,
-    push_current_branch_to_remote_branch, ref_hash, remote_branch_exists, stage_all,
-    tracked_worktree_status, worktree_status,
+    push_current_branch_to_new_remote_branch, push_current_branch_to_remote_branch, ref_hash,
+    remote_branch_exists, stage_all, tracked_worktree_status, worktree_status,
 };
 pub(crate) use worktree::{create_worktree, detect_git_info, find_git_repo_root, remove_worktree};

--- a/crates/ag-git/src/sync.rs
+++ b/crates/ag-git/src/sync.rs
@@ -923,52 +923,6 @@ async fn push_current_branch_with_runner(
     primary_upstream_reference(&repo_path, command_runner).await
 }
 
-/// Checks whether a branch already exists on the remote.
-///
-/// Resolves the remote name from the current branch config, falling back
-/// to `origin`, then runs `git ls-remote --heads <remote> <branch>`.
-/// Returns `true` when the remote reports at least one matching ref.
-///
-/// # Arguments
-/// * `repo_path` - Path to the git repository or worktree
-/// * `remote_branch_name` - Branch name to look up on the remote
-///
-/// # Errors
-/// Returns a [`GitError`] if the `git ls-remote` command fails.
-pub(crate) async fn remote_branch_exists(
-    repo_path: PathBuf,
-    remote_branch_name: String,
-) -> Result<bool, GitError> {
-    let command_runner = ProcessAsyncGitCommandRunner;
-
-    remote_branch_exists_with_runner(repo_path, remote_branch_name, &command_runner).await
-}
-
-/// Checks a remote branch through an injected asynchronous command boundary.
-async fn remote_branch_exists_with_runner(
-    repo_path: PathBuf,
-    remote_branch_name: String,
-    command_runner: &dyn AsyncGitCommandRunner,
-) -> Result<bool, GitError> {
-    let remote_name = current_branch_remote_name(&repo_path, command_runner)
-        .await?
-        .unwrap_or_else(|| "origin".to_string());
-    let arguments = vec![
-        "ls-remote".to_string(),
-        "--heads".to_string(),
-        remote_name,
-        remote_branch_name,
-    ];
-    let stdout = run_git_command_with_runner(
-        AsyncGitCommand::new(repo_path, arguments),
-        "Git ls-remote failed",
-        command_runner,
-    )
-    .await?;
-
-    Ok(!stdout.trim().is_empty())
-}
-
 /// Pushes the current branch to one explicit remote branch name with
 /// `--force-with-lease` and returns the resulting upstream reference.
 ///
@@ -993,6 +947,58 @@ pub(crate) async fn push_current_branch_to_remote_branch(
 
     push_current_branch_to_remote_branch_with_runner(repo_path, remote_branch_name, &command_runner)
         .await
+}
+
+/// Pushes the current branch to one explicit remote branch name while
+/// requiring that the remote ref does not exist.
+///
+/// The explicit empty lease ignores stale local remote-tracking refs left
+/// behind after the remote branch was deleted, while still refusing to
+/// overwrite a branch created concurrently.
+///
+/// # Arguments
+/// * `repo_path` - Path to the git repository or worktree
+/// * `remote_branch_name` - Target branch name to create or update on the
+///   remote
+///
+/// # Returns
+/// The upstream reference on success, for example `origin/feature/review`.
+///
+/// # Errors
+/// Returns a [`GitError`] if the remote branch exists or `git push` fails.
+pub(crate) async fn push_current_branch_to_new_remote_branch(
+    repo_path: PathBuf,
+    remote_branch_name: String,
+) -> Result<String, GitError> {
+    let command_runner = ProcessAsyncGitCommandRunner;
+
+    push_current_branch_to_new_remote_branch_with_runner(
+        repo_path,
+        remote_branch_name,
+        &command_runner,
+    )
+    .await
+}
+
+/// Checks whether a branch already exists on the remote.
+///
+/// Resolves the remote name from the current branch config, falling back
+/// to `origin`, then runs `git ls-remote --heads <remote> <branch>`.
+/// Returns `true` when the remote reports at least one matching ref.
+///
+/// # Arguments
+/// * `repo_path` - Path to the git repository or worktree
+/// * `remote_branch_name` - Branch name to look up on the remote
+///
+/// # Errors
+/// Returns a [`GitError`] if the `git ls-remote` command fails.
+pub(crate) async fn remote_branch_exists(
+    repo_path: PathBuf,
+    remote_branch_name: String,
+) -> Result<bool, GitError> {
+    let command_runner = ProcessAsyncGitCommandRunner;
+
+    remote_branch_exists_with_runner(repo_path, remote_branch_name, &command_runner).await
 }
 
 /// Pushes one explicit branch through an injected asynchronous command
@@ -1021,6 +1027,60 @@ async fn push_current_branch_to_remote_branch_with_runner(
     .await?;
 
     Ok(format!("{remote_name}/{remote_branch_name}"))
+}
+
+/// Pushes one explicit branch while requiring its remote ref to be absent.
+async fn push_current_branch_to_new_remote_branch_with_runner(
+    repo_path: PathBuf,
+    remote_branch_name: String,
+    command_runner: &dyn AsyncGitCommandRunner,
+) -> Result<String, GitError> {
+    let remote_name = current_branch_remote_name(&repo_path, command_runner)
+        .await?
+        .unwrap_or_else(|| "origin".to_string());
+    let remote_ref = format!("refs/heads/{remote_branch_name}");
+    let lease_argument = format!("--force-with-lease={remote_ref}:");
+    let push_refspec = format!("HEAD:{remote_branch_name}");
+    let arguments = vec![
+        "push".to_string(),
+        lease_argument,
+        "--set-upstream".to_string(),
+        remote_name.clone(),
+        push_refspec,
+    ];
+    run_git_command_with_runner(
+        AsyncGitCommand::new(repo_path, arguments),
+        "Git push failed",
+        command_runner,
+    )
+    .await?;
+
+    Ok(format!("{remote_name}/{remote_branch_name}"))
+}
+
+/// Checks a remote branch through an injected asynchronous command boundary.
+async fn remote_branch_exists_with_runner(
+    repo_path: PathBuf,
+    remote_branch_name: String,
+    command_runner: &dyn AsyncGitCommandRunner,
+) -> Result<bool, GitError> {
+    let remote_name = current_branch_remote_name(&repo_path, command_runner)
+        .await?
+        .unwrap_or_else(|| "origin".to_string());
+    let arguments = vec![
+        "ls-remote".to_string(),
+        "--heads".to_string(),
+        remote_name,
+        remote_branch_name,
+    ];
+    let stdout = run_git_command_with_runner(
+        AsyncGitCommand::new(repo_path, arguments),
+        "Git ls-remote failed",
+        command_runner,
+    )
+    .await?;
+
+    Ok(!stdout.trim().is_empty())
 }
 
 /// Returns the current upstream reference for `HEAD`.
@@ -2581,6 +2641,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn new_remote_branch_push_requires_missing_remote_ref() {
+        // Arrange
+        let repo_path = PathBuf::from("test-repo");
+        let mut command_runner = MockAsyncGitCommandRunner::new();
+        let mut sequence = Sequence::new();
+        let expectations = [
+            (
+                vec!["rev-parse", "--abbrev-ref", "HEAD"],
+                async_git_output(0, "main\n", Vec::new()),
+            ),
+            (
+                vec!["config", "--get", "branch.main.remote"],
+                async_git_output(1, Vec::new(), Vec::new()),
+            ),
+            (
+                vec![
+                    "push",
+                    "--force-with-lease=refs/heads/review/topic:",
+                    "--set-upstream",
+                    "origin",
+                    "HEAD:review/topic",
+                ],
+                async_git_output(0, Vec::new(), Vec::new()),
+            ),
+        ];
+        for (arguments, output) in expectations {
+            let arguments = arguments
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            command_runner
+                .expect_run()
+                .with(function(move |command: &AsyncGitCommand| {
+                    command.arguments == arguments
+                }))
+                .times(1)
+                .in_sequence(&mut sequence)
+                .return_once(move |_| Box::pin(async move { Ok(output) }));
+        }
+
+        // Act
+        let upstream_reference = push_current_branch_to_new_remote_branch_with_runner(
+            repo_path,
+            "review/topic".to_string(),
+            &command_runner,
+        )
+        .await
+        .expect("new remote branch push should succeed");
+
+        // Assert
+        assert_eq!(upstream_reference, "origin/review/topic");
+    }
+
+    #[tokio::test]
     async fn remote_branch_lookup_checks_isolated_local_remote() {
         // Arrange
         let temp_dir = tempdir().expect("failed to create temp dir");
@@ -2598,55 +2712,6 @@ mod tests {
 
         // Assert
         assert!(exists);
-    }
-
-    #[tokio::test]
-    async fn remote_branch_lookup_preserves_remote_config_failure() {
-        // Arrange
-        let repo_path = PathBuf::from("test-repo");
-        let mut command_runner = MockAsyncGitCommandRunner::new();
-        let mut sequence = Sequence::new();
-        command_runner
-            .expect_run()
-            .with(function(|command: &AsyncGitCommand| {
-                command.arguments == ["rev-parse", "--abbrev-ref", "HEAD"]
-            }))
-            .times(1)
-            .in_sequence(&mut sequence)
-            .return_once(|_| Box::pin(async { Ok(async_git_output(0, "main\n", Vec::new())) }));
-        command_runner
-            .expect_run()
-            .with(function(|command: &AsyncGitCommand| {
-                command.arguments == ["config", "--get", "branch.main.remote"]
-            }))
-            .times(1)
-            .in_sequence(&mut sequence)
-            .return_once(|_| {
-                Box::pin(async {
-                    Ok(async_git_output(
-                        128,
-                        Vec::new(),
-                        "fatal: malformed branch config",
-                    ))
-                })
-            });
-
-        // Act
-        let error = remote_branch_exists_with_runner(
-            repo_path,
-            "review/topic".to_string(),
-            &command_runner,
-        )
-        .await
-        .expect_err("remote config failure should not fall back to origin");
-
-        // Assert
-        assert!(matches!(
-            error,
-            GitError::CommandFailed { command, stderr }
-                if command == "git config --get branch.main.remote"
-                    && stderr.contains("malformed branch config")
-        ));
     }
 
     #[tokio::test]
@@ -2900,6 +2965,108 @@ main\torigin/main\tbehind 2\nwt/1234abcd\torigin/wt/1234abcd\tahead 3, behind \
 
         // Assert
         assert_eq!(upstream_reference, "origin/review/custom-branch");
+    }
+
+    #[tokio::test]
+    async fn new_remote_branch_push_rejects_existing_remote_branch() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let remote_dir = tempdir().expect("failed to create remote temp dir");
+        setup_test_git_repo(temp_dir.path());
+        run_git_command(remote_dir.path(), &["init", "--bare"]);
+        let remote_path = remote_dir.path().to_string_lossy().to_string();
+        run_git_command(temp_dir.path(), &["remote", "add", "origin", &remote_path]);
+        run_git_command(
+            temp_dir.path(),
+            &["push", "origin", "HEAD:review/existing-branch"],
+        );
+        let remote_head_before = git_command_stdout(
+            remote_dir.path(),
+            &["rev-parse", "refs/heads/review/existing-branch"],
+        );
+        fs::write(temp_dir.path().join("new.txt"), "new local review\n")
+            .expect("failed to write new local review file");
+        run_git_command(temp_dir.path(), &["add", "new.txt"]);
+        run_git_command(temp_dir.path(), &["commit", "-m", "New local review"]);
+
+        // Act
+        let result = push_current_branch_to_new_remote_branch(
+            temp_dir.path().to_path_buf(),
+            "review/existing-branch".to_string(),
+        )
+        .await;
+        let remote_head_after = git_command_stdout(
+            remote_dir.path(),
+            &["rev-parse", "refs/heads/review/existing-branch"],
+        );
+
+        // Assert
+        let error = result.expect_err("existing remote branch should be rejected");
+        assert!(error.to_string().contains("stale info"));
+        assert_eq!(remote_head_before, remote_head_after);
+    }
+
+    #[tokio::test]
+    async fn new_remote_branch_push_ignores_stale_remote_tracking_ref() {
+        // Arrange
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let remote_dir = tempdir().expect("failed to create remote temp dir");
+        setup_test_git_repo(temp_dir.path());
+        run_git_command(remote_dir.path(), &["init", "--bare"]);
+        let remote_path = remote_dir.path().to_string_lossy().to_string();
+        run_git_command(temp_dir.path(), &["remote", "add", "origin", &remote_path]);
+        run_git_command(temp_dir.path(), &["checkout", "-b", "previous-review"]);
+        fs::write(temp_dir.path().join("previous.txt"), "previous review\n")
+            .expect("failed to write previous review file");
+        run_git_command(temp_dir.path(), &["add", "previous.txt"]);
+        run_git_command(temp_dir.path(), &["commit", "-m", "Previous review"]);
+        let previous_head = git_command_stdout(temp_dir.path(), &["rev-parse", "HEAD"]);
+        run_git_command(
+            temp_dir.path(),
+            &[
+                "push",
+                "--set-upstream",
+                "origin",
+                "HEAD:review/deleted-branch",
+            ],
+        );
+        run_git_command(
+            temp_dir.path(),
+            &["push", "origin", ":review/deleted-branch"],
+        );
+        run_git_command(
+            temp_dir.path(),
+            &[
+                "update-ref",
+                "refs/remotes/origin/review/deleted-branch",
+                &previous_head,
+            ],
+        );
+        run_git_command(temp_dir.path(), &["checkout", "main"]);
+        fs::write(
+            temp_dir.path().join("replacement.txt"),
+            "replacement review\n",
+        )
+        .expect("failed to write replacement review file");
+        run_git_command(temp_dir.path(), &["add", "replacement.txt"]);
+        run_git_command(temp_dir.path(), &["commit", "-m", "Replacement review"]);
+
+        // Act
+        let upstream_reference = push_current_branch_to_new_remote_branch(
+            temp_dir.path().to_path_buf(),
+            "review/deleted-branch".to_string(),
+        )
+        .await
+        .expect("new branch push should ignore the stale remote-tracking ref");
+        let local_head = git_command_stdout(temp_dir.path(), &["rev-parse", "HEAD"]);
+        let remote_head = git_command_stdout(
+            remote_dir.path(),
+            &["rev-parse", "refs/heads/review/deleted-branch"],
+        );
+
+        // Assert
+        assert_eq!(upstream_reference, "origin/review/deleted-branch");
+        assert_eq!(local_head, remote_head);
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/branch_publish.rs
+++ b/crates/agentty/src/app/branch_publish.rs
@@ -465,8 +465,10 @@ async fn publish_pull_request(
 /// resulting upstream reference.
 ///
 /// When `remote_branch_name` is supplied and the session has no prior
-/// `published_upstream_ref`, a pre-flight `git ls-remote` check blocks
-/// the push if the remote branch already exists. Without a caller-supplied
+/// `published_upstream_ref`, a pre-flight remote lookup blocks the push when
+/// that branch currently exists. When it does not exist, an explicit empty
+/// lease allows recreation despite stale local remote-tracking refs while
+/// still refusing a concurrent remote creation. Without a caller-supplied
 /// branch name, the default session branch name is still pushed explicitly so
 /// Git does not reuse an inherited base-branch upstream such as `origin/main`.
 pub(crate) async fn push_session_branch_to_remote(
@@ -527,28 +529,30 @@ pub(crate) async fn push_session_branch_to_remote(
         }
     }
 
-    let upstream_reference = git_client
-        .push_current_branch_to_remote_branch(folder, target_branch)
-        .await
-        .map_err(|error| {
-            let detail = error.to_string();
-            let normalized = detail.to_ascii_lowercase();
+    let push = if remote_branch_name.is_some() && published_upstream_ref.is_none() {
+        git_client.push_current_branch_to_new_remote_branch(folder, target_branch)
+    } else {
+        git_client.push_current_branch_to_remote_branch(folder, target_branch)
+    };
+    let upstream_reference = push.await.map_err(|error| {
+        let detail = error.to_string();
+        let normalized = detail.to_ascii_lowercase();
 
-            if has_authentication_error_keywords(&normalized) {
-                BranchPublishTaskFailure::blocked(
-                    publish_branch_action,
-                    git_push_authentication_message(
-                        detected_forge_kind_from_git_push_error(&detail),
-                        retry_text,
-                    ),
-                )
-            } else {
-                BranchPublishTaskFailure::failed(
-                    publish_branch_action,
-                    format!("Failed to publish session branch: {error}"),
-                )
-            }
-        })?;
+        if has_authentication_error_keywords(&normalized) {
+            BranchPublishTaskFailure::blocked(
+                publish_branch_action,
+                git_push_authentication_message(
+                    detected_forge_kind_from_git_push_error(&detail),
+                    retry_text,
+                ),
+            )
+        } else {
+            BranchPublishTaskFailure::failed(
+                publish_branch_action,
+                format!("Failed to publish session branch: {error}"),
+            )
+        }
+    })?;
 
     db.sessions()
         .update_session_published_upstream_ref(session_id, Some(upstream_reference.clone()))
@@ -1043,7 +1047,7 @@ mod tests {
             .returning(|_, _| Box::pin(async { Ok(false) }));
         expect_safe_session_branch_push(&mut mock_git_client, "session-id");
         mock_git_client
-            .expect_push_current_branch_to_remote_branch()
+            .expect_push_current_branch_to_new_remote_branch()
             .once()
             .withf(move |folder, remote_branch_name| {
                 folder == &expected_session_folder && remote_branch_name == "wt/session-id"
@@ -1266,7 +1270,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn push_skips_existence_check_when_upstream_ref_already_set() {
+    async fn push_uses_tracked_lease_when_upstream_ref_is_already_set() {
         // Arrange
         let database = AppRepositories::in_memory().await.expect("db should open");
         let project_id = database
@@ -1307,7 +1311,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn push_skips_existence_check_when_no_custom_branch_name() {
+    async fn push_uses_tracked_lease_for_default_session_branch_name() {
         // Arrange
         let database = AppRepositories::in_memory().await.expect("db should open");
         let project_id = database
@@ -1378,6 +1382,9 @@ mod tests {
         mock_git_client.expect_remote_branch_exists().times(0);
         mock_git_client
             .expect_push_current_branch_to_remote_branch()
+            .times(0);
+        mock_git_client
+            .expect_push_current_branch_to_new_remote_branch()
             .times(0);
 
         // Act

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -1949,7 +1949,7 @@ async fn push_session_branch_uses_custom_remote_branch_name_when_provided() {
         .once()
         .returning(|_| Box::pin(async { Some(session::session_branch("session-1")) }));
     mock_git_client
-        .expect_push_current_branch_to_remote_branch()
+        .expect_push_current_branch_to_new_remote_branch()
         .with(
             mockall::predicate::eq(PathBuf::from("/tmp/review-session")),
             mockall::predicate::eq("review/custom-branch".to_string()),

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1107,7 +1107,18 @@ fn seed_slow_successful_review_request_publish(
     seed_review_ready_session(env)?;
     seed_review_worktree_with_diff(env)?;
 
-    seed_successful_review_request_publish(env, 3, 15)
+    seed_successful_review_request_publish(env, 3, 15, "wt/review-s", false)
+}
+
+/// Seeds a review-ready session whose chosen review branch was deleted from
+/// the remote before its first publish.
+fn seed_review_request_publish_with_deleted_remote_branch(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    seed_review_ready_session(env)?;
+    seed_review_worktree_with_diff(env)?;
+
+    seed_successful_review_request_publish(env, 0, 0, "review/deleted", true)
 }
 
 /// Seeds a live focused review that completes before a delayed review-request
@@ -1115,7 +1126,7 @@ fn seed_slow_successful_review_request_publish(
 fn seed_review_request_timeline(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
     seed_review_with_resolved_decision(env)?;
 
-    seed_successful_review_request_publish(env, 0, 0)
+    seed_successful_review_request_publish(env, 0, 0, "wt/review-s", false)
 }
 
 /// Configures the review-ready worktree and forge stubs for one successful
@@ -1124,20 +1135,49 @@ fn seed_successful_review_request_publish(
     env: &BuilderEnv,
     push_delay_seconds: u64,
     create_delay_seconds: u64,
+    review_branch_name: &str,
+    remote_branch_was_deleted: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let session_worktree = env.agentty_root.join("wt").join("review-s");
     run_git(&session_worktree, &["branch", "-m", "wt/review-s"])?;
     run_git(&session_worktree, &["branch", "main", "HEAD"])?;
+    if remote_branch_was_deleted {
+        let stale_tracking_ref = format!("refs/remotes/origin/{review_branch_name}");
+        run_git(
+            &session_worktree,
+            &["update-ref", stale_tracking_ref.as_str(), "HEAD"],
+        )?;
+    }
 
     let real_git = std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
         .map(|path| path.join("git"))
         .find(|path| path.is_file())
         .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "git not found"))?;
     let git_path = env.stub_bin.join("git");
+    let remote_lookup = if remote_branch_was_deleted {
+        r#"if [ "$1" = "ls-remote" ]; then
+  exit 0
+fi
+"#
+        .to_string()
+    } else {
+        String::new()
+    };
+    let push_lease_guard = if remote_branch_was_deleted {
+        format!(
+            r#"  case "$*" in
+    *"--force-with-lease=refs/heads/{review_branch_name}: --set-upstream"*) ;;
+    *) printf '%s\n' 'missing empty lease for deleted remote branch' >&2; exit 1 ;;
+  esac
+"#
+        )
+    } else {
+        String::new()
+    };
     let script = format!(
         r#"#!/bin/sh
-if [ "$1" = "push" ]; then
-  sleep {push_delay_seconds}
+{remote_lookup}if [ "$1" = "push" ]; then
+{push_lease_guard}  sleep {push_delay_seconds}
   exit 0
 fi
 exec '{}' "$@"
@@ -1167,7 +1207,7 @@ case "$*" in
     touch "$marker_path"
     ;;
   *"pr view"*)
-    printf '%s\n' '{"number":42,"title":"Review-ready session shortcuts","state":"OPEN","url":"https://github.com/agentty-xyz/agentty/pull/42","baseRefName":"main","headRefName":"wt/review-s","isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"REVIEW_REQUIRED","mergedAt":null}'
+    printf '%s\n' '{"number":42,"title":"Review-ready session shortcuts","state":"OPEN","url":"https://github.com/agentty-xyz/agentty/pull/42","baseRefName":"main","headRefName":"__REVIEW_BRANCH_NAME__","isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"REVIEW_REQUIRED","mergedAt":null}'
     ;;
   *)
     echo "unexpected gh invocation: $*" >&2
@@ -1178,7 +1218,8 @@ esac
     .replace(
         "__CREATE_DELAY_SECONDS__",
         &create_delay_seconds.to_string(),
-    );
+    )
+    .replace("__REVIEW_BRANCH_NAME__", review_branch_name);
     std::fs::write(&gh_path, gh_script)?;
     #[cfg(unix)]
     std::fs::set_permissions(&gh_path, std::fs::Permissions::from_mode(0o755))?;
@@ -7136,6 +7177,44 @@ fn review_request_publish_shortcut_opens_publish_popup() -> E2eResult {
                     "Leave blank to push as `wt/review-s`",
                     &full,
                 );
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that a first review-request publish can recreate a custom branch
+/// that was deleted remotely despite a stale local remote-tracking ref.
+#[test]
+fn review_request_publish_recreates_deleted_remote_branch() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("review_request_deleted_remote_branch")
+        .with_git()
+        .setup(seed_review_request_publish_with_deleted_remote_branch)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .compose(&common::open_selected_session_view())
+                    .press_key("p")
+                    .wait_for_text("Publish Review Request", 5000)
+                    .write_text("review/deleted")
+                    .press_key("Enter")
+                    .wait_for_text("[Review Request] Created PR", 15000)
+                    .capture_labeled(
+                        "deleted_remote_branch_recreated",
+                        "Review request published after its former remote branch was deleted",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(
+                    frame,
+                    "[Review Request] Created PR https://github.com/agentty-xyz/agentty/pull/42",
+                    &full,
+                );
+                assertion::assert_not_visible(frame, "already exists");
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -813,9 +813,12 @@ orchestration paths:
   the existing session channel so the provider keeps conversation context while Agentty
   owns staging and `git rebase --continue`.
 - Review-request publish: push with `--force-with-lease`, then create or refresh the
-  forge review request through `ReviewRequestClient`; only open same-branch requests are
-  reused. The task does not own the active app mode, so its completion cannot interrupt
-  later navigation. It holds the same branch-operation lock as post-turn auto-push, so
+  forge review request through `ReviewRequestClient`; a first publish to a custom branch
+  rejects a currently existing remote ref. When the ref is absent, the push supplies an
+  explicit empty lease so a stale local remote-tracking ref cannot block recreation and
+  a concurrent remote creation still wins. Only open same-branch requests are reused.
+  The task does not own the active app mode, so its completion cannot interrupt later
+  navigation. It holds the same branch-operation lock as post-turn auto-push, so
   overlapping requests queue rather than running concurrent force-pushes.
 - Background review-request sync: review-ready sessions with a published branch or
   linked request are polled; merged requests persist the reviewed session-head hash and

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -598,7 +598,9 @@ can retry without reporting a false terminal cancellation.
 **InProgress**, `p` opens a publish popup for the linked forge review request:
 
 - Leave the field empty to keep the default branch target, or type a custom remote
-  branch name. After the first publish, the popup is locked to that same remote branch.
+  branch name. Agentty rejects a custom name that currently exists remotely. A name
+  whose remote branch was deleted can be reused even if a stale local remote-tracking
+  ref remains. After the first publish, the popup is locked to that same remote branch.
 - Agentty publishes with `git push --force-with-lease`, then creates or refreshes the
   linked review request. After confirmation, the popup closes and publishing continues
   on the session worker while session chat remains interactive. During **InProgress**,


### PR DESCRIPTION
- First publishes reject existing remote refs while allowing deleted branches to be recreated despite stale tracking refs.
- Subsequent publishes retain force-with-lease protection against concurrent updates.
- Cover fresh leases and reused branches in unit and E2E tests.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)