### PR TITLE
Keep repository documentation concise and conceptual

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,8 @@ workflows.
 
 Apply the smallest documentation update matching the change:
 
+- Keep documentation short and conceptual unless detailed implementation documentation
+  is explicitly requested.
 - Keep Rust doc comments current for touched public APIs and related elements.
 - Update `docs/site/content/docs/` for user-visible behavior and
   `docs/site/content/docs/architecture/` for ownership, boundaries, or runtime flow.


### PR DESCRIPTION
## Why?

Across nine sessions, 23 follow-ups asked agents to shorten, remove, or revert documentation, showing that the repository lacked a stable convention for documentation depth.

## What?

- Establishes short, conceptual documentation as the repository default.
- Reserves detailed implementation documentation for explicit requests.

## Project impact

Agents should produce less oversized documentation by default, reducing review cleanup without changing product behavior.