### PR TITLE
Preserve review routing and isolate E2E environments

### DIFF
--- a/crates/ag-agent/src/agent/submission.rs
+++ b/crates/ag-agent/src/agent/submission.rs
@@ -744,7 +744,8 @@ mod tests {
         .expect_err("wrapped plain-text utility output should fail");
 
         // Assert — the provider parser extracts "plain text" from the
-        // `result` wrapper, so the protocol parser sees raw text, not JSON keys.
+        // `result` wrapper, so the protocol parser sees raw text, not JSON
+        // keys.
         assert!(error.contains("did not match the required JSON schema"));
         assert!(error.contains("direct_json_error:"));
         assert!(error.contains("response:\nplain text"));

--- a/crates/ag-agent/src/app_server_transport.rs
+++ b/crates/ag-agent/src/app_server_transport.rs
@@ -215,7 +215,8 @@ pub(crate) async fn shutdown_child(child: &mut AppServerRuntimeChild) {
         .is_err()
     {
         child.signal_process_group(Signal::KILL);
-        // Best-effort fallback for a runtime that failed to enter its process group.
+        // Best-effort fallback for a runtime that failed to enter its process
+        // group.
         let _ = child.child.kill().await;
         // Best-effort: process may have already exited.
         let _ = child.child.wait().await;

--- a/crates/ag-agent/src/channel/app_server.rs
+++ b/crates/ag-agent/src/channel/app_server.rs
@@ -61,7 +61,8 @@ impl AppServerAgentChannel {
                         }
 
                         if agent::is_app_server_thought_chunk(kind, is_delta, phase.as_deref()) {
-                            // Fire-and-forget: receiver may be dropped during shutdown.
+                            // Fire-and-forget: receiver may be dropped during
+                            // shutdown.
                             let _ = events.send(TurnEvent::ThoughtDelta(trimmed.to_string()));
                         }
                     }
@@ -71,7 +72,8 @@ impl AppServerAgentChannel {
                             continue;
                         }
 
-                        // Fire-and-forget: receiver may be dropped during shutdown.
+                        // Fire-and-forget: receiver may be dropped during
+                        // shutdown.
                         let _ = events.send(TurnEvent::ThoughtDelta(trimmed.to_string()));
                     }
                 }

--- a/crates/ag-git/src/worktree.rs
+++ b/crates/ag-git/src/worktree.rs
@@ -15,9 +15,8 @@ pub(crate) async fn detect_git_info(dir: PathBuf) -> Option<String> {
         .flatten()
 }
 
-/// Walks up the directory tree to find a .git directory.
-/// Returns the directory containing .git (the repository root) if found, None
-/// otherwise.
+/// Walks upward to find a `.git` directory or a file pointing to one.
+/// Invalid `.git` files stop discovery without selecting a parent checkout.
 pub(crate) async fn find_git_repo_root(dir: PathBuf) -> Option<PathBuf> {
     spawn_blocking(move || find_git_repo_root_sync(&dir))
         .await
@@ -110,13 +109,16 @@ fn find_git_repo(dir: &Path) -> Option<PathBuf> {
     find_git_repo_root_sync(dir)
 }
 
-/// Returns the repository root by searching upward for `.git`.
+/// Returns the repository root by searching upward for resolvable `.git`
+/// metadata, stopping at invalid entries instead of selecting a parent repo.
 fn find_git_repo_root_sync(dir: &Path) -> Option<PathBuf> {
     let mut current = dir.to_path_buf();
     loop {
         let git_dir = current.join(".git");
         if git_dir.exists() {
-            return Some(current);
+            let resolved_git_dir = resolve_git_dir(&current)?;
+
+            return resolved_git_dir.is_dir().then_some(current);
         }
 
         if !current.pop() {
@@ -182,13 +184,68 @@ mod tests {
     #[test]
     fn find_git_repo_root_sync_returns_none_when_no_git_dir() {
         // Arrange
-        let temp_dir = tempfile::tempdir().expect("should create temp dir");
+        // A custom temporary directory may itself be inside a checkout.
+        let non_repository_path = Path::new(std::path::MAIN_SEPARATOR_STR);
 
         // Act
-        let result = find_git_repo_root_sync(temp_dir.path());
+        let result = find_git_repo_root_sync(non_repository_path);
 
         // Assert — walks up to filesystem root and returns None
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn find_git_repo_root_sync_stops_at_invalid_git_file() {
+        for contents in [
+            "not a gitdir file\n",
+            "gitdir: missing\n",
+            "gitdir: ordinary-file\n",
+        ] {
+            // Arrange
+            let temp_dir = tempfile::tempdir().expect("should create temp dir");
+            fs::create_dir(temp_dir.path().join(".git")).expect("should create parent repo");
+            let boundary = temp_dir.path().join("fixture");
+            let nested = boundary.join("project");
+            fs::create_dir_all(&nested).expect("should create nested fixture");
+            fs::write(boundary.join(".git"), contents).expect("should write invalid git file");
+            fs::write(boundary.join("ordinary-file"), "not a directory")
+                .expect("should create non-directory target");
+
+            // Act
+            let result = find_git_repo_root_sync(&nested);
+
+            // Assert
+            assert_eq!(result, None, "invalid git file: {contents}");
+        }
+    }
+
+    #[test]
+    fn find_git_repo_root_sync_accepts_relative_and_absolute_git_files() {
+        for absolute_target in [false, true] {
+            // Arrange
+            let temp_dir = tempfile::tempdir().expect("should create temp dir");
+            let metadata = temp_dir.path().join("metadata");
+            let nested = temp_dir.path().join("src");
+            fs::create_dir(&metadata).expect("should create metadata directory");
+            fs::create_dir(&nested).expect("should create nested directory");
+            fs::write(metadata.join("HEAD"), "ref: refs/heads/main\n").expect("should write HEAD");
+            let target = if absolute_target {
+                metadata
+            } else {
+                PathBuf::from("metadata")
+            };
+            fs::write(
+                temp_dir.path().join(".git"),
+                format!("gitdir: {}\n", target.display()),
+            )
+            .expect("should write git file");
+
+            // Act
+            let result = find_git_repo_root_sync(&nested);
+
+            // Assert
+            assert_eq!(result.as_deref(), Some(temp_dir.path()));
+        }
     }
 
     #[test]
@@ -266,10 +323,11 @@ mod tests {
     #[test]
     fn detect_git_info_sync_returns_none_for_non_repo() {
         // Arrange
-        let temp_dir = tempfile::tempdir().expect("should create temp dir");
+        // A custom temporary directory may itself be inside a checkout.
+        let non_repository_path = Path::new(std::path::MAIN_SEPARATOR_STR);
 
         // Act
-        let result = detect_git_info_sync(temp_dir.path());
+        let result = detect_git_info_sync(non_repository_path);
 
         // Assert
         assert!(result.is_none());

--- a/crates/ag-harness/src/file_system.rs
+++ b/crates/ag-harness/src/file_system.rs
@@ -355,11 +355,12 @@ impl LocalFileSystem {
         flags: CopyfileFlags,
     ) -> io::Result<()> {
         let state = rustix::fs::copyfile_state_alloc().map_err(io::Error::from)?;
-        // SAFETY: `state` was allocated immediately above and remains live until
-        // the matching `copyfile_state_free` call below.
+        // SAFETY: `state` was allocated immediately above and remains live
+        // until the matching `copyfile_state_free` call below.
         let copy_result = unsafe { rustix::fs::fcopyfile(source, destination, state, flags) }
             .map_err(io::Error::from);
-        // SAFETY: This is the one matching free for the live state allocated above.
+        // SAFETY: This is the one matching free for the live state allocated
+        // above.
         let free_result =
             unsafe { rustix::fs::copyfile_state_free(state) }.map_err(io::Error::from);
 

--- a/crates/ag-tui-text/src/text_util.rs
+++ b/crates/ag-tui-text/src/text_util.rs
@@ -682,7 +682,8 @@ mod tests {
             Span::styled("efgh".to_string(), red),
         ];
 
-        // Act — width 7 means 4 visible + "...", cutting exactly at first span boundary
+        // Act — width 7 means 4 visible + "...", cutting exactly at first span
+        // boundary
         let result = truncate_spans_with_ellipsis(spans, 7);
 
         // Assert
@@ -751,8 +752,8 @@ mod tests {
 
     #[test]
     fn test_truncate_spans_with_ellipsis_handles_combining_characters() {
-        // Arrange — combining accent has 0 display width, so "e\u{0301}" = 1 column.
-        // "e\u{0301}abcdef" = 7 columns total.
+        // Arrange — combining accent has 0 display width, so "e\u{0301}" = 1
+        // column. "e\u{0301}abcdef" = 7 columns total.
         let spans = vec![Span::raw("e\u{0301}abcdef".to_string())];
 
         // Act — max_width 7 means all 7 columns fit.

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -1675,7 +1675,8 @@ impl App {
             return;
         }
         if self.merge_queue.has_work() {
-            // Best-effort: merge queue progression failures are surfaced in session output.
+            // Best-effort: merge queue progression failures are surfaced in
+            // session output.
             let _ = self.start_next_merge_from_queue(false).await;
         }
 

--- a/crates/agentty/src/app/prompt_intent.rs
+++ b/crates/agentty/src/app/prompt_intent.rs
@@ -153,8 +153,9 @@ impl App {
         }
         self.clear_diff_comment_progress(session_id);
 
-        // Reply enqueueing cannot reorder the exclusively borrowed session state,
-        // so the validated index remains stable across the awaited operation.
+        // Reply enqueueing cannot reorder the exclusively borrowed session
+        // state, so the validated index remains stable across the
+        // awaited operation.
         let session = &mut self.sessions.sessions_mut()[session_index];
         session.transient_messages.upsert(TransientMessage {
             anchor: TransientMessageAnchor::Tail,

--- a/crates/agentty/src/app/session/workflow/turn.rs
+++ b/crates/agentty/src/app/session/workflow/turn.rs
@@ -735,7 +735,8 @@ fn coalesce_ready_turn_progress_events(
 /// Records the latest child process id observed from a provider turn stream.
 fn set_child_pid(child_pid: &Mutex<Option<u32>>, pid: Option<u32>) {
     // Sync critical section (single assignment, no `.await`);
-    // `std::sync::Mutex` is the correct choice per CLAUDE.md §"Mutex Selection".
+    // `std::sync::Mutex` is the correct choice per CLAUDE.md §"Mutex
+    // Selection".
     if let Ok(mut guard) = child_pid.lock() {
         *guard = pid;
     }
@@ -792,8 +793,9 @@ pub(super) fn terminate_child_process(child_pid: &Mutex<Option<u32>>, kind: Agen
 fn fresh_turn_cancel_token(
     context: &SessionWorkerContext,
 ) -> Result<CancellationToken, SessionError> {
-    // Sync critical section (assignment + clone, no `.await`); `std::sync::Mutex`
-    // is the correct choice per CLAUDE.md §"Mutex Selection".
+    // Sync critical section (assignment + clone, no `.await`);
+    // `std::sync::Mutex` is the correct choice per CLAUDE.md §"Mutex
+    // Selection".
     let mut guard = context
         .cancel_token
         .lock()

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -440,8 +440,9 @@ impl SessionWorkerRebaseAssistClient {
 
     /// Replaces the shared cancellation token for one rebase-assist turn.
     fn fresh_turn_cancel_token(&self) -> Result<CancellationToken, SessionError> {
-        // Sync critical section (assignment + clone, no `.await`); `std::sync::Mutex`
-        // is the correct choice per CLAUDE.md §"Mutex Selection".
+        // Sync critical section (assignment + clone, no `.await`);
+        // `std::sync::Mutex` is the correct choice per CLAUDE.md
+        // §"Mutex Selection".
         let mut guard = self
             .cancel_token
             .lock()
@@ -3510,7 +3511,8 @@ mod tests {
                     .await
             };
 
-            // Assert — cancellation cannot signal a retained runtime's recycled PID.
+            // Assert — cancellation cannot signal a retained runtime's recycled
+            // PID.
             assert!(
                 unrelated_child
                     .try_wait()

--- a/crates/agentty/src/app/session_api.rs
+++ b/crates/agentty/src/app/session_api.rs
@@ -265,7 +265,8 @@ impl App {
         };
         let branch_operation_lock = Arc::clone(&branch_publish_context.branch_operation_lock);
         // Reserve an idle branch before persistence. An existing owner
-        // already serializes worker execution, so the runtime actor never waits here.
+        // already serializes worker execution, so the runtime actor never waits
+        // here.
         let _branch_operation_guard = branch_operation_lock.try_lock_owned().ok();
         let enqueue_result = self
             .sessions

--- a/crates/agentty/src/app/sync.rs
+++ b/crates/agentty/src/app/sync.rs
@@ -610,7 +610,7 @@ impl SyncOrchestrator {
                 .send(AppEvent::ReviewRequestStatusUpdated {
                     generation: context.generation,
                     result,
-                    session_id: target.session_id.clone(),
+                    session_id: target.session_id,
                 });
         }
     }
@@ -1219,6 +1219,63 @@ mod tests {
                 && review_request_updates[0].session_id.as_str() == "session-1"
                 && review_request_updates[0].result.is_err()
         ));
+    }
+
+    #[test]
+    /// Each collected update keeps its session, generation, and result when
+    /// forwarded to the foreground event queue.
+    fn emit_review_request_pass_updates_preserves_batch_routing() {
+        // Arrange
+        let context = sync_context_fixture(7, Vec::new());
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let (_context_tx, context_rx) = watch::channel(context.clone());
+        let (_command_tx, command_rx) = mpsc::unbounded_channel();
+        let orchestrator = SyncOrchestrator {
+            app_event_tx,
+            command_rx,
+            context_rx,
+            review_pass_index: 0,
+            review_sync_failures: HashMap::new(),
+            tick_index: 0,
+        };
+        let updates = vec![
+            ReviewRequestPassUpdate {
+                result: Ok(SyncReviewRequestTaskResult {
+                    outcome: session::SyncReviewRequestOutcome::NoReviewRequest,
+                    summary: None,
+                }),
+                target: review_request_sync_target("session-1", None),
+            },
+            ReviewRequestPassUpdate {
+                result: Err("forge unavailable".to_string()),
+                target: review_request_sync_target("session-2", None),
+            },
+        ];
+
+        // Act
+        orchestrator.emit_review_request_pass_updates(&context, updates);
+
+        // Assert
+        assert!(matches!(
+            app_event_rx.try_recv().expect("first update should be emitted"),
+            AppEvent::ReviewRequestStatusUpdated {
+                generation: 7,
+                result: Ok(SyncReviewRequestTaskResult {
+                    outcome: session::SyncReviewRequestOutcome::NoReviewRequest,
+                    summary: None,
+                }),
+                session_id,
+            } if session_id.as_str() == "session-1"
+        ));
+        assert!(matches!(
+            app_event_rx.try_recv().expect("second update should be emitted"),
+            AppEvent::ReviewRequestStatusUpdated {
+                generation: 7,
+                result: Err(error),
+                session_id,
+            } if session_id.as_str() == "session-2" && error == "forge unavailable"
+        ));
+        assert!(app_event_rx.try_recv().is_err());
     }
 
     #[test]

--- a/crates/agentty/src/app/task.rs
+++ b/crates/agentty/src/app/task.rs
@@ -1357,8 +1357,8 @@ mod tests {
         let mut permissions = std::fs::metadata(&npm_path)
             .expect("failed to load fake npm metadata")
             .permissions();
-        // The isolated child retains the test process's UID, so owner execution is
-        // sufficient.
+        // The isolated child retains the test process's UID, so owner execution
+        // is sufficient.
         permissions.set_mode(0o700);
         std::fs::set_permissions(&npm_path, permissions)
             .expect("failed to make fake npm executable");

--- a/crates/agentty/src/infra/file_index.rs
+++ b/crates/agentty/src/infra/file_index.rs
@@ -466,7 +466,8 @@ mod tests {
             },
         ];
 
-        // Act — "smr" matches "src/main.rs" (s...m...r) and "src/model.rs" (s...m...r)
+        // Act — "smr" matches "src/main.rs" (s...m...r) and "src/model.rs"
+        // (s...m...r)
         let filtered = filter_entries(&entries, "smr");
 
         // Assert
@@ -487,7 +488,8 @@ mod tests {
             },
         ];
 
-        // Act — "main" is consecutive in "src/main.rs" but scattered in the other
+        // Act — "main" is consecutive in "src/main.rs" but scattered in the
+        // other
         let filtered = filter_entries(&entries, "main");
 
         // Assert — consecutive match ranked first
@@ -556,11 +558,12 @@ mod tests {
             },
         ];
 
-        // Act — "d" matches segment start in "src/db.rs" (after /) and mid-word in
-        // "docs"
+        // Act — "d" matches segment start in "src/db.rs" (after /) and mid-word
+        // in "docs"
         let filtered = filter_entries(&entries, "d");
 
-        // Assert — both match, segment-start bonus means "docs" and "db" both have it
+        // Assert — both match, segment-start bonus means "docs" and "db" both
+        // have it
         assert_eq!(filtered.len(), 2);
     }
 

--- a/crates/agentty/src/main.rs
+++ b/crates/agentty/src/main.rs
@@ -29,7 +29,6 @@ async fn main() -> ExitCode {
     match run(cli).await {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
-            // Best-effort: stderr may be unavailable if the terminal is detached.
             let _ = writeln!(io::stderr().lock(), "{error}");
 
             ExitCode::FAILURE

--- a/crates/agentty/src/runtime/key_handler.rs
+++ b/crates/agentty/src/runtime/key_handler.rs
@@ -2293,8 +2293,8 @@ mod tests {
         let backend = ratatui::backend::TestBackend::new(120, 30);
         let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
 
-        // Act — submit from Diff while another turn runs, then retract the queued
-        // prompt.
+        // Act — submit from Diff while another turn runs, then retract the
+        // queued prompt.
         handle_key_event(
             &mut app,
             &PresentationState::default(),
@@ -3465,7 +3465,8 @@ mod tests {
         let event_result =
             handle_confirmation_decision(&mut app, ConfirmationDecision::Confirm).await;
 
-        // Assert — view is restored with loading state, cache shows new Loading entry
+        // Assert — view is restored with loading state, cache shows new Loading
+        // entry
         assert!(matches!(event_result, Ok(EventResult::Continue)));
         assert!(matches!(app.mode, AppMode::View { .. }));
         assert!(matches!(

--- a/crates/agentty/src/runtime/mode/diff.rs
+++ b/crates/agentty/src/runtime/mode/diff.rs
@@ -2509,7 +2509,8 @@ mod tests {
             KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
         );
 
-        // Assert — restored to prompt mode with the draft intact and input focus.
+        // Assert — restored to prompt mode with the draft intact and input
+        // focus.
         assert!(matches!(event_result, EventResult::Continue));
         assert!(matches!(
             &app.mode,
@@ -2556,7 +2557,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_prompt_then_help_then_exit_preserves_composer_context() {
-        // Arrange — diff opened from prompt mode, then the user opens help with `?`.
+        // Arrange — diff opened from prompt mode, then the user opens help with
+        // `?`.
         let (mut app, _base_dir) = crate::test_support::new_test_app().await;
         app.mode = AppMode::Diff {
             session_id: "session-p".into(),
@@ -2621,7 +2623,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_question_then_help_then_exit_preserves_restore_question() {
-        // Arrange — diff opened from question mode, then user opens help with `?`.
+        // Arrange — diff opened from question mode, then user opens help with
+        // `?`.
         use crate::domain::input::InputState;
         use crate::domain::question::QuestionItem;
         use crate::presentation::app_mode::QuestionModeSnapshot;
@@ -2775,7 +2778,8 @@ mod tests {
             KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
         );
 
-        // Assert — an unhandled key leaves the diff selection and scroll intact.
+        // Assert — an unhandled key leaves the diff selection and scroll
+        // intact.
         assert!(matches!(event_result, EventResult::Continue));
         assert!(matches!(
             app.mode,
@@ -3011,8 +3015,8 @@ mod tests {
             line_comments.clear_comment_selection();
         }
 
-        // Act — move from the source row to its comment, back, and onto the comment
-        // again.
+        // Act — move from the source row to its comment, back, and onto the
+        // comment again.
         handle(
             &mut app,
             TEST_TERMINAL_SIZE,
@@ -3087,7 +3091,8 @@ mod tests {
         ])
         .expect("first two changed rows should create a range target");
 
-        // Act — start downward selection, then cancel without leaving content focus.
+        // Act — start downward selection, then cancel without leaving content
+        // focus.
         handle(
             &mut app,
             TEST_TERMINAL_SIZE,
@@ -3937,8 +3942,8 @@ mod tests {
     #[test]
     #[should_panic(expected = "expected AppMode::Prompt after leaving diff")]
     fn test_assert_restored_prompt_composer_rejects_non_prompt_mode() {
-        // Arrange, Act & Assert — the helper rejects modes that are not a restored
-        // composer.
+        // Arrange, Act & Assert — the helper rejects modes that are not a
+        // restored composer.
         assert_restored_prompt_composer(&AppMode::List);
     }
 }

--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -1578,7 +1578,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_enter_on_last_question_restores_answer_when_reply_is_not_enqueued() {
-        // Arrange — free-text mode on last question with no matching session handle.
+        // Arrange — free-text mode on last question with no matching session
+        // handle.
         let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
         app.mode = AppMode::Question {
             at_mention_state: None,
@@ -1623,7 +1624,8 @@ mod tests {
 
     #[tokio::test]
     async fn mark_session_in_progress_advances_snapshot_and_handle_status() {
-        // Arrange — a session sits in `Question` with a matching runtime handle.
+        // Arrange — a session sits in `Question` with a matching runtime
+        // handle.
         use crate::domain::session::SessionHandles;
 
         let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
@@ -1795,12 +1797,14 @@ mod tests {
             selected_option_index: None,
         };
 
-        // Act — answer the final question so `submit_response` attempts the reply.
+        // Act — answer the final question so `submit_response` attempts the
+        // reply.
         submit_response(&mut app, "Unit and integration tests".to_string()).await;
 
         // Assert — the failed reply leaves the session on `Question` instead of
-        // stranding it behind an optimistic `InProgress` no worker will advance,
-        // and restores the panel with the completed answers ready to retry.
+        // stranding it behind an optimistic `InProgress` no worker will
+        // advance, and restores the panel with the completed answers
+        // ready to retry.
         let session = app
             .sessions
             .sessions()

--- a/crates/agentty/src/ui/layout.rs
+++ b/crates/agentty/src/ui/layout.rs
@@ -1867,7 +1867,8 @@ mod tests {
         let input = "ab\ncd";
         let width = 20;
 
-        // Act — cursor at char index 3 = 'a','b','\n' -> position 0 of second line
+        // Act — cursor at char index 3 = 'a','b','\n' -> position 0 of second
+        // line
         let (_, cursor_x, cursor_y) = compute_input_layout(input, width, 3);
 
         // Assert

--- a/crates/agentty/tests/e2e/common.rs
+++ b/crates/agentty/tests/e2e/common.rs
@@ -4,6 +4,7 @@
 //! [`FeatureTest`] for declarative feature demo tests with optional Zola
 //! page generation.
 
+use std::io::Write;
 use std::os::unix::fs::{PermissionsExt, symlink};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard, OnceLock};
@@ -50,7 +51,7 @@ pub(crate) struct BuilderEnv {
 }
 
 impl BuilderEnv {
-    /// Create a new isolated environment under `temp_root`.
+    /// Create a new isolated environment under an existing, empty `temp_root`.
     ///
     /// Creates `agentty_root` and `test-project` subdirectories so each test
     /// gets a fresh database and deterministic project name.
@@ -66,9 +67,21 @@ impl BuilderEnv {
     ///
     /// # Errors
     ///
-    /// Returns an error if directory creation fails.
+    /// Returns an error if the root is not empty or filesystem setup fails.
     pub(crate) fn new(temp_root: &Path) -> std::io::Result<Self> {
         let temp_root = temp_root.canonicalize()?;
+        if temp_root.read_dir()?.next().transpose()?.is_some() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "fixture root must be empty",
+            ));
+        }
+
+        // Stop placeholder session folders from discovering a host checkout
+        // above the fixture. Exclusive creation also protects Git metadata
+        // created after the empty-directory check.
+        std::fs::File::create_new(temp_root.join(".git"))?
+            .write_all(b"gitdir: .nonexistent-fixture-repository\n")?;
         let home_dir = temp_root.join("home");
         let agentty_root = home_dir.join(".agentty");
         let workdir = home_dir.join("test-project");
@@ -186,7 +199,8 @@ impl BuilderEnv {
     ///
     /// This keeps feature tests able to choose between inheriting system
     /// commands, using only deterministic stub agent executables, and
-    /// exercising responsive layouts at their intended widths.
+    /// exercising responsive layouts at their intended widths. Clear inherited
+    /// tmux state so host shortcuts cannot change captured frames.
     fn builder_with_path_and_size(
         &self,
         path_env: String,
@@ -199,6 +213,7 @@ impl BuilderEnv {
             .env("HOME", self.home_dir.to_string_lossy())
             .env(NO_COLOR_ENV_VAR, NO_COLOR_ENV_VALUE)
             .env("PATH", path_env)
+            .env("TMUX", "")
             .workdir(&self.workdir)
     }
 
@@ -243,6 +258,7 @@ impl BuilderEnv {
             ),
             (NO_COLOR_ENV_VAR.to_string(), NO_COLOR_ENV_VALUE.to_string()),
             ("PATH".to_string(), path_env),
+            ("TMUX".to_string(), String::new()),
         ]
     }
 
@@ -1476,6 +1492,8 @@ pub(crate) fn create_session_with_prompt_and_return_to_list(prompt: &str) -> Jou
 
 #[cfg(test)]
 mod tests {
+    use ag_git::{GitClient, RealGitClient};
+
     use super::*;
 
     #[test]
@@ -1589,7 +1607,109 @@ mod tests {
     }
 
     #[test]
-    fn builder_env_exports_no_color_to_vhs_recording() {
+    fn builder_env_preserves_existing_git_file() {
+        // Arrange
+        let temp = tempfile::TempDir::new().expect("failed to create temporary directory");
+        let git_path = temp.path().join(".git");
+        let git_contents = "gitdir: linked-worktree-metadata\n";
+        std::fs::write(&git_path, git_contents).expect("failed to write worktree pointer");
+
+        // Act
+        let error = BuilderEnv::new(temp.path())
+            .err()
+            .expect("existing worktree root should be rejected");
+
+        // Assert
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            std::fs::read_to_string(&git_path).expect("failed to read worktree pointer"),
+            git_contents,
+        );
+        assert_eq!(
+            temp.path()
+                .read_dir()
+                .expect("failed to read fixture root")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn builder_env_preserves_nonempty_directories() {
+        for directory_name in [".git", "home"] {
+            // Arrange
+            let temp = tempfile::TempDir::new().expect("failed to create temporary directory");
+            let existing_dir = temp.path().join(directory_name);
+            std::fs::create_dir(&existing_dir).expect("failed to create existing directory");
+            let existing_file = existing_dir.join("keep.txt");
+            std::fs::write(&existing_file, "preserve this data")
+                .expect("failed to write existing data");
+
+            // Act
+            let error = BuilderEnv::new(temp.path())
+                .err()
+                .expect("nonempty fixture root should be rejected");
+
+            // Assert
+            assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+            assert_eq!(
+                std::fs::read_to_string(&existing_file).expect("failed to read existing data"),
+                "preserve this data",
+            );
+            assert_eq!(
+                temp.path()
+                    .read_dir()
+                    .expect("failed to read fixture root")
+                    .count(),
+                1
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn builder_env_isolates_parent_git_repositories() {
+        // Arrange
+        let temp = tempfile::TempDir::new().expect("failed to create temporary directory");
+        let parent_git_dir = temp.path().join(".git");
+        std::fs::create_dir(&parent_git_dir).expect("failed to create parent Git marker");
+        std::fs::write(parent_git_dir.join("HEAD"), "ref: refs/heads/host-only\n")
+            .expect("failed to seed parent branch");
+        let fixture_root = temp.path().join("fixture");
+        std::fs::create_dir(&fixture_root).expect("failed to create fixture root");
+        let env = BuilderEnv::new(&fixture_root).expect("failed to create builder environment");
+        env.init_git()
+            .expect("failed to initialize fixture project");
+
+        // Act
+        let placeholder_root = RealGitClient
+            .find_git_repo_root(env.agentty_root.clone())
+            .await;
+        let project_root = RealGitClient.find_git_repo_root(env.workdir.clone()).await;
+        let placeholder_branch = RealGitClient.detect_git_info(env.agentty_root).await;
+        let project_branch = RealGitClient.detect_git_info(env.workdir.clone()).await;
+
+        // Assert
+        assert_eq!(placeholder_root, None);
+        assert_eq!(project_root, Some(env.workdir));
+        assert_eq!(placeholder_branch, None);
+        assert_eq!(project_branch.as_deref(), Some("main"));
+    }
+
+    #[tokio::test]
+    async fn builder_env_without_git_has_no_repository_root() {
+        // Arrange
+        let temp = tempfile::TempDir::new().expect("failed to create temporary directory");
+        let env = BuilderEnv::new(temp.path()).expect("failed to create builder environment");
+
+        // Act
+        let repository_root = RealGitClient.find_git_repo_root(env.workdir).await;
+
+        // Assert
+        assert_eq!(repository_root, None);
+    }
+
+    #[test]
+    fn builder_env_pins_vhs_terminal_environment() {
         // Arrange
         let temp = tempfile::TempDir::new().expect("failed to create temporary directory");
         let env = BuilderEnv::new(temp.path()).expect("failed to create builder environment");
@@ -1603,6 +1723,12 @@ mod tests {
                 .iter()
                 .any(|(key, value)| { key == NO_COLOR_ENV_VAR && value == NO_COLOR_ENV_VALUE }),
             "feature recording must disable color"
+        );
+        assert!(
+            environment
+                .iter()
+                .any(|(key, value)| key == "TMUX" && value.is_empty()),
+            "feature recording must not inherit host tmux shortcuts"
         );
     }
 

--- a/crates/agentty/tests/e2e/project.rs
+++ b/crates/agentty/tests/e2e/project.rs
@@ -122,6 +122,9 @@ fn projects_page_shows_cwd() {
             |scenario| {
                 scenario
                     .compose(&common::wait_for_agentty_startup())
+                    .wait_for_text("gemini 0.0.1-updated", 10000)
+                    .wait_for_text("claude 0.0.1-updated", 10000)
+                    .wait_for_text("codex 0.0.1-updated", 10000)
                     .viewing_pause_ms(3000)
                     .capture_labeled("projects", "Projects page with registered project")
             },

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -9467,7 +9467,8 @@ fn assert_diff_line_comments(frame: &TerminalFrame, report: &ProofReport) {
 /// Verify that `Shift+V` selects a changed-row range for one inline comment.
 #[test]
 fn test_diff_row_selection_comments() -> E2eResult {
-    // Arrange — Ctrl+M emits Enter's carriage return consistently in PTY and VHS.
+    // Arrange — Ctrl+M emits Enter's carriage return consistently in PTY and
+    // VHS.
     const ENTER_KEY: &str = "Ctrl+m";
 
     // Act, Assert
@@ -9655,6 +9656,7 @@ fn test_session_review_comments() -> E2eResult {
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::open_selected_session_view())
                     .press_key("d")
+                    .wait_for_text("j/k: select file", 5000)
                     .wait_for_text("c: comments", 5000)
                     .press_key("c")
                     .wait_for_text("Please explain why this review output is needed.", 5000)
@@ -9739,6 +9741,7 @@ fn test_review_comments_escape_focuses_files() -> E2eResult {
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::open_selected_session_view())
                     .press_key("d")
+                    .wait_for_text("j/k: select file", 5000)
                     .wait_for_text("c: comments", 5000)
                     .press_key("c")
                     .wait_for_text("Space: select", 5000)
@@ -9775,6 +9778,7 @@ fn test_review_comment_addressed_guard() -> E2eResult {
                     .compose(&common::wait_for_agentty_startup())
                     .compose(&common::open_selected_session_view())
                     .press_key("d")
+                    .wait_for_text("j/k: select file", 5000)
                     .wait_for_text("c: comments", 5000)
                     .press_key("c")
                     .wait_for_text("addressed", 5000)
@@ -10022,6 +10026,7 @@ fn session_review_comment_agent_resolution() -> E2eResult {
                     .compose(&common::switch_to_tab("Sessions"))
                     .compose(&common::open_selected_session_view())
                     .press_key("d")
+                    .wait_for_text("j/k: select file", 5000)
                     .wait_for_text("c: comments", 5000)
                     .press_key("c")
                     .wait_for_text("Space: select", 5000)
@@ -10096,6 +10101,7 @@ fn test_review_comment_incomplete_outcomes() -> E2eResult {
                     .compose(&common::switch_to_tab("Sessions"))
                     .compose(&common::open_selected_session_view())
                     .press_key("d")
+                    .wait_for_text("j/k: select file", 5000)
                     .wait_for_text("c: comments", 5000)
                     .press_key("c")
                     .wait_for_text("Space: select", 5000)

--- a/crates/testty/src/assertion.rs
+++ b/crates/testty/src/assertion.rs
@@ -700,7 +700,8 @@ fn format_text_not_found(frame: &TerminalFrame, needle: &str, region: Region) ->
     let region_text = frame.text_in_region(&region);
     let mut message = String::new();
 
-    // Infallible: all `writeln!` calls below write to a String, which cannot fail.
+    // Infallible: all `writeln!` calls below write to a String, which cannot
+    // fail.
     let _ = writeln!(
         message,
         "Text '{needle}' not found in region (col:{}, row:{}, {}x{})",
@@ -800,8 +801,8 @@ mod tests {
             "unexpected expected variant: {:?}",
             failure.expected
         );
-        // The needle does appear elsewhere in the frame, so structured spans should
-        // record it.
+        // The needle does appear elsewhere in the frame, so structured spans
+        // should record it.
         assert_eq!(failure.matched_spans.len(), 1);
     }
 

--- a/crates/testty/src/diff.rs
+++ b/crates/testty/src/diff.rs
@@ -318,7 +318,8 @@ mod tests {
         // Act
         let diff = FrameDiff::compute(&frame_a, &frame_b);
 
-        // Assert — first 5 cols unchanged, cols 5-9 are "out of bounds" = changed.
+        // Assert — first 5 cols unchanged, cols 5-9 are "out of bounds" =
+        // changed.
         assert_eq!(diff.cell_change(0, 0), Some(CellChange::Unchanged));
         assert_eq!(diff.cell_change(0, 5), Some(CellChange::BothChanged));
     }

--- a/crates/testty/src/main.rs
+++ b/crates/testty/src/main.rs
@@ -495,7 +495,8 @@ mod tests {
     fn run_scenario_warns_when_proof_requested() {
         use std::os::unix::fs::PermissionsExt;
 
-        // Arrange — a passing fixture scenario plus a requested proof directory.
+        // Arrange — a passing fixture scenario plus a requested proof
+        // directory.
         let temp = tempfile::tempdir().expect("temp dir");
         let script = temp.path().join("greet.sh");
         std::fs::write(&script, "#!/bin/sh\nprintf 'Hello World'\nsleep 60\n").expect("write");

--- a/crates/testty/src/recipe.rs
+++ b/crates/testty/src/recipe.rs
@@ -423,7 +423,8 @@ mod tests {
         // Act
         let failure = match_selected_tab(&frame, "Projects").expect_err("should be Err");
 
-        // Assert — composition stops at the region check before reaching highlight.
+        // Assert — composition stops at the region check before reaching
+        // highlight.
         assert!(matches!(
             &failure.expected,
             crate::assertion::Expected::TextInRegion { needle, .. } if needle == "Projects"

--- a/crates/testty/src/renderer.rs
+++ b/crates/testty/src/renderer.rs
@@ -705,7 +705,8 @@ mod tests {
         let glyph_a = lookup_glyph('A');
         let glyph_space = lookup_glyph(' ');
 
-        // Assert — 'A' glyph should have non-zero bytes, space should be all zeros.
+        // Assert — 'A' glyph should have non-zero bytes, space should be all
+        // zeros.
         assert!(glyph_a.iter().any(|&byte| byte != 0));
         assert!(glyph_space.iter().all(|&byte| byte == 0));
     }

--- a/crates/testty/src/vhs.rs
+++ b/crates/testty/src/vhs.rs
@@ -253,8 +253,8 @@ fn compile_tape(
 ) -> String {
     let mut tape = String::new();
 
-    // Infallible: all `writeln!` calls below write to a String, which cannot fail.
-    // Header settings.
+    // Infallible: all `writeln!` calls below write to a String, which cannot
+    // fail. Header settings.
     let _ = writeln!(tape, "Set Shell \"bash\"");
     let _ = writeln!(tape, "Set FontSize {}", settings.font_size);
     let _ = writeln!(tape, "Set Width {}", settings.width);
@@ -327,7 +327,8 @@ fn compile_tape(
 
 /// Compile a single step into VHS tape commands.
 fn compile_step(tape: &mut String, step: &Step, screenshot_path: &Path) {
-    // Infallible: all `writeln!` calls below write to a String, which cannot fail.
+    // Infallible: all `writeln!` calls below write to a String, which cannot
+    // fail.
     match step {
         Step::WriteText(text) => {
             let _ = writeln!(tape, "Type \"{}\"", escape_vhs_double_quote(text));

--- a/crates/testty/tests/public_api.rs
+++ b/crates/testty/tests/public_api.rs
@@ -169,9 +169,10 @@ fn public_surface_is_stable() {
     );
     let _: FramePredicate = Arc::new(|_frame: &TerminalFrame| Ok(()));
 
-    // Declarative YAML scenario surface (the language-agnostic `run` front end).
-    // Pin the load/lower/run entry points and the spec types so the published
-    // shape the CLI and external tooling depend on cannot drift silently.
+    // Declarative YAML scenario surface (the language-agnostic `run` front
+    // end). Pin the load/lower/run entry points and the spec types so the
+    // published shape the CLI and external tooling depend on cannot drift
+    // silently.
     let _: fn(&str) -> Result<ScenarioSpec, SpecError> = ScenarioSpec::from_yaml;
     let _: fn(&ScenarioSpec) -> LoweredScenario = ScenarioSpec::lower;
     let _: fn(&LoweredScenario, &TerminalFrame) -> Vec<AssertionFailure> = LoweredScenario::check;
@@ -188,8 +189,8 @@ fn public_surface_is_stable() {
 /// public surface and are documented as part of the public contract.
 #[test]
 fn auxiliary_surface_is_stable() {
-    // Arrange, Act, Assert: compile-time references exercise documented auxiliary
-    // APIs.
+    // Arrange, Act, Assert: compile-time references exercise documented
+    // auxiliary APIs.
     let _: &str = testty::snapshot::DEFAULT_UPDATE_ENV_VAR;
 
     let config = SnapshotConfig::new("/baselines", "/artifacts")

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # Keep local and CI lint and coverage behavior reproducible.
-channel = "nightly-2026-08-28"
+channel = "nightly-2026-09-04"


### PR DESCRIPTION
- Keep batched review status updates associated with their originating sessions.
- Prevent parent Git repositories and inherited tmux state from affecting feature-test fixtures.
- Stabilize E2E navigation with readiness checks and pin the nightly toolchain.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)