### PR TITLE
Continue automatic reviews for inactive projects

### DIFF
--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -1052,6 +1052,12 @@ impl App {
         let mut auto_review_session_ids =
             self.sessions_entering_review(&event_batch.session_ids, &previous_session_states);
         auto_review_session_ids.extend(completed_review_session_ids);
+        auto_review_session_ids.extend(
+            event_batch
+                .session_ids
+                .intersection(&self.deferred_auto_review_session_ids)
+                .cloned(),
+        );
         self.start_or_defer_auto_reviews(&auto_review_session_ids)
             .await;
         app::review::hydrate_review_transients(&self.review_cache, self.sessions.state_mut());
@@ -1921,8 +1927,8 @@ impl App {
         self.start_auto_review_diff_loads(session_ids);
     }
 
-    /// Starts automatic reviews for loaded sessions and retains triggers for
-    /// sessions whose owning project is currently inactive.
+    /// Starts automatic reviews for loaded and inactive-project sessions,
+    /// retaining durable triggers when preparation cannot start yet.
     async fn start_or_defer_auto_reviews(&mut self, session_ids: &HashSet<SessionId>) {
         let mut loaded_session_ids = HashSet::new();
 
@@ -1943,7 +1949,9 @@ impl App {
                 continue;
             }
 
-            self.defer_auto_review_session(session_id).await;
+            if !self.start_inactive_auto_review_diff_load(session_id).await {
+                self.defer_auto_review_session(session_id).await;
+            }
         }
 
         self.start_auto_review_diff_loads(&loaded_session_ids);
@@ -2598,6 +2606,7 @@ impl App {
 #[cfg(test)]
 mod tests {
     use std::panic::AssertUnwindSafe;
+    use std::sync::Arc;
 
     use ag_forge::{
         ReviewComment, ReviewCommentAnchorSide, ReviewCommentSnapshot, ReviewCommentThread,
@@ -3090,9 +3099,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn completed_turn_defers_auto_review_when_project_is_inactive() {
+    async fn completed_turn_starts_auto_review_when_project_is_inactive() {
         // Arrange
-        let (mut app, base_dir) = crate::test_support::new_test_app().await;
+        let diff_text = "diff --git a/file.rs b/file.rs\n+inactive change";
+        let expected_hash = crate::app::diff_content_hash(diff_text);
+        let mut git_client = ag_git::MockGitClient::new();
+        git_client
+            .expect_diff()
+            .once()
+            .returning(move |_, _| Box::pin(async move { Ok(diff_text.to_string()) }));
+        let clients = crate::test_support::test_app_clients().with_git_client(Arc::new(git_client));
+        let (mut app, base_dir) = crate::test_support::new_test_app_with_clients(clients).await;
         let session_id = SessionId::from("inactive-completed-session");
         let inactive_project_path = base_dir.path().join("inactive-project");
         let inactive_project_id = app
@@ -3114,6 +3131,32 @@ mod tests {
             )
             .await
             .expect("failed to insert inactive session");
+        app.services
+            .db()
+            .settings()
+            .upsert_project_settings(
+                inactive_project_id,
+                vec![
+                    (
+                        crate::domain::setting::SettingName::DefaultReviewAgent,
+                        "claude".to_string(),
+                    ),
+                    (
+                        crate::domain::setting::SettingName::DefaultReviewModel,
+                        "claude-sonnet-5".to_string(),
+                    ),
+                    (
+                        crate::domain::setting::SettingName::DefaultReviewReasoningLevel,
+                        "low".to_string(),
+                    ),
+                    (
+                        crate::domain::setting::SettingName::DefaultReviewSpeedMode,
+                        "fast".to_string(),
+                    ),
+                ],
+            )
+            .await
+            .expect("failed to persist inactive-project review settings");
         let turn_applied_state = TurnAppliedState {
             follow_up_tasks: Vec::new(),
             questions: Vec::new(),
@@ -3126,12 +3169,31 @@ mod tests {
             turn_applied_state,
         })
         .await;
+        let diff_event =
+            tokio::time::timeout(std::time::Duration::from_secs(1), app.next_app_event())
+                .await
+                .expect("timed out waiting for inactive-project diff")
+                .expect("inactive-project diff should emit an event");
+        app.apply_app_events(diff_event).await;
 
         // Assert
-        assert_eq!(
-            app.deferred_auto_review_session_ids,
-            HashSet::from([session_id.clone()])
-        );
+        assert!(app.deferred_auto_review_session_ids.is_empty());
+        assert!(app.pending_session_diff_requests.is_empty());
+        assert!(matches!(
+            app.review_cache.get(&session_id),
+            Some(app::review::ReviewCacheEntry::Loading {
+                diff_hash,
+                review_agent,
+            }) if *diff_hash == expected_hash
+                && *review_agent == (
+                    crate::domain::agent::AgentSelection::new(
+                        crate::domain::agent::AgentKind::Claude,
+                        crate::domain::agent::AgentModel::ClaudeOpus5,
+                    ),
+                    crate::domain::agent::ReasoningLevel::Low,
+                    crate::domain::agent::SpeedMode::Fast,
+                )
+        ));
         assert_eq!(
             app.services
                 .db()

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -1491,14 +1491,15 @@ impl App {
     ///
     /// The review assist prompt enforces inspection-only review constraints
     /// and recommends verification commands instead of running them.
-    pub(crate) fn start_review_assist(
+    pub(crate) async fn start_review_assist(
         &mut self,
         session_id: &str,
         session_folder: &Path,
         diff_hash: u64,
         review_diff: &str,
+        review_agent: app::review::ReviewAgent,
     ) {
-        let review_agent = app::review::normalize_review_agent(self.review_agent());
+        let review_agent = app::review::normalize_review_agent(review_agent);
         self.review_cache.insert(
             SessionId::from(session_id),
             ReviewCacheEntry::Loading {
@@ -1506,24 +1507,7 @@ impl App {
                 review_agent,
             },
         );
-        let session_chat_history = self
-            .sessions
-            .session_handles()
-            .get(session_id)
-            .and_then(|handles| {
-                handles
-                    .transcript
-                    .lock()
-                    .ok()
-                    .as_deref()
-                    .and_then(SessionTranscript::conversation_replay_text)
-            })
-            .or_else(|| {
-                self.sessions
-                    .session_for_id(session_id)
-                    .and_then(|session| session.transcript.as_ref())
-                    .and_then(SessionTranscript::conversation_replay_text)
-            });
+        let session_chat_history = self.session_chat_history(session_id).await;
 
         mark_session_agent_review(self.sessions.state_mut(), session_id);
         if let Some(session) = self.sessions.state_mut().session_mut_for_id(session_id) {
@@ -1545,6 +1529,36 @@ impl App {
             review_diff,
             session_chat_history.as_deref(),
         );
+    }
+
+    /// Returns saved conversation context from live state or persistence.
+    pub(super) async fn session_chat_history(&self, session_id: &str) -> Option<String> {
+        let live_history = self
+            .sessions
+            .session_handles()
+            .get(session_id)
+            .and_then(|handles| {
+                handles
+                    .transcript
+                    .lock()
+                    .ok()
+                    .as_deref()
+                    .and_then(SessionTranscript::conversation_replay_text)
+            })
+            .or_else(|| {
+                self.sessions
+                    .session_for_id(session_id)
+                    .and_then(|session| session.transcript.as_ref())
+                    .and_then(SessionTranscript::conversation_replay_text)
+            });
+        if live_history.is_some() {
+            return live_history;
+        }
+
+        session::load_session_transcript(self.services.db(), session_id)
+            .await
+            .ok()
+            .and_then(|transcript| transcript.conversation_replay_text())
     }
 
     /// Reloads sessions when metadata cache indicates changes.

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -669,6 +669,55 @@ async fn test_switch_project_recovers_persisted_deferred_review_after_restart() 
 }
 
 #[tokio::test]
+async fn session_chat_history_loads_persisted_transcript_for_unloaded_session() {
+    // Arrange
+    let (app, _base_dir) = crate::test_support::new_test_app().await;
+    let session_id = "unloaded-review-history";
+    app.services
+        .db()
+        .sessions()
+        .insert_session(
+            session_id,
+            AgentModel::Gpt56Sol.as_str(),
+            "main",
+            "Review",
+            app.active_project_id(),
+        )
+        .await
+        .expect("failed to insert unloaded review session");
+    app.services
+        .db()
+        .sessions()
+        .append_session_message(
+            session_id,
+            SessionMessageKind::UserPrompt,
+            "Keep the accepted tradeoff",
+        )
+        .await
+        .expect("failed to persist review prompt");
+    app.services
+        .db()
+        .sessions()
+        .append_session_message(
+            session_id,
+            SessionMessageKind::AssistantAnswer,
+            "The accepted tradeoff remains in place.",
+        )
+        .await
+        .expect("failed to persist review answer");
+    assert!(app.sessions.session_for_id(session_id).is_none());
+
+    // Act
+    let session_chat_history = app.session_chat_history(session_id).await;
+
+    // Assert
+    assert_eq!(
+        session_chat_history.as_deref(),
+        Some(" › Keep the accepted tradeoff\n\nThe accepted tradeoff remains in place.\n\n")
+    );
+}
+
+#[tokio::test]
 async fn test_switch_immediately_after_response_recovers_in_progress_review() {
     // Arrange
     let base_dir = tempdir().expect("failed to create temp dir");
@@ -751,6 +800,7 @@ async fn test_switch_immediately_after_response_recovers_in_progress_review() {
         version: 1,
     })
     .await;
+    let pending_before_return = app.pending_session_diff_requests.len();
     let pending_after_status_transition = repositories
         .sessions()
         .load_pending_focused_review_session_ids(first_project_id)
@@ -766,6 +816,7 @@ async fn test_switch_immediately_after_response_recovers_in_progress_review() {
         HashSet::from([SessionId::from(session_id)])
     );
     assert_eq!(pending_after_status_transition, [session_id]);
+    assert_eq!(pending_before_return, 1);
     assert!(app.deferred_auto_review_session_ids.is_empty());
     assert_eq!(app.pending_session_diff_requests.len(), 1);
 }

--- a/crates/agentty/src/app/session.rs
+++ b/crates/agentty/src/app/session.rs
@@ -20,6 +20,7 @@ pub use error::SessionError;
 pub(crate) use state::SessionGitStatus;
 pub use state::SessionState;
 pub(crate) use workflow::load::{
-    SessionLoadInput, migrate_active_sessions_off_retired_models, migrate_session_off_retired_model,
+    SessionLoadInput, load_session_transcript, migrate_active_sessions_off_retired_models,
+    migrate_session_off_retired_model,
 };
 pub(crate) use workflow::refresh::SyncReviewRequestOutcome;

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -621,7 +621,7 @@ fn insert_loaded_session_handle(
 }
 
 /// Loads ordered session messages into the render transcript snapshot.
-async fn load_session_transcript(
+pub(crate) async fn load_session_transcript(
     db: &AppRepositories,
     session_id: &str,
 ) -> Result<SessionTranscript, DbError> {

--- a/crates/agentty/src/app/session_diff.rs
+++ b/crates/agentty/src/app/session_diff.rs
@@ -2,14 +2,15 @@
 
 use std::collections::HashSet;
 use std::collections::hash_map::Entry;
+use std::path::PathBuf;
 
 use tracing::warn;
 
-use crate::app::App;
-use crate::app::review::{self, FocusedReviewPersistence, ReviewCacheEntry};
+use crate::app::review::{self, FocusedReviewPersistence, ReviewAgent, ReviewCacheEntry};
 use crate::app::task::{SessionDiffTaskInput, SessionDiffTaskSource, TaskService};
+use crate::app::{App, session};
 use crate::domain::review::FocusedReviewStatus;
-use crate::domain::session::{SessionId, SessionRole, Status};
+use crate::domain::session::{Session, SessionId, SessionRole, Status};
 use crate::domain::transient_message::{
     TransientMessage, TransientMessageAnchor, TransientMessageBody, TransientMessageLifecycle,
     TransientMessageSlot,
@@ -66,6 +67,13 @@ pub(crate) struct PendingSessionDiffRequest {
     session_id: SessionId,
 }
 
+/// Stable focused-review inputs captured before a project switch can unload
+/// the session snapshot.
+struct FocusedReviewTarget {
+    folder: PathBuf,
+    review_agent: ReviewAgent,
+}
+
 /// Action resumed after one full diff finishes loading.
 enum SessionDiffPurpose {
     ApplyFocusedReview {
@@ -78,6 +86,7 @@ enum SessionDiffPurpose {
     Review {
         cached_diff_hash: Option<u64>,
         is_manual: bool,
+        target: FocusedReviewTarget,
     },
 }
 
@@ -315,6 +324,69 @@ impl App {
         }
     }
 
+    /// Starts automatic review preparation for a review-ready session whose
+    /// project is not currently loaded.
+    pub(super) async fn start_inactive_auto_review_diff_load(
+        &mut self,
+        session_id: &SessionId,
+    ) -> bool {
+        if self.pending_session_diff_requests.values().any(|request| {
+            request.session_id == *session_id
+                && matches!(&request.purpose, SessionDiffPurpose::Review { .. })
+        }) || matches!(
+            self.review_cache.get(session_id),
+            Some(ReviewCacheEntry::Loading { .. } | ReviewCacheEntry::Suppressed)
+        ) {
+            return true;
+        }
+
+        let Ok(Some(row)) = self
+            .services
+            .db()
+            .sessions()
+            .load_session(session_id.as_str())
+            .await
+        else {
+            return false;
+        };
+        let status = row.status.parse::<Status>().ok();
+        let role = row
+            .role
+            .as_deref()
+            .and_then(|value| value.parse::<SessionRole>().ok())
+            .unwrap_or_default();
+        if role == SessionRole::Orchestrator
+            || !matches!(status, Some(Status::Review | Status::AgentReview))
+        {
+            return false;
+        }
+        let Some(project_id) = row.project_id else {
+            return false;
+        };
+        let review_agent =
+            crate::app::setting::load_default_review_agent_setting(&self.services, project_id)
+                .await;
+        let folder = session::session_folder(self.services.base_path(), session_id.as_str());
+        let source = SessionDiffTaskSource::Worktree {
+            archived_fallback: None,
+            base_branch: row.base_branch,
+            git_client: self.services.git_client(),
+        };
+
+        self.defer_auto_review_session(session_id).await;
+
+        self.start_review_diff_load_for_target(
+            session_id,
+            false,
+            FocusedReviewTarget {
+                folder: folder.clone(),
+                review_agent,
+            },
+            folder,
+            source,
+        )
+    }
+
     /// Invalidates review and apply continuations captured before newly
     /// completed turns, then clears their stale focused-review generations.
     pub(super) fn supersede_review_diff_loads(&mut self, session_ids: &HashSet<SessionId>) {
@@ -360,8 +432,9 @@ impl App {
             SessionDiffPurpose::Review {
                 cached_diff_hash,
                 is_manual,
+                target,
             } => {
-                self.apply_review_diff_update(update, cached_diff_hash, is_manual)
+                self.apply_review_diff_update(update, cached_diff_hash, is_manual, target)
                     .await;
             }
         }
@@ -441,6 +514,14 @@ impl App {
         purpose: SessionDiffPurpose,
     ) -> Option<u64> {
         let session = self.sessions.session_for_id(session_id)?;
+        let (folder, source) = self.session_diff_task_target(session);
+
+        Some(self.spawn_session_diff_request_for_target(session_id, purpose, folder, source))
+    }
+
+    /// Captures one loaded session's folder and archive-or-worktree diff
+    /// source.
+    fn session_diff_task_target(&self, session: &Session) -> (PathBuf, SessionDiffTaskSource) {
         let source = if session.is_managed()
             && (session.status == Status::Done
                 || (session.role == SessionRole::OrchestrationResearcher
@@ -457,9 +538,22 @@ impl App {
                 git_client: self.services.git_client(),
             }
         };
+
+        (session.folder.clone(), source)
+    }
+
+    /// Spawns one diff task from captured session metadata and registers its
+    /// foreground continuation.
+    fn spawn_session_diff_request_for_target(
+        &mut self,
+        session_id: &SessionId,
+        purpose: SessionDiffPurpose,
+        folder: PathBuf,
+        source: SessionDiffTaskSource,
+    ) -> u64 {
         let input = SessionDiffTaskInput {
             app_event_tx: self.services.event_sender(),
-            folder: session.folder.clone(),
+            folder,
             session_id: session_id.clone(),
             source,
         };
@@ -472,12 +566,39 @@ impl App {
             },
         );
 
-        Some(request_id)
+        request_id
     }
 
     /// Starts one deduplicated review-preparation request and shows loading
     /// state only when there is no prior review output to retain.
     fn start_review_diff_load(&mut self, session_id: &SessionId, is_manual: bool) -> bool {
+        let review_agent = review::normalize_review_agent(self.review_agent());
+        let Some(session) = self.sessions.session_for_id(session_id) else {
+            return false;
+        };
+        let (folder, source) = self.session_diff_task_target(session);
+
+        self.start_review_diff_load_for_target(
+            session_id,
+            is_manual,
+            FocusedReviewTarget {
+                folder: folder.clone(),
+                review_agent,
+            },
+            folder,
+            source,
+        )
+    }
+
+    /// Starts one review-preparation request from stable target metadata.
+    fn start_review_diff_load_for_target(
+        &mut self,
+        session_id: &SessionId,
+        is_manual: bool,
+        target: FocusedReviewTarget,
+        folder: PathBuf,
+        source: SessionDiffTaskSource,
+    ) -> bool {
         if self.pending_session_diff_requests.values().any(|request| {
             request.session_id == *session_id
                 && matches!(&request.purpose, SessionDiffPurpose::Review { .. })
@@ -489,21 +610,19 @@ impl App {
             .review_cache
             .get(session_id)
             .and_then(ReviewCacheEntry::diff_hash);
-        if self
-            .spawn_session_diff_request(
-                session_id,
-                SessionDiffPurpose::Review {
-                    cached_diff_hash,
-                    is_manual,
-                },
-            )
-            .is_none()
-        {
-            return false;
-        }
+        let review_agent = target.review_agent;
+        self.spawn_session_diff_request_for_target(
+            session_id,
+            SessionDiffPurpose::Review {
+                cached_diff_hash,
+                is_manual,
+                target,
+            },
+            folder,
+            source,
+        );
 
         if is_manual && cached_diff_hash.is_none() {
-            let review_agent = review::normalize_review_agent(self.review_agent());
             self.review_cache.insert(
                 session_id.clone(),
                 ReviewCacheEntry::Loading {
@@ -613,26 +732,29 @@ impl App {
         update: SessionDiffUpdate,
         cached_diff_hash: Option<u64>,
         is_manual: bool,
+        target: FocusedReviewTarget,
     ) {
         let session_id = update.session_id;
-        let Some(session) = self.sessions.session_for_id(&session_id) else {
-            if !is_manual {
-                self.defer_auto_review_session(&session_id).await;
-            }
-            if cached_diff_hash.is_none() {
-                self.review_cache.remove(&session_id);
-            }
-
-            return;
+        let status = if let Some(session) = self.sessions.session_for_id(&session_id) {
+            Some(session.status)
+        } else {
+            self.services
+                .db()
+                .sessions()
+                .load_session(session_id.as_str())
+                .await
+                .ok()
+                .flatten()
+                .and_then(|row| row.status.parse::<Status>().ok())
         };
-        if !matches!(session.status, Status::Review | Status::AgentReview) {
+        if !matches!(status, Some(Status::Review | Status::AgentReview)) {
             if cached_diff_hash.is_none() {
                 self.clear_review_output(&session_id);
             }
 
             return;
         }
-        let session_folder = session.folder.clone();
+        self.deferred_auto_review_session_ids.remove(&session_id);
         let diff = match update.result {
             Ok(diff) if !diff.starts_with("Failed to run git diff:") => diff,
             Ok(error) | Err(error) => {
@@ -681,7 +803,14 @@ impl App {
             return;
         }
 
-        self.start_review_assist(&session_id, &session_folder, diff_hash, &diff);
+        self.start_review_assist(
+            &session_id,
+            &target.folder,
+            diff_hash,
+            &diff,
+            target.review_agent,
+        )
+        .await;
         self.persist_focused_review_updates(vec![FocusedReviewPersistence {
             diff_hash: Some(diff_hash),
             session_id,
@@ -740,6 +869,19 @@ mod tests {
                 web_url: "https://example.test/pull/42".to_string(),
             },
         });
+    }
+
+    /// Builds stable review inputs for direct diff-completion tests.
+    fn test_review_target(app: &App, session_id: &SessionId) -> FocusedReviewTarget {
+        let folder = app.sessions.session_for_id(session_id).map_or_else(
+            || session::session_folder(app.services.base_path(), session_id.as_str()),
+            |session| session.folder.clone(),
+        );
+
+        FocusedReviewTarget {
+            folder,
+            review_agent: app.review_agent(),
+        }
     }
 
     #[tokio::test]
@@ -985,7 +1127,102 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn automatic_review_diff_completion_after_project_switch_survives_restart() {
+    async fn automatic_review_diff_load_ignores_missing_loaded_session() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+        let session_ids = HashSet::from([SessionId::from("missing-session")]);
+
+        // Act
+        app.start_auto_review_diff_loads(&session_ids);
+
+        // Assert
+        assert!(app.pending_session_diff_requests.is_empty());
+        assert!(app.review_cache.is_empty());
+    }
+
+    #[tokio::test]
+    async fn inactive_auto_review_diff_load_accepts_existing_request() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+        let session_id = SessionId::from("inactive-review-pending");
+        let target = test_review_target(&app, &session_id);
+        app.pending_session_diff_requests.insert(
+            42,
+            PendingSessionDiffRequest {
+                purpose: SessionDiffPurpose::Review {
+                    cached_diff_hash: None,
+                    is_manual: false,
+                    target,
+                },
+                session_id: session_id.clone(),
+            },
+        );
+
+        // Act
+        let accepted = app.start_inactive_auto_review_diff_load(&session_id).await;
+
+        // Assert
+        assert!(accepted);
+        assert_eq!(app.pending_session_diff_requests.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn inactive_auto_review_diff_load_rejects_invalid_persisted_metadata() {
+        // Arrange
+        let (mut app, _base_dir, pool) = crate::test_support::new_git_test_app_with_pool().await;
+        let project_id = app.projects.active_project_id();
+        let invalid_status_id = SessionId::from("inactive-invalid-status");
+        let inactive_status_id = SessionId::from("inactive-done-status");
+        let missing_project_id = SessionId::from("inactive-missing-project");
+        for (session_id, status) in [
+            (&invalid_status_id, "Review"),
+            (&inactive_status_id, "Done"),
+            (&missing_project_id, "Review"),
+        ] {
+            app.services
+                .db()
+                .sessions()
+                .insert_session(
+                    session_id.as_str(),
+                    "gpt-5.6-sol",
+                    "main",
+                    status,
+                    project_id,
+                )
+                .await
+                .expect("failed to insert inactive session fixture");
+        }
+        sqlx::query("UPDATE session SET status = 'Unknown' WHERE id = ?")
+            .bind(invalid_status_id.as_str())
+            .execute(&pool)
+            .await
+            .expect("failed to invalidate inactive session status");
+        sqlx::query("UPDATE session SET project_id = NULL WHERE id = ?")
+            .bind(missing_project_id.as_str())
+            .execute(&pool)
+            .await
+            .expect("failed to clear inactive session project");
+
+        // Act
+        let invalid_status_started = app
+            .start_inactive_auto_review_diff_load(&invalid_status_id)
+            .await;
+        let inactive_status_started = app
+            .start_inactive_auto_review_diff_load(&inactive_status_id)
+            .await;
+        let missing_project_started = app
+            .start_inactive_auto_review_diff_load(&missing_project_id)
+            .await;
+
+        // Assert
+        assert!(!invalid_status_started);
+        assert!(!inactive_status_started);
+        assert!(!missing_project_started);
+        assert!(app.pending_session_diff_requests.is_empty());
+    }
+
+    #[tokio::test]
+    async fn automatic_review_diff_completion_continues_for_inactive_project() {
         // Arrange
         let (mut app, base_dir) = crate::test_support::new_test_app().await;
         let repositories = app.services.db().clone();
@@ -1014,8 +1251,13 @@ mod tests {
         };
 
         // Act
-        app.apply_review_diff_update(update, None, false).await;
-        let deferred_in_memory = app.deferred_auto_review_session_ids.clone();
+        let target = test_review_target(&app, &session_id);
+        app.apply_review_diff_update(update, None, false, target)
+            .await;
+        let review_is_loading = matches!(
+            app.review_cache.get(&session_id),
+            Some(ReviewCacheEntry::Loading { .. })
+        );
         drop(app);
         let recoverable_session_ids = repositories
             .sessions()
@@ -1024,7 +1266,7 @@ mod tests {
             .expect("failed to recover deferred review after restart");
 
         // Assert
-        assert_eq!(deferred_in_memory, HashSet::from([session_id.clone()]));
+        assert!(review_is_loading);
         assert_eq!(recoverable_session_ids, [session_id.as_str()]);
     }
 
@@ -1142,7 +1384,9 @@ mod tests {
         };
 
         // Act
-        app.apply_review_diff_update(update, None, false).await;
+        let target = test_review_target(&app, &session_id);
+        app.apply_review_diff_update(update, None, false, target)
+            .await;
 
         // Assert
         assert_eq!(
@@ -1158,6 +1402,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn automatic_empty_review_diff_preserves_cached_output() {
+        // Arrange
+        let (mut app, _base_dir, session_id) = review_app().await;
+        let cached_diff_hash = 42;
+        app.review_cache.insert(
+            session_id.clone(),
+            ReviewCacheEntry::Ready {
+                diff_hash: cached_diff_hash,
+                text: "## Review\nExisting finding.".to_string(),
+            },
+        );
+        let update = SessionDiffUpdate {
+            request_id: 1,
+            result: Ok(String::new()),
+            session_id: session_id.clone(),
+        };
+        let target = test_review_target(&app, &session_id);
+
+        // Act
+        app.apply_review_diff_update(update, Some(cached_diff_hash), false, target)
+            .await;
+
+        // Assert
+        assert!(matches!(
+            app.review_cache.get(&session_id),
+            Some(ReviewCacheEntry::Ready { diff_hash, text })
+                if *diff_hash == cached_diff_hash && text.contains("Existing finding")
+        ));
+        assert_eq!(app.sessions.sessions()[0].status, Status::Review);
+    }
+
+    #[tokio::test]
     async fn deleting_session_discards_pending_review_diff_and_late_completion() {
         // Arrange
         let (mut app, _base_dir, session_id) = review_app().await;
@@ -1168,6 +1444,7 @@ mod tests {
                 purpose: SessionDiffPurpose::Review {
                     cached_diff_hash: None,
                     is_manual: false,
+                    target: test_review_target(&app, &session_id),
                 },
                 session_id: session_id.clone(),
             },
@@ -1199,6 +1476,7 @@ mod tests {
                 purpose: SessionDiffPurpose::Review {
                     cached_diff_hash: None,
                     is_manual: false,
+                    target: test_review_target(&app, &session_id),
                 },
                 session_id: session_id.clone(),
             },

--- a/crates/agentty/src/app/setting.rs
+++ b/crates/agentty/src/app/setting.rs
@@ -72,6 +72,52 @@ pub(crate) async fn load_default_fast_agent_setting(
     .await
 }
 
+/// Loads the persisted review-agent defaults for one project.
+///
+/// Background review workflows use this when the owning project is not the
+/// active UI project, so generation keeps the model, reasoning, and speed
+/// configured for the session's project. Unconfigured projects use the same
+/// provider-aware baseline as normal project loading, independent of the
+/// active project's defaults.
+pub(crate) async fn load_default_review_agent_setting(
+    services: &AppServices,
+    project_id: i64,
+) -> crate::app::review::ReviewAgent {
+    let available_agent_kinds = services.available_agent_kinds();
+    let fallback_selection = default_smart_fallback_selection(&available_agent_kinds);
+    let default_smart_agent = load_default_smart_agent_selection_from_repositories(
+        services.db(),
+        Some(project_id),
+        fallback_selection,
+        &available_agent_kinds,
+    )
+    .await;
+    let default_review_agent = load_model_selection_setting(
+        services.db(),
+        Some(project_id),
+        SettingName::DefaultReviewAgent,
+        SettingName::DefaultReviewModel,
+        default_smart_agent,
+        &available_agent_kinds,
+    )
+    .await
+    .unwrap_or(default_smart_agent);
+    let defaults = load_model_role_defaults(
+        services.db(),
+        project_id,
+        SettingName::DefaultReviewReasoningLevel,
+        SettingName::DefaultReviewSpeedMode,
+        default_review_agent,
+    )
+    .await;
+
+    (
+        defaults.selection,
+        defaults.reasoning_level,
+        defaults.speed_mode,
+    )
+}
+
 /// Loads the persisted fast-model default from repositories as an agent/model
 /// selection.
 ///
@@ -246,10 +292,7 @@ impl SettingsManager {
         available_agent_kinds: Vec<AgentKind>,
         project_id: i64,
     ) -> Self {
-        let default_smart_fallback = fallback_selection_for_available_model(
-            AgentKind::Antigravity.default_model(),
-            &available_agent_kinds,
-        );
+        let default_smart_fallback = default_smart_fallback_selection(&available_agent_kinds);
         let default_smart_agent = load_default_smart_agent_selection_from_repositories(
             &repositories,
             Some(project_id),
@@ -839,6 +882,14 @@ fn fallback_selection_for_available_model(
         agent::resolve_agent_kind_for_model(model, available_agent_kinds, fallback_agent_kind);
 
     AgentSelection::new(agent_kind, model)
+}
+
+/// Returns the owner-independent smart-model baseline for one provider set.
+fn default_smart_fallback_selection(available_agent_kinds: &[AgentKind]) -> AgentSelection {
+    fallback_selection_for_available_model(
+        AgentKind::Antigravity.default_model(),
+        available_agent_kinds,
+    )
 }
 
 /// Loads the persisted terminal color theme through the settings repository.
@@ -1475,6 +1526,54 @@ mod tests {
 
         // Assert
         assert_eq!(fallback_loaded_model, AgentModel::ClaudeHaiku4520251001);
+    }
+
+    #[tokio::test]
+    async fn load_default_review_agent_setting_uses_inactive_project_baseline() {
+        // Arrange
+        let (services, active_project_id) = test_services().await;
+        let inactive_project_id = services
+            .db()
+            .projects()
+            .upsert_project("/tmp/inactive-project", Some("main".to_string()))
+            .await
+            .expect("failed to create inactive project");
+        services
+            .db()
+            .settings()
+            .upsert_project_settings(
+                active_project_id,
+                vec![
+                    (
+                        SettingName::DefaultSmartAgent,
+                        AgentKind::Codex.name().to_string(),
+                    ),
+                    (
+                        SettingName::DefaultSmartModel,
+                        AgentModel::Gpt56Sol.as_str().to_string(),
+                    ),
+                ],
+            )
+            .await
+            .expect("failed to persist active project smart default");
+        services
+            .db()
+            .settings()
+            .set_active_project_id(active_project_id)
+            .await
+            .expect("failed to set active project");
+
+        // Act
+        let (selection, reasoning_level, speed_mode) =
+            load_default_review_agent_setting(&services, inactive_project_id).await;
+
+        // Assert
+        assert_eq!(
+            selection,
+            AgentSelection::new(AgentKind::Gemini, AgentModel::Gemini31Pro)
+        );
+        assert_eq!(reasoning_level, ReasoningLevel::default());
+        assert_eq!(speed_mode, SpeedMode::default());
     }
 
     #[tokio::test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -2160,11 +2160,21 @@ const QUEUED_REVIEW_FOLLOW_UP_ANSWER: &str = "Queued review follow-up completed 
 const QUEUED_FIFO_UTILITY_ANSWER: &str = "Queued FIFO helper response";
 /// Focused-review result emitted after a turn completes in an inactive project.
 const DEFERRED_PROJECT_REVIEW_TEXT: &str = "Deferred project completion received focused review.";
+/// Prompt persisted before the owning project becomes inactive.
+const DEFERRED_PROJECT_REVIEW_PROMPT: &str = "Finish while I view another project";
+/// Turn result that the inactive project's focused review must receive as
+/// history.
+const DEFERRED_PROJECT_TURN_ANSWER: &str = "Completed work while another project was active.";
+/// Diagnostic emitted when inactive focused review loses persisted chat
+/// history.
+const MISSING_DEFERRED_PROJECT_HISTORY_TEXT: &str =
+    "Inactive focused review omitted saved session history.";
 
 /// Installs a delayed session turn plus a distinct focused-review response so
 /// project-switching scenarios can prove the automatic review ran.
 fn install_deferred_project_review_claude_stub(
     env: &BuilderEnv,
+    review_started_marker: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let claude_path = env.stub_bin.join("claude");
     let script = format!(
@@ -2174,7 +2184,15 @@ if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
 prompt=$(cat)
 case "$prompt" in
   *"Review the Git diff for display in a terminal UI."*)
-    result='{{\"answer\":\"## Review\\n\\n### Project Impact\\n\\n- {DEFERRED_PROJECT_REVIEW_TEXT}\\n\\n### Suggestions\\n\\n- None.\",\"questions\":[]}}'
+    case "$prompt" in
+      *"{DEFERRED_PROJECT_REVIEW_PROMPT}"*"{DEFERRED_PROJECT_TURN_ANSWER}"*)
+        printf 'started\n' > '{}'
+        result='{{\"answer\":\"## Review\\n\\n### Project Impact\\n\\n- {DEFERRED_PROJECT_REVIEW_TEXT}\\n\\n### Suggestions\\n\\n- None.\",\"questions\":[]}}'
+        ;;
+      *)
+        result='{{\"answer\":\"## Review\\n\\n### Project Impact\\n\\n- {MISSING_DEFERRED_PROJECT_HISTORY_TEXT}\\n\\n### Suggestions\\n\\n- Restore saved session history.\",\"questions\":[]}}'
+        ;;
+    esac
     ;;
   *"Generate a concise, commit-style title"*)
     result='{{\"answer\":\"Cross-project focused review\",\"questions\":[]}}'
@@ -2185,12 +2203,13 @@ case "$prompt" in
   *)
     sleep 3
     printf 'review me\n' > deferred-project-review.txt
-    result='{{\"answer\":\"Completed work while another project was active.\",\"questions\":[]}}'
+    result='{{\"answer\":\"{DEFERRED_PROJECT_TURN_ANSWER}\",\"questions\":[]}}'
     ;;
 esac
 printf '%s\n' '{{"type":"system","subtype":"init"}}'
 printf '%s\n' "{{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"$result\",\"usage\":{{\"input_tokens\":5,\"output_tokens\":9}}}}"
 "###,
+        review_started_marker.display(),
     );
 
     std::fs::write(&claude_path, script)?;
@@ -4750,30 +4769,64 @@ fn session_queued_action_survives_project_switching() -> E2eResult {
     Ok(())
 }
 
-/// Verify a turn that finishes while another project is active starts and
-/// displays focused review after its owning project is restored.
+/// Verify a turn that finishes while another project is active starts focused
+/// review immediately and displays it after its owning project is restored.
 #[test]
 fn completed_session_review_survives_project_switching() -> E2eResult {
-    // Arrange, Act, Assert
+    // Arrange
+    let review_started_marker = Arc::new(Mutex::new(None::<PathBuf>));
+    let setup_review_started_marker = Arc::clone(&review_started_marker);
+
     FeatureTest::new("completed_session_review_survives_project_switching")
         .with_git()
-        .setup(|env| {
-            install_deferred_project_review_claude_stub(env)?;
+        .setup(move |env| {
+            let marker_path = env.stub_bin.join("deferred-project-review-started");
+            setup_review_started_marker
+                .lock()
+                .expect("review marker capture should remain available")
+                .replace(marker_path.clone());
+            install_deferred_project_review_claude_stub(env, &marker_path)?;
             common::seed_second_project(env)
         })
         .run(
-            |scenario| {
+            move |scenario| {
+                // Act
+                let review_started_marker = review_started_marker
+                    .lock()
+                    .expect("review marker capture should remain available")
+                    .clone()
+                    .expect("setup should capture the review marker path");
+
                 scenario
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::create_session_with_prompt_and_return_to_list(
-                        "Finish while I view another project",
+                        DEFERRED_PROJECT_REVIEW_PROMPT,
                     ))
                     .press_key("p")
                     .wait_for_text("Switch project", 5000)
                     .press_key("j")
                     .press_key("Enter")
                     .wait_for_text("Project: zeta-project", 5000)
-                    .sleep_ms(6000)
+                    .eventually(
+                        Duration::from_secs(30),
+                        Duration::from_millis(100),
+                        move |frame| {
+                            if review_started_marker.is_file() {
+                                return Ok(());
+                            }
+
+                            let full = Region::full(frame.cols(), frame.rows());
+                            assertion::match_text_in_region(
+                                frame,
+                                "focused review request started",
+                                &full,
+                            )
+                        },
+                    )
+                    .capture_labeled(
+                        "inactive_project_review_started",
+                        "Focused review starts while zeta-project remains active",
+                    )
                     .press_key("p")
                     .wait_for_text("Switch project", 5000)
                     .press_key("Enter")
@@ -4786,11 +4839,22 @@ fn completed_session_review_survives_project_switching() -> E2eResult {
                         "Focused review after inactive-project completion",
                     )
             },
-            |frame, _report| {
+            |frame, report| {
+                // Assert
+                let inactive_project_frame = common::frame_from_capture(&report.captures[0]);
+                let inactive_project_full =
+                    Region::full(inactive_project_frame.cols(), inactive_project_frame.rows());
+                assertion::assert_text_in_region(
+                    &inactive_project_frame,
+                    "Project: zeta-project",
+                    &inactive_project_full,
+                );
+
                 let full = Region::full(frame.cols(), frame.rows());
                 assertion::assert_text_in_region(frame, DEFERRED_PROJECT_REVIEW_TEXT, &full);
                 assertion::assert_text_in_region(frame, "Suggestions", &full);
                 assertion::assert_not_visible(frame, "Reviewing changes with");
+                assertion::assert_not_visible(frame, MISSING_DEFERRED_PROJECT_HISTORY_TEXT);
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -466,17 +466,18 @@ flowchart LR
    changes durable and loaded availability to unknown, since external edits can make a
    previously empty diff stale. A durable invalidation failure prevents the tmux window
    from opening, so restart cannot restore a stale empty state after external edits.
-   When a turn completes while another project is active, the foreground reducer
-   atomically marks the existing worker session's focused review as pending. A late
-   completion event for a deleted session therefore cannot recreate an orphaned trigger.
-   The same marker is written when the response arrives before the loaded session's
-   final `Review` transition. Transient write failures retain the in-memory trigger and
-   retry through the event reducer with bounded backoff. Startup and project switching
-   reload pending triggers for the active project after its session snapshots reload. A
-   diff preparation result that lands while its project is inactive persists and
-   requeues the same trigger, and an automatic review with no diff clears the durable
-   marker, so switching projects or restarting cannot drop or endlessly replay the
-   review.
+   When a turn completes while another project is active, the foreground reducer loads
+   the persisted session target, atomically marks its focused review as pending, and
+   starts diff preparation without adding that session to the active-project snapshot.
+   Captured folder, review-agent, and diff-source inputs let preparation continue if a
+   project switch unloads an already-started session. A late completion event for a
+   deleted session therefore cannot recreate an orphaned trigger. The same marker is
+   written when the response arrives before the loaded session's final `Review`
+   transition. Transient write failures retain the in-memory trigger and retry through
+   the event reducer with bounded backoff. Startup and project switching reload pending
+   triggers for the active project after its session snapshots reload. An automatic
+   review with no diff clears the durable marker, so switching projects or restarting
+   cannot drop or endlessly replay the review.
 
 ### Operation Lifecycle and Recovery
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -310,19 +310,20 @@ output, or to see a loading message with the review agent, model, reasoning leve
 speed while generation is still running. The appended review stays visible across diff
 mode, question mode, session switching, project switching, and background session
 metadata refreshes, and is cleared when you submit the next prompt. If a turn finishes
-while another project is active, returning to the session's project resumes its
-automatic focused review, including after Agentty restarts. Deleted sessions do not
-Focused review includes the saved user and agent chat history for context. It uses
-inspection-only context: it may read files, search, inspect git history, and browse when
-needed, but it recommends verification commands instead of running checks itself. The
-review treats explicit decisions, accepted tradeoffs, and explanations in the chat as
-constraints, and only reopens a resolved suggestion when the current diff contradicts
-the resolution or inspection finds a new significant risk. `Project Impact` renders
-concise bullets directly beneath its heading. `Suggestions` uses the same compact
-spacing and formats its bullets as `[Severity]: Issue details`, using `[High]` or
-`[Medium]` when follow-up work is needed. Empty `Suggestions` output does not offer the
-`/apply` action. A turn stopped with `Ctrl+c` does not start a focused review
-automatically; press `f` for a manual one.
+while another project is active, its automatic focused review continues in the
+background without requiring you to switch back. Pending generation remains recoverable
+after Agentty restarts. Deleted sessions do not start or resume reviews from late
+completion events. Focused review includes the saved user and agent chat history for
+context. It uses inspection-only context: it may read files, search, inspect git
+history, and browse when needed, but it recommends verification commands instead of
+running checks itself. The review treats explicit decisions, accepted tradeoffs, and
+explanations in the chat as constraints, and only reopens a resolved suggestion when the
+current diff contradicts the resolution or inspection finds a new significant risk.
+`Project Impact` renders concise bullets directly beneath its heading. `Suggestions`
+uses the same compact spacing and formats its bullets as `[Severity]: Issue details`,
+using `[High]` or `[Medium]` when follow-up work is needed. Empty `Suggestions` output
+does not offer the `/apply` action. A turn stopped with `Ctrl+c` does not start a
+focused review automatically; press `f` for a manual one.
 
 ### Session Output Markdown
 


### PR DESCRIPTION
- Start diff preparation and review generation while the owning project is inactive.
- Preserve project-specific review settings, stable target metadata, and saved chat history across project switches.
- Recover pending generation after restart without reviving deleted sessions.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)