### PR TITLE
Avoid allocating terminal output during size validation

### DIFF
--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -1561,20 +1561,21 @@ mod tests {
         let events = events
             .lock()
             .expect("event recorder should not be poisoned");
-        assert!(matches!(
-            events[2].kind(),
+        assert_eq!(events.len(), 4);
+        assert!(events.iter().any(|event| matches!(
+            event.kind(),
             crate::LifecycleEventKind::ModelRequestFailed {
                 error_type: crate::ModelErrorType::InvalidOutput,
                 ..
             }
-        ));
-        assert!(matches!(
-            events[3].kind(),
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event.kind(),
             crate::LifecycleEventKind::TurnFailed {
                 error_type: TurnErrorType::Model(crate::ModelErrorType::InvalidOutput),
                 ..
             }
-        ));
+        )));
     }
 
     #[tokio::test]

--- a/crates/ag-harness/src/schema_contract.rs
+++ b/crates/ag-harness/src/schema_contract.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::io::{self, Write};
 use std::sync::Arc;
 
 use jsonschema::error::ValidationErrorKind;
@@ -86,7 +87,8 @@ impl OutputSchema {
     }
 
     pub(crate) fn validate_value(&self, output: &Value) -> Result<(), OutputValidationError> {
-        ensure_content_size(&output.to_string())?;
+        let mut writer = ContentSizeWriter { bytes_written: 0 };
+        serde_json::to_writer(&mut writer, output).map_err(|_| OutputValidationError::TooLarge)?;
         self.validate(output)
     }
 
@@ -103,6 +105,25 @@ impl OutputSchema {
             });
         }
 
+        Ok(())
+    }
+}
+
+struct ContentSizeWriter {
+    bytes_written: usize,
+}
+
+impl Write for ContentSizeWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if buffer.len() > RESPONSE_CONTENT_LIMIT_BYTES.saturating_sub(self.bytes_written) {
+            return Err(io::ErrorKind::WriteZero.into());
+        }
+        self.bytes_written += buffer.len();
+
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
 }
@@ -467,6 +488,18 @@ mod tests {
 
         // Assert
         assert_eq!(error, OutputValidationError::TooLarge);
+    }
+
+    #[test]
+    fn flushes_content_size_writer() {
+        // Arrange
+        let mut writer = ContentSizeWriter { bytes_written: 0 };
+
+        // Act
+        let result = writer.flush();
+
+        // Assert
+        assert!(result.is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Why?

Harness validation serialized every injected terminal value into a complete string before enforcing the response-size limit, allowing oversized model output to cause an avoidable allocation at the trust boundary.

## What?

- Stream terminal values through a capped writer and fail as soon as serialized output exceeds the existing limit.
- Preserve schema validation and the existing oversized-response error contract.
- Assert failure lifecycle events by kind while retaining an exact event-count check.

## Project impact

Custom model output validation no longer creates a second full-size JSON representation; provider behavior and public APIs are unchanged.