### PR TITLE
Harness validates terminal model output

### DIFF
--- a/crates/ag-harness-cli/src/main.rs
+++ b/crates/ag-harness-cli/src/main.rs
@@ -1012,7 +1012,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn chat_rejects_model_output_without_a_message() {
+    async fn chat_rejects_model_output_that_violates_schema() {
         // Arrange
         let harness = Harness::new(FixedModel(json!({"unexpected": true})));
         let mut session = harness.chat(chat_schema().expect("chat schema should compile"));
@@ -1026,13 +1026,19 @@ mod tests {
             Some("question".to_string()),
             input,
             &mut output,
-            ChatMode::NonInteractive,
+            ChatMode::OneShot,
         )
         .await
-        .expect_err("missing message output should fail");
+        .expect_err("schema-invalid output should fail");
 
         // Assert
-        assert!(matches!(error, CliError::MissingMessage));
+        assert!(matches!(
+            error,
+            CliError::Turn(ag_harness::TurnError::Model(
+                ag_harness::ModelError::SchemaViolation { path, .. }
+            )) if path == "$"
+        ));
+        assert_eq!(output, [] as [u8; 0]);
     }
 
     #[tokio::test]

--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -571,6 +571,16 @@ impl Harness {
                 return Err(error.into());
             }
         };
+        if let Some(output) = response.output()
+            && let Err(error) = request.schema().validate_value(output)
+        {
+            let error = ModelError::from(error);
+            if let Some(model_lifecycle) = model_lifecycle {
+                model_lifecycle.failed(error.error_type(), error.http_status());
+            }
+
+            return Err(error.into());
+        }
         let response_type = response.response_type();
         let activity = ModelRequestActivity {
             completion: completion.as_ref().map(sanitized_completion_metadata),
@@ -1514,6 +1524,57 @@ mod tests {
             TurnError::Model(ModelError::InvalidResponse)
         ));
         assert_eq!(recovered.output(), &json!({"summary": "recovered"}));
+    }
+
+    #[tokio::test]
+    async fn rejects_schema_invalid_output_from_injected_model() {
+        // Arrange
+        let mut model = model();
+        model
+            .expect_complete_with_optional_metadata()
+            .times(1)
+            .returning(|_| {
+                Ok(response_without_metadata(ModelResponse::Output(json!({
+                    "summary": 42
+                }))))
+            });
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let observed_events = Arc::clone(&events);
+        let harness = Harness::new(model).with_lifecycle_observer(move |event| {
+            observed_events
+                .lock()
+                .expect("event recorder should not be poisoned")
+                .push(event);
+        });
+
+        // Act
+        let error = harness
+            .run("inspect", object_schema())
+            .await
+            .expect_err("schema-invalid custom output should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            TurnError::Model(ModelError::SchemaViolation { path, .. }) if path == "/summary"
+        ));
+        let events = events
+            .lock()
+            .expect("event recorder should not be poisoned");
+        assert!(matches!(
+            events[2].kind(),
+            crate::LifecycleEventKind::ModelRequestFailed {
+                error_type: crate::ModelErrorType::InvalidOutput,
+                ..
+            }
+        ));
+        assert!(matches!(
+            events[3].kind(),
+            crate::LifecycleEventKind::TurnFailed {
+                error_type: TurnErrorType::Model(crate::ModelErrorType::InvalidOutput),
+                ..
+            }
+        ));
     }
 
     #[tokio::test]

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -666,7 +666,10 @@ impl CompletionUsage {
 /// Provider-neutral output from one model request.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ModelResponse {
-    /// Terminal, locally schema-validated model output.
+    /// Terminal structured model output.
+    ///
+    /// [`ModelClient`] and [`crate::Harness`] validate this value locally
+    /// against the request schema before returning it to applications.
     Output(Value),
     /// One validated native function call requiring application handling.
     ToolCall(tool::ToolCall),
@@ -677,7 +680,7 @@ pub enum ModelResponse {
 }
 
 impl ModelResponse {
-    /// Returns parsed, schema-validated terminal output, when present.
+    /// Returns terminal structured output, when present.
     pub fn output(&self) -> Option<&Value> {
         match self {
             Self::Output(output) => Some(output),
@@ -1340,7 +1343,7 @@ mod tests {
     }
 
     #[test]
-    fn response_exposes_validated_output() {
+    fn response_exposes_terminal_output() {
         // Arrange
         let value = json!({ "name": "Ada" });
 

--- a/crates/ag-harness/src/schema_contract.rs
+++ b/crates/ag-harness/src/schema_contract.rs
@@ -80,7 +80,18 @@ impl OutputSchema {
 
         let value = serde_json::from_str(output)
             .map_err(|error| OutputValidationError::InvalidJson(bounded_diagnostic(error)))?;
-        if let Err(error) = self.validator.validate(&value) {
+        self.validate(&value)?;
+
+        Ok(value)
+    }
+
+    pub(crate) fn validate_value(&self, output: &Value) -> Result<(), OutputValidationError> {
+        ensure_content_size(&output.to_string())?;
+        self.validate(output)
+    }
+
+    fn validate(&self, value: &Value) -> Result<(), OutputValidationError> {
+        if let Err(error) = self.validator.validate(value) {
             let path = match error.instance_path().as_str() {
                 "" => "$".to_string(),
                 path => bounded_diagnostic(path),
@@ -92,7 +103,7 @@ impl OutputSchema {
             });
         }
 
-        Ok(value)
+        Ok(())
     }
 }
 
@@ -436,6 +447,22 @@ mod tests {
         // Act
         let error = schema
             .parse_and_validate(&output)
+            .expect_err("oversized output should fail");
+
+        // Assert
+        assert_eq!(error, OutputValidationError::TooLarge);
+    }
+
+    #[test]
+    fn rejects_oversized_structured_value() {
+        // Arrange
+        let schema =
+            OutputSchema::new(json!({ "type": "string" })).expect("schema should be valid");
+        let output = Value::String("x".repeat(RESPONSE_CONTENT_LIMIT_BYTES));
+
+        // Act
+        let error = schema
+            .validate_value(&output)
             .expect_err("oversized output should fail");
 
         // Assert

--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -1866,6 +1866,12 @@ mod tests {
     async fn test_d_key_in_chat_focus_keeps_prompt_when_diff_empty() {
         // Arrange — prompt mode with chat focused over an unchanged worktree.
         let (mut app, _base_dir) = new_test_prompt_app("draft text", None).await;
+        let mut mock_git_client = ag_git::MockGitClient::new();
+        mock_git_client
+            .expect_diff()
+            .once()
+            .returning(|_, _| Box::pin(async { Ok(String::new()) }));
+        install_mock_git_client(&mut app, mock_git_client);
         press_prompt_key(&mut app, KeyCode::Tab).await;
 
         // Act

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -63,7 +63,9 @@ applications store supported clients behind `dyn Model`. `ModelClient` implement
 boundary, owns request-duration telemetry, and validates every response against the
 request's `OutputSchema`. Provider request execution remains private so applications
 cannot bypass this lifecycle. `ModelClient` validates and retains the provider and model
-identity during construction, before any request starts.
+identity during construction, before any request starts. `Harness` independently
+validates every terminal `ModelResponse::Output` against the same schema, so injected
+`Model` implementations cannot bypass the application-facing output contract.
 
 `ModelWithMetadata` guarantees completion metadata and automatically implements the
 optional metadata path on `Model`; response-only `Model` implementations remain valid.
@@ -194,7 +196,9 @@ The model contract requires provider-neutral structured output:
 - The caller supplies the expected JSON shape as a provider-independent schema.
 - Each adapter uses the strongest structured-output mechanism its provider supports and
   returns raw assistant text. The shared `ModelClient` lifecycle parses and validates
-  the returned JSON against the caller's schema.
+  the returned JSON against the caller's schema. `Harness` validates terminal values
+  again as the final application-facing trust boundary, including values returned by
+  custom `Model` implementations.
 - Provider-specific request fields remain inside the adapter. For Qwen, the adapter uses
   JSON Object mode and performs schema validation in the harness because Qwen guarantees
   valid JSON, not schema conformance.


### PR DESCRIPTION
- Applies the request schema and content-size limit to every structured value returned by a `Model`.
- Reports schema violations as model failures and preserves the application-facing error contract across harness and CLI paths.