### PR TITLE
Prevents optional Git locks during inspection

### DIFF
--- a/crates/ag-agent/src/agent/cli/execution.rs
+++ b/crates/ag-agent/src/agent/cli/execution.rs
@@ -107,7 +107,9 @@ pub(crate) async fn execute_cli_command(
     let stdin_payload = agent::build_command_stdin_payload(kind, build_request)
         .map_err(CliExecutionError::StdinBuild)?;
     let mut tokio_command = tokio::process::Command::from(command);
+    // Agent tools must not refresh Git's index during read-only inspection.
     tokio_command
+        .env("GIT_OPTIONAL_LOCKS", "0")
         .stdin(if stdin_payload.is_some() {
             std::process::Stdio::piped()
         } else {
@@ -496,6 +498,35 @@ mod tests {
             .expect("PID update lock should be available");
         assert!(pid_updates.first().is_some_and(Option::is_some));
         assert_eq!(pid_updates.last(), Some(&None));
+    }
+
+    #[tokio::test]
+    async fn test_execute_cli_command_disables_optional_git_locks_for_tools() {
+        // Arrange
+        let folder = tempdir().expect("temporary folder should be created");
+        let request_kind = AgentRequestKind::UtilityPrompt;
+        let mut backend = MockAgentBackend::new();
+        backend.expect_build_command().once().returning(|_| {
+            let mut command = shell_command("sh -c 'printf %s \"$GIT_OPTIONAL_LOCKS\"'");
+            command.env("GIT_OPTIONAL_LOCKS", "1");
+
+            Ok(command)
+        });
+
+        // Act
+        let output = execute_cli_command(
+            &backend,
+            AgentKind::Codex,
+            build_request(&[], folder.path(), "prompt", &request_kind),
+            &CollectingCliObserver,
+            None,
+        )
+        .await
+        .expect("process should complete");
+
+        // Assert
+        assert_eq!(output.exit_status, CliExitStatus::Success);
+        assert_eq!(output.stdout, "0");
     }
 
     #[tokio::test]

--- a/crates/ag-agent/src/app_server_transport.rs
+++ b/crates/ag-agent/src/app_server_transport.rs
@@ -252,7 +252,10 @@ pub(crate) fn spawn_runtime_command(
     let mut command = command;
     command.process_group(0);
     let mut command = tokio::process::Command::from(command);
+    // Descendant Git reads must not compete with Agentty's index writers or
+    // leave optional index locks behind when the runtime is terminated.
     command
+        .env("GIT_OPTIONAL_LOCKS", "0")
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
@@ -306,6 +309,29 @@ mod tests {
 
         // Act / Assert
         assert!(response_id_matches(&response_value, "init-123"));
+    }
+
+    #[tokio::test]
+    async fn runtime_disables_optional_git_locks_for_tools() {
+        // Arrange
+        let mut command = std::process::Command::new("sh");
+        command
+            .args(["-c", "sh -c 'printf \"%s\\n\" \"$GIT_OPTIONAL_LOCKS\"'"])
+            .env("GIT_OPTIONAL_LOCKS", "1");
+
+        // Act
+        let (mut child, stdin, stdout) =
+            spawn_runtime_command(command, "test").expect("runtime should start");
+        drop(stdin);
+        let line = BufReader::new(stdout)
+            .lines()
+            .next_line()
+            .await
+            .expect("stdout should be readable");
+        shutdown_child(&mut child).await;
+
+        // Assert
+        assert_eq!(line.as_deref(), Some("0"));
     }
 
     #[test]

--- a/crates/ag-git/src/client.rs
+++ b/crates/ag-git/src/client.rs
@@ -787,10 +787,10 @@ impl GitClient for RealGitClient {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::path::{Path, PathBuf};
     use std::process::Command;
     use std::time::Duration;
-    use std::{fs, thread};
 
     use tempfile::tempdir;
 
@@ -1141,10 +1141,10 @@ mod tests {
         let commit_message = "Session commit".to_string();
         fs::write(dir.path().join("work.txt"), "locked change").expect("failed to write file");
         let index_lock_path = dir.path().join(".git").join("index.lock");
-        fs::write(&index_lock_path, "stale lock").expect("failed to write lock file");
-        let lock_cleanup = thread::spawn(move || {
-            thread::sleep(Duration::from_millis(250));
-            let _ = fs::remove_file(index_lock_path);
+        fs::write(&index_lock_path, "active writer").expect("failed to write lock file");
+        let lock_cleanup = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            fs::remove_file(index_lock_path).expect("writer should release its lock");
         });
 
         // Act
@@ -1156,8 +1156,8 @@ mod tests {
         )
         .await;
         lock_cleanup
-            .join()
-            .expect("failed to join lock cleanup thread");
+            .await
+            .expect("failed to join lock cleanup task");
         let head_message = run_git_command_stdout(dir.path(), &["log", "-1", "--pretty=%B"]);
 
         // Assert
@@ -1297,6 +1297,58 @@ mod tests {
         // Assert
         assert!(status.contains("README.md"));
         assert!(status.contains("new-file.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_status_reads_preserve_index_with_stale_file_metadata() {
+        // Arrange
+        let dir = tempdir().expect("failed to create temp dir");
+        setup_test_git_repo(dir.path());
+        let index_path = dir.path().join(".git/index");
+        let original_index = fs::read(&index_path).expect("failed to read index");
+        let readme = fs::File::options()
+            .write(true)
+            .open(dir.path().join("README.md"))
+            .expect("failed to open tracked file");
+        readme
+            .set_times(fs::FileTimes::new().set_modified(std::time::SystemTime::UNIX_EPOCH))
+            .expect("failed to invalidate cached file metadata");
+
+        // Act
+        let status = worktree_status(dir.path().to_path_buf())
+            .await
+            .expect("failed to read worktree status");
+        let tracked_status = tracked_worktree_status(dir.path().to_path_buf())
+            .await
+            .expect("failed to read tracked status");
+        let sync_status = crate::repo::run_git_command_sync(
+            dir.path(),
+            &["status", "--porcelain"],
+            "Failed to read synchronous status",
+        )
+        .expect("failed to read synchronous status");
+
+        // Assert
+        assert_eq!(status, "");
+        assert_eq!(tracked_status, "");
+        assert_eq!(sync_status, "");
+        assert_eq!(
+            fs::read(&index_path).expect("failed to read index"),
+            original_index
+        );
+        // Prove the fixture actually needs an index refresh when optional
+        // writes are enabled, rather than merely reading an unchanged index.
+        let refresh = Command::new("git")
+            .args(["status", "--porcelain"])
+            .env("GIT_OPTIONAL_LOCKS", "1")
+            .current_dir(dir.path())
+            .output()
+            .expect("failed to refresh index");
+        assert!(refresh.status.success());
+        assert_ne!(
+            fs::read(index_path).expect("failed to read refreshed index"),
+            original_index
+        );
     }
 
     #[tokio::test]

--- a/crates/ag-git/src/rebase.rs
+++ b/crates/ag-git/src/rebase.rs
@@ -13,8 +13,9 @@ use super::repo::{
 };
 use crate::{Sleeper, ThreadSleeper};
 
-pub(super) const GIT_INDEX_LOCK_RETRY_ATTEMPTS: usize = 5;
-pub(super) const GIT_INDEX_LOCK_RETRY_DELAY: Duration = Duration::from_millis(100);
+/// Allow five seconds of waiting for an in-flight index writer to finish.
+pub(super) const GIT_INDEX_LOCK_RETRY_ATTEMPTS: usize = 21;
+pub(super) const GIT_INDEX_LOCK_RETRY_DELAY: Duration = Duration::from_millis(250);
 
 /// Executes git commands for rebase operations.
 #[cfg_attr(test, mockall::automock)]

--- a/crates/ag-git/src/repo.rs
+++ b/crates/ag-git/src/repo.rs
@@ -432,8 +432,8 @@ where
     })
 }
 
-/// Applies non-interactive defaults so git failures return immediately instead
-/// of waiting for terminal credential prompts.
+/// Disables optional index writes and interactive prompts for Git subprocesses.
+/// Required locks for staging, commits, and other mutations remain enabled.
 fn apply_non_interactive_environment(command: &mut Command) {
     let git_ssh_command = std::env::var("GIT_SSH_COMMAND").map_or_else(
         |_| "ssh -o BatchMode=yes".to_string(),
@@ -441,12 +441,13 @@ fn apply_non_interactive_environment(command: &mut Command) {
     );
 
     command
+        .env("GIT_OPTIONAL_LOCKS", "0")
         .env("GIT_TERMINAL_PROMPT", "0")
         .env("GCM_INTERACTIVE", "never")
         .env("GIT_SSH_COMMAND", git_ssh_command);
 }
 
-/// Applies non-interactive defaults to one async git subprocess.
+/// Disables optional index writes and interactive prompts for async Git.
 fn apply_non_interactive_environment_async(command: &mut AsyncCommand) {
     let git_ssh_command = std::env::var("GIT_SSH_COMMAND").map_or_else(
         |_| "ssh -o BatchMode=yes".to_string(),
@@ -454,6 +455,7 @@ fn apply_non_interactive_environment_async(command: &mut AsyncCommand) {
     );
 
     command
+        .env("GIT_OPTIONAL_LOCKS", "0")
         .env("GIT_TERMINAL_PROMPT", "0")
         .env("GCM_INTERACTIVE", "never")
         .env("GIT_SSH_COMMAND", git_ssh_command);

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -194,8 +194,14 @@ if [ "$1" = "update" ]; then exit 0; fi
 if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
 prompt=$(cat)
 response='{"answer":"Preserve pending worktree change","questions":[],"review_comment_outcomes":[],"subtasks":[],"verification_verdicts":[]}'
+printf '%s\n' "$GIT_OPTIONAL_LOCKS" > "$AGENTTY_TEST_EVIDENCE/optional-locks"
 case "$prompt" in
-  *"Generate the canonical session commit message"*) ;;
+  *"Generate the canonical session commit message"*)
+    if [ "$AGENTTY_TEST_RELEASE_LOCK" = "1" ]; then
+      lock_path=$(cat "$AGENTTY_TEST_EVIDENCE/lock-path") || exit 93
+      (sleep 2; rm "$lock_path") </dev/null >/dev/null 2>&1 &
+    fi
+    ;;
   *"Review the Git diff for display in a terminal UI."*)
     response='{"project_impact":[],"suggestions":[]}'
     ;;
@@ -4321,6 +4327,63 @@ fn test_session_commit_index_lock() -> E2eResult {
                         .expect("auto-commit should preserve the fixture");
                     assert_eq!(content, expected);
                 }
+            },
+        )?;
+
+    Ok(())
+}
+
+/// Verify that auto-commit waits for a short-lived writer without assistance.
+#[test]
+fn test_session_commit_index_lock_recovers() -> E2eResult {
+    // Arrange
+    let evidence = tempfile::tempdir()?;
+
+    // Act / Assert
+    FeatureTest::new("session_commit_index_lock_recovers")
+        .with_git()
+        .with_terminal_size(100, 40)
+        .env("AGENTTY_TEST_EVIDENCE", evidence.path().to_string_lossy())
+        .env("AGENTTY_TEST_RELEASE_LOCK", "1")
+        .env("GIT_OPTIONAL_LOCKS", "1")
+        .setup(seed_commit_index_lock_project)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .wait_for_text("Select session type", 5000)
+                    .press_key("Enter")
+                    .wait_for_stable_frame(300, 5000)
+                    .write_text("Create a pending change")
+                    .press_key("Enter")
+                    .wait_for_text("Enter: reply", 30000)
+                    .write_text("g")
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled("commit_recovered", "Auto-commit waits for the index writer")
+            },
+            |frame, _report| {
+                assertion::assert_not_visible(frame, "[Commit Error]");
+                assertion::assert_not_visible(frame, "[Commit Assist]");
+                assert!(!evidence.path().join("assist").exists());
+                assert_eq!(
+                    std::fs::read_to_string(evidence.path().join("optional-locks"))
+                        .expect("agent should record the inherited Git environment"),
+                    "0\n"
+                );
+                let change_path = std::fs::read_to_string(evidence.path().join("change-path"))
+                    .expect("agent should record its changed file");
+                let worktree = Path::new(change_path.trim())
+                    .parent()
+                    .expect("changed file should have a worktree");
+                let committed = Command::new("git")
+                    .args(["show", "HEAD:generated.txt"])
+                    .current_dir(worktree)
+                    .output()
+                    .expect("committed file should be readable");
+                assert!(committed.status.success());
+                assert_eq!(committed.stdout, b"pending change\n");
             },
         )?;
 

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -440,7 +440,10 @@ flowchart LR
    project's `Default Fast Model` and amend `HEAD`; an empty amend drops the reverted
    commit. After a successful normal commit, the app checks hook readiness again and
    persists the first copy of each distinct `[Commit Warning]` when configured
-   validation did not run, avoiding repeated identical notices across later turns.
+   validation did not run, avoiding repeated identical notices across later turns. Git
+   commands and agent subprocesses inherit `GIT_OPTIONAL_LOCKS=0` so read-only
+   inspection does not write the index or leave optional locks on interruption. Required
+   index writes retry with up to five seconds of waiting for an active writer to finish.
    Persistent index-lock failures stop after the Git layer's bounded retries and persist
    recovery guidance without invoking commit assistance or deleting the lock.
    Installed-hook failures continue through normal commit error handling. The session

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -415,11 +415,12 @@ amends `HEAD`, and refreshes the session title from the commit text. If a later 
 reverts every change, the empty session commit is dropped. Commit and merge notices
 appear as transient status rows rather than persisted transcript messages.
 
-If an index lock still blocks auto-commit after brief retries, Agentty stops and records
-a `[Commit Error]` with recovery guidance instead of invoking commit assistance. Your
-changes and the lock remain intact. Wait for active Git operations to finish before
-retrying. If the lock persists, the repository owner must confirm it is stale before
-removing it; linked-worktree locks may live outside the session workspace.
+Auto-commit waits up to five seconds in total for a busy Git index to become available.
+If an index lock still blocks auto-commit, Agentty stops and records a `[Commit Error]`
+with recovery guidance instead of invoking commit assistance. Your changes and the lock
+remain intact. Wait for active Git operations to finish before retrying. If the lock
+persists, the repository owner must confirm it is stale before removing it;
+linked-worktree locks may live outside the session workspace.
 
 When a project contains `.pre-commit-config.yaml` or `.pre-commit-config.yml`, Agentty
 checks for an executable Git pre-commit hook when you press `a`. A missing hook opens a


### PR DESCRIPTION
- Sets `GIT_OPTIONAL_LOCKS=0` for Git and agent subprocesses so read-only inspection preserves the index.
- Extends required index-lock retries to five seconds, allowing in-flight writers to finish without commit assistance.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)