### PR TITLE
Expire terminal project-sync status after ten seconds

### DIFF
--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -1278,6 +1278,7 @@ impl App {
                 message: Self::sync_failure_message(error),
             },
         };
+        self.schedule_project_sync_status_expiry();
     }
 
     /// Applies completed linked-session comment loads only while the matching

--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -185,6 +185,7 @@ impl App {
             merge_queue: crate::app::merge_queue::MergeQueue::default(),
             next_sync_operation_id: 1,
             project_sync_status: None,
+            project_sync_status_expires_at: None,
             session_progress_messages: std::collections::HashMap::new(),
             update_status: None,
             sync_handle,

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Instant;
 
 use ag_agent::{AgentAvailabilityProbe, AppServerClient, RealAgentAvailabilityProbe};
 #[cfg(test)]
@@ -28,8 +29,8 @@ use app::session::SessionManager;
 use app::session_runtime::SessionRuntime;
 use app::setting::SettingsManager;
 use app::sync::{
-    ProjectSyncContext, ProjectSyncPhase, ProjectSyncStatus, SyncMainCompletion, SyncMainRequest,
-    SyncMainRunner,
+    PROJECT_SYNC_STATUS_VISIBLE_DURATION, ProjectSyncContext, ProjectSyncPhase, ProjectSyncStatus,
+    SyncMainCompletion, SyncMainRequest, SyncMainRunner,
 };
 use app::tab::TabManager;
 use app::{sync, task};
@@ -307,6 +308,8 @@ pub struct App {
     pub(crate) sync_main_runner: Arc<dyn SyncMainRunner>,
     /// Latest non-modal explicit project-sync lifecycle state.
     pub(crate) project_sync_status: Option<ProjectSyncStatus>,
+    /// Deadline after which the terminal project-sync result is removed.
+    pub(crate) project_sync_status_expires_at: Option<Instant>,
     /// Owns the active-project sync orchestrator command and context
     /// channels.
     pub(crate) sync_handle: sync::SyncHandle,
@@ -1570,6 +1573,7 @@ impl App {
                     message: "a merge is active or queued; try again after it finishes".to_string(),
                 },
             });
+            self.schedule_project_sync_status_expiry();
             self.mark_dirty();
 
             return;
@@ -1606,6 +1610,7 @@ impl App {
 
     /// Starts one request after the foreground mutation slot is reserved.
     fn dispatch_sync_main_request(&mut self, request: SyncMainRequest) {
+        self.project_sync_status_expires_at = None;
         self.project_sync_status = Some(ProjectSyncStatus {
             context: request.operation.clone(),
             phase: ProjectSyncPhase::Running,
@@ -1618,6 +1623,26 @@ impl App {
             request.session_model,
             request.sync_context,
         );
+    }
+
+    /// Keeps the current terminal sync result visible for a short period.
+    pub(super) fn schedule_project_sync_status_expiry(&mut self) {
+        self.project_sync_status_expires_at =
+            Some(self.services.clock().now_instant() + PROJECT_SYNC_STATUS_VISIBLE_DURATION);
+    }
+
+    /// Clears a terminal sync result once its visibility deadline is reached.
+    pub(crate) fn expire_project_sync_status(&mut self, now: Instant) {
+        if self
+            .project_sync_status_expires_at
+            .is_none_or(|expires_at| now < expires_at)
+        {
+            return;
+        }
+
+        self.project_sync_status = None;
+        self.project_sync_status_expires_at = None;
+        self.mark_dirty();
     }
 
     /// Starts the oldest queued project sync when base-checkout mutation is

--- a/crates/agentty/src/app/core/state_test.rs
+++ b/crates/agentty/src/app/core/state_test.rs
@@ -3018,6 +3018,71 @@ async fn project_sync_completion_preserves_the_active_navigation_mode() {
             ..
         })
     ));
+    assert!(app.project_sync_status_expires_at.is_some());
+}
+
+#[tokio::test]
+async fn project_sync_terminal_status_expires_at_its_deadline() {
+    // Arrange
+    let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+    let project_id = app.active_project_id();
+    app.project_sync_status = Some(sync::ProjectSyncStatus {
+        context: sync::ProjectSyncContext {
+            default_branch: "main".to_string(),
+            operation_id: 1,
+            project_id,
+            project_name: "agentty".to_string(),
+        },
+        phase: sync::ProjectSyncPhase::Running,
+    });
+    app.apply_app_events(successful_manual_sync(project_id, "main", 2))
+        .await;
+    let expires_at = app
+        .project_sync_status_expires_at
+        .expect("terminal sync status should have an expiry");
+
+    // Act
+    app.expire_project_sync_status(
+        expires_at
+            .checked_sub(Duration::from_millis(1))
+            .expect("sync status expiry should be after the monotonic clock origin"),
+    );
+
+    // Assert
+    assert!(app.project_sync_status.is_some());
+
+    // Act
+    app.clear_redraw();
+    app.expire_project_sync_status(expires_at);
+
+    // Assert
+    assert!(app.project_sync_status.is_none());
+    assert!(app.project_sync_status_expires_at.is_none());
+    assert!(app.needs_redraw());
+}
+
+#[tokio::test]
+async fn project_sync_running_status_has_no_expiry() {
+    // Arrange
+    let (mut app, _base_dir) = crate::test_support::new_git_test_app().await;
+    let mut sync_main_runner = crate::app::MockSyncMainRunner::new();
+    sync_main_runner
+        .expect_start_sync_main()
+        .times(1)
+        .returning(|_, _, _, _| {});
+    app.sync_main_runner = Arc::new(sync_main_runner);
+
+    // Act
+    app.start_sync_main();
+    let future = app.services.clock().now_instant() + Duration::from_secs(60);
+    app.expire_project_sync_status(future);
+
+    // Assert
+    assert!(matches!(
+        app.project_sync_status.as_ref().map(|status| &status.phase),
+        Some(sync::ProjectSyncPhase::Running)
+    ));
+    assert!(app.project_sync_status_expires_at.is_none());
 }
 
 #[tokio::test]
@@ -3349,6 +3414,7 @@ async fn project_sync_is_blocked_while_merge_work_is_pending() {
         Some(sync::ProjectSyncPhase::Blocked { message })
             if message.contains("merge is active or queued")
     ));
+    assert!(app.project_sync_status_expires_at.is_some());
 }
 
 #[tokio::test]

--- a/crates/agentty/src/app/sync.rs
+++ b/crates/agentty/src/app/sync.rs
@@ -30,6 +30,8 @@ use crate::domain::session::{ReviewRequestState, SessionId};
 
 /// Seconds between background read-only sync passes.
 const SYNC_TICK_INTERVAL_SECONDS: u64 = 30;
+/// Duration terminal project-sync results remain visible in the status bar.
+pub(crate) const PROJECT_SYNC_STATUS_VISIBLE_DURATION: Duration = Duration::from_secs(10);
 /// Number of ticks between review-request refresh passes, so forge CLIs are
 /// polled at half the git-status cadence.
 const REVIEW_REQUEST_PASS_TICKS: u64 = 2;

--- a/crates/agentty/src/runtime/core.rs
+++ b/crates/agentty/src/runtime/core.rs
@@ -233,6 +233,8 @@ where
     async fn run_cycle(&mut self) -> io::Result<EventResult> {
         self.app.process_pending_app_events().await;
         self.app.reconcile_open_session_question_mode().await;
+        self.app
+            .expire_project_sync_status(self.clock.now_instant());
         render_frame(
             self.app,
             self.terminal,

--- a/crates/agentty/tests/e2e/project.rs
+++ b/crates/agentty/tests/e2e/project.rs
@@ -258,11 +258,30 @@ fn test_project_sync_non_modal() {
                         "sync_complete",
                         "Project sync completes in the status bar without a popup",
                     )
+                    .sleep_ms(10_500)
+                    .capture_labeled(
+                        "sync_status_expired",
+                        "The status bar returns to its normal page hint",
+                    )
             },
             |frame, report| {
                 let full = Region::full(frame.cols(), frame.rows());
-                assertion::assert_text_in_region(frame, "Synced zeta-project/main", &full);
+                assertion::assert_not_visible(frame, "Synced zeta-project/main");
+                assertion::assert_text_in_region(frame, "FYI:", &full);
                 assertion::assert_not_visible(frame, "Sync complete");
+
+                let complete_capture = report
+                    .captures
+                    .iter()
+                    .find(|capture| capture.label == "sync_complete")
+                    .expect("missing completed sync capture");
+                let complete_frame = common::frame_from_capture(complete_capture);
+                let complete_full = Region::full(complete_frame.cols(), complete_frame.rows());
+                assertion::assert_text_in_region(
+                    &complete_frame,
+                    "Synced zeta-project/main",
+                    &complete_full,
+                );
 
                 let syncing_capture = report
                     .captures

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -827,12 +827,13 @@ orchestration paths:
   event carries the captured project and operation IDs, so project switching cannot
   redirect Git work, and a stale completion cannot replace a newer status or reconcile
   superseded review and merged-session state. The lifecycle state is separate from
-  `AppMode`; navigation and unrelated overlays therefore remain active. Base-checkout
-  operations for the owning project—session creation or draft start, merge, and
-  rebase—fail with retryable workflow guidance until the operation settles, while
-  isolated session turns and other projects remain usable. If completion arrives while
-  another project is active, project-scoped review and merged-session reconciliation is
-  retained in memory and applied after switching back.
+  `AppMode`; navigation and unrelated overlays therefore remain active. Terminal display
+  state expires after ten seconds, independently of deferred project reconciliation.
+  Base-checkout operations for the owning project—session creation or draft start,
+  merge, and rebase—fail with retryable workflow guidance until the operation settles,
+  while isolated session turns and other projects remain usable. If completion arrives
+  while another project is active, project-scoped review and merged-session
+  reconciliation is retained in memory and applied after switching back.
 - Session merge: queue-aware workflow for sessions without a linked forge review request
   — assisted rebase first, squash commit into the base branch reusing the session-branch
   `HEAD` commit message, then worktree cleanup and status `Done`. Once a review request

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -90,7 +90,8 @@ has priority: requesting sync while a merge is active or queued reports retryabl
 guidance in the status bar, and a queued merge rechecks the sync guard before it starts.
 If the sync stops on rebase conflicts, the status bar reports the number of files handed
 to the assist agent. Completion, blocked preflight, and failure summaries remain in that
-bar instead of opening a popup.
+bar for ten seconds instead of opening a popup, then the page's normal `FYI:` message
+returns.
 
 ## Session Lifecycle
 


### PR DESCRIPTION
- Keep terminal completion, blocked, and failure summaries visible for ten seconds before clearing them.
- Preserve running status and project-scoped reconciliation while terminal display state expires independently.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)