### PR TITLE
Keep session creation in the terminal UI during project sync

### DIFF
--- a/crates/agentty/src/runtime/key_handler.rs
+++ b/crates/agentty/src/runtime/key_handler.rs
@@ -299,10 +299,20 @@ async fn create_selected_session(app: &mut App) -> io::Result<()> {
         mode,
         project_id,
     });
-    let session_id = app
-        .drive_session_request(request)
-        .await
-        .map_err(io::Error::other)?;
+    let session_id = match app.drive_session_request(request).await {
+        Ok(session_id) => session_id,
+        Err(error) => {
+            app.mode = AppMode::SyncBlockedPopup {
+                default_branch: None,
+                is_loading: false,
+                message: error.to_string(),
+                project_name: None,
+                title: "Session creation unavailable".to_string(),
+            };
+
+            return Ok(());
+        }
+    };
     mode::list::open_session_prompt(app, session_id.into());
 
     Ok(())
@@ -1170,6 +1180,47 @@ mod tests {
                 } if !session_id.is_empty()
             ));
         }
+    }
+
+    #[tokio::test]
+    async fn test_session_creation_rejection_stays_in_terminal_ui() {
+        // Arrange
+        let (mut app, _base_dir) =
+            crate::test_support::new_git_test_app_with_mock_tmux_client().await;
+        let project_id = app.active_project_id();
+        app.project_sync_status = Some(crate::app::ProjectSyncStatus {
+            context: crate::app::ProjectSyncContext {
+                default_branch: "main".to_string(),
+                operation_id: 1,
+                project_id,
+                project_name: "agentty".to_string(),
+            },
+            phase: crate::app::ProjectSyncPhase::Running,
+        });
+        app.mode = AppMode::SessionCreation {
+            selected_option_index: 0,
+        };
+
+        // Act
+        let result = handle_session_creation_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(result, Ok(EventResult::Continue)));
+        assert!(app.sessions.sessions().is_empty());
+        assert!(matches!(
+            app.mode,
+            AppMode::SyncBlockedPopup {
+                is_loading: false,
+                ref message,
+                ref title,
+                ..
+            } if title == "Session creation unavailable"
+                && message.contains("is synchronizing `main`")
+        ));
     }
 
     #[tokio::test]

--- a/crates/agentty/tests/e2e/project.rs
+++ b/crates/agentty/tests/e2e/project.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 
 use testty::assertion;
+use testty::proof::report::ProofReport;
 use testty::region::Region;
 
 use crate::common;
@@ -82,6 +83,21 @@ fn run_git(working_directory: &Path, args: &[&str]) -> Result<(), Box<dyn std::e
     if !status.success() {
         return Err(format!("git {} failed with {status}", args.join(" ")).into());
     }
+
+    Ok(())
+}
+
+/// Verifies that session creation is rejected in-app during project sync.
+fn verify_session_creation_blocked(report: &ProofReport) -> Result<(), &'static str> {
+    let capture = report
+        .captures
+        .iter()
+        .find(|capture| capture.label == "session_creation_blocked")
+        .ok_or("missing blocked session creation capture")?;
+    let frame = common::frame_from_capture(capture);
+    let full = Region::full(frame.cols(), frame.rows());
+    assertion::assert_text_in_region(&frame, "Session creation unavailable", &full);
+    assertion::assert_text_in_region(&frame, "is synchronizing main", &full);
 
     Ok(())
 }
@@ -241,6 +257,16 @@ fn test_project_sync_non_modal() {
                         "syncing_while_navigating",
                         "Sessions tab remains interactive during project sync",
                     )
+                    .press_key("a")
+                    .wait_for_text("Regular", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Session creation unavailable", 5000)
+                    .capture_labeled(
+                        "session_creation_blocked",
+                        "Session creation is safely blocked without exiting Agentty",
+                    )
+                    .press_key("Enter")
+                    .wait_for_text("Sessions", 5000)
                     .press_key("p")
                     .wait_for_text("Switch project", 5000)
                     .press_key("j")
@@ -297,6 +323,9 @@ fn test_project_sync_non_modal() {
                 );
                 assertion::assert_text_in_region(&syncing_frame, "Sessions", &syncing_full);
                 assertion::assert_not_visible(&syncing_frame, "Sync in progress");
+
+                verify_session_creation_blocked(report)
+                    .expect("missing blocked session creation capture");
 
                 let queued_capture = report
                     .captures

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -83,15 +83,15 @@ New session worktrees start from the local active base branch. If local `main` i
 List-mode sync stays non-modal: you can navigate, switch projects, inspect sessions, and
 continue work already running in isolated session worktrees while it proceeds. Agentty
 coalesces repeated `s` presses for the same project and queues one request per other
-project in FIFO order. Operations that read or change the syncing project's base
+project in FIFO order. Operations that change the syncing project's base
 checkout—creating or starting a draft session, merging, and rebasing—return a retryable
-workflow error until sync finishes; other projects remain available. Existing merge work
-has priority: requesting sync while a merge is active or queued reports retryable
-guidance in the status bar, and a queued merge rechecks the sync guard before it starts.
-If the sync stops on rebase conflicts, the status bar reports the number of files handed
-to the assist agent. Completion, blocked preflight, and failure summaries remain in that
-bar for ten seconds instead of opening a popup, then the page's normal `FYI:` message
-returns.
+workflow error until sync finishes; the TUI keeps running and shows that guidance
+in-app. Other projects remain available. Existing merge work has priority: requesting
+sync while a merge is active or queued reports retryable guidance in the status bar, and
+a queued merge rechecks the sync guard before it starts. If the sync stops on rebase
+conflicts, the status bar reports the number of files handed to the assist agent.
+Completion, blocked preflight, and failure summaries remain in that bar for ten seconds
+instead of opening a popup, then the page's normal `FYI:` message returns.
 
 ## Session Lifecycle
 


### PR DESCRIPTION
- Show retryable in-app guidance when synchronization blocks session creation.
- Keep other project and session workflows available while synchronization continues.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)