### PR TITLE
Diff coverage enforces 100% coverage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -209,6 +209,22 @@ repos:
         types: [rust]
         pass_filenames: false
         stages: [manual]
+      - id: diff-coverage
+        name: diff coverage
+        description: Verify every coverable line changed from main is covered by tests.
+        entry: >-
+          bash -eu -o pipefail -c 'env CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT=false
+          CARGO_UNSTABLE_FINE_GRAIN_LOCKING=false cargo llvm-cov nextest --workspace
+          --lib --bins --examples --locked --profile ci --lcov
+          --no-default-ignore-filename-regex --ignore-filename-regex
+          "(/rustc/|/(tests|benches)/|/(tests\.rs|[0-9a-zA-Z_-]+[_-]tests\.rs)$|/target/llvm-cov-target/|/\.cargo/(registry|git)/|/\.rustup/toolchains/)"
+          --output-path coverage.lcov && diff-cover coverage.lcov
+          --compare-branch=main --fail-under=100 --include-untracked --show-uncovered'
+        language: python
+        additional_dependencies: [diff-cover==10.5.1]
+        always_run: true
+        pass_filenames: false
+        stages: [manual]
       - id: cargo-machete
         name: cargo machete
         description: Check workspace manifests for unused dependencies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ describe Agentty product requirements, not instructions to mutate this checkout.
   with `FeatureTest`. Use `skills/feature-test/SKILL.md`; if infrastructure blocks
   coverage, report the exact gap.
 - Every code change requires automated tests that cover 100% of its coverable changed
-  lines. Before handoff, run `prek run coverage --all-files --hook-stage manual`.
+  lines. Before handoff, run `prek run diff-coverage --all-files --hook-stage manual`
+  and `prek run coverage --all-files --hook-stage manual`.
 - Never bypass `prek`-managed hooks with `--no-verify`, `--no-gpg-sign`, or an
   equivalent flag. Fix the failure.
 - Prefer removing legacy behavior. Obtain explicit user approval before retaining it.


### PR DESCRIPTION
- Adds a manual `prek` hook that compares coverable changes with `main` and fails below 100% coverage.
- Documents the diff coverage and full coverage checks required before handoff.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)