### PR TITLE
Accept bounded tool-call content and expand benchmark coverage

### DIFF
--- a/crates/ag-harness/src/chat_completion.rs
+++ b/crates/ag-harness/src/chat_completion.rs
@@ -368,8 +368,8 @@ impl ChatCompletionBackend {
         reasoning_content: Option<&str>,
         calls: Vec<ChatCompletionToolCall>,
     ) -> Result<Vec<tool::ToolCall>, model::ModelError> {
-        if content.is_some_and(|content| !content.is_empty()) {
-            return Err(model::ModelError::ToolCallWithContent);
+        if let Some(content) = content {
+            schema_contract::ensure_content_size(content).map_err(model::ModelError::from)?;
         }
         if calls.is_empty() {
             return Err(model::ModelError::MissingToolCall);
@@ -1250,7 +1250,7 @@ mod tests {
         // Act
         let response = ChatCompletionBackend::decode_tool_call(
             &request,
-            None,
+            Some("I will update the requested file."),
             None,
             calls,
             model::CompletionMetadata::new("tool_calls".to_string(), None, None, None, None),
@@ -1268,6 +1268,44 @@ mod tests {
                         arguments.path() == "src/lib.rs"
                             && arguments.patch().starts_with("--- a/src/lib.rs")
                     })
+        ));
+    }
+
+    #[test]
+    fn rejects_oversized_content_with_tool_calls() {
+        // Arrange
+        let schema = schema_contract::OutputSchema::new(serde_json::json!({
+            "type": "object"
+        }))
+        .expect("schema should be valid");
+        let request =
+            model::ModelRequest::new("inspect", schema).with_tool(tool::ToolDefinition::read());
+        let content = "x".repeat(schema_contract::RESPONSE_CONTENT_LIMIT_BYTES + 1);
+        let calls = vec![ChatCompletionToolCall {
+            function: serde_json::json!({
+                "name": "read",
+                "arguments": r#"{"path":"Cargo.toml"}"#
+            }),
+            id: "call_read".to_string(),
+            kind: "function".to_string(),
+        }];
+
+        // Act
+        let response = ChatCompletionBackend::decode_tool_call(
+            &request,
+            Some(&content),
+            None,
+            calls,
+            model::CompletionMetadata::new("tool_calls".to_string(), None, None, None, None),
+        );
+
+        // Assert
+        assert!(matches!(
+            response,
+            GeneratedResponse::Failed {
+                error: model::ModelError::ResponseContentTooLarge,
+                ..
+            }
         ));
     }
 

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -779,9 +779,6 @@ pub enum ModelError {
         /// Bounded duplicate identifier returned by the provider.
         id: String,
     },
-    /// A tool-call response also contained terminal assistant content.
-    #[error("model tool call response contained terminal content")]
-    ToolCallWithContent,
     /// A terminal response also contained native tool calls.
     #[error("model terminal response contained tool calls")]
     TerminalResponseWithToolCalls,
@@ -895,7 +892,6 @@ impl ModelError {
             Self::MissingToolCall
             | Self::MultipleToolCalls
             | Self::DuplicateToolCallId { .. }
-            | Self::ToolCallWithContent
             | Self::TerminalResponseWithToolCalls
             | Self::UnsupportedToolType { .. }
             | Self::UnsupportedToolName { .. }
@@ -1574,10 +1570,6 @@ mod tests {
             (ModelError::MissingToolCall, ModelErrorType::InvalidToolCall),
             (
                 ModelError::MultipleToolCalls,
-                ModelErrorType::InvalidToolCall,
-            ),
-            (
-                ModelError::ToolCallWithContent,
                 ModelErrorType::InvalidToolCall,
             ),
             (

--- a/crates/ag-harness/src/provider/muse.rs
+++ b/crates/ag-harness/src/provider/muse.rs
@@ -401,7 +401,7 @@ mod tests {
                 "choices": [{
                     "finish_reason": "tool_calls",
                     "message": {
-                        "content": null,
+                        "content": "I will inspect the manifest before answering.",
                         "tool_calls": [{
                             "id": "call_muse_read",
                             "type": "function",

--- a/crates/ag-harness/src/provider/qwen.rs
+++ b/crates/ag-harness/src/provider/qwen.rs
@@ -487,7 +487,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejects_unsupported_tool_type_name_and_terminal_content() {
+    async fn rejects_unsupported_tool_type_and_name() {
         // Arrange
         let messages = [
             (
@@ -510,17 +510,6 @@ mod tests {
                     }]
                 }),
                 "model requested unsupported tool: write",
-            ),
-            (
-                json!({
-                    "content": "done",
-                    "tool_calls": [{
-                        "id": "call_content",
-                        "type": "function",
-                        "function": {"name": "read", "arguments": r#"{"path":"Cargo.toml"}"#}
-                    }]
-                }),
-                "model tool call response contained terminal content",
             ),
             (
                 json!({
@@ -550,6 +539,40 @@ mod tests {
         assert!(errors.iter().all(|(error, expected)| {
             error == expected || (expected.ends_with(':') && error.starts_with(expected))
         }));
+    }
+
+    #[tokio::test]
+    async fn accepts_bounded_content_with_tool_calls() {
+        // Arrange
+        let server = MockServer::start().await;
+        mount_tool_response(
+            &server,
+            "inspect the manifest",
+            json!({
+                "content": "I will inspect the manifest.",
+                "tool_calls": [{
+                    "id": "call_content",
+                    "type": "function",
+                    "function": {"name": "read", "arguments": r#"{"path":"Cargo.toml"}"#}
+                }]
+            }),
+        )
+        .await;
+
+        // Act
+        let response = qwen(&server)
+            .complete(read_request("inspect the manifest"))
+            .await
+            .expect("incidental tool-call content should be ignored");
+
+        // Assert
+        assert_eq!(
+            response
+                .call()
+                .expect("response should contain a tool call")
+                .id(),
+            "call_content"
+        );
     }
 
     #[tokio::test]

--- a/crates/ag-harness/tests/benchmark/README.md
+++ b/crates/ag-harness/tests/benchmark/README.md
@@ -3,16 +3,18 @@
 This manual benchmark exercises `ag-harness` against every supported live provider. It
 is a small system benchmark, not an official leaderboard submission. Each case has a
 deterministic scorer: schema validation, exact tool activity, or final filesystem state.
+Expected answers are deliberately absent from tool and memory schemas so models cannot
+solve a case by copying constraints instead of using tools or persisted history.
 
 ## Benchmark coverage
 
-| Public benchmark   | Applicable case           | Scope boundary                                                                                                                                                                                                                                                  |
-| ------------------ | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| JSONSchemaBench    | `structured`              | Exercises a nested object, constants, and a fixed tuple. The official 10K-schema constrained-decoding benchmark is not run because `ag-harness` intentionally accepts only explicit object-root response schemas and providers impose their own schema subsets. |
-| BFCL               | `parallel_read`           | Scores exact batched function selection and arguments. Full BFCL needs arbitrary user-defined functions, parallel execution, and categories outside the closed repository-tool surface.                                                                         |
-| tau-bench          | `read_recovery`, `memory` | Scores multi-step recovery after a rejected tool and cross-turn state. Full tau-bench needs domain APIs, a stateful database, policy documents, and a simulated user.                                                                                           |
-| GAIA               | `parallel_read`           | Covers bounded local-file retrieval only. Full GAIA needs web, Python, and shell tools plus its gated validation data.                                                                                                                                          |
-| SWE-bench Verified | `write`                   | Verifies the resulting file rather than trusting the terminal answer. Full SWE-bench needs per-task repositories, dependency installation, shell execution, and test-based patch scoring.                                                                       |
+| Public benchmark   | Applicable case                      | Scope boundary                                                                                                                                                                                                                                                  |
+| ------------------ | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| JSONSchemaBench    | `structured`                         | Exercises a nested object, constants, and a fixed tuple. The official 10K-schema constrained-decoding benchmark is not run because `ag-harness` intentionally accepts only explicit object-root response schemas and providers impose their own schema subsets. |
+| BFCL               | `parallel_read`                      | Scores exact batched function selection and arguments. Full BFCL needs arbitrary user-defined functions, parallel execution, and categories outside the closed repository-tool surface.                                                                         |
+| tau-bench          | `read_recovery`, `persistent_memory` | Scores multi-step recovery after a rejected tool and cross-process-style state restored from SQLite. Full tau-bench needs domain APIs, policy documents, and a simulated user.                                                                                  |
+| GAIA               | `parallel_read`                      | Covers bounded local-file retrieval only. Full GAIA needs web, Python, and shell tools plus its gated validation data.                                                                                                                                          |
+| SWE-bench Verified | `write`                              | Verifies the resulting file rather than trusting the terminal answer. Full SWE-bench needs per-task repositories, dependency installation, shell execution, and test-based patch scoring.                                                                       |
 
 EleutherAI's LM Evaluation Harness, OpenAI Evals, and Inspect AI are evaluation
 frameworks rather than additional task datasets. Their model adapters and task catalogs
@@ -29,10 +31,20 @@ AG_HARNESS_BENCHMARK_REPETITIONS=2 \
   cargo test --locked -p ag-harness --test benchmark
 ```
 
-`MODEL_API_BASE_URL` and `MODEL_API_MODEL` remain optional. Every result line records
-pass/fail, wall time, successful model requests, executed tool calls, and
-provider-reported total tokens. Failed cases report zero activity because the public
-turn report is available only after a successful turn. The benchmark does not estimate
-missing tokens or cost.
+Set `AG_HARNESS_BENCHMARK_PROVIDER` to `kimi`, `muse`, or `qwen`, and
+`AG_HARNESS_BENCHMARK_CASE` to one case name for targeted reruns.
 
-See `results/2026-08-23.md` for the baseline and post-change report.
+`MODEL_API_BASE_URL` and `MODEL_API_MODEL` remain optional. Kimi cases use a full-minute
+cooldown to respect its three-request-per-minute organization limit. Results stream
+after every case and record pass/fail, wall time, summed provider and turn latency,
+SQLite create/reopen latency for `persistent_memory`, successful model requests,
+executed tool calls, and provider-reported total tokens. Provider error bodies are
+redacted. Failed cases report zero activity because the public turn report is available
+only after a successful turn.
+
+The benchmark captures OpenTelemetry metrics and spans in-process. It verifies client
+duration/token metrics plus lifecycle duration/call metrics, and requires one correlated
+agent and model span for every persistent-session turn. It does not export telemetry,
+estimate missing tokens, or calculate cost.
+
+See `results/2026-09-03.md` for the completed live persistence and compatibility report.

--- a/crates/ag-harness/tests/benchmark/main.rs
+++ b/crates/ag-harness/tests/benchmark/main.rs
@@ -2,19 +2,38 @@
 
 mod summary;
 
+use std::collections::BTreeSet;
 use std::io::Write as _;
 use std::time::{Duration, Instant};
 use std::{env, fmt};
 
 use ag_harness::{
-    Harness, KimiConfig, MUSE_SPARK_1_3, ModelClient, ModelRequestActivity, ModelResponseType,
-    MuseConfig, OutputSchema, QwenConfig, Tool, ToolActivity, TurnOutcome,
+    Database, Harness, KimiConfig, LifecycleMetrics, LifecycleObserverSet, LifecycleTraceObserver,
+    MUSE_SPARK_1_3, ModelClient, ModelRequestActivity, ModelResponseType, MuseConfig, OutputSchema,
+    QwenConfig, SessionConfig, Tool, ToolActivity, TurnOutcome,
 };
+use opentelemetry::global;
+use opentelemetry::trace::SpanId;
+use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
 use serde_json::{Value, json};
 
 type DynError = Box<dyn std::error::Error + Send + Sync>;
 
 const MODEL_API_BASE_URL: &str = "https://api.meta.ai/v1";
+const KIMI_CASE_INTERVAL: Duration = Duration::from_secs(60);
+const PERSISTENT_TURNS_PER_CASE: usize = 2;
+
+type CaseFuture = std::pin::Pin<Box<dyn Future<Output = Result<CaseMeasurement, DynError>>>>;
+type CaseRunner = fn(Provider) -> CaseFuture;
+
+const CASES: [(&str, CaseRunner); 5] = [
+    ("structured", structured),
+    ("parallel_read", parallel_read),
+    ("read_recovery", read_recovery),
+    ("write", write),
+    ("persistent_memory", persistent_memory),
+];
 
 #[tokio::main]
 async fn main() -> Result<(), DynError> {
@@ -22,27 +41,58 @@ async fn main() -> Result<(), DynError> {
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or(1);
-    let mut results = Vec::new();
+    let provider_filter = env::var("AG_HARNESS_BENCHMARK_PROVIDER").ok();
+    let providers = Provider::ALL
+        .into_iter()
+        .filter(|provider| {
+            provider_filter
+                .as_deref()
+                .is_none_or(|filter| provider.as_str() == filter)
+        })
+        .collect::<Vec<_>>();
+    if providers.is_empty() {
+        return Err("benchmark provider filter did not match kimi, muse, or qwen".into());
+    }
+    let case_filter = env::var("AG_HARNESS_BENCHMARK_CASE").ok();
+    let cases = CASES
+        .into_iter()
+        .filter(|(case, _)| case_filter.as_deref().is_none_or(|filter| *case == filter))
+        .collect::<Vec<_>>();
+    if cases.is_empty() {
+        return Err("benchmark case filter did not match a known case".into());
+    }
+    let telemetry = TelemetryCapture::install();
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    let mut last_kimi_case = None;
+    let mut passed = 0;
+    let mut total = 0;
 
     for repetition in 1..=repetitions {
-        for provider in Provider::ALL {
-            results.push(run_case(provider, repetition, "structured", structured).await);
-            results.push(run_case(provider, repetition, "parallel_read", parallel_read).await);
-            results.push(run_case(provider, repetition, "read_recovery", read_recovery).await);
-            results.push(run_case(provider, repetition, "write", write).await);
-            results.push(run_case(provider, repetition, "memory", memory).await);
+        for provider in providers.iter().copied() {
+            for &(case, run) in &cases {
+                provider.wait_for_case_slot(last_kimi_case).await;
+                let result = run_case(provider, repetition, case, run).await;
+                if matches!(provider, Provider::Kimi) {
+                    last_kimi_case = Some(Instant::now());
+                }
+                passed += usize::from(result.passed);
+                total += 1;
+                writeln!(stdout, "{result}")?;
+                stdout.flush()?;
+            }
         }
     }
 
-    let stdout = std::io::stdout();
-    let mut stdout = stdout.lock();
-    for result in &results {
-        writeln!(stdout, "{result}")?;
-    }
-    let passed = results.iter().filter(|result| result.passed).count();
-    let total = results.len();
+    let telemetry = telemetry.finish()?;
+    writeln!(stdout, "{telemetry}")?;
     writeln!(stdout, "SUMMARY passed={passed} total={total}")?;
     stdout.flush()?;
+    let persistent_turns = repetitions
+        * providers.len()
+        * usize::from(cases.iter().any(|(case, _)| *case == "persistent_memory"))
+        * PERSISTENT_TURNS_PER_CASE;
+    telemetry.ensure_complete(persistent_turns)?;
     summary::ensure_all_passed(passed, total)?;
 
     Ok(())
@@ -71,8 +121,6 @@ async fn run_case(
         repetition,
     }
 }
-
-type CaseFuture = std::pin::Pin<Box<dyn Future<Output = Result<CaseMeasurement, DynError>>>>;
 
 fn structured(provider: Provider) -> CaseFuture {
     Box::pin(async move {
@@ -123,12 +171,13 @@ fn parallel_read(provider: Provider) -> CaseFuture {
         let repository = tempfile::tempdir()?;
         std::fs::write(repository.path().join("alpha.txt"), "first=amber\n")?;
         std::fs::write(repository.path().join("beta.txt"), "second=17\n")?;
-        let schema = exact_value_schema("code", "amber-17")?;
+        let schema = string_value_schema("code")?;
         let outcome = Harness::new(provider.client()?)
             .repository(repository.path())
             .allow(Tool::Read)
             .run_report(
-                "Read both alpha.txt and beta.txt. Combine their values as first-second.",
+                "In one response, call read twice using exactly the paths alpha.txt and beta.txt \
+                 without a ./ prefix. Combine their values as first-second.",
                 schema,
             )
             .await?;
@@ -174,7 +223,7 @@ fn read_recovery(provider: Provider) -> CaseFuture {
     Box::pin(async move {
         let repository = tempfile::tempdir()?;
         std::fs::write(repository.path().join("fallback.txt"), "code=violet-29\n")?;
-        let schema = exact_value_schema("code", "violet-29")?;
+        let schema = string_value_schema("code")?;
         let outcome = Harness::new(provider.client()?)
             .repository(repository.path())
             .allow(Tool::Read)
@@ -232,36 +281,62 @@ fn write(provider: Provider) -> CaseFuture {
     })
 }
 
-fn memory(provider: Provider) -> CaseFuture {
+fn persistent_memory(provider: Provider) -> CaseFuture {
     Box::pin(async move {
         let schema = schema(json!({
             "type": "object",
             "properties": {
-                "answer": { "type": "string", "enum": ["stored", "cobalt-41"] }
+                "answer": { "type": "string" }
             },
             "required": ["answer"],
             "additionalProperties": false
         }))?;
-        let harness = Harness::new(provider.client()?);
-        let mut chat = harness.chat(schema);
-        let stored = chat
+        let directory = tempfile::tempdir()?;
+        let database_path = directory.path().join("sessions.db");
+        let harness = instrumented_harness(provider)?;
+        let config = SessionConfig::new("benchmark-session", schema);
+        let create_started = Instant::now();
+        let database = Database::open(&database_path).await?;
+        let mut session = harness.create_session(&database, config).await?;
+        let create_duration = create_started.elapsed();
+        let stored = session
             .send("Remember the code cobalt-41 and answer only with stored.")
             .await?;
-        let recalled = chat
+        drop(session);
+        drop(database);
+        drop(harness);
+
+        let harness = instrumented_harness(provider)?;
+        let reopen_started = Instant::now();
+        let database = Database::open(&database_path).await?;
+        let mut session = harness.open_session(&database, "benchmark-session").await?;
+        let reopen_duration = reopen_started.elapsed();
+        let recalled = session
             .send("What exact code did I ask you to remember?")
             .await?;
-        if stored.output()["answer"] != "stored" || recalled.output()["answer"] != "cobalt-41" {
-            return Err("chat did not retain the exact code across turns".into());
+        if stored.output()["answer"] != "stored"
+            || recalled.output()["answer"] != "cobalt-41"
+            || session.id() != "benchmark-session"
+        {
+            return Err("reopened session did not retain the exact code across turns".into());
         }
 
-        Ok(CaseMeasurement::from_outcomes([&stored, &recalled]))
+        Ok(CaseMeasurement::from_outcomes([&stored, &recalled])
+            .with_storage_duration(create_duration + reopen_duration))
     })
 }
 
-fn exact_value_schema(property: &str, value: &str) -> Result<OutputSchema, DynError> {
+fn instrumented_harness(provider: Provider) -> Result<Harness, DynError> {
+    let observers = LifecycleObserverSet::new(LifecycleMetrics::new())
+        .with_observer(LifecycleTraceObserver::new());
+
+    Ok(Harness::new(provider.client()?).with_lifecycle_observer(observers))
+}
+
+fn string_value_schema(property: &str) -> Result<OutputSchema, DynError> {
     schema(json!({
         "type": "object",
-        "properties": { property: { "type": "string", "const": value } },
+        "properties": { property: { "type": "string" } },
         "required": [property],
         "additionalProperties": false
     }))
@@ -301,15 +376,32 @@ impl Provider {
             })?),
         }
     }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Kimi => "kimi",
+            Self::Muse => "muse",
+            Self::Qwen => "qwen",
+        }
+    }
+
+    async fn wait_for_case_slot(self, last_kimi_case: Option<Instant>) {
+        if !matches!(self, Self::Kimi) {
+            return;
+        }
+        let Some(last_kimi_case) = last_kimi_case else {
+            return;
+        };
+        let elapsed = last_kimi_case.elapsed();
+        if let Some(delay) = KIMI_CASE_INTERVAL.checked_sub(elapsed) {
+            tokio::time::sleep(delay).await;
+        }
+    }
 }
 
 impl fmt::Display for Provider {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Kimi => formatter.write_str("kimi"),
-            Self::Muse => formatter.write_str("muse"),
-            Self::Qwen => formatter.write_str("qwen"),
-        }
+        formatter.write_str(self.as_str())
     }
 }
 
@@ -328,20 +420,24 @@ impl fmt::Display for ResultLine {
         write!(
             formatter,
             "RESULT provider={} case={} repetition={} passed={} duration_ms={} model_requests={} \
-             tool_calls={} total_tokens={}",
+             model_duration_ms={} turn_duration_ms={} storage_duration_ms={} tool_calls={} \
+             total_tokens={}",
             self.provider,
             self.case,
             self.repetition,
             self.passed,
             self.duration.as_millis(),
             self.measurement.model_requests,
+            self.measurement.model_duration.as_millis(),
+            self.measurement.turn_duration.as_millis(),
+            self.measurement.storage_duration.as_millis(),
             self.measurement.tool_calls,
             self.measurement
                 .total_tokens
                 .map_or_else(|| "unknown".to_string(), |tokens| tokens.to_string())
         )?;
         if let Some(detail) = &self.detail {
-            write!(formatter, " detail={}", detail.replace(['\n', '\r'], " "))?;
+            write!(formatter, " detail={}", summary::sanitize_detail(detail))?;
         }
 
         Ok(())
@@ -350,9 +446,12 @@ impl fmt::Display for ResultLine {
 
 #[derive(Default)]
 struct CaseMeasurement {
+    model_duration: Duration,
     model_requests: usize,
+    storage_duration: Duration,
     tool_calls: usize,
     total_tokens: Option<u64>,
+    turn_duration: Duration,
 }
 
 impl CaseMeasurement {
@@ -362,9 +461,11 @@ impl CaseMeasurement {
         let mut total_tokens = 0_u64;
 
         for outcome in outcomes {
+            measurement.turn_duration += outcome.report().duration();
             measurement.model_requests += outcome.report().model_requests().len();
             measurement.tool_calls += outcome.report().tool_calls().len();
             for request in outcome.report().model_requests() {
+                measurement.model_duration += request.duration();
                 if let Some(tokens) = request
                     .completion()
                     .and_then(|completion| completion.usage())
@@ -378,5 +479,168 @@ impl CaseMeasurement {
         measurement.total_tokens = reported_tokens.then_some(total_tokens);
 
         measurement
+    }
+
+    fn with_storage_duration(mut self, storage_duration: Duration) -> Self {
+        self.storage_duration = storage_duration;
+
+        self
+    }
+}
+
+struct TelemetryCapture {
+    metric_exporter: InMemoryMetricExporter,
+    meter_provider: SdkMeterProvider,
+    span_exporter: InMemorySpanExporter,
+    tracer_provider: SdkTracerProvider,
+}
+
+impl TelemetryCapture {
+    fn install() -> Self {
+        let metric_exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(metric_exporter.clone())
+            .build();
+        global::set_meter_provider(meter_provider.clone());
+        let span_exporter = InMemorySpanExporter::default();
+        let tracer_provider = SdkTracerProvider::builder()
+            .with_simple_exporter(span_exporter.clone())
+            .build();
+        global::set_tracer_provider(tracer_provider.clone());
+
+        Self {
+            metric_exporter,
+            meter_provider,
+            span_exporter,
+            tracer_provider,
+        }
+    }
+
+    fn finish(self) -> Result<TelemetryMeasurement, DynError> {
+        self.meter_provider.force_flush()?;
+        self.tracer_provider.force_flush()?;
+        let metric_names = self
+            .metric_exporter
+            .get_finished_metrics()?
+            .iter()
+            .flat_map(opentelemetry_sdk::metrics::data::ResourceMetrics::scope_metrics)
+            .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+            .map(|metric| metric.name().to_string())
+            .collect();
+        let spans = self.span_exporter.get_finished_spans()?;
+        self.tracer_provider.shutdown()?;
+        self.meter_provider.shutdown()?;
+
+        Ok(TelemetryMeasurement {
+            metric_names,
+            spans,
+        })
+    }
+}
+
+struct TelemetryMeasurement {
+    metric_names: BTreeSet<String>,
+    spans: Vec<SpanData>,
+}
+
+impl TelemetryMeasurement {
+    fn ensure_complete(&self, expected_turns: usize) -> Result<(), DynError> {
+        let mut allowed_metrics = BTreeSet::from([
+            "gen_ai.client.operation.duration".to_string(),
+            "gen_ai.client.token.usage".to_string(),
+        ]);
+        let mut required_metrics = BTreeSet::from(["gen_ai.client.operation.duration".to_string()]);
+        if expected_turns > 0 {
+            required_metrics.extend([
+                "gen_ai.client.token.usage".to_string(),
+                "gen_ai.invoke_agent.duration".to_string(),
+                "gen_ai.invoke_agent.inference_calls".to_string(),
+                "gen_ai.invoke_agent.tool_calls".to_string(),
+            ]);
+            allowed_metrics.clone_from(&required_metrics);
+        }
+        if !required_metrics.is_subset(&self.metric_names)
+            || !self.metric_names.is_subset(&allowed_metrics)
+        {
+            return Err(format!(
+                "telemetry metrics differ: required={required_metrics:?} \
+                 allowed={allowed_metrics:?} actual={:?}",
+                self.metric_names,
+            )
+            .into());
+        }
+        let agent_spans = self.agent_spans();
+        let model_spans = self.model_spans();
+        if agent_spans.len() != expected_turns || model_spans.len() != expected_turns {
+            return Err(format!(
+                "telemetry spans differ: expected={expected_turns} agent={} model={}",
+                agent_spans.len(),
+                model_spans.len()
+            )
+            .into());
+        }
+        for agent_span in &agent_spans {
+            if agent_span.parent_span_id != SpanId::INVALID {
+                return Err("invoke-agent telemetry span is not a root span".into());
+            }
+            let child_count = model_spans
+                .iter()
+                .filter(|model_span| Self::is_direct_model_child(model_span, agent_span))
+                .count();
+            if child_count != 1 {
+                return Err(format!(
+                    "invoke-agent telemetry span has {child_count} direct model children"
+                )
+                .into());
+            }
+        }
+        for model_span in &model_spans {
+            let parent_count = agent_spans
+                .iter()
+                .filter(|agent_span| Self::is_direct_model_child(model_span, agent_span))
+                .count();
+            if parent_count != 1 {
+                return Err(format!(
+                    "model telemetry span has {parent_count} direct invoke-agent parents"
+                )
+                .into());
+            }
+        }
+
+        Ok(())
+    }
+
+    fn agent_spans(&self) -> Vec<&SpanData> {
+        self.spans
+            .iter()
+            .filter(|span| span.name == "invoke_agent")
+            .collect()
+    }
+
+    fn model_spans(&self) -> Vec<&SpanData> {
+        self.spans
+            .iter()
+            .filter(|span| span.name.starts_with("chat "))
+            .collect()
+    }
+
+    fn is_direct_model_child(model_span: &SpanData, agent_span: &SpanData) -> bool {
+        model_span.span_context.trace_id() == agent_span.span_context.trace_id()
+            && model_span.parent_span_id == agent_span.span_context.span_id()
+    }
+}
+
+impl fmt::Display for TelemetryMeasurement {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let agent_spans = self.agent_spans().len();
+        let model_spans = self.model_spans().len();
+
+        write!(
+            formatter,
+            "TELEMETRY metrics={} agent_spans={} model_spans={}",
+            self.metric_names.len(),
+            agent_spans,
+            model_spans
+        )
     }
 }

--- a/crates/ag-harness/tests/benchmark/results/2026-09-03.md
+++ b/crates/ag-harness/tests/benchmark/results/2026-09-03.md
@@ -1,0 +1,52 @@
+# `ag-harness` benchmark report - 2026-09-03
+
+## Configuration
+
+- The current worktree was based on `31f6c9cc`, which introduced persistent harness
+  sessions.
+- The live matrix used Kimi K2.6, Muse Spark 1.3, and Qwen Plus. The persistent-memory
+  case ran twice per provider and reconstructed both the database and provider client
+  between turns.
+- Expected values were absent from the response schemas. The recall result therefore
+  depended on restored conversation history rather than schema leakage.
+- OpenTelemetry metrics and spans were captured with in-process exporters. No telemetry
+  was sent to an external collector.
+
+## Persistent-memory results
+
+All six live cases passed exact first-turn and recalled-value scoring.
+
+| Provider | Repetition | Result | Wall time | Provider time | SQLite create/reopen | Tokens |
+| -------- | ---------: | -----: | --------: | ------------: | -------------------: | -----: |
+| Kimi     |          1 |   pass |  9,215 ms |      9,190 ms |                 8 ms |    497 |
+| Kimi     |          2 |   pass |  9,445 ms |      9,429 ms |                12 ms |    513 |
+| Muse     |          1 |   pass | 18,326 ms |     18,317 ms |                 5 ms |  1,058 |
+| Muse     |          2 |   pass | 21,993 ms |     21,983 ms |                 6 ms |  1,339 |
+| Qwen     |          1 |   pass |  2,452 ms |      2,404 ms |                44 ms |    199 |
+| Qwen     |          2 |   pass |  2,392 ms |      2,380 ms |                 8 ms |    199 |
+
+The telemetry capture contained the five required metric families, twelve `invoke_agent`
+spans, and twelve model spans. The benchmark validates that each agent span is a root
+and has exactly one direct model child in the same trace.
+
+## Compatibility findings
+
+The original live matrix passed 20 of 30 cases. Direct inspection of a failing Muse
+response found valid tool calls with `finish_reason=tool_calls` plus a short textual
+preamble. Accepting bounded incidental content for that finish reason removed the
+harness-side rejection while preserving the existing content-size limit and the
+rejection of tool calls paired with `finish_reason=stop`.
+
+A post-fix full matrix passed 26 of 30 cases. The four remaining failures were provider
+behavior rather than persistence loss: two Kimi quota responses, one Kimi response that
+serialized reads instead of batching them, and one Muse response that used invalid
+`./`-prefixed paths. A tightened parallel-read prompt subsequently passed three Muse
+runs; two later Kimi attempts still received quota responses.
+
+## Interpretation
+
+The persistence result supports only the tested two-turn create/reopen path. Provider
+calls took 2.4 to 22.0 seconds, while isolated SQLite create/reopen work stayed at or
+below 44 milliseconds. Two repetitions remain insufficient for model ranking,
+tail-latency, or reliability claims. No cost estimate is reported because provider
+responses exposed usage, not billed cost.

--- a/crates/ag-harness/tests/benchmark/summary.rs
+++ b/crates/ag-harness/tests/benchmark/summary.rs
@@ -19,6 +19,19 @@ impl fmt::Display for BenchmarkFailure {
 
 impl Error for BenchmarkFailure {}
 
+pub(super) fn sanitize_detail(detail: &str) -> String {
+    let detail = detail.replace(['\n', '\r'], " ");
+    let Some(http_offset) = detail.find(" returned HTTP ") else {
+        return detail;
+    };
+    let Some(body_offset) = detail[http_offset..].find(": ") else {
+        return detail;
+    };
+    let body_offset = http_offset + body_offset;
+
+    format!("{}: <redacted>", &detail[..body_offset])
+}
+
 pub(super) fn ensure_all_passed(passed: usize, total: usize) -> Result<(), BenchmarkFailure> {
     if passed == total {
         Ok(())

--- a/crates/ag-harness/tests/benchmark_summary.rs
+++ b/crates/ag-harness/tests/benchmark_summary.rs
@@ -29,3 +29,30 @@ fn rejects_incomplete_benchmark_summary() {
     // Assert
     assert_eq!(error.to_string(), "benchmark failed: 29 of 30 cases passed");
 }
+
+#[test]
+fn redacts_provider_response_bodies_from_benchmark_details() {
+    // Arrange
+    let detail = "model request failed: Kimi returned HTTP 429 Too Many Requests: secret body";
+
+    // Act
+    let sanitized = summary::sanitize_detail(detail);
+
+    // Assert
+    assert_eq!(
+        sanitized,
+        "model request failed: Kimi returned HTTP 429 Too Many Requests: <redacted>"
+    );
+}
+
+#[test]
+fn normalizes_non_provider_benchmark_details() {
+    // Arrange
+    let detail = "schema failed\nwithout provider response";
+
+    // Act
+    let sanitized = summary::sanitize_detail(detail);
+
+    // Assert
+    assert_eq!(sanitized, "schema failed without provider response");
+}


### PR DESCRIPTION
- Allow bounded assistant content with tool calls while preserving response-size limits.
- Exercise persistent SQLite session reopening with lifecycle telemetry, filtering, rate limiting, and latency reporting.
- Redact provider error bodies and record compatibility and persistence benchmark results.