### PR TITLE
Agentty suppresses duplicate review replies

### DIFF
--- a/crates/ag-forge/src/adapter_common.rs
+++ b/crates/ag-forge/src/adapter_common.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 
 use super::{
     ForgeCommand, ForgeCommandError, ForgeCommandOutput, ForgeCommandRunner, ForgeFuture,
-    ForgeKind, ForgeRemote, ReviewCommentSnapshot, ReviewRequestError, ReviewRequestMetadata,
-    ReviewRequestSummary, UpdateReviewRequestInput, command_output_detail,
+    ForgeKind, ForgeRemote, ReviewRequestError, ReviewRequestMetadata, ReviewRequestSummary,
+    UpdateReviewRequestInput, command_output_detail,
 };
 
 /// Provider-neutral partial edit produced after a best-effort recheck that the
@@ -287,33 +287,6 @@ impl ReviewRequestOperations {
             }
 
             refresh_review_request(remote, display_id).await
-        })
-    }
-
-    /// Fetches and parses one review-comment snapshot in an owned future for
-    /// adapter trait implementations.
-    pub(crate) fn fetch_review_comment_snapshot_future(
-        &self,
-        remote: ForgeRemote,
-        display_id: String,
-        parse_display_id: fn(&str) -> Result<String, ReviewRequestError>,
-        snapshot_command: fn(&ForgeRemote, &str) -> ForgeCommand,
-        operation: &'static str,
-        parse_snapshot_response: fn(&str) -> Result<ReviewCommentSnapshot, String>,
-    ) -> ForgeFuture<Result<ReviewCommentSnapshot, ReviewRequestError>> {
-        let operations = self.clone();
-
-        Box::pin(async move {
-            let command_display_id = parse_display_id(&display_id)?;
-            let output = operations
-                .run_review_command(
-                    &remote,
-                    snapshot_command(&remote, &command_display_id),
-                    operation,
-                )
-                .await?;
-
-            map_parse_error(remote.forge_kind, parse_snapshot_response(&output.stdout))
         })
     }
 

--- a/crates/ag-forge/src/github.rs
+++ b/crates/ag-forge/src/github.rs
@@ -18,19 +18,19 @@ const REVIEW_THREADS_QUERY: &str =
     "query($owner: String!, $repo: String!, $number: Int!, $endCursor: String) { \
      repository(owner: $owner, name: $repo) { pullRequest(number: $number) { reviewThreads(first: \
      100, after: $endCursor) { nodes { id diffSide isOutdated isResolved line path startLine \
-     subjectType comments(first: 100) { nodes { author { login } body } pageInfo { hasNextPage \
-     endCursor } } } pageInfo { hasNextPage endCursor } } } } }";
+     subjectType comments(first: 100) { nodes { author { login } body viewerDidAuthor } pageInfo \
+     { hasNextPage endCursor } } } pageInfo { hasNextPage endCursor } } } } }";
 /// Paginated GraphQL query used to fetch pull-request conversation comments.
 const PULL_REQUEST_COMMENTS_QUERY: &str =
     "query($owner: String!, $repo: String!, $number: Int!, $endCursor: String) { \
      repository(owner: $owner, name: $repo) { pullRequest(number: $number) { comments(first: 100, \
-     after: $endCursor) { nodes { author { login } body } pageInfo { hasNextPage endCursor } } } \
-     } }";
+     after: $endCursor) { nodes { author { login } body viewerDidAuthor } pageInfo { hasNextPage \
+     endCursor } } } } }";
 /// Paginated GraphQL query used when one review thread exceeds 100 comments.
-const THREAD_COMMENTS_QUERY: &str = "query($threadId: ID!, $endCursor: String) { node(id: \
-                                     $threadId) { ... on PullRequestReviewThread { \
-                                     comments(first: 100, after: $endCursor) { nodes { author { \
-                                     login } body } pageInfo { hasNextPage endCursor } } } } }";
+const THREAD_COMMENTS_QUERY: &str =
+    "query($threadId: ID!, $endCursor: String) { node(id: $threadId) { ... on \
+     PullRequestReviewThread { comments(first: 100, after: $endCursor) { nodes { author { login } \
+     body viewerDidAuthor } pageInfo { hasNextPage endCursor } } } } }";
 /// GraphQL mutation used to add one reply to a pull-request review thread.
 const REPLY_TO_THREAD_MUTATION: &str =
     "mutation($threadId: ID!, $body: String!) { addPullRequestReviewThreadReply(input: { \
@@ -681,6 +681,7 @@ fn review_comment_from_node(node: GitHubReviewCommentNode) -> ReviewComment {
         author: node
             .author
             .map_or_else(|| "ghost".to_string(), |author| author.login),
+        authored_by_current_user: node.viewer_did_author,
         body: node.body,
     }
 }
@@ -814,6 +815,8 @@ struct GitHubThreadCommentsNode {
 struct GitHubReviewCommentNode {
     author: Option<GitHubReviewCommentAuthor>,
     body: String,
+    #[serde(default, rename = "viewerDidAuthor")]
+    viewer_did_author: bool,
 }
 
 /// GraphQL author node for a review comment. The `ghost` author is the only
@@ -1376,7 +1379,10 @@ mod tests {
         assert!(!unresolved.is_resolved);
         assert_eq!(unresolved.comments.len(), 2);
         assert_eq!(unresolved.comments[0].author, "alice");
+        assert!(!unresolved.comments[0].authored_by_current_user);
         assert_eq!(unresolved.comments[0].body, "Why aren't we handling None?");
+        assert!(unresolved.comments[1].authored_by_current_user);
+        assert!(unresolved.is_addressed_by_agentty());
 
         let resolved = &snapshot.threads[1];
         assert_eq!(resolved.path, "src/bar.rs");
@@ -1853,7 +1859,10 @@ mod tests {
             review_threads_page(vec![review_thread_node(ReviewThreadFixture {
                 comments: vec![
                     review_comment_node(Some("alice"), "Why aren't we handling None?"),
-                    review_comment_node(Some("bob"), "Good catch. Will fix."),
+                    current_user_review_comment_node(
+                        "No change needed.\n\n<!-- agentty review \
+                         resolution:123e4567-e89b-12d3-a456-426614174000 -->",
+                    ),
                 ],
                 diff_side: "RIGHT",
                 has_next_comment_page: false,
@@ -2020,7 +2029,16 @@ mod tests {
     fn review_comment_node(author: Option<&str>, body: &str) -> serde_json::Value {
         serde_json::json!({
             "author": author.map(|login| serde_json::json!({"login": login})),
-            "body": body
+            "body": body,
+            "viewerDidAuthor": false
+        })
+    }
+
+    fn current_user_review_comment_node(body: &str) -> serde_json::Value {
+        serde_json::json!({
+            "author": {"login": "agentty"},
+            "body": body,
+            "viewerDidAuthor": true
         })
     }
 

--- a/crates/ag-forge/src/gitlab.rs
+++ b/crates/ag-forge/src/gitlab.rs
@@ -146,14 +146,34 @@ impl ReviewRequestAdapter for GitLabReviewRequestAdapter {
         remote: ForgeRemote,
         display_id: String,
     ) -> ForgeFuture<Result<ReviewCommentSnapshot, ReviewRequestError>> {
-        self.operations.fetch_review_comment_snapshot_future(
-            remote,
-            display_id,
-            parse_display_id,
-            discussions_command,
-            "fetch merge-request discussions",
-            parse_review_comment_snapshot_response,
-        )
+        let operations = self.operations.clone();
+
+        Box::pin(async move {
+            let merge_request_iid = parse_display_id(&display_id)?;
+            let current_user_output = operations
+                .run_review_command(
+                    &remote,
+                    current_user_command(&remote),
+                    "fetch authenticated GitLab user",
+                )
+                .await?;
+            let current_user = map_parse_error(
+                ForgeKind::GitLab,
+                parse_current_user_response(&current_user_output.stdout),
+            )?;
+            let discussions_output = operations
+                .run_review_command(
+                    &remote,
+                    discussions_command(&remote, &merge_request_iid),
+                    "fetch merge-request discussions",
+                )
+                .await?;
+
+            map_parse_error(
+                ForgeKind::GitLab,
+                parse_review_comment_snapshot_response(&discussions_output.stdout, current_user.id),
+            )
+        })
     }
 
     fn reply_to_authenticated_thread(
@@ -411,6 +431,20 @@ fn update_metadata_command(
     gitlab_command(remote, "glab", arguments)
 }
 
+/// Builds the GitLab API request for the authenticated user identity.
+fn current_user_command(remote: &ForgeRemote) -> ForgeCommand {
+    gitlab_command(
+        remote,
+        "glab",
+        vec![
+            "api".to_string(),
+            "--hostname".to_string(),
+            remote.host.clone(),
+            "/user".to_string(),
+        ],
+    )
+}
+
 /// Builds the `glab api` command for merge-request discussions.
 fn discussions_command(remote: &ForgeRemote, merge_request_iid: &str) -> ForgeCommand {
     let encoded_project_path: String =
@@ -506,7 +540,10 @@ fn discussion_endpoint(
 }
 
 /// Parses merge-request discussions into inline threads and MR-level comments.
-fn parse_review_comment_snapshot_response(stdout: &str) -> Result<ReviewCommentSnapshot, String> {
+fn parse_review_comment_snapshot_response(
+    stdout: &str,
+    current_user_id: u64,
+) -> Result<ReviewCommentSnapshot, String> {
     let discussions: Vec<GitLabDiscussion> = serde_json::from_str(stdout)
         .map_err(|error| format!("invalid GitLab merge-request discussions response: {error}"))?;
     let mut pr_level_comments = Vec::new();
@@ -522,10 +559,16 @@ fn parse_review_comment_snapshot_response(stdout: &str) -> Result<ReviewCommentS
             continue;
         }
 
-        if let Some(thread) = review_comment_thread_from_discussion(&discussion.id, &notes) {
+        if let Some(thread) =
+            review_comment_thread_from_discussion(&discussion.id, &notes, current_user_id)
+        {
             threads.push(thread);
         } else {
-            pr_level_comments.extend(notes.drain(..).map(review_comment_from_note));
+            pr_level_comments.extend(
+                notes
+                    .drain(..)
+                    .map(|note| review_comment_from_note(note, current_user_id)),
+            );
         }
     }
 
@@ -540,6 +583,7 @@ fn parse_review_comment_snapshot_response(stdout: &str) -> Result<ReviewCommentS
 fn review_comment_thread_from_discussion(
     discussion_id: &str,
     notes: &[GitLabDiscussionNote],
+    current_user_id: u64,
 ) -> Option<ReviewCommentThread> {
     let anchor_note = notes.iter().find(|note| {
         note.note_type.as_deref() == Some("DiffNote") && note.position.as_ref().is_some()
@@ -552,7 +596,7 @@ fn review_comment_thread_from_discussion(
         comments: notes
             .iter()
             .cloned()
-            .map(review_comment_from_note)
+            .map(|note| review_comment_from_note(note, current_user_id))
             .collect(),
         id: discussion_id.to_string(),
         is_outdated: None,
@@ -603,15 +647,24 @@ fn gitlab_anchor_from_position(
 }
 
 /// Converts one GitLab discussion note into the forge-neutral comment shape.
-fn review_comment_from_note(note: GitLabDiscussionNote) -> ReviewComment {
+fn review_comment_from_note(note: GitLabDiscussionNote, current_user_id: u64) -> ReviewComment {
+    let authored_by_current_user = note.author.id == Some(current_user_id);
+
     ReviewComment {
         author: note
             .author
             .username
             .or(note.author.name)
             .unwrap_or_default(),
+        authored_by_current_user,
         body: note.body,
     }
+}
+
+/// Parses the authenticated GitLab user required to identify Agentty replies.
+fn parse_current_user_response(stdout: &str) -> Result<GitLabCurrentUser, String> {
+    serde_json::from_str(stdout)
+        .map_err(|error| format!("invalid GitLab current-user response: {error}"))
 }
 
 /// Builds one base `glab` command with deterministic color settings and the
@@ -716,6 +769,12 @@ struct GitLabMetadataResponse {
     title: String,
 }
 
+/// Authenticated GitLab user returned by `GET /user`.
+#[derive(Deserialize)]
+struct GitLabCurrentUser {
+    id: u64,
+}
+
 /// GitLab merge-request discussion returned by the discussions API.
 #[derive(Clone, Deserialize)]
 struct GitLabDiscussion {
@@ -740,6 +799,7 @@ struct GitLabDiscussionNote {
 /// Minimal GitLab note author data shown in session review-comment views.
 #[derive(Clone, Deserialize)]
 struct GitLabDiscussionAuthor {
+    id: Option<u64>,
     name: Option<String>,
     username: Option<String>,
 }
@@ -1210,6 +1270,16 @@ mod tests {
             .withf({
                 let remote = remote.clone();
 
+                move |command| command == &current_user_command(&remote)
+            })
+            .returning(|_| Box::pin(async { Ok(success_output(gitlab_current_user_json())) }));
+        command_runner
+            .expect_run()
+            .once()
+            .in_sequence(&mut sequence)
+            .withf({
+                let remote = remote.clone();
+
                 move |command| command == &discussions_command(&remote, "42")
             })
             .returning(|_| Box::pin(async { Ok(success_output(gitlab_discussions_json())) }));
@@ -1232,7 +1302,10 @@ mod tests {
         assert!(!thread.is_resolved);
         assert_eq!(thread.comments.len(), 2);
         assert_eq!(thread.comments[0].author, "alice");
+        assert!(!thread.comments[0].authored_by_current_user);
         assert_eq!(thread.comments[0].body, "Please simplify this.");
+        assert!(thread.comments[1].authored_by_current_user);
+        assert!(thread.is_addressed_by_agentty());
 
         assert_eq!(snapshot.pr_level_comments.len(), 1);
         assert_eq!(snapshot.pr_level_comments[0].author, "carol");
@@ -1288,6 +1361,37 @@ mod tests {
         let encoded_endpoint =
             discussion_endpoint(&gitlab_remote(), "42", "discussion/1", Some("notes"));
         assert!(encoded_endpoint.contains("discussion%2F1/notes"));
+    }
+
+    #[tokio::test]
+    async fn fetch_authenticated_review_comment_snapshot_preserves_current_user_parse_failure() {
+        // Arrange
+        let remote = gitlab_remote();
+        let mut command_runner = MockForgeCommandRunner::new();
+        command_runner
+            .expect_run()
+            .once()
+            .withf({
+                let remote = remote.clone();
+
+                move |command| command == &current_user_command(&remote)
+            })
+            .returning(|_| Box::pin(async { Ok(success_output("not-json".to_string())) }));
+        let adapter = GitLabReviewRequestAdapter::new(Arc::new(command_runner));
+
+        // Act
+        let error = adapter
+            .fetch_authenticated_review_comment_snapshot(remote, "!42".to_string())
+            .await
+            .expect_err("invalid current user should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            ReviewRequestError::OperationFailed { forge_kind, message }
+                if forge_kind == ForgeKind::GitLab
+                    && message.contains("invalid GitLab current-user response")
+        ));
     }
 
     #[test]
@@ -1455,7 +1559,7 @@ mod tests {
                         "id": 1,
                         "type": "DiffNote",
                         "body": "Please simplify this.",
-                        "author": {"name": "Alice", "username": "alice"},
+                        "author": {"id": 1, "name": "Alice", "username": "alice"},
                         "system": false,
                         "resolved": false,
                         "position": {
@@ -1468,8 +1572,8 @@ mod tests {
                     {
                         "id": 2,
                         "type": "DiscussionNote",
-                        "body": "Agreed.",
-                        "author": {"name": "Bob", "username": "bob"},
+                        "body": "No change needed.\n\n<!-- agentty review resolution:123e4567-e89b-12d3-a456-426614174000 -->",
+                        "author": {"id": 2, "name": "Bob", "username": "bob"},
                         "system": false,
                         "resolved": false,
                         "position": null
@@ -1484,7 +1588,7 @@ mod tests {
                         "id": 3,
                         "type": "DiscussionNote",
                         "body": "Looks good overall.",
-                        "author": {"name": "Carol", "username": "carol"},
+                        "author": {"id": 3, "name": "Carol", "username": "carol"},
                         "system": false,
                         "resolved": false,
                         "position": null
@@ -1493,5 +1597,9 @@ mod tests {
             }
         ]"#
         .to_string()
+    }
+
+    fn gitlab_current_user_json() -> String {
+        serde_json::json!({"id": 2, "username": "bob"}).to_string()
     }
 }

--- a/crates/ag-forge/src/lib.rs
+++ b/crates/ag-forge/src/lib.rs
@@ -23,10 +23,11 @@ pub(crate) use command::{
 pub(crate) use github::GitHubReviewRequestAdapter;
 pub(crate) use gitlab::GitLabReviewRequestAdapter;
 pub use model::{
-    CreateReviewRequestInput, ForgeFuture, ForgeKind, ForgeRemote, ReviewComment,
-    ReviewCommentAnchorSide, ReviewCommentSnapshot, ReviewCommentThread, ReviewRequestError,
-    ReviewRequestMetadata, ReviewRequestMetadataFieldUpdate, ReviewRequestState,
-    ReviewRequestSummary, UpdateReviewRequestInput, is_gitlab_host,
+    AGENTTY_REVIEW_REPLY_MARKER_PREFIX, CreateReviewRequestInput, ForgeFuture, ForgeKind,
+    ForgeRemote, ReviewComment, ReviewCommentAnchorSide, ReviewCommentSnapshot,
+    ReviewCommentThread, ReviewRequestError, ReviewRequestMetadata,
+    ReviewRequestMetadataFieldUpdate, ReviewRequestState, ReviewRequestSummary,
+    UpdateReviewRequestInput, is_gitlab_host,
 };
 pub use remote::detect_remote;
 pub(crate) use remote::{parse_remote_url, strip_port};

--- a/crates/ag-forge/src/model.rs
+++ b/crates/ag-forge/src/model.rs
@@ -9,6 +9,10 @@ use std::str::FromStr;
 
 use url::Url;
 
+/// Prefix for the per-operation identity marker Agentty appends to review
+/// thread replies.
+pub const AGENTTY_REVIEW_REPLY_MARKER_PREFIX: &str = "<!-- agentty review resolution:";
+
 /// Shared forge family enum reused by persistence and forge adapters.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ForgeKind {
@@ -234,10 +238,31 @@ impl ForgeRemote {
 /// One inline review comment emitted by a reviewer on a forge review thread.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReviewComment {
-    /// Reviewer login or display name.
+    /// Forge author login or display name.
     pub author: String,
-    /// Markdown body as authored by the reviewer.
+    /// Whether the forge reports that the authenticated user authored this
+    /// comment.
+    pub authored_by_current_user: bool,
+    /// Markdown body as authored on the forge.
     pub body: String,
+}
+
+impl ReviewComment {
+    /// Returns whether this comment ends with an Agentty reply marker.
+    pub fn is_agentty_reply(&self) -> bool {
+        if !self.authored_by_current_user {
+            return false;
+        }
+        let Some((reply, marker)) = self.body.rsplit_once(AGENTTY_REVIEW_REPLY_MARKER_PREFIX)
+        else {
+            return false;
+        };
+        let Some(reply_token) = marker.strip_suffix(" -->") else {
+            return false;
+        };
+
+        reply.ends_with("\n\n") && is_uuid_like(reply_token)
+    }
 }
 
 /// Diff side used to anchor one inline review-thread comment.
@@ -279,13 +304,40 @@ pub struct ReviewCommentThread {
 }
 
 impl ReviewCommentThread {
-    /// Returns whether this thread remains open for a reply and resolution.
+    /// Returns whether this thread has an unaddressed reviewer message.
     ///
     /// Outdated threads remain actionable because their forge-native thread
-    /// identifiers survive after their original line anchors become stale.
+    /// identifiers survive after their original line anchors become stale. An
+    /// unresolved thread whose latest comment is an Agentty reply becomes
+    /// actionable again when a reviewer adds a follow-up comment.
     pub fn is_actionable(&self) -> bool {
-        !self.is_resolved
+        !self.is_resolved && !self.is_addressed_by_agentty()
     }
+
+    /// Returns whether Agentty authored the latest comment on this unresolved
+    /// thread.
+    pub fn is_addressed_by_agentty(&self) -> bool {
+        !self.is_resolved
+            && self
+                .comments
+                .last()
+                .is_some_and(ReviewComment::is_agentty_reply)
+    }
+}
+
+/// Returns whether `value` has the canonical hyphenated UUID shape used for
+/// review-reply tokens.
+fn is_uuid_like(value: &str) -> bool {
+    const GROUP_LENGTHS: [usize; 5] = [8, 4, 4, 4, 12];
+
+    value
+        .split('-')
+        .map(str::as_bytes)
+        .zip(GROUP_LENGTHS)
+        .all(|(group, expected_length)| {
+            group.len() == expected_length && group.iter().all(u8::is_ascii_hexdigit)
+        })
+        && value.matches('-').count() == GROUP_LENGTHS.len() - 1
 }
 
 /// Full review-comments payload captured for one review request.
@@ -541,18 +593,73 @@ mod tests {
     }
 
     #[test]
-    fn review_comment_thread_is_actionable_when_unresolved_even_if_outdated() {
+    fn review_comment_thread_is_actionable_until_agentty_addresses_latest_feedback() {
         // Arrange
         let actionable = review_comment_thread();
         let mut resolved = review_comment_thread();
         resolved.is_resolved = true;
         let mut outdated = review_comment_thread();
         outdated.is_outdated = Some(true);
+        let mut addressed = review_comment_thread();
+        addressed.comments.push(ReviewComment {
+            author: "agentty".to_string(),
+            authored_by_current_user: true,
+            body: [
+                "No change needed.\n\n",
+                AGENTTY_REVIEW_REPLY_MARKER_PREFIX,
+                "123e4567-e89b-12d3-a456-426614174000 -->",
+            ]
+            .concat(),
+        });
+        let mut followed_up = addressed.clone();
+        followed_up.comments.push(ReviewComment {
+            author: "reviewer".to_string(),
+            authored_by_current_user: false,
+            body: "Please reconsider.".to_string(),
+        });
+        let mut reviewer_marker = review_comment_thread();
+        reviewer_marker.comments.push(ReviewComment {
+            author: "reviewer".to_string(),
+            authored_by_current_user: false,
+            body: [
+                "Please reconsider.\n\n",
+                AGENTTY_REVIEW_REPLY_MARKER_PREFIX,
+                "123e4567-e89b-12d3-a456-426614174000 -->",
+            ]
+            .concat(),
+        });
 
         // Act, Assert
         assert!(actionable.is_actionable());
         assert!(!resolved.is_actionable());
         assert!(outdated.is_actionable());
+        assert!(addressed.is_addressed_by_agentty());
+        assert!(!addressed.is_actionable());
+        assert!(!followed_up.is_addressed_by_agentty());
+        assert!(followed_up.is_actionable());
+        assert!(!reviewer_marker.is_addressed_by_agentty());
+        assert!(reviewer_marker.is_actionable());
+    }
+
+    #[test]
+    fn review_comment_rejects_malformed_agentty_reply_markers() {
+        // Arrange
+        let malformed_comments = [
+            "Ordinary comment",
+            "No separator<!-- agentty review resolution:123e4567-e89b-12d3-a456-426614174000 -->",
+            "No terminator\n\n<!-- agentty review resolution:123e4567-e89b-12d3-a456-426614174000",
+            "Bad token\n\n<!-- agentty review resolution:not-a-uuid -->",
+        ];
+
+        // Act
+        let results = malformed_comments.map(|body| ReviewComment {
+            author: "agentty".to_string(),
+            authored_by_current_user: true,
+            body: body.to_string(),
+        });
+
+        // Assert
+        assert!(results.iter().all(|comment| !comment.is_agentty_reply()));
     }
 
     #[test]

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -2969,6 +2969,7 @@ mod tests {
             anchor_side: ReviewCommentAnchorSide::New,
             comments: vec![ReviewComment {
                 author: "reviewer".to_string(),
+                authored_by_current_user: false,
                 body: "Review comment".to_string(),
             }],
             id: id.to_string(),

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -5702,6 +5702,7 @@ fn review_comment_snapshot() -> forge::ReviewCommentSnapshot {
     forge::ReviewCommentSnapshot {
         pr_level_comments: vec![forge::ReviewComment {
             author: "alice".to_string(),
+            authored_by_current_user: false,
             body: "Looks good.".to_string(),
         }],
         threads: Vec::new(),

--- a/crates/agentty/src/app/prompt_intent.rs
+++ b/crates/agentty/src/app/prompt_intent.rs
@@ -1554,6 +1554,7 @@ mod tests {
         ReviewCommentSnapshot {
             pr_level_comments: vec![ReviewComment {
                 author: "general-reviewer".to_string(),
+                authored_by_current_user: false,
                 body: "Update the overview.".to_string(),
             }],
             threads: vec![
@@ -1582,6 +1583,7 @@ mod tests {
             anchor_side: ReviewCommentAnchorSide::New,
             comments: vec![ReviewComment {
                 author: "inline-reviewer".to_string(),
+                authored_by_current_user: false,
                 body: "Add validation.".to_string(),
             }],
             id: id.to_string(),

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -3176,6 +3176,7 @@ fn review_comment_resolution_snapshot() -> ReviewCommentSnapshot {
             anchor_side: ReviewCommentAnchorSide::New,
             comments: vec![ReviewComment {
                 author: "reviewer".to_string(),
+                authored_by_current_user: false,
                 body: "Add validation.".to_string(),
             }],
             id: "thread-42".to_string(),

--- a/crates/agentty/src/app/session/workflow/published_branch.rs
+++ b/crates/agentty/src/app/session/workflow/published_branch.rs
@@ -23,9 +23,6 @@ use crate::domain::session_message::SessionTranscript;
 use crate::domain::transcript_notice::TranscriptNotice;
 use crate::infra::db::{AppRepositories, SessionReviewCommentResolutionRow};
 
-/// Prefix for the per-operation marker appended to forge replies.
-const REVIEW_COMMENT_REPLY_MARKER_PREFIX: &str = "<!-- agentty review resolution:";
-
 /// Result of ensuring one durable operation has an Agentty-authored reply.
 enum ReviewCommentReplyProgress {
     /// The durable operation proves the reply was posted.
@@ -675,7 +672,10 @@ async fn remove_review_comment_operation(
 
 /// Appends an operation-specific non-rendering identity marker to one reply.
 fn review_comment_reply_body(reply: &str, reply_token: &str) -> String {
-    format!("{reply}\n\n{REVIEW_COMMENT_REPLY_MARKER_PREFIX}{reply_token} -->")
+    format!(
+        "{reply}\n\n{}{reply_token} -->",
+        forge::AGENTTY_REVIEW_REPLY_MARKER_PREFIX
+    )
 }
 
 /// Reports that durable review-comment work could not be loaded after push.
@@ -1346,6 +1346,7 @@ mod tests {
             .comments
             .push(forge::ReviewComment {
                 author: "agentty".to_string(),
+                authored_by_current_user: true,
                 body: review_comment_reply_body("Addressed fixed.", "token-fixed"),
             });
         let mut review_request_client = MockReviewRequestClient::new();
@@ -1400,6 +1401,7 @@ mod tests {
             .comments
             .push(forge::ReviewComment {
                 author: "collaborator".to_string(),
+                authored_by_current_user: false,
                 body: review_comment_reply_body("Addressed fixed.", "token-fixed"),
             });
         let mut review_request_client = MockReviewRequestClient::new();
@@ -1753,6 +1755,7 @@ mod tests {
             .comments
             .push(forge::ReviewComment {
                 author: "agentty".to_string(),
+                authored_by_current_user: true,
                 body: review_comment_reply_body("Addressed fixed.", "token-fixed"),
             });
         let mut review_request_client = MockReviewRequestClient::new();

--- a/crates/agentty/src/app/task.rs
+++ b/crates/agentty/src/app/task.rs
@@ -1874,6 +1874,7 @@ mod tests {
         ReviewCommentSnapshot {
             pr_level_comments: vec![ReviewComment {
                 author: "alice".to_string(),
+                authored_by_current_user: false,
                 body: "Looks ready.".to_string(),
             }],
             threads: Vec::new(),

--- a/crates/agentty/src/presentation/review_comment.rs
+++ b/crates/agentty/src/presentation/review_comment.rs
@@ -218,6 +218,7 @@ mod tests {
         ]);
         snapshot.pr_level_comments.push(ReviewComment {
             author: "reviewer".to_string(),
+            authored_by_current_user: false,
             body: "Standalone comment".to_string(),
         });
 
@@ -277,6 +278,7 @@ mod tests {
         let mut snapshot = snapshot_with_threads([thread("thread", false)]);
         snapshot.pr_level_comments.push(ReviewComment {
             author: "reviewer".to_string(),
+            authored_by_current_user: false,
             body: "Standalone comment".to_string(),
         });
         let rows = grouped_review_comment_rows(&snapshot);
@@ -394,6 +396,7 @@ mod tests {
             anchor_side: ReviewCommentAnchorSide::New,
             comments: vec![ReviewComment {
                 author: "reviewer".to_string(),
+                authored_by_current_user: false,
                 body: "Review comment".to_string(),
             }],
             id: id.to_string(),

--- a/crates/agentty/src/runtime/mode/review_comment.rs
+++ b/crates/agentty/src/runtime/mode/review_comment.rs
@@ -289,12 +289,14 @@ mod tests {
         ReviewCommentSnapshot {
             pr_level_comments: vec![ReviewComment {
                 author: "alice".to_string(),
+                authored_by_current_user: false,
                 body: "General comment".to_string(),
             }],
             threads: vec![ReviewCommentThread {
                 anchor_side: ReviewCommentAnchorSide::New,
                 comments: vec![ReviewComment {
                     author: "bob".to_string(),
+                    authored_by_current_user: false,
                     body: "Inline comment".to_string(),
                 }],
                 id: "thread-id".to_string(),

--- a/crates/agentty/src/ui/page/review_comment.rs
+++ b/crates/agentty/src/ui/page/review_comment.rs
@@ -610,6 +610,7 @@ mod tests {
             anchor_side: ReviewCommentAnchorSide::New,
             comments: vec![ReviewComment {
                 author: "alice".to_string(),
+                authored_by_current_user: false,
                 body: "Please explain this output.".to_string(),
             }],
             id: "thread-id".to_string(),
@@ -626,6 +627,7 @@ mod tests {
             anchor_side: ReviewCommentAnchorSide::File,
             comments: vec![ReviewComment {
                 author: "bob".to_string(),
+                authored_by_current_user: false,
                 body: "Please review the whole file.".to_string(),
             }],
             id: "thread-id".to_string(),
@@ -647,6 +649,7 @@ mod tests {
         ReviewCommentSnapshot {
             pr_level_comments: vec![ReviewComment {
                 author: "alice".to_string(),
+                authored_by_current_user: false,
                 body: "General comment".to_string(),
             }],
             threads: vec![thread],
@@ -1176,6 +1179,7 @@ mod tests {
         let snapshot = ReviewCommentSnapshot {
             pr_level_comments: vec![ReviewComment {
                 author: "bob".to_string(),
+                authored_by_current_user: false,
                 body: "General note".to_string(),
             }],
             threads: vec![inline_thread(2), inline_thread(3)],
@@ -1199,6 +1203,7 @@ mod tests {
         let snapshot = ReviewCommentSnapshot {
             pr_level_comments: vec![ReviewComment {
                 author: "bob".to_string(),
+                authored_by_current_user: false,
                 body: "Standalone note".to_string(),
             }],
             threads: vec![resolved, unresolved],
@@ -1227,6 +1232,7 @@ mod tests {
         let snapshot = ReviewCommentSnapshot {
             pr_level_comments: vec![ReviewComment {
                 author: "bob".to_string(),
+                authored_by_current_user: false,
                 body: "General note".to_string(),
             }],
             threads: vec![current, resolved, outdated],
@@ -1261,6 +1267,7 @@ mod tests {
         let snapshot = ReviewCommentSnapshot {
             pr_level_comments: vec![ReviewComment {
                 author: "bob".to_string(),
+                authored_by_current_user: false,
                 body: "Standalone note".to_string(),
             }],
             threads: vec![resolved],

--- a/crates/agentty/src/ui/review_comment_format.rs
+++ b/crates/agentty/src/ui/review_comment_format.rs
@@ -40,12 +40,18 @@ pub(crate) fn thread_header_line(
     } else {
         ""
     };
+    let addressed_tag = if thread.is_addressed_by_agentty() {
+        "  ·  addressed"
+    } else {
+        ""
+    };
 
     Line::from(vec![
         Span::styled(anchor, anchor_style),
         Span::styled(
             format!(
-                "  ·  {side_tag}  ·  {comment_count} comments  ·  {resolution_tag}{outdated_tag}"
+                "  ·  {side_tag}  ·  {comment_count} comments  ·  \
+                 {resolution_tag}{outdated_tag}{addressed_tag}"
             ),
             Style::default().fg(style::palette::text_muted()),
         ),
@@ -118,6 +124,7 @@ mod tests {
             anchor_side: ReviewCommentAnchorSide::Old,
             comments: vec![ReviewComment {
                 author: "alice".to_string(),
+                authored_by_current_user: false,
                 body: "Please check this.".to_string(),
             }],
             id: "thread-id".to_string(),
@@ -145,6 +152,7 @@ mod tests {
             anchor_side: ReviewCommentAnchorSide::New,
             comments: vec![ReviewComment {
                 author: "alice".to_string(),
+                authored_by_current_user: false,
                 body: "Please check these lines.".to_string(),
             }],
             id: "thread-id".to_string(),
@@ -166,11 +174,45 @@ mod tests {
     }
 
     #[test]
+    fn test_thread_header_line_marks_unresolved_agentty_reply_as_addressed() {
+        // Arrange
+        let thread = ReviewCommentThread {
+            anchor_side: ReviewCommentAnchorSide::New,
+            comments: vec![ReviewComment {
+                author: "agentty".to_string(),
+                authored_by_current_user: true,
+                body: concat!(
+                    "No change needed.\n\n",
+                    "<!-- agentty review resolution:",
+                    "123e4567-e89b-12d3-a456-426614174000 -->",
+                )
+                .to_string(),
+            }],
+            id: "thread-id".to_string(),
+            is_outdated: Some(false),
+            is_resolved: false,
+            line: Some(12),
+            path: "src/lib.rs".to_string(),
+            start_line: None,
+        };
+
+        // Act
+        let line = thread_header_line(&thread, Style::default());
+
+        // Assert
+        assert_eq!(
+            line.to_string(),
+            "src/lib.rs:12  ·  new  ·  1 comments  ·  unresolved  ·  addressed"
+        );
+    }
+
+    #[test]
     fn test_append_comment_bodies_indents_markdown_under_author() {
         // Arrange
         let mut lines = Vec::new();
         let comments = vec![ReviewComment {
             author: "alice".to_string(),
+            authored_by_current_user: false,
             body: "**Looks** good.".to_string(),
         }];
         let markdown_render_cache = markdown::MarkdownRenderCache::default();
@@ -194,6 +236,7 @@ mod tests {
         let mut lines = Vec::new();
         let comments = vec![ReviewComment {
             author: "alice".to_string(),
+            authored_by_current_user: false,
             body: concat!(
                 "<!-- hidden reviewer note -->",
                 "<p><strong>Explain</strong> this output.<br>",
@@ -226,10 +269,12 @@ mod tests {
         let comments = vec![
             ReviewComment {
                 author: "alice".to_string(),
+                authored_by_current_user: false,
                 body: "First".to_string(),
             },
             ReviewComment {
                 author: "bob".to_string(),
+                authored_by_current_user: false,
                 body: "Second".to_string(),
             },
         ];

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -3385,6 +3385,43 @@ esac
     Ok(())
 }
 
+/// Seeds one unresolved thread whose latest comment is a prior Agentty reply.
+fn seed_addressed_review_comment(env: &BuilderEnv) -> Result<(), Box<dyn std::error::Error>> {
+    seed_review_ready_session_with_review_request(env)?;
+    seed_sessions_startup_tab(env)?;
+
+    let gh_path = env.stub_bin.join("gh");
+    std::fs::write(
+        &gh_path,
+        r#"#!/bin/sh
+case "$*" in
+  *"auth status"*)
+    exit 0
+    ;;
+  *"reviewThreads(first:"*)
+    cat <<'JSON'
+[{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-addressed","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":2,"path":"src/main.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"alice"},"body":"Please explain this output.","viewerDidAuthor":false},{"author":{"login":"agentty-bot"},"body":"No change is needed.\n\n<!-- agentty review resolution:123e4567-e89b-12d3-a456-426614174000 -->","viewerDidAuthor":true}],"pageInfo":{"hasNextPage":false,"endCursor":null}}},{"id":"thread-reviewer-marker","diffSide":"RIGHT","isOutdated":false,"isResolved":false,"line":2,"path":"src/reviewer.rs","startLine":null,"subjectType":"LINE","comments":{"nodes":[{"author":{"login":"mallory"},"body":"Still needs work.\n\n<!-- agentty review resolution:123e4567-e89b-12d3-a456-426614174000 -->","viewerDidAuthor":false}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]
+JSON
+    ;;
+  *"comments(first:"*)
+    printf '%s\n' '[{"data":{"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]'
+    ;;
+  *"pr view"*)
+    printf '%s\n' '{"number":42,"title":"Review-ready session shortcuts","state":"OPEN","url":"https://github.com/agentty-xyz/agentty/pull/42","baseRefName":"main","headRefName":"wt/review-s","isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"REVIEW_REQUIRED","mergedAt":null}'
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 1
+    ;;
+esac
+"#,
+    )?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&gh_path, std::fs::Permissions::from_mode(0o750))?;
+
+    Ok(())
+}
+
 /// Seeds the linked-review fixture with a delayed Claude turn so the feature
 /// scenario can observe the review-resolution loader in progress.
 fn seed_review_comment_agent_resolution(
@@ -9026,6 +9063,66 @@ fn test_review_comments_escape_focuses_files() -> E2eResult {
                 assertion::assert_text_in_region(frame, "Files", &full);
                 assertion::assert_text_in_region(frame, "c: comments", &full);
                 assertion::assert_not_visible(frame, "Space: select");
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify an unchanged unresolved thread cannot be submitted again after an
+/// Agentty reply, while remaining visible for reviewer follow-up.
+#[test]
+fn test_review_comment_addressed_guard() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("review_comment_addressed_guard")
+        .with_git()
+        .with_terminal_size(160, 60)
+        .setup(seed_addressed_review_comment)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::open_selected_session_view())
+                    .press_key("d")
+                    .wait_for_text("c: comments", 5000)
+                    .press_key("c")
+                    .wait_for_text("addressed", 5000)
+                    .press_key("Space")
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled(
+                        "agentty_addressed",
+                        "Agentty-authored marker disables unchanged feedback",
+                    )
+                    .press_key("j")
+                    .wait_for_text("Space: select", 5000)
+                    .press_key("Space")
+                    .wait_for_text("[x]", 5000)
+                    .wait_for_stable_frame(300, 5000)
+            },
+            |frame, report| {
+                let addressed_frame = common::frame_from_capture(&report.captures[0]);
+                let addressed_full = Region::full(addressed_frame.cols(), addressed_frame.rows());
+                assertion::assert_text_in_region(
+                    &addressed_frame,
+                    "unresolved  ·  addressed",
+                    &addressed_full,
+                );
+                assertion::assert_text_in_region(
+                    &addressed_frame,
+                    "No change is needed.",
+                    &addressed_full,
+                );
+                assertion::assert_not_visible(&addressed_frame, "[x]");
+                assertion::assert_not_visible(&addressed_frame, "Space: select");
+                assertion::assert_not_visible(&addressed_frame, "Enter: submit");
+
+                let full = Region::full(frame.cols(), frame.rows());
+
+                assertion::assert_text_in_region(frame, "Still needs work.", &full);
+                assertion::assert_text_in_region(frame, "[x]", &full);
+                assertion::assert_text_in_region(frame, "Selected 1", &full);
+                assertion::assert_text_in_region(frame, "Space: select", &full);
+                assertion::assert_text_in_region(frame, "Enter: submit", &full);
             },
         )?;
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -673,25 +673,30 @@ can retry without reporting a false terminal cancellation.
   an already published branch, it refreshes the live threads, posts the agent's concise
   reply for every valid allowlisted outcome, and resolves only threads reported as
   `fixed`. Threads reported as `no_change_needed` receive their explanatory reply but
-  remain open. Unknown thread IDs are ignored. Unresolved outdated threads remain
-  actionable through their forge thread ID while their stale line anchor is omitted from
-  current diff context. Agentty saves each operation's original reply and random marker
-  token in the same database transaction that completes the agent turn, so restart
-  recovery cannot observe one without the other. It flags the operation immediately
-  before posting and deletes it after completion, so a later successful branch push
-  resumes saved work and reuses a reply that reached the forge before an interruption
-  instead of posting it twice. A new agent response cannot replace a bound unfinished
-  operation's saved reply, and an unrelated comment that copies Agentty's old static
-  marker is not accepted as its audit reply. Commit, reply, resolution, and
-  missing-open-review failures produce a `[Review Comments Warning]` transcript notice.
-  A commit failure discards that review batch, so a later unrelated push cannot apply
-  its stale outcomes; reopen the comments to retry. A push failure keeps a successfully
-  committed batch for the next push attempt. Before applying that batch, Agentty
-  verifies the pushed tip still exactly matches its saved fix commit. Any later commit,
-  including a revert, causes Agentty to discard the saved outcomes and require a fresh
-  review batch. If shutdown or persistence failure interrupts commit binding, Agentty
-  keeps the unbound batch pending, reports that a fresh agent turn is required, and lets
-  that turn replace only the unbound operation.
+  remain open. While an authenticated Agentty reply is the thread's latest comment, the
+  thread is shown as `addressed` and cannot be submitted again. The forge-reported
+  authorship and Agentty's reply marker must both match, so a reviewer-authored marker
+  cannot suppress feedback. A later reviewer follow-up makes the thread actionable
+  again, preventing repeated replies to unchanged feedback without hiding new feedback.
+  Unknown thread IDs are ignored. Unresolved outdated threads remain actionable through
+  their forge thread ID while their stale line anchor is omitted from current diff
+  context. Agentty saves each operation's original reply and random marker token in the
+  same database transaction that completes the agent turn, so restart recovery cannot
+  observe one without the other. It flags the operation immediately before posting and
+  deletes it after completion, so a later successful branch push resumes saved work and
+  reuses a reply that reached the forge before an interruption instead of posting it
+  twice. A new agent response cannot replace a bound unfinished operation's saved reply,
+  and an unrelated comment that copies Agentty's old static marker is not accepted as
+  its audit reply. Commit, reply, resolution, and missing-open-review failures produce a
+  `[Review Comments Warning]` transcript notice. A commit failure discards that review
+  batch, so a later unrelated push cannot apply its stale outcomes; reopen the comments
+  to retry. A push failure keeps a successfully committed batch for the next push
+  attempt. Before applying that batch, Agentty verifies the pushed tip still exactly
+  matches its saved fix commit. Any later commit, including a revert, causes Agentty to
+  discard the saved outcomes and require a fresh review batch. If shutdown or
+  persistence failure interrupts commit binding, Agentty keeps the unbound batch
+  pending, reports that a fresh agent turn is required, and lets that turn replace only
+  the unbound operation.
 
 <a id="usage-review-request-prerequisites"></a> Publishing needs regular Git
 authentication (credential helper or PAT for HTTPS remotes, SSH key for SSH remotes)


### PR DESCRIPTION
- Shares a canonical marker and verifies forge-reported authorship before recognizing Agentty review replies.
- Keeps addressed threads visible but non-actionable until reviewer follow-up, and labels them in the TUI.
- Fetches the authenticated GitLab user to apply the same identity check to merge-request discussions.