### PR TITLE
Stop auto-commit on persistent Git index locks

### DIFF
--- a/crates/ag-git/src/error.rs
+++ b/crates/ag-git/src/error.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use crate::rebase;
+
 /// Typed error returned by git infrastructure operations.
 ///
 /// Wraps command execution failures, output parsing issues, and I/O errors so
@@ -58,9 +60,62 @@ pub enum GitError {
     Join(#[from] tokio::task::JoinError),
 }
 
+impl GitError {
+    /// Returns whether a failed command reports Git index-lock contention.
+    ///
+    /// This identifies the lock failure without implying that the lock is
+    /// stale or safe to remove.
+    #[must_use]
+    pub fn is_index_locked(&self) -> bool {
+        matches!(self, Self::CommandFailed { stderr, .. } if rebase::is_git_index_lock_error(stderr))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn index_lock_classification_requires_a_matching_command_failure() {
+        // Arrange
+        let cases = [
+            (
+                "fatal: Unable to create '.git/index.lock': File exists.",
+                true,
+            ),
+            (
+                "fatal: Unable to create '.git/worktrees/session/index.lock': File exists.",
+                true,
+            ),
+            (
+                "fatal: Unable to create '.git/HEAD.lock': File exists.",
+                false,
+            ),
+            (
+                "fatal: Unable to create '.git/index.lock': Permission denied",
+                false,
+            ),
+            ("index.lock: another git process is running", true),
+            ("pre-commit hook rejected changes", false),
+            ("index.lock mentioned by a hook", false),
+        ];
+
+        for (stderr, expected) in cases {
+            let error = GitError::CommandFailed {
+                command: "git add -A".to_string(),
+                stderr: stderr.to_string(),
+            };
+
+            // Act / Assert
+            assert_eq!(error.is_index_locked(), expected, "{stderr}");
+        }
+
+        // Arrange
+        let error = GitError::OutputParse(cases[0].0.to_string());
+
+        // Act / Assert
+        assert!(!error.is_index_locked());
+    }
 
     #[test]
     fn command_failed_display_includes_command_and_stderr() {

--- a/crates/ag-git/src/rebase.rs
+++ b/crates/ag-git/src/rebase.rs
@@ -611,7 +611,6 @@ pub(super) fn is_git_index_lock_error(detail: &str) -> bool {
 
     normalized_detail.contains("index.lock")
         && (normalized_detail.contains("file exists")
-            || normalized_detail.contains("unable to create")
             || normalized_detail.contains("another git process"))
 }
 

--- a/crates/agentty/src/app/session/workflow/task.rs
+++ b/crates/agentty/src/app/session/workflow/task.rs
@@ -675,6 +675,16 @@ impl SessionTaskService {
                 Err(commit_error) if commit_error.to_string().contains("Nothing to commit") => {
                     return Ok(None);
                 }
+                Err(SessionError::Git(error)) if error.is_index_locked() => {
+                    return Err(SessionError::Workflow(format!(
+                        "Auto-commit blocked by a Git index lock after retries. Wait for any \
+                         active Git operation to finish, then retry. If the lock persists, have \
+                         the repository owner confirm it is stale before removing it. \
+                         Linked-worktree locks may be outside the session workspace. Agentty left \
+                         the lock and your changes intact; commit assistance cannot repair this \
+                         failure.\n\n{error}"
+                    )));
+                }
                 Err(commit_error) => {
                     // Keep test execution deterministic and offline by skipping
                     // model-assisted commit retries.
@@ -2678,6 +2688,90 @@ mod tests {
             .unwrap_or_default();
         assert!(output_text.contains("[Commit Error] commit failed"));
         assert!(matches!(outcome, AutoCommitOutcome::Failed));
+    }
+
+    #[tokio::test]
+    /// Verifies persistent index contention ends auto-commit with recovery
+    /// guidance and clears progress without asking an agent to repair it.
+    async fn test_handle_auto_commit_stops_on_index_lock() {
+        // Arrange
+        let mut mock_git_client = MockGitClient::new();
+        mock_git_client
+            .expect_is_worktree_clean()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(false) }));
+        mock_git_client
+            .expect_diff()
+            .times(1)
+            .returning(|_, _| Box::pin(async { Ok("+pending change".to_string()) }));
+        mock_git_client
+            .expect_has_commits_since()
+            .times(1)
+            .returning(|_, _| Box::pin(async { Ok(false) }));
+        mock_git_client
+            .expect_commit_all_preserving_single_commit()
+            .times(1)
+            .returning(|_, _, _, _| {
+                Box::pin(async {
+                    Err(GitError::CommandFailed {
+                        command: "git add -A".to_string(),
+                        stderr: "fatal: Unable to create '.git/worktrees/session/index.lock': \
+                                 File exists."
+                            .to_string(),
+                    })
+                })
+            });
+        let mut one_shot_client = MockOneShotClient::new();
+        one_shot_client
+            .expect_submit()
+            .times(1)
+            .returning(|request| {
+                assert!(
+                    request
+                        .prompt
+                        .contains("Generate the canonical session commit message")
+                );
+
+                Ok(one_shot_submission("Preserve pending changes", 0, 0))
+            });
+        let database = AppRepositories::in_memory().await.expect("db should open");
+        insert_review_session(&database, AgentModel::Gpt56Sol.as_str()).await;
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let transcript = Arc::new(Mutex::new(SessionTranscript::default()));
+        let context = AssistContext {
+            app_event_tx,
+            child_pid: Arc::new(Mutex::new(None)),
+            db: database.clone(),
+            folder: PathBuf::from("project"),
+            git_client: Arc::new(mock_git_client),
+            id: "session-id".to_string(),
+            one_shot_client: Arc::new(one_shot_client),
+            session_agent: AgentSelection::new(AgentKind::Codex, AgentModel::Gpt56Sol),
+            session_update_versions: Arc::default(),
+            transcript: Arc::clone(&transcript),
+        };
+
+        // Act
+        let outcome = SessionTaskService::handle_auto_commit(context).await;
+
+        // Assert
+        assert!(matches!(outcome, AutoCommitOutcome::Failed));
+        let messages = database
+            .sessions()
+            .load_session_messages("session-id")
+            .await
+            .expect("persisted messages should load");
+        assert_eq!(messages.len(), 1);
+        let message = &messages[0].content;
+        assert!(message.contains("[Commit Error] Auto-commit blocked by a Git index lock"));
+        assert!(message.contains("confirm it is stale before removing it"));
+        assert!(message.contains("left the lock and your changes intact"));
+        assert!(message.contains("git add -A: fatal: Unable to create"));
+        let events = std::iter::from_fn(|| app_event_rx.try_recv().ok()).collect::<Vec<_>>();
+        assert!(events.contains(&AppEvent::SessionProgressUpdated {
+            progress_message: None,
+            session_id: "session-id".into(),
+        }));
     }
 
     #[tokio::test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -187,6 +187,50 @@ duration: 283ms
     Ok(())
 }
 
+/// Creates a real worktree index lock after a stubbed agent edits a file.
+fn seed_commit_index_lock_project(env: &BuilderEnv) -> E2eResult {
+    let script = r#"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
+prompt=$(cat)
+response='{"answer":"Preserve pending worktree change","questions":[],"review_comment_outcomes":[],"subtasks":[],"verification_verdicts":[]}'
+case "$prompt" in
+  *"Generate the canonical session commit message"*) ;;
+  *"Review the Git diff for display in a terminal UI."*)
+    response='{"project_impact":[],"suggestions":[]}'
+    ;;
+  *"Repair a failed git commit"*)
+    printf 'unexpected assistance\n' > "$AGENTTY_TEST_EVIDENCE/assist"
+    exit 91
+    ;;
+  *)
+    printf 'pending change\n' > generated.txt
+    lock_path=$(git rev-parse --git-path index.lock) || exit 92
+    printf 'test lock\n' > "$lock_path"
+    printf '%s\n' "$lock_path" > "$AGENTTY_TEST_EVIDENCE/lock-path"
+    printf '%s/generated.txt\n' "$PWD" > "$AGENTTY_TEST_EVIDENCE/change-path"
+    ;;
+esac
+printf '%s\n' '{"type":"system","subtype":"init"}'
+printf '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"StructuredOutput","input":%s}]}}\n' "$response"
+printf '{"type":"result","subtype":"success","result":"","structured_output":%s,"usage":{"input_tokens":5,"output_tokens":9}}\n' "$response"
+"#;
+    let claude_path = env.stub_bin.join("claude");
+    std::fs::write(&claude_path, script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o750))?;
+
+    seed_project_settings(
+        env,
+        &[
+            ("DefaultSmartAgent", "claude"),
+            ("DefaultSmartModel", "claude-haiku-4-5-20251001"),
+            ("DefaultFastAgent", "claude"),
+            ("DefaultFastModel", "claude-haiku-4-5-20251001"),
+        ],
+    )
+}
+
 /// Seeds configured pre-commit validation without installing its Git hook.
 fn seed_missing_pre_commit_hook_project(
     env: &BuilderEnv,
@@ -4215,6 +4259,68 @@ fn test_session_antigravity_accepts_large_replay() -> E2eResult {
                     &full,
                 );
                 assertion::assert_not_visible(frame, "32768-byte");
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that a persistent worktree index lock stops commit recovery without
+/// invoking assistance or deleting either the lock or the pending changes.
+#[test]
+fn test_session_commit_index_lock() -> E2eResult {
+    // Arrange
+    let evidence = tempfile::tempdir()?;
+
+    // Act / Assert
+    FeatureTest::new("session_commit_index_lock")
+        .with_git()
+        .with_terminal_size(100, 40)
+        .env("AGENTTY_TEST_EVIDENCE", evidence.path().to_string_lossy())
+        .setup(seed_commit_index_lock_project)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .wait_for_text("Select session type", 5000)
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("Create a pending change")
+                    .press_key("Enter")
+                    .wait_for_text("Auto-commit blocked by a Git index lock", 30000)
+                    .wait_for_text("Enter: reply", 5000)
+                    .write_text("g")
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled(
+                        "index_lock",
+                        "Commit stops with index-lock recovery guidance",
+                    )
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "[Commit Error]", &full);
+                assertion::assert_text_in_region(
+                    frame,
+                    "Auto-commit blocked by a Git index lock",
+                    &full,
+                );
+                assertion::assert_text_in_region(frame, "repository owner confirm it is", &full);
+                assertion::assert_text_in_region(frame, "stale before removing it", &full);
+                assertion::assert_not_visible(frame, "Committing...");
+                assertion::assert_not_visible(frame, "[Commit Assist]");
+                assert!(!evidence.path().join("assist").exists());
+                for (record, expected) in [
+                    ("lock-path", "test lock\n"),
+                    ("change-path", "pending change\n"),
+                ] {
+                    let path = std::fs::read_to_string(evidence.path().join(record))
+                        .expect("stub should record the fixture path");
+                    let content = std::fs::read_to_string(path.trim())
+                        .expect("auto-commit should preserve the fixture");
+                    assert_eq!(content, expected);
+                }
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -433,6 +433,8 @@ flowchart LR
    commit. After a successful normal commit, the app checks hook readiness again and
    persists the first copy of each distinct `[Commit Warning]` when configured
    validation did not run, avoiding repeated identical notices across later turns.
+   Persistent index-lock failures stop after the Git layer's bounded retries and persist
+   recovery guidance without invoking commit assistance or deleting the lock.
    Installed-hook failures continue through normal commit error handling. The session
    title is synced from the commit text. Orchestrator controllers skip diff refresh,
    commit, publish, sync, and merge work. Research children refresh diff evidence but

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -415,6 +415,12 @@ amends `HEAD`, and refreshes the session title from the commit text. If a later 
 reverts every change, the empty session commit is dropped. Commit and merge notices
 appear as transient status rows rather than persisted transcript messages.
 
+If an index lock still blocks auto-commit after brief retries, Agentty stops and records
+a `[Commit Error]` with recovery guidance instead of invoking commit assistance. Your
+changes and the lock remain intact. Wait for active Git operations to finish before
+retrying. If the lock persists, the repository owner must confirm it is stale before
+removing it; linked-worktree locks may live outside the session workspace.
+
 When a project contains `.pre-commit-config.yaml` or `.pre-commit-config.yml`, Agentty
 checks for an executable Git pre-commit hook when you press `a`. A missing hook opens a
 warning before the session-type selector. Press `Enter` to continue to the selector or


### PR DESCRIPTION
- Classify index-lock failures without treating unrelated lock errors as recoverable.
- Preserve pending changes and locks while recording recovery guidance instead of invoking commit assistance.
- Cover the behavior with unit, E2E, and runtime documentation updates.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)