### PR TITLE
Support five-level stacked sessions

### DIFF
--- a/crates/ag-session/src/model.rs
+++ b/crates/ag-session/src/model.rs
@@ -332,8 +332,13 @@ impl SessionStatus {
             ) | (
                 SessionStatus::Draft | SessionStatus::InProgress,
                 SessionStatus::Rebasing
-            ) | (SessionStatus::InProgress, SessionStatus::Canceled)
-                | (SessionStatus::Review, SessionStatus::AgentReview)
+            ) | (
+                SessionStatus::InProgress
+                    | SessionStatus::Queued
+                    | SessionStatus::Rebasing
+                    | SessionStatus::Merging,
+                SessionStatus::Canceled
+            ) | (SessionStatus::Review, SessionStatus::AgentReview)
                 | (SessionStatus::AgentReview, SessionStatus::Review)
                 | (
                     SessionStatus::Review | SessionStatus::AgentReview,
@@ -413,7 +418,7 @@ pub struct SessionSettings {
     pub base_branch: String,
     /// Whether the session uses deferred draft materialization.
     pub is_draft: bool,
-    /// Parent session for a one-level stacked session.
+    /// Immediate parent session for a stacked session.
     pub parent_session_id: Option<SessionId>,
     /// Provider permission mode used for future turns.
     pub permission_mode: PermissionMode,
@@ -583,6 +588,24 @@ mod tests {
         assert!(status.can_transition_to(SessionStatus::Merged));
         assert!(status.can_transition_to(SessionStatus::Done));
         assert!(!status.can_transition_to(SessionStatus::Review));
+    }
+
+    #[test]
+    fn active_branch_work_statuses_can_transition_to_canceled() {
+        // Arrange
+        let statuses = [
+            SessionStatus::Question,
+            SessionStatus::Queued,
+            SessionStatus::Rebasing,
+            SessionStatus::Merging,
+        ];
+
+        // Act
+        let cancellation_transitions =
+            statuses.map(|status| status.can_transition_to(SessionStatus::Canceled));
+
+        // Assert
+        assert_eq!(cancellation_transitions, [true; 4]);
     }
 
     #[test]

--- a/crates/ag-session/src/service.rs
+++ b/crates/ag-session/src/service.rs
@@ -27,7 +27,7 @@ pub enum CreateSessionMode {
         /// Durable task row used to re-link the child after restart.
         task_id: i64,
     },
-    /// Creates a one-level draft stacked on an existing parent session.
+    /// Creates a draft stacked on an existing parent session.
     Stacked {
         /// Review-ready parent session whose branch becomes the stack base.
         parent_session_id: SessionId,

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -1699,44 +1699,36 @@ impl App {
     /// Returns the lookup root for one session's at-mention entries.
     ///
     /// Materialized sessions use their own worktree. An unmaterialized
-    /// stacked draft uses its parent worktree so files introduced by the
-    /// parent remain available before the child worktree is created.
+    /// stacked draft walks its parent chain to the nearest materialized
+    /// ancestor so files introduced there remain available before the
+    /// intermediate child worktrees are created.
     pub(crate) fn at_mention_lookup_root(&self, session_id: &str) -> PathBuf {
         let project_working_dir = self.working_dir().to_path_buf();
+        let mut candidate_session_id = Some(SessionId::from(session_id));
+        let mut visited_session_ids = HashSet::new();
+        let mut nearest_materialized_folder = None;
 
-        self.sessions.session_for_id(session_id).map_or_else(
-            || project_working_dir.clone(),
-            |session| {
-                let project_working_dir = project_working_dir.clone();
-                let session_folder = session.folder.clone();
-                let has_session_folder = self.services.fs_client().is_dir(session_folder.clone());
-                if has_session_folder {
-                    return session_folder;
-                }
-                let parent_session_folder =
-                    session
-                        .parent_session_id
-                        .as_ref()
-                        .and_then(|parent_session_id| {
-                            self.sessions
-                                .session_for_id(parent_session_id)
-                                .map(|parent_session| parent_session.folder.clone())
-                        });
-                let has_parent_session_folder =
-                    parent_session_folder
-                        .as_ref()
-                        .is_some_and(|parent_session_folder| {
-                            self.services
-                                .fs_client()
-                                .is_dir(parent_session_folder.clone())
-                        });
+        while let Some(ref session_id) = candidate_session_id {
+            if !visited_session_ids.insert(session_id.clone()) {
+                break;
+            }
+            let Some(session) = self.sessions.session_for_id(session_id) else {
+                break;
+            };
+            if self.services.fs_client().is_dir(session.folder.clone()) {
+                nearest_materialized_folder = Some(session.folder.clone());
 
-                at_mention_lookup_root(
-                    project_working_dir,
-                    parent_session_folder,
-                    has_parent_session_folder,
-                )
-            },
+                break;
+            }
+            candidate_session_id.clone_from(&session.parent_session_id);
+        }
+
+        let has_materialized_folder = nearest_materialized_folder.is_some();
+
+        at_mention_lookup_root(
+            project_working_dir,
+            nearest_materialized_folder,
+            has_materialized_folder,
         )
     }
 
@@ -2379,7 +2371,8 @@ impl App {
         let status_transition =
             StatusTransition::from_services(&self.services, handles, session_id);
         let _ = status_transition.apply(Status::Canceled).await;
-        self.sessions
+        let _ = self
+            .sessions
             .cancel_stacked_child_sessions(&self.services, session_id)
             .await;
     }

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -3097,6 +3097,66 @@ async fn app_event_applies_at_mention_entries_to_session_runtime() {
     );
 }
 
+#[tokio::test]
+async fn at_mention_lookup_root_uses_nearest_materialized_stacked_ancestor() {
+    // Arrange
+    let (mut app, temp_dir) = crate::test_support::new_test_app().await;
+    let ancestor_folder = temp_dir.path().join("materialized-ancestor");
+    fs::create_dir(&ancestor_folder).expect("failed to create ancestor folder");
+    app.sessions.push_session(
+        crate::test_support::SessionFixtureBuilder::new()
+            .id("ancestor-session")
+            .folder(ancestor_folder.clone())
+            .build(),
+    );
+    app.sessions.push_session(
+        crate::test_support::SessionFixtureBuilder::new()
+            .id("unmaterialized-parent")
+            .folder(temp_dir.path().join("missing-parent"))
+            .parent_session_id(Some(SessionId::from("ancestor-session")))
+            .build(),
+    );
+    app.sessions.push_session(
+        crate::test_support::SessionFixtureBuilder::new()
+            .id("unmaterialized-child")
+            .folder(temp_dir.path().join("missing-child"))
+            .parent_session_id(Some(SessionId::from("unmaterialized-parent")))
+            .build(),
+    );
+
+    // Act
+    let lookup_root = app.at_mention_lookup_root("unmaterialized-child");
+
+    // Assert
+    assert_eq!(lookup_root, ancestor_folder);
+}
+
+#[tokio::test]
+async fn at_mention_lookup_root_falls_back_for_cyclic_parent_chain() {
+    // Arrange
+    let (mut app, temp_dir) = crate::test_support::new_test_app().await;
+    app.sessions.push_session(
+        crate::test_support::SessionFixtureBuilder::new()
+            .id("first-session")
+            .folder(temp_dir.path().join("missing-first"))
+            .parent_session_id(Some(SessionId::from("second-session")))
+            .build(),
+    );
+    app.sessions.push_session(
+        crate::test_support::SessionFixtureBuilder::new()
+            .id("second-session")
+            .folder(temp_dir.path().join("missing-second"))
+            .parent_session_id(Some(SessionId::from("first-session")))
+            .build(),
+    );
+
+    // Act
+    let lookup_root = app.at_mention_lookup_root("first-session");
+
+    // Assert
+    assert_eq!(lookup_root, app.working_dir());
+}
+
 #[test]
 /// Verifies repeated `AgentResponseReceived` events keep the newest
 /// reducer projection while accumulating token usage for the session.

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -1991,33 +1991,26 @@ async fn test_create_stacked_draft_session_persists_parent_and_base_branch() {
 }
 
 #[tokio::test]
-async fn test_create_stacked_draft_session_rejects_nested_child() {
+async fn test_create_stacked_draft_session_chains_five_drafts_and_rejects_sixth() {
     // Arrange
     let dir = tempdir().expect("failed to create temp dir");
     let mut app = new_test_app_with_git(dir.path()).await;
-    let parent_session_id = app.create_session().await.expect("failed to create parent");
-    let parent_session = app
-        .sessions
-        .sessions_mut()
-        .iter_mut()
-        .find(|session| session.id == parent_session_id)
-        .expect("expected parent session");
-    parent_session.status = Status::Review;
-    let child_session_id = app
-        .create_stacked_draft_session(&parent_session_id)
-        .await
-        .expect("failed to create stacked draft session");
+    let root_session_id = app.create_session().await.expect("failed to create root");
+    let mut parent_session_id = root_session_id;
+    for _ in 1..=5 {
+        parent_session_id = app
+            .create_stacked_draft_session(&parent_session_id)
+            .await
+            .expect("failed to create nested stack level");
+    }
 
     // Act
-    let result = app.create_stacked_draft_session(&child_session_id).await;
+    let result = app.create_stacked_draft_session(&parent_session_id).await;
 
     // Assert
-    let error = result.expect_err("nested stacked draft creation should fail");
-    assert!(
-        error
-            .to_string()
-            .contains("Stacked sessions can only be created from root sessions")
-    );
+    let error = result.expect_err("sixth stack level should fail");
+    assert!(error.to_string().contains("five-level stack limit"));
+    assert_eq!(app.sessions.sessions().len(), 6);
 }
 
 #[tokio::test]
@@ -6133,8 +6126,9 @@ async fn test_cancel_draft_session() {
 }
 
 #[tokio::test]
-/// Ensures canceling a parent session also cancels its stacked draft child.
-async fn test_cancel_session_cascades_to_stacked_child() {
+/// Ensures canceling a parent session stops and cancels every nonterminal
+/// stacked descendant.
+async fn test_cancel_session_cascades_to_stacked_descendants() {
     // Arrange
     let dir = tempdir().expect("failed to create temp dir");
     let mut app = new_test_app_with_git(dir.path()).await;
@@ -6143,6 +6137,22 @@ async fn test_cancel_session_cascades_to_stacked_child() {
         .create_stacked_draft_session(&parent_session_id)
         .await
         .expect("failed to create stacked draft session");
+    crate::test_support::set_session_status_for_test(&mut app, &child_session_id, Status::Review);
+    let grandchild_session_id = app
+        .create_stacked_draft_session(&child_session_id)
+        .await
+        .expect("failed to create nested stacked draft session");
+    crate::test_support::set_session_status_for_test(
+        &mut app,
+        &grandchild_session_id,
+        Status::Queued,
+    );
+    app.services
+        .db()
+        .operations()
+        .insert_session_operation("grandchild-operation", &grandchild_session_id, "rebase")
+        .await
+        .expect("failed to insert grandchild operation");
     crate::test_support::set_session_status_for_test(&mut app, &parent_session_id, Status::Review);
 
     // Act
@@ -6165,8 +6175,34 @@ async fn test_cancel_session_cascades_to_stacked_child() {
         .iter()
         .find(|session| session.id == child_session_id)
         .expect("missing child session");
+    let grandchild_session = app
+        .sessions
+        .sessions()
+        .iter()
+        .find(|session| session.id == grandchild_session_id)
+        .expect("missing grandchild session");
     assert_eq!(parent_session.status, Status::Canceled);
     assert_eq!(child_session.status, Status::Canceled);
+    assert_eq!(grandchild_session.status, Status::Canceled);
+    let grandchild_handles = app
+        .sessions
+        .session_handles_or_err(&grandchild_session_id)
+        .expect("missing grandchild session handles");
+    assert!(
+        grandchild_handles
+            .cancel_token
+            .lock()
+            .expect("grandchild cancel token lock")
+            .is_cancelled()
+    );
+    assert!(
+        app.services
+            .db()
+            .operations()
+            .is_cancel_requested_for_operation("grandchild-operation")
+            .await
+            .expect("failed to load grandchild operation cancellation")
+    );
 
     let db_sessions = app
         .services
@@ -6183,8 +6219,105 @@ async fn test_cancel_session_cascades_to_stacked_child() {
         .iter()
         .find(|session| session.id == child_session_id)
         .expect("missing persisted child session");
+    let db_grandchild_session = db_sessions
+        .iter()
+        .find(|session| session.id == grandchild_session_id)
+        .expect("missing persisted grandchild session");
     assert_eq!(db_parent_session.status, "Canceled");
     assert_eq!(db_child_session.status, "Canceled");
+    assert_eq!(db_grandchild_session.status, "Canceled");
+}
+
+#[tokio::test]
+/// Ensures a stack cascade preserves a descendant that is already terminal.
+async fn test_cancel_session_preserves_terminal_stacked_descendant() {
+    // Arrange
+    let dir = tempdir().expect("failed to create temp dir");
+    let mut app = new_test_app_with_git(dir.path()).await;
+    let parent_session_id = app.create_session().await.expect("failed to create parent");
+    let child_session_id = app
+        .create_stacked_draft_session(&parent_session_id)
+        .await
+        .expect("failed to create stacked draft session");
+    crate::test_support::set_session_status_for_test(&mut app, &child_session_id, Status::Done);
+    app.services
+        .db()
+        .sessions()
+        .update_session_status_with_timing_at(&child_session_id, "Done", 0)
+        .await
+        .expect("failed to persist terminal child status");
+    crate::test_support::set_session_status_for_test(&mut app, &parent_session_id, Status::Review);
+
+    // Act
+    app.sessions
+        .cancel_session(&app.services, &parent_session_id)
+        .await
+        .expect("failed to cancel parent session");
+
+    // Assert
+    app.sessions.sync_from_handles();
+    let child_session = app
+        .sessions
+        .sessions()
+        .iter()
+        .find(|session| session.id == child_session_id)
+        .expect("missing terminal child session");
+    assert_eq!(child_session.status, Status::Done);
+    let db_sessions = app
+        .services
+        .db()
+        .sessions()
+        .load_sessions()
+        .await
+        .expect("failed to load sessions");
+    let db_child_session = db_sessions
+        .iter()
+        .find(|session| session.id == child_session_id)
+        .expect("missing persisted terminal child session");
+    assert_eq!(db_child_session.status, "Done");
+}
+
+#[tokio::test]
+/// Ensures parent cancellation reports a descendant cascade failure instead
+/// of returning success after the parent status was already persisted.
+async fn test_cancel_session_reports_stacked_descendant_failure() {
+    // Arrange
+    let dir = tempdir().expect("failed to create temp dir");
+    let mut app = new_test_app_with_git(dir.path()).await;
+    let parent_session_id = app.create_session().await.expect("failed to create parent");
+    let child_session_id = app
+        .create_stacked_draft_session(&parent_session_id)
+        .await
+        .expect("failed to create stacked draft session");
+    crate::test_support::set_session_status_for_test(&mut app, &parent_session_id, Status::Review);
+    app.sessions
+        .session_handles_mut()
+        .remove(child_session_id.as_str());
+
+    // Act
+    let result = app
+        .sessions
+        .cancel_session(&app.services, &parent_session_id)
+        .await;
+
+    // Assert
+    let error = result.expect_err("descendant cancellation failure should be reported");
+    assert!(error.to_string().contains(child_session_id.as_str()));
+    app.sessions.sync_from_handles();
+    let parent_session = app
+        .sessions
+        .sessions()
+        .iter()
+        .find(|session| session.id == parent_session_id)
+        .expect("missing parent session");
+    let child_session = app
+        .sessions
+        .sessions()
+        .iter()
+        .find(|session| session.id == child_session_id)
+        .expect("missing child session");
+    assert_eq!(parent_session.status, Status::Canceled);
+    assert_eq!(child_session.status, Status::Draft);
 }
 
 #[tokio::test]

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -26,6 +26,7 @@ use crate::domain::agent::{
 use crate::domain::permission::PermissionMode;
 use crate::domain::session::{
     QueuedMessage, ReviewRequest, SESSION_DATA_DIR, Session, SessionHandles, SessionId, Status,
+    can_create_stacked_child as stack_can_create_stacked_child,
     can_merge_session_branch_in_stack as stack_can_merge_session_branch,
     can_mutate_session_branch_in_stack as stack_can_mutate_session_branch,
     can_rebase_session_branch_in_stack as stack_can_rebase_session_branch,
@@ -104,6 +105,42 @@ enum ReplyEligibility {
     /// Accept a structured question answer during turn finalization or while
     /// the session is already waiting in `Question`.
     QuestionAnswer,
+}
+
+/// Capability used to authorize and stop one terminal cancellation.
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum CancellationCapability {
+    /// Cancellation initiated through the ordinary user action.
+    User,
+    /// Coordinator-only cancellation of a managed worker.
+    Managed,
+    /// Forced cancellation of a descendant after its stack parent is canceled.
+    StackedDescendant,
+}
+
+impl CancellationCapability {
+    /// Returns whether this capability can cancel the current session state.
+    fn allows(self, session: &Session) -> bool {
+        match self {
+            Self::User => session.allows_cancel_action(),
+            Self::Managed => {
+                session.allows_cancel_action()
+                    || (session.is_managed()
+                        && (matches!(session.status, Status::Draft | Status::InProgress)
+                            || session.status.allows_review_actions()))
+            }
+            Self::StackedDescendant => {
+                session.status != Status::Canceled
+                    && session.status.can_transition_to(Status::Canceled)
+            }
+        }
+    }
+
+    /// Returns whether cancellation must stop active or reserved branch work.
+    fn stops_branch_work(self, status: Status) -> bool {
+        status == Status::InProgress
+            || (self == Self::StackedDescendant && status.is_stack_branch_mutating())
+    }
 }
 
 impl ReplyEligibility {
@@ -491,9 +528,10 @@ impl SessionManager {
     ) -> Result<String, SessionError> {
         let (base_branch, parent_id) = {
             let parent_session = self.session_or_err(parent_session_id)?;
-            if !parent_session.allows_stacked_child_creation() {
+            if !stack_can_create_stacked_child(&self.state.sessions, parent_session_id) {
                 return Err(SessionError::Workflow(
-                    "Stacked sessions can only be created from root sessions with active branches"
+                    "Stacked sessions require an active materialized parent below the five-level \
+                     stack limit"
                         .to_string(),
                 ));
             }
@@ -1311,26 +1349,31 @@ impl SessionManager {
         })
     }
 
-    /// Returns whether a staged draft can start under the current one-level
-    /// stack constraints.
+    /// Returns whether the selected session can parent another stacked draft.
+    pub(crate) fn can_create_stacked_child(&self, session_id: &str) -> bool {
+        stack_can_create_stacked_child(&self.state.sessions, session_id)
+    }
+
+    /// Returns whether a staged draft can start under the current stack
+    /// constraints.
     pub(crate) fn can_start_staged_session(&self, session_id: &str) -> bool {
         stack_can_start_staged_session(&self.state.sessions, session_id)
     }
 
     /// Returns whether a session can start branch-mutating work without
-    /// competing with another member of its one-level stack.
+    /// competing with another member of its stack.
     pub(crate) fn can_mutate_session_branch_in_stack(&self, session_id: &str) -> bool {
         stack_can_mutate_session_branch(&self.state.sessions, session_id)
     }
 
     /// Returns whether a session can enter the merge queue without competing
-    /// with another member of its one-level stack.
+    /// with another member of its stack.
     pub(crate) fn can_merge_session_branch_in_stack(&self, session_id: &str) -> bool {
         stack_can_merge_session_branch(&self.state.sessions, session_id)
     }
 
     /// Returns whether a session can start sync work without competing with
-    /// another member of its one-level stack.
+    /// another member of its stack.
     pub(crate) fn can_rebase_session_branch_in_stack(&self, session_id: &str) -> bool {
         stack_can_rebase_session_branch(&self.state.sessions, session_id)
     }
@@ -3306,13 +3349,13 @@ impl SessionManager {
         session_id: &str,
     ) -> Result<(), SessionError> {
         let status_updated = self
-            .cancel_single_session(services, session_id, false)
+            .cancel_single_session(services, session_id, CancellationCapability::User)
             .await?;
         if !status_updated {
             return Ok(());
         }
         self.cancel_stacked_child_sessions(services, session_id)
-            .await;
+            .await?;
 
         Ok(())
     }
@@ -3327,11 +3370,11 @@ impl SessionManager {
         session_id: &str,
     ) -> Result<(), SessionError> {
         let status_updated = self
-            .cancel_single_session(services, session_id, true)
+            .cancel_single_session(services, session_id, CancellationCapability::Managed)
             .await?;
         if status_updated {
             self.cancel_stacked_child_sessions(services, session_id)
-                .await;
+                .await?;
         }
 
         Ok(())
@@ -3342,14 +3385,14 @@ impl SessionManager {
         &self,
         services: &AppServices,
         session_id: &str,
-        allow_managed: bool,
+        cancellation_capability: CancellationCapability,
     ) -> Result<bool, SessionError> {
         let session = self.session_or_err(session_id)?;
-        let managed_cancel_allowed = allow_managed
-            && session.is_managed()
-            && (matches!(session.status, Status::Draft | Status::InProgress)
-                || session.status.allows_review_actions());
-        if !session.allows_cancel_action() && !managed_cancel_allowed {
+        if !cancellation_capability.allows(session) {
+            if cancellation_capability == CancellationCapability::StackedDescendant {
+                return Ok(false);
+            }
+
             return Err(SessionError::Workflow(
                 "Session is not cancelable in its current state".to_string(),
             ));
@@ -3357,13 +3400,13 @@ impl SessionManager {
 
         let branch_name = session_branch(&session.id);
         let folder = session.folder.clone();
-        let is_running = session.status == Status::InProgress;
+        let stops_branch_work = cancellation_capability.stops_branch_work(session.status);
         let has_worktree = services.fs_client().is_dir(folder.clone());
         let handles = self.session_handles_or_err(session_id)?;
         let status_transition = StatusTransition::from_services(services, handles, session_id);
 
-        if is_running {
-            Self::signal_running_session_cancellation(services, handles, session_id).await;
+        if stops_branch_work {
+            Self::signal_session_cancellation(services, handles, session_id).await;
         }
 
         let status_updated = status_transition.apply(Status::Canceled).await;
@@ -3381,20 +3424,28 @@ impl SessionManager {
         Ok(status_updated)
     }
 
-    /// Cancels every loaded one-level stacked child of `parent_session_id`.
+    /// Cancels every loaded stacked descendant of `parent_session_id`.
     ///
-    /// Child cancellation is best-effort after the parent has already reached
-    /// `Canceled`, but it reuses the same single-session cancellation path so
-    /// staged draft temp data and any future child worktree resources are
-    /// cleaned consistently.
+    /// The cascade bypasses the ordinary user-action gate, stops active or
+    /// reserved descendant branch work, and attempts every loaded descendant
+    /// before reporting any failures to the parent cancellation caller.
+    ///
+    /// # Errors
+    /// Returns a workflow error listing descendants that could not be
+    /// canceled after all other descendants have been attempted.
     pub(crate) async fn cancel_stacked_child_sessions(
         &self,
         services: &AppServices,
         parent_session_id: &str,
-    ) {
-        for child_session_id in self.stacked_child_session_ids(parent_session_id) {
+    ) -> Result<(), SessionError> {
+        let mut cancellation_failures = Vec::new();
+        for child_session_id in self.stacked_descendant_session_ids(parent_session_id) {
             if let Err(error) = self
-                .cancel_single_session(services, child_session_id.as_str(), false)
+                .cancel_single_session(
+                    services,
+                    child_session_id.as_str(),
+                    CancellationCapability::StackedDescendant,
+                )
                 .await
             {
                 warn!(
@@ -3403,23 +3454,47 @@ impl SessionManager {
                     error = %error,
                     "failed to cancel stacked child session after parent cancellation"
                 );
+                cancellation_failures.push(format!("{child_session_id}: {error}"));
             }
         }
+
+        if cancellation_failures.is_empty() {
+            return Ok(());
+        }
+
+        Err(SessionError::Workflow(format!(
+            "Failed to cancel stacked descendants: {}",
+            cancellation_failures.join("; ")
+        )))
     }
 
-    /// Returns loaded one-level child ids for one parent session.
-    fn stacked_child_session_ids(&self, parent_session_id: &str) -> Vec<SessionId> {
-        self.state
-            .sessions
-            .iter()
-            .filter(|session| {
-                session
-                    .parent_session_id
-                    .as_ref()
-                    .is_some_and(|parent_id| parent_id.as_str() == parent_session_id)
-            })
-            .map(|session| session.id.clone())
-            .collect()
+    /// Returns loaded descendant ids in parent-before-child order.
+    fn stacked_descendant_session_ids(&self, parent_session_id: &str) -> Vec<SessionId> {
+        let mut ancestor_session_ids = vec![SessionId::from(parent_session_id)];
+        let mut descendant_session_ids = Vec::new();
+
+        loop {
+            let next_descendants = self
+                .state
+                .sessions
+                .iter()
+                .filter(|session| {
+                    session.parent_session_id.as_ref().is_some_and(|parent_id| {
+                        ancestor_session_ids.contains(parent_id)
+                            && !descendant_session_ids.contains(&session.id)
+                    })
+                })
+                .map(|session| session.id.clone())
+                .collect::<Vec<_>>();
+            if next_descendants.is_empty() {
+                break;
+            }
+
+            ancestor_session_ids.extend(next_descendants.iter().cloned());
+            descendant_session_ids.extend(next_descendants);
+        }
+
+        descendant_session_ids
     }
 
     /// Defers terminal cancellation cleanup so foreground key handling returns
@@ -3459,9 +3534,9 @@ impl SessionManager {
         services.track_cleanup_task(cleanup_task_handle);
     }
 
-    /// Requests cancellation for queued operations and signals the active
-    /// running turn for a session that is being terminally canceled.
-    async fn signal_running_session_cancellation(
+    /// Requests cancellation for unfinished operations, clears queued work,
+    /// and signals any active agent turn for a terminally canceled session.
+    async fn signal_session_cancellation(
         services: &AppServices,
         handles: &SessionHandles,
         session_id: &str,

--- a/crates/agentty/src/domain/session.rs
+++ b/crates/agentty/src/domain/session.rs
@@ -24,6 +24,9 @@ use crate::domain::turn_prompt::{TurnPrompt, TurnPromptAttachment};
 /// Folder name under a project root that stores Agentty session metadata.
 pub const SESSION_DATA_DIR: &str = ".agentty";
 
+/// Maximum number of stacked descendants in one root-to-child chain.
+pub const MAX_STACK_DEPTH: usize = 5;
+
 /// Full in-progress loader label shown while post-turn commit-message
 /// generation and git commit orchestration are running.
 pub(crate) const COMMITTING_PROGRESS_LABEL: &str = "Committing...";
@@ -358,20 +361,27 @@ impl Session {
         self.is_draft_session() && self.status == Status::Draft && !self.prompt.is_empty()
     }
 
-    /// Returns whether this session can create a one-level stacked draft
-    /// child.
+    /// Returns whether this session can parent a stacked draft.
     ///
-    /// Only root sessions with materialized branches can be parents in the
-    /// first stacked-session version. Explicit draft sessions are excluded
-    /// because their worktree branch is deferred until start, and terminal
-    /// sessions no longer provide an active branch to stack on.
+    /// Unstarted standalone drafts are excluded because their worktree branch
+    /// is deferred until start. Unstarted stacked drafts can stage descendants
+    /// against their deterministic future branch, though each descendant must
+    /// still wait for its immediate parent to reach review before starting.
+    /// Terminal sessions no longer provide an active branch to stack on. The
+    /// stack-wide depth policy is evaluated separately because it requires the
+    /// loaded session graph.
     pub fn allows_stacked_child_creation(&self) -> bool {
-        self.parent_session_id.is_none()
-            && !self.is_draft_session()
-            && !matches!(
-                self.status,
-                Status::Merged | Status::Done | Status::Canceled
-            )
+        if self.is_draft_session()
+            && self.status == Status::Draft
+            && self.parent_session_id.is_none()
+        {
+            return false;
+        }
+
+        !matches!(
+            self.status,
+            Status::Merged | Status::Done | Status::Canceled
+        )
     }
 
     /// Returns whether this session can be forked into a new independent
@@ -427,8 +437,7 @@ impl Session {
         self.role.is_managed()
     }
 
-    /// Returns whether this session belongs to a one-level stack beneath a
-    /// parent session branch.
+    /// Returns whether this session is stacked beneath another session branch.
     pub fn is_stacked_child(&self) -> bool {
         self.parent_session_id.is_some()
     }
@@ -596,11 +605,23 @@ impl Session {
     }
 }
 
+/// Returns whether `parent_session_id` can parent another stacked draft
+/// without exceeding [`MAX_STACK_DEPTH`].
+pub(crate) fn can_create_stacked_child(sessions: &[Session], parent_session_id: &str) -> bool {
+    let Some(parent_session) = find_session(sessions, parent_session_id) else {
+        return false;
+    };
+
+    parent_session.allows_stacked_child_creation()
+        && session_stack_depth(sessions, parent_session_id)
+            .is_some_and(|depth| depth < MAX_STACK_DEPTH)
+}
+
 /// Returns whether the staged draft identified by `session_id` can start
-/// under the currently loaded one-level stack.
+/// under the currently loaded stack.
 ///
 /// Root drafts only need their own staged prompt state. Stacked drafts also
-/// require a review-ready parent and no sibling/parent branch work already
+/// require a review-ready immediate parent and no other branch work already
 /// running or queued in the same stack.
 pub(crate) fn can_start_staged_session_in_stack(sessions: &[Session], session_id: &str) -> bool {
     let Some(stack) = SessionStack::for_session(sessions, session_id) else {
@@ -614,7 +635,7 @@ pub(crate) fn can_start_staged_session_in_stack(sessions: &[Session], session_id
     if session.parent_session_id.is_none() {
         return true;
     }
-    if !stack.root_allows_stacked_child_start() {
+    if !stack.parent_allows_stacked_child_start() {
         return false;
     }
 
@@ -623,7 +644,7 @@ pub(crate) fn can_start_staged_session_in_stack(sessions: &[Session], session_id
 
 /// Returns whether the session identified by `session_id` can start slash
 /// command branch mutation while preserving one active branch worker per
-/// one-level stack.
+/// stack.
 ///
 /// This blocks parent branch edits once a child branch has materialized, and
 /// blocks any stack member from starting branch work while a different member
@@ -637,7 +658,7 @@ pub(crate) fn can_mutate_session_branch_in_stack(sessions: &[Session], session_i
         return false;
     }
 
-    if stack.requested_session_is_root() && stack.has_materialized_child() {
+    if stack.has_materialized_descendant() {
         return false;
     }
 
@@ -676,7 +697,7 @@ pub(crate) fn can_rebase_session_branch_in_stack(sessions: &[Session], session_i
     !stack.has_branch_mutating_member_except(session_id)
 }
 
-/// Returns whether a session can accept a chat reply under one-level stack
+/// Returns whether a session can accept a chat reply under stack
 /// constraints.
 ///
 /// Replies are allowed when the stack has no other member actively running or
@@ -691,41 +712,31 @@ pub(crate) fn can_reply_to_session_in_stack(sessions: &[Session], session_id: &s
     !stack.has_branch_mutating_member_except(session_id)
 }
 
-/// Snapshot of a loaded one-level stack for branch-work policy checks.
+/// Snapshot of one loaded stack tree for branch-work policy checks.
 struct SessionStack<'a> {
     members: Vec<&'a Session>,
     requested_session: &'a Session,
-    root_session: &'a Session,
 }
 
 impl<'a> SessionStack<'a> {
     /// Builds the stack containing `session_id` from the loaded session list.
     fn for_session(sessions: &'a [Session], session_id: &str) -> Option<Self> {
         let requested_session = find_session(sessions, session_id)?;
-        let root_session = match requested_session.parent_session_id.as_ref() {
-            Some(parent_session_id) => find_session(sessions, parent_session_id.as_str())?,
-            None => requested_session,
-        };
+        let root_session = stack_root_session(sessions, requested_session)?;
         let members = sessions
             .iter()
-            .filter(|session| Self::session_belongs_to_root(session, root_session.id.as_str()))
+            .filter(|session| session_stack_root_id(sessions, session) == Some(&root_session.id))
             .collect();
 
         Some(Self {
             members,
             requested_session,
-            root_session,
         })
     }
 
     /// Returns the session whose action is being evaluated.
     fn requested_session(&self) -> &'a Session {
         self.requested_session
-    }
-
-    /// Returns whether the requested session is the stack root.
-    fn requested_session_is_root(&self) -> bool {
-        self.requested_session.parent_session_id.is_none()
     }
 
     /// Returns whether another stack member is currently reserving or
@@ -737,11 +748,16 @@ impl<'a> SessionStack<'a> {
             .any(|session| session.status.is_stack_branch_mutating())
     }
 
-    /// Returns whether the root already has a non-terminal child branch that
-    /// has started at least one live turn.
-    fn has_materialized_child(&self) -> bool {
+    /// Returns whether the requested session has a non-terminal descendant
+    /// branch that has started at least one live turn.
+    fn has_materialized_descendant(&self) -> bool {
         self.members.iter().any(|session| {
-            session.parent_session_id.is_some()
+            session.id != self.requested_session.id
+                && session_is_descendant_of(
+                    &self.members,
+                    session,
+                    self.requested_session.id.as_str(),
+                )
                 && !matches!(
                     session.status,
                     Status::Draft | Status::Merged | Status::Done | Status::Canceled
@@ -749,21 +765,84 @@ impl<'a> SessionStack<'a> {
         })
     }
 
-    /// Returns whether the root is in a state that lets a stacked draft child
-    /// materialize.
-    fn root_allows_stacked_child_start(&self) -> bool {
-        self.root_session.status.allows_stacked_child_start()
+    /// Returns whether the immediate parent is in a state that lets the
+    /// requested stacked draft materialize.
+    ///
+    /// The caller handles root drafts before invoking this stacked-only gate.
+    fn parent_allows_stacked_child_start(&self) -> bool {
+        self.requested_session
+            .parent_session_id
+            .as_ref()
+            .is_some_and(|parent_session_id| {
+                self.members.iter().any(|session| {
+                    session.id == *parent_session_id && session.status.allows_stacked_child_start()
+                })
+            })
+    }
+}
+
+/// Returns the zero-based stack depth of a session, rejecting missing or
+/// cyclic parent chains. Root sessions have depth zero.
+fn session_stack_depth(sessions: &[Session], session_id: &str) -> Option<usize> {
+    let mut current_session = find_session(sessions, session_id)?;
+    let mut visited_session_ids = Vec::new();
+    let mut depth = 0;
+
+    while let Some(parent_session_id) = current_session.parent_session_id.as_ref() {
+        if visited_session_ids.contains(&current_session.id) {
+            return None;
+        }
+        visited_session_ids.push(current_session.id.clone());
+        current_session = find_session(sessions, parent_session_id.as_str())?;
+        depth += 1;
     }
 
-    /// Returns whether `session` belongs to the one-level stack rooted at
-    /// `root_session_id`.
-    fn session_belongs_to_root(session: &Session, root_session_id: &str) -> bool {
-        session.id.as_str() == root_session_id
-            || session
-                .parent_session_id
-                .as_ref()
-                .is_some_and(|parent_session_id| parent_session_id.as_str() == root_session_id)
+    (!visited_session_ids.contains(&current_session.id)).then_some(depth)
+}
+
+/// Returns the root session for a valid loaded parent chain.
+fn stack_root_session<'a>(sessions: &'a [Session], session: &'a Session) -> Option<&'a Session> {
+    let depth = session_stack_depth(sessions, session.id.as_str())?;
+    let mut root_session = session;
+
+    for _ in 0..depth {
+        root_session = find_session(sessions, root_session.parent_session_id.as_deref()?)?;
     }
+
+    Some(root_session)
+}
+
+/// Returns the root id for a session with a valid loaded parent chain.
+fn session_stack_root_id<'a>(
+    sessions: &'a [Session],
+    session: &'a Session,
+) -> Option<&'a SessionId> {
+    stack_root_session(sessions, session).map(|root_session| &root_session.id)
+}
+
+/// Returns whether `session` descends from `ancestor_session_id` within the
+/// already-connected stack member set.
+fn session_is_descendant_of(
+    members: &[&Session],
+    session: &Session,
+    ancestor_session_id: &str,
+) -> bool {
+    let mut current_session = session;
+
+    while let Some(parent_session_id) = current_session.parent_session_id.as_ref() {
+        if parent_session_id.as_str() == ancestor_session_id {
+            return true;
+        }
+        let Some(parent_session) = members
+            .iter()
+            .find(|candidate| candidate.id == *parent_session_id)
+        else {
+            return false;
+        };
+        current_session = parent_session;
+    }
+
+    false
 }
 
 /// Finds one loaded session by id.
@@ -1087,7 +1166,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_allows_stacked_child_creation_returns_true_for_root_active_session() {
+    fn test_allows_stacked_child_creation_returns_true_for_materialized_active_session() {
         // Arrange
         let session = SessionFixtureBuilder::new()
             .draft(false)
@@ -1102,13 +1181,19 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_allows_stacked_child_creation_rejects_drafts_children_and_terminal_sessions() {
+    fn test_stacked_child_creation_accepts_stacked_drafts_and_rejects_root_drafts_or_terminal() {
         // Arrange
         let draft_session = SessionFixtureBuilder::new()
             .draft(true)
             .status(Status::Draft)
             .build();
+        let stacked_draft_session = SessionFixtureBuilder::new()
+            .draft(true)
+            .parent_session_id(Some(SessionId::from("parent-session")))
+            .status(Status::Draft)
+            .build();
         let child_session = SessionFixtureBuilder::new()
+            .draft(true)
             .parent_session_id(Some(SessionId::from("parent-session")))
             .status(Status::Review)
             .build();
@@ -1120,6 +1205,7 @@ pub(crate) mod tests {
 
         // Act
         let allows_draft_child = draft_session.allows_stacked_child_creation();
+        let allows_stacked_draft_child = stacked_draft_session.allows_stacked_child_creation();
         let allows_nested_child = child_session.allows_stacked_child_creation();
         let allows_merged_child = merged_session.allows_stacked_child_creation();
         let allows_done_child = done_session.allows_stacked_child_creation();
@@ -1127,10 +1213,128 @@ pub(crate) mod tests {
 
         // Assert
         assert!(!allows_draft_child);
-        assert!(!allows_nested_child);
+        assert!(allows_stacked_draft_child);
+        assert!(allows_nested_child);
         assert!(!allows_merged_child);
         assert!(!allows_done_child);
         assert!(!allows_canceled_child);
+    }
+
+    #[test]
+    fn test_can_create_stacked_child_allows_depth_five_and_rejects_depth_six() {
+        // Arrange
+        let root_session = SessionFixtureBuilder::new()
+            .id("root")
+            .draft(false)
+            .status(Status::Review)
+            .build();
+        let level_1 = SessionFixtureBuilder::new()
+            .id("level-1")
+            .draft(true)
+            .status(Status::Review)
+            .parent_session_id(Some(SessionId::from("root")))
+            .build();
+        let level_2 = SessionFixtureBuilder::new()
+            .id("level-2")
+            .draft(true)
+            .status(Status::Review)
+            .parent_session_id(Some(SessionId::from("level-1")))
+            .build();
+        let level_3 = SessionFixtureBuilder::new()
+            .id("level-3")
+            .draft(true)
+            .status(Status::Review)
+            .parent_session_id(Some(SessionId::from("level-2")))
+            .build();
+        let level_4 = SessionFixtureBuilder::new()
+            .id("level-4")
+            .draft(true)
+            .status(Status::Review)
+            .parent_session_id(Some(SessionId::from("level-3")))
+            .build();
+        let level_5 = SessionFixtureBuilder::new()
+            .id("level-5")
+            .draft(true)
+            .status(Status::Review)
+            .parent_session_id(Some(SessionId::from("level-4")))
+            .build();
+        let sessions = vec![root_session, level_1, level_2, level_3, level_4, level_5];
+
+        // Act
+        let can_create_level_5 = can_create_stacked_child(&sessions, "level-4");
+        let can_create_level_6 = can_create_stacked_child(&sessions, "level-5");
+
+        // Assert
+        assert!(can_create_level_5);
+        assert!(!can_create_level_6);
+    }
+
+    #[test]
+    fn test_can_create_stacked_child_rejects_missing_sessions_and_invalid_parent_chains() {
+        // Arrange
+        let missing_parent = SessionFixtureBuilder::new()
+            .id("missing-parent-child")
+            .draft(true)
+            .status(Status::Review)
+            .parent_session_id(Some(SessionId::from("missing")))
+            .build();
+        let first_cycle_member = SessionFixtureBuilder::new()
+            .id("cycle-a")
+            .draft(true)
+            .status(Status::Review)
+            .parent_session_id(Some(SessionId::from("cycle-b")))
+            .build();
+        let second_cycle_member = SessionFixtureBuilder::new()
+            .id("cycle-b")
+            .draft(true)
+            .status(Status::Review)
+            .parent_session_id(Some(SessionId::from("cycle-a")))
+            .build();
+        let sessions = vec![missing_parent, first_cycle_member, second_cycle_member];
+
+        // Act
+        let missing_session_allowed = can_create_stacked_child(&sessions, "missing-session");
+        let missing_parent_allowed = can_create_stacked_child(&sessions, "missing-parent-child");
+        let cycle_allowed = can_create_stacked_child(&sessions, "cycle-a");
+
+        // Assert
+        assert!(!missing_session_allowed);
+        assert!(!missing_parent_allowed);
+        assert!(!cycle_allowed);
+    }
+
+    #[test]
+    fn test_session_is_descendant_of_walks_nested_chain_and_rejects_missing_parent() {
+        // Arrange
+        let root_session = SessionFixtureBuilder::new().id("root-session").build();
+        let parent_session = SessionFixtureBuilder::new()
+            .id("parent-session")
+            .parent_session_id(Some(SessionId::from("root-session")))
+            .build();
+        let child_session = SessionFixtureBuilder::new()
+            .id("child-session")
+            .parent_session_id(Some(SessionId::from("parent-session")))
+            .build();
+        let orphan_session = SessionFixtureBuilder::new()
+            .id("orphan-session")
+            .parent_session_id(Some(SessionId::from("missing-session")))
+            .build();
+        let members = vec![
+            &root_session,
+            &parent_session,
+            &child_session,
+            &orphan_session,
+        ];
+
+        // Act
+        let child_is_descendant =
+            session_is_descendant_of(&members, &child_session, "root-session");
+        let orphan_is_descendant =
+            session_is_descendant_of(&members, &orphan_session, "root-session");
+
+        // Assert
+        assert!(child_is_descendant);
+        assert!(!orphan_is_descendant);
     }
 
     #[test]
@@ -1360,6 +1564,36 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_can_start_nested_staged_session_uses_immediate_parent_review_state() {
+        // Arrange
+        let root_session = SessionFixtureBuilder::new()
+            .id("root-session")
+            .draft(false)
+            .status(Status::Draft)
+            .build();
+        let parent_session = SessionFixtureBuilder::new()
+            .id("parent-session")
+            .draft(true)
+            .status(Status::Review)
+            .parent_session_id(Some(SessionId::from("root-session")))
+            .build();
+        let child_session = SessionFixtureBuilder::new()
+            .id("child-session")
+            .draft(true)
+            .status(Status::Draft)
+            .prompt("Ready nested draft")
+            .parent_session_id(Some(SessionId::from("parent-session")))
+            .build();
+        let sessions = vec![root_session, parent_session, child_session];
+
+        // Act
+        let can_start_child = can_start_staged_session_in_stack(&sessions, "child-session");
+
+        // Assert
+        assert!(can_start_child);
+    }
+
+    #[test]
     fn test_can_mutate_session_branch_in_stack_blocks_parent_with_materialized_child() {
         // Arrange
         let parent_session = SessionFixtureBuilder::new()
@@ -1374,6 +1608,35 @@ pub(crate) mod tests {
             .parent_session_id(Some(SessionId::from("parent-session")))
             .build();
         let sessions = vec![parent_session, child_session];
+
+        // Act
+        let can_mutate_parent = can_mutate_session_branch_in_stack(&sessions, "parent-session");
+
+        // Assert
+        assert!(!can_mutate_parent);
+    }
+
+    #[test]
+    fn test_can_mutate_session_branch_in_stack_blocks_parent_with_nested_descendant() {
+        // Arrange
+        let root_session = SessionFixtureBuilder::new()
+            .id("root-session")
+            .draft(false)
+            .status(Status::Review)
+            .build();
+        let parent_session = SessionFixtureBuilder::new()
+            .id("parent-session")
+            .draft(true)
+            .status(Status::Review)
+            .parent_session_id(Some(SessionId::from("root-session")))
+            .build();
+        let child_session = SessionFixtureBuilder::new()
+            .id("child-session")
+            .draft(true)
+            .status(Status::Review)
+            .parent_session_id(Some(SessionId::from("parent-session")))
+            .build();
+        let sessions = vec![root_session, parent_session, child_session];
 
         // Act
         let can_mutate_parent = can_mutate_session_branch_in_stack(&sessions, "parent-session");
@@ -1589,6 +1852,35 @@ pub(crate) mod tests {
 
         // Assert
         assert!(!can_reply_to_parent);
+    }
+
+    #[test]
+    fn test_can_reply_to_session_in_stack_blocks_active_nested_descendant() {
+        // Arrange
+        let root_session = SessionFixtureBuilder::new()
+            .id("root-session")
+            .draft(false)
+            .status(Status::Review)
+            .build();
+        let child_session = SessionFixtureBuilder::new()
+            .id("child-session")
+            .draft(true)
+            .status(Status::Review)
+            .parent_session_id(Some(SessionId::from("root-session")))
+            .build();
+        let running_grandchild_session = SessionFixtureBuilder::new()
+            .id("grandchild-session")
+            .draft(true)
+            .status(Status::InProgress)
+            .parent_session_id(Some(SessionId::from("child-session")))
+            .build();
+        let sessions = vec![root_session, child_session, running_grandchild_session];
+
+        // Act
+        let can_reply_to_root = can_reply_to_session_in_stack(&sessions, "root-session");
+
+        // Assert
+        assert!(!can_reply_to_root);
     }
 
     /// Builds a minimal session fixture for reasoning-level tests.

--- a/crates/agentty/src/domain/session_order.rs
+++ b/crates/agentty/src/domain/session_order.rs
@@ -20,8 +20,10 @@ pub enum SessionGroup {
 pub enum SessionTreePosition {
     /// Root-level session row with no tree marker.
     Root,
-    /// One-level child row connected to its parent.
+    /// Nested child row connected to its parent.
     Child {
+        /// One-based depth below the root row.
+        depth: usize,
         /// Whether this is the final child rendered under the parent.
         is_last: bool,
     },
@@ -177,17 +179,18 @@ fn append_group_rows<'a>(
             session,
             tree_position: SessionTreePosition::Root,
         });
-        append_stacked_child_rows(rows, stacked_children, session.id.as_str(), group);
+        append_stacked_child_rows(rows, stacked_children, session.id.as_str(), group, 1);
     }
 }
 
-/// Adds the one-level stacked children that belong in the parent's current
-/// display group.
+/// Adds stacked descendants that belong in the parent's current display
+/// group.
 fn append_stacked_child_rows<'a>(
     rows: &mut Vec<GroupedSessionRow<'a>>,
     stacked_children: &StackedChildIndex<'a>,
     parent_session_id: &str,
     group: SessionGroup,
+    depth: usize,
 ) {
     let Some(children) = stacked_children.get(parent_session_id) else {
         return;
@@ -204,9 +207,17 @@ fn append_stacked_child_rows<'a>(
             index,
             session,
             tree_position: SessionTreePosition::Child {
+                depth,
                 is_last: child_position + 1 == child_count,
             },
         });
+        append_stacked_child_rows(
+            rows,
+            stacked_children,
+            session.id.as_str(),
+            group,
+            depth + 1,
+        );
     }
 }
 
@@ -555,11 +566,17 @@ mod tests {
                 ("parent-1".to_string(), SessionTreePosition::Root),
                 (
                     "child-1".to_string(),
-                    SessionTreePosition::Child { is_last: false },
+                    SessionTreePosition::Child {
+                        depth: 1,
+                        is_last: false,
+                    },
                 ),
                 (
                     "child-2".to_string(),
-                    SessionTreePosition::Child { is_last: true },
+                    SessionTreePosition::Child {
+                        depth: 1,
+                        is_last: true,
+                    },
                 ),
             ]
         );
@@ -633,7 +650,80 @@ mod tests {
             vec![
                 "Archive".to_string(),
                 "parent-1:Root".to_string(),
-                "child-1:Child { is_last: true }".to_string(),
+                "child-1:Child { depth: 1, is_last: true }".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_grouped_session_rows_nests_descendants_to_depth_five() {
+        // Arrange
+        let root_session = crate::test_support::titled_session_fixture("root", Status::Review);
+        let mut level_1 = crate::test_support::titled_session_fixture("level-1", Status::Review);
+        level_1.parent_session_id = Some("root".into());
+        let mut level_2 = crate::test_support::titled_session_fixture("level-2", Status::Review);
+        level_2.parent_session_id = Some("level-1".into());
+        let mut level_3 = crate::test_support::titled_session_fixture("level-3", Status::Review);
+        level_3.parent_session_id = Some("level-2".into());
+        let mut level_4 = crate::test_support::titled_session_fixture("level-4", Status::Review);
+        level_4.parent_session_id = Some("level-3".into());
+        let mut level_5 = crate::test_support::titled_session_fixture("level-5", Status::Review);
+        level_5.parent_session_id = Some("level-4".into());
+        let sessions = vec![level_5, level_3, root_session, level_1, level_2, level_4];
+
+        // Act
+        let ordered_rows = grouped_session_rows(&sessions)
+            .into_iter()
+            .filter_map(|row| match row {
+                GroupedSessionRow::Session {
+                    session,
+                    tree_position,
+                    ..
+                } => Some((session.id.to_string(), tree_position)),
+                GroupedSessionRow::GroupLabel(_) => None,
+            })
+            .collect::<Vec<_>>();
+
+        // Assert
+        assert_eq!(
+            ordered_rows,
+            vec![
+                ("root".to_string(), SessionTreePosition::Root),
+                (
+                    "level-1".to_string(),
+                    SessionTreePosition::Child {
+                        depth: 1,
+                        is_last: true,
+                    },
+                ),
+                (
+                    "level-2".to_string(),
+                    SessionTreePosition::Child {
+                        depth: 2,
+                        is_last: true,
+                    },
+                ),
+                (
+                    "level-3".to_string(),
+                    SessionTreePosition::Child {
+                        depth: 3,
+                        is_last: true,
+                    },
+                ),
+                (
+                    "level-4".to_string(),
+                    SessionTreePosition::Child {
+                        depth: 4,
+                        is_last: true,
+                    },
+                ),
+                (
+                    "level-5".to_string(),
+                    SessionTreePosition::Child {
+                        depth: 5,
+                        is_last: true,
+                    },
+                ),
             ]
         );
     }

--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -138,16 +138,16 @@ pub(crate) struct ViewHelpState {
     /// Whether this session can fork into a new independent session.
     pub(crate) can_fork_session: ViewActionAvailability,
     /// Whether this session can enter the merge queue under the current
-    /// one-level stack consistency rules.
+    /// stack consistency rules.
     pub(crate) can_merge_session_branch: ViewActionAvailability,
     /// Whether this session can start branch-mutating work under the current
-    /// one-level stack consistency rules.
+    /// stack consistency rules.
     pub(crate) can_mutate_session_branch: ViewActionAvailability,
     /// Whether the current session currently has a local worktree directory
     /// available to open.
     pub(crate) can_open_worktree: ViewActionAvailability,
-    /// Whether this session can start sync work under the current one-level
-    /// stack consistency rules.
+    /// Whether this session can start sync work under the current stack
+    /// consistency rules.
     pub(crate) can_rebase_session_branch: ViewActionAvailability,
     /// Whether the current session has a diff available to inspect.
     pub(crate) can_show_diff: ViewActionAvailability,

--- a/crates/agentty/src/runtime/key_handler.rs
+++ b/crates/agentty/src/runtime/key_handler.rs
@@ -303,7 +303,7 @@ fn next_session_creation_selection(app: &App) -> usize {
 /// Returns the selected session id when it can parent a stacked draft.
 fn selected_stacked_parent_session_id(app: &App) -> Option<SessionId> {
     app.selected_session()
-        .filter(|session| session.allows_stacked_child_creation())
+        .filter(|session| app.sessions.can_create_stacked_child(&session.id))
         .map(|session| session.id.clone())
 }
 

--- a/crates/agentty/src/ui/component/session_creation_overlay.rs
+++ b/crates/agentty/src/ui/component/session_creation_overlay.rs
@@ -19,8 +19,8 @@ const OPTION_DETAIL_WIDTH: usize = 27;
 const OPTION_LABEL_WIDTH: usize = 12;
 /// Detail text for the experimental orchestrator session creation path.
 const ORCHESTRATOR_SESSION_PREVIEW_DETAIL: &str = "[Preview] Plan workers";
-/// Detail text for the experimental stacked session creation path.
-const STACKED_SESSION_PREVIEW_DETAIL: &str = "[Preview] Stack on selected";
+/// Detail text for the stacked session creation path.
+const STACKED_SESSION_DETAIL: &str = "Stack on selected";
 /// Popup dimensions for the compact session selector.
 const OVERLAY_DIMENSIONS: overlay::OverlayDimensions =
     overlay::OverlayDimensions::new(30, 22, MIN_OVERLAY_WIDTH, MIN_OVERLAY_HEIGHT);
@@ -69,7 +69,7 @@ impl SessionCreationOverlay {
                 3,
                 "Stacked",
                 if self.can_create_stacked_session {
-                    STACKED_SESSION_PREVIEW_DETAIL
+                    STACKED_SESSION_DETAIL
                 } else {
                     "Select parent first"
                 },
@@ -216,7 +216,8 @@ mod tests {
         assert!(text.contains("Draft"));
         assert!(text.contains(ORCHESTRATOR_SESSION_PREVIEW_DETAIL));
         assert!(text.contains("Stacked"));
-        assert!(text.contains(STACKED_SESSION_PREVIEW_DETAIL));
+        assert!(text.contains(STACKED_SESSION_DETAIL));
+        assert!(!text.contains("[Preview] Stack on selected"));
         assert!(text.contains("j/k: move | Enter: select | q: close"));
     }
 
@@ -301,7 +302,7 @@ mod tests {
             stacked_line
                 .spans
                 .iter()
-                .any(|span| span.content.contains(STACKED_SESSION_PREVIEW_DETAIL))
+                .any(|span| span.content.contains(STACKED_SESSION_DETAIL))
         );
     }
 

--- a/crates/agentty/src/ui/page/session_list.rs
+++ b/crates/agentty/src/ui/page/session_list.rs
@@ -314,12 +314,19 @@ fn session_group_label(group: SessionGroup) -> &'static str {
     }
 }
 
-/// Returns the rendered tree marker for one grouped session row.
-fn tree_position_label(tree_position: SessionTreePosition) -> &'static str {
+/// Returns the indented tree marker for one grouped session row.
+fn tree_position_label(tree_position: SessionTreePosition) -> String {
     match tree_position {
-        SessionTreePosition::Root => "",
-        SessionTreePosition::Child { is_last: true } => TREE_BRANCH_LAST,
-        SessionTreePosition::Child { is_last: false } => TREE_BRANCH_MIDDLE,
+        SessionTreePosition::Root => String::new(),
+        SessionTreePosition::Child { depth, is_last } => {
+            let branch = if is_last {
+                TREE_BRANCH_LAST
+            } else {
+                TREE_BRANCH_MIDDLE
+            };
+
+            format!("{}{branch}", "  ".repeat(depth.saturating_sub(1)))
+        }
     }
 }
 
@@ -1187,6 +1194,65 @@ mod tests {
         assert_eq!(tree_cell.fg, style::palette::text_muted());
         assert_eq!(tree_cell.bg, style::palette::surface_selection());
         assert_ne!(tree_cell.fg, tree_cell.bg);
+    }
+
+    #[test]
+    fn test_tree_position_label_uses_middle_branch_for_nonfinal_child() {
+        // Arrange
+        let tree_position = SessionTreePosition::Child {
+            depth: 2,
+            is_last: false,
+        };
+
+        // Act
+        let label = tree_position_label(tree_position);
+
+        // Assert
+        assert_eq!(label, "  ├ ");
+    }
+
+    #[test]
+    fn test_render_session_rows_indent_to_stack_depth_five() {
+        // Arrange
+        let backend = ratatui::backend::TestBackend::new(100, 14);
+        let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+        let mut table_state = TableState::default();
+        table_state.select(Some(5));
+        let sessions = (0..=5)
+            .map(|depth| {
+                let mut session = crate::test_support::titled_session_fixture(
+                    &format!("level-{depth}"),
+                    Status::Review,
+                );
+                session.title = Some(if depth == 0 {
+                    "Stack root".to_string()
+                } else {
+                    format!("Stack level {depth}")
+                });
+                if depth > 0 {
+                    session.parent_session_id = Some(format!("level-{}", depth - 1).into());
+                }
+
+                session
+            })
+            .collect::<Vec<_>>();
+
+        // Act
+        terminal
+            .draw(|frame| {
+                SessionListPage::new(&sessions, &mut table_state, ReasoningLevel::default(), 0)
+                    .render(frame, frame.area());
+            })
+            .expect("failed to draw");
+
+        // Assert
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(text.contains("Stack root"));
+        assert!(text.contains("└ [XS] Stack level 1"));
+        assert!(text.contains("  └ [XS] Stack level 2"));
+        assert!(text.contains("    └ [XS] Stack level 3"));
+        assert!(text.contains("      └ [XS] Stack level 4"));
+        assert!(text.contains("        └ [XS] Stack level 5"));
     }
 
     #[test]

--- a/crates/agentty/src/ui/router.rs
+++ b/crates/agentty/src/ui/router.rs
@@ -8,7 +8,9 @@ use crate::app::Tab;
 use crate::app::session_state::SessionGitStatus;
 use crate::domain::agent::{AgentCliInfo, ReasoningLevel};
 use crate::domain::project::{ProjectListItem, ordered_project_items};
-use crate::domain::session::{DailyActivity, Session, SessionId, activity_day_key_with_offset};
+use crate::domain::session::{
+    DailyActivity, Session, SessionId, activity_day_key_with_offset, can_create_stacked_child,
+};
 use crate::presentation::app_mode::{
     AppMode, ConfirmationIntent, DiffFocus, DiffLineComments, DiffPreview, DiffRestoreTarget,
     DiffReviewComments, DiffSidebarFocus, HelpContext, allows_diff_line_comment_reply,
@@ -46,7 +48,7 @@ impl RouteSharedContext<'_> {
                 .table_state
                 .selected()
                 .and_then(|selected_index| self.sessions.get(selected_index))
-                .is_some_and(Session::allows_stacked_child_creation)
+                .is_some_and(|session| can_create_stacked_child(self.sessions, session.id.as_str()))
     }
 }
 

--- a/crates/agentty/tests/e2e/confirmation.rs
+++ b/crates/agentty/tests/e2e/confirmation.rs
@@ -98,6 +98,68 @@ fn seed_cancelable_stacked_child_session(env: &BuilderEnv) -> E2eResult {
     Ok(())
 }
 
+/// Seeds a review-ready stack parent with a nested descendant waiting on a
+/// question so parent cancellation must stop non-`InProgress` branch work.
+fn seed_cancelable_parent_with_active_stacked_descendant(env: &BuilderEnv) -> E2eResult {
+    let parent_session_id = "cascadep-0001";
+    let child_session_id = "cascadec-0001";
+    let grandchild_session_id = "cascadeg-0001";
+
+    common::seed_session(
+        env,
+        SessionSeed::regular(parent_session_id, "gpt-5.6-sol", "main", "Review")
+            .with_title("Cancel cascade parent"),
+    )?;
+    common::seed_session(
+        env,
+        SessionSeed::stacked_draft(
+            child_session_id,
+            "gpt-5.6-sol",
+            "wt/cascadep",
+            "Review",
+            parent_session_id,
+        )
+        .with_title("Cancel cascade child"),
+    )?;
+    common::seed_session(
+        env,
+        SessionSeed::stacked_draft(
+            grandchild_session_id,
+            "gpt-5.6-sol",
+            "wt/cascadec",
+            "Question",
+            child_session_id,
+        )
+        .with_title("Active cascade grandchild"),
+    )?;
+
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        for (session_id, updated_at) in [
+            (grandchild_session_id, 1),
+            (child_session_id, 2),
+            (parent_session_id, 3),
+        ] {
+            database
+                .sessions()
+                .update_session_updated_at(session_id, updated_at)
+                .await?;
+        }
+
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })?;
+
+    for session_id in [parent_session_id, child_session_id, grandchild_session_id] {
+        std::fs::create_dir_all(test_support::session_folder(
+            &env.agentty_root.join("wt"),
+            session_id,
+        ))?;
+    }
+
+    Ok(())
+}
+
 /// Verify that confirming quit with `y` causes the process to exit with
 /// code 0.
 ///
@@ -441,6 +503,75 @@ fn stacked_child_cancel_confirmation_archives_child() -> E2eResult {
                     &final_full,
                 );
                 assertion::assert_not_visible(frame, "└ [XS] Stacked child");
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that canceling a stack parent also cancels a nested descendant in
+/// active non-`InProgress` branch work.
+#[test]
+fn stacked_parent_cancel_cascades_active_descendant() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("stacked_parent_cancel_cascade")
+        .with_git()
+        .setup(seed_cancelable_parent_with_active_stacked_descendant)
+        .zola(
+            "Stacked cancellation cascade",
+            "Cancel a stack parent and stop every active nested descendant.",
+            122,
+        )
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .wait_for_text("Active cascade grandchild", 5000)
+                    .wait_for_text("c: cancel", 5000)
+                    .capture_labeled(
+                        "active_nested_stack",
+                        "Nested stack before parent cancellation",
+                    )
+                    .press_key("c")
+                    .wait_for_text("Confirm Cancel", 3000)
+                    .capture_labeled(
+                        "confirm_parent_cancel",
+                        "Confirmation for stack parent cancellation",
+                    )
+                    .press_key("y")
+                    .wait_for_text("ARCHIVE", 5000)
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled(
+                        "canceled_nested_stack",
+                        "Parent and active descendants canceled together",
+                    )
+            },
+            |frame, report| {
+                let active_frame = common::frame_from_capture(&report.captures[0]);
+                let active_full = Region::full(active_frame.cols(), active_frame.rows());
+                assertion::assert_text_in_region(
+                    &active_frame,
+                    "Active cascade grandchild",
+                    &active_full,
+                );
+                assertion::assert_text_in_region(&active_frame, "Question", &active_full);
+
+                let confirmation_frame = common::frame_from_capture(&report.captures[1]);
+                let confirmation_full =
+                    Region::full(confirmation_frame.cols(), confirmation_frame.rows());
+                assertion::assert_text_in_region(
+                    &confirmation_frame,
+                    "Confirm Cancel",
+                    &confirmation_full,
+                );
+
+                let final_full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Cancel cascade parent", &final_full);
+                assertion::assert_text_in_region(frame, "Cancel cascade child", &final_full);
+                assertion::assert_text_in_region(frame, "Active cascade grandchild", &final_full);
+                let final_text = frame.text_in_region(&final_full);
+                assert_eq!(final_text.matches("Canceled").count(), 3);
             },
         )?;
 

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1319,7 +1319,7 @@ fn seed_agent_review_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error:
     Ok(())
 }
 
-/// Seeds a one-level stack where both parent and child are review-ready.
+/// Seeds a stack where both parent and child are review-ready.
 fn seed_review_ready_parent_with_review_child(
     env: &BuilderEnv,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -1342,6 +1342,54 @@ fn seed_review_ready_parent_with_review_child(
 
     std::fs::create_dir_all(env.agentty_root.join("wt").join("stack-pa"))?;
     std::fs::create_dir_all(env.agentty_root.join("wt").join("stack-ch"))?;
+
+    Ok(())
+}
+
+/// Seeds four review-ready stack levels for nested creation coverage.
+fn seed_four_level_review_stack(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    common::seed_session(
+        env,
+        SessionSeed::regular("stackl00-0001", "gpt-5.6-sol", "main", "Review")
+            .with_title("Stack root"),
+    )?;
+    for level in 1..=4 {
+        let session_id = format!("stackl0{level}-0001");
+        let parent_level = level - 1;
+        let parent_session_id = format!("stackl0{parent_level}-0001");
+        let parent_branch = format!("wt/stackl0{parent_level}");
+        let title = format!("Stack level {level}");
+        common::seed_session(
+            env,
+            SessionSeed::stacked_draft(
+                &session_id,
+                "gpt-5.6-sol",
+                &parent_branch,
+                "Review",
+                &parent_session_id,
+            )
+            .with_title(&title),
+        )?;
+    }
+
+    let runtime = common::seed_runtime()?;
+    runtime.block_on(async {
+        let database = common::open_database(env).await?;
+        for level in 0..=4 {
+            let session_id = format!("stackl0{level}-0001");
+            let updated_at = i64::from(5 - level);
+            database
+                .sessions()
+                .update_session_updated_at(&session_id, updated_at)
+                .await?;
+        }
+
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })?;
+
+    for level in 0..=4 {
+        std::fs::create_dir_all(env.agentty_root.join("wt").join(format!("stackl0{level}")))?;
+    }
 
     Ok(())
 }
@@ -3252,33 +3300,47 @@ fn seed_draft_at_lookup_project(env: &BuilderEnv) -> Result<(), Box<dyn std::err
     Ok(())
 }
 
-/// Seeds an unmaterialized stacked draft whose parent worktree contains a new
-/// file that is absent from the project checkout.
-fn seed_stacked_at_lookup_session(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
-    let parent_session_id = "atparent-0001";
+/// Seeds two unmaterialized stacked drafts whose nearest materialized ancestor
+/// contains a new file that is absent from the project checkout.
+fn seed_nested_stacked_at_lookup_session(
+    env: &BuilderEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ancestor_session_id = "atparent-0001";
+    let parent_session_id = "atmiddle-0001";
     let child_session_id = "atchildx-0001";
     common::seed_session(
         env,
-        SessionSeed::regular(parent_session_id, "gpt-5.6-sol", "main", "Review")
-            .with_title("Parent with lookup file"),
+        SessionSeed::regular(ancestor_session_id, "gpt-5.6-sol", "main", "Review")
+            .with_title("Ancestor with lookup file"),
+    )?;
+    common::seed_session(
+        env,
+        SessionSeed::stacked_draft(
+            parent_session_id,
+            "gpt-5.6-sol",
+            "wt/atparent",
+            "Draft",
+            ancestor_session_id,
+        )
+        .with_title("Unmaterialized middle draft"),
     )?;
     common::seed_session(
         env,
         SessionSeed::stacked_draft(
             child_session_id,
             "gpt-5.6-sol",
-            "wt/atparent",
+            "wt/atmiddle",
             "Draft",
             parent_session_id,
         )
-        .with_title("Stacked lookup child"),
+        .with_title("Nested lookup child"),
     )?;
 
     let parent_worktree = env.agentty_root.join("wt").join("atparent");
     std::fs::create_dir_all(&parent_worktree)?;
     std::fs::write(
-        parent_worktree.join("parent_lookup_target.txt"),
-        "parent lookup target\n",
+        parent_worktree.join("ancestor_lookup_target.txt"),
+        "ancestor lookup target\n",
     )?;
 
     Ok(())
@@ -6193,33 +6255,36 @@ fn prompt_image_paste_unavailable_shows_inline_error() -> E2eResult {
     Ok(())
 }
 
-/// Verify that choosing Stacked creates a startable draft under the selected
-/// parent and renders the one-level stack with a tree connection in the
-/// session list.
+/// Verify that choosing Stacked creates a fifth-level draft under the selected
+/// parent without a preview marker and renders the nested tree.
 #[test]
 fn stacked_session_creation() -> E2eResult {
     // Arrange, Act, Assert
     FeatureTest::new("stacked_session_creation")
         .with_git()
-        .setup(seed_review_ready_session)
+        .setup(seed_four_level_review_stack)
         .run(
             |scenario| {
                 scenario
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::switch_to_tab("Sessions"))
-                    .wait_for_text("Review-ready session shortcuts", 5000)
+                    .wait_for_text("Stack level 4", 5000)
+                    .press_key("Down")
+                    .press_key("Down")
+                    .press_key("Down")
+                    .press_key("Down")
                     .viewing_pause_ms(1200)
                     .press_key("a")
                     .wait_for_text("Stacked", 5000)
                     .press_key("Down")
                     .press_key("Down")
                     .press_key("Down")
-                    .wait_for_text("[Preview] Stack on selected", 5000)
+                    .wait_for_text("Stack on selected", 5000)
                     .capture_labeled("stacked_selector", "Stacked creation selector")
                     .press_key("Enter")
                     .wait_for_text("Enter: stage draft", 5000)
                     .capture_labeled("stacked_draft_view", "Stacked draft action footer")
-                    .write_text("Stacked draft")
+                    .write_text("Stack level 5")
                     .press_key("Enter")
                     .wait_for_text("Draft Session", 5000)
                     .capture_labeled(
@@ -6228,7 +6293,7 @@ fn stacked_session_creation() -> E2eResult {
                     )
                     .viewing_pause_ms(1200)
                     .press_key("q")
-                    .wait_for_text("Stacked draft", 5000)
+                    .wait_for_text("ACTIVE", 5000)
                     .capture_labeled("stacked_list", "Stacked draft connected in session list")
             },
             |frame, report| {
@@ -6237,9 +6302,10 @@ fn stacked_session_creation() -> E2eResult {
                 assertion::assert_text_in_region(&selector_frame, "Stacked", &selector_full);
                 assertion::assert_text_in_region(
                     &selector_frame,
-                    "[Preview] Stack on selected",
+                    "Stack on selected",
                     &selector_full,
                 );
+                assertion::assert_not_visible(&selector_frame, "[Preview] Stack on selected");
 
                 let draft_view_frame = common::frame_from_capture(&report.captures[1]);
                 assertion::assert_not_visible(&draft_view_frame, "s: start");
@@ -6253,8 +6319,8 @@ fn stacked_session_creation() -> E2eResult {
                 assertion::assert_not_visible(&ready_frame, "r: sync");
 
                 let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(frame, "Review-ready ses", &full);
-                assertion::assert_text_in_region(frame, "└ [XS] Stacked draft", &full);
+                assertion::assert_text_in_region(frame, "Stack root", &full);
+                assertion::assert_text_in_region(frame, "        └ [XS]", &full);
             },
         )?;
 
@@ -6382,9 +6448,9 @@ fn stacked_pending_post_merge_restack_failure_is_visible() -> E2eResult {
     Ok(())
 }
 
-/// Verify that a stacked draft can keep collecting staged prompts while its
-/// parent is still running, but the start shortcut stays hidden until the
-/// parent returns to review.
+/// Verify that a stacked draft can keep collecting staged prompts and parent
+/// another stacked draft while its own parent is still running, but the start
+/// shortcut stays hidden until the parent returns to review.
 #[test]
 fn stacked_session_start_waits_for_parent_review() -> E2eResult {
     // Arrange, Act, Assert
@@ -6402,7 +6468,7 @@ fn stacked_session_start_waits_for_parent_review() -> E2eResult {
                     .press_key("Down")
                     .press_key("Down")
                     .press_key("Down")
-                    .wait_for_text("[Preview] Stack on selected", 5000)
+                    .wait_for_text("Stack on selected", 5000)
                     .press_key("Enter")
                     .wait_for_text("Enter: stage draft", 5000)
                     .write_text("Waiting child draft")
@@ -6412,13 +6478,30 @@ fn stacked_session_start_waits_for_parent_review() -> E2eResult {
                         "stacked_draft_waiting_parent",
                         "Stacked draft staged while parent is still running",
                     )
+                    .press_key("q")
+                    .wait_for_text("ACTIVE", 5000)
+                    .press_key("a")
+                    .wait_for_text("Stacked", 5000)
+                    .press_key("Down")
+                    .press_key("Down")
+                    .press_key("Down")
+                    .wait_for_text("Stack on selected", 5000)
+                    .capture_labeled(
+                        "stacked_draft_parent_selector",
+                        "Stacked draft can parent another staged draft",
+                    )
             },
-            |frame, _report| {
+            |frame, report| {
+                let draft_frame = common::frame_from_capture(&report.captures[0]);
+                let draft_full = Region::full(draft_frame.cols(), draft_frame.rows());
+                assertion::assert_text_in_region(&draft_frame, "Enter: add draft", &draft_full);
+                assertion::assert_not_visible(&draft_frame, "s: start");
+                assertion::assert_not_visible(&draft_frame, "m: add to merge queue");
+                assertion::assert_not_visible(&draft_frame, "r: sync");
+
                 let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(frame, "Enter: add draft", &full);
-                assertion::assert_not_visible(frame, "s: start");
-                assertion::assert_not_visible(frame, "m: add to merge queue");
-                assertion::assert_not_visible(frame, "r: sync");
+                assertion::assert_text_in_region(frame, "Stack on selected", &full);
+                assertion::assert_not_visible(frame, "Select parent first");
             },
         )?;
 
@@ -6860,30 +6943,30 @@ fn draft_session_at_lookup() -> E2eResult {
     Ok(())
 }
 
-/// Verify that an unmaterialized stacked draft resolves `@` suggestions from
-/// its parent worktree.
+/// Verify that a nested unmaterialized stacked draft resolves `@` suggestions
+/// from its nearest materialized ancestor worktree.
 #[test]
 fn stacked_session_at_lookup() -> E2eResult {
     // Arrange, Act, Assert
     FeatureTest::new("stacked_session_at_lookup")
         .with_git()
-        .setup(seed_stacked_at_lookup_session)
+        .setup(seed_nested_stacked_at_lookup_session)
         .run(
             |scenario| {
                 scenario
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::switch_to_tab("Sessions"))
-                    .wait_for_text("Stacked lookup child", 5000)
+                    .wait_for_text("Nested lookup child", 5000)
                     .press_key("Enter")
                     .wait_for_text("Enter: add draft", 3000)
                     .press_key("Enter")
                     .wait_for_text("Enter: stage draft", 3000)
-                    .write_text("@parent_lookup")
-                    .wait_for_text("parent_lookup_target.txt", 5000)
+                    .write_text("@ancestor_lookup")
+                    .wait_for_text("ancestor_lookup_target.txt", 5000)
             },
             |frame, _report| {
                 let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(frame, "parent_lookup_target.txt", &full);
+                assertion::assert_text_in_region(frame, "ancestor_lookup_target.txt", &full);
                 assertion::assert_text_in_region(frame, "Enter: stage draft", &full);
             },
         )?;

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -440,8 +440,8 @@ unchanged.
 ## Session Types
 
 <a id="usage-draft-stacked"></a> From the **Sessions** tab, press `a` to choose between
-`Regular`, `Draft`, `Orchestrator`, and `Stacked` session creation. `Orchestrator` and
-an available `Stacked` option are marked `[Preview]`:
+`Regular`, `Draft`, `Orchestrator`, and `Stacked` session creation. `Orchestrator` is
+marked `[Preview]`:
 
 - `Regular` starts the agent immediately on the first `Enter`.
 - `Draft` stages each `Enter` as one ordered draft message and starts only after you
@@ -454,18 +454,24 @@ an available `Stacked` option are marked `[Preview]`:
   worker sessions, verifies their results, and integrates the approved work. The
   controller reads the repository but never owns branch changes.
 - `Stacked` creates a draft below the selected parent session, with its future branch
-  based on the parent session branch. Only one stacking level is available.
+  based on the parent session branch. A stack can contain up to five stacked levels
+  below its root session.
 
 Stacked drafts show `s` start only when the parent is in **Review** or **AgentReview**
-and no stack member is running, queued, syncing, merging, or waiting on a question.
-While a materialized child is linked, the parent keeps `Enter` replies, `m` merge
-queueing, `r` sync, and direct `/` access to slash commands. Syncing the parent (or
-completing a parent turn) rebases review-ready children onto the refreshed parent branch
-automatically. When the parent merges, children are retargeted onto the parent's base
-branch and review-ready children are synced with `git rebase --onto` so they keep only
-their own commits. If an automatic child sync cannot start or complete, the affected
-child session shows a `[Sync Error]` notice with the failure. When the parent is
-canceled, its stacked child is canceled too.
+and no stack member is running, queued, syncing, merging, or waiting on a question. An
+unstarted stacked draft can already parent another stacked draft, so you can stage the
+full stack before any child worktree exists. Start the drafts from parent to child; each
+child's `s` action appears only after its immediate parent reaches review. While a
+materialized child is linked, the parent keeps `Enter` replies, `m` merge queueing, `r`
+sync, and direct `/` access to slash commands. Syncing the parent (or completing a
+parent turn) rebases review-ready direct children onto the refreshed parent branch
+automatically, cascading through deeper descendants. When a parent merges, its children
+are retargeted onto the parent's base branch as root sessions and review-ready children
+are synced with `git rebase --onto` so they keep only their own commits. If an automatic
+child sync cannot start or complete, the affected child session shows a `[Sync Error]`
+notice with the failure. When a parent is canceled, Agentty stops queued, running,
+question, sync, and merge work throughout the stack before canceling every nonterminal
+descendant. Descendants already in a terminal state keep that state.
 
 ### Parallel Orchestration
 
@@ -751,7 +757,8 @@ Ghostty may consume `Cmd+Z` before Agentty or a surrounding `tmux` session recei
 `@` file lookups keep the raw `@path/to/file` text visible and highlighted in the
 composer and transcript; the agent-facing prompt rewrites them to quoted `path/to/file`
 tokens. Before a stacked draft materializes its own worktree, lookup suggestions come
-from the parent session worktree so newly created parent files remain available.
+from the nearest materialized ancestor worktree so newly created ancestor files remain
+available through unstarted intermediate drafts.
 
 If an agent command exits with an error, Agentty prints a short failure header followed
 by captured `stdout` and `stderr` sections, with JSONL provider events summarized into


### PR DESCRIPTION
- Allow nested stack creation through five descendant levels with depth-aware lifecycle policies.
- Cascade stack rendering, cancellation, synchronization, branch-work constraints, and file lookup across descendants.
- Remove the stacked-session preview label and document the supported depth.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)