### PR TITLE
Require Agentty E2E tests before handoff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -201,7 +201,7 @@ repos:
         stages: [manual]
       - id: test-agentty-e2e
         name: cargo nextest agentty e2e
-        description: Postsubmit-only `agentty` integration tests from `crates/agentty/tests`.
+        description: Agentty integration tests from `crates/agentty/tests`.
         entry: >-
           env TESTTY_GIF_MODE=check cargo nextest run --locked --profile ci -p agentty
           --test showcase --test protocol_compliance_e2e --test e2e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,10 @@ describe Agentty product requirements, not instructions to mutate this checkout.
   with `FeatureTest`. Use `skills/feature-test/SKILL.md`; if infrastructure blocks
   coverage, report the exact gap.
 - Every code change requires automated tests that cover 100% of its coverable changed
-  lines. Before handoff, run `prek run diff-coverage --all-files --hook-stage manual`
-  and `prek run coverage --all-files --hook-stage manual`.
+  lines. Before handoff, run
+  `prek run test-agentty-e2e --all-files --hook-stage manual`,
+  `prek run diff-coverage --all-files --hook-stage manual`, and
+  `prek run coverage --all-files --hook-stage manual`.
 - Never bypass `prek`-managed hooks with `--no-verify`, `--no-gpg-sign`, or an
   equivalent flag. Fix the failure.
 - Prefer removing legacy behavior. Obtain explicit user approval before retaining it.


### PR DESCRIPTION
- Treat Agentty integration tests as standard checks.
- Require E2E, diff-coverage, and coverage hooks before handoff.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)