### PR TITLE
Muse Spark 1.3 replaces the 1.2 model catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- ag-harness: replace the Muse Spark 1.2 model catalog with Muse Spark 1.3.
+
 ## [v0.15.9] - 2026-08-31
 
 ### Added

--- a/crates/ag-harness-cli/README.md
+++ b/crates/ag-harness-cli/README.md
@@ -5,7 +5,7 @@ Interactive command-line chat powered by the `ag-harness` model runtime.
 Set the provider credentials, then start a chat:
 
 ```sh
-MODEL_API_KEY=your-key cargo run -p ag-harness-cli -- run muse-spark-1.2
+MODEL_API_KEY=your-key cargo run -p ag-harness-cli -- run muse-spark-1.3
 ```
 
 The package keeps the executable name `ag-harness`. The current directory is readable by

--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -5,9 +5,9 @@ Run a model with bounded repository tools and validated structured output.
 ## Library
 
 ```rust
-use ag_harness::{Harness, MUSE_SPARK_1_2, Muse, Tool};
+use ag_harness::{Harness, MUSE_SPARK_1_3, Muse, Tool};
 
-let harness = Harness::new(Muse::from_env(MUSE_SPARK_1_2)?)
+let harness = Harness::new(Muse::from_env(MUSE_SPARK_1_3)?)
     .repository(&repository_root)
     .allow(Tool::Read)
     .allow(Tool::Write);

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -33,7 +33,7 @@ pub use model::{
     ModelWithMetadata,
 };
 pub use provider::{
-    KIMI_K2_6, KimiConfig, MUSE_SPARK_1_2, MUSE_SPARK_1_2_CONTRIBUTOR, ModelConfiguration,
+    KIMI_K2_6, KimiConfig, MUSE_SPARK_1_3, MUSE_SPARK_1_3_CONTRIBUTOR, ModelConfiguration,
     ModelConfigurationError, ModelProvider, ModelProviderParseError, Muse, MuseConfig, QWEN_PLUS,
     QwenConfig,
 };

--- a/crates/ag-harness/src/provider.rs
+++ b/crates/ag-harness/src/provider.rs
@@ -11,6 +11,6 @@ pub use catalog::{
 pub(crate) use kimi::POLICY as KIMI_POLICY;
 pub use kimi::{KIMI_K2_6, KimiConfig};
 pub(crate) use muse::POLICY as MUSE_POLICY;
-pub use muse::{MUSE_SPARK_1_2, MUSE_SPARK_1_2_CONTRIBUTOR, Muse, MuseConfig};
+pub use muse::{MUSE_SPARK_1_3, MUSE_SPARK_1_3_CONTRIBUTOR, Muse, MuseConfig};
 pub(crate) use qwen::POLICY as QWEN_POLICY;
 pub use qwen::{QWEN_PLUS, QwenConfig};

--- a/crates/ag-harness/src/provider/catalog.rs
+++ b/crates/ag-harness/src/provider/catalog.rs
@@ -38,7 +38,7 @@ impl ModelProvider {
     pub const fn known_models(self) -> &'static [&'static str] {
         match self {
             Self::Kimi => &[kimi::KIMI_K2_6],
-            Self::Muse => &[muse::MUSE_SPARK_1_2, muse::MUSE_SPARK_1_2_CONTRIBUTOR],
+            Self::Muse => &[muse::MUSE_SPARK_1_3, muse::MUSE_SPARK_1_3_CONTRIBUTOR],
             Self::Qwen => &[qwen::QWEN_PLUS],
         }
     }
@@ -242,7 +242,7 @@ mod tests {
         );
         assert_eq!(
             ModelProvider::Muse.known_models(),
-            &["muse-spark-1.2", "muse-spark-1.2-contributor"]
+            &["muse-spark-1.3", "muse-spark-1.3-contributor"]
         );
         assert_eq!(ModelProvider::Kimi.known_models(), &["kimi-k2.6"]);
         assert_eq!(ModelProvider::Qwen.known_models(), &["qwen-plus"]);
@@ -311,8 +311,8 @@ mod tests {
     #[test]
     fn configuration_uses_default_and_explicit_base_urls() {
         // Arrange
-        let default = ModelConfiguration::new(ModelProvider::Muse, muse::MUSE_SPARK_1_2);
-        let explicit = ModelConfiguration::new(ModelProvider::Muse, muse::MUSE_SPARK_1_2)
+        let default = ModelConfiguration::new(ModelProvider::Muse, muse::MUSE_SPARK_1_3);
+        let explicit = ModelConfiguration::new(ModelProvider::Muse, muse::MUSE_SPARK_1_3)
             .base_url("https://cli.example/v1");
 
         // Act
@@ -368,7 +368,7 @@ mod tests {
     fn configuration_redacts_api_key_lookup_failures() {
         // Arrange
         let secret = "visible-secret-material";
-        let configuration = ModelConfiguration::new(ModelProvider::Muse, muse::MUSE_SPARK_1_2);
+        let configuration = ModelConfiguration::new(ModelProvider::Muse, muse::MUSE_SPARK_1_3);
 
         // Act
         let error = configuration
@@ -387,7 +387,7 @@ mod tests {
     #[test]
     fn configuration_reports_optional_environment_failures() {
         // Arrange
-        let configuration = ModelConfiguration::new(ModelProvider::Muse, muse::MUSE_SPARK_1_2);
+        let configuration = ModelConfiguration::new(ModelProvider::Muse, muse::MUSE_SPARK_1_3);
 
         // Act
         let error = configuration
@@ -414,7 +414,7 @@ mod tests {
     #[test]
     fn configuration_reports_missing_api_key() {
         // Arrange
-        let configuration = ModelConfiguration::new(ModelProvider::Muse, muse::MUSE_SPARK_1_2);
+        let configuration = ModelConfiguration::new(ModelProvider::Muse, muse::MUSE_SPARK_1_3);
 
         // Act
         let error = configuration

--- a/crates/ag-harness/src/provider/muse.rs
+++ b/crates/ag-harness/src/provider/muse.rs
@@ -13,13 +13,13 @@ pub(crate) const DEFAULT_BASE_URL: &str = "https://api.meta.ai/v1";
 pub(crate) const MODEL_API_BASE_URL_ENV: &str = "MODEL_API_BASE_URL";
 pub(crate) const MODEL_API_KEY_ENV: &str = "MODEL_API_KEY";
 
-/// Standard Muse Spark 1.2 model whose prompts and completions are not used
+/// Standard Muse Spark 1.3 model whose prompts and completions are not used
 /// to train Meta models.
-pub const MUSE_SPARK_1_2: &str = "muse-spark-1.2";
+pub const MUSE_SPARK_1_3: &str = "muse-spark-1.3";
 
-/// Discounted Muse Spark 1.2 model that permits Meta to use prompts and
+/// Discounted Muse Spark 1.3 model that permits Meta to use prompts and
 /// completions to train future models.
-pub const MUSE_SPARK_1_2_CONTRIBUTOR: &str = "muse-spark-1.2-contributor";
+pub const MUSE_SPARK_1_3_CONTRIBUTOR: &str = "muse-spark-1.3-contributor";
 
 pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
     chat_completion::ChatCompletionProviderPolicy {
@@ -147,7 +147,7 @@ mod tests {
     }
 
     fn muse(server: &MockServer) -> Muse {
-        Muse::from_environment(MUSE_SPARK_1_2, |name| {
+        Muse::from_environment(MUSE_SPARK_1_3, |name| {
             if name == MODEL_API_KEY_ENV {
                 Ok("test-key".to_string())
             } else {
@@ -170,23 +170,23 @@ mod tests {
     #[test]
     fn exposes_standard_and_contributor_model_identifiers() {
         // Arrange and Act
-        let models = [MUSE_SPARK_1_2, MUSE_SPARK_1_2_CONTRIBUTOR];
+        let models = [MUSE_SPARK_1_3, MUSE_SPARK_1_3_CONTRIBUTOR];
 
         // Assert
-        assert_eq!(models, ["muse-spark-1.2", "muse-spark-1.2-contributor"]);
+        assert_eq!(models, ["muse-spark-1.3", "muse-spark-1.3-contributor"]);
     }
 
     #[test]
     fn environment_configuration_uses_official_base_url_default() {
         // Arrange and Act
-        let muse = Muse::from_environment(MUSE_SPARK_1_2, default_environment)
+        let muse = Muse::from_environment(MUSE_SPARK_1_3, default_environment)
             .expect("fixture environment should be valid");
         let metadata = ModelWithMetadata::metadata(&muse)
             .expect("Muse should expose its configured model identity");
 
         // Assert
         assert_eq!(metadata.provider(), "meta");
-        assert_eq!(metadata.model(), MUSE_SPARK_1_2);
+        assert_eq!(metadata.model(), MUSE_SPARK_1_3);
     }
 
     #[test]
@@ -218,20 +218,20 @@ mod tests {
     #[ignore = "run by environment_configuration_from_env_runs_in_isolated_process"]
     fn environment_configuration_from_env_subprocess() {
         // Arrange and Act
-        let muse = Muse::from_env(MUSE_SPARK_1_2)
+        let muse = Muse::from_env(MUSE_SPARK_1_3)
             .expect("isolated process environment should configure Muse");
         let metadata = ModelWithMetadata::metadata(&muse)
             .expect("Muse should expose its configured model identity");
 
         // Assert
         assert_eq!(metadata.provider(), "meta");
-        assert_eq!(metadata.model(), MUSE_SPARK_1_2);
+        assert_eq!(metadata.model(), MUSE_SPARK_1_3);
     }
 
     #[test]
     fn environment_configuration_requires_api_key() {
         // Arrange and Act
-        let error = Muse::from_environment(MUSE_SPARK_1_2, |_| Err(env::VarError::NotPresent))
+        let error = Muse::from_environment(MUSE_SPARK_1_3, |_| Err(env::VarError::NotPresent))
             .err()
             .expect("missing API key should fail");
 
@@ -247,7 +247,7 @@ mod tests {
     #[test]
     fn environment_configuration_rejects_non_unicode_base_url() {
         // Arrange and Act
-        let error = Muse::from_environment(MUSE_SPARK_1_2, |name| {
+        let error = Muse::from_environment(MUSE_SPARK_1_3, |name| {
             if name == MODEL_API_KEY_ENV {
                 Ok("test-key".to_string())
             } else {
@@ -287,7 +287,7 @@ mod tests {
         let model = model::ModelClient::muse(MuseConfig {
             api_key: "test-key".to_string(),
             base_url: "https://api.meta.ai/v1".to_string(),
-            model: MUSE_SPARK_1_2_CONTRIBUTOR.to_string(),
+            model: MUSE_SPARK_1_3_CONTRIBUTOR.to_string(),
         })
         .expect("fixture configuration should be valid");
 
@@ -296,7 +296,7 @@ mod tests {
 
         // Assert
         assert_eq!(metadata.provider(), "meta");
-        assert_eq!(metadata.model(), "muse-spark-1.2-contributor");
+        assert_eq!(metadata.model(), "muse-spark-1.3-contributor");
     }
 
     #[test]
@@ -320,7 +320,7 @@ mod tests {
     #[test]
     fn configures_lifecycle_observer() {
         // Arrange
-        let muse = Muse::from_environment(MUSE_SPARK_1_2, default_environment)
+        let muse = Muse::from_environment(MUSE_SPARK_1_3, default_environment)
             .expect("fixture environment should be valid");
 
         // Act
@@ -329,7 +329,7 @@ mod tests {
 
         // Assert
         assert_eq!(metadata.provider(), "meta");
-        assert_eq!(metadata.model(), MUSE_SPARK_1_2);
+        assert_eq!(metadata.model(), MUSE_SPARK_1_3);
     }
 
     #[tokio::test]
@@ -343,7 +343,7 @@ mod tests {
                 "messages": [
                     {"content": "extract the name", "role": "user"}
                 ],
-                "model": "muse-spark-1.2",
+                "model": "muse-spark-1.3",
                 "response_format": response_format()
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -393,7 +393,7 @@ mod tests {
                 "messages": [
                     {"content": "inspect the manifest", "role": "user"}
                 ],
-                "model": "muse-spark-1.2",
+                "model": "muse-spark-1.3",
                 "response_format": response_format(),
                 "tools": [read_tool_wire()]
             })))
@@ -450,7 +450,7 @@ mod tests {
                 "messages": [
                     {"content": "inspect the manifest", "role": "user"}
                 ],
-                "model": "muse-spark-1.2",
+                "model": "muse-spark-1.3",
                 "response_format": response_format(),
                 "tools": [read_tool_wire()]
             })))
@@ -510,7 +510,7 @@ mod tests {
                         "tool_call_id": "call_muse_read"
                     }
                 ],
-                "model": "muse-spark-1.2",
+                "model": "muse-spark-1.3",
                 "response_format": response_format(),
                 "tools": [read_tool_wire()]
             })))

--- a/crates/ag-harness/tests/benchmark/main.rs
+++ b/crates/ag-harness/tests/benchmark/main.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use std::{env, fmt};
 
 use ag_harness::{
-    Harness, KimiConfig, MUSE_SPARK_1_2, ModelClient, ModelRequestActivity, ModelResponseType,
+    Harness, KimiConfig, MUSE_SPARK_1_3, ModelClient, ModelRequestActivity, ModelResponseType,
     MuseConfig, OutputSchema, QwenConfig, Tool, ToolActivity, TurnOutcome,
 };
 use serde_json::{Value, json};
@@ -292,7 +292,7 @@ impl Provider {
                 api_key: env::var("MODEL_API_KEY")?,
                 base_url: env::var("MODEL_API_BASE_URL")
                     .unwrap_or_else(|_| MODEL_API_BASE_URL.to_string()),
-                model: env::var("MODEL_API_MODEL").unwrap_or_else(|_| MUSE_SPARK_1_2.to_string()),
+                model: env::var("MODEL_API_MODEL").unwrap_or_else(|_| MUSE_SPARK_1_3.to_string()),
             })?),
             Self::Qwen => Ok(ModelClient::qwen(QwenConfig {
                 api_key: env::var("DASHSCOPE_API_KEY")?,

--- a/crates/ag-harness/tests/e2e/README.md
+++ b/crates/ag-harness/tests/e2e/README.md
@@ -16,7 +16,7 @@ cargo test --locked -p ag-harness --test e2e kimi::test_kimi -- --exact --ignore
 ## Muse
 
 `MODEL_API_BASE_URL` defaults to `https://api.meta.ai/v1`, and `MODEL_API_MODEL`
-defaults to `muse-spark-1.2`.
+defaults to `muse-spark-1.3`.
 
 ```sh
 MODEL_API_KEY=... \

--- a/crates/ag-harness/tests/e2e/muse.rs
+++ b/crates/ag-harness/tests/e2e/muse.rs
@@ -1,6 +1,6 @@
 //! Live Muse provider check.
 
-use ag_harness::{MUSE_SPARK_1_2, ModelClient, MuseConfig};
+use ag_harness::{MUSE_SPARK_1_3, ModelClient, MuseConfig};
 
 use crate::{DynError, greeting};
 
@@ -14,7 +14,7 @@ async fn test_muse() -> Result<(), DynError> {
         api_key: std::env::var("MODEL_API_KEY")?,
         base_url: std::env::var("MODEL_API_BASE_URL")
             .unwrap_or_else(|_| MODEL_API_BASE_URL.to_string()),
-        model: std::env::var("MODEL_API_MODEL").unwrap_or_else(|_| MUSE_SPARK_1_2.to_string()),
+        model: std::env::var("MODEL_API_MODEL").unwrap_or_else(|_| MUSE_SPARK_1_3.to_string()),
     };
     let client = ModelClient::muse(config)?;
 

--- a/crates/ag-harness/tests/e2e/muse_read.rs
+++ b/crates/ag-harness/tests/e2e/muse_read.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, Write as _};
 
-use ag_harness::{Harness, MUSE_SPARK_1_2, Muse, OutputSchema, Tool};
+use ag_harness::{Harness, MUSE_SPARK_1_3, Muse, OutputSchema, Tool};
 use serde_json::json;
 
 use crate::DynError;
@@ -16,7 +16,7 @@ const PROMPT: &str = concat!(
 #[ignore = "requires live Muse credentials"]
 async fn test_muse_read() -> Result<(), DynError> {
     // Arrange
-    let model = Muse::from_env(MUSE_SPARK_1_2)?;
+    let model = Muse::from_env(MUSE_SPARK_1_3)?;
 
     // Act and Assert
     inspect_manifest(model).await


### PR DESCRIPTION
- Expose updated standard and contributor model identifiers.
- Use Muse Spark 1.3 in CLI, benchmark, and E2E defaults.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)