### PR TITLE
Refactor read paths and tighten test script permissions

### DIFF
--- a/crates/ag-harness/src/read.rs
+++ b/crates/ag-harness/src/read.rs
@@ -983,26 +983,19 @@ impl ReadTool {
         let file: Box<dyn AsyncRead + Send + Unpin> =
             Box::new(file.take((MAX_SCAN_BYTES + 1) as u64));
         let mut reader = BufReader::new(file);
-        let mut current_line = 1_u64;
         let mut remaining_scan_bytes = MAX_SCAN_BYTES;
 
-        while current_line < start_line {
-            if !Self::skip_line(&mut reader, &path, &mut remaining_scan_bytes).await? {
-                if source_truncated {
-                    return Err(ReadError::ScanLimitExceeded {
-                        limit: MAX_SCAN_BYTES,
-                        path,
-                    });
-                }
-                return Err(ReadError::OffsetBeyondEnd {
-                    offset: start_line,
-                    path,
-                });
-            }
-            current_line += 1;
-        }
+        Self::skip_to_line(
+            &mut reader,
+            start_line,
+            &path,
+            source_truncated,
+            &mut remaining_scan_bytes,
+        )
+        .await?;
 
         let mut content = String::new();
+        let mut current_line = start_line;
         let mut lines_read = 0_u64;
         let mut next_offset = None;
         while lines_read < selected_lines {
@@ -1061,6 +1054,34 @@ impl ReadTool {
             start_line,
             truncated: next_offset.is_some(),
         })
+    }
+
+    async fn skip_to_line(
+        reader: &mut BufReader<Box<dyn AsyncRead + Send + Unpin>>,
+        start_line: u64,
+        path: &str,
+        source_truncated: bool,
+        remaining_scan_bytes: &mut usize,
+    ) -> Result<(), ReadError> {
+        let mut current_line = 1_u64;
+        while current_line < start_line {
+            if !Self::skip_line(reader, path, remaining_scan_bytes).await? {
+                return Err(if source_truncated {
+                    ReadError::ScanLimitExceeded {
+                        limit: MAX_SCAN_BYTES,
+                        path: path.to_string(),
+                    }
+                } else {
+                    ReadError::OffsetBeyondEnd {
+                        offset: start_line,
+                        path: path.to_string(),
+                    }
+                });
+            }
+            current_line += 1;
+        }
+
+        Ok(())
     }
 
     async fn next_line(

--- a/crates/ag-harness/src/session.rs
+++ b/crates/ag-harness/src/session.rs
@@ -313,6 +313,47 @@ VALUES (?, ?, ?, ?, ?, ?, ?)
         session_id: &str,
         max_history_bytes: usize,
     ) -> Result<Vec<Vec<ModelMessage>>, SessionError> {
+        let Some(oldest_turn) = self
+            .oldest_turn_within_budget(session_id, max_history_bytes)
+            .await?
+        else {
+            return Ok(Vec::new());
+        };
+        let rows = sqlx::query_as::<_, (i64, String, String)>(
+            r"
+SELECT turn_position, kind, payload
+FROM session_message
+WHERE session_id = ? AND turn_position >= ?
+ORDER BY turn_position, message_position
+",
+        )
+        .bind(session_id)
+        .bind(oldest_turn)
+        .fetch_all(&self.pool)
+        .await
+        .session_context("load persistent session history")?;
+        let mut turns = Vec::<Vec<ModelMessage>>::new();
+        let mut current_position = None;
+
+        for (turn_position, kind, payload) in rows {
+            if current_position != Some(turn_position) {
+                turns.push(Vec::new());
+                current_position = Some(turn_position);
+            }
+            let message = EncodedMessage::into_message(&kind, &payload)?;
+            if let Some(turn) = turns.last_mut() {
+                turn.push(message);
+            }
+        }
+
+        Ok(turns)
+    }
+
+    async fn oldest_turn_within_budget(
+        &self,
+        session_id: &str,
+        max_history_bytes: usize,
+    ) -> Result<Option<i64>, SessionError> {
         let mut retained_bytes = 0_usize;
         let mut oldest_turn = None;
         let mut before_turn = None;
@@ -346,37 +387,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?)
             }
         }
 
-        let Some(oldest_turn) = oldest_turn else {
-            return Ok(Vec::new());
-        };
-        let rows = sqlx::query_as::<_, (i64, String, String)>(
-            r"
-SELECT turn_position, kind, payload
-FROM session_message
-WHERE session_id = ? AND turn_position >= ?
-ORDER BY turn_position, message_position
-",
-        )
-        .bind(session_id)
-        .bind(oldest_turn)
-        .fetch_all(&self.pool)
-        .await
-        .session_context("load persistent session history")?;
-        let mut turns = Vec::<Vec<ModelMessage>>::new();
-        let mut current_position = None;
-
-        for (turn_position, kind, payload) in rows {
-            if current_position != Some(turn_position) {
-                turns.push(Vec::new());
-                current_position = Some(turn_position);
-            }
-            let message = EncodedMessage::into_message(&kind, &payload)?;
-            if let Some(turn) = turns.last_mut() {
-                turn.push(message);
-            }
-        }
-
-        Ok(turns)
+        Ok(oldest_turn)
     }
 }
 

--- a/crates/agentty/src/app/task.rs
+++ b/crates/agentty/src/app/task.rs
@@ -1357,7 +1357,9 @@ mod tests {
         let mut permissions = std::fs::metadata(&npm_path)
             .expect("failed to load fake npm metadata")
             .permissions();
-        permissions.set_mode(0o755);
+        // The isolated child retains the test process's UID, so owner execution is
+        // sufficient.
+        permissions.set_mode(0o700);
         std::fs::set_permissions(&npm_path, permissions)
             .expect("failed to make fake npm executable");
         let current_test_binary =

--- a/crates/agentty/tests/e2e/update.rs
+++ b/crates/agentty/tests/e2e/update.rs
@@ -38,7 +38,9 @@ exit 1
         env!("CARGO_PKG_VERSION")
     );
     std::fs::write(&npm_path, npm_script)?;
-    std::fs::set_permissions(&npm_path, std::fs::Permissions::from_mode(0o755))?;
+    // The PTY child retains the test process's UID, so owner execution is
+    // sufficient.
+    std::fs::set_permissions(&npm_path, std::fs::Permissions::from_mode(0o700))?;
 
     Ok(())
 }


### PR DESCRIPTION
- Extract line-offset scanning and session history budget selection into focused helpers.
- Restrict generated npm test scripts to owner-only executable permissions.