### PR TITLE
Release Agentty 0.15.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.15.11] - 2026-09-05
+
+### Added
+
+- agentty: add the `gpt-6-astra` Codex model with its large-context compaction policy.
+
+### Changed
+
+- ag-harness: accept bounded assistant content alongside native tool calls while
+  preserving response-size limits.
+- ag-harness: expand live benchmarks with persistent session reopening, lifecycle
+  telemetry, filtering, rate limiting, latency reporting, and redacted provider errors.
+- ag-harness: simplify file line scanning and session history budget selection.
+- release: bump workspace crate metadata and lockfile package versions to `0.15.11`.
+
+### Fixed
+
+- agentty: restrict generated npm test scripts to owner-only executable permissions.
+
+### Contributors
+
+- @andagaev
+- @minev-dev
+
 ## [v0.15.10] - 2026-09-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.15.10"
+version = "0.15.11"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.15.10"
+version = "0.15.11"
 dependencies = [
  "image",
  "mockall",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.15.10"
+version = "0.15.11"
 dependencies = [
  "mockall",
  "serde",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.15.10"
+version = "0.15.11"
 dependencies = [
  "mockall",
  "rustix",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "ag-harness"
-version = "0.15.10"
+version = "0.15.11"
 dependencies = [
  "async-trait",
  "jsonschema",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "ag-harness-cli"
-version = "0.15.10"
+version = "0.15.11"
 dependencies = [
  "ag-harness",
  "assert_cmd",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.15.10"
+version = "0.15.11"
 dependencies = [
  "askama",
  "schemars 1.2.2",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "ag-session"
-version = "0.15.10"
+version = "0.15.11"
 dependencies = [
  "ag-agent",
  "ag-forge",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "ag-store"
-version = "0.15.10"
+version = "0.15.11"
 dependencies = [
  "ag-agent",
  "ag-session",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.15.10"
+version = "0.15.11"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.15.10"
+version = "0.15.11"
 dependencies = [
  "clap",
  "tempfile",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.15.10"
+version = "0.15.11"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.15.10"
+version = "0.15.11"
 dependencies = [
  "base64 0.23.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.15.10"
+version = "0.15.11"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -16,16 +16,16 @@ repository = "https://github.com/agentty-xyz/agentty"
 homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.15.10" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.15.10" }
-ag-forge = { path = "crates/ag-forge", version = "0.15.10" }
-ag-git = { path = "crates/ag-git", version = "0.15.10" }
-ag-harness = { path = "crates/ag-harness", version = "0.15.10" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.15.10" }
-ag-session = { path = "crates/ag-session", version = "0.15.10" }
-ag-store = { path = "crates/ag-store", version = "0.15.10" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.15.10" }
-testty = { path = "crates/testty", version = "0.15.10" }
+ag-agent = { path = "crates/ag-agent", version = "0.15.11" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.15.11" }
+ag-forge = { path = "crates/ag-forge", version = "0.15.11" }
+ag-git = { path = "crates/ag-git", version = "0.15.11" }
+ag-harness = { path = "crates/ag-harness", version = "0.15.11" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.15.11" }
+ag-session = { path = "crates/ag-session", version = "0.15.11" }
+ag-store = { path = "crates/ag-store", version = "0.15.11" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.15.11" }
+testty = { path = "crates/testty", version = "0.15.11" }
 async-trait = "0.1"
 agent-client-protocol = "2.0.0"
 assert_cmd = "2"


### PR DESCRIPTION
- Adds the `gpt-6-astra` Codex model with large-context compaction.
- Expands harness assistant handling and live benchmark coverage.
- Restricts generated npm test scripts to owner-only executable permissions.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)