### PR TITLE
Exposes model history and validates tool calls

### DIFF
--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -55,6 +55,16 @@ let outcome = session.send(prompt).await?;
 
 Use `ModelWithMetadata::complete_with_metadata()` for normalized completion metadata.
 
+External adapters implement `Model` or `ModelWithMetadata`. Translate the ordered
+`ModelRequest::messages()` entries, including system instructions, previous turns,
+assistant tool calls, and correlated tool results; `prompt()` alone is insufficient for
+chat. Construct built-in calls with `ToolCall::from_json()`, which applies the same
+bounded argument validation as built-in providers. Call IDs must contain non-whitespace
+text and fit within 1,024 UTF-8 bytes; accepted IDs are preserved exactly. Use
+`arguments_json()` and, when required by the provider, `reasoning_content()` to replay
+calls. The harness still owns history, tool permissions, execution limits, and terminal
+output validation.
+
 Use `ModelProvider` and `ModelConfiguration` to discover built-in providers and
 construct a provider client from its standard environment variables. The catalog owns
 known model identifiers, credential variables, endpoint variables, and provider defaults

--- a/crates/ag-harness/src/chat_completion.rs
+++ b/crates/ag-harness/src/chat_completion.rs
@@ -406,29 +406,12 @@ impl ChatCompletionBackend {
                 name: schema_contract::bounded_diagnostic(function.name),
             });
         }
-        schema_contract::ensure_content_size(&function.arguments)
-            .map_err(model::ModelError::from)?;
-        if let Some(reasoning_content) = reasoning_content {
-            schema_contract::ensure_content_size(reasoning_content)
-                .map_err(model::ModelError::from)?;
-        }
-        let call = if function.name == "write" {
-            let arguments = serde_json::from_str::<tool::WriteArguments>(&function.arguments)
-                .map_err(|error| model::ModelError::InvalidToolArguments {
-                    reason: schema_contract::bounded_diagnostic(error),
-                })?;
-
-            tool::ToolCall::write(call.id, arguments, reasoning_content.map(str::to_string))
-        } else {
-            let arguments = serde_json::from_str::<tool::ReadArguments>(&function.arguments)
-                .map_err(|error| model::ModelError::InvalidToolArguments {
-                    reason: schema_contract::bounded_diagnostic(error),
-                })?;
-
-            tool::ToolCall::read(call.id, arguments, reasoning_content.map(str::to_string))
-        };
-
-        Ok(call)
+        tool::ToolCall::from_json(
+            call.id,
+            &function.name,
+            &function.arguments,
+            reasoning_content.map(str::to_string),
+        )
     }
 }
 

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -31,7 +31,7 @@ pub use lifecycle::{
 };
 pub use model::{
     CompletionMetadata, CompletionUsage, Model, ModelClient, ModelCompletion, ModelError,
-    ModelErrorType, ModelMetadata, ModelMetadataError, ModelRequest, ModelResponse,
+    ModelErrorType, ModelMessage, ModelMetadata, ModelMetadataError, ModelRequest, ModelResponse,
     ModelWithMetadata,
 };
 pub use provider::{

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -404,12 +404,17 @@ impl ModelRequest {
         &self.tools
     }
 
-    pub(crate) fn advertises_tool(&self, name: &str) -> bool {
-        self.tools.iter().any(|tool| tool.name() == name)
+    /// Returns the ordered conversation to send to the provider, including
+    /// the system prompt, retained turns, current prompt, and tool results.
+    ///
+    /// Model adapters must use this history rather than only [`Self::prompt`]
+    /// to support chat and tool execution. The harness owns its mutation.
+    pub fn messages(&self) -> &[ModelMessage] {
+        &self.messages
     }
 
-    pub(crate) fn messages(&self) -> &[ModelMessage] {
-        &self.messages
+    pub(crate) fn advertises_tool(&self, name: &str) -> bool {
+        self.tools.iter().any(|tool| tool.name() == name)
     }
 
     pub(crate) fn lifecycle_observed(&self) -> bool {
@@ -465,17 +470,32 @@ impl ModelRequest {
     }
 }
 
+/// Provider-neutral conversation entry supplied through
+/// [`ModelRequest::messages`].
+///
+/// Tool results retain their call identifiers so adapters can correlate them
+/// with the preceding assistant calls without parsing provider wire formats.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum ModelMessage {
+#[non_exhaustive]
+pub enum ModelMessage {
+    /// Validated structured assistant output serialized as JSON text.
     Assistant(String),
+    /// One assistant tool call, followed by its result.
     AssistantToolCall(tool::ToolCall),
+    /// An ordered assistant tool-call batch, followed by its ordered results.
     AssistantToolCalls(Vec<tool::ToolCall>),
+    /// Application-provided instructions for the conversation.
     System(String),
+    /// Harness-produced feedback for one assistant tool call.
     ToolResult {
+        /// Identifier of the corresponding assistant tool call.
         call_id: String,
+        /// Serialized tool output or corrective failure feedback.
         content: String,
+        /// Built-in tool name.
         name: String,
     },
+    /// User prompt for a retained or current turn.
     User(String),
 }
 
@@ -770,6 +790,9 @@ pub enum ModelError {
     /// The provider returned tool calls without any call entries.
     #[error("model returned no tool call")]
     MissingToolCall,
+    /// The provider tool-call identifier is blank or exceeds its byte limit.
+    #[error("model returned a blank or oversized tool call identifier")]
+    InvalidToolCallId,
     /// The provider returned more than the single supported call.
     #[error("model returned multiple tool calls")]
     MultipleToolCalls,
@@ -890,6 +913,7 @@ impl ModelError {
                 ModelErrorType::InvalidOutput
             }
             Self::MissingToolCall
+            | Self::InvalidToolCallId
             | Self::MultipleToolCalls
             | Self::DuplicateToolCallId { .. }
             | Self::TerminalResponseWithToolCalls

--- a/crates/ag-harness/src/tool.rs
+++ b/crates/ag-harness/src/tool.rs
@@ -4,6 +4,8 @@ use std::num::NonZeroU64;
 use serde::{Deserialize, Deserializer, Serialize, de};
 use serde_json::{Number, Value, json};
 
+use crate::{model, schema_contract};
+
 const READ_DESCRIPTION: &str = concat!(
     "Inspect the repository with one bounded read-only action. Use `file` with `path` and ",
     "optional `offset`/`limit` for worktree text; `list` with optional `path`/`limit`; ",
@@ -15,6 +17,7 @@ const READ_NAME: &str = "read";
 const MAX_PATCH_BYTES: usize = 1024 * 1024;
 const MAX_PATH_BYTES: usize = 4 * 1024;
 const MAX_QUERY_BYTES: usize = 4 * 1024;
+const MAX_TOOL_CALL_ID_BYTES: usize = 1024;
 pub(crate) const MAX_TOOL_RESULT_BYTES: usize = 64 * 1024;
 const WRITE_DESCRIPTION: &str = concat!(
     "Apply one unified diff to one repository-relative text file. To create an empty file, use ",
@@ -142,22 +145,55 @@ pub struct ToolCall {
     reasoning_content: Option<String>,
 }
 
-impl fmt::Debug for ToolCall {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("ToolCall")
-            .field("arguments", &self.arguments)
-            .field("id", &self.id)
-            .field("name", &self.name())
-            .field(
-                "reasoning_content",
-                &self.reasoning_content.as_ref().map(|_| "[REDACTED]"),
-            )
-            .finish()
-    }
-}
-
 impl ToolCall {
+    /// Decodes a built-in tool call returned by a model adapter.
+    ///
+    /// The call identifier must contain non-whitespace text and be at most
+    /// 1,024 UTF-8 bytes. Accepted identifiers are preserved verbatim.
+    /// Arguments and optional provider reasoning are bounded before decoding.
+    /// Structurally valid read-action mistakes are retained for corrective
+    /// tool feedback. The harness separately enforces tool permissions,
+    /// repository containment, batch identifiers, and execution limits.
+    ///
+    /// # Errors
+    /// Returns [`crate::ModelError`] for an invalid call identifier,
+    /// unsupported tool name, oversized content, or invalid JSON arguments,
+    /// including unsafe repository paths.
+    pub fn from_json(
+        id: String,
+        name: &str,
+        arguments: &str,
+        reasoning_content: Option<String>,
+    ) -> Result<Self, model::ModelError> {
+        if id.len() > MAX_TOOL_CALL_ID_BYTES || id.trim().is_empty() {
+            return Err(model::ModelError::InvalidToolCallId);
+        }
+
+        schema_contract::ensure_content_size(arguments).map_err(model::ModelError::from)?;
+        if let Some(reasoning_content) = &reasoning_content {
+            schema_contract::ensure_content_size(reasoning_content)
+                .map_err(model::ModelError::from)?;
+        }
+        let arguments = match name {
+            READ_NAME => serde_json::from_str(arguments).map(ToolArguments::Read),
+            WRITE_NAME => serde_json::from_str(arguments).map(ToolArguments::Write),
+            _ => {
+                return Err(model::ModelError::UnsupportedToolName {
+                    name: schema_contract::bounded_diagnostic(name),
+                });
+            }
+        }
+        .map_err(|error| model::ModelError::InvalidToolArguments {
+            reason: schema_contract::bounded_diagnostic(error),
+        })?;
+
+        Ok(Self {
+            arguments,
+            id,
+            reasoning_content,
+        })
+    }
+
     /// Returns the typed arguments for this native tool call.
     pub fn arguments(&self) -> ToolCallArguments<'_> {
         match &self.arguments {
@@ -195,6 +231,23 @@ impl ToolCall {
         }
     }
 
+    /// Serializes the validated arguments for replay to a provider.
+    ///
+    /// # Errors
+    /// Returns an error if the argument values cannot be serialized as JSON.
+    pub fn arguments_json(&self) -> Result<String, serde_json::Error> {
+        match &self.arguments {
+            ToolArguments::Read(arguments) => serde_json::to_string(arguments),
+            ToolArguments::Write(arguments) => serde_json::to_string(arguments),
+        }
+    }
+
+    /// Returns optional provider reasoning needed to replay the assistant
+    /// tool call. This sensitive content is redacted from debug output.
+    pub fn reasoning_content(&self) -> Option<&str> {
+        self.reasoning_content.as_deref()
+    }
+
     pub(crate) fn read(
         id: String,
         arguments: ReadArguments,
@@ -218,16 +271,20 @@ impl ToolCall {
             reasoning_content,
         }
     }
+}
 
-    pub(crate) fn arguments_json(&self) -> Result<String, serde_json::Error> {
-        match &self.arguments {
-            ToolArguments::Read(arguments) => serde_json::to_string(arguments),
-            ToolArguments::Write(arguments) => serde_json::to_string(arguments),
-        }
-    }
-
-    pub(crate) fn reasoning_content(&self) -> Option<&str> {
-        self.reasoning_content.as_deref()
+impl fmt::Debug for ToolCall {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ToolCall")
+            .field("arguments", &self.arguments)
+            .field("id", &self.id)
+            .field("name", &self.name())
+            .field(
+                "reasoning_content",
+                &self.reasoning_content.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
     }
 }
 
@@ -600,6 +657,158 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn tool_call_from_json_rejects_blank_and_oversized_identifiers() {
+        // Arrange
+        let identifiers = [
+            String::new(),
+            " \t\n".to_string(),
+            "x".repeat(MAX_TOOL_CALL_ID_BYTES + 1),
+            "é".repeat(MAX_TOOL_CALL_ID_BYTES / 2 + 1),
+        ];
+
+        // Act
+        let results =
+            identifiers.map(|id| ToolCall::from_json(id, "read", r#"{"path":"name.txt"}"#, None));
+
+        // Assert
+        for result in results {
+            let error = result.expect_err("invalid identifier must be rejected");
+            assert!(matches!(error, model::ModelError::InvalidToolCallId));
+            assert_eq!(error.error_type(), model::ModelErrorType::InvalidToolCall);
+            assert_eq!(error.http_status(), None);
+            assert_eq!(
+                error.to_string(),
+                "model returned a blank or oversized tool call identifier"
+            );
+        }
+    }
+
+    #[test]
+    fn tool_call_from_json_preserves_identifiers_within_the_byte_limit() {
+        // Arrange
+        let identifiers = [
+            "x".to_string(),
+            " provider-id ".to_string(),
+            "x".repeat(MAX_TOOL_CALL_ID_BYTES),
+            "é".repeat(MAX_TOOL_CALL_ID_BYTES / 2),
+        ];
+
+        // Act
+        let calls = identifiers.clone().map(|id| {
+            ToolCall::from_json(id, "read", r#"{"path":"name.txt"}"#, None)
+                .expect("valid identifier must be accepted")
+        });
+
+        // Assert
+        for (call, expected_id) in calls.iter().zip(identifiers) {
+            assert_eq!(call.id(), expected_id);
+        }
+    }
+
+    #[test]
+    fn tool_call_from_json_preserves_read_and_write_payloads() {
+        // Arrange
+        let inputs = [
+            (
+                "read",
+                r#"{"path":"Cargo.toml"}"#,
+                Some("reasoning".to_string()),
+            ),
+            ("write", r#"{"path":"name.txt","patch":"patch"}"#, None),
+        ];
+
+        // Act
+        let calls = inputs.clone().map(|(name, arguments, reasoning)| {
+            ToolCall::from_json("call-id".to_string(), name, arguments, reasoning)
+                .expect("valid built-in call should decode")
+        });
+
+        // Assert
+        for (call, (name, arguments, reasoning)) in calls.iter().zip(inputs) {
+            assert_eq!(call.id(), "call-id");
+            assert_eq!(call.name(), name);
+            assert_eq!(call.reasoning_content(), reasoning.as_deref());
+            assert_eq!(
+                serde_json::from_str::<Value>(&call.arguments_json().expect("arguments encode"))
+                    .expect("encoded arguments are JSON"),
+                serde_json::from_str::<Value>(arguments).expect("fixture is JSON")
+            );
+        }
+    }
+
+    #[test]
+    fn tool_call_from_json_rejects_unsupported_names_and_invalid_arguments() {
+        // Arrange
+        let inputs = [
+            ("bash", "{}"),
+            ("read", "{"),
+            ("read", r#"{"path":"../secret"}"#),
+            ("read", r#"{"path":"name.txt","limit":0}"#),
+            ("write", r#"{"path":"name.txt","patch":""}"#),
+            (
+                "write",
+                r#"{"path":"name.txt","patch":"patch","extra":true}"#,
+            ),
+        ];
+
+        // Act
+        let results = inputs.map(|(name, arguments)| {
+            ToolCall::from_json("call-id".to_string(), name, arguments, None)
+        });
+
+        // Assert
+        assert!(matches!(
+            results[0],
+            Err(model::ModelError::UnsupportedToolName { .. })
+        ));
+        assert!(
+            results[1..].iter().all(|result| matches!(
+                result,
+                Err(model::ModelError::InvalidToolArguments { .. })
+            ))
+        );
+    }
+
+    #[test]
+    fn tool_call_from_json_bounds_arguments_and_reasoning() {
+        // Arrange
+        let oversized = "x".repeat(schema_contract::RESPONSE_CONTENT_LIMIT_BYTES + 1);
+        let inputs = [
+            (oversized.as_str(), None),
+            (r#"{"path":"name.txt"}"#, Some(oversized.clone())),
+        ];
+
+        // Act
+        let results = inputs.map(|(arguments, reasoning)| {
+            ToolCall::from_json("call-id".to_string(), "read", arguments, reasoning)
+        });
+
+        // Assert
+        assert!(
+            results
+                .iter()
+                .all(|result| matches!(result, Err(model::ModelError::ResponseContentTooLarge)))
+        );
+    }
+
+    #[test]
+    fn tool_call_from_json_retains_correctable_read_action_errors() {
+        // Arrange
+        let arguments = r#"{"action":"search"}"#;
+
+        // Act
+        let call = ToolCall::from_json("call-id".to_string(), "read", arguments, None)
+            .expect("structurally valid action should reach tool feedback");
+
+        // Assert
+        assert_eq!(
+            call.read_arguments()
+                .and_then(ReadArguments::validation_error),
+            Some("search requires a query and accepts only an optional path and limit")
+        );
+    }
 
     #[test]
     fn read_definition_exposes_native_function_contract() {

--- a/crates/ag-harness/tests/public_api.rs
+++ b/crates/ag-harness/tests/public_api.rs
@@ -1,16 +1,270 @@
 //! External-consumer coverage for the `ag-harness` model traits.
 
 use std::error::Error;
+use std::io::{self, Cursor};
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use ag_harness::{
-    CompletionMetadata, CompletionUsage, Database, Harness, LifecycleEventKind, LifecycleMetrics,
-    LifecycleObserverSet, LifecycleTraceObserver, Model, ModelCompletion, ModelConfiguration,
-    ModelError, ModelMetadata, ModelProvider, ModelRequest, ModelResponse, ModelWithMetadata,
-    OutputSchema, OutputSchemaError, SessionConfig,
+    CompletionMetadata, CompletionUsage, Database, FileSystem, Harness, LifecycleEventKind,
+    LifecycleMetrics, LifecycleObserverSet, LifecycleTraceObserver, Model, ModelCompletion,
+    ModelConfiguration, ModelError, ModelMessage, ModelMetadata, ModelProvider, ModelRequest,
+    ModelResponse, ModelWithMetadata, OutputSchema, OutputSchemaError, SessionConfig, Tool,
+    ToolCall, TurnError,
 };
 use async_trait::async_trait;
 use serde_json::json;
+use tokio::io::AsyncRead;
+
+struct ExternalToolModel {
+    batched: bool,
+    requests: Arc<Mutex<Vec<Vec<ModelMessage>>>>,
+}
+
+#[async_trait]
+impl Model for ExternalToolModel {
+    async fn complete(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
+        self.requests
+            .lock()
+            .map_err(|_| ModelError::request(io::Error::other("request recorder poisoned")))?
+            .push(request.messages().to_vec());
+
+        match request.messages().last() {
+            Some(ModelMessage::User(prompt)) if prompt == "Read the name" => {
+                let call = ToolCall::from_json(
+                    "read-name".to_string(),
+                    "read",
+                    r#"{"path":"name.txt"}"#,
+                    Some("provider replay context".to_string()),
+                )?;
+                if self.batched {
+                    let second = ToolCall::from_json(
+                        "read-again".to_string(),
+                        "read",
+                        r#"{"path":"name.txt"}"#,
+                        None,
+                    )?;
+
+                    return Ok(ModelResponse::ToolCalls(vec![call, second]));
+                }
+
+                Ok(ModelResponse::ToolCall(call))
+            }
+            Some(ModelMessage::ToolResult { content, .. }) => {
+                let result: serde_json::Value =
+                    serde_json::from_str(content).map_err(ModelError::request)?;
+                let name = result["content"]
+                    .as_str()
+                    .ok_or(ModelError::InvalidResponse)?;
+
+                Ok(ModelResponse::Output(json!({ "name": name.trim() })))
+            }
+            Some(ModelMessage::User(_)) => {
+                let previous = request
+                    .messages()
+                    .iter()
+                    .rev()
+                    .find_map(|message| {
+                        if let ModelMessage::Assistant(output) = message {
+                            return Some(output);
+                        }
+
+                        None
+                    })
+                    .ok_or(ModelError::InvalidResponse)?;
+
+                Ok(ModelResponse::Output(
+                    serde_json::from_str(previous).map_err(ModelError::request)?,
+                ))
+            }
+            _ => Err(ModelError::InvalidResponse),
+        }
+    }
+}
+
+struct NameFileSystem;
+
+#[async_trait]
+impl FileSystem for NameFileSystem {
+    async fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        Ok(path.to_path_buf())
+    }
+
+    async fn open_beneath(
+        &self,
+        root: &Path,
+        path: &Path,
+    ) -> io::Result<Box<dyn AsyncRead + Send + Unpin>> {
+        assert_eq!(root, Path::new("fixture"));
+        assert_eq!(path, Path::new("name.txt"));
+
+        Ok(Box::new(Cursor::new(b"Ada\n")))
+    }
+
+    async fn replace_beneath(
+        &self,
+        _root: &Path,
+        _path: &Path,
+        _expected: Option<Vec<u8>>,
+        _content: Vec<u8>,
+    ) -> io::Result<()> {
+        Err(io::Error::other("read-only fixture"))
+    }
+}
+
+#[tokio::test]
+async fn external_model_reads_tool_results_and_retains_chat_history() -> Result<(), Box<dyn Error>>
+{
+    for batched in [false, true] {
+        // Arrange
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let model = ExternalToolModel {
+            batched,
+            requests: Arc::clone(&requests),
+        };
+        let harness = Harness::new(model)
+            .repository("fixture")
+            .file_system(NameFileSystem)
+            .allow(Tool::Read);
+        let mut chat = harness
+            .chat(request()?.schema().clone())
+            .with_system_prompt("Extract names");
+
+        // Act
+        let first = chat.send("Read the name").await?;
+        let second = chat.send("Recall the name").await?;
+
+        // Assert
+        assert_eq!(first.output(), &json!({ "name": "Ada" }));
+        assert_eq!(second.output(), first.output());
+        assert_eq!(
+            first.report().tool_calls().len(),
+            if batched { 2 } else { 1 }
+        );
+        assert_eq!(second.report().tool_calls().len(), 0);
+        let requests = requests
+            .lock()
+            .expect("request recorder should not be poisoned");
+        assert_eq!(requests.len(), 3);
+        assert!(
+            matches!(requests[0].as_slice(), [ModelMessage::System(system), ModelMessage::User(prompt)]
+            if system == "Extract names" && prompt == "Read the name")
+        );
+        let calls = match &requests[1][2] {
+            ModelMessage::AssistantToolCall(call) if !batched => std::slice::from_ref(call),
+            ModelMessage::AssistantToolCalls(calls) if batched => calls.as_slice(),
+            message => return Err(format!("unexpected assistant message: {message:?}").into()),
+        };
+        assert_eq!(requests[1].len(), 3 + calls.len());
+        assert_eq!(
+            calls[0].reasoning_content(),
+            Some("provider replay context")
+        );
+        assert_eq!(calls[0].arguments_json()?, r#"{"path":"name.txt"}"#);
+        for (call, result) in calls.iter().zip(&requests[1][3..]) {
+            assert!(
+                matches!(result, ModelMessage::ToolResult { call_id, content, name }
+                if call_id == call.id() && name == "read" && content.contains("Ada"))
+            );
+        }
+        assert_eq!(&requests[2][..requests[1].len()], requests[1].as_slice());
+        assert!(matches!(&requests[2][requests[1].len()..],
+            [ModelMessage::Assistant(output), ModelMessage::User(prompt)]
+                if serde_json::from_str::<serde_json::Value>(output)? == *first.output()
+                    && prompt == "Recall the name"));
+    }
+
+    Ok(())
+}
+
+#[test]
+fn external_adapter_enforces_tool_call_identifier_limits() -> Result<(), Box<dyn Error>> {
+    for (name, arguments) in [
+        ("read", r#"{"path":"name.txt"}"#),
+        ("write", r#"{"path":"name.txt","patch":"patch"}"#),
+    ] {
+        // Arrange
+        let invalid_identifiers = [
+            String::new(),
+            " \t\n".to_string(),
+            "x".repeat(1025),
+            "é".repeat(513),
+        ];
+        let boundary_id = "é".repeat(512);
+
+        // Act
+        let rejected = invalid_identifiers.map(|id| ToolCall::from_json(id, name, arguments, None));
+        let accepted = ToolCall::from_json(boundary_id.clone(), name, arguments, None)?;
+
+        // Assert
+        assert!(
+            rejected
+                .iter()
+                .all(|result| matches!(result, Err(ModelError::InvalidToolCallId)))
+        );
+        assert_eq!(accepted.id(), boundary_id);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn external_adapter_constructs_a_validated_write_call() -> Result<(), Box<dyn Error>> {
+    // Arrange
+    let arguments = json!({
+        "path": "name.txt",
+        "patch": "--- a/name.txt\n+++ b/name.txt\n@@ -1 +1 @@\n-Ada\n+Grace\n"
+    });
+
+    // Act
+    let call = ToolCall::from_json(
+        "write-name".to_string(),
+        "write",
+        &arguments.to_string(),
+        None,
+    )?;
+    let invalid = ToolCall::from_json(
+        "unsafe".to_string(),
+        "write",
+        r#"{"path":"../secret","patch":"patch"}"#,
+        None,
+    );
+
+    // Assert
+    assert_eq!(
+        call.write_arguments().expect("write arguments").path(),
+        "name.txt"
+    );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&call.arguments_json()?)?,
+        arguments
+    );
+    assert!(matches!(
+        invalid,
+        Err(ModelError::InvalidToolArguments { .. })
+    ));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn external_tool_call_still_requires_harness_permission() -> Result<(), Box<dyn Error>> {
+    // Arrange
+    let harness = Harness::new(ExternalToolModel {
+        batched: false,
+        requests: Arc::new(Mutex::new(Vec::new())),
+    });
+
+    // Act
+    let result = harness
+        .run("Read the name", request()?.schema().clone())
+        .await;
+
+    // Assert
+    assert!(matches!(result, Err(TurnError::ToolDenied { name }) if name == "read"));
+
+    Ok(())
+}
 
 struct ExternalModel;
 

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -125,6 +125,16 @@ sequenceDiagram
 Unsupported configurations return an explicit error instead of silently falling back to
 unstructured text.
 
+### External model adapters
+
+`ModelRequest::messages()` exposes the ordered conversation as immutable `ModelMessage`
+entries. External adapters translate system instructions, retained turns, assistant tool
+calls, and correlated results from this view rather than from `prompt()` alone.
+`ToolCall::from_json()` shares bounded built-in argument decoding with native providers;
+call serialization and optional reasoning are available for provider replay. History
+mutation, tool permissions, execution limits, and terminal schema validation remain
+owned by the harness.
+
 ## Telemetry
 
 - **Metrics** - record model and tool duration, token usage, and outcomes.


### PR DESCRIPTION
- Publishes `ModelMessage` and `ModelRequest::messages()` for complete conversation translation, including tool calls and correlated results.
- Adds bounded `ToolCall` decoding, argument serialization, reasoning access, and call-ID validation for provider replay.
- Documents external adapter requirements and covers the public API with integration tests.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)