### PR TITLE
Keep session workflows responsive during background work

### DIFF
--- a/crates/ag-git/src/error.rs
+++ b/crates/ag-git/src/error.rs
@@ -17,10 +17,10 @@ pub enum GitError {
         stderr: String,
     },
 
-    /// A git subprocess exceeded its configured runtime bound.
+    /// A git subprocess or index preparation exceeded its runtime bound.
     #[error("{command} timed out after {timeout:?}")]
     CommandTimedOut {
-        /// Git invocation that exceeded the timeout.
+        /// Git invocation or preparation step that exceeded the timeout.
         command: String,
         /// Configured command timeout.
         timeout: Duration,

--- a/crates/ag-git/src/repo.rs
+++ b/crates/ag-git/src/repo.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::fs;
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -20,7 +21,7 @@ pub(super) struct AsyncGitCommand {
     /// Git arguments excluding the executable name.
     pub(super) arguments: Vec<String>,
     /// Environment overrides applied after noninteractive defaults.
-    pub(super) environment: Vec<(String, String)>,
+    pub(super) environment: Vec<(OsString, OsString)>,
     /// Repository or worktree used as the process working directory.
     pub(super) repo_path: PathBuf,
 }
@@ -36,7 +37,7 @@ impl AsyncGitCommand {
     }
 
     /// Applies environment overrides to this command.
-    pub(super) fn with_environment(mut self, environment: Vec<(String, String)>) -> Self {
+    pub(super) fn with_environment(mut self, environment: Vec<(OsString, OsString)>) -> Self {
         self.environment = environment;
 
         self
@@ -271,6 +272,17 @@ pub(super) async fn run_git_command_with_runner(
     error_context: &str,
     command_runner: &dyn AsyncGitCommandRunner,
 ) -> Result<String, GitError> {
+    let stdout = run_git_command_bytes_with_runner(command, error_context, command_runner).await?;
+
+    Ok(String::from_utf8_lossy(&stdout).into_owned())
+}
+
+/// Runs a git command while preserving stdout bytes for native path consumers.
+pub(super) async fn run_git_command_bytes_with_runner(
+    command: AsyncGitCommand,
+    error_context: &str,
+    command_runner: &dyn AsyncGitCommandRunner,
+) -> Result<Vec<u8>, GitError> {
     let git_invocation = format_git_invocation_from_strings(&command.arguments);
     let output = command_runner.run(command).await?;
     if !output.success() {
@@ -282,7 +294,7 @@ pub(super) async fn run_git_command_with_runner(
         });
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    Ok(output.stdout)
 }
 
 /// Runs a cancellable git subprocess with an explicit runtime bound.

--- a/crates/ag-git/src/sync.rs
+++ b/crates/ag-git/src/sync.rs
@@ -1,11 +1,19 @@
 use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+#[cfg(unix)]
+use std::ffi::OsString;
+use std::hash::{Hash, Hasher};
 use std::io::Read;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
 use std::path::{Component, Path, PathBuf};
 use std::process::Output;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 #[cfg(unix)]
 use rustix::fs::{self as rustix_fs, Access};
+use tokio::sync::Semaphore;
 use tokio::task::spawn_blocking;
 use tokio::time;
 
@@ -16,8 +24,8 @@ use super::rebase::{
 };
 use super::repo::{
     AsyncGitCommand, AsyncGitCommandOutput, AsyncGitCommandRunner, ProcessAsyncGitCommandRunner,
-    command_output_detail, run_git_command, run_git_command_output_sync,
-    run_git_command_output_with_env_sync, run_git_command_sync, run_git_command_with_runner,
+    command_output_detail, run_git_command, run_git_command_bytes_with_runner,
+    run_git_command_output_sync, run_git_command_sync, run_git_command_with_runner,
 };
 
 /// Map of local branch names to their ahead/behind counts relative to their
@@ -25,6 +33,11 @@ use super::repo::{
 pub type BranchTrackingMap = HashMap<String, Option<(u32, u32)>>;
 
 const COMMIT_ALL_HOOK_RETRY_ATTEMPTS: usize = 5;
+const INDEX_COPY_TIMEOUT: Duration = Duration::from_secs(30);
+/// Four path-hashed lanes bound blocking index copies across all requests.
+/// Repeated copies of the same path share a lane, including after cancellation.
+static INDEX_COPY_LANES: LazyLock<[Arc<Semaphore>; 4]> =
+    LazyLock::new(|| std::array::from_fn(|_| Arc::new(Semaphore::new(1))));
 const MAX_WORKTREE_FILE_BYTE_COUNT: usize = 1024 * 1024;
 const PRE_COMMIT_CONFIG_FILES: [&str; 2] = [".pre-commit-config.yaml", ".pre-commit-config.yml"];
 
@@ -345,75 +358,128 @@ async fn diff_output(
     base_branch: String,
     name_only: bool,
 ) -> Result<String, GitError> {
-    spawn_blocking(move || -> Result<String, GitError> {
-        let index_path = resolve_diff_index_path(&repo_path)?;
-        let index_path = PathBuf::from(index_path.trim());
-        let index_path = if index_path.is_absolute() {
-            index_path
-        } else {
-            repo_path.join(index_path)
-        };
+    let index_path = resolve_diff_index_path(&repo_path, &ProcessAsyncGitCommandRunner).await?;
+    let index_path = if index_path.is_absolute() {
+        index_path
+    } else {
+        repo_path.join(index_path)
+    };
 
-        diff_output_after_index_resolution(&repo_path, &base_branch, name_only, &index_path)
-    })
-    .await?
+    diff_output_after_index_resolution(&repo_path, &base_branch, name_only, &index_path).await
 }
 
-/// Generates diff output after the real index path has been resolved.
-fn diff_output_after_index_resolution(
+/// Generates diff output with cancellable, deadline-bound subprocesses. Only
+/// copying the isolated index runs on a bounded blocking lane.
+async fn diff_output_after_index_resolution(
     repo_path: &Path,
     base_branch: &str,
     name_only: bool,
     index_path: &Path,
 ) -> Result<String, GitError> {
-    let result = (|| -> Result<String, GitError> {
-        let temporary_index = copy_git_index_to_temp(index_path)?;
-
-        run_git_command_with_index_sync(
+    let result = async {
+        let temporary_index = copy_git_index_with_lane(
+            index_path.to_path_buf(),
+            index_copy_lane(index_path),
+            INDEX_COPY_TIMEOUT,
+            copy_git_index_to_temp,
+        )
+        .await?;
+        run_git_command_with_index(
             repo_path,
             &["add", "-A", "--intent-to-add"],
             &temporary_index,
             "Git add --intent-to-add failed",
-        )?;
+        )
+        .await?;
 
-        let merge_base_output =
-            run_git_command_output_sync(repo_path, &["merge-base", "HEAD", base_branch])?;
-
-        let diff_target = if merge_base_output.status.success() {
+        let merge_base_output = ProcessAsyncGitCommandRunner
+            .run(AsyncGitCommand::new(
+                repo_path.to_path_buf(),
+                vec!["merge-base".into(), "HEAD".into(), base_branch.into()],
+            ))
+            .await?;
+        let diff_target = if merge_base_output.success() {
             resolve_diff_target(
                 repo_path,
                 base_branch,
                 String::from_utf8_lossy(&merge_base_output.stdout).trim(),
-            )?
+            )
+            .await?
         } else {
             base_branch.to_string()
         };
-
         let args = if name_only {
             vec!["diff", "--name-only", diff_target.as_str()]
         } else {
             vec!["diff", diff_target.as_str()]
         };
 
-        run_git_command_with_index_sync(repo_path, &args, &temporary_index, "Git diff failed")
-    })();
+        run_git_command_with_index(repo_path, &args, &temporary_index, "Git diff failed").await
+    }
+    .await;
 
-    result.map_err(|error| classify_diff_repository_error(repo_path, error))
+    match result {
+        Ok(output) => Ok(output),
+        Err(error) => Err(classify_diff_repository_error(repo_path, error).await),
+    }
 }
 
-/// Resolves the real index path and classifies a reclaimed repository.
-fn resolve_diff_index_path(repo_path: &Path) -> Result<String, GitError> {
-    run_git_command_sync(
-        repo_path,
-        &["rev-parse", "--git-path", "index"],
+/// Resolves the native index path and classifies a reclaimed repository.
+async fn resolve_diff_index_path(
+    repo_path: &Path,
+    command_runner: &dyn AsyncGitCommandRunner,
+) -> Result<PathBuf, GitError> {
+    let result = run_git_command_bytes_with_runner(
+        AsyncGitCommand::new(
+            repo_path.to_path_buf(),
+            vec!["rev-parse".into(), "--git-path".into(), "index".into()],
+        ),
         "Git index path resolution failed",
+        command_runner,
     )
-    .map_err(|error| classify_diff_repository_error(repo_path, error))
+    .await
+    .and_then(parse_diff_index_path);
+
+    match result {
+        Ok(path) => Ok(path),
+        Err(error) => Err(classify_diff_repository_error(repo_path, error).await),
+    }
+}
+
+/// Removes only Git's output terminator, preserving native path bytes and
+/// whitespace that belongs to the filename. Non-Unix platforms reject invalid
+/// UTF-8 rather than silently substituting a different path.
+fn parse_diff_index_path(mut stdout: Vec<u8>) -> Result<PathBuf, GitError> {
+    if stdout.ends_with(b"\n") {
+        stdout.truncate(stdout.len() - 1);
+        #[cfg(not(unix))]
+        if stdout.ends_with(b"\r") {
+            stdout.truncate(stdout.len() - 1);
+        }
+    }
+    if stdout.is_empty() {
+        return Err(GitError::OutputParse("Git index path is empty".to_string()));
+    }
+
+    #[cfg(unix)]
+    let path = OsString::from_vec(stdout);
+    #[cfg(not(unix))]
+    let path = String::from_utf8(stdout)
+        .map_err(|error| GitError::OutputParse(format!("Invalid Git index path: {error}")))?;
+
+    Ok(PathBuf::from(path))
 }
 
 /// Preserves ordinary Git failures while typing unavailable repository paths.
-fn classify_diff_repository_error(repo_path: &Path, error: GitError) -> GitError {
-    if !diff_repository_is_unavailable(repo_path) {
+async fn classify_diff_repository_error(repo_path: &Path, error: GitError) -> GitError {
+    let probe = ProcessAsyncGitCommandRunner
+        .run(AsyncGitCommand::new(
+            repo_path.to_path_buf(),
+            vec!["rev-parse".into(), "--git-dir".into()],
+        ))
+        .await;
+    let missing_directory = !tokio::fs::try_exists(repo_path).await.unwrap_or(true);
+    if !missing_directory && !diff_repository_probe_is_unavailable(probe) {
         return error;
     }
 
@@ -422,24 +488,9 @@ fn classify_diff_repository_error(repo_path: &Path, error: GitError) -> GitError
     }
 }
 
-/// Probes repository discovery without interpreting localized Git output.
-fn diff_repository_is_unavailable(repo_path: &Path) -> bool {
-    if !repo_path.is_dir() {
-        return true;
-    }
-
-    diff_repository_probe_is_unavailable(run_git_command_output_sync(
-        repo_path,
-        &["rev-parse", "--git-dir"],
-    ))
-}
-
 /// Treats only a completed, unsuccessful discovery probe as unavailable.
-fn diff_repository_probe_is_unavailable(probe: Result<Output, GitError>) -> bool {
-    match probe {
-        Ok(output) => !output.status.success(),
-        Err(_) => false,
-    }
+fn diff_repository_probe_is_unavailable(probe: Result<AsyncGitCommandOutput, GitError>) -> bool {
+    probe.is_ok_and(|output| !output.success())
 }
 
 /// Reads one repository-relative worktree file with a fixed memory bound.
@@ -508,6 +559,46 @@ fn worktree_file_content(bytes: Vec<u8>) -> WorktreeFileContent {
     }
 }
 
+/// Selects a stable lane so the same index cannot accumulate blocking copies.
+/// Hash collisions serialize unrelated indexes, keeping the registry bounded.
+fn index_copy_lane(index_path: &Path) -> Arc<Semaphore> {
+    let mut hasher = DefaultHasher::new();
+    index_path.hash(&mut hasher);
+    let lane = usize::from(hasher.finish().to_le_bytes()[0]) % INDEX_COPY_LANES.len();
+
+    Arc::clone(&INDEX_COPY_LANES[lane])
+}
+
+/// Bounds both queueing and waiting for a copy. Blocking filesystem calls
+/// cannot be aborted, so the closure retains its lane after caller cancellation
+/// or timeout until the copy actually exits. Waiting requests remain async and
+/// cancelable without spawning more blocking work.
+async fn copy_git_index_with_lane(
+    index_path: PathBuf,
+    lane: Arc<Semaphore>,
+    timeout: Duration,
+    copy: impl FnOnce(&Path) -> Result<tempfile::TempPath, GitError> + Send + 'static,
+) -> Result<tempfile::TempPath, GitError> {
+    time::timeout(timeout, async {
+        let permit = lane
+            .acquire_owned()
+            .await
+            .map_err(|error| GitError::Io(std::io::Error::other(error)))?;
+
+        spawn_blocking(move || {
+            let _permit = permit;
+
+            copy(&index_path)
+        })
+        .await?
+    })
+    .await
+    .map_err(|_| GitError::CommandTimedOut {
+        command: "copy git index".to_string(),
+        timeout,
+    })?
+}
+
 /// Copies one repository index beside its source and returns the temporary
 /// path used by isolated read-only diff commands.
 fn copy_git_index_to_temp(index_path: &Path) -> Result<tempfile::TempPath, GitError> {
@@ -532,28 +623,25 @@ fn copy_git_index_to_temp(index_path: &Path) -> Result<tempfile::TempPath, GitEr
 
 /// Runs one git command against a temporary index without touching the real
 /// index.
-fn run_git_command_with_index_sync(
+async fn run_git_command_with_index(
     repo_path: &Path,
     args: &[&str],
     index_path: &Path,
     error_context: &str,
 ) -> Result<String, GitError> {
-    let output = run_git_command_output_with_env_sync(
-        repo_path,
-        args,
-        &[("GIT_INDEX_FILE", index_path.as_os_str())],
-    )?;
-    if !output.status.success() {
-        return Err(GitError::CommandFailed {
-            command: format!("git {}", args.join(" ")),
-            stderr: format!(
-                "{error_context}: {}",
-                command_output_detail(&output.stdout, &output.stderr)
-            ),
-        });
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    run_git_command_with_runner(
+        AsyncGitCommand::new(
+            repo_path.to_path_buf(),
+            args.iter().map(|arg| (*arg).to_string()).collect(),
+        )
+        .with_environment(vec![(
+            "GIT_INDEX_FILE".into(),
+            index_path.as_os_str().to_os_string(),
+        )]),
+        error_context,
+        &ProcessAsyncGitCommandRunner,
+    )
+    .await
 }
 
 /// Returns whether a repository or worktree has no uncommitted changes.
@@ -654,8 +742,8 @@ async fn pull_rebase_with_runner(
 ) -> Result<PullRebaseResult, GitError> {
     let pull_arguments = pull_rebase_arguments(&repo_path, command_runner).await?;
     let command = AsyncGitCommand::new(repo_path, pull_arguments).with_environment(vec![
-        ("GIT_EDITOR".to_string(), ":".to_string()),
-        ("GIT_SEQUENCE_EDITOR".to_string(), ":".to_string()),
+        ("GIT_EDITOR".into(), ":".into()),
+        ("GIT_SEQUENCE_EDITOR".into(), ":".into()),
     ]);
     let output =
         run_async_git_command_with_index_lock_retry(command, command_runner, retry_delay).await?;
@@ -1372,13 +1460,18 @@ fn parse_branch_tracking_counts(track: &str) -> Option<(u32, u32)> {
 /// Starts from the merge-base fallback and, when `git cherry` reports leading
 /// commits already applied to `base_branch`, advances the baseline to the last
 /// such commit so squash-merged session changes are not shown again.
-fn resolve_diff_target(
+async fn resolve_diff_target(
     repo_path: &Path,
     base_branch: &str,
     merge_base: &str,
 ) -> Result<String, GitError> {
-    let cherry_output = run_git_command_output_sync(repo_path, &["cherry", base_branch, "HEAD"])?;
-    if !cherry_output.status.success() {
+    let cherry_output = ProcessAsyncGitCommandRunner
+        .run(AsyncGitCommand::new(
+            repo_path.to_path_buf(),
+            vec!["cherry".into(), base_branch.into(), "HEAD".into()],
+        ))
+        .await?;
+    if !cherry_output.success() {
         return Ok(merge_base.to_string());
     }
 
@@ -1700,10 +1793,13 @@ pub(super) fn is_no_upstream_error(detail: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::future::{Future, poll_fn};
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use std::path::Path;
     use std::process::{Command, Output};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::task::Poll;
 
     use mockall::Sequence;
     use mockall::predicate::function;
@@ -1839,6 +1935,312 @@ mod tests {
         assert_eq!(status_after, status_before);
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn index_resolution_preserves_native_bytes_and_filename_whitespace() {
+        // Arrange
+        let path_bytes = b" /repo-\xff/.git/worktrees/topic/index \t\r";
+        let mut stdout = path_bytes.to_vec();
+        stdout.push(b'\n');
+        let mut runner = MockAsyncGitCommandRunner::new();
+        runner
+            .expect_run()
+            .once()
+            .with(function(|command: &AsyncGitCommand| {
+                command.arguments == ["rev-parse", "--git-path", "index"]
+            }))
+            .return_once(move |_| {
+                Box::pin(async move { Ok(async_git_output(0, stdout, Vec::new())) })
+            });
+
+        // Act
+        let path = resolve_diff_index_path(Path::new("worktree"), &runner).await;
+
+        // Assert
+        assert_eq!(
+            path.expect("native index path"),
+            PathBuf::from(OsString::from_vec(path_bytes.to_vec()))
+        );
+    }
+
+    #[test]
+    fn index_path_parser_preserves_paths_with_and_without_output_terminators() {
+        // Arrange
+        let cases = [
+            (b"relative index\n".to_vec(), "relative index"),
+            (b"relative index".to_vec(), "relative index"),
+            (b" index \t\n".to_vec(), " index \t"),
+            (b"index\n\n".to_vec(), "index\n"),
+        ];
+
+        for (stdout, expected) in cases {
+            // Act
+            let path = parse_diff_index_path(stdout);
+
+            // Assert
+            assert_eq!(path.expect("index path"), PathBuf::from(expected));
+        }
+    }
+
+    #[test]
+    fn index_path_parser_rejects_empty_output() {
+        // Arrange
+        for stdout in [Vec::new(), b"\n".to_vec()] {
+            // Act
+            let result = parse_diff_index_path(stdout);
+
+            // Assert
+            assert!(matches!(result, Err(GitError::OutputParse(_))));
+        }
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn index_path_parser_handles_crlf_and_rejects_invalid_utf8() {
+        // Arrange
+        let valid = b"index\r\n".to_vec();
+        let invalid = b"index-\xff\n".to_vec();
+
+        // Act
+        let path = parse_diff_index_path(valid);
+        let error = parse_diff_index_path(invalid);
+
+        // Assert
+        assert_eq!(path.expect("CRLF-terminated path"), PathBuf::from("index"));
+        assert!(matches!(error, Err(GitError::OutputParse(_))));
+    }
+
+    #[tokio::test]
+    async fn diff_in_linked_worktree_preserves_native_repository_paths() {
+        // Arrange
+        let temp_dir = tempdir().expect("temporary directory");
+        let initial_repo_path = temp_dir.path().join("initial-repo");
+        fs::create_dir(&initial_repo_path).expect("initial repository directory");
+        setup_test_git_repo(&initial_repo_path);
+
+        // Linux exercises a real non-UTF-8 repository name. APFS cannot create
+        // such names; other platforms exercise the same linked-worktree flow
+        // with spaces, while the Unix runner test checks arbitrary path bytes.
+        #[cfg(target_os = "linux")]
+        let repo_path = temp_dir
+            .path()
+            .join(OsString::from_vec(b"repo-\xff".to_vec()));
+        #[cfg(not(target_os = "linux"))]
+        let repo_path = temp_dir.path().join("repo with spaces");
+        fs::rename(initial_repo_path, &repo_path).expect("native repository directory");
+        let worktree_path = temp_dir.path().join("linked-worktree");
+        crate::create_worktree(
+            repo_path.clone(),
+            worktree_path.clone(),
+            "topic".to_string(),
+            "main".to_string(),
+        )
+        .await
+        .expect("linked worktree");
+        fs::write(worktree_path.join("README.md"), "staged change\n").expect("staged content");
+        run_git_command(&worktree_path, &["add", "README.md"]);
+        fs::write(
+            worktree_path.join("README.md"),
+            "staged change\nunstaged change\n",
+        )
+        .expect("unstaged content");
+        fs::write(worktree_path.join("new.txt"), "untracked change\n").expect("untracked content");
+        let main_index = repo_path.join(".git/index");
+        let linked_index = repo_path.join(".git/worktrees/linked-worktree/index");
+        let main_index_before = fs::read(&main_index).expect("main index");
+        let linked_index_before = fs::read(&linked_index).expect("linked index");
+
+        // Act
+        let patch = diff(worktree_path.clone(), "main".to_string()).await;
+        let paths = diff_changed_files(worktree_path, "main".to_string()).await;
+
+        // Assert
+        let patch = patch.expect("linked-worktree diff");
+        assert!(patch.contains("staged change"));
+        assert!(patch.contains("unstaged change"));
+        assert!(patch.contains("untracked change"));
+        assert_eq!(paths.expect("changed paths"), ["README.md", "new.txt"]);
+        assert_eq!(fs::read(main_index).expect("main index"), main_index_before);
+        assert_eq!(
+            fs::read(linked_index).expect("linked index"),
+            linked_index_before
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn diff_preserves_non_utf8_index_paths_and_the_real_index() {
+        // Arrange
+        let temp_dir = tempdir().expect("temporary directory");
+        setup_test_git_repo(temp_dir.path());
+        let index_path = PathBuf::from(std::ffi::OsString::from_vec(b"repo-\xff/index".to_vec()));
+        let index_before = fs::read(temp_dir.path().join(".git/index")).expect("real index");
+        // Inspect the path bytes inside a real Git child. This also works on
+        // filesystems that cannot create non-UTF-8 filenames, including APFS.
+        let arguments = [
+            "-c",
+            r#"alias.check-index=!test "$GIT_INDEX_FILE" = "$(printf 'repo-\377/index')""#,
+            "check-index",
+        ];
+
+        // Act
+        let result = run_git_command_with_index(
+            temp_dir.path(),
+            &arguments,
+            &index_path,
+            "Git index path bytes changed",
+        )
+        .await;
+
+        // Assert
+        assert!(result.is_ok(), "{result:?}");
+        assert_eq!(
+            fs::read(temp_dir.path().join(".git/index")).expect("real index"),
+            index_before,
+        );
+    }
+
+    /// Builds a copy callback that records when blocking work begins.
+    fn recording_index_copy(
+        started: Arc<AtomicBool>,
+    ) -> impl FnOnce(&Path) -> Result<tempfile::TempPath, GitError> {
+        move |path| {
+            started.store(true, Ordering::SeqCst);
+
+            copy_git_index_to_temp(path)
+        }
+    }
+
+    #[tokio::test]
+    async fn canceled_index_copy_retains_its_lane_and_discards_waiting_copies() {
+        // Arrange
+        let temp_dir = tempdir().expect("temporary directory");
+        let index_path = temp_dir.path().join("index");
+        fs::write(&index_path, "index content").expect("index fixture");
+        let lane = index_copy_lane(&index_path);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let request = tokio::spawn(copy_git_index_with_lane(
+            index_path.clone(),
+            Arc::clone(&lane),
+            INDEX_COPY_TIMEOUT,
+            move |path| {
+                started_tx.send(()).expect("copy started");
+                release_rx.recv().expect("release copy");
+
+                copy_git_index_to_temp(path)
+            },
+        ));
+        started_rx.await.expect("blocking copy started");
+        let duplicate_started = Arc::new(AtomicBool::new(false));
+        let resumed_copy_started = Arc::new(AtomicBool::new(false));
+
+        // Act
+        request.abort();
+        let cancellation = request.await;
+        let mut duplicate = Box::pin(copy_git_index_with_lane(
+            index_path.clone(),
+            index_copy_lane(&index_path),
+            INDEX_COPY_TIMEOUT,
+            recording_index_copy(Arc::clone(&duplicate_started)),
+        ));
+        poll_fn(|context| {
+            assert!(duplicate.as_mut().poll(context).is_pending());
+
+            Poll::Ready(())
+        })
+        .await;
+        drop(duplicate);
+        let lane_was_held = lane.try_acquire().is_err();
+        release_tx.send(()).expect("release original copy");
+        let next_copy = copy_git_index_with_lane(
+            index_path,
+            lane,
+            Duration::from_secs(1),
+            recording_index_copy(Arc::clone(&resumed_copy_started)),
+        )
+        .await;
+
+        // Assert
+        assert!(resumed_copy_started.load(Ordering::SeqCst));
+        assert!(cancellation.expect_err("request canceled").is_cancelled());
+        assert!(lane_was_held);
+        assert!(!duplicate_started.load(Ordering::SeqCst));
+        assert_eq!(
+            fs::read(next_copy.expect("lane reusable")).expect("copied index"),
+            b"index content"
+        );
+    }
+
+    #[tokio::test]
+    async fn closed_index_copy_lane_returns_an_error_without_copying() {
+        // Arrange
+        let lane = Arc::new(Semaphore::new(1));
+        lane.close();
+
+        // Act
+        let result = copy_git_index_with_lane(
+            PathBuf::from("index"),
+            lane,
+            INDEX_COPY_TIMEOUT,
+            copy_git_index_to_temp,
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(result, Err(GitError::Io(_))));
+    }
+
+    #[tokio::test]
+    async fn index_copy_deadline_bounds_running_and_queued_requests() {
+        // Arrange
+        let temp_dir = tempdir().expect("temporary directory");
+        let index_path = temp_dir.path().join("index");
+        fs::write(&index_path, "index content").expect("index fixture");
+        let lane = Arc::new(Semaphore::new(1));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let request = tokio::spawn(copy_git_index_with_lane(
+            index_path.clone(),
+            Arc::clone(&lane),
+            Duration::from_millis(25),
+            move |path| {
+                started_tx.send(()).expect("copy started");
+                release_rx.recv().expect("release copy");
+
+                copy_git_index_to_temp(path)
+            },
+        ));
+        started_rx.await.expect("blocking copy started");
+        let duplicate_started = Arc::new(AtomicBool::new(false));
+
+        // Act
+        let running_result = request.await.expect("copy request joined");
+        let queued_result = copy_git_index_with_lane(
+            index_path,
+            Arc::clone(&lane),
+            Duration::from_millis(25),
+            recording_index_copy(Arc::clone(&duplicate_started)),
+        )
+        .await;
+        let lane_was_held = lane.try_acquire().is_err();
+        release_tx.send(()).expect("release timed-out copy");
+        let released = time::timeout(Duration::from_secs(1), lane.acquire()).await;
+
+        // Assert
+        assert!(matches!(
+            running_result,
+            Err(GitError::CommandTimedOut { .. })
+        ));
+        assert!(matches!(
+            queued_result,
+            Err(GitError::CommandTimedOut { .. })
+        ));
+        assert!(lane_was_held);
+        assert!(!duplicate_started.load(Ordering::SeqCst));
+        assert!(released.is_ok());
+    }
+
     #[tokio::test]
     async fn diff_reports_repository_unavailable_outside_git_repository() {
         // Arrange
@@ -1855,15 +2257,15 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn diff_reports_repository_unavailable_when_removed_after_index_resolution() {
+    #[tokio::test]
+    async fn diff_reports_repository_unavailable_when_removed_after_index_resolution() {
         // Arrange
         let temp_dir = tempdir().expect("failed to create temp dir");
         let preserved_index_dir = tempdir().expect("failed to create preserved index dir");
         setup_test_git_repo(temp_dir.path());
-        let index_path =
-            resolve_diff_index_path(temp_dir.path()).expect("index path should resolve");
-        let index_path = PathBuf::from(index_path.trim());
+        let index_path = resolve_diff_index_path(temp_dir.path(), &ProcessAsyncGitCommandRunner)
+            .await
+            .expect("index path should resolve");
         let index_path = temp_dir.path().join(index_path);
         let preserved_index_path = preserved_index_dir.path().join("index");
         fs::copy(index_path, &preserved_index_path).expect("index copy should succeed");
@@ -1875,7 +2277,8 @@ mod tests {
             "main",
             false,
             &preserved_index_path,
-        );
+        )
+        .await;
 
         // Assert
         assert!(matches!(
@@ -1907,8 +2310,8 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn diff_repository_error_classification_preserves_unrelated_failures() {
+    #[tokio::test]
+    async fn diff_repository_error_classification_preserves_unrelated_failures() {
         // Arrange
         let temp_dir = tempdir().expect("failed to create temp dir");
         setup_test_git_repo(temp_dir.path());
@@ -1918,7 +2321,7 @@ mod tests {
         };
 
         // Act
-        let classified = classify_diff_repository_error(temp_dir.path(), error);
+        let classified = classify_diff_repository_error(temp_dir.path(), error).await;
 
         // Assert
         assert!(matches!(
@@ -1929,8 +2332,8 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn diff_repository_error_classification_ignores_localized_diagnostic() {
+    #[tokio::test]
+    async fn diff_repository_error_classification_ignores_localized_diagnostic() {
         // Arrange
         let temp_dir = tempdir().expect("failed to create temp dir");
         let error = GitError::CommandFailed {
@@ -1939,7 +2342,7 @@ mod tests {
         };
 
         // Act
-        let classified = classify_diff_repository_error(temp_dir.path(), error);
+        let classified = classify_diff_repository_error(temp_dir.path(), error).await;
 
         // Assert
         assert!(matches!(
@@ -1964,8 +2367,8 @@ mod tests {
         assert!(!unavailable);
     }
 
-    #[test]
-    fn diff_repository_error_classification_types_missing_directory() {
+    #[tokio::test]
+    async fn diff_repository_error_classification_types_missing_directory() {
         // Arrange
         let temp_dir = tempdir().expect("failed to create temp dir");
         let missing_path = temp_dir.path().join("removed-worktree");
@@ -1975,7 +2378,7 @@ mod tests {
         ));
 
         // Act
-        let classified = classify_diff_repository_error(&missing_path, error);
+        let classified = classify_diff_repository_error(&missing_path, error).await;
 
         // Assert
         assert!(matches!(
@@ -2124,8 +2527,8 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn run_git_command_with_index_sync_maps_process_and_command_failures() {
+    #[tokio::test]
+    async fn run_git_command_with_index_maps_process_and_command_failures() {
         // Arrange
         let temp_dir = tempdir().expect("failed to create temp dir");
         let index_path = temp_dir.path().join("index");
@@ -2133,18 +2536,20 @@ mod tests {
         fs::write(&index_path, []).expect("failed to create temporary index");
 
         // Act
-        let process_error = run_git_command_with_index_sync(
+        let process_error = run_git_command_with_index(
             &missing_repo_path,
             &["status"],
             &index_path,
             "Expected process failure",
-        );
-        let command_error = run_git_command_with_index_sync(
+        )
+        .await;
+        let command_error = run_git_command_with_index(
             temp_dir.path(),
             &["definitely-not-a-git-command"],
             &index_path,
             "Expected git failure",
-        );
+        )
+        .await;
 
         // Assert
         assert!(matches!(
@@ -2541,8 +2946,8 @@ mod tests {
                     command.arguments == ["pull", "--rebase", "origin", "main"]
                         && command.environment
                             == [
-                                ("GIT_EDITOR".to_string(), ":".to_string()),
-                                ("GIT_SEQUENCE_EDITOR".to_string(), ":".to_string()),
+                                ("GIT_EDITOR".into(), ":".into()),
+                                ("GIT_SEQUENCE_EDITOR".into(), ":".into()),
                             ]
                 }))
                 .times(1)

--- a/crates/ag-git/src/worktree.rs
+++ b/crates/ag-git/src/worktree.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use tokio::task::spawn_blocking;
 
 use super::error::GitError;
-use super::repo::{main_repo_root, resolve_git_dir, run_git_command, run_git_command_sync};
+use super::repo::{main_repo_root, resolve_git_dir, run_git_command};
 
 /// Detects git repository information for the given directory.
 /// Returns the current branch name if in a git repository, None otherwise.
@@ -45,24 +45,21 @@ pub(crate) async fn create_worktree(
     branch_name: String,
     start_ref: String,
 ) -> Result<(), GitError> {
-    spawn_blocking(move || {
-        let worktree_path = worktree_path.to_string_lossy().to_string();
-        run_git_command_sync(
-            &repo_path,
-            &[
-                "worktree",
-                "add",
-                "-b",
-                branch_name.as_str(),
-                worktree_path.as_str(),
-                start_ref.as_str(),
-            ],
-            "Git worktree command failed",
-        )?;
+    run_git_command(
+        repo_path,
+        vec![
+            "worktree".into(),
+            "add".into(),
+            "-b".into(),
+            branch_name,
+            worktree_path.to_string_lossy().into_owned(),
+            start_ref,
+        ],
+        "Git worktree command failed".into(),
+    )
+    .await?;
 
-        Ok(())
-    })
-    .await?
+    Ok(())
 }
 
 /// Removes a git worktree at the specified path.
@@ -182,12 +179,14 @@ mod tests {
     #[test]
     fn find_git_repo_root_sync_returns_none_when_no_git_dir() {
         // Arrange
-        let temp_dir = tempfile::tempdir().expect("should create temp dir");
+        // TMPDIR may itself be inside a checkout. The filesystem root has no
+        // parent checkout and exercises the search exhaustion boundary.
+        let root = Path::new(std::path::MAIN_SEPARATOR_STR);
 
         // Act
-        let result = find_git_repo_root_sync(temp_dir.path());
+        let result = find_git_repo_root_sync(root);
 
-        // Assert — walks up to filesystem root and returns None
+        // Assert
         assert!(result.is_none());
     }
 
@@ -266,10 +265,10 @@ mod tests {
     #[test]
     fn detect_git_info_sync_returns_none_for_non_repo() {
         // Arrange
-        let temp_dir = tempfile::tempdir().expect("should create temp dir");
+        let root = Path::new(std::path::MAIN_SEPARATOR_STR);
 
         // Act
-        let result = detect_git_info_sync(temp_dir.path());
+        let result = detect_git_info_sync(root);
 
         // Assert
         assert!(result.is_none());

--- a/crates/ag-session/src/model.rs
+++ b/crates/ag-session/src/model.rs
@@ -329,16 +329,19 @@ impl SessionStatus {
             (
                 SessionStatus::Draft,
                 SessionStatus::InProgress | SessionStatus::Canceled
-            ) | (
-                SessionStatus::Draft | SessionStatus::InProgress,
-                SessionStatus::Rebasing
-            ) | (
-                SessionStatus::InProgress
-                    | SessionStatus::Queued
-                    | SessionStatus::Rebasing
-                    | SessionStatus::Merging,
-                SessionStatus::Canceled
-            ) | (SessionStatus::Review, SessionStatus::AgentReview)
+            ) | (SessionStatus::InProgress, SessionStatus::Draft)
+                | (
+                    SessionStatus::Draft | SessionStatus::InProgress,
+                    SessionStatus::Rebasing
+                )
+                | (
+                    SessionStatus::InProgress
+                        | SessionStatus::Queued
+                        | SessionStatus::Rebasing
+                        | SessionStatus::Merging,
+                    SessionStatus::Canceled
+                )
+                | (SessionStatus::Review, SessionStatus::AgentReview)
                 | (SessionStatus::AgentReview, SessionStatus::Review)
                 | (
                     SessionStatus::Review | SessionStatus::AgentReview,
@@ -590,6 +593,22 @@ mod tests {
         assert!(status.can_transition_to(SessionStatus::Merged));
         assert!(status.can_transition_to(SessionStatus::Done));
         assert!(!status.can_transition_to(SessionStatus::Review));
+    }
+
+    #[test]
+    fn failed_start_can_return_to_draft_without_reviving_terminal_sessions() {
+        // Arrange
+        let statuses = [
+            SessionStatus::InProgress,
+            SessionStatus::Done,
+            SessionStatus::Canceled,
+        ];
+
+        // Act
+        let transitions = statuses.map(|status| status.can_transition_to(SessionStatus::Draft));
+
+        // Assert
+        assert_eq!(transitions, [true, false, false]);
     }
 
     #[test]

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -1396,7 +1396,11 @@ impl App {
     async fn apply_app_event_effects(&mut self, effects: Vec<AppEventEffect>) {
         for effect in effects {
             match effect {
-                AppEventEffect::ReloadSessions => self.refresh_sessions_now().await,
+                AppEventEffect::ReloadSessions => self.sessions.request_session_refresh(
+                    &self.mode,
+                    &self.projects,
+                    &self.services,
+                ),
                 AppEventEffect::ReloadProjects => self.reload_projects().await,
                 AppEventEffect::RefreshGitStatus => self.restart_git_status_task(),
                 AppEventEffect::ApplyReviewUpdates(review_updates) => {
@@ -1911,8 +1915,7 @@ impl App {
         }
 
         if let Some(state) = at_mention_state.as_mut() {
-            state.all_entries = entries;
-            state.selected_index = 0;
+            state.replace_entries(entries);
 
             return;
         }
@@ -2612,6 +2615,44 @@ mod tests {
         ForgeKind, ReviewRequest, ReviewRequestState, ReviewRequestSummary,
     };
     use crate::presentation::app_mode::{DiffFocus, DiffLineComments};
+    use crate::presentation::prompt::{
+        PromptAttachmentState, PromptHistoryState, PromptSlashState,
+    };
+
+    #[tokio::test]
+    async fn new_mention_index_invalidates_the_visible_ranking_cache() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        let old_entries = vec![FileEntry {
+            path: "old.rs".into(),
+            is_dir: false,
+        }];
+        let state = PromptAtMentionState::new(old_entries);
+        let _ = state.filtered_entries("");
+        app.mode = AppMode::Prompt {
+            at_mention_state: Some(state),
+            attachment_state: PromptAttachmentState::default(),
+            focus: ChatFocus::Input,
+            history_state: PromptHistoryState::default(),
+            slash_state: PromptSlashState::default(),
+            session_id: "session-id".into(),
+            input: InputState::with_text("@".into()),
+            scroll_offset: None,
+        };
+        let entries = vec![FileEntry {
+            path: "new.rs".into(),
+            is_dir: false,
+        }];
+
+        // Act
+        app.apply_prompt_at_mention_entries("session-id", entries.clone());
+
+        // Assert
+        assert!(
+            matches!(&app.mode, AppMode::Prompt { at_mention_state: Some(state), .. }
+            if &*state.filtered_entries("") == entries.as_slice() && state.selected_index == 0)
+        );
+    }
 
     #[tokio::test]
     async fn merged_branch_eligibility_rejects_incomplete_session_context() {

--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -343,6 +343,22 @@ impl App {
         services: &AppServices,
         clients: &AppClients,
     ) {
+        let repositories = services.db().clone();
+        let git_client = services.git_client();
+        let discovery_client = Arc::clone(&clients.project_discovery_client);
+        let event_tx_for_discovery = event_tx.clone();
+        tokio::spawn(async move {
+            if AppStartup::refresh_project_catalog_on_startup(
+                &repositories,
+                git_client.as_ref(),
+                discovery_client.as_ref(),
+            )
+            .await
+            {
+                let _ = event_tx_for_discovery.send(AppEvent::RefreshProjects);
+            }
+        });
+
         let agent_cli_version_probe = Self::startup_agent_cli_version_probe(clients);
         AppStartup::spawn_background_tasks(
             auto_update,
@@ -372,7 +388,6 @@ impl App {
             repositories,
             clients.fs_client.as_ref(),
             &clients.git_client,
-            clients.project_discovery_client.as_ref(),
             working_dir,
             git_branch,
             current_project_id,
@@ -667,6 +682,116 @@ mod tests {
 
         // Assert
         assert!(child_status.success());
+    }
+
+    #[tokio::test]
+    async fn startup_returns_before_home_discovery_completes() {
+        // Arrange
+        let base_dir = tempdir().expect("temp directory");
+        let database = AppRepositories::in_memory().await.expect("database");
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let resume = Arc::new(tokio::sync::Notify::new());
+        let discovered = base_dir.path().join("discovered");
+        let mut discovery = crate::infra::project_discovery::MockProjectDiscoveryClient::new();
+        discovery
+            .expect_discover_home_project_paths()
+            .once()
+            .return_once({
+                let resume = Arc::clone(&resume);
+                let discovered = discovered.clone();
+                let entered = Arc::clone(&entered);
+                move |_, _| {
+                    let entered = Arc::clone(&entered);
+                    Box::pin(async move {
+                        entered.notify_one();
+                        resume.notified().await;
+                        Ok(vec![discovered])
+                    })
+                }
+            });
+        let mut clients = crate::test_support::test_app_clients();
+        clients.project_discovery_client = Arc::new(discovery);
+
+        // Act
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            App::new_with_clients(
+                base_dir.path().to_path_buf(),
+                base_dir.path().to_path_buf(),
+                None,
+                database.clone(),
+                clients,
+            ),
+        )
+        .await;
+        tokio::time::timeout(std::time::Duration::from_secs(1), entered.notified())
+            .await
+            .expect("discovery starts");
+
+        // Assert
+        let mut app = result
+            .expect("startup must not wait for discovery")
+            .expect("app starts");
+
+        // Act
+        resume.notify_one();
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while !matches!(app.event_rx.recv().await, Some(AppEvent::RefreshProjects)) {}
+        })
+        .await
+        .expect("discovery notifies the foreground");
+
+        // Assert
+        assert!(
+            database
+                .projects()
+                .load_projects_with_stats()
+                .await
+                .expect("projects")
+                .iter()
+                .any(|project| project.path == discovered.to_string_lossy())
+        );
+    }
+
+    #[tokio::test]
+    async fn home_catalog_handles_missing_home_and_discovery_failure() {
+        // Arrange
+        let database = AppRepositories::in_memory().await.expect("database");
+        let git_client = ag_git::MockGitClient::new();
+        let task = tokio::spawn(std::future::pending::<()>());
+        task.abort();
+        let error = task.await.expect_err("aborted discovery");
+        let mut discovery = crate::infra::project_discovery::MockProjectDiscoveryClient::new();
+        discovery
+            .expect_discover_home_project_paths()
+            .once()
+            .return_once(move |_, _| {
+                Box::pin(async move {
+                    Err(crate::infra::project_discovery::ProjectDiscoveryError::TaskJoin(error))
+                })
+            });
+
+        // Act
+        let no_home = AppStartup::load_projects_from_home_directory(
+            &database,
+            &git_client,
+            &discovery,
+            Path::new("worktrees"),
+            None,
+        )
+        .await;
+        let failed_scan = AppStartup::load_projects_from_home_directory(
+            &database,
+            &git_client,
+            &discovery,
+            Path::new("worktrees"),
+            Some(Path::new("home")),
+        )
+        .await;
+
+        // Assert
+        assert!(!no_home);
+        assert!(!failed_scan);
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -712,6 +712,7 @@ impl App {
     /// session.
     async fn finish_session_creation(&mut self, session_id: &str) {
         self.process_pending_app_events().await;
+        self.refresh_sessions_now().await;
         self.reload_projects().await;
 
         let index = self
@@ -1788,6 +1789,7 @@ impl App {
             .refresh_sessions_if_needed(&mut self.mode, &self.projects, &self.services)
             .await;
         if refreshed {
+            self.publish_sync_context();
             app::review::prune_review_cache(
                 &mut self.review_cache,
                 &self.pending_focused_review_persistence,

--- a/crates/agentty/src/app/service.rs
+++ b/crates/agentty/src/app/service.rs
@@ -55,6 +55,7 @@ pub(crate) struct AppServiceDeps {
 }
 
 /// Shared app dependencies used by managers and background workflows.
+#[derive(Clone)]
 pub struct AppServices {
     available_agent_clis: Arc<Mutex<Vec<AgentCliInfo>>>,
     available_agent_kinds: Arc<[AgentKind]>,

--- a/crates/agentty/src/app/session/core.rs
+++ b/crates/agentty/src/app/session/core.rs
@@ -173,6 +173,7 @@ pub struct SessionManager {
     pub(super) git_client: Arc<dyn git::GitClient>,
     pub(super) merge_service: SessionMergeService,
     pub(super) resources: super::resource::ResourceMonitor,
+    pub(super) pending_refresh: Option<super::workflow::refresh::BackgroundSessionRefresh>,
     pub(super) state: SessionState,
     pub(super) stats_activity: Vec<DailyActivity>,
     pub(super) workflow_state: SessionWorkflowState,
@@ -215,6 +216,7 @@ impl SessionManager {
 
         Self {
             active_prompt_outputs: HashMap::new(),
+            pending_refresh: None,
             resources: super::resource::ResourceMonitor::new(Arc::new(
                 crate::infra::resource::RealResourceClient,
             )),
@@ -1078,6 +1080,7 @@ impl SessionManager {
 
     /// Updates cached worktree availability for one session after its
     /// lifecycle materializes or removes the worktree.
+    #[cfg(test)]
     pub(crate) fn set_session_worktree_available(&mut self, session_id: &str, is_available: bool) {
         self.state
             .set_session_worktree_available(session_id, is_available);

--- a/crates/agentty/src/app/session/core_test.rs
+++ b/crates/agentty/src/app/session/core_test.rs
@@ -1460,6 +1460,28 @@ async fn create_and_start_session(app: &mut App, prompt: &str) {
         .await;
 }
 
+/// Waits for background draft preparation and projects its completed metadata.
+async fn wait_for_draft_preparation(app: &mut App, session_id: &str) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let rows = app
+                .services
+                .db()
+                .sessions()
+                .load_sessions()
+                .await
+                .expect("load sessions");
+            if rows.iter().any(|row| row.id == session_id && !row.is_draft) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("draft preparation must complete");
+    app.refresh_sessions_now().await;
+}
+
 async fn wait_for_status(app: &mut App, session_id: &str, expected: Status) {
     wait_for_status_with_retries(app, session_id, expected, 2000, false).await;
 }
@@ -2577,6 +2599,8 @@ async fn test_start_staged_session_launches_bundle_and_clears_staged_drafts() {
         .await
         .expect("failed to start staged session");
 
+    wait_for_draft_preparation(&mut app, &session_id).await;
+
     // Assert
     assert_eq!(
         app.sessions.sessions()[0].prompt,
@@ -2620,6 +2644,8 @@ async fn test_start_staged_session_clears_draft_flag() {
     app.start_staged_session(&session_id)
         .await
         .expect("failed to start staged session");
+
+    wait_for_draft_preparation(&mut app, &session_id).await;
 
     // Assert
     let session = app
@@ -2710,6 +2736,8 @@ async fn test_start_staged_session_launches_stacked_draft_child() {
         .await
         .expect("failed to start stacked draft");
     app.sessions.sync_from_handles();
+
+    wait_for_draft_preparation(&mut app, &child_session_id).await;
 
     // Assert
     let child_session = app
@@ -4010,10 +4038,16 @@ async fn test_periodic_session_refresh_preserves_focused_review_states() {
     clock.advance(SESSION_REFRESH_INTERVAL);
 
     // Act
-    let refreshed = app.refresh_sessions_if_needed().await;
+    app.refresh_sessions_if_needed().await;
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !app.refresh_sessions_if_needed().await {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("background refresh must complete");
 
     // Assert
-    assert!(refreshed);
     let ready_message = review_message_body(&app, ready_session_id);
     assert_eq!(ready_message.text(), review_text);
 

--- a/crates/agentty/src/app/session/state.rs
+++ b/crates/agentty/src/app/session/state.rs
@@ -223,6 +223,13 @@ impl SessionState {
 
         let session = self.sessions.remove(session_index);
         self.rebuild_session_index_by_id();
+        let selected = self.table_state.selected().and_then(|selected| {
+            self.sessions
+                .len()
+                .checked_sub(1)
+                .map(|last| selected.min(last))
+        });
+        self.table_state.select(selected);
 
         Some(session)
     }
@@ -395,6 +402,7 @@ impl SessionState {
 
     /// Updates cached worktree availability for one session after a lifecycle
     /// transition materializes or removes its worktree.
+    #[cfg(test)]
     pub(crate) fn set_session_worktree_available(&mut self, session_id: &str, is_available: bool) {
         self.session_worktree_availability
             .insert(SessionId::from(session_id), is_available);

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -349,6 +349,52 @@ pub(super) struct SessionTitleGenerationTaskInput {
     pub(super) tracked_generation: Option<u64>,
 }
 
+/// Captured draft preparation owned by the serialized session worker.
+pub(super) struct SessionWorktreePreparation {
+    base_branch: String,
+    folder: PathBuf,
+    parent_session_id: Option<SessionId>,
+    services: AppServices,
+    session_agent: AgentSelection,
+    session_id: SessionId,
+}
+
+impl SessionWorktreePreparation {
+    fn new(services: &AppServices, session: &Session) -> Option<Self> {
+        session.is_draft_session().then(|| Self {
+            base_branch: session.base_branch.clone(),
+            folder: session.folder.clone(),
+            parent_session_id: session.parent_session_id.clone(),
+            services: services.clone(),
+            session_agent: session.agent,
+            session_id: session.id.clone(),
+        })
+    }
+
+    /// Materializes the captured draft before the provider starts its turn.
+    pub(super) async fn prepare(self) -> Result<(), SessionError> {
+        SessionManager::prepare_session_worktree(&self).await?;
+        self.services
+            .db()
+            .sessions()
+            .clear_session_draft_flag(&self.session_id)
+            .await?;
+        if let Err(error) = draft::store_staged_draft_attachments(
+            self.services.fs_client().as_ref(),
+            self.services.base_path(),
+            &self.session_id,
+            &[],
+        )
+        .await
+        {
+            warn!(session_id = %self.session_id, %error, "failed to clear staged attachments");
+        }
+        let _ = self.services.event_sender().send(AppEvent::RefreshSessions);
+
+        Ok(())
+    }
+}
+
 impl SessionManager {
     /// Moves selection to the next selectable session in grouped list order.
     ///
@@ -753,9 +799,7 @@ impl SessionManager {
                 )
             })?;
 
-        let repo_root = self
-            .load_session_repo_root(services, source_session_id)
-            .await?;
+        let repo_root = Self::load_session_repo_root(services, source_session_id).await?;
         let session_id = Uuid::new_v4().to_string();
         let folder = session_folder(services.base_path(), &session_id);
         if services.fs_client().exists(folder.clone()) {
@@ -765,7 +809,7 @@ impl SessionManager {
         }
 
         let worktree_branch = session_branch(&session_id);
-        self.create_session_worktree(
+        Self::create_session_worktree(
             services,
             &session_id,
             &folder,
@@ -876,7 +920,7 @@ impl SessionManager {
             .ok_or_else(|| {
                 SessionError::Workflow("Failed to find git repository root".to_string())
             })?;
-        self.create_session_worktree(
+        Self::create_session_worktree(
             services,
             &session_id,
             &folder,
@@ -959,7 +1003,6 @@ impl SessionManager {
     /// Returns an error if git worktree creation fails or the `.agentty`
     /// metadata directory cannot be created inside the worktree.
     async fn create_session_worktree(
-        &self,
         services: &AppServices,
         session_id: &str,
         folder: &Path,
@@ -982,15 +1025,16 @@ impl SessionManager {
 
         let data_dir = folder.join(SESSION_DATA_DIR);
         if let Err(error) = services.fs_client().create_dir_all(data_dir).await {
-            self.rollback_failed_session_creation(
-                services,
-                folder,
-                repo_root,
-                session_id,
-                worktree_branch,
-                false,
+            let cleanup_errors = Self::cleanup_session_worktree_resources(
+                services.fs_client(),
+                services.git_client(),
+                folder.to_path_buf(),
+                worktree_branch.to_string(),
+                Some(repo_root.to_path_buf()),
+                true,
             )
             .await;
+            Self::warn_cleanup_errors(session_id, &cleanup_errors);
 
             return Err(SessionError::Workflow(format!(
                 "Failed to create session metadata directory: {error}"
@@ -1010,25 +1054,17 @@ impl SessionManager {
     /// # Errors
     /// Returns an error if repository discovery, worktree creation, or
     /// backend setup fails.
-    async fn ensure_session_worktree_ready(
-        &mut self,
-        services: &AppServices,
-        session_id: &str,
+    async fn prepare_session_worktree(
+        preparation: &SessionWorktreePreparation,
     ) -> Result<(), SessionError> {
-        let (base_branch, folder, parent_session_id, persisted_session_id, session_agent) = {
-            let session = self.session_or_err(session_id)?;
-            if !session.is_draft_session() {
-                return Ok(());
-            }
-
-            (
-                session.base_branch.clone(),
-                session.folder.clone(),
-                session.parent_session_id.clone(),
-                session.id.clone(),
-                session.agent,
-            )
-        };
+        let services = &preparation.services;
+        let (base_branch, folder, parent_session_id, persisted_session_id, session_agent) = (
+            preparation.base_branch.clone(),
+            preparation.folder.clone(),
+            preparation.parent_session_id.clone(),
+            preparation.session_id.clone(),
+            preparation.session_agent,
+        );
 
         let worktree_branch = session_branch(&persisted_session_id);
         if services.fs_client().is_dir(folder.clone()) {
@@ -1044,21 +1080,20 @@ impl SessionManager {
                 .map_err(|error| {
                     SessionError::Workflow(format!("Failed to setup session backend: {error}"))
                 })?;
-            self.persist_stack_base_for_stacked_draft_worktree(
+            Self::persist_stack_base_for_stacked_draft_worktree(
                 services,
                 &folder,
                 parent_session_id.as_ref(),
                 &persisted_session_id,
             )
             .await?;
-            self.set_session_worktree_available(session_id, true);
 
             return Ok(());
         }
 
-        let repo_root = self.load_session_repo_root(services, session_id).await?;
+        let repo_root = Self::load_session_repo_root(services, &persisted_session_id).await?;
 
-        self.create_session_worktree(
+        Self::create_session_worktree(
             services,
             &persisted_session_id,
             &folder,
@@ -1090,47 +1125,13 @@ impl SessionManager {
                 "Failed to setup session backend: {error}"
             )));
         }
-        self.persist_stack_base_for_stacked_draft_worktree(
+        Self::persist_stack_base_for_stacked_draft_worktree(
             services,
             &folder,
             parent_session_id.as_ref(),
             &persisted_session_id,
         )
         .await?;
-        self.set_session_worktree_available(session_id, true);
-
-        Ok(())
-    }
-
-    /// Clears the persisted and in-memory draft flag once a draft session
-    /// starts its first live turn.
-    ///
-    /// The flag only means "still staging draft prompts", so it must not
-    /// outlive the session start; a sticky flag would keep draft-only
-    /// restrictions, such as the fork gate, active for the session's whole
-    /// life. Non-draft sessions skip the write.
-    ///
-    /// # Errors
-    /// Returns an error if the session is missing or persistence fails.
-    async fn clear_session_draft_flag(
-        &mut self,
-        services: &AppServices,
-        session_id: &str,
-    ) -> Result<(), SessionError> {
-        if !self.session_or_err(session_id)?.is_draft_session() {
-            return Ok(());
-        }
-
-        services
-            .db()
-            .sessions()
-            .clear_session_draft_flag(session_id)
-            .await?;
-
-        let session_index = self.session_index_or_err(session_id)?;
-        if let Some(session) = self.session_at_mut(session_index) {
-            session.is_draft = false;
-        }
 
         Ok(())
     }
@@ -1146,7 +1147,6 @@ impl SessionManager {
     /// Returns an error when the worktree `HEAD` cannot be resolved or stack
     /// metadata cannot be persisted.
     async fn persist_stack_base_for_stacked_draft_worktree(
-        &self,
         services: &AppServices,
         folder: &Path,
         parent_session_id: Option<&SessionId>,
@@ -1177,7 +1177,6 @@ impl SessionManager {
     /// Returns an error if the session project cannot be resolved or no git
     /// repository root can be found for the project path.
     async fn load_session_repo_root(
-        &self,
         services: &AppServices,
         session_id: &str,
     ) -> Result<PathBuf, SessionError> {
@@ -1191,7 +1190,7 @@ impl SessionManager {
                     "Session project is required to create a worktree".to_string(),
                 )
             })?;
-        let project_path = self.load_project_path(services, project_id).await?;
+        let project_path = Self::load_project_path(services, project_id).await?;
 
         services
             .git_client()
@@ -1205,7 +1204,6 @@ impl SessionManager {
     /// # Errors
     /// Returns an error if the project row does not exist or cannot be loaded.
     async fn load_project_path(
-        &self,
         services: &AppServices,
         project_id: i64,
     ) -> Result<PathBuf, SessionError> {
@@ -1404,7 +1402,7 @@ impl SessionManager {
         session_agent: AgentSelection,
         session_folder: PathBuf,
     ) -> Result<DraftTitleGenerationContext, SessionError> {
-        let project_working_dir = self.load_project_path(services, project_id).await?;
+        let project_working_dir = Self::load_project_path(services, project_id).await?;
         let title_generation_agent =
             setting::load_default_fast_agent_setting(services, Some(project_id), session_agent)
                 .await;
@@ -1523,39 +1521,21 @@ impl SessionManager {
 
         self.start_session(services, session_id, prompt).await?;
 
-        if let Ok(session_index) = self.session_index_or_err(session_id)
-            && let Some(session) = self.session_at_mut(session_index)
-        {
-            session.draft_attachments.clear();
-        }
-
-        if let Err(error) = draft::store_staged_draft_attachments(
-            services.fs_client().as_ref(),
-            services.base_path(),
-            session_id,
-            &[],
-        )
-        .await
-        {
-            warn!(
-                session_id = session_id,
-                error = %error,
-                "failed to clear staged draft attachments after session start"
-            );
-        }
-
         Ok(())
     }
 
     /// Submits the first prompt for a blank session and starts the agent.
     ///
     /// The first prompt is persisted as both session prompt and session title.
+    /// Draft starts append it to the transcript only after worktree preparation
+    /// succeeds, so failed attempts leave the staged bundle safe to retry.
     /// A detached one-shot title-generation task may replace that provisional
     /// title when the prompt contains actionable intent.
     ///
     /// # Errors
-    /// Returns an error if the session is missing, its worktree cannot be
-    /// prepared, or prompt persistence fails.
+    /// Returns an error if the session is missing or the turn cannot be queued.
+    /// Worktree preparation runs on the worker; failures appear in the session
+    /// transcript and restore the draft for retry.
     pub async fn start_session(
         &mut self,
         services: &AppServices,
@@ -1563,8 +1543,8 @@ impl SessionManager {
         prompt: impl Into<TurnPrompt>,
     ) -> Result<(), SessionError> {
         let prompt = prompt.into();
-        self.ensure_session_worktree_ready(services, session_id)
-            .await?;
+        let session = self.session_or_err(session_id)?;
+        let preparation = SessionWorktreePreparation::new(services, session).map(Box::new);
 
         let session_index = self.session_index_or_err(session_id)?;
         let (persisted_session_id, session_agent, title) = {
@@ -1590,20 +1570,22 @@ impl SessionManager {
         self.persist_first_message_metadata(services, &persisted_session_id, &prompt.text, &title)
             .await;
 
-        let prompt_transcript_text = prompt.transcript_text();
         let initial_output = Self::formatted_prompt_output(&prompt, false);
-        SessionTaskService::append_session_transcript_message(
-            &transcript,
-            services.db(),
-            &app_event_tx,
-            &services.session_update_versions(),
-            &persisted_session_id,
-            SessionTranscriptMessageAppend {
-                kind: SessionMessageKind::UserPrompt,
-                raw_content: &prompt_transcript_text,
-            },
-        )
-        .await;
+        if preparation.is_none() {
+            let prompt_transcript_text = prompt.transcript_text();
+            SessionTaskService::append_session_transcript_message(
+                &transcript,
+                services.db(),
+                &app_event_tx,
+                &services.session_update_versions(),
+                &persisted_session_id,
+                SessionTranscriptMessageAppend {
+                    kind: SessionMessageKind::UserPrompt,
+                    raw_content: &prompt_transcript_text,
+                },
+            )
+            .await;
+        }
         self.set_active_prompt_output(&persisted_session_id, initial_output);
 
         if !status_transition.apply(Status::InProgress).await {
@@ -1615,6 +1597,7 @@ impl SessionManager {
 
         let operation_id = Uuid::new_v4().to_string();
         let command = SessionCommand::Run {
+            preparation,
             operation_id,
             request_kind: AgentRequestKind::SessionStart,
             replay_transcript: None,
@@ -1633,14 +1616,6 @@ impl SessionManager {
                 .await;
 
             return Err(error);
-        }
-
-        if let Err(error) = self.clear_session_draft_flag(services, session_id).await {
-            warn!(
-                session_id,
-                %error,
-                "failed to clear draft flag after session start"
-            );
         }
 
         Ok(())
@@ -2708,6 +2683,7 @@ impl SessionManager {
         };
 
         SessionCommand::Run {
+            preparation: None,
             operation_id,
             request_kind,
             replay_transcript,
@@ -3522,9 +3498,12 @@ impl SessionManager {
 
         let branch_name = session_branch(&session.id);
         let folder = session.folder.clone();
-        let stops_branch_work = cancellation_capability.stops_branch_work(session.status);
-        let has_worktree = services.fs_client().is_dir(folder.clone());
         let handles = self.session_handles_or_err(session_id)?;
+        // The render snapshot may still be Draft after start_session updates
+        // the live handle. A poisoned status must not suppress cancellation.
+        let stops_branch_work = handles.status.lock().map_or(true, |status| {
+            cancellation_capability.stops_branch_work(*status)
+        });
         let status_transition = StatusTransition::from_services(services, handles, session_id);
 
         if stops_branch_work {
@@ -3538,7 +3517,7 @@ impl SessionManager {
                 services,
                 folder,
                 branch_name,
-                has_worktree,
+                Arc::clone(&handles.branch_operation_lock),
                 session_id.to_string(),
             );
         }
@@ -3623,21 +3602,24 @@ impl SessionManager {
     /// after persisted status changes instead of waiting on git and filesystem
     /// removal.
     ///
-    /// The background task resolves the shared repository root only when a
-    /// worktree exists, removes git worktree/branch resources, then clears the
-    /// session-scoped prompt temp directory. Cleanup remains best-effort and
-    /// reports failures through debug-visible warnings.
+    /// The background task waits for canceled preparation or branch work to
+    /// release its lock before checking for a worktree. Preparation can create
+    /// the checkout while the foreground is signaling cancellation, so an
+    /// earlier existence snapshot is unsafe. Cleanup removes the worktree and
+    /// branch, then clears session-scoped prompt files. Failures remain
+    /// best-effort and are reported through debug-visible warnings.
     fn spawn_canceled_session_cleanup(
         services: &AppServices,
         folder: PathBuf,
         branch_name: String,
-        has_worktree: bool,
+        branch_operation_lock: Arc<tokio::sync::Mutex<()>>,
         session_id: String,
     ) {
         let fs_client = services.fs_client();
         let git_client = services.git_client();
         let cleanup_task_handle = tokio::spawn(async move {
-            if has_worktree {
+            let _branch_operation_guard = branch_operation_lock.lock().await;
+            if fs_client.is_dir(folder.clone()) {
                 let repo_root = git_client.main_repo_root(folder.clone()).await.ok();
                 let cleanup_errors = Self::cleanup_session_worktree_resources(
                     Arc::clone(&fs_client),
@@ -3929,6 +3911,7 @@ mod test_support {
 mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::{Duration, Instant, SystemTime};
 
     use ag_agent::MockOneShotClient;
@@ -3939,6 +3922,7 @@ mod tests {
 
     use super::*;
     use crate::app::session::SessionDefaults;
+    use crate::app::session::workflow::worker::{SessionWorkerContext, SessionWorkerService};
     use crate::app::{AppEvent, AppServices, SessionState};
     use crate::domain::agent::{AgentKind, AgentModel, ReasoningLevel};
     use crate::domain::selection::SelectionState;
@@ -4281,6 +4265,482 @@ mod tests {
             .into_iter()
             .find(|row| row.id == "session-id")
             .expect("session row should exist")
+    }
+
+    /// Builds a worker that shares cancellation and branch ownership with the
+    /// lifecycle manager, with every provider call forbidden.
+    fn draft_worker_context(
+        manager: &SessionManager,
+        services: &AppServices,
+    ) -> SessionWorkerContext {
+        let session = manager.session_or_err("session-id").expect("session");
+        let handles = manager
+            .session_handles_or_err("session-id")
+            .expect("handles");
+        let mut channel = agent::MockAgentChannel::new();
+        channel.expect_run_turn().never();
+
+        SessionWorkerContext {
+            app_event_tx: services.event_sender(),
+            branch_operation_lock: Arc::clone(&handles.branch_operation_lock),
+            cancel_token: Arc::clone(&handles.cancel_token),
+            channel: Arc::new(channel),
+            child_pid: Arc::clone(&handles.child_pid),
+            clock: services.clock(),
+            db: services.db().clone(),
+            folder: session.folder.clone(),
+            fs_client: services.fs_client(),
+            git_client: services.git_client(),
+            personality_catalog_client: services.personality_catalog_client(),
+            queued_messages: Arc::clone(&handles.queued_messages),
+            review_request_client: services.review_request_client(),
+            session_update_versions: services.session_update_versions(),
+            session_id: session.id.clone(),
+            session_agent: session.agent,
+            status: Arc::clone(&handles.status),
+            transcript: Arc::clone(&handles.transcript),
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_after_final_preflight_prevents_draft_work_after_cleanup() {
+        // Arrange
+        let mut session = test_session("Staged prompt", Status::InProgress, None, "");
+        session.is_draft = true;
+        let database = database_with_session(&session).await;
+        let manager = session_manager_with_one_session(session);
+        let mut fs_client = fs::MockFsClient::new();
+        fs_client.expect_is_dir().once().return_const(false);
+        fs_client
+            .expect_remove_dir_all()
+            .once()
+            .returning(|_| Box::pin(async { Ok(()) }));
+        let mut git_client = git::MockGitClient::new();
+        git_client.expect_find_git_repo_root().never();
+        git_client.expect_create_worktree().never();
+        let services = test_services_with_fs_client(
+            &database,
+            Arc::new(RealClock),
+            Arc::new(fs_client),
+            Arc::new(git_client),
+            Arc::new(forge::MockReviewRequestClient::new()),
+        );
+        let context = draft_worker_context(&manager, &services);
+        let command = SessionCommand::Run {
+            operation_id: "draft-start".to_string(),
+            preparation: SessionWorktreePreparation::new(
+                &services,
+                manager.session_or_err("session-id").expect("draft"),
+            )
+            .map(Box::new),
+            prompt: "Staged prompt".into(),
+            replay_transcript: None,
+            request_kind: AgentRequestKind::SessionStart,
+            turn_metadata: TurnMetadata {
+                published_upstream_ref: None,
+                review_comment_thread_ids: Vec::new(),
+                session_agent: context.session_agent,
+            },
+        };
+        database
+            .operations()
+            .insert_session_operation("draft-start", "session-id", "start_prompt")
+            .await
+            .expect("queued operation");
+        let one_shot_client: Arc<dyn OneShotClient> = Arc::new(MockOneShotClient::new());
+
+        // Act: stop precisely between the real worker preflight and execution.
+        assert!(SessionWorkerService::prepare_session_command(&context, &command).await);
+        manager
+            .cancel_session(&services, "session-id")
+            .await
+            .expect("canceled");
+        services.wait_for_cleanup_tasks().await;
+        let result =
+            SessionWorkerService::execute_session_command(&context, &one_shot_client, command)
+                .await;
+
+        // Assert
+        assert!(matches!(result, Err(SessionError::StoppedByUser(_))));
+        assert!(context.cancel_token.lock().expect("token").is_cancelled());
+        let row = load_persisted_session_row(&database).await;
+        assert_eq!(row.status, "Canceled");
+        assert!(row.is_draft);
+        assert_eq!(row.prompt, "Staged prompt");
+        assert_session_user_prompts(&manager, &database, &[]).await;
+    }
+
+    #[tokio::test]
+    async fn draft_start_stays_responsive_and_cancels_before_snapshot_refresh() {
+        // Arrange
+        let mut session = test_session("", Status::Draft, None, "");
+        session.is_draft = true;
+        let database = database_with_session(&session).await;
+        let mut session_manager = session_manager_with_one_session(session);
+        let entered = Arc::new(Notify::new());
+        let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel::<()>();
+        let mut git_client = git::MockGitClient::new();
+        git_client
+            .expect_find_git_repo_root()
+            .once()
+            .returning(|path| Box::pin(async move { Some(path) }));
+        git_client.expect_create_worktree().once().return_once({
+            let entered = Arc::clone(&entered);
+            move |_, _, _, _| {
+                let entered = Arc::clone(&entered);
+                Box::pin(std::future::poll_fn(move |_| {
+                    let _guard = &dropped_tx;
+                    entered.notify_one();
+                    std::task::Poll::Pending
+                }))
+            }
+        });
+        let mut fs_client = create_passthrough_mock_fs_client();
+        fs_client.expect_is_dir().return_const(false);
+        let services = test_services_with_fs_client(
+            &database,
+            Arc::new(RealClock),
+            Arc::new(fs_client),
+            Arc::new(git_client),
+            Arc::new(forge::MockReviewRequestClient::new()),
+        );
+
+        // Act
+        let accepted = tokio::time::timeout(
+            Duration::from_secs(1),
+            session_manager.start_session(&services, "session-id", "Prepare this draft"),
+        )
+        .await;
+        tokio::time::timeout(Duration::from_secs(1), entered.notified())
+            .await
+            .expect("worker must begin preparation");
+
+        let status_before_cancellation = load_persisted_session_row(&database).await.status;
+        let snapshot_status = session_manager.state.sessions[0].status;
+        let canceled = session_manager
+            .cancel_session(&services, "session-id")
+            .await;
+        let dropped = tokio::time::timeout(Duration::from_secs(1), dropped_rx).await;
+        services.wait_for_cleanup_tasks().await;
+
+        // Assert
+        assert!(accepted.expect("foreground must remain responsive").is_ok());
+        assert_eq!(status_before_cancellation, "InProgress");
+        assert_eq!(snapshot_status, Status::Draft);
+        assert!(canceled.is_ok());
+        assert!(dropped.expect("preparation canceled").is_err());
+        assert_eq!(
+            load_persisted_session_row(&database).await.status,
+            "Canceled"
+        );
+    }
+
+    /// Expects terminal cleanup of the test session's worktree and branch.
+    fn expect_canceled_worktree_cleanup(git_client: &mut git::MockGitClient) {
+        git_client
+            .expect_main_repo_root()
+            .with(mockall::predicate::eq(PathBuf::from("/tmp/session")))
+            .once()
+            .returning(|_| Box::pin(async { Ok(PathBuf::from("/tmp/project")) }));
+        git_client
+            .expect_remove_worktree()
+            .with(mockall::predicate::eq(PathBuf::from("/tmp/session")))
+            .once()
+            .returning(|_| Box::pin(async { Ok(()) }));
+        git_client
+            .expect_delete_branch()
+            .with(
+                mockall::predicate::eq(PathBuf::from("/tmp/project")),
+                mockall::predicate::eq(session_branch("session-id")),
+            )
+            .once()
+            .returning(|_, _| Box::pin(async { Ok(()) }));
+    }
+
+    #[tokio::test]
+    async fn cancellation_rechecks_worktree_after_branch_work_releases_lock() {
+        // Arrange
+        let mut session = test_session("Staged prompt", Status::InProgress, None, "");
+        session.is_draft = true;
+        let database = database_with_session(&session).await;
+        let manager = session_manager_with_one_session(session);
+        let branch_lock = Arc::clone(
+            &manager
+                .session_handles_or_err("session-id")
+                .expect("handles")
+                .branch_operation_lock,
+        );
+        let guard = Arc::clone(&branch_lock).lock_owned().await;
+        let has_worktree = Arc::new(AtomicBool::new(false));
+        let mut fs_client = fs::MockFsClient::new();
+        fs_client.expect_is_dir().returning({
+            let has_worktree = Arc::clone(&has_worktree);
+            move |_| has_worktree.load(Ordering::SeqCst)
+        });
+        fs_client
+            .expect_remove_dir_all()
+            .returning(|_| Box::pin(async { Ok(()) }));
+        let mut git_client = git::MockGitClient::new();
+        expect_canceled_worktree_cleanup(&mut git_client);
+        let git_client = Arc::new(git_client);
+        let services = test_services_with_fs_client(
+            &database,
+            Arc::new(RealClock),
+            Arc::new(fs_client),
+            git_client.clone(),
+            Arc::new(forge::MockReviewRequestClient::new()),
+        );
+
+        // Act
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            manager.cancel_session(&services, "session-id"),
+        )
+        .await
+        .expect("cancellation must not wait for branch work")
+        .expect("canceled");
+        tokio::task::yield_now().await;
+        has_worktree.store(true, Ordering::SeqCst);
+        drop(guard);
+        services.wait_for_cleanup_tasks().await;
+
+        // Assert
+        assert_eq!(
+            load_persisted_session_row(&database).await.status,
+            "Canceled"
+        );
+        drop(services);
+        Arc::try_unwrap(git_client)
+            .expect("cleanup released git client")
+            .checkpoint();
+    }
+
+    #[tokio::test]
+    async fn cancellation_after_worktree_creation_cleans_up_before_provider_start() {
+        // Arrange
+        let mut session = test_session("Staged prompt", Status::Draft, None, "");
+        session.is_draft = true;
+        let database = database_with_session(&session).await;
+        let mut manager = session_manager_with_one_session(session);
+        let cancellation = Arc::clone(
+            &manager
+                .session_handles_or_err("session-id")
+                .expect("handles")
+                .cancel_token,
+        );
+        let has_worktree = Arc::new(AtomicBool::new(false));
+        let setup_entered = Arc::new(Notify::new());
+        let (setup_dropped_tx, setup_dropped_rx) = tokio::sync::oneshot::channel::<()>();
+        let mut git_client = git::MockGitClient::new();
+        git_client
+            .expect_find_git_repo_root()
+            .once()
+            .returning(|path| Box::pin(async move { Some(path) }));
+        git_client.expect_create_worktree().once().return_once({
+            let has_worktree = Arc::clone(&has_worktree);
+            move |_, _, _, _| {
+                Box::pin(async move {
+                    has_worktree.store(true, Ordering::SeqCst);
+                    // Cancel after Git succeeds, before metadata setup can yield.
+                    cancellation.lock().expect("token").cancel();
+
+                    Ok(())
+                })
+            }
+        });
+        expect_canceled_worktree_cleanup(&mut git_client);
+        let mut fs_client = fs::MockFsClient::new();
+        fs_client.expect_is_dir().returning({
+            let has_worktree = Arc::clone(&has_worktree);
+            move |_| has_worktree.load(Ordering::SeqCst)
+        });
+        fs_client.expect_create_dir_all().once().return_once({
+            let setup_entered = Arc::clone(&setup_entered);
+            move |_| {
+                Box::pin(std::future::poll_fn(move |_| {
+                    let _guard = &setup_dropped_tx;
+                    setup_entered.notify_one();
+
+                    std::task::Poll::Pending
+                }))
+            }
+        });
+        fs_client.expect_remove_dir_all().returning({
+            let has_worktree = Arc::clone(&has_worktree);
+            move |path| {
+                if path == Path::new("/tmp/session") {
+                    has_worktree.store(false, Ordering::SeqCst);
+                }
+
+                Box::pin(async { Ok(()) })
+            }
+        });
+        let services = test_services_with_fs_client(
+            &database,
+            Arc::new(RealClock),
+            Arc::new(fs_client),
+            Arc::new(git_client),
+            Arc::new(forge::MockReviewRequestClient::new()),
+        );
+
+        // Act
+        manager
+            .start_session(&services, "session-id", "Staged prompt")
+            .await
+            .expect("queued");
+        tokio::time::timeout(Duration::from_secs(1), setup_entered.notified())
+            .await
+            .expect("creation succeeded and setup started");
+        manager.state.sync_from_handles();
+        manager
+            .cancel_session(&services, "session-id")
+            .await
+            .expect("canceled");
+        services.wait_for_cleanup_tasks().await;
+
+        // Assert
+        assert!(
+            setup_dropped_rx.await.is_err(),
+            "cancellation drops pending setup"
+        );
+        assert!(!has_worktree.load(Ordering::SeqCst));
+        let row = load_persisted_session_row(&database).await;
+        assert_eq!(row.status, "Canceled");
+        assert!(row.is_draft);
+        assert_eq!(row.prompt, "Staged prompt");
+        assert_session_user_prompts(&manager, &database, &[]).await;
+    }
+
+    #[tokio::test]
+    async fn failed_draft_preparation_preserves_bundle_for_retry() {
+        // Arrange
+        let mut session = test_session("Staged prompt", Status::Draft, None, "");
+        session.is_draft = true;
+        let database = database_with_session(&session).await;
+        let mut manager = session_manager_with_one_session(session);
+        let worktree_ready = Arc::new(AtomicBool::new(false));
+        let prepared = Arc::new(Notify::new());
+        let mut git_client = git::MockGitClient::new();
+        git_client
+            .expect_find_git_repo_root()
+            .times(2)
+            .returning(|_| Box::pin(async { None }));
+        git_client
+            .expect_detect_git_info()
+            .once()
+            .returning(|_| Box::pin(async { Some(session_branch("session-id")) }));
+        // Hold the next setup step after successful preparation so assertions
+        // observe exactly the transcript that the provider will replay.
+        git_client.expect_detect_git_info().once().return_once({
+            let prepared = Arc::clone(&prepared);
+            move |_| {
+                prepared.notify_one();
+
+                Box::pin(std::future::pending())
+            }
+        });
+        git_client
+            .expect_main_checkout_working_tree()
+            .once()
+            .returning(|_| Box::pin(async { Ok(None) }));
+        let mut fs_client = fs::MockFsClient::new();
+        fs_client.expect_is_dir().returning({
+            let worktree_ready = Arc::clone(&worktree_ready);
+            move |path| path == Path::new("/tmp/session") && worktree_ready.load(Ordering::SeqCst)
+        });
+        fs_client.expect_remove_file().once().returning({
+            let worktree_ready = Arc::clone(&worktree_ready);
+            move |_| {
+                assert!(worktree_ready.load(Ordering::SeqCst));
+
+                Box::pin(async { Ok(()) })
+            }
+        });
+        fs_client.expect_write_file().never();
+        let services = test_services_with_fs_client(
+            &database,
+            Arc::new(RealClock),
+            Arc::new(fs_client),
+            Arc::new(git_client),
+            Arc::new(forge::MockReviewRequestClient::new()),
+        );
+
+        // Act
+        for _ in 0..2 {
+            manager
+                .start_staged_session(&services, "session-id")
+                .await
+                .expect("queued");
+            tokio::time::timeout(Duration::from_secs(1), async {
+                loop {
+                    let row = load_persisted_session_row(&database).await;
+                    if row.status == "Draft" {
+                        break;
+                    }
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("preparation failure restores draft");
+            manager.state.sync_from_handles();
+
+            // Assert
+            let row = load_persisted_session_row(&database).await;
+            assert!(row.is_draft);
+            assert_eq!(row.prompt, "Staged prompt");
+            assert_eq!(manager.state.sessions[0].status, Status::Draft);
+            assert_session_user_prompts(&manager, &database, &[]).await;
+        }
+
+        // Act
+        worktree_ready.store(true, Ordering::SeqCst);
+        manager
+            .start_staged_session(&services, "session-id")
+            .await
+            .expect("retry queued");
+        tokio::time::timeout(Duration::from_secs(1), prepared.notified())
+            .await
+            .expect("retry completes preparation");
+
+        // Assert
+        let row = load_persisted_session_row(&database).await;
+        assert!(!row.is_draft);
+        assert_eq!(row.prompt, "Staged prompt");
+        assert_eq!(row.status, "InProgress");
+        assert_session_user_prompts(&manager, &database, &["Staged prompt"]).await;
+    }
+
+    /// Checks both durable history and the live provider replay source.
+    async fn assert_session_user_prompts(
+        manager: &SessionManager,
+        database: &AppRepositories,
+        expected: &[&str],
+    ) {
+        let messages = database
+            .sessions()
+            .load_session_messages("session-id")
+            .await
+            .expect("persisted transcript");
+        let persisted_prompts: Vec<_> = messages
+            .iter()
+            .filter(|message| message.kind == SessionMessageKind::UserPrompt.as_str())
+            .map(|message| message.content.trim())
+            .collect();
+        assert_eq!(persisted_prompts, expected);
+
+        let transcript = manager
+            .session_handles_or_err("session-id")
+            .expect("session handles")
+            .transcript
+            .lock()
+            .expect("live transcript");
+        let live_prompts: Vec<_> = transcript
+            .messages()
+            .iter()
+            .filter(|message| message.kind == SessionMessageKind::UserPrompt)
+            .map(|message| message.content.trim())
+            .collect();
+        assert_eq!(live_prompts, expected);
     }
 
     #[tokio::test]
@@ -4661,7 +5121,7 @@ mod tests {
         // Arrange
         let session = test_session("", Status::Draft, None, "");
         let database = database_with_session(&session).await;
-        let mut session_manager = session_manager_with_one_session(session);
+        let session_manager = session_manager_with_one_session(session);
         let mut mock_fs_client = fs::MockFsClient::new();
         mock_fs_client.expect_is_dir().times(0);
         let mut mock_git_client = git::MockGitClient::new();
@@ -4676,12 +5136,15 @@ mod tests {
         );
 
         // Act
-        let result = session_manager
-            .ensure_session_worktree_ready(&services, "session-id")
-            .await;
+        let preparation = SessionWorktreePreparation::new(
+            &services,
+            session_manager
+                .session_or_err("session-id")
+                .expect("session exists"),
+        );
 
         // Assert
-        assert!(result.is_ok());
+        assert!(preparation.is_none());
     }
 
     #[tokio::test]
@@ -4690,7 +5153,7 @@ mod tests {
         let mut session = test_session("", Status::Draft, None, "");
         session.is_draft = true;
         let database = database_with_session(&session).await;
-        let mut session_manager = session_manager_with_one_session(session);
+        let session_manager = session_manager_with_one_session(session);
         let mut mock_fs_client = fs::MockFsClient::new();
         mock_fs_client.expect_is_dir().times(3).return_const(true);
         mock_fs_client
@@ -4705,6 +5168,13 @@ mod tests {
                     }
                 })
             });
+        mock_fs_client.expect_remove_file().once().returning(|_| {
+            Box::pin(async {
+                Err(fs::FsError::Io(std::io::Error::other(
+                    "staged metadata cleanup failed",
+                )))
+            })
+        });
         let mut mock_git_client = git::MockGitClient::new();
         mock_git_client
             .expect_detect_git_info()
@@ -4725,12 +5195,77 @@ mod tests {
         );
 
         // Act
-        let result = session_manager
-            .ensure_session_worktree_ready(&services, "session-id")
-            .await;
+        let result = SessionWorktreePreparation::new(
+            &services,
+            session_manager
+                .session_or_err("session-id")
+                .expect("session exists"),
+        )
+        .expect("draft preparation")
+        .prepare()
+        .await;
 
         // Assert
         assert!(result.is_ok());
+        assert!(!load_persisted_session_row(&database).await.is_draft);
+    }
+
+    #[tokio::test]
+    async fn worktree_metadata_failure_cleans_resources_and_keeps_the_draft() {
+        // Arrange
+        let mut session = test_session("Keep this prompt", Status::Draft, None, "");
+        session.is_draft = true;
+        let database = database_with_session(&session).await;
+        let mut fs_client = fs::MockFsClient::new();
+        fs_client.expect_create_dir_all().once().returning(|_| {
+            Box::pin(async { Err(fs::FsError::Io(std::io::Error::other("metadata failed"))) })
+        });
+        fs_client
+            .expect_remove_dir_all()
+            .once()
+            .returning(|_| Box::pin(async { Ok(()) }));
+        let mut git_client = git::MockGitClient::new();
+        git_client
+            .expect_create_worktree()
+            .once()
+            .returning(|_, _, _, _| Box::pin(async { Ok(()) }));
+        git_client
+            .expect_remove_worktree()
+            .once()
+            .returning(|_| Box::pin(async { Ok(()) }));
+        git_client
+            .expect_delete_branch()
+            .once()
+            .returning(|_, _| Box::pin(async { Ok(()) }));
+        let services = test_services_with_fs_client(
+            &database,
+            Arc::new(RealClock),
+            Arc::new(fs_client),
+            Arc::new(git_client),
+            Arc::new(forge::MockReviewRequestClient::new()),
+        );
+
+        // Act
+        let result = SessionManager::create_session_worktree(
+            &services,
+            "session-id",
+            Path::new("worktree"),
+            Path::new("repo"),
+            "wt/session",
+            "main",
+        )
+        .await;
+
+        // Assert
+        assert!(
+            result
+                .expect_err("metadata failure")
+                .to_string()
+                .contains("metadata failed")
+        );
+        let row = load_persisted_session_row(&database).await;
+        assert!(row.is_draft);
+        assert_eq!(row.prompt, "Keep this prompt");
     }
 
     #[tokio::test]
@@ -4738,7 +5273,6 @@ mod tests {
         // Arrange
         let session = test_session("", Status::Draft, None, "");
         let database = database_with_session(&session).await;
-        let session_manager = session_manager_with_one_session(session);
         let repo_root = PathBuf::from("/tmp/project");
         let folder = PathBuf::from("/tmp/session-worktree");
         let expected_repo_root = repo_root.clone();
@@ -4765,16 +5299,15 @@ mod tests {
         );
 
         // Act
-        let result = session_manager
-            .create_session_worktree(
-                &services,
-                "session-id",
-                folder.as_path(),
-                repo_root.as_path(),
-                "wt/session-id",
-                "main",
-            )
-            .await;
+        let result = SessionManager::create_session_worktree(
+            &services,
+            "session-id",
+            folder.as_path(),
+            repo_root.as_path(),
+            "wt/session-id",
+            "main",
+        )
+        .await;
 
         // Assert
         assert!(result.is_ok());

--- a/crates/agentty/src/app/session/workflow/load.rs
+++ b/crates/agentty/src/app/session/workflow/load.rs
@@ -322,8 +322,11 @@ impl SessionManager {
         let session_agent =
             migrate_session_off_retired_model(db, &row.id, &row.agent, &row.model, session_status)
                 .await;
-        let draft_attachments =
-            draft::load_staged_draft_attachments(*fs_client, base, &session_id).await;
+        let draft_attachments = if row.is_draft {
+            draft::load_staged_draft_attachments(*fs_client, base, &session_id).await
+        } else {
+            Vec::new()
+        };
         let questions = Self::loaded_session_questions(session_detail.as_ref());
         let reasoning_level_override = row
             .reasoning_level_override
@@ -679,7 +682,7 @@ fn should_skip_missing_folder_session(
         return false;
     }
 
-    if is_draft_session && persisted_status == Status::Draft {
+    if is_draft_session {
         return false;
     }
 
@@ -695,7 +698,10 @@ fn should_skip_missing_folder_session(
 /// snapshots from clobbering in-memory updates. Persisted read-only and
 /// terminal statuses (`Merged`, `Done`, `Canceled`) take precedence so remote
 /// merge truth and explicit terminal transitions still appear after refresh.
-fn merge_loaded_session_status(status_from_db: Status, status_from_handle: Status) -> Status {
+pub(super) fn merge_loaded_session_status(
+    status_from_db: Status,
+    status_from_handle: Status,
+) -> Status {
     if matches!(
         status_from_db,
         Status::Merged | Status::Done | Status::Canceled
@@ -2085,19 +2091,21 @@ WHERE id = ?
     fn should_skip_missing_folder_session_keeps_new_draft_session() {
         // Arrange
         let has_session_folder = false;
-        let persisted_status = Status::Draft;
+        let statuses = [Status::Draft, Status::InProgress];
         let live_handle_status = None;
 
         // Act
-        let should_skip = should_skip_missing_folder_session(
-            has_session_folder,
-            true,
-            persisted_status,
-            live_handle_status,
-        );
+        let skipped = statuses.map(|persisted_status| {
+            should_skip_missing_folder_session(
+                has_session_folder,
+                true,
+                persisted_status,
+                live_handle_status,
+            )
+        });
 
         // Assert
-        assert!(!should_skip);
+        assert_eq!(skipped, [false, false]);
     }
 
     #[test]

--- a/crates/agentty/src/app/session/workflow/refresh.rs
+++ b/crates/agentty/src/app/session/workflow/refresh.rs
@@ -4,14 +4,41 @@ use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 use ag_forge as forge;
+use tokio::task::{JoinHandle, JoinSet};
 use tracing::warn;
 
 use super::SESSION_REFRESH_INTERVAL;
 use super::load::SessionLoadInput;
 use crate::app::session::SessionError;
 use crate::app::{AppServices, ProjectManager, SessionManager};
-use crate::domain::session::{ForgeKind, ReviewRequest, SessionId};
+use crate::domain::session::{
+    DailyActivity, ForgeKind, ReviewRequest, Session, SessionHandles, SessionId,
+};
+use crate::infra::db::DbError;
 use crate::presentation::app_mode::{AppMode, ConfirmationViewMode, HelpContext};
+
+/// One coalesced snapshot load, isolated from live handles until reduction.
+pub(in crate::app::session) struct BackgroundSessionRefresh {
+    detail_session_id: Option<SessionId>,
+    project_id: i64,
+    refresh_again: bool,
+    task: JoinHandle<Result<Option<SessionRefreshSnapshot>, DbError>>,
+}
+
+impl Drop for BackgroundSessionRefresh {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+struct SessionRefreshSnapshot {
+    branch_names: HashMap<SessionId, String>,
+    handles: HashMap<SessionId, SessionHandles>,
+    metadata: Option<(i64, i64)>,
+    sessions: Vec<Session>,
+    stats_activity: Vec<DailyActivity>,
+    worktree_availability: HashMap<SessionId, bool>,
+}
 
 impl SessionManager {
     /// Reloads session rows when the metadata cache indicates a change.
@@ -25,24 +52,210 @@ impl SessionManager {
         projects: &ProjectManager,
         services: &AppServices,
     ) -> bool {
-        if !self.is_session_refresh_due() {
-            return false;
+        let refreshed = self
+            .finish_background_refresh(mode, projects, services)
+            .await;
+        if self.is_session_refresh_due() && self.pending_refresh.is_none() {
+            self.start_session_refresh(mode, projects, services, false);
         }
 
-        self.state.refresh_deadline = self.next_refresh_deadline();
+        refreshed
+    }
 
-        let Ok(sessions_metadata) = services.db().sessions().load_sessions_metadata().await else {
+    /// Coalesces refresh requests without awaiting disk or repository work.
+    pub(crate) fn request_session_refresh(
+        &mut self,
+        mode: &AppMode,
+        projects: &ProjectManager,
+        services: &AppServices,
+    ) {
+        self.start_session_refresh(mode, projects, services, true);
+    }
+
+    fn start_session_refresh(
+        &mut self,
+        mode: &AppMode,
+        projects: &ProjectManager,
+        services: &AppServices,
+        force: bool,
+    ) {
+        if let Some(pending) = self.pending_refresh.as_mut()
+            && pending.project_id == projects.active_project_id()
+        {
+            pending.refresh_again = true;
+            return;
+        }
+        let project_id = projects.active_project_id();
+        let detail_session_id = Self::mode_session_id(mode).cloned().or_else(|| {
+            self.state
+                .table_state
+                .selected()
+                .and_then(|index| self.state.sessions.get(index))
+                .map(|session| session.id.clone())
+        });
+        let base = services.base_path().to_path_buf();
+        let working_dir = projects.working_dir().to_path_buf();
+        let repositories = services.db().clone();
+        let clock = services.clock();
+        let fs_client = services.fs_client();
+        let git_client = self.git_client.clone();
+        let task_detail_id = detail_session_id.clone();
+        let previous_metadata = (self.state.row_count, self.state.updated_at_max);
+        let mut handles = self
+            .state
+            .handles()
+            .iter()
+            .filter_map(|(id, handles)| {
+                handles
+                    .status
+                    .lock()
+                    .ok()
+                    .map(|status| (id.clone(), SessionHandles::new_unloaded(*status)))
+            })
+            .collect();
+        let task = tokio::spawn(async move {
+            let metadata = repositories.sessions().load_sessions_metadata().await.ok();
+            if !force && metadata == Some(previous_metadata) {
+                return Ok(None);
+            }
+            let (sessions, stats_activity, worktree_availability) =
+                Self::try_load_sessions_with_fs_client(
+                    SessionLoadInput {
+                        active_project_id: project_id,
+                        active_session_id: task_detail_id.as_deref(),
+                        base: &base,
+                        clock: clock.as_ref(),
+                        db: &repositories,
+                        fs_client: fs_client.as_ref(),
+                        working_dir: &working_dir,
+                    },
+                    &mut handles,
+                )
+                .await?;
+            let mut branch_names = HashMap::new();
+            let mut tasks = JoinSet::new();
+            for session in &sessions {
+                let git_client = git_client.clone();
+                let session_id = session.id.clone();
+                let folder = session.folder.clone();
+                tasks.spawn(async move {
+                    let name = git_client
+                        .detect_git_info(folder)
+                        .await
+                        .unwrap_or_else(|| super::session_branch(&session_id));
+                    (session_id, name)
+                });
+                if tasks.len() >= 8
+                    && let Some(Ok((session_id, name))) = tasks.join_next().await
+                {
+                    branch_names.insert(session_id, name);
+                }
+            }
+            while let Some(result) = tasks.join_next().await {
+                if let Ok((session_id, name)) = result {
+                    branch_names.insert(session_id, name);
+                }
+            }
+
+            Ok(Some(SessionRefreshSnapshot {
+                branch_names,
+                handles,
+                metadata,
+                sessions,
+                stats_activity,
+                worktree_availability,
+            }))
+        });
+        self.pending_refresh = Some(BackgroundSessionRefresh {
+            detail_session_id,
+            project_id,
+            refresh_again: false,
+            task,
+        });
+        self.state.refresh_deadline = self.next_refresh_deadline();
+    }
+
+    /// Applies completed I/O against current selection and live worker handles.
+    async fn finish_background_refresh(
+        &mut self,
+        mode: &mut AppMode,
+        projects: &ProjectManager,
+        services: &AppServices,
+    ) -> bool {
+        let Some(mut pending) = self
+            .pending_refresh
+            .take_if(|pending| pending.task.is_finished())
+        else {
             return false;
         };
-        let (sessions_row_count, sessions_updated_at_max) = sessions_metadata;
-        if sessions_row_count == self.state.row_count
-            && sessions_updated_at_max == self.state.updated_at_max
-        {
+        if pending.project_id != projects.active_project_id() {
             return false;
         }
-
-        self.reload_sessions(mode, projects, services, Some(sessions_metadata))
-            .await;
+        if pending.refresh_again
+            || Self::mode_session_id(mode)
+                .is_some_and(|id| pending.detail_session_id.as_ref() != Some(id))
+        {
+            self.request_session_refresh(mode, projects, services);
+            return false;
+        }
+        let Ok(Ok(Some(mut snapshot))) = (&mut pending.task).await else {
+            return false;
+        };
+        let selected_index = self.state.table_state.selected();
+        let selected_id = selected_index
+            .and_then(|index| self.state.sessions.get(index))
+            .map(|session| session.id.clone());
+        let live_progress = self
+            .state
+            .sessions
+            .iter()
+            .filter_map(|session| {
+                session
+                    .orchestration_progress
+                    .as_ref()
+                    .filter(|progress| progress.starts_with("Phase:"))
+                    .map(|progress| (session.id.clone(), progress.clone()))
+            })
+            .collect();
+        for session in &mut snapshot.sessions {
+            if let Some(handles) = self.state.handles().get(&session.id) {
+                session.status = super::load::merge_loaded_session_status(
+                    session.status,
+                    handles
+                        .status
+                        .lock()
+                        .map_or(session.status, |status| *status),
+                );
+                if let Ok(mut status) = handles.status.lock() {
+                    *status = session.status;
+                }
+                handles.transcript_snapshot_with_loaded(session.transcript.as_ref());
+            } else if let Some(handles) = snapshot.handles.remove(&session.id) {
+                self.state.handles_mut().insert(session.id.clone(), handles);
+            }
+        }
+        Self::preserve_live_orchestration_progress(&mut snapshot.sessions, &live_progress);
+        self.state.replace_sessions(snapshot.sessions);
+        self.state.sync_from_handles();
+        self.state
+            .replace_session_worktree_availability(snapshot.worktree_availability);
+        self.replace_session_branch_names(snapshot.branch_names);
+        self.stats_activity = snapshot.stats_activity;
+        self.restore_table_selection(selected_id.as_deref(), selected_index);
+        self.ensure_mode_session_exists(mode);
+        let active_session_ids = self
+            .state
+            .sessions
+            .iter()
+            .map(|session| session.id.clone())
+            .collect();
+        self.state
+            .retain_follow_up_task_positions(&active_session_ids);
+        self.state.retain_session_git_statuses(&active_session_ids);
+        if let Some((count, updated_at)) = snapshot.metadata {
+            self.state.row_count = count;
+            self.state.updated_at_max = updated_at;
+        }
 
         true
     }
@@ -54,6 +267,7 @@ impl SessionManager {
         projects: &ProjectManager,
         services: &AppServices,
     ) {
+        self.pending_refresh = None;
         let sessions_metadata = services.db().sessions().load_sessions_metadata().await.ok();
         self.reload_sessions(mode, projects, services, sessions_metadata)
             .await;
@@ -967,7 +1181,12 @@ mod tests {
 
     /// Builds a session manager with deterministic time and empty state.
     fn session_manager_fixture(clock: Arc<dyn Clock>) -> SessionManager {
-        let git_client: Arc<dyn git::GitClient> = Arc::new(git::MockGitClient::new());
+        let mut git_client = git::MockGitClient::new();
+        git_client
+            .expect_detect_git_info()
+            .times(0..)
+            .returning(|_| Box::pin(async { None }));
+        let git_client: Arc<dyn git::GitClient> = Arc::new(git_client);
 
         SessionManager::new(
             SessionDefaults {
@@ -1052,6 +1271,52 @@ mod tests {
             .refresh_sessions_if_needed(&mut mode, &projects, &services)
             .await;
 
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !session_manager
+                .pending_refresh
+                .as_ref()
+                .expect("pending refresh")
+                .task
+                .is_finished()
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("metadata check completes");
+        assert!(
+            !session_manager
+                .refresh_sessions_if_needed(&mut mode, &projects, &services)
+                .await
+        );
+        session_manager.request_session_refresh(&mode, &projects, &services);
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !session_manager
+                .pending_refresh
+                .as_ref()
+                .expect("pending refresh")
+                .task
+                .is_finished()
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("forced snapshot completes");
+        let other_projects = ProjectManager::new(
+            2,
+            "other".into(),
+            None,
+            None,
+            Vec::new(),
+            temp_dir.path().to_path_buf(),
+        );
+        assert!(
+            !session_manager
+                .refresh_sessions_if_needed(&mut mode, &other_projects, &services)
+                .await
+        );
+
         // Assert
         assert!(session_manager.state.refresh_deadline > original_deadline);
         assert_eq!(session_manager.state.row_count, 0);
@@ -1063,6 +1328,19 @@ mod tests {
         // Arrange
         let session = test_session(PathBuf::from("/tmp/session"), None, Status::Done);
         let database = database_with_session(&session).await;
+        for index in 0..9 {
+            database
+                .sessions()
+                .insert_session(
+                    &format!("extra-{index}"),
+                    session.agent.model().as_str(),
+                    "main",
+                    "Done",
+                    1,
+                )
+                .await
+                .expect("extra session");
+        }
         let now = Instant::now();
         let fake_clock = Arc::new(FakeClock::new(now, SystemTime::UNIX_EPOCH));
         let clock: Arc<dyn Clock> = fake_clock.clone();
@@ -1082,10 +1360,119 @@ mod tests {
             .refresh_sessions_if_needed(&mut mode, &projects, &services)
             .await;
 
+        assert!(session_manager.state.sessions.is_empty());
+        session_manager.request_session_refresh(&mode, &projects, &services);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !session_manager
+                .refresh_sessions_if_needed(&mut mode, &projects, &services)
+                .await
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("background snapshot must complete");
+
         // Assert
-        assert_eq!(session_manager.state.row_count, 1);
-        assert_eq!(session_manager.state.sessions.len(), 1);
-        assert_eq!(session_manager.state.sessions[0].id, "session-id");
+        assert_eq!(session_manager.state.row_count, 10);
+        assert_eq!(session_manager.state.sessions.len(), 10);
+        assert!(
+            session_manager
+                .state
+                .sessions
+                .iter()
+                .any(|session| session.id == "session-id")
+        );
+    }
+
+    #[tokio::test]
+    async fn background_refresh_preserves_live_worker_updates() {
+        // Arrange
+        let session = test_session(PathBuf::from("/tmp/session"), None, Status::Review);
+        let database = database_with_session(&session).await;
+        let clock: Arc<dyn Clock> =
+            Arc::new(FakeClock::new(Instant::now(), SystemTime::UNIX_EPOCH));
+        let mut manager = session_manager_with_session(clock, session);
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let resume = Arc::new(tokio::sync::Notify::new());
+        let mut git_client = git::MockGitClient::new();
+        git_client.expect_detect_git_info().once().returning({
+            let entered = Arc::clone(&entered);
+            let resume = Arc::clone(&resume);
+            move |_| {
+                let entered = Arc::clone(&entered);
+                let resume = Arc::clone(&resume);
+                Box::pin(async move {
+                    entered.notify_one();
+                    resume.notified().await;
+                    Some("wt/live".to_string())
+                })
+            }
+        });
+        manager.git_client = Arc::new(git_client);
+        let mut fs_client = create_passthrough_mock_fs_client();
+        fs_client.checkpoint();
+        fs_client.expect_is_dir().return_const(true);
+        fs_client.expect_read_file().never();
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        let services = AppServices::new_with_agent_clis(
+            PathBuf::from("/tmp/agentty-tests"),
+            Arc::new(crate::infra::clock::RealClock),
+            event_tx,
+            crate::app::service::AppServiceDeps {
+                app_server_client_override: Some(crate::test_support::mock_app_server()),
+                available_agent_kinds: AgentKind::ALL.to_vec(),
+                clipboard_image_client_override: None,
+                fs_client: Arc::new(fs_client),
+                git_client: manager.git_client.clone(),
+                one_shot_client_override: None,
+                personality_catalog_client_override: None,
+                repositories: database.clone(),
+                review_request_client: Arc::new(forge::MockReviewRequestClient::new()),
+            },
+            crate::domain::agent::AgentCliInfo::from_kinds(AgentKind::ALL),
+        );
+        let temp_dir = tempdir().expect("temporary directory");
+        let projects = empty_project_manager(temp_dir.path().to_path_buf());
+        let mut mode = AppMode::List;
+
+        manager.state.table_state.select(Some(0));
+
+        // Act
+        manager.request_session_refresh(&mode, &projects, &services);
+        tokio::time::timeout(Duration::from_secs(1), entered.notified())
+            .await
+            .expect("background probe starts");
+        let handles = manager
+            .state
+            .handles()
+            .get("session-id")
+            .expect("live handles");
+        *handles.status.lock().expect("status") = Status::InProgress;
+        let live_transcript = crate::test_support::assistant_transcript("New streamed answer");
+        *handles.transcript.lock().expect("transcript") = live_transcript.clone();
+        mode = AppMode::View {
+            session_id: "session-id".into(),
+            scroll_offset: None,
+        };
+        resume.notify_one();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !manager
+                .refresh_sessions_if_needed(&mut mode, &projects, &services)
+                .await
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("snapshot applied");
+
+        // Assert
+        assert_eq!(manager.state.sessions[0].status, Status::InProgress);
+        assert_eq!(
+            manager.state.sessions[0].transcript.as_ref(),
+            Some(&live_transcript)
+        );
     }
 
     /// Test clock implementation with mutable `Instant` and `SystemTime`.

--- a/crates/agentty/src/app/session/workflow/turn.rs
+++ b/crates/agentty/src/app/session/workflow/turn.rs
@@ -14,6 +14,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
 use super::lifecycle::SessionTitleGenerationTaskInput;
+use super::task::SessionTranscriptMessageAppend;
 use super::worker::{SessionWorkerContext, TurnMetadata};
 use super::{SessionTaskService, StatusTransition, isolation, post_turn};
 use crate::app::session::SessionError;
@@ -21,7 +22,7 @@ use crate::app::{AppEvent, SessionManager, setting};
 use crate::domain::agent::{AgentKind, AgentSelection, ReasoningLevel, ResponseStyle};
 use crate::domain::permission::PermissionMode;
 use crate::domain::session::{SessionId, SessionRole, Status};
-use crate::domain::session_message::SessionTranscript;
+use crate::domain::session_message::{SessionMessageKind, SessionTranscript};
 use crate::domain::setting::SettingName;
 use crate::domain::transcript_notice::TranscriptNotice;
 use crate::domain::turn_prompt::{TurnPrompt, TurnPromptTextSource};
@@ -146,11 +147,8 @@ impl MainCheckoutSnapshot {
 /// user-stopped turns skip that fallback so the UI cancellation path can
 /// finalize `Canceled`.
 ///
-/// A fresh [`CancellationToken`] is swapped into the shared mutex at
-/// the top of this function so stale cancellations from previous
-/// turns cannot affect new work. A `Ctrl+c` arriving during setup
-/// cancels the new token, which is detected by the early-exit check
-/// in [`run_turn_with_cancellation`].
+/// Uses the token renewed by worker preflight without replacing it. A cancel
+/// after preflight therefore remains visible before setup and provider work.
 pub(super) async fn run_channel_turn(
     context: &SessionWorkerContext,
     one_shot_client: Arc<dyn OneShotClient>,
@@ -158,14 +156,18 @@ pub(super) async fn run_channel_turn(
     request_kind: AgentRequestKind,
     replay_transcript: Option<String>,
     prompt: TurnPrompt,
+    preparation: Option<Box<super::lifecycle::SessionWorktreePreparation>>,
 ) -> Result<(), SessionError> {
-    // Discard stale cancellations, then keep the new token for this turn.
-    let turn_cancel_token = fresh_turn_cancel_token(context)?;
+    let turn_cancel_token = current_turn_cancel_token(context)?;
+    ensure_turn_active(&turn_cancel_token)?;
 
     prepare_resume_turn(context, &request_kind).await;
 
     let post_turn_context =
         post_turn::PostTurnContext::from_worker(context, Arc::clone(&one_shot_client));
+    if let Some(preparation) = preparation {
+        prepare_draft_turn(context, preparation, &turn_cancel_token, &prompt).await?;
+    }
     let main_checkout_snapshot = match MainCheckoutSnapshot::capture(context).await {
         Ok(snapshot) => snapshot,
         Err(error) => {
@@ -297,6 +299,69 @@ fn apply_read_only_chat_prompt(
         text: format!("{READ_ONLY_CHAT_PROMPT}\n\n{agent_prompt}"),
         text_source: TurnPromptTextSource::AgentData,
     }
+}
+
+/// Prepares a draft and records its first prompt only on success, leaving the
+/// staged bundle available for retry on failure.
+/// Cancellation leaves terminal status ownership with the explicit user action.
+async fn prepare_draft_turn(
+    context: &SessionWorkerContext,
+    preparation: Box<super::lifecycle::SessionWorktreePreparation>,
+    cancellation: &CancellationToken,
+    prompt: &TurnPrompt,
+) -> Result<(), SessionError> {
+    let result = tokio::select! {
+        biased;
+        () = cancellation.cancelled() => {
+            return Err(SessionError::StoppedByUser("Session preparation canceled".into()));
+        }
+        result = async {
+            let _guard = context.branch_operation_lock.lock().await;
+            ensure_turn_active(cancellation)?;
+            preparation.prepare().await
+        } => result,
+    };
+    if let Err(error) = &result
+        && !matches!(error, SessionError::StoppedByUser(_))
+    {
+        let message: String = error.to_string().chars().take(800).collect();
+        SessionTaskService::append_workflow_notice(
+            &context.transcript,
+            &context.db,
+            &context.app_event_tx,
+            &context.session_update_versions,
+            &context.session_id,
+            &message,
+        )
+        .await;
+        let transition = StatusTransition::from_parts(
+            context.app_event_tx.clone(),
+            Arc::clone(&context.clock),
+            context.db.clone(),
+            context.session_id.clone(),
+            Arc::clone(&context.session_update_versions),
+            Arc::clone(&context.status),
+        );
+        let _ = transition.apply(Status::Draft).await;
+    }
+
+    result?;
+
+    let prompt_transcript_text = prompt.transcript_text();
+    SessionTaskService::append_session_transcript_message(
+        &context.transcript,
+        &context.db,
+        &context.app_event_tx,
+        &context.session_update_versions,
+        &context.session_id,
+        SessionTranscriptMessageAppend {
+            kind: SessionMessageKind::UserPrompt,
+            raw_content: &prompt_transcript_text,
+        },
+    )
+    .await;
+
+    Ok(())
 }
 
 /// Cleans up and reports a failure that occurs after turn setup has started
@@ -525,9 +590,7 @@ async fn prepare_resume_turn(context: &SessionWorkerContext, request_kind: &Agen
 /// targets: their runtime owners handle cancellation through
 /// `shutdown_session`, including when a retained PID has been recycled.
 ///
-/// Each turn receives its own fresh token, created at the start of
-/// [`run_channel_turn`]. This eliminates the stale-permit problem that
-/// required the previous `Notify` + `AtomicBool` flag-check pattern.
+/// Each turn retains the token renewed before worker preflight.
 pub(super) async fn run_turn_with_cancellation(
     context: &SessionWorkerContext,
     cancel_token: CancellationToken,
@@ -535,9 +598,7 @@ pub(super) async fn run_turn_with_cancellation(
     event_tx: mpsc::UnboundedSender<TurnEvent>,
 ) -> Result<TurnResult, AgentError> {
     // Honour a cancel that arrived during pre-turn setup, before the
-    // select had a chance to observe it. The token was freshly created
-    // at the top of `run_channel_turn`, so a cancelled state here is a
-    // real `Ctrl+c`, not a stale leftover.
+    // select had a chance to observe it, using the same token as preflight.
     if cancel_token.is_cancelled() {
         terminate_child_process(&context.child_pid, context.session_agent.kind());
         let _ = context
@@ -787,20 +848,27 @@ pub(super) fn terminate_child_process(child_pid: &Mutex<Option<u32>>, kind: Agen
     }
 }
 
-/// Replaces the shared cancellation token for a new turn and returns the
-/// token used by the running channel future.
-fn fresh_turn_cancel_token(
+/// Captures the token selected before worker preflight without resetting it.
+fn current_turn_cancel_token(
     context: &SessionWorkerContext,
 ) -> Result<CancellationToken, SessionError> {
-    // Sync critical section (assignment + clone, no `.await`); `std::sync::Mutex`
-    // is the correct choice per CLAUDE.md §"Mutex Selection".
-    let mut guard = context
+    let guard = context
         .cancel_token
         .lock()
         .map_err(|_| SessionError::Workflow("cancel token lock poisoned".to_string()))?;
-    *guard = CancellationToken::new();
 
     Ok(guard.clone())
+}
+
+/// Stops canceled work before setup and after acquiring branch ownership.
+fn ensure_turn_active(cancellation: &CancellationToken) -> Result<(), SessionError> {
+    if cancellation.is_cancelled() {
+        return Err(SessionError::StoppedByUser(
+            "Session turn canceled".to_string(),
+        ));
+    }
+
+    Ok(())
 }
 
 /// Appends one main-checkout warning to the live and persisted transcript.
@@ -892,6 +960,21 @@ fn normalize_thinking_stream_text(text: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::infra::db::{DbError, PersistedSessionCreation};
+
+    #[test]
+    fn turn_guard_preserves_cancellation() {
+        // Arrange
+        let cancellation = CancellationToken::new();
+
+        // Act
+        let active = ensure_turn_active(&cancellation);
+        cancellation.cancel();
+        let canceled = ensure_turn_active(&cancellation);
+
+        // Assert
+        assert!(active.is_ok());
+        assert!(matches!(canceled, Err(SessionError::StoppedByUser(_))));
+    }
 
     #[test]
     fn read_only_chat_prompt_redirects_write_access_requests_to_mode_shortcut() {

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -106,6 +106,8 @@ pub(super) enum SessionCommand {
     },
     /// Executes one agent turn with the given request kind and prompt.
     Run {
+        /// Optional draft materialization executed before the first turn.
+        preparation: Option<Box<super::lifecycle::SessionWorktreePreparation>>,
         /// Persisted operation identifier.
         operation_id: String,
         /// Whether this is a first-message start or a follow-up resume.
@@ -246,8 +248,8 @@ pub(super) struct SessionWorkerContext {
     /// Serializes post-turn publish ownership with queued branch operations.
     pub(super) branch_operation_lock: Arc<tokio::sync::Mutex<()>>,
     /// Per-turn cancellation token shared with the UI through
-    /// [`SessionHandles`]. The worker swaps in a fresh token at the start
-    /// of each turn; the UI calls `cancel()` on the current token to
+    /// [`SessionHandles`]. The worker renews it before command preflight;
+    /// the UI calls `cancel()` on the current token to
     /// interrupt a running turn.
     pub(super) cancel_token: Arc<Mutex<CancellationToken>>,
     /// Provider-agnostic agent channel for this session's worker.
@@ -1040,19 +1042,7 @@ impl SessionWorkerService {
         command: SessionCommand,
     ) -> Option<Result<(), SessionError>> {
         let operation_id = command.operation_id().to_string();
-        let should_skip = if Self::should_skip_worker_command(context, &operation_id).await {
-            true
-        } else {
-            // Best-effort: operation tracking metadata is non-critical.
-            let _ = context
-                .db
-                .operations()
-                .mark_session_operation_running(&operation_id)
-                .await;
-
-            Self::should_skip_worker_command(context, &operation_id).await
-        };
-        if should_skip {
+        if !Self::prepare_session_command(context, &command).await {
             Self::complete_skipped_session_command(context, &command);
 
             return None;
@@ -1091,6 +1081,34 @@ impl SessionWorkerService {
         }
 
         Some(result)
+    }
+
+    /// Renews turn cancellation before checking whether this operation may run.
+    /// The selected token remains shared through execution, so cancellation
+    /// after the final preflight check cannot be erased by turn startup.
+    pub(super) async fn prepare_session_command(
+        context: &SessionWorkerContext,
+        command: &SessionCommand,
+    ) -> bool {
+        if matches!(command, SessionCommand::Run { .. })
+            && let Ok(mut token) = context.cancel_token.lock()
+        {
+            *token = CancellationToken::new();
+        }
+
+        let operation_id = command.operation_id();
+        if Self::should_skip_worker_command(context, operation_id).await {
+            return false;
+        }
+
+        // Best-effort: operation tracking metadata is non-critical.
+        let _ = context
+            .db
+            .operations()
+            .mark_session_operation_running(operation_id)
+            .await;
+
+        !Self::should_skip_worker_command(context, operation_id).await
     }
 
     /// Resolves external observers when a queued command is canceled or
@@ -1152,6 +1170,7 @@ impl SessionWorkerService {
         let published_upstream_ref = context.load_published_upstream_ref().await;
         append_drained_prompt_to_transcript(context, &prompt).await;
         let command = SessionCommand::Run {
+            preparation: None,
             operation_id,
             request_kind: AgentRequestKind::SessionResume,
             replay_transcript: None,
@@ -1181,7 +1200,7 @@ impl SessionWorkerService {
     }
 
     /// Executes the queued command through the session's agent channel.
-    async fn execute_session_command(
+    pub(super) async fn execute_session_command(
         context: &SessionWorkerContext,
         one_shot_client: &Arc<dyn OneShotClient>,
         command: SessionCommand,
@@ -1205,6 +1224,7 @@ impl SessionWorkerService {
                 Self::run_rebase_command(context, Arc::clone(one_shot_client), base_branch).await
             }
             SessionCommand::Run {
+                preparation,
                 request_kind,
                 replay_transcript,
                 prompt,
@@ -1218,6 +1238,7 @@ impl SessionWorkerService {
                     request_kind,
                     replay_transcript,
                     prompt,
+                    preparation,
                 )
                 .await
             }
@@ -1736,6 +1757,7 @@ mod tests {
 
     fn resume_command(operation_id: &str) -> SessionCommand {
         SessionCommand::Run {
+            preparation: None,
             operation_id: operation_id.to_string(),
             request_kind: AgentRequestKind::SessionResume,
             replay_transcript: None,
@@ -1912,6 +1934,7 @@ mod tests {
             response: None,
         };
         let start_command = SessionCommand::Run {
+            preparation: None,
             operation_id: "op-start".to_string(),
             request_kind: AgentRequestKind::SessionStart,
             replay_transcript: None,
@@ -1926,6 +1949,7 @@ mod tests {
             },
         };
         let resume_command = SessionCommand::Run {
+            preparation: None,
             operation_id: "op-resume".to_string(),
             request_kind: AgentRequestKind::SessionResume,
             replay_transcript: None,
@@ -1940,6 +1964,7 @@ mod tests {
             },
         };
         let account_read_command = SessionCommand::Run {
+            preparation: None,
             operation_id: "op-account-read".to_string(),
             request_kind: AgentRequestKind::AccountRead,
             replay_transcript: None,
@@ -1954,6 +1979,7 @@ mod tests {
             },
         };
         let focused_review_command = SessionCommand::Run {
+            preparation: None,
             operation_id: "op-focused-review".to_string(),
             request_kind: AgentRequestKind::FocusedReview,
             replay_transcript: None,
@@ -2413,6 +2439,7 @@ mod tests {
             AgentRequestKind::SessionResume,
             None,
             prompt,
+            None,
         )
         .await;
         let persisted_session = db
@@ -2535,6 +2562,7 @@ mod tests {
             AgentRequestKind::SessionStart,
             None,
             "test prompt".into(),
+            None,
         )
         .await;
 
@@ -2571,12 +2599,11 @@ mod tests {
     }
 
     #[tokio::test]
-    /// Verifies a read-only chat turn carries its persisted permission after a
-    /// previous turn's cancelled token is replaced.
-    async fn test_run_channel_turn_proceeds_read_only_after_previous_cancellation() {
+    /// Verifies worker preflight renews a previous turn's cancelled token while
+    /// preserving the persisted read-only permission for the new operation.
+    async fn test_worker_proceeds_read_only_after_previous_cancellation() {
         // Arrange — pre-cancel the token to simulate a previous turn's
-        // cancellation. `run_channel_turn` swaps in a fresh token so the
-        // stale cancellation is discarded.
+        // cancellation. Worker preflight renews it for this new operation.
         let base_dir = tempdir().expect("failed to create temp dir");
         let db = AppRepositories::in_memory().await.expect("db should open");
         let project_id = db
@@ -2608,21 +2635,7 @@ mod tests {
                     && request.prompt.text.contains("# Read Only Mode")
             })
             .returning(|_session_id, _req, _events| {
-                Box::pin(async {
-                    Ok(TurnResult {
-                        assistant_message: AgentResponse {
-                            answer: "done".to_string(),
-                            questions: Vec::new(),
-                            review_comment_outcomes: Vec::new(),
-                            subtasks: Vec::new(),
-                            verification_verdicts: Vec::new(),
-                        },
-                        context_reset: false,
-                        input_tokens: 0,
-                        output_tokens: 0,
-                        provider_conversation_id: None,
-                    })
-                })
+                Box::pin(async { Ok(successful_turn_result("done")) })
             });
 
         let mut mock_git_client = mock_git_client_detecting_main_repo(base_dir.path().join("main"));
@@ -2664,17 +2677,27 @@ mod tests {
             status: Arc::new(Mutex::new(Status::InProgress)),
         };
 
-        // Act — the turn should complete normally because
-        // `run_channel_turn` swaps in a fresh token.
-        let result = run_channel_turn(
+        db.operations()
+            .insert_session_operation("new-turn", "sess1", "start_prompt")
+            .await
+            .expect("new operation");
+        let command = SessionCommand::Run {
+            operation_id: "new-turn".to_string(),
+            preparation: None,
+            prompt: "test prompt".into(),
+            replay_transcript: None,
+            request_kind: AgentRequestKind::SessionStart,
+            turn_metadata: default_turn_metadata(),
+        };
+
+        // Act
+        let result = SessionWorkerService::process_session_command(
             &context,
-            auto_commit_one_shot_client(),
-            default_turn_metadata(),
-            AgentRequestKind::SessionStart,
-            None,
-            "test prompt".into(),
+            &auto_commit_one_shot_client(),
+            command,
         )
-        .await;
+        .await
+        .expect("new operation runs");
 
         // Assert — turn succeeded despite the stale cancellation.
         assert!(
@@ -2774,6 +2797,7 @@ mod tests {
             AgentRequestKind::SessionStart,
             None,
             "test prompt".into(),
+            None,
         )
         .await;
 
@@ -2877,6 +2901,7 @@ mod tests {
             AgentRequestKind::SessionStart,
             None,
             "test prompt".into(),
+            None,
         )
         .await;
 
@@ -2967,6 +2992,7 @@ mod tests {
             AgentRequestKind::SessionStart,
             None,
             "test prompt".into(),
+            None,
         )
         .await;
 
@@ -3063,6 +3089,7 @@ mod tests {
             AgentRequestKind::SessionStart,
             None,
             "test prompt".into(),
+            None,
         )
         .await;
 
@@ -3110,6 +3137,7 @@ mod tests {
             AgentRequestKind::SessionStart,
             None,
             "test prompt".into(),
+            None,
         )
         .await;
 

--- a/crates/agentty/src/app/session_diff.rs
+++ b/crates/agentty/src/app/session_diff.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 use std::collections::hash_map::Entry;
 use std::path::PathBuf;
 
+use tokio_util::sync::{CancellationToken, DropGuard};
 use tracing::warn;
 
 use crate::app::review::{self, FocusedReviewPersistence, ReviewAgent, ReviewCacheEntry};
@@ -63,6 +64,7 @@ pub(crate) struct SessionDiffUpdate {
 
 /// Foreground continuation waiting on one background diff result.
 pub(crate) struct PendingSessionDiffRequest {
+    _cancellation: DropGuard,
     purpose: SessionDiffPurpose,
     session_id: SessionId,
 }
@@ -113,6 +115,12 @@ impl App {
         sidebar_focus: DiffSidebarFocus,
         allow_empty: bool,
     ) -> bool {
+        if matches!(&self.mode, AppMode::DiffLoading { session_id: loading_session_id, .. }
+            if loading_session_id == session_id)
+        {
+            return true;
+        }
+
         let fallback_view_scroll_offset = match &self.mode {
             AppMode::View {
                 scroll_offset,
@@ -142,7 +150,7 @@ impl App {
     }
 
     /// Cancels a still-current interactive diff load and restores its source
-    /// page. The detached Git task may finish, but its event is then stale.
+    /// page. Dropping the request cancels its Git task and active subprocess.
     pub(crate) fn cancel_diff_view_load(&mut self) {
         let mode = std::mem::replace(&mut self.mode, AppMode::List);
         let AppMode::DiffLoading {
@@ -686,7 +694,9 @@ impl App {
         folder: PathBuf,
         source: SessionDiffTaskSource,
     ) -> u64 {
+        let cancellation = CancellationToken::new();
         let input = SessionDiffTaskInput {
+            cancellation: cancellation.clone(),
             app_event_tx: self.services.event_sender(),
             folder,
             session_id: session_id.clone(),
@@ -696,6 +706,7 @@ impl App {
         self.pending_session_diff_requests.insert(
             request_id,
             PendingSessionDiffRequest {
+                _cancellation: cancellation.drop_guard(),
                 purpose,
                 session_id: session_id.clone(),
             },
@@ -1033,6 +1044,9 @@ mod tests {
         assert_eq!(loading_request_id(&app), None);
         assert!(app.start_diff_view_load(&session_id, None, DiffSidebarFocus::Files, false,));
         let request_id = loading_request_id(&app).expect("diff loading mode should have a request");
+        assert!(app.start_diff_view_load(&session_id, None, DiffSidebarFocus::Files, false));
+        assert_eq!(loading_request_id(&app), Some(request_id));
+        assert_eq!(app.pending_session_diff_requests.len(), 1);
 
         // Act
         app.cancel_diff_view_load();
@@ -1287,6 +1301,7 @@ mod tests {
         app.pending_session_diff_requests.insert(
             42,
             PendingSessionDiffRequest {
+                _cancellation: CancellationToken::new().drop_guard(),
                 purpose: SessionDiffPurpose::Review {
                     cached_diff_hash: None,
                     is_manual: false,
@@ -1579,6 +1594,7 @@ mod tests {
         app.pending_session_diff_requests.insert(
             request_id,
             PendingSessionDiffRequest {
+                _cancellation: CancellationToken::new().drop_guard(),
                 purpose: SessionDiffPurpose::Review {
                     cached_diff_hash: None,
                     is_manual: false,
@@ -1611,6 +1627,7 @@ mod tests {
         app.pending_session_diff_requests.insert(
             42,
             PendingSessionDiffRequest {
+                _cancellation: CancellationToken::new().drop_guard(),
                 purpose: SessionDiffPurpose::Review {
                     cached_diff_hash: None,
                     is_manual: false,

--- a/crates/agentty/src/app/startup.rs
+++ b/crates/agentty/src/app/startup.rs
@@ -110,7 +110,6 @@ impl AppStartup {
         db: &AppRepositories,
         fs_client: &dyn FsClient,
         git_client: &Arc<dyn GitClient>,
-        project_discovery_client: &dyn ProjectDiscoveryClient,
         working_dir: &Path,
         git_branch: Option<String>,
         current_project_id: i64,
@@ -176,9 +175,6 @@ impl AppStartup {
                     startup_working_dir.display()
                 ))
             })?;
-        Self::refresh_project_catalog_on_startup(db, git_client.as_ref(), project_discovery_client)
-            .await;
-
         let project_items = Self::load_project_items(db, fs_client).await;
         let active_project_name =
             Self::project_title_for_id(&project_items, active_project_id, &startup_working_dir);
@@ -340,7 +336,7 @@ impl AppStartup {
         db: &AppRepositories,
         git_client: &dyn GitClient,
         project_discovery_client: &dyn ProjectDiscoveryClient,
-    ) {
+    ) -> bool {
         let session_worktree_root = super::core::agentty_home().join(AGENTTY_WT_DIR);
         let home_directory = env::home_dir();
 
@@ -351,7 +347,7 @@ impl AppStartup {
             session_worktree_root.as_path(),
             home_directory.as_deref(),
         )
-        .await;
+        .await
     }
 
     /// Discovers git repositories under the user home directory through the
@@ -362,18 +358,19 @@ impl AppStartup {
         project_discovery_client: &dyn ProjectDiscoveryClient,
         session_worktree_root: &Path,
         home_directory: Option<&Path>,
-    ) {
+    ) -> bool {
         let Some(home_directory) = home_directory.map(Path::to_path_buf) else {
-            return;
+            return false;
         };
 
         let Ok(discovered_project_paths) = project_discovery_client
             .discover_home_project_paths(home_directory, session_worktree_root.to_path_buf())
             .await
         else {
-            return;
+            return false;
         };
 
+        let discovered_any = !discovered_project_paths.is_empty();
         for project_path in discovered_project_paths {
             let git_branch = git_client.detect_git_info(project_path.clone()).await;
             let project_path = project_path.to_string_lossy().to_string();
@@ -383,6 +380,8 @@ impl AppStartup {
                 .upsert_project(project_path.as_str(), git_branch)
                 .await;
         }
+
+        discovered_any
     }
 
     /// Returns git repository roots discovered under the user home directory.

--- a/crates/agentty/src/app/sync.rs
+++ b/crates/agentty/src/app/sync.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 use ag_forge::ReviewRequestClient;
 use ag_git::GitClient;
 use tokio::sync::{mpsc, watch};
+use tokio::task::JoinSet;
 use tokio::time::MissedTickBehavior;
 
 use crate::app::core::SyncReviewRequestTaskResult;
@@ -408,7 +409,6 @@ fn review_target_polling_keys(
 /// the periodic passes through the same queue.
 pub(crate) struct SyncOrchestrator {
     app_event_tx: mpsc::UnboundedSender<AppEvent>,
-    command_rx: mpsc::UnboundedReceiver<SyncCommand>,
     context_rx: watch::Receiver<SyncContext>,
     review_pass_index: u64,
     review_sync_failures: HashMap<SessionId, ReviewSyncFailureState>,
@@ -427,14 +427,13 @@ impl SyncOrchestrator {
     ) {
         let orchestrator = Self {
             app_event_tx,
-            command_rx,
             context_rx,
             review_pass_index: 0,
             review_sync_failures: HashMap::new(),
             tick_index: 0,
         };
 
-        tokio::spawn(orchestrator.run());
+        tokio::spawn(orchestrator.run(command_rx));
     }
 
     /// Runs the command/tick loop until the command channel closes.
@@ -442,30 +441,43 @@ impl SyncOrchestrator {
     /// Commands take priority over ticks, and every command-triggered pass
     /// resets the tick timer so one refresh is never immediately duplicated
     /// by the periodic cadence.
-    async fn run(mut self) {
+    async fn run(mut self, mut command_rx: mpsc::UnboundedReceiver<SyncCommand>) {
         let mut tick = tokio::time::interval(Duration::from_secs(SYNC_TICK_INTERVAL_SECONDS));
         tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
-
+        let mut pending_command = None;
         loop {
-            tokio::select! {
-                biased;
-                command = self.command_rx.recv() => {
-                    let Some(command) = command else {
-                        break;
-                    };
-
-                    match command {
-                        SyncCommand::RefreshNow => self.run_refresh_pass(true).await,
-                        SyncCommand::SyncMain(request) => self.run_sync_main(*request).await,
+            let command = if let Some(command) = pending_command.take() {
+                Some(command)
+            } else {
+                tokio::select! {
+                    biased;
+                    command = command_rx.recv() => {
+                        let Some(command) = command else { break; };
+                        Some(command)
                     }
+                    _ = tick.tick() => None,
+                }
+            };
+            let include_review_pass = match command {
+                Some(SyncCommand::SyncMain(request)) => {
+                    self.run_sync_main(*request).await;
                     tick.reset();
+                    continue;
                 }
-                _ = tick.tick() => {
-                    let include_review_pass = self.tick_index.is_multiple_of(REVIEW_REQUEST_PASS_TICKS);
+                Some(SyncCommand::RefreshNow) => true,
+                None => {
+                    let include = self.tick_index.is_multiple_of(REVIEW_REQUEST_PASS_TICKS);
                     self.tick_index = self.tick_index.wrapping_add(1);
-                    self.run_refresh_pass(include_review_pass).await;
+                    include
                 }
-            }
+            };
+            // Interrupt only read-only passes. Mutating manual sync stays serialized.
+            pending_command = tokio::select! {
+                biased;
+                command = command_rx.recv() => command,
+                () = self.run_refresh_pass(include_review_pass) => None,
+            };
+            tick.reset();
         }
     }
 
@@ -517,7 +529,7 @@ impl SyncOrchestrator {
             &branch_tracking_statuses,
             &repo_root,
             &context.session_git_status_targets,
-            context.git_client.as_ref(),
+            Arc::clone(&context.git_client),
         )
         .await;
 
@@ -560,36 +572,51 @@ impl SyncOrchestrator {
     ) -> Vec<ReviewRequestPassUpdate> {
         let review_pass_index = self.review_pass_index;
         self.review_pass_index = self.review_pass_index.wrapping_add(1);
-        let mut updates = Vec::new();
-
-        for review_request_sync_target in &context.review_request_sync_targets {
+        let mut tasks = JoinSet::new();
+        let mut completed = Vec::new();
+        for (index, target) in context.review_request_sync_targets.iter().enumerate() {
             if reject_stale_context && self.context_is_stale(context) {
-                return updates;
+                return Vec::new();
             }
-            if self.is_target_backed_off(&review_request_sync_target.session_id, review_pass_index)
-            {
+            if self.is_target_backed_off(&target.session_id, review_pass_index) {
                 continue;
             }
-
-            let result = sync_review_request_status(
-                review_request_sync_target.folder.clone(),
-                context.git_client.as_ref(),
-                review_request_sync_target.linked_review_request.clone(),
-                review_request_sync_target.published_upstream_ref.clone(),
-                context.review_request_client.as_ref(),
-            )
-            .await;
-
-            if reject_stale_context && self.context_is_stale(context) {
-                return updates;
-            }
-
-            self.record_review_sync_outcome(review_request_sync_target, &result, review_pass_index);
-            updates.push(ReviewRequestPassUpdate {
-                result,
-                target: review_request_sync_target.clone(),
+            let target = target.clone();
+            let git_client = Arc::clone(&context.git_client);
+            let review_client = Arc::clone(&context.review_request_client);
+            tasks.spawn(async move {
+                let result = sync_review_request_status(
+                    target.folder.clone(),
+                    git_client.as_ref(),
+                    target.linked_review_request.clone(),
+                    target.published_upstream_ref.clone(),
+                    review_client.as_ref(),
+                )
+                .await;
+                (index, ReviewRequestPassUpdate { result, target })
             });
+            if tasks.len() >= 4
+                && let Some(Ok(result)) = tasks.join_next().await
+            {
+                completed.push(result);
+            }
         }
+        while let Some(result) = tasks.join_next().await {
+            if let Ok(result) = result {
+                completed.push(result);
+            }
+        }
+        if reject_stale_context && self.context_is_stale(context) {
+            return Vec::new();
+        }
+        completed.sort_by_key(|(index, _)| *index);
+        let updates = completed
+            .into_iter()
+            .map(|(_, update)| {
+                self.record_review_sync_outcome(&update.target, &update.result, review_pass_index);
+                update
+            })
+            .collect();
 
         self.retain_active_failure_states(&context.review_request_sync_targets);
 
@@ -778,46 +805,61 @@ async fn session_git_statuses(
     branch_tracking_statuses: &HashMap<String, Option<(u32, u32)>>,
     repo_root: &Path,
     session_git_status_targets: &[SessionGitStatusTarget],
-    git_client: &dyn GitClient,
+    git_client: Arc<dyn GitClient>,
 ) -> HashMap<SessionId, SessionGitStatus> {
-    let mut session_git_statuses = HashMap::with_capacity(session_git_status_targets.len());
-
+    let mut statuses = HashMap::with_capacity(session_git_status_targets.len());
+    let mut tasks = JoinSet::new();
     for session_git_status_target in session_git_status_targets {
-        let base_status = git_client
-            .get_ref_ahead_behind(
-                repo_root.to_path_buf(),
-                session_git_status_target.branch_name.clone(),
-                session_git_status_target.base_branch.clone(),
-            )
-            .await
-            .ok();
-        let has_merge_conflict = match base_status {
-            Some((ahead, behind)) if ahead > 0 && behind > 0 => git_client
-                .has_merge_conflicts(
-                    repo_root.to_path_buf(),
-                    session_git_status_target.branch_name.clone(),
-                    session_git_status_target.base_branch.clone(),
-                )
-                .await
-                .ok(),
-            Some(_) => Some(false),
-            None => None,
-        };
+        let session_git_status_target = session_git_status_target.clone();
         let remote_status = branch_tracking_statuses
             .get(&session_git_status_target.branch_name)
             .copied()
             .flatten();
-        session_git_statuses.insert(
-            session_git_status_target.session_id.clone(),
-            SessionGitStatus {
-                base_status,
-                has_merge_conflict,
-                remote_status,
-            },
-        );
+        let repo_root = repo_root.to_path_buf();
+        let git_client = Arc::clone(&git_client);
+        tasks.spawn(async move {
+            let base_status = git_client
+                .get_ref_ahead_behind(
+                    repo_root.clone(),
+                    session_git_status_target.branch_name.clone(),
+                    session_git_status_target.base_branch.clone(),
+                )
+                .await
+                .ok();
+            let has_merge_conflict = match base_status {
+                Some((ahead, behind)) if ahead > 0 && behind > 0 => git_client
+                    .has_merge_conflicts(
+                        repo_root.clone(),
+                        session_git_status_target.branch_name.clone(),
+                        session_git_status_target.base_branch.clone(),
+                    )
+                    .await
+                    .ok(),
+                Some(_) => Some(false),
+                None => None,
+            };
+            (
+                session_git_status_target.session_id,
+                SessionGitStatus {
+                    base_status,
+                    has_merge_conflict,
+                    remote_status,
+                },
+            )
+        });
+        if tasks.len() >= 4
+            && let Some(Ok((session_id, status))) = tasks.join_next().await
+        {
+            statuses.insert(session_id, status);
+        }
+    }
+    while let Some(result) = tasks.join_next().await {
+        if let Ok((session_id, status)) = result {
+            statuses.insert(session_id, status);
+        }
     }
 
-    session_git_statuses
+    statuses
 }
 
 /// Runs one review-request sync against the forge.
@@ -1115,6 +1157,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn manual_sync_preempts_a_stalled_background_fetch() {
+        // Arrange
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel::<()>();
+        let mut git_client = MockGitClient::new();
+        git_client
+            .expect_find_git_repo_root()
+            .returning(|path| Box::pin(async move { Some(path) }));
+        git_client.expect_fetch_remote().once().return_once({
+            let entered = Arc::clone(&entered);
+            move |_| {
+                Box::pin(std::future::poll_fn(move |_| {
+                    let _guard = &dropped_tx;
+                    entered.notify_one();
+                    std::task::Poll::Pending
+                }))
+            }
+        });
+        let mut context = sync_context_fixture(0, Vec::new());
+        context.git_client = Arc::new(git_client);
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let handle = SyncHandle::spawn(event_tx.clone(), context.clone());
+        tokio::time::timeout(Duration::from_secs(1), entered.notified())
+            .await
+            .expect("fetch starts");
+        context.project_branch_name = None;
+
+        // Act
+        handle.sync_main_runner().start_sync_main(
+            event_tx,
+            project_sync_context(),
+            AgentModel::Gemini38Flash,
+            context,
+        );
+        let event = tokio::time::timeout(Duration::from_secs(1), event_rx.recv())
+            .await
+            .expect("manual request preempts fetch")
+            .expect("completion");
+
+        // Assert
+        assert!(matches!(event, AppEvent::SyncMainCompleted { .. }));
+        assert!(
+            dropped_rx.await.is_err(),
+            "background fetch future was dropped"
+        );
+    }
+
+    #[tokio::test]
     /// Successful manual syncs preserve their captured review results and
     /// emit them only with the matching project operation.
     async fn run_sync_main_emits_captured_review_updates_after_success() {
@@ -1179,11 +1269,9 @@ mod tests {
             ..sync_context_fixture(0, Vec::new())
         };
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
-        let (_command_tx, command_rx) = mpsc::unbounded_channel();
         let (_context_tx, context_rx) = watch::channel(sync_context.clone());
         let mut orchestrator = SyncOrchestrator {
             app_event_tx: app_event_tx.clone(),
-            command_rx,
             context_rx,
             review_pass_index: 0,
             review_sync_failures: HashMap::new(),
@@ -1321,10 +1409,8 @@ mod tests {
         // Arrange
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
         let (_context_tx, context_rx) = watch::channel(sync_context_fixture(0, Vec::new()));
-        let (_command_tx, command_rx) = mpsc::unbounded_channel();
         let mut orchestrator = SyncOrchestrator {
             app_event_tx,
-            command_rx,
             context_rx,
             review_pass_index: 0,
             review_sync_failures: HashMap::new(),
@@ -1366,10 +1452,8 @@ mod tests {
         // Arrange
         let (app_event_tx, _app_event_rx) = mpsc::unbounded_channel();
         let (_context_tx, context_rx) = watch::channel(sync_context_fixture(0, Vec::new()));
-        let (_command_tx, command_rx) = mpsc::unbounded_channel();
         let mut orchestrator = SyncOrchestrator {
             app_event_tx,
-            command_rx,
             context_rx,
             review_pass_index: 0,
             review_sync_failures: HashMap::new(),
@@ -1390,6 +1474,151 @@ mod tests {
         // Assert
         assert!(!orchestrator.is_target_backed_off(&target.session_id, 5));
         assert!(orchestrator.review_sync_failures.is_empty());
+    }
+
+    #[tokio::test]
+    async fn session_status_probes_run_concurrently_with_a_four_task_limit() {
+        // Arrange
+        let started = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let permits = Arc::new(tokio::sync::Semaphore::new(0));
+        let targets = (0..9)
+            .map(|index| SessionGitStatusTarget {
+                base_branch: "main".to_string(),
+                branch_name: format!("wt/session-{index}"),
+                session_id: format!("session-{index}").into(),
+            })
+            .collect::<Vec<_>>();
+        let mut git_client = MockGitClient::new();
+        git_client
+            .expect_get_ref_ahead_behind()
+            .times(9)
+            .returning({
+                let started = Arc::clone(&started);
+                let permits = Arc::clone(&permits);
+                move |_, _, _| {
+                    let started = Arc::clone(&started);
+                    let permits = Arc::clone(&permits);
+                    Box::pin(async move {
+                        started.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        permits.acquire().await.expect("permit").forget();
+                        Ok((1, 0))
+                    })
+                }
+            });
+
+        // Act
+        let task = tokio::spawn(async move {
+            session_git_statuses(
+                &HashMap::new(),
+                Path::new("/tmp/project"),
+                &targets,
+                Arc::new(git_client),
+            )
+            .await
+        });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while started.load(std::sync::atomic::Ordering::SeqCst) < 4 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("four probes start without serial waiting");
+        tokio::task::yield_now().await;
+        let initial_count = started.load(std::sync::atomic::Ordering::SeqCst);
+        permits.add_permits(9);
+        let statuses = task.await.expect("status task");
+
+        // Assert
+        assert_eq!(initial_count, 4, "queued probes remain bounded");
+        assert_eq!(statuses.len(), 9);
+        assert!(
+            statuses
+                .values()
+                .all(|status| status.base_status == Some((1, 0)))
+        );
+    }
+
+    #[tokio::test]
+    async fn review_pass_discards_results_after_project_context_changes() {
+        // Arrange
+        let mut context =
+            sync_context_fixture(0, vec![review_request_sync_target("session-id", None)]);
+        let (context_tx, context_rx) = watch::channel(context.clone());
+        let mut git_client = MockGitClient::new();
+        git_client.expect_repo_url().once().return_once(move |_| {
+            Box::pin(async move {
+                context_tx.send_modify(|context| context.generation += 1);
+                Err(GitError::OutputParse("remote unavailable".into()))
+            })
+        });
+        context.git_client = Arc::new(git_client);
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        let mut orchestrator = SyncOrchestrator {
+            app_event_tx: event_tx,
+            context_rx,
+            review_pass_index: 0,
+            review_sync_failures: HashMap::new(),
+            tick_index: 0,
+        };
+
+        // Act
+        let changed_during_pass = orchestrator
+            .collect_review_request_pass_updates(&context, true)
+            .await;
+        let already_stale = orchestrator
+            .collect_review_request_pass_updates(&context, true)
+            .await;
+
+        // Assert
+        assert!(changed_during_pass.is_empty());
+        assert!(already_stale.is_empty());
+        assert!(orchestrator.review_sync_failures.is_empty());
+    }
+
+    #[tokio::test]
+    async fn parallel_review_pass_preserves_target_order_and_backoff() {
+        // Arrange
+        let targets = (0..6)
+            .map(|index| review_request_sync_target(&format!("session-{index}"), None))
+            .collect::<Vec<_>>();
+        let expected_ids = targets
+            .iter()
+            .map(|target| target.session_id.clone())
+            .collect::<Vec<_>>();
+        let mut context = sync_context_fixture(0, targets);
+        let mut git_client = MockGitClient::new();
+        git_client.expect_repo_url().times(6).returning(|_| {
+            Box::pin(async {
+                tokio::task::yield_now().await;
+                Err(GitError::OutputParse("remote unavailable".to_string()))
+            })
+        });
+        context.git_client = Arc::new(git_client);
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        let (_context_tx, context_rx) = watch::channel(context.clone());
+        let mut orchestrator = SyncOrchestrator {
+            app_event_tx: event_tx,
+            context_rx,
+            review_pass_index: 0,
+            review_sync_failures: HashMap::new(),
+            tick_index: 0,
+        };
+
+        // Act
+        let updates = orchestrator
+            .collect_review_request_pass_updates(&context, true)
+            .await;
+
+        // Assert
+        assert_eq!(
+            updates
+                .iter()
+                .map(|update| update.target.session_id.clone())
+                .collect::<Vec<_>>(),
+            expected_ids
+        );
+        assert!(updates.iter().all(|update| update.result.is_err()));
+        assert_eq!(orchestrator.review_sync_failures.len(), 6);
     }
 
     #[tokio::test]
@@ -1442,7 +1671,7 @@ mod tests {
             &branch_tracking_statuses,
             repo_root,
             &session_git_status_targets,
-            &mock_git_client,
+            Arc::new(mock_git_client),
         )
         .await;
 
@@ -1494,7 +1723,7 @@ mod tests {
             &branch_tracking_statuses,
             repo_root,
             &session_git_status_targets,
-            &mock_git_client,
+            Arc::new(mock_git_client),
         )
         .await;
 
@@ -1541,7 +1770,7 @@ mod tests {
             &HashMap::new(),
             repo_root,
             &session_git_status_targets,
-            &mock_git_client,
+            Arc::new(mock_git_client),
         )
         .await;
 

--- a/crates/agentty/src/app/task.rs
+++ b/crates/agentty/src/app/task.rs
@@ -19,6 +19,7 @@ use async_trait::async_trait;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 use crate::app::error::AppError;
@@ -136,6 +137,7 @@ pub(super) enum SessionDiffTaskSource {
 
 /// Inputs needed to load one session diff without blocking the foreground UI.
 pub(super) struct SessionDiffTaskInput {
+    pub(super) cancellation: CancellationToken,
     pub(super) app_event_tx: mpsc::UnboundedSender<AppEvent>,
     pub(super) folder: PathBuf,
     pub(super) session_id: SessionId,
@@ -175,7 +177,9 @@ impl TaskService {
     pub(super) fn spawn_session_diff_task(input: SessionDiffTaskInput) -> u64 {
         let request_id = NEXT_SESSION_DIFF_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
         tokio::spawn(async move {
-            let result = match input.source {
+            let result = tokio::select! {
+            () = input.cancellation.cancelled() => return,
+                result = async { match input.source {
                 SessionDiffTaskSource::Archived { repositories } => repositories
                     .sessions()
                     .load_session_archived_diff(&input.session_id)
@@ -205,6 +209,7 @@ impl TaskService {
                     }
                     Err(error) => Err(format!("Failed to run git diff: {error}")),
                 },
+            } } => result,
             };
             let _ = input.app_event_tx.send(AppEvent::SessionDiffLoaded {
                 request_id,
@@ -813,6 +818,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancel_session_diff_drops_running_git_future() {
+        // Arrange
+        let cancellation = CancellationToken::new();
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel::<()>();
+        let mut signals = Some((entered_tx, dropped_tx));
+        let mut git_client = MockGitClient::new();
+        git_client.expect_diff().once().returning(move |_, _| {
+            let (entered, dropped) = signals.take().expect("one diff invocation");
+            let mut entered = Some(entered);
+            Box::pin(std::future::poll_fn(move |_| {
+                let _dropped = &dropped;
+                if let Some(entered) = entered.take() {
+                    let _ = entered.send(());
+                }
+                std::task::Poll::Pending
+            }))
+        });
+        let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
+        let input = SessionDiffTaskInput {
+            cancellation: cancellation.clone(),
+            app_event_tx,
+            folder: PathBuf::from("worktree"),
+            session_id: "session".into(),
+            source: SessionDiffTaskSource::Worktree {
+                archived_fallback: None,
+                base_branch: "main".into(),
+                git_client: Arc::new(git_client),
+            },
+        };
+
+        // Act
+        TaskService::spawn_session_diff_task(input);
+        entered_rx.await.expect("diff started");
+        cancellation.cancel();
+        let dropped = tokio::time::timeout(Duration::from_secs(1), dropped_rx).await;
+
+        // Assert
+        assert!(
+            dropped
+                .expect("cancellation must drop Git promptly")
+                .is_err()
+        );
+        assert!(app_event_rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
     async fn session_diff_task_falls_back_to_archived_managed_merge_diff() {
         // Arrange
         let archived_diff = "diff --git a/file.rs b/file.rs\n+archived\n";
@@ -827,6 +879,7 @@ mod tests {
         });
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
         let input = SessionDiffTaskInput {
+            cancellation: CancellationToken::new(),
             app_event_tx,
             folder: PathBuf::from("/tmp/removed-worktree"),
             session_id: "session-id".into(),
@@ -871,6 +924,7 @@ mod tests {
         });
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
         let input = SessionDiffTaskInput {
+            cancellation: CancellationToken::new(),
             app_event_tx,
             folder: PathBuf::from("/tmp/removed-worktree"),
             session_id: "session-id".into(),
@@ -915,6 +969,7 @@ mod tests {
         });
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
         let input = SessionDiffTaskInput {
+            cancellation: CancellationToken::new(),
             app_event_tx,
             folder: PathBuf::from("/tmp/removed-worktree"),
             session_id: "session-id".into(),
@@ -958,6 +1013,7 @@ mod tests {
         });
         let (app_event_tx, mut app_event_rx) = mpsc::unbounded_channel();
         let input = SessionDiffTaskInput {
+            cancellation: CancellationToken::new(),
             app_event_tx,
             folder: PathBuf::from("/tmp/live-worktree"),
             session_id: "session-id".into(),

--- a/crates/agentty/src/presentation/prompt.rs
+++ b/crates/agentty/src/presentation/prompt.rs
@@ -1,3 +1,6 @@
+use std::cell::RefCell;
+use std::sync::Arc;
+
 pub use crate::domain::composer::{
     PromptAttachment, PromptAttachmentState, PromptComposerState, PromptComposerSubmission,
     PromptHistoryState, PromptSlashStage, PromptSlashState, PromptSuggestionItem,
@@ -7,15 +10,17 @@ pub use crate::domain::composer::{
     insert_prompt_local_image, insert_prompt_text, prompt_slash_option_count,
     resolve_prompt_slash_selection,
 };
-use crate::domain::file_entry::FileEntry;
+use crate::domain::file_entry::{self, FileEntry};
 
 /// UI state for prompt `@` file and directory mention selection.
 #[derive(Clone, Debug)]
 pub struct PromptAtMentionState {
-    /// Cached list of all files and directories in the session directory.
-    pub all_entries: Vec<FileEntry>,
     /// Currently selected index in the filtered dropdown.
     pub selected_index: usize,
+    all_entries: Vec<FileEntry>,
+    /// One ranked query shared by input handling and painting. Replacing the
+    /// index or changing the query invalidates it; selection does not.
+    ranked_entries: RefCell<Option<(String, Arc<[FileEntry]>)>>,
 }
 
 impl PromptAtMentionState {
@@ -25,6 +30,73 @@ impl PromptAtMentionState {
         Self {
             all_entries,
             selected_index: 0,
+            ranked_entries: RefCell::new(None),
         }
+    }
+
+    /// Replaces the file index and invalidates selection and ranked results.
+    pub fn replace_entries(&mut self, entries: Vec<FileEntry>) {
+        self.all_entries = entries;
+        self.selected_index = 0;
+        *self.ranked_entries.get_mut() = None;
+    }
+
+    /// Returns shared ranked results without repeating search on redraws.
+    #[must_use]
+    pub fn filtered_entries(&self, query: &str) -> Arc<[FileEntry]> {
+        let mut cached = self.ranked_entries.borrow_mut();
+        if let Some((cached_query, entries)) = cached.as_ref()
+            && cached_query == query
+        {
+            return Arc::clone(entries);
+        }
+
+        let entries: Arc<[FileEntry]> = file_entry::filter_entries(&self.all_entries, query)
+            .into_iter()
+            .cloned()
+            .collect();
+        *cached = Some((query.to_string(), Arc::clone(&entries)));
+
+        entries
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ranked_results_survive_selection_and_invalidate_on_query_or_index_change() {
+        // Arrange
+        let mut state = PromptAtMentionState::new(vec![
+            FileEntry {
+                is_dir: false,
+                path: "src/main.rs".into(),
+            },
+            FileEntry {
+                is_dir: false,
+                path: "README.md".into(),
+            },
+        ]);
+
+        // Act
+        let initial = state.filtered_entries("main");
+        state.selected_index = 1;
+        let redraw = state.filtered_entries("main");
+        let changed_query = state.filtered_entries("README");
+        state.replace_entries(vec![FileEntry {
+            is_dir: false,
+            path: "main.txt".into(),
+        }]);
+        let changed_index = state.filtered_entries("main");
+
+        // Assert
+        assert!(Arc::ptr_eq(&initial, &redraw));
+        assert_eq!(initial[0].path, "src/main.rs");
+        assert_eq!(changed_query[0].path, "README.md");
+        assert_eq!(changed_index[0].path, "main.txt");
+        assert_eq!(state.selected_index, 0);
+        assert!(state.filtered_entries("missing").is_empty());
+        assert_eq!(state.filtered_entries("").len(), 1);
     }
 }

--- a/crates/agentty/src/runtime/mode/at_mention.rs
+++ b/crates/agentty/src/runtime/mode/at_mention.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
 #[cfg(test)]
 use at_mention_task::clear_pending_load;
@@ -8,7 +9,7 @@ use tokio::sync::mpsc;
 use crate::app::at_mention_task;
 use crate::app::session::SessionManager;
 use crate::app::{AppEvent, TaskService};
-use crate::domain::file_entry::{FileEntry, filter_entries};
+use crate::domain::file_entry::FileEntry;
 use crate::domain::input::InputState;
 use crate::domain::session::SessionId;
 use crate::presentation::prompt::PromptAtMentionState;
@@ -98,7 +99,7 @@ pub(crate) fn selected_replacement(
     at_mention_state: &PromptAtMentionState,
 ) -> Option<AtMentionSelection> {
     let (at_start, query) = input.at_mention_query()?;
-    let filtered = filter_entries(&at_mention_state.all_entries, &query);
+    let filtered = at_mention_state.filtered_entries(&query);
     let clamped_index = at_mention_state
         .selected_index
         .min(filtered.len().saturating_sub(1));
@@ -111,13 +112,13 @@ pub(crate) fn selected_replacement(
 }
 
 /// Returns the filtered `@`-mention entries for the current input query.
-fn filtered_entries<'a>(
+fn filtered_entries(
     input: &InputState,
-    at_mention_state: &'a PromptAtMentionState,
-) -> Option<Vec<&'a FileEntry>> {
+    at_mention_state: &PromptAtMentionState,
+) -> Option<Arc<[FileEntry]>> {
     let (_, query) = input.at_mention_query()?;
 
-    Some(filter_entries(&at_mention_state.all_entries, &query))
+    Some(at_mention_state.filtered_entries(&query))
 }
 
 /// Formats one selected file or directory entry for insertion into the input.

--- a/crates/agentty/src/runtime/mode/diff.rs
+++ b/crates/agentty/src/runtime/mode/diff.rs
@@ -1297,9 +1297,10 @@ mod tests {
         slash_state.selected_index = 2;
 
         PromptModeSnapshot {
-            at_mention_state: Some(PromptAtMentionState {
-                all_entries: vec![prompt_mention_entry()],
-                selected_index: 1,
+            at_mention_state: Some({
+                let mut state = PromptAtMentionState::new(vec![prompt_mention_entry()]);
+                state.selected_index = 1;
+                state
             }),
             attachment_state,
             history_state,
@@ -1352,7 +1353,10 @@ mod tests {
             .as_ref()
             .expect("at-mention state must survive leaving diff");
         assert_eq!(at_mention_state.selected_index, 1);
-        assert_eq!(at_mention_state.all_entries, vec![prompt_mention_entry()]);
+        assert_eq!(
+            at_mention_state.filtered_entries("").as_ref(),
+            &[prompt_mention_entry()]
+        );
     }
 
     #[tokio::test]

--- a/crates/agentty/src/ui/prompt_format.rs
+++ b/crates/agentty/src/ui/prompt_format.rs
@@ -3,7 +3,6 @@
 use ratatui::text::Line;
 
 use crate::domain::agent::AgentKind;
-use crate::domain::file_entry::filter_entries;
 use crate::presentation::app_mode::ChatFocus;
 use crate::presentation::help_action;
 use crate::presentation::prompt::{
@@ -147,7 +146,7 @@ pub(crate) fn file_lookup_suggestion_list(
     max_visible: usize,
 ) -> Option<SuggestionList> {
     let (_, query) = crate::domain::input::extract_at_mention_query(input_text, cursor)?;
-    let filtered = filter_entries(&at_mention_state.all_entries, &query);
+    let filtered = at_mention_state.filtered_entries(&query);
 
     if filtered.is_empty() {
         return None;

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -9151,6 +9151,46 @@ fn test_worktree_open_reenables_diff_action() -> E2eResult {
     Ok(())
 }
 
+/// Slow checkout hooks must not hold the foreground input loop.
+#[test]
+fn test_slow_draft_start_keeps_navigation_responsive() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("slow_draft_start_keeps_navigation_responsive")
+        .with_git()
+        .setup(|env| {
+            let hook = env.workdir.join(".git/hooks/post-checkout");
+            std::fs::write(&hook, "#!/bin/sh\nsleep 10\n")?;
+            std::fs::set_permissions(hook, std::fs::Permissions::from_mode(0o750))?;
+            Ok(())
+        })
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("a")
+                    .wait_for_text("Regular", 5000)
+                    .press_key("Down")
+                    .press_key("Enter")
+                    .wait_for_text("Enter: stage draft", 5000)
+                    .write_text("Slow worktree preparation")
+                    .press_key("Enter")
+                    .wait_for_text("s: start", 5000)
+                    .press_key("s")
+                    .press_key("q")
+                    .wait_for_text("new session", 2000)
+                    .press_key("?")
+                    .wait_for_text("Help", 2000)
+            },
+            |frame, _report| {
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Help", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
 /// Verify that a slow full diff leaves redraw and input handling responsive.
 #[test]
 fn test_slow_diff_loading_remains_cancelable() -> E2eResult {

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -51,9 +51,9 @@ flowchart TD
   db["ag-store Database::open()<br/>WAL + keys + migrations"]
   app_new["App::new()"]
   model_migration["Migrate active retired models<br/>across saved projects"]
-  scan["Startup-only home-directory project scan<br/>then project/session snapshot load"]
+  scan["Saved project/session snapshot load"]
   fail_ops["Fail unfinished operations from previous run"]
-  background["Spawn app background tasks"]
+  background["Spawn app background tasks<br/>including project discovery"]
   runtime["runtime::run(&mut app)"]
   terminal["terminal::setup_terminal()"]
   event_reader["event::spawn_event_reader()<br/>dedicated OS thread"]
@@ -115,6 +115,23 @@ instead of returning an ambiguous error that could prompt duplicate creation.
   lag.
 - Tick interval is `50ms`; metadata-based session reload fallback is `5s`.
 
+Draft worktree preparation runs inside the serialized session worker before its first
+agent turn. The foreground can continue handling input while checkout runs. Preparation
+shares the turn cancellation token and reports failures through the turn finalizer. The
+first prompt enters the transcript only after draft preparation succeeds, so failed
+attempts can retry the staged bundle without duplicating provider replay history. The
+worker renews the turn token before operation preflight and retains it through setup and
+provider execution. Preparation checks cancellation again after acquiring the branch
+lock. Cancellation signals use live session handles even before the render snapshot
+refreshes. Terminal cancellation cleanup waits for branch work to release its lock, then
+checks for a worktree so a checkout created during cancellation is also removed.
+
+File-mention ranking caches one query per dropdown. Input selection and rendering share
+the ranked result; replacing the file index or changing the query invalidates it.
+
+Background sync probes run with bounded concurrency. Manual sync interrupts an active
+read-only refresh pass; mutating sync operations remain serialized.
+
 ## Data Channels
 
 <a id="architecture-runtime-flow-channels"></a> Agentty uses five primary runtime data
@@ -147,26 +164,35 @@ ordered effects that must run before cached snapshot updates from effects that c
 the resulting snapshot afterward. Reload effects currently run before snapshot updates;
 focused-review state application and persistence run afterward. Key behaviors:
 
-- Refresh events set reload flags instead of reloading inline; the expensive
-  home-directory project discovery runs only during `App::new()`.
+- Refresh events set reload flags instead of reloading inline; home-directory project
+  discovery runs once in the background after loading the saved catalog. Recurring
+  session refreshes coalesce into one background snapshot load; the foreground applies
+  completed snapshots only for the current project and detail view, preserving live
+  handles and selection. Session creation retains immediate snapshot visibility before
+  returning its identifier.
 - Git-status and review-request events carry a sync-context generation so stale
   completions are discarded after the active project or session changes.
 - Diff markdown preview reads carry the selected session, path, and request generation
   in `AppEvent::DiffPreviewLoaded`; the reducer applies them only to the matching
   loading diff or help-overlay snapshot.
 - Full session diffs used by Diff view, focused-review preparation, and `/apply`
-  validation run in background tasks. `AppEvent::SessionDiffLoaded` carries the session
-  and request generation; the reducer discards canceled or superseded completions, so
-  Git work never blocks terminal redraw or input handling. Automatic review checks start
-  only from completed-turn and session-status events, not unrelated per-session updates.
-  A completed turn supersedes pending review and `/apply` diff continuations before
-  queued diff results are reduced, and repeated `/apply` checks are deduplicated per
-  session. Clearing or regenerating focused review also invalidates pending `/apply`
-  continuations, whose completions revalidate the current review-ready cache generation
-  before submitting an agent turn. Sessions in `Auto Edit + Auto Address Comments` reuse
-  this continuation automatically when a ready review has actionable suggestions. Each
-  resulting turn re-enters focused review, and an in-memory per-user-prompt counter
-  stops automatic application after three turns.
+  validation run in background tasks. Dropping a pending request cancels its task and
+  active Git subprocess; repeated requests for the open loading view reuse its request.
+  Index discovery and temporary-index commands preserve native path bytes. Index copies
+  have bounded concurrency and serialize repeated copies of the same path. A canceled
+  blocking copy retains its slot until filesystem I/O finishes; queued callers remain
+  cancelable, and waiting for a copy has a deadline. `AppEvent::SessionDiffLoaded`
+  carries the session and request generation; the reducer discards canceled or
+  superseded completions, so Git work never blocks terminal redraw or input handling.
+  Automatic review checks start only from completed-turn and session-status events, not
+  unrelated per-session updates. A completed turn supersedes pending review and `/apply`
+  diff continuations before queued diff results are reduced, and repeated `/apply`
+  checks are deduplicated per session. Clearing or regenerating focused review also
+  invalidates pending `/apply` continuations, whose completions revalidate the current
+  review-ready cache generation before submitting an agent turn. Sessions in
+  `Auto Edit + Auto Address Comments` reuse this continuation automatically when a ready
+  review has actionable suggestions. Each resulting turn re-enters focused review, and
+  an in-memory per-user-prompt counter stops automatic application after three turns.
 - Externally merged review requests transition sessions to read-only `Merged`; only a
   successful user-triggered sync of the request's local target advances them to `Done`.
   Closed requests transition editable sessions to `Canceled`.

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -11,6 +11,11 @@ For keyboard shortcuts by view, see [Keybindings](@/docs/usage/keybindings.md).
 
 <!-- more -->
 
+Starting a staged session prepares its worktree in the background. You can continue
+navigating while preparation runs. Preparation errors appear in the session output and
+return the session to `Draft`, preserving its staged prompt and attachments for retry.
+Retrying adds the prompt to the conversation once preparation succeeds.
+
 ## Interface Layout
 
 <a id="usage-interface-layout"></a> Agentty organizes its interface into six primary


### PR DESCRIPTION
- Move Git inspection, project discovery, session refreshes, draft preparation, and sync probes off the foreground path with cancellation and bounded concurrency.
- Preserve draft retry state, live session updates, selection, native Git paths, and cleanup across failures, cancellation, and context changes.
- Cache file-mention rankings and cover responsive workflows with end-to-end tests.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)