### PR TITLE
Transcript rendering and scrolling stay responsive

### DIFF
--- a/crates/ag-tui-text/src/mermaid.rs
+++ b/crates/ag-tui-text/src/mermaid.rs
@@ -1,4 +1,6 @@
+use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
 
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
@@ -21,6 +23,7 @@ pub const MAX_SOURCE_BYTE_COUNT: usize = 16 * 1024;
 /// Maximum source lines accepted for one mermaid source preview.
 pub const MAX_SOURCE_LINE_COUNT: usize = 128;
 const NODE_BOX_HEIGHT: usize = 3;
+const PARSED_MERMAID_CACHE_ENTRY_LIMIT: usize = 64;
 const SEQUENCE_MAX_GAP_COLUMNS: usize = MAX_LABEL_WIDTH + 2;
 const SEQUENCE_MIN_GAP_COLUMNS: usize = 8;
 const SEQUENCE_SELF_LOOP_COLUMNS: usize = 3;
@@ -63,15 +66,19 @@ pub fn render_mermaid_with_settings(
 /// Renders a diagram within `max_width`, stacking an over-wide left-to-right
 /// graph from top to bottom before giving up on its terminal preview.
 pub(crate) fn render_mermaid_for_width(source: &str, max_width: usize) -> Option<MermaidDiagram> {
-    let diagram = render_mermaid_active_settings(source)?;
+    let parsed = parsed_mermaid(source)?;
+    let diagram = parsed.render()?;
     if diagram.width <= max_width {
         return Some(diagram);
     }
 
-    let mut graph = parse_graph(source)?;
+    let ParsedMermaid::Graph(graph) = parsed.as_ref() else {
+        return None;
+    };
     if !matches!(graph.direction, FlowDirection::LeftRight) {
         return None;
     }
+    let mut graph = graph.clone();
     graph.direction = FlowDirection::TopDown;
 
     let diagram = render_graph(graph)?;
@@ -79,16 +86,68 @@ pub(crate) fn render_mermaid_for_width(source: &str, max_width: usize) -> Option
 }
 
 fn render_mermaid_active_settings(source: &str) -> Option<MermaidDiagram> {
+    parsed_mermaid(source)?.render()
+}
+
+/// Parsing is independent of width and palette. Cache at most 64 bounded
+/// sources, including unsupported syntax, so resizing and scrollbar probes
+/// reuse parsing without retaining styled output from another theme.
+struct ParsedMermaidCacheEntry {
+    diagram: Option<Arc<ParsedMermaid>>,
+    source: Box<str>,
+}
+
+thread_local! {
+    static PARSED_MERMAID_CACHE: RefCell<VecDeque<ParsedMermaidCacheEntry>> =
+        const { RefCell::new(VecDeque::new()) };
+}
+
+enum ParsedMermaid {
+    Graph(MermaidGraph),
+    Sequence(SequenceDiagram),
+}
+
+impl ParsedMermaid {
+    fn render(&self) -> Option<MermaidDiagram> {
+        match self {
+            Self::Graph(graph) => render_graph(graph.clone()),
+            Self::Sequence(diagram) => Some(draw_sequence_diagram(diagram)),
+        }
+    }
+}
+
+fn parsed_mermaid(source: &str) -> Option<Arc<ParsedMermaid>> {
     if !is_source_within_bounds(source) {
         return None;
     }
 
-    if let Some(sequence_diagram) = parse_sequence_diagram(source) {
-        return Some(draw_sequence_diagram(&sequence_diagram));
-    }
+    PARSED_MERMAID_CACHE.with(|cache| {
+        let mut entries = cache.borrow_mut();
+        if let Some(index) = entries
+            .iter()
+            .position(|entry| entry.source.as_ref() == source)
+        {
+            let entry = entries.remove(index)?;
+            let diagram = entry.diagram.clone();
+            entries.push_front(entry);
 
-    let graph = parse_graph(source)?;
-    render_graph(graph)
+            return diagram;
+        }
+
+        let diagram = parse_sequence_diagram(source)
+            .map(ParsedMermaid::Sequence)
+            .or_else(|| parse_graph(source).map(ParsedMermaid::Graph))
+            .map(Arc::new);
+        entries.push_front(ParsedMermaidCacheEntry {
+            diagram: diagram.clone(),
+            source: source.into(),
+        });
+        if entries.len() > PARSED_MERMAID_CACHE_ENTRY_LIMIT {
+            entries.pop_back();
+        }
+
+        diagram
+    })
 }
 
 /// Lays out one parsed graph using its current direction.
@@ -133,6 +192,7 @@ enum NodeShape {
 }
 
 /// One declared diagram node.
+#[derive(Clone)]
 struct MermaidNode {
     is_hidden: bool,
     is_visible: bool,
@@ -141,6 +201,7 @@ struct MermaidNode {
 }
 
 /// One directed or undirected link between two nodes.
+#[derive(Clone)]
 struct MermaidEdge {
     from_index: usize,
     has_arrow: bool,
@@ -153,6 +214,7 @@ struct MermaidEdge {
 }
 
 /// Parsed mermaid diagram ready for layered layout.
+#[derive(Clone)]
 struct MermaidGraph {
     direction: FlowDirection,
     edges: Vec<MermaidEdge>,
@@ -3320,5 +3382,91 @@ mod tests {
         assert!(text.contains('A'));
         assert!(text.contains('C'));
         assert!(!text.contains('▼'));
+    }
+
+    #[test]
+    fn test_parsed_cache_reuses_source_across_widths_and_palettes() {
+        // Arrange
+        let source = "graph LR\nParse[Parse once] --> Paint[Paint twice]";
+        let first = parsed_mermaid(source).expect("parsed graph");
+        let mut settings = TextRenderSettings::default();
+        settings.palette.text = ratatui::style::Color::Red;
+
+        // Act
+        let wide = render_mermaid_for_width(source, 80).expect("wide diagram");
+        let narrow = render_mermaid_for_width(source, 20).expect("stacked diagram");
+        let themed = render_mermaid_with_settings(source, settings).expect("themed diagram");
+        let repeated = parsed_mermaid(source).expect("cached graph");
+
+        // Assert
+        assert!(Arc::ptr_eq(&first, &repeated));
+        assert!(wide.width > narrow.width);
+        assert!(narrow.lines.len() > wide.lines.len());
+        assert!(
+            themed
+                .lines
+                .iter()
+                .flat_map(|line| &line.spans)
+                .any(|span| span.style.fg == Some(ratatui::style::Color::Red))
+        );
+    }
+
+    #[test]
+    fn test_sequence_preview_rejects_narrow_width_and_reuses_parse_when_widened() {
+        // Arrange
+        let source = "sequenceDiagram\nAlice->>Bob: Hello";
+        let original = render_mermaid_for_width(source, 80).expect("sequence preview");
+
+        // Act
+        let too_narrow = render_mermaid_for_width(source, original.width - 1);
+        let widened = render_mermaid_for_width(source, original.width).expect("restored preview");
+
+        // Assert
+        assert!(too_narrow.is_none());
+        assert_eq!(widened.lines, original.lines);
+        assert_eq!(widened.width, original.width);
+    }
+
+    #[test]
+    fn test_parsed_cache_is_bounded_and_promotes_hits() {
+        // Arrange
+        PARSED_MERMAID_CACHE.with(|cache| cache.borrow_mut().clear());
+        let source = "graph TD\nKeep --> Cached";
+        let first = parsed_mermaid(source).expect("first diagram");
+        for index in 0..PARSED_MERMAID_CACHE_ENTRY_LIMIT - 1 {
+            parsed_mermaid(&format!("graph TD\nNode{index} --> End"));
+        }
+
+        // Act
+        let promoted = parsed_mermaid(source).expect("promoted diagram");
+        parsed_mermaid("graph TD\nExtra --> End");
+        let retained = parsed_mermaid(source).expect("retained diagram");
+
+        // Assert
+        assert!(Arc::ptr_eq(&first, &promoted));
+        assert!(Arc::ptr_eq(&first, &retained));
+        PARSED_MERMAID_CACHE.with(|cache| {
+            let entries = cache.borrow();
+            assert_eq!(entries.len(), PARSED_MERMAID_CACHE_ENTRY_LIMIT);
+            assert!(entries.iter().all(|entry| !entry.source.contains("Node0 ")));
+        });
+    }
+
+    #[test]
+    fn test_parsed_cache_retains_unsupported_source_but_rejects_oversized_input() {
+        // Arrange
+        PARSED_MERMAID_CACHE.with(|cache| cache.borrow_mut().clear());
+        let unsupported = "classDiagram\nA <|-- B";
+
+        // Act
+        let first = parsed_mermaid(unsupported);
+        let repeated = parsed_mermaid(unsupported);
+        let oversized = parsed_mermaid(&"x".repeat(MAX_SOURCE_BYTE_COUNT + 1));
+
+        // Assert
+        assert!(first.is_none());
+        assert!(repeated.is_none());
+        assert!(oversized.is_none());
+        PARSED_MERMAID_CACHE.with(|cache| assert_eq!(cache.borrow().len(), 1));
     }
 }

--- a/crates/agentty/src/runtime/event.rs
+++ b/crates/agentty/src/runtime/event.rs
@@ -14,14 +14,19 @@ use tracing::debug;
 
 use crate::app::{App, AppRuntimeEvent};
 use crate::domain::input::InputCommand;
+use crate::infra::clock::Clock;
 use crate::presentation::app_mode::AppMode;
+use crate::runtime::mode::chat_scroll::ChatScrollBatch;
 use crate::runtime::{EventResult, FRAME_INTERVAL, PresentationState, key_handler, mode};
+use crate::ui::RenderCacheStore;
 
 /// Maximum terminal input events processed in one foreground cycle.
 ///
 /// Additional queued events remain buffered for the next runtime cycle so the
 /// render loop can redraw between large paste/key-repeat bursts.
 const TERMINAL_EVENT_DRAIN_BUDGET: usize = 64;
+/// Yield to painting after eight milliseconds even when keys remain queued.
+const TERMINAL_EVENT_DRAIN_DURATION: Duration = Duration::from_millis(8);
 
 /// Reads terminal events from an underlying event backend.
 #[cfg_attr(test, mockall::automock)]
@@ -140,17 +145,73 @@ pub(crate) async fn process_events<B: Backend, Message: TerminalEventMessage>(
 where
     B::Error: std::error::Error + Send + Sync + 'static,
 {
-    process_events_with_handler(app, terminal, event_rx, tick, |app, terminal, event| {
-        let presentation = Rc::clone(&presentation);
+    process_events_with_scroll_handler(
+        app,
+        presentation,
+        terminal,
+        event_rx,
+        tick,
+        ChatScrollBatch::handle,
+    )
+    .await
+}
 
-        Box::pin(process_event(app, presentation, terminal, event))
-    })
+/// Runs the production dispatcher with an injectable scroll handler so
+/// measurement failures can be tested without a failing physical terminal.
+async fn process_events_with_scroll_handler<B: Backend, Message: TerminalEventMessage>(
+    app: &mut App,
+    presentation: Rc<PresentationState>,
+    terminal: &mut Terminal<B>,
+    event_rx: &mut mpsc::UnboundedReceiver<Message>,
+    tick: &mut tokio::time::Interval,
+    mut handle_scroll: impl FnMut(
+        &mut ChatScrollBatch,
+        &mut App,
+        &RenderCacheStore,
+        &Terminal<B>,
+        KeyEvent,
+    ) -> io::Result<bool>,
+) -> io::Result<EventResult>
+where
+    B::Error: std::error::Error + Send + Sync + 'static,
+{
+    let clock = app.services.clock();
+    let mut scroll_batch = ChatScrollBatch::default();
+    process_events_with_handler(
+        clock.as_ref(),
+        app,
+        terminal,
+        event_rx,
+        tick,
+        |app, terminal, event| {
+            if let Some(Event::Key(key)) = event.as_ref()
+                && is_press_key_event(*key)
+            {
+                match handle_scroll(
+                    &mut scroll_batch,
+                    app,
+                    presentation.render_cache_store(),
+                    terminal,
+                    *key,
+                ) {
+                    Ok(true) => return Box::pin(std::future::ready(Ok(EventResult::Continue))),
+                    Err(error) => return Box::pin(std::future::ready(Err(error))),
+                    Ok(false) => {}
+                }
+            }
+            scroll_batch = ChatScrollBatch::default();
+            let presentation = Rc::clone(&presentation);
+
+            Box::pin(process_event(app, presentation, terminal, event))
+        },
+    )
     .await
 }
 
 /// Processes one event/tick cycle with an injected event handler so loop exit
 /// branches can be tested without a real terminal.
 async fn process_events_with_handler<Terminal, Message, EventHandler>(
+    clock: &dyn Clock,
     app: &mut App,
     terminal: &mut Terminal,
     event_rx: &mut mpsc::UnboundedReceiver<Message>,
@@ -177,6 +238,7 @@ where
         runtime_event = app.next_runtime_event() => LoopSignal::Runtime(runtime_event),
         _ = tick.tick() => LoopSignal::Tick,
     };
+    let batch_started_at = clock.now_instant();
     let mut handled_terminal_events = 0;
     let maybe_event = match signal {
         LoopSignal::Runtime(runtime_event) => {
@@ -219,6 +281,13 @@ where
     let remaining_terminal_event_budget =
         TERMINAL_EVENT_DRAIN_BUDGET.saturating_sub(handled_terminal_events);
     for _ in 0..remaining_terminal_event_budget {
+        if clock
+            .now_instant()
+            .saturating_duration_since(batch_started_at)
+            >= TERMINAL_EVENT_DRAIN_DURATION
+        {
+            break;
+        }
         let event = match event_rx.try_recv() {
             Ok(message) => message.into_event_result()?,
             Err(mpsc::error::TryRecvError::Empty) => break,
@@ -954,6 +1023,7 @@ mod tests {
 
         // Act
         let result = process_events_with_handler(
+            &crate::test_support::FixedClock::unix_epoch(),
             &mut app,
             &mut terminal,
             &mut event_rx,
@@ -980,6 +1050,7 @@ mod tests {
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
         let mut tick = tokio::time::interval(Duration::from_mins(1));
         let initial_result = process_events_with_handler(
+            &crate::test_support::FixedClock::unix_epoch(),
             &mut app,
             &mut terminal,
             &mut event_rx,
@@ -993,6 +1064,7 @@ mod tests {
 
         // Act
         let result = process_events_with_handler(
+            &crate::test_support::FixedClock::unix_epoch(),
             &mut app,
             &mut terminal,
             &mut event_rx,
@@ -1020,6 +1092,7 @@ mod tests {
         let (event_tx, mut event_rx) = mpsc::unbounded_channel::<io::Result<Event>>();
         let mut tick = tokio::time::interval(Duration::from_mins(1));
         let initial_result = process_events_with_handler(
+            &crate::test_support::FixedClock::unix_epoch(),
             &mut app,
             &mut terminal,
             &mut event_rx,
@@ -1031,6 +1104,7 @@ mod tests {
 
         // Act
         let result = process_events_with_handler(
+            &crate::test_support::FixedClock::unix_epoch(),
             &mut app,
             &mut terminal,
             &mut event_rx,
@@ -1068,6 +1142,7 @@ mod tests {
         let result = tokio::time::timeout(Duration::from_secs(1), async {
             loop {
                 let result = process_events_with_handler(
+                    &crate::test_support::FixedClock::unix_epoch(),
                     &mut app,
                     &mut terminal,
                     &mut event_rx,
@@ -1111,6 +1186,7 @@ mod tests {
 
         // Act
         let result = process_events_with_handler(
+            &crate::test_support::FixedClock::unix_epoch(),
             &mut app,
             &mut terminal,
             &mut event_rx,
@@ -1147,8 +1223,13 @@ mod tests {
         let mut tick = tokio::time::interval(Duration::from_mins(1));
 
         // Act
-        let result =
-            process_events_with_handler(&mut app, &mut terminal, &mut event_rx, &mut tick, {
+        let result = process_events_with_handler(
+            &crate::test_support::FixedClock::unix_epoch(),
+            &mut app,
+            &mut terminal,
+            &mut event_rx,
+            &mut tick,
+            {
                 let handled_events = Arc::clone(&handled_events);
 
                 move |_, (), event| {
@@ -1158,8 +1239,9 @@ mod tests {
 
                     Box::pin(async { Ok(EventResult::Continue) })
                 }
-            })
-            .await;
+            },
+        )
+        .await;
 
         // Assert
         assert!(matches!(result, Ok(EventResult::Continue)));
@@ -1190,8 +1272,13 @@ mod tests {
         tick.tick().await;
 
         // Act
-        let result =
-            process_events_with_handler(&mut app, &mut terminal, &mut event_rx, &mut tick, {
+        let result = process_events_with_handler(
+            &crate::test_support::FixedClock::unix_epoch(),
+            &mut app,
+            &mut terminal,
+            &mut event_rx,
+            &mut tick,
+            {
                 let handled_events = Arc::clone(&handled_events);
 
                 move |_, (), event| {
@@ -1201,8 +1288,9 @@ mod tests {
 
                     Box::pin(async { Ok(EventResult::Continue) })
                 }
-            })
-            .await;
+            },
+        )
+        .await;
 
         // Assert
         let error = result
@@ -1210,5 +1298,173 @@ mod tests {
             .expect("closed reader channel should exit during drain");
         assert_eq!(error.kind(), ErrorKind::UnexpectedEof);
         assert_eq!(handled_events.load(Ordering::Relaxed), 1);
+    }
+
+    struct BatchClock {
+        elapsed_millis: AtomicUsize,
+        start: std::time::Instant,
+    }
+
+    impl Clock for BatchClock {
+        fn now_instant(&self) -> std::time::Instant {
+            self.start + Duration::from_millis(self.elapsed_millis.load(Ordering::Relaxed) as u64)
+        }
+
+        fn now_system_time(&self) -> std::time::SystemTime {
+            std::time::SystemTime::UNIX_EPOCH
+        }
+    }
+
+    #[tokio::test]
+    async fn test_event_batch_yields_when_elapsed_budget_is_reached() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let clock = BatchClock {
+            elapsed_millis: AtomicUsize::new(0),
+            start: std::time::Instant::now(),
+        };
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        for _ in 0..3 {
+            event_tx
+                .send(Ok(Event::Key(KeyEvent::new(
+                    KeyCode::Char('j'),
+                    KeyModifiers::NONE,
+                ))))
+                .expect("queue key");
+        }
+        let mut tick = tokio::time::interval(Duration::from_mins(1));
+        tick.tick().await;
+        let mut handled = 0;
+
+        // Act
+        let result = process_events_with_handler(
+            &clock,
+            &mut app,
+            &mut (),
+            &mut event_rx,
+            &mut tick,
+            |_, (), event| {
+                if event.is_some() {
+                    handled += 1;
+                    clock.elapsed_millis.store(8, Ordering::Relaxed);
+                }
+
+                Box::pin(async { Ok(EventResult::Continue) })
+            },
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(result, Ok(EventResult::Continue)));
+        assert_eq!(handled, 1);
+        assert_eq!(event_rx.len(), 2);
+        assert_eq!(clock.now_system_time(), std::time::SystemTime::UNIX_EPOCH);
+    }
+
+    #[tokio::test]
+    async fn test_production_event_batch_scrolls_then_leaves_mermaid_session() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let session = crate::test_support::SessionFixtureBuilder::new()
+            .status(Status::Review)
+            .transcript("```mermaid\ngraph TD\nA --> B\n```\n".repeat(20))
+            .build();
+        app.mode = AppMode::View {
+            session_id: session.id.clone(),
+            scroll_offset: Some(0),
+        };
+        app.sessions.push_session(session);
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, 24)).expect("terminal");
+        let presentation = Rc::new(PresentationState::default());
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        for key in ['j', 'j', 'k'] {
+            event_tx
+                .send(Ok(Event::Key(KeyEvent::new(
+                    KeyCode::Char(key),
+                    KeyModifiers::NONE,
+                ))))
+                .expect("queue scroll");
+        }
+        event_tx
+            .send(Ok(Event::Resize(80, 24)))
+            .expect("queue resize");
+        event_tx
+            .send(Ok(Event::Key(KeyEvent::new(
+                KeyCode::Char('q'),
+                KeyModifiers::NONE,
+            ))))
+            .expect("queue navigation");
+        let mut tick = tokio::time::interval(Duration::from_mins(1));
+        tick.tick().await;
+
+        // Act
+        while !event_rx.is_empty() {
+            process_events(
+                &mut app,
+                Rc::clone(&presentation),
+                &mut terminal,
+                &mut event_rx,
+                &mut tick,
+            )
+            .await
+            .expect("dispatch input");
+        }
+
+        // Assert
+        assert!(matches!(app.mode, AppMode::List));
+        assert!(app.needs_redraw());
+    }
+
+    #[tokio::test]
+    async fn test_event_batch_propagates_scroll_measurement_error() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let session = crate::test_support::SessionFixtureBuilder::new()
+            .status(Status::Review)
+            .build();
+        app.mode = AppMode::View {
+            session_id: session.id.clone(),
+            scroll_offset: Some(3),
+        };
+        app.sessions.push_session(session);
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, 24)).expect("terminal");
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let key = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE);
+        event_tx.send(Event::Key(key)).expect("queue scroll");
+        let mut tick = tokio::time::interval(Duration::from_mins(1));
+        tick.tick().await;
+
+        // Act
+        let result = process_events_with_scroll_handler(
+            &mut app,
+            Rc::new(PresentationState::default()),
+            &mut terminal,
+            &mut event_rx,
+            &mut tick,
+            |_, _, _, _, received_key| {
+                assert_eq!(received_key, key);
+
+                Err(io::Error::new(
+                    ErrorKind::BrokenPipe,
+                    "terminal size unavailable",
+                ))
+            },
+        )
+        .await;
+
+        // Assert
+        let error = result.err().expect("scroll failure must reach the caller");
+        assert_eq!(error.kind(), ErrorKind::BrokenPipe);
+        assert_eq!(error.to_string(), "terminal size unavailable");
+        assert!(event_rx.is_empty());
+        assert!(matches!(
+            app.mode,
+            AppMode::View {
+                scroll_offset: Some(3),
+                ..
+            }
+        ));
     }
 }

--- a/crates/agentty/src/runtime/mode/chat_scroll.rs
+++ b/crates/agentty/src/runtime/mode/chat_scroll.rs
@@ -4,12 +4,16 @@
 //! transcript with the same keys, so the metrics and offset math live here
 //! instead of in each mode handler.
 
+use std::io;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::Terminal;
+use ratatui::backend::Backend;
 use ratatui::layout::Rect;
 
 use crate::app::App;
 use crate::domain::session::{SessionId, SessionRole};
-use crate::presentation::app_mode::ChatFocus;
+use crate::presentation::app_mode::{AppMode, ChatFocus};
 use crate::runtime::mode::session_output_metric;
 use crate::ui::page::session_chat::{self, SessionChatLayoutInput};
 use crate::ui::{RenderCacheStore, input_layout, layout, page, session_format};
@@ -24,6 +28,88 @@ pub(crate) struct ChatScrollMetrics {
     pub(crate) total_lines: u16,
     /// Visible transcript height in terminal lines.
     pub(crate) view_height: u16,
+}
+
+/// Metrics reused only during consecutive transcript scroll events in one
+/// input batch. The event dispatcher drops this cache on any other event and
+/// at the next cycle, before applying background updates or new geometry.
+#[derive(Default)]
+pub(crate) struct ChatScrollBatch {
+    metrics: Option<ChatScrollMetrics>,
+}
+
+impl ChatScrollBatch {
+    pub(crate) fn handle<B: Backend>(
+        &mut self,
+        app: &mut App,
+        render_cache_store: &RenderCacheStore,
+        terminal: &Terminal<B>,
+        key: KeyEvent,
+    ) -> io::Result<bool>
+    where
+        B::Error: std::error::Error + Send + Sync + 'static,
+    {
+        self.handle_with_measurement(app, key, |app, session_id| {
+            let Some(index) = app.session_index_for_id(session_id) else {
+                return Ok(None);
+            };
+            let size = terminal.size().map_err(crate::runtime::backend_err)?;
+            let terminal_size = Rect::new(0, 0, size.width, size.height);
+
+            Ok(Some(ChatScrollMetrics::new(
+                app,
+                render_cache_store,
+                session_id,
+                index,
+                terminal_size,
+            )))
+        })
+    }
+
+    fn handle_with_measurement(
+        &mut self,
+        app: &mut App,
+        key: KeyEvent,
+        measure: impl FnOnce(&App, &SessionId) -> io::Result<Option<ChatScrollMetrics>>,
+    ) -> io::Result<bool> {
+        if !is_scroll_key(key) {
+            return Ok(false);
+        }
+        let (AppMode::View { session_id, .. }
+        | AppMode::Prompt {
+            at_mention_state: None,
+            session_id,
+            focus: ChatFocus::Chat,
+            ..
+        }
+        | AppMode::Question {
+            session_id,
+            focus: ChatFocus::Chat,
+            ..
+        }) = &app.mode
+        else {
+            return Ok(false);
+        };
+        let metrics = if let Some(metrics) = self.metrics {
+            metrics
+        } else {
+            let Some(metrics) = measure(app, session_id)? else {
+                return Ok(false);
+            };
+            self.metrics = Some(metrics);
+
+            metrics
+        };
+        if let AppMode::View { scroll_offset, .. }
+        | AppMode::Prompt { scroll_offset, .. }
+        | AppMode::Question { scroll_offset, .. } = &mut app.mode
+        {
+            apply_scroll_key(scroll_offset, metrics, key);
+        }
+        app.mark_dirty();
+
+        Ok(true)
+    }
 }
 
 /// A semantic action for a key while a chat page owns the active focus.
@@ -290,11 +376,16 @@ fn half_page_step(metrics: ChatScrollMetrics) -> u16 {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
     use std::collections::HashMap;
 
     use super::*;
     use crate::app::session_state::SessionGitStatus;
+    use crate::domain::input::InputState;
     use crate::domain::session::Status;
+    use crate::presentation::prompt::{
+        PromptAtMentionState, PromptAttachmentState, PromptHistoryState, PromptSlashState,
+    };
     use crate::test_support::SessionFixtureBuilder;
 
     /// Builds a plain key press without modifiers.
@@ -632,5 +723,198 @@ mod tests {
             orchestrator_metrics.view_height + 7,
             regular_metrics.view_height
         );
+    }
+
+    #[tokio::test]
+    async fn test_scroll_batch_measures_once_and_preserves_key_steps() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+        app.mode = AppMode::View {
+            session_id: SessionId::from("scroll-batch"),
+            scroll_offset: Some(0),
+        };
+        let mut batch = ChatScrollBatch::default();
+        let mut measurements = 0;
+
+        // Act
+        for _ in 0..5 {
+            assert!(
+                batch
+                    .handle_with_measurement(&mut app, plain_key(KeyCode::Char('j')), |_, _| {
+                        measurements += 1;
+
+                        Ok(Some(ChatScrollMetrics {
+                            total_lines: 100,
+                            view_height: 10,
+                        }))
+                    })
+                    .expect("scroll should succeed")
+            );
+        }
+
+        // Assert
+        assert_eq!(measurements, 1);
+        assert!(matches!(
+            app.mode,
+            AppMode::View {
+                scroll_offset: Some(5),
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_scroll_batch_ignores_non_scroll_and_unfocused_keys() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+        let mut batch = ChatScrollBatch::default();
+        let measurements = Cell::new(0);
+        let measure_missing = |_: &App, _: &SessionId| {
+            measurements.set(measurements.get() + 1);
+
+            Ok(None)
+        };
+
+        // Act
+        let ignored_action =
+            batch.handle_with_measurement(&mut app, plain_key(KeyCode::Char('q')), measure_missing);
+        let ignored_list_scroll =
+            batch.handle_with_measurement(&mut app, plain_key(KeyCode::Char('j')), measure_missing);
+        assert_eq!(measurements.get(), 0);
+        app.mode = AppMode::View {
+            session_id: SessionId::from("missing"),
+            scroll_offset: Some(0),
+        };
+        let missing_session =
+            batch.handle_with_measurement(&mut app, plain_key(KeyCode::Char('j')), measure_missing);
+        let failed_measurement =
+            batch.handle_with_measurement(&mut app, plain_key(KeyCode::Char('j')), |_, _| {
+                Err(io::Error::other("size unavailable"))
+            });
+
+        // Assert
+        assert!(!ignored_action.expect("ignored action"));
+        assert!(!ignored_list_scroll.expect("ignored list scroll"));
+        assert!(!missing_session.expect("missing session falls through"));
+        assert_eq!(measurements.get(), 1);
+        assert_eq!(
+            failed_measurement
+                .expect_err("measurement error")
+                .to_string(),
+            "size unavailable"
+        );
+        assert!(batch.metrics.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_scroll_batch_missing_session_does_not_cache_empty_metrics() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+        let session = SessionFixtureBuilder::new()
+            .status(Status::Review)
+            .transcript("line\n".repeat(60))
+            .build();
+        app.mode = AppMode::View {
+            session_id: session.id.clone(),
+            scroll_offset: Some(0),
+        };
+        let terminal =
+            Terminal::new(ratatui::backend::TestBackend::new(80, 24)).expect("test terminal");
+        let cache = RenderCacheStore::default();
+        let mut batch = ChatScrollBatch::default();
+        let key = plain_key(KeyCode::Char('j'));
+
+        // Act
+        let missing = batch.handle(&mut app, &cache, &terminal, key);
+        app.sessions.push_session(session);
+        let loaded = batch.handle(&mut app, &cache, &terminal, key);
+
+        // Assert
+        assert!(!missing.expect("missing session falls through"));
+        assert!(loaded.expect("loaded session scrolls"));
+        assert!(matches!(
+            app.mode,
+            AppMode::View {
+                scroll_offset: Some(1),
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_scroll_batch_respects_prompt_and_question_focus() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+        let prompt = AppMode::Prompt {
+            at_mention_state: None,
+            attachment_state: PromptAttachmentState::default(),
+            focus: ChatFocus::Chat,
+            history_state: PromptHistoryState::default(),
+            input: InputState::default(),
+            scroll_offset: Some(0),
+            session_id: SessionId::from("focused"),
+            slash_state: PromptSlashState::default(),
+        };
+        let question = AppMode::Question {
+            at_mention_state: None,
+            current_index: 0,
+            focus: ChatFocus::Chat,
+            input: InputState::default(),
+            questions: Vec::new(),
+            responses: Vec::new(),
+            scroll_offset: Some(0),
+            selected_option_index: None,
+            session_id: SessionId::from("focused"),
+        };
+
+        // Act
+        for mode in [prompt, question] {
+            app.mode = mode;
+            let mut batch = ChatScrollBatch::default();
+            let handled =
+                batch.handle_with_measurement(&mut app, plain_key(KeyCode::Char('j')), |_, _| {
+                    Ok(Some(ChatScrollMetrics {
+                        total_lines: 30,
+                        view_height: 10,
+                    }))
+                });
+
+            // Assert
+            assert!(handled.expect("focused scroll"));
+            if let AppMode::Prompt {
+                focus,
+                scroll_offset,
+                ..
+            }
+            | AppMode::Question {
+                focus,
+                scroll_offset,
+                ..
+            } = &mut app.mode
+            {
+                assert_eq!(*scroll_offset, Some(1));
+                *focus = ChatFocus::Input;
+            }
+            let ignored =
+                batch.handle_with_measurement(&mut app, plain_key(KeyCode::Char('j')), |_, _| {
+                    Err(io::Error::other("input must not measure"))
+                });
+            assert!(!ignored.expect("input key falls through"));
+
+            if let AppMode::Prompt {
+                at_mention_state,
+                focus,
+                ..
+            } = &mut app.mode
+            {
+                *focus = ChatFocus::Chat;
+                *at_mention_state = Some(PromptAtMentionState::new(Vec::new()));
+                let dropdown_key =
+                    batch.handle_with_measurement(&mut app, plain_key(KeyCode::Down), |_, _| {
+                        Err(io::Error::other("dropdown must keep arrow-key precedence"))
+                    });
+                assert!(!dropdown_key.expect("dropdown key falls through"));
+            }
+        }
     }
 }

--- a/crates/agentty/src/runtime/mode/session_view.rs
+++ b/crates/agentty/src/runtime/mode/session_view.rs
@@ -49,7 +49,6 @@ impl ViewPendingUpdate {
 /// Borrowed per-key context used while processing one session-view key event.
 struct ViewKeyContext<'a> {
     context: &'a ViewContext,
-    metrics: ChatScrollMetrics,
     session_snapshot: &'a ViewSessionSnapshot,
 }
 
@@ -219,15 +218,20 @@ where
     let Some(view_context) = view_context(app) else {
         return Ok(EventResult::Continue);
     };
-    let view_metrics = view_metrics(app, render_cache_store, terminal, &view_context)?;
     let mut pending_update = ViewPendingUpdate::from_context(&view_context);
+    if chat_scroll::is_scroll_key(key) {
+        let metrics = view_metrics(app, render_cache_store, terminal, &view_context)?;
+        chat_scroll::apply_scroll_key(&mut pending_update.scroll_offset, metrics, key);
+        apply_view_scroll_and_output_mode(app, pending_update.scroll_offset);
+
+        return Ok(EventResult::Continue);
+    }
 
     let Some(view_session_snapshot) = view_session_snapshot(app, &view_context) else {
         return Ok(EventResult::Continue);
     };
     let view_key_context = ViewKeyContext {
         context: &view_context,
-        metrics: view_metrics,
         session_snapshot: &view_session_snapshot,
     };
 
@@ -263,7 +267,6 @@ async fn handle_view_key(
     pending_update: &mut ViewPendingUpdate,
 ) -> bool {
     let view_context = view_key_context.context;
-    let view_metrics = view_key_context.metrics;
     let view_session_snapshot = view_key_context.session_snapshot;
 
     if let Some(should_apply_pending_update) = handle_primary_view_key(
@@ -276,10 +279,6 @@ async fn handle_view_key(
     .await
     {
         return should_apply_pending_update;
-    }
-
-    if chat_scroll::apply_scroll_key(&mut pending_update.scroll_offset, view_metrics, key) {
-        return true;
     }
 
     if let Some(should_apply_pending_update) = handle_workflow_view_key(
@@ -2965,10 +2964,6 @@ mod tests {
         };
         let view_key_context = ViewKeyContext {
             context: &view_context,
-            metrics: ChatScrollMetrics {
-                total_lines: 10,
-                view_height: 5,
-            },
             session_snapshot: &view_session_snapshot,
         };
 
@@ -3026,10 +3021,6 @@ mod tests {
         };
         let view_key_context = ViewKeyContext {
             context: &view_context,
-            metrics: ChatScrollMetrics {
-                total_lines: 10,
-                view_height: 5,
-            },
             session_snapshot: &view_session_snapshot,
         };
 
@@ -3549,10 +3540,6 @@ mod tests {
         let view_session_snapshot = reply_enabled_review_snapshot();
         let view_key_context = ViewKeyContext {
             context: &view_context,
-            metrics: ChatScrollMetrics {
-                total_lines: 10,
-                view_height: 5,
-            },
             session_snapshot: &view_session_snapshot,
         };
 
@@ -3600,10 +3587,6 @@ mod tests {
         let view_session_snapshot = reply_enabled_review_snapshot();
         let view_key_context = ViewKeyContext {
             context: &view_context,
-            metrics: ChatScrollMetrics {
-                total_lines: 10,
-                view_height: 5,
-            },
             session_snapshot: &view_session_snapshot,
         };
 
@@ -3669,10 +3652,6 @@ mod tests {
         view_session_snapshot.mutate_session_branch = ViewActionState::Disabled;
         let view_key_context = ViewKeyContext {
             context: &view_context,
-            metrics: ChatScrollMetrics {
-                total_lines: 10,
-                view_height: 5,
-            },
             session_snapshot: &view_session_snapshot,
         };
 
@@ -3715,10 +3694,6 @@ mod tests {
         view_session_snapshot.reply_to_session = ViewActionState::Disabled;
         let view_key_context = ViewKeyContext {
             context: &view_context,
-            metrics: ChatScrollMetrics {
-                total_lines: 10,
-                view_height: 5,
-            },
             session_snapshot: &view_session_snapshot,
         };
 
@@ -3818,10 +3793,6 @@ mod tests {
         };
         let view_key_context = ViewKeyContext {
             context: &view_context,
-            metrics: ChatScrollMetrics {
-                total_lines: 10,
-                view_height: 5,
-            },
             session_snapshot: &view_session_snapshot,
         };
 
@@ -3877,10 +3848,6 @@ mod tests {
         };
         let view_key_context = ViewKeyContext {
             context: &view_context,
-            metrics: ChatScrollMetrics {
-                total_lines: 10,
-                view_height: 5,
-            },
             session_snapshot: &view_session_snapshot,
         };
 
@@ -3916,10 +3883,6 @@ mod tests {
             scroll_offset: Some(2),
         };
         let view_context = view_context(&mut app).expect("expected view context");
-        let view_metrics = ChatScrollMetrics {
-            total_lines: 10,
-            view_height: 5,
-        };
 
         // Act
         for key in [
@@ -3954,7 +3917,6 @@ mod tests {
             };
             let view_key_context = ViewKeyContext {
                 context: &view_context,
-                metrics: view_metrics,
                 session_snapshot: &view_session_snapshot,
             };
             let should_apply =
@@ -4399,5 +4361,59 @@ mod tests {
             "snapshot must rebuild from the handle state and not show a phantom row for a prompt \
              the worker is already executing"
         );
+    }
+
+    #[tokio::test]
+    async fn test_scroll_keys_bypass_action_snapshot_and_keep_navigation_working() {
+        // Arrange
+        let (mut app, _base_dir) = crate::test_support::new_test_app().await;
+        let session = crate::test_support::SessionFixtureBuilder::new()
+            .status(Status::Review)
+            .build();
+        let session_id = session.id.clone();
+        app.sessions.push_session(session);
+        app.sessions.sessions_mut()[0].transcript =
+            Some(SessionTranscript::new(vec![SessionMessage::conversation(
+                0,
+                SessionMessageKind::AssistantAnswer,
+                "```mermaid\ngraph TD\nA --> B\n```\n".repeat(100),
+            )]));
+        app.mode = AppMode::View {
+            session_id,
+            scroll_offset: Some(0),
+        };
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, 24)).expect("terminal");
+        let cache = RenderCacheStore::default();
+
+        // Act
+        for key in ['j', 'j', 'k'] {
+            handle_with_cache(
+                &mut app,
+                &cache,
+                &mut terminal,
+                KeyEvent::new(KeyCode::Char(key), KeyModifiers::NONE),
+            )
+            .await
+            .expect("scroll");
+        }
+
+        // Assert
+        assert!(matches!(
+            app.mode,
+            AppMode::View {
+                scroll_offset: Some(1),
+                ..
+            }
+        ));
+        handle_with_cache(
+            &mut app,
+            &cache,
+            &mut terminal,
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
+        )
+        .await
+        .expect("leave session");
+        assert!(matches!(app.mode, AppMode::List));
     }
 }

--- a/crates/agentty/src/ui/component/session_output.rs
+++ b/crates/agentty/src/ui/component/session_output.rs
@@ -21,7 +21,7 @@ use crate::ui::component::vertical_scrollbar::{SCROLLBAR_THUMB_SYMBOL, SCROLLBAR
 use crate::ui::icon::Icon;
 use crate::ui::icon::{QUEUED_ACTION_WIDTH, TACHYON_LOADER_WIDTH};
 use crate::ui::input_layout::{bottom_pinned_scroll_offset, panel_inner_width};
-use crate::ui::session_output_assembly::{self, SessionOutputBody, SessionOutputLines};
+use crate::ui::session_output_assembly::{self, SessionOutputBody};
 use crate::ui::{Component, markdown, session_format, style};
 
 const SCROLLBAR_PADDING_WIDTH: u16 = 1;
@@ -181,15 +181,58 @@ pub(crate) struct SessionOutputLayout {
     /// Number of rendered lines, saturated for scroll metric arithmetic.
     pub(crate) line_count: u16,
     /// Rendered lines shared between scroll metrics and frame painting.
-    pub(crate) lines: Arc<[Line<'static>]>,
+    pub(crate) lines: Arc<SessionOutputLayoutLines>,
     /// Indices of queued rows whose leading glyph receives a calm pulse.
     pub(crate) queued_line_indices: Arc<[usize]>,
     /// Index of an explicit transient loader row within `lines`, when present.
     pub(crate) transient_loader_line_index: Option<usize>,
 }
 
+/// Shared body plus a small status tail. Status updates allocate only the tail.
+/// `body_line_count` excludes trailing blank body rows when a status separator
+/// replaces them, without copying or changing the cached body.
+pub(crate) struct SessionOutputLayoutLines {
+    body: Arc<[Line<'static>]>,
+    body_line_count: usize,
+    tail: Vec<Line<'static>>,
+}
+
+impl SessionOutputLayoutLines {
+    fn len(&self) -> usize {
+        self.body_line_count + self.tail.len()
+    }
+
+    #[cfg(test)]
+    fn iter(&self) -> impl Iterator<Item = &Line<'static>> {
+        self.body[..self.body_line_count]
+            .iter()
+            .chain(self.tail.iter())
+    }
+
+    /// Borrows only the visible slices on either side of the body/tail
+    /// boundary.
+    fn paint_lines(&self, first: usize, height: usize) -> Vec<Line<'_>> {
+        let body_start = first.min(self.body_line_count);
+        let body_end = first.saturating_add(height).min(self.body_line_count);
+        let tail_start = first
+            .saturating_sub(self.body_line_count)
+            .min(self.tail.len());
+        let tail_end = first
+            .saturating_add(height)
+            .saturating_sub(self.body_line_count)
+            .min(self.tail.len());
+        let mut lines = text_util::borrowed_paint_lines(&self.body[body_start..body_end]);
+        lines.extend(text_util::borrowed_paint_lines(
+            &self.tail[tail_start..tail_end],
+        ));
+
+        lines
+    }
+}
+
 /// Final session-output layout selected for the current viewport and
 /// scrollbar state.
+#[derive(Clone)]
 struct SessionOutputResolvedLayout {
     layout: SessionOutputLayout,
     show_scrollbar: bool,
@@ -199,6 +242,13 @@ struct SessionOutputResolvedLayout {
 struct SessionOutputLayoutCacheEntry {
     key: SessionOutputLayoutCacheKey,
     layout: SessionOutputLayout,
+}
+
+/// One resolved viewport, shared by measurement and painting.
+struct SessionOutputResolvedCacheEntry {
+    key: SessionOutputLayoutCacheKey,
+    resolved: SessionOutputResolvedLayout,
+    viewport_height: u16,
 }
 
 /// Cached stable output-body entry.
@@ -220,6 +270,7 @@ struct SessionOutputBodyCacheEntry {
 pub struct SessionOutputLayoutCache {
     body_entries: RefCell<VecDeque<SessionOutputBodyCacheEntry>>,
     entries: RefCell<VecDeque<SessionOutputLayoutCacheEntry>>,
+    resolved_entries: RefCell<VecDeque<SessionOutputResolvedCacheEntry>>,
     tachyon_loader_effects: RefCell<HashMap<SessionId, TachyonLoaderEffect>>,
 }
 
@@ -232,6 +283,7 @@ impl Default for SessionOutputLayoutCache {
             entries: RefCell::new(VecDeque::with_capacity(
                 SESSION_OUTPUT_LAYOUT_CACHE_ENTRY_LIMIT,
             )),
+            resolved_entries: RefCell::new(VecDeque::new()),
             tachyon_loader_effects: RefCell::new(HashMap::new()),
         }
     }
@@ -274,15 +326,64 @@ impl SessionOutputLayoutCache {
 
             body
         });
-        let layout = SessionOutput::layout_from_assembled_lines(
-            session_output_assembly::layout_from_body(session, context.active_progress, &body),
-        );
+        let layout = SessionOutput::layout_from_body(session, context.active_progress, &body);
         self.store_entry(SessionOutputLayoutCacheEntry {
             key,
             layout: layout.clone(),
         });
 
         layout
+    }
+
+    /// Reuses the selected width and lines for identical viewport inputs.
+    /// Content, theme, progress and width changes invalidate this bounded LRU.
+    fn resolved_layout(
+        &self,
+        session: &Session,
+        output_area: Rect,
+        viewport_height: u16,
+        context: SessionOutputLineContext<'_>,
+        markdown_render_cache: Option<&markdown::MarkdownRenderCache>,
+    ) -> SessionOutputResolvedLayout {
+        let key = SessionOutput::layout_cache_key(
+            session,
+            output_area,
+            context,
+            markdown_render_cache.map_or(0, markdown::MarkdownRenderCache::version),
+        );
+        {
+            let mut entries = self.resolved_entries.borrow_mut();
+            if let Some(index) = entries
+                .iter()
+                .position(|entry| entry.key == key && entry.viewport_height == viewport_height)
+                && let Some(entry) = entries.remove(index)
+            {
+                let resolved = entry.resolved.clone();
+                entries.push_front(entry);
+
+                return resolved;
+            }
+        }
+        let resolved = SessionOutput::derive_resolved_layout(
+            session,
+            output_area,
+            viewport_height,
+            context,
+            markdown_render_cache,
+            Some(self),
+        );
+        let mut entries = self.resolved_entries.borrow_mut();
+        entries.retain(|entry| {
+            entry.key.session_id != key.session_id || entry.key.output_width != key.output_width
+        });
+        entries.push_front(SessionOutputResolvedCacheEntry {
+            key,
+            resolved: resolved.clone(),
+            viewport_height,
+        });
+        entries.truncate(SESSION_OUTPUT_LAYOUT_CACHE_ENTRY_LIMIT);
+
+        resolved
     }
 
     /// Returns a matching stable output body and promotes it in the body LRU.
@@ -299,6 +400,10 @@ impl SessionOutputLayoutCache {
     /// Stores one stable output body within the same bound as full layouts.
     fn store_body_entry(&self, entry: SessionOutputBodyCacheEntry) {
         let mut entries = self.body_entries.borrow_mut();
+        entries.retain(|cached| {
+            cached.key.session_id != entry.key.session_id
+                || cached.key.output_width != entry.key.output_width
+        });
         entries.push_front(entry);
 
         while entries.len() > SESSION_OUTPUT_LAYOUT_CACHE_ENTRY_LIMIT {
@@ -324,6 +429,10 @@ impl SessionOutputLayoutCache {
         let mut evicted_session_ids = Vec::new();
         {
             let mut entries = self.entries.borrow_mut();
+            entries.retain(|cached| {
+                cached.key.session_id != entry.key.session_id
+                    || cached.key.output_width != entry.key.output_width
+            });
             entries.push_front(entry);
 
             while entries.len() > SESSION_OUTPUT_LAYOUT_CACHE_ENTRY_LIMIT {
@@ -506,6 +615,34 @@ impl<'a> SessionOutput<'a> {
         markdown_render_cache: Option<&markdown::MarkdownRenderCache>,
         output_layout_cache: Option<&SessionOutputLayoutCache>,
     ) -> SessionOutputResolvedLayout {
+        if let Some(cache) = output_layout_cache {
+            return cache.resolved_layout(
+                session,
+                output_area,
+                viewport_height,
+                context,
+                markdown_render_cache,
+            );
+        }
+
+        Self::derive_resolved_layout(
+            session,
+            output_area,
+            viewport_height,
+            context,
+            markdown_render_cache,
+            None,
+        )
+    }
+
+    fn derive_resolved_layout(
+        session: &Session,
+        output_area: Rect,
+        viewport_height: u16,
+        context: SessionOutputLineContext<'_>,
+        markdown_render_cache: Option<&markdown::MarkdownRenderCache>,
+        output_layout_cache: Option<&SessionOutputLayoutCache>,
+    ) -> SessionOutputResolvedLayout {
         let layout_without_scrollbar = Self::rendered_layout(
             session,
             output_area,
@@ -562,27 +699,41 @@ impl<'a> SessionOutput<'a> {
     ) -> SessionOutputLayout {
         let inner_width =
             panel_inner_width(output_area, session_format::session_output_panel_borders());
-        let output_lines = session_output_assembly::output_lines(
-            session,
-            inner_width,
-            context.active_progress,
-            markdown_render_cache,
-        );
+        let body =
+            session_output_assembly::output_body(session, inner_width, markdown_render_cache);
 
-        Self::layout_from_assembled_lines(output_lines)
+        Self::layout_from_body(session, context.active_progress, &body)
     }
 
-    /// Converts pure assembled lines into a cacheable layout for scrolling and
-    /// Ratatui painting.
-    fn layout_from_assembled_lines(output_lines: SessionOutputLines) -> SessionOutputLayout {
-        let line_count = u16::try_from(output_lines.lines.len()).unwrap_or(u16::MAX);
+    /// Shares the stable body and allocates only the dynamic tail.
+    fn layout_from_body(
+        session: &Session,
+        active_progress: Option<&str>,
+        body: &SessionOutputBody,
+    ) -> SessionOutputLayout {
+        let tail = session_output_assembly::output_tail(session, active_progress);
+        let body_line_count = if tail.trim_body {
+            body.lines
+                .iter()
+                .rposition(|line| line.width() > 0)
+                .map_or(0, |index| index + 1)
+        } else {
+            body.lines.len()
+        };
+        let line_count = u16::try_from(body_line_count + tail.lines.len()).unwrap_or(u16::MAX);
 
         SessionOutputLayout {
-            active_loader_line_index: output_lines.active_loader_line_index,
+            active_loader_line_index: tail
+                .active_loader_line_index
+                .map(|index| body_line_count + index),
             line_count,
-            lines: Arc::from(output_lines.lines),
-            queued_line_indices: Arc::from(output_lines.queued_line_indices),
-            transient_loader_line_index: output_lines.transient_loader_line_index,
+            lines: Arc::new(SessionOutputLayoutLines {
+                body: Arc::clone(&body.lines),
+                body_line_count,
+                tail: tail.lines,
+            }),
+            queued_line_indices: Arc::clone(&body.queued_line_indices),
+            transient_loader_line_index: body.transient_loader_line_index,
         }
     }
 
@@ -711,18 +862,13 @@ impl<'a> SessionOutput<'a> {
     /// span vectors for every off-screen row on each scroll frame. Slicing
     /// before borrowing keeps paint preparation proportional to terminal
     /// height while retaining `Paragraph`'s established cell semantics.
-    fn visible_paint_lines<'line>(
+    fn visible_paint_lines(
         output_area: Rect,
-        lines: &'line [Line<'static>],
+        lines: &SessionOutputLayoutLines,
         final_scroll: u16,
-    ) -> Vec<Line<'line>> {
+    ) -> Vec<Line<'_>> {
         let inner_area = Self::session_output_inner_area(output_area);
-        let first_visible_index = usize::from(final_scroll).min(lines.len());
-        let last_visible_index = first_visible_index
-            .saturating_add(usize::from(inner_area.height))
-            .min(lines.len());
-
-        text_util::borrowed_paint_lines(&lines[first_visible_index..last_visible_index])
+        lines.paint_lines(usize::from(final_scroll), usize::from(inner_area.height))
     }
 
     /// Returns the width used to wrap output while leaving padding before the
@@ -1187,7 +1333,11 @@ mod tests {
 
         // Assert
         assert!(
-            layout.lines[loader_line_index]
+            layout
+                .lines
+                .iter()
+                .nth(loader_line_index)
+                .expect("loader row")
                 .to_string()
                 .contains("Publishing review request...")
         );
@@ -1245,7 +1395,11 @@ mod tests {
         // Assert
         assert!(!Arc::ptr_eq(&review_layout.lines, &rebase_layout.lines));
         assert_eq!(output_layout_cache.body_entries.borrow().len(), 1);
-        assert_eq!(output_layout_cache.entries.borrow().len(), 2);
+        assert_eq!(output_layout_cache.entries.borrow().len(), 1);
+        assert!(Arc::ptr_eq(
+            &review_layout.lines.body,
+            &rebase_layout.lines.body
+        ));
         assert!(rebase_text.contains("Completed answer stays stable."));
         assert!(rebase_text.contains("Rebasing..."));
     }
@@ -1781,12 +1935,16 @@ mod tests {
     #[test]
     fn test_visible_paint_lines_skip_rows_outside_viewport() {
         // Arrange
-        let cached_lines = [
-            Line::from("hidden before viewport"),
-            Line::from("visible first row"),
-            Line::from("visible second row"),
-            Line::from("hidden after viewport"),
-        ];
+        let cached_lines = SessionOutputLayoutLines {
+            body: Arc::from([
+                Line::from("hidden before viewport"),
+                Line::from("visible first row"),
+                Line::from("visible second row"),
+                Line::from("hidden after viewport"),
+            ]),
+            body_line_count: 4,
+            tail: Vec::new(),
+        };
 
         // Act
         let paint_lines =
@@ -3410,5 +3568,160 @@ mod tests {
         // Assert
         assert!(text.contains("Working..."));
         assert!(text.contains(Icon::TachyonLoader.as_str()));
+    }
+
+    #[test]
+    fn test_progress_updates_share_body_and_discard_superseded_layouts() {
+        // Arrange
+        let mut session = session_fixture();
+        session.status = Status::InProgress;
+        set_assistant_transcript(
+            &mut session,
+            &"```mermaid\ngraph TD\nA --> B\n```\n".repeat(100),
+        );
+        let cache = SessionOutputLayoutCache::default();
+        let area = Rect::new(0, 0, 80, 24);
+        let initial = cache.layout(&session, area, line_context(), None);
+
+        // Act
+        for version in 1..20 {
+            let progress = format!("Step {version}");
+            let updated = cache.layout(
+                &session,
+                area,
+                SessionOutputLineContext {
+                    active_progress: Some(&progress),
+                    session_update_version: version,
+                    ..line_context()
+                },
+                None,
+            );
+
+            // Assert
+            assert!(Arc::ptr_eq(&initial.lines.body, &updated.lines.body));
+            assert!(!Arc::ptr_eq(&initial.lines, &updated.lines));
+            assert_eq!(cache.entries.borrow().len(), 1);
+            assert_eq!(cache.body_entries.borrow().len(), 1);
+            assert!(
+                updated
+                    .lines
+                    .tail
+                    .iter()
+                    .any(|line| line.to_string().contains(&progress))
+            );
+        }
+    }
+
+    #[test]
+    fn test_segmented_layout_matches_assembled_status_rows() {
+        // Arrange
+        let mut session = session_fixture();
+        set_assistant_transcript(&mut session, "Body\n\n");
+        let area = Rect::new(0, 0, 80, 24);
+
+        // Act
+        for status in [
+            Status::Review,
+            Status::Done,
+            Status::Rebasing,
+            Status::InProgress,
+            Status::Queued,
+        ] {
+            session.status = status;
+            let layout = SessionOutput::derive_layout(&session, area, line_context(), None);
+            let expected = session_output_assembly::output_lines(&session, 80, None, None);
+
+            // Assert
+            assert_eq!(
+                layout.lines.iter().cloned().collect::<Vec<_>>(),
+                expected.lines
+            );
+            assert_eq!(
+                layout.active_loader_line_index,
+                expected.active_loader_line_index
+            );
+            assert_eq!(
+                layout.queued_line_indices.as_ref(),
+                expected.queued_line_indices.as_slice()
+            );
+            assert_eq!(usize::from(layout.line_count), layout.lines.len());
+        }
+    }
+
+    #[test]
+    fn test_visible_rows_cross_shared_body_and_tail_without_copying_hidden_rows() {
+        // Arrange
+        let lines = SessionOutputLayoutLines {
+            body: Arc::from([Line::from("one"), Line::from("two"), Line::from("")]),
+            body_line_count: 2,
+            tail: vec![Line::from("status"), Line::from("done")],
+        };
+
+        // Act
+        let crossing = lines.paint_lines(1, 2);
+        let tail_only = lines.paint_lines(2, 8);
+        let past_end = lines.paint_lines(10, 2);
+        let zero_height = lines.paint_lines(0, 0);
+
+        // Assert
+        assert_eq!(
+            crossing.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            ["two", "status"]
+        );
+        assert_eq!(
+            tail_only
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            ["status", "done"]
+        );
+        assert_eq!(past_end, Vec::<Line<'_>>::new());
+        assert_eq!(zero_height, Vec::<Line<'_>>::new());
+    }
+
+    #[test]
+    fn test_resolved_cache_reuses_scrollbar_decision_and_invalidates_viewport() {
+        // Arrange
+        let mut session = session_fixture();
+        set_assistant_transcript(&mut session, &"line\n".repeat(40));
+        let cache = SessionOutputLayoutCache::default();
+        let area = Rect::new(0, 0, 80, 24);
+        let first = cache.resolved_layout(&session, area, 10, line_context(), None);
+        cache.entries.borrow_mut().clear();
+        cache.body_entries.borrow_mut().clear();
+
+        // Act
+        let repeated = cache.resolved_layout(&session, area, 10, line_context(), None);
+
+        // Assert
+        assert!(first.show_scrollbar);
+        assert!(Arc::ptr_eq(&first.layout.lines, &repeated.layout.lines));
+        assert!(cache.entries.borrow().is_empty());
+        assert!(cache.body_entries.borrow().is_empty());
+        let taller = cache.resolved_layout(&session, area, 100, line_context(), None);
+        assert!(!taller.show_scrollbar);
+        assert_eq!(cache.resolved_entries.borrow().len(), 1);
+    }
+
+    #[test]
+    fn test_resolved_cache_evicts_old_sessions() {
+        // Arrange
+        let mut session = session_fixture();
+        let cache = SessionOutputLayoutCache::default();
+
+        // Act
+        for index in 0..=SESSION_OUTPUT_LAYOUT_CACHE_ENTRY_LIMIT {
+            session.id = SessionId::from(format!("resolved-{index}"));
+            cache.resolved_layout(&session, Rect::new(0, 0, 80, 24), 22, line_context(), None);
+        }
+
+        // Assert
+        let entries = cache.resolved_entries.borrow();
+        assert_eq!(entries.len(), SESSION_OUTPUT_LAYOUT_CACHE_ENTRY_LIMIT);
+        assert!(
+            entries
+                .iter()
+                .all(|entry| entry.key.session_id.as_str() != "resolved-0")
+        );
     }
 }

--- a/crates/agentty/src/ui/session_output_assembly.rs
+++ b/crates/agentty/src/ui/session_output_assembly.rs
@@ -37,6 +37,7 @@ const DRAFT_PREVIEW_STACKED_STAGED_NOTE: &str =
 const USER_PROMPT_TAB_WIDTH: usize = 4;
 
 /// Fully assembled session-output lines plus metadata derived during assembly.
+#[cfg(test)]
 pub(crate) struct SessionOutputLines {
     pub(crate) active_loader_line_index: Option<usize>,
     pub(crate) lines: Vec<Line<'static>>,
@@ -53,6 +54,7 @@ pub(crate) struct SessionOutputBody {
 }
 
 /// Assembles a complete session-output panel in canonical display order.
+#[cfg(test)]
 pub(crate) fn output_lines(
     session: &Session,
     inner_width: usize,
@@ -72,27 +74,21 @@ pub(crate) fn output_body(
     output_assembly(session, inner_width, None, markdown_render_cache).into_output_body()
 }
 
-/// Appends the dynamic status tail to a cached stable transcript body.
-pub(crate) fn layout_from_body(
-    session: &Session,
-    active_progress: Option<&str>,
-    body: &SessionOutputBody,
-) -> SessionOutputLines {
-    let mut lines = body.lines.iter().cloned().collect::<Vec<_>>();
-    let active_loader_line_index = append_session_tail_lines(
-        &mut lines,
+/// Dynamic rows rendered after the shared transcript body.
+pub(crate) struct SessionOutputTail {
+    pub(crate) active_loader_line_index: Option<usize>,
+    pub(crate) lines: Vec<Line<'static>>,
+    pub(crate) trim_body: bool,
+}
+
+/// Builds only the status rows; the cached transcript stays shared.
+pub(crate) fn output_tail(session: &Session, active_progress: Option<&str>) -> SessionOutputTail {
+    session_tail_lines(
         session.status,
         active_progress,
         review_loading_message(session),
         review_comment_resolution_loading_message(session),
-    );
-
-    SessionOutputLines {
-        active_loader_line_index,
-        lines,
-        queued_line_indices: body.queued_line_indices.iter().copied().collect(),
-        transient_loader_line_index: body.transient_loader_line_index,
-    }
+    )
 }
 
 /// Returns whether the status owns a live or queued turn whose newest prompt
@@ -224,6 +220,7 @@ impl SessionOutputTranscriptSection<'_> {
 }
 
 impl SessionOutputAssembly<'_> {
+    #[cfg(test)]
     fn into_output_lines(mut self) -> SessionOutputLines {
         for block in SESSION_OUTPUT_BLOCK_ORDER {
             self.append_block(block);
@@ -384,32 +381,55 @@ fn append_session_tail_lines(
     review_status_message: Option<&str>,
     review_comment_resolution_message: Option<&str>,
 ) -> Option<usize> {
+    let tail = session_tail_lines(
+        status,
+        active_progress,
+        review_status_message,
+        review_comment_resolution_message,
+    );
+    if tail.trim_body {
+        trim_trailing_blank_lines(lines);
+    }
+    let active_loader_line_index = tail
+        .active_loader_line_index
+        .map(|index| lines.len() + index);
+    lines.extend(tail.lines);
+
+    active_loader_line_index
+}
+
+fn session_tail_lines(
+    status: Status,
+    active_progress: Option<&str>,
+    review_status_message: Option<&str>,
+    review_comment_resolution_message: Option<&str>,
+) -> SessionOutputTail {
     let status_lines = session_format::session_output_status_lines(
         status,
         active_progress,
         review_status_message,
         review_comment_resolution_message,
     );
-    if !status_lines.is_empty() {
-        append_block_separator(lines, SessionOutputSeparator::Always);
-        let active_loader_line_index =
-            session_format::session_output_uses_tachyon_loader(status).then_some(lines.len());
+    let trim_body = !status_lines.is_empty();
+    let mut lines = vec![Line::from("")];
+    let active_loader_line_index = if trim_body {
         lines.extend(status_lines);
 
-        return active_loader_line_index;
+        session_format::session_output_uses_tachyon_loader(status).then_some(1)
+    } else {
+        if status == Status::Done {
+            lines.push(session_format::session_output_done_line());
+            lines.push(Line::from(""));
+        }
+
+        None
+    };
+
+    SessionOutputTail {
+        active_loader_line_index,
+        lines,
+        trim_body,
     }
-
-    if status == Status::Done {
-        lines.push(Line::from(""));
-        lines.push(session_format::session_output_done_line());
-        lines.push(Line::from(""));
-
-        return None;
-    }
-
-    lines.push(Line::from(""));
-
-    None
 }
 
 fn review_loading_message(session: &Session) -> Option<&str> {

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -9591,6 +9591,10 @@ fn session_view_compact_mermaid_output() -> E2eResult {
                         "session_compact_mermaid_output_top",
                         "Top of compacted over-wide Mermaid flow",
                     )
+                    .write_text("j".repeat(80))
+                    .write_text("k".repeat(80))
+                    .write_text("g")
+                    .wait_for_text("Qwen complete", 5000)
                     .write_text("G")
                     .wait_for_text("Grafana on port 3000", 5000)
                     .wait_for_stable_frame(300, 5000)
@@ -9599,8 +9603,16 @@ fn session_view_compact_mermaid_output() -> E2eResult {
                         "session_compact_mermaid_output_bottom",
                         "Bottom of compacted over-wide Mermaid flow",
                     )
+                    .write_text("q")
+                    .wait_for_stable_frame(300, 5000)
             },
-            |_frame, report| {
+            |frame, report| {
+                assertion::assert_not_visible(frame, "Grafana on port 3000");
+                assertion::assert_text_in_region(
+                    frame,
+                    "Compact Mermaid output",
+                    &Region::full(frame.cols(), frame.rows()),
+                );
                 assert_eq!(report.captures.len(), 2);
                 let top_frame = common::frame_from_capture(&report.captures[0]);
                 let bottom_frame = common::frame_from_capture(&report.captures[1]);

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -242,9 +242,17 @@ Runtime owns one shared `RenderCacheStore` for markdown, diff, and session-outpu
 caches. The session-output cache keeps a bounded stable-body layer keyed by the typed
 transcript's cached content hash, width, theme, queued input, and transient-message
 version. Workflow-only status changes such as `Review` entering `Rebasing` reuse that
-body and append only the dynamic status tail. Changes in this area should keep caches
-bounded and route layout/count helpers and the final paint path through the same cached
-derived data instead of recomputing the render twice per frame.
+body and allocate only the dynamic status tail. Painting borrows visible slices across
+that shared body and tail. Superseded entries for the same session and width are
+dropped; measurement and painting share the cached scrollbar decision and resolved
+layout. Mermaid parsing is cached independently of width and theme, while each preview
+is painted with the current palette.
+
+Transcript scroll keys bypass workflow action-availability checks. Consecutive scroll
+keys reuse measurements within one input batch; other input events and the next runtime
+cycle invalidate those measurements. The foreground drains at most 64 input events or 8
+milliseconds before returning to painting, so held keys cannot indefinitely delay the
+next frame. An individual render or handler still runs to completion.
 
 ## Session Turn Data Flow
 


### PR DESCRIPTION
- Cache parsed Mermaid diagrams and segmented session-output layouts for reuse across widths, themes, progress updates, and scroll frames.
- Reuse scroll measurements across consecutive transcript keys while preserving navigation precedence.
- Yield queued terminal input after 64 events or 8 milliseconds so painting continues promptly.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)