### PR TITLE
Support whole-file comments from row selections

### DIFF
--- a/crates/agentty/src/presentation/help_action.rs
+++ b/crates/agentty/src/presentation/help_action.rs
@@ -851,6 +851,12 @@ impl DiffFileCommentAvailability {
     fn is_available(self) -> bool {
         matches!(self, Self::Available)
     }
+
+    /// Returns the whole-file comment action when the selected row supports it.
+    fn help_action(self, footer_label: &'static str) -> Option<HelpAction> {
+        self.is_available()
+            .then(|| HelpAction::new(footer_label, "Shift+C", "Comment on the selected file"))
+    }
 }
 
 /// Inline-comment state that changes the compact Diff footer actions.
@@ -892,12 +898,15 @@ pub(crate) fn diff_footer_actions(context: DiffFooterContext) -> Vec<HelpAction>
         context.line_comment_state,
         DiffLineCommentFooterState::Selecting
     ) {
-        return vec![
+        let mut actions = vec![
             HelpAction::new("back", "q", "Back to session"),
             HelpAction::new("cancel", "Esc", "Cancel row selection"),
             HelpAction::new("extend", "j/k", "Extend row selection"),
             HelpAction::new("comment", "Enter", "Comment on selected rows"),
         ];
+        actions.extend(context.file_comment.help_action("comment file"));
+
+        return actions;
     }
 
     let can_submit_line_comments = context.line_comment_state.can_submit();
@@ -917,13 +926,7 @@ pub(crate) fn diff_footer_actions(context: DiffFooterContext) -> Vec<HelpAction>
                 "Focus the selected file's changed lines",
             ));
             actions.push(HelpAction::new("preview", "p", "Toggle markdown preview"));
-            if context.file_comment.is_available() {
-                actions.push(HelpAction::new(
-                    "comment",
-                    "Shift+C",
-                    "Comment on the selected file",
-                ));
-            }
+            actions.extend(context.file_comment.help_action("comment"));
             if context.has_review_comments {
                 actions.push(HelpAction::new("comments", "c", "Focus review comments"));
             }
@@ -2349,7 +2352,7 @@ mod tests {
     fn test_diff_content_footer_exposes_visual_row_selection_actions() {
         // Arrange, Act
         let selecting_keys = diff_footer_actions(DiffFooterContext {
-            file_comment: DiffFileCommentAvailability::Unavailable,
+            file_comment: DiffFileCommentAvailability::Available,
             can_mark_selected: false,
             can_submit: false,
             focus: DiffFocus::Content,
@@ -2362,7 +2365,7 @@ mod tests {
         .collect::<Vec<_>>();
 
         // Assert
-        assert_eq!(selecting_keys, ["q", "Esc", "j/k", "Enter"]);
+        assert_eq!(selecting_keys, ["q", "Esc", "j/k", "Enter", "Shift+C"]);
     }
 
     #[test]

--- a/crates/agentty/src/runtime/mode/diff.rs
+++ b/crates/agentty/src/runtime/mode/diff.rs
@@ -327,11 +327,7 @@ fn selected_line_comment_target(
         .review_comments
         .as_ref()
         .is_some_and(|review_comments| review_comments.sidebar_focus == DiffSidebarFocus::Comments);
-    if can_reply_with_line_comments
-        && is_shift_char_key(key, 'c')
-        && *navigation.focus == DiffFocus::Files
-        && !review_comments_are_focused
-    {
+    if can_reply_with_line_comments && is_shift_char_key(key, 'c') && !review_comments_are_focused {
         return render_cache_store
             .diff_layout_cache()
             .content(navigation.diff)
@@ -409,6 +405,8 @@ fn start_line_comment_edit(
         DiffCommentTarget::File { path }
             if content.selected_file_path(*file_explorer_selected_index) == Some(path.as_str()) =>
         {
+            line_comments.cancel_selection();
+
             (0, true)
         }
         DiffCommentTarget::File { .. } => return,
@@ -2802,7 +2800,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_comments_on_selected_file_and_builds_next_turn() {
+    async fn test_handle_comments_on_selected_file_from_active_row_selection() {
         // Arrange
         let (mut app, _base_dir) = preview_test_app(ag_git::MockGitClient::new()).await;
         let diff = concat!(
@@ -2810,13 +2808,24 @@ mod tests {
             "@@ -0,0 +1 @@\n",
             "+fn main() {}\n",
         );
-        app.mode = diff_mode_fixture(diff, 1, DiffFocus::Files, DiffPreview::default());
+        app.mode = diff_mode_fixture(diff, 1, DiffFocus::Content, DiffPreview::default());
 
-        // Act
+        // Act — start a row selection from inside the file, then replace it
+        // with a whole-file comment.
+        handle(
+            &mut app,
+            TEST_TERMINAL_SIZE,
+            KeyEvent::new(KeyCode::Char('V'), KeyModifiers::SHIFT),
+        );
         handle(
             &mut app,
             TEST_TERMINAL_SIZE,
             KeyEvent::new(KeyCode::Char('C'), KeyModifiers::SHIFT),
+        );
+        let selection_cleared_while_editing = matches!(
+            &app.mode,
+            AppMode::Diff { line_comments, .. }
+                if line_comments.is_editing() && !line_comments.is_selecting()
         );
         handle(
             &mut app,
@@ -2830,6 +2839,7 @@ mod tests {
         );
 
         // Assert
+        assert!(selection_cleared_while_editing);
         assert!(matches!(
             &app.mode,
             AppMode::Diff {
@@ -2840,6 +2850,7 @@ mod tests {
                 && line_comments.comments[0].target
                     == DiffCommentTarget::file("src/main.rs")
                 && line_comments.comments[0].input.text() == "R"
+                && !line_comments.is_selecting()
         ));
 
         // Act

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -8178,6 +8178,17 @@ fn test_diff_row_selection_comments() -> E2eResult {
                         "selected_comment_rows",
                         "Visual line selection highlights a changed-row range",
                     )
+                    .write_text("C")
+                    .wait_for_text("file comment: |", 5000)
+                    .write_text("Review the selected file.")
+                    .press_key(ENTER_KEY)
+                    .wait_for_text("file comment: Review the selected file.", 3000)
+                    .capture_labeled(
+                        "file_comment_from_row_selection",
+                        "Whole-file feedback replaces the visual row selection",
+                    )
+                    .write_text("V")
+                    .press_key("j")
                     .press_key(ENTER_KEY)
                     .wait_for_text("comment: |", 5000)
                     .write_text("Explain these lines.")
@@ -8199,8 +8210,19 @@ fn test_diff_row_selection_comments() -> E2eResult {
                 let selection_frame = common::frame_from_capture(&report.captures[0]);
                 let selection_full = Region::full(selection_frame.cols(), selection_frame.rows());
                 assertion::assert_text_in_region(&selection_frame, "Esc: cancel", &selection_full);
+                assertion::assert_text_in_region(&selection_frame, "Shift+C", &selection_full);
 
-                let editor_frame = common::frame_from_capture(&report.captures[1]);
+                let file_comment_frame = common::frame_from_capture(&report.captures[1]);
+                let file_comment_full =
+                    Region::full(file_comment_frame.cols(), file_comment_frame.rows());
+                assertion::assert_text_in_region(
+                    &file_comment_frame,
+                    "file comment: Review the selected file.",
+                    &file_comment_full,
+                );
+                assertion::assert_not_visible(&file_comment_frame, "Esc: cancel");
+
+                let editor_frame = common::frame_from_capture(&report.captures[2]);
                 let editor_full = Region::full(editor_frame.cols(), editor_frame.rows());
                 assertion::assert_text_in_region(
                     &editor_frame,

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -273,18 +273,20 @@ Pressing `d` from session view opens Diff mode focused on Files with the right p
 showing the git diff. While Files remains focused, use `Shift+j` / `Shift+k` or `Up` /
 `Down` to scroll the selected file without moving focus. Press `Enter` or `l` on a file
 to focus its changes, or press `Shift+C` to open a whole-file comment above its patch.
-Within the patch, press `Enter` to edit the selected changed line inline. After
-finishing with `Enter` or `Esc`, use `j` / `k` or the arrow keys to move through changed
-lines and completed file or inline comments. Press `Enter` on a selected comment to edit
-its text again. Press `Shift+V` on a changed line to start a visual changed-row
-selection, extend it with the same navigation keys, then press `Enter` to comment on the
-range or `Esc` to cancel the selection. The range stays highlighted while its inline
-editor is open and after the comment is finished, so the comment's source remains
-visible. `Esc`, `Left`, `h`, or `f` returns focus to the file tree when no visual
-selection is active. Linked review requests add a Comments section below Files; `c`
-focuses Comments while the file tree is focused, and `f` returns to Files. The Comments
-section keeps its own `Enter` action for submitting marked review threads. Press `s` to
-submit every file, line, and range comment together in the next turn from any Diff pane.
+Within the patch, `Shift+C` also opens the whole-file comment, including while a visual
+row selection is active; opening it clears that row selection. Press `Enter` to edit the
+selected changed line inline. After finishing with `Enter` or `Esc`, use `j` / `k` or
+the arrow keys to move through changed lines and completed file or inline comments.
+Press `Enter` on a selected comment to edit its text again. Press `Shift+V` on a changed
+line to start a visual changed-row selection, extend it with the same navigation keys,
+then press `Enter` to comment on the range or `Esc` to cancel the selection. The range
+stays highlighted while its inline editor is open and after the comment is finished, so
+the comment's source remains visible. `Esc`, `Left`, `h`, or `f` returns focus to the
+file tree when no visual selection is active. Linked review requests add a Comments
+section below Files; `c` focuses Comments while the file tree is focused, and `f`
+returns to Files. The Comments section keeps its own `Enter` action for submitting
+marked review threads. Press `s` to submit every file, line, and range comment together
+in the next turn from any Diff pane.
 
 | Key                   | Action                                         |
 | --------------------- | ---------------------------------------------- |

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -225,38 +225,40 @@ there instead of opening an empty Diff workspace.
 Inside diff view, `Shift+j` / `Shift+k` and `Up` / `Down` scroll the selected file while
 Files remains focused. Press `Enter` or `l` on a file to move focus from the file tree
 to its patch, or press `Shift+C` to open a whole-file editor above that patch. Within
-the patch, press `Enter` to open an inline editor beneath the selected added or removed
-line. Type the feedback, then press `Enter` or `Esc` to finish without leaving Diff
-mode. Use `j` / `k` or the arrow keys to move through changed lines and completed file
-or inline comments while Agentty keeps the cursor visible. Press `Enter` on a changed
-line to add feedback or on a completed comment to edit its text again. To comment on a
-range, press `Shift+V` on the first changed row, extend the visual selection with `j` /
-`k` or the arrow keys, then press `Enter`; `Esc` cancels the selection without leaving
-the patch. The full range stays highlighted while its inline editor is open and after
-the comment is finished, so every inline comment retains its visible source context.
-Finishing empty text removes the comment and its source highlight. Completed comments
-keep a distinct inset background, and the active editor uses the stronger selection
-highlight. The linked review-request Comments section retains its separate `Enter`
-action for submitting marked review threads. Press `s` to submit every finished file,
-line, or range comment together as the next session turn from any Diff pane. The
-submitted prompt uses one compact row per comment: file feedback carries its
-repository-relative path, while inline feedback also carries its old or new side and
-line or range. The batch keeps draft instructions or image attachments that were present
-before opening the diff. Selected deleted rows also include their captured pre-change
-source text because that context is absent from the current worktree. Diff comment
-editing and submission are available only when the session can accept a reply. Read-only
-diffs such as `Merged` sessions keep line navigation but omit the comment actions from
-the footer and help overlay. With no visual selection active, press `Esc`, `Left`, `h`,
-or `f` to return to the file tree. Select a changed markdown file and press `p` to
-render its complete post-change worktree content, including supported Mermaid diagrams.
-Preview remains active across file navigation; non-markdown selections keep showing raw
-diff lines, and files that are deleted, binary, too large, or unreadable show a concise
-notice. Press `p` again to restore the patch view. Pressing `q` returns to the sessions
-list and saves the complete composer; reopening the session restores the typed draft
-with input focus. Pressing `Tab` again returns focus to the composer. The same focus
-toggle, `d` diff preview, and `q` preservation flow are available while answering
-clarification questions. Long transcripts show a slim scrollbar on the right side of the
-output panel to indicate the current position.
+the patch, `Shift+C` also opens the whole-file editor, including while a visual row
+selection is active; opening it clears that row selection. Press `Enter` to open an
+inline editor beneath the selected added or removed line. Type the feedback, then press
+`Enter` or `Esc` to finish without leaving Diff mode. Use `j` / `k` or the arrow keys to
+move through changed lines and completed file or inline comments while Agentty keeps the
+cursor visible. Press `Enter` on a changed line to add feedback or on a completed
+comment to edit its text again. To comment on a range, press `Shift+V` on the first
+changed row, extend the visual selection with `j` / `k` or the arrow keys, then press
+`Enter`; `Esc` cancels the selection without leaving the patch. The full range stays
+highlighted while its inline editor is open and after the comment is finished, so every
+inline comment retains its visible source context. Finishing empty text removes the
+comment and its source highlight. Completed comments keep a distinct inset background,
+and the active editor uses the stronger selection highlight. The linked review-request
+Comments section retains its separate `Enter` action for submitting marked review
+threads. Press `s` to submit every finished file, line, or range comment together as the
+next session turn from any Diff pane. The submitted prompt uses one compact row per
+comment: file feedback carries its repository-relative path, while inline feedback also
+carries its old or new side and line or range. The batch keeps draft instructions or
+image attachments that were present before opening the diff. Selected deleted rows also
+include their captured pre-change source text because that context is absent from the
+current worktree. Diff comment editing and submission are available only when the
+session can accept a reply. Read-only diffs such as `Merged` sessions keep line
+navigation but omit the comment actions from the footer and help overlay. With no visual
+selection active, press `Esc`, `Left`, `h`, or `f` to return to the file tree. Select a
+changed markdown file and press `p` to render its complete post-change worktree content,
+including supported Mermaid diagrams. Preview remains active across file navigation;
+non-markdown selections keep showing raw diff lines, and files that are deleted, binary,
+too large, or unreadable show a concise notice. Press `p` again to restore the patch
+view. Pressing `q` returns to the sessions list and saves the complete composer;
+reopening the session restores the typed draft with input focus. Pressing `Tab` again
+returns focus to the composer. The same focus toggle, `d` diff preview, and `q`
+preservation flow are available while answering clarification questions. Long
+transcripts show a slim scrollbar on the right side of the output panel to indicate the
+current position.
 
 Pressing `r` during a running turn queues session sync on the same session worker. The
 session stays **InProgress** while the active turn runs, then moves to **Rebasing** when


### PR DESCRIPTION
- Make `Shift+C` available while visual row selection is active and clear the selection when editing starts.
- Cover the workflow in unit and E2E tests and document the updated behavior.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)