### PR TITLE
Resume fallback preserves replacement continuations

### DIFF
--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -57,7 +57,9 @@ requires `Harness::repository()`.
 External providers implement the single `Model` trait and return `ModelCompletion`. They
 receive the complete ordered history in `ModelRequest::messages()`. A provider may also
 return an opaque continuation identifier; if native resume is unavailable, the harness
-retries once using the SQLite history.
+retries once using the SQLite history and retains any replacement continuation returned
+by that replay.
 
 Attach `Harness::with_lifecycle_observer()` for content-free turn, model, and tool
-events. `TurnOutcome::report()` contains the same sanitized activity summary.
+events. The rejected resume and replay are separate model attempts in lifecycle events
+and `TurnOutcome::report()`.

--- a/crates/ag-harness/src/chat_completion.rs
+++ b/crates/ag-harness/src/chat_completion.rs
@@ -334,12 +334,14 @@ impl ChatCompletionBackend {
             error @ ChatCompletionError::InvalidResponse(_) => {
                 model::ModelError::classified_request(
                     model::ModelErrorType::InvalidProviderResponse,
+                    None,
                     error.into(),
                 )
             }
             ChatCompletionError::ResponseBodyTooLarge => model::ModelError::ResponseBodyTooLarge,
             error @ ChatCompletionError::Transport(_) => model::ModelError::classified_request(
                 model::ModelErrorType::Transport,
+                None,
                 error.into(),
             ),
         }

--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -78,7 +78,7 @@ impl TurnReport {
     }
 }
 
-/// Observable facts about one successful provider request.
+/// Observable facts about one provider request in a successful turn.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ModelRequestActivity {
     completion: Option<CompletionMetadata>,
@@ -97,7 +97,8 @@ impl ModelRequestActivity {
         self.duration
     }
 
-    /// Returns whether the request produced output or a tool call.
+    /// Returns whether the request produced output, a tool call, or a rejected
+    /// native continuation that the harness replayed.
     pub fn response_type(&self) -> crate::lifecycle::ModelResponseType {
         self.response_type
     }
@@ -644,16 +645,15 @@ impl Harness {
         let mut tool_calls = Vec::new();
 
         loop {
-            let (response, activity, provider_session_id, native_resume_rejected) = self
+            let (response, activities, provider_session_id, native_resume_rejected) = self
                 .complete_model_request(&request, model_request_index, turn_id)
                 .await?;
-            if native_resume_rejected {
-                request.set_provider_session_id(None);
-            } else if provider_session_id.is_some() {
+            if native_resume_rejected || provider_session_id.is_some() {
                 request.set_provider_session_id(provider_session_id);
             }
-            model_requests.push(activity);
-            model_request_index += 1;
+            model_request_index = model_request_index
+                .saturating_add(u64::try_from(activities.len()).unwrap_or(u64::MAX));
+            model_requests.extend(activities);
 
             match response {
                 ModelResponse::Output(output) => {
@@ -750,45 +750,87 @@ impl Harness {
         request: &ModelRequest,
         model_request_index: u64,
         turn_id: Option<LifecycleId>,
-    ) -> Result<(ModelResponse, ModelRequestActivity, Option<String>, bool), TurnError> {
+    ) -> Result<
+        (
+            ModelResponse,
+            Vec<ModelRequestActivity>,
+            Option<String>,
+            bool,
+        ),
+        TurnError,
+    > {
+        let native_resume = request.provider_session_id().is_some();
+        match self
+            .complete_model_attempt(request.clone(), model_request_index, turn_id)
+            .await
+        {
+            Ok((response, activity, provider_session_id)) => {
+                Ok((response, vec![activity], provider_session_id, false))
+            }
+            Err(ModelAttemptError {
+                duration,
+                error: ModelError::ResumeUnavailable,
+            }) if native_resume => {
+                let rejected_activity = ModelRequestActivity {
+                    completion: None,
+                    duration,
+                    response_type: crate::lifecycle::ModelResponseType::ResumeUnavailable,
+                };
+                let mut replay_request = request.clone();
+                replay_request.set_provider_session_id(None);
+                let replay_index = model_request_index.saturating_add(1);
+                match self
+                    .complete_model_attempt(replay_request, replay_index, turn_id)
+                    .await
+                {
+                    Ok((response, replay_activity, provider_session_id)) => Ok((
+                        response,
+                        vec![rejected_activity, replay_activity],
+                        provider_session_id,
+                        true,
+                    )),
+                    Err(failure) => Err(ResumeFailure::Replay {
+                        source: failure.error,
+                    }
+                    .into_model_error()
+                    .into()),
+                }
+            }
+            Err(failure) if native_resume => Err(ResumeFailure::Native {
+                source: failure.error,
+            }
+            .into_model_error()
+            .into()),
+            Err(failure) => Err(failure.error.into()),
+        }
+    }
+
+    async fn complete_model_attempt(
+        &self,
+        request: ModelRequest,
+        model_request_index: u64,
+        turn_id: Option<LifecycleId>,
+    ) -> Result<(ModelResponse, ModelRequestActivity, Option<String>), ModelAttemptError> {
         let started_at = Instant::now();
         let model_lifecycle =
             self.lifecycle
                 .start_model_request(self.model.metadata(), model_request_index, turn_id);
-        let operation = async {
-            match self.model.complete(request.clone()).await {
-                Err(ModelError::ResumeUnavailable) if request.provider_session_id().is_some() => {
-                    let mut replay_request = request.clone();
-                    replay_request.set_provider_session_id(None);
-                    self.model
-                        .complete(replay_request)
-                        .await
-                        .map(|completion| (completion, true))
-                }
-                result => result.map(|completion| (completion, false)),
-            }
-        };
+        let operation = self.model.complete(request.clone());
         let completion = match model_lifecycle.as_ref() {
             Some(model_lifecycle) => model_lifecycle.scope(operation).await,
             None => operation.await,
         };
-        let (response, completion, provider_session_id, native_resume_rejected) = match completion {
-            Ok((completion, native_resume_rejected)) => {
-                let (response, completion, provider_session_id) = completion.into_parts();
-
-                (
-                    response,
-                    completion,
-                    provider_session_id,
-                    native_resume_rejected,
-                )
-            }
+        let (response, completion, provider_session_id) = match completion {
+            Ok(completion) => completion.into_parts(),
             Err(error) => {
                 if let Some(model_lifecycle) = model_lifecycle {
                     model_lifecycle.failed(error.error_type(), error.http_status());
                 }
 
-                return Err(error.into());
+                return Err(ModelAttemptError {
+                    duration: started_at.elapsed(),
+                    error,
+                });
             }
         };
         if let Some(output) = response.output()
@@ -799,7 +841,10 @@ impl Harness {
                 model_lifecycle.failed(error.error_type(), error.http_status());
             }
 
-            return Err(error.into());
+            return Err(ModelAttemptError {
+                duration: started_at.elapsed(),
+                error,
+            });
         }
         let response_type = response.response_type();
         let activity = ModelRequestActivity {
@@ -811,12 +856,7 @@ impl Harness {
             model_lifecycle.completed(completion, response_type);
         }
 
-        Ok((
-            response,
-            activity,
-            provider_session_id,
-            native_resume_rejected,
-        ))
+        Ok((response, activity, provider_session_id))
     }
 
     async fn execute_tool_call(
@@ -945,6 +985,42 @@ impl TurnError {
 enum ToolExecution<'a> {
     Read(&'a ReadTool, &'a ReadArguments),
     Write(&'a WriteTool, &'a WriteArguments),
+}
+
+struct ModelAttemptError {
+    duration: Duration,
+    error: ModelError,
+}
+
+#[derive(Debug, Error)]
+enum ResumeFailure {
+    #[error("native provider continuation failed: {source}")]
+    Native {
+        #[source]
+        source: ModelError,
+    },
+    #[error("native provider continuation was unavailable and history replay failed: {source}")]
+    Replay {
+        #[source]
+        source: ModelError,
+    },
+}
+
+impl ResumeFailure {
+    fn into_model_error(self) -> ModelError {
+        let source = match &self {
+            Self::Native { source } | Self::Replay { source } => source,
+        };
+        if !matches!(source, ModelError::Request(_)) {
+            return match self {
+                Self::Native { source } | Self::Replay { source } => source,
+            };
+        }
+        let error_type = source.error_type();
+        let http_status = source.http_status();
+
+        ModelError::classified_request(error_type, http_status, Box::new(self))
+    }
 }
 
 async fn execute_tool(execution: ToolExecution<'_>) -> Result<(String, ToolActivity), TurnError> {
@@ -1175,6 +1251,59 @@ mod tests {
         model
     }
 
+    fn resume_fallback_model() -> crate::model::MockModel {
+        let mut model = model();
+        let mut sequence = Sequence::new();
+        model
+            .expect_complete()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .withf(|request| request.provider_session_id().is_none())
+            .returning(|_| {
+                Ok(response_without_metadata(ModelResponse::Output(json!({
+                    "summary": "first"
+                })))
+                .with_provider_session_id("native-session"))
+            });
+        model
+            .expect_complete()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .withf(|request| request.provider_session_id() == Some("native-session"))
+            .returning(|_| Err(ModelError::ResumeUnavailable));
+        model
+            .expect_complete()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .withf(|request| {
+                request.provider_session_id().is_none()
+                    && request.messages()
+                        == [
+                            ModelMessage::User("first".to_string()),
+                            ModelMessage::Assistant(r#"{"summary":"first"}"#.to_string()),
+                            ModelMessage::User("second".to_string()),
+                        ]
+            })
+            .returning(|_| {
+                Ok(response_without_metadata(ModelResponse::Output(json!({
+                    "summary": "second"
+                })))
+                .with_provider_session_id("replacement-session"))
+            });
+        model
+            .expect_complete()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .withf(|request| request.provider_session_id() == Some("replacement-session"))
+            .returning(|_| {
+                Ok(response_without_metadata(ModelResponse::Output(json!({
+                    "summary": "third"
+                }))))
+            });
+
+        model
+    }
+
     fn object_schema() -> OutputSchema {
         OutputSchema::new(json!({
             "type": "object",
@@ -1223,6 +1352,14 @@ mod tests {
 
     fn response_without_metadata(response: ModelResponse) -> crate::ModelCompletion {
         crate::ModelCompletion::from_response(response)
+    }
+
+    fn request_error_with_http_status(status: u16) -> ModelError {
+        ModelError::classified_request(
+            crate::ModelErrorType::Provider,
+            Some(status),
+            io::Error::other("provider request failed").into(),
+        )
     }
 
     fn response_with_metadata(response: ModelResponse) -> crate::ModelCompletion {
@@ -2169,7 +2306,12 @@ mod tests {
             .times(1)
             .in_sequence(&mut sequence)
             .withf(|request| request.provider_session_id() == Some("native-session"))
-            .returning(|_| Err(ModelError::InvalidResponse));
+            .returning(|_| {
+                Err(ModelError::SchemaViolation {
+                    path: "/summary".to_string(),
+                    reason: "required property is missing".to_string(),
+                })
+            });
         model
             .expect_complete()
             .times(1)
@@ -2217,54 +2359,27 @@ mod tests {
 
         // Assert
         assert!(matches!(
-            error,
-            SessionError::Turn(TurnError::Model(ModelError::InvalidResponse))
+            &error,
+            SessionError::Turn(TurnError::Model(ModelError::SchemaViolation { path, reason }))
+                if path == "/summary" && reason == "required property is missing"
         ));
         assert_eq!(recovered.output(), &json!({"summary": "recovered"}));
     }
 
     #[tokio::test]
-    async fn session_replays_sqlite_history_when_native_resume_is_unavailable() {
+    async fn session_accounts_for_resume_fallback_and_persists_its_continuation() {
         // Arrange
         let directory = tempdir().expect("temporary directory should be created");
-        let mut model = model();
-        let mut sequence = Sequence::new();
-        model
-            .expect_complete()
-            .times(1)
-            .in_sequence(&mut sequence)
-            .withf(|request| request.provider_session_id().is_none())
-            .returning(|_| {
-                Ok(response_without_metadata(ModelResponse::Output(json!({
-                    "summary": "first"
-                })))
-                .with_provider_session_id("native-session"))
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let observed_events = Arc::clone(&events);
+        let harness = Harness::new(resume_fallback_model())
+            .database(directory.path().join("harness.db"))
+            .with_lifecycle_observer(move |event| {
+                observed_events
+                    .lock()
+                    .expect("event recorder should not be poisoned")
+                    .push(event);
             });
-        model
-            .expect_complete()
-            .times(1)
-            .in_sequence(&mut sequence)
-            .withf(|request| request.provider_session_id() == Some("native-session"))
-            .returning(|_| Err(ModelError::ResumeUnavailable));
-        model
-            .expect_complete()
-            .times(1)
-            .in_sequence(&mut sequence)
-            .withf(|request| {
-                request.provider_session_id().is_none()
-                    && request.messages()
-                        == [
-                            ModelMessage::User("first".to_string()),
-                            ModelMessage::Assistant(r#"{"summary":"first"}"#.to_string()),
-                            ModelMessage::User("second".to_string()),
-                        ]
-            })
-            .returning(|_| {
-                Ok(response_without_metadata(ModelResponse::Output(json!({
-                    "summary": "second"
-                }))))
-            });
-        let harness = Harness::new(model).database(directory.path().join("harness.db"));
         let mut session = harness
             .session("session-a", object_schema())
             .create()
@@ -2285,9 +2400,140 @@ mod tests {
             .send("second")
             .await
             .expect("history replay should succeed");
+        drop(session);
+        let mut session = harness
+            .resume("session-a")
+            .await
+            .expect("session should resume with replacement continuation");
+        let third = session
+            .send("third")
+            .await
+            .expect("replacement continuation should succeed");
 
         // Assert
         assert_eq!(outcome.output(), &json!({"summary": "second"}));
+        assert_eq!(outcome.report().model_requests().len(), 2);
+        assert_eq!(
+            outcome.report().model_requests()[0].response_type(),
+            crate::ModelResponseType::ResumeUnavailable
+        );
+        assert_eq!(
+            outcome.report().model_requests()[1].response_type(),
+            crate::ModelResponseType::Output
+        );
+        assert_eq!(third.output(), &json!({"summary": "third"}));
+        let events = events
+            .lock()
+            .expect("event recorder should not be poisoned");
+        assert!(matches!(
+            events[5].kind(),
+            crate::LifecycleEventKind::ModelRequestStarted {
+                request_index: 0,
+                ..
+            }
+        ));
+        assert!(matches!(
+            events[6].kind(),
+            crate::LifecycleEventKind::ModelRequestFailed {
+                error_type: crate::ModelErrorType::Provider,
+                ..
+            }
+        ));
+        assert!(matches!(
+            events[7].kind(),
+            crate::LifecycleEventKind::ModelRequestStarted {
+                request_index: 1,
+                ..
+            }
+        ));
+        assert!(matches!(
+            events[8].kind(),
+            crate::LifecycleEventKind::ModelRequestCompleted {
+                response_type: crate::ModelResponseType::Output,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn resume_failure_preserves_request_context_and_http_status() {
+        // Arrange
+        let failures = [
+            ResumeFailure::Native {
+                source: request_error_with_http_status(429),
+            },
+            ResumeFailure::Replay {
+                source: request_error_with_http_status(503),
+            },
+        ];
+
+        // Act
+        let errors = failures.map(ResumeFailure::into_model_error);
+
+        // Assert
+        assert_eq!(errors[0].http_status(), Some(429));
+        assert_eq!(errors[1].http_status(), Some(503));
+        assert!(
+            errors[0]
+                .to_string()
+                .starts_with("model request failed: native provider continuation failed:")
+        );
+        assert!(errors[1].to_string().starts_with(
+            "model request failed: native provider continuation was unavailable and history \
+             replay failed:"
+        ));
+    }
+
+    #[tokio::test]
+    async fn session_preserves_structured_failure_after_native_resume_fallback() {
+        // Arrange
+        let mut model = model();
+        let mut sequence = Sequence::new();
+        model
+            .expect_complete()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(|_| {
+                Ok(response_without_metadata(ModelResponse::Output(json!({
+                    "summary": "first"
+                })))
+                .with_provider_session_id("native-session"))
+            });
+        model
+            .expect_complete()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .withf(|request| request.provider_session_id() == Some("native-session"))
+            .returning(|_| Err(ModelError::ResumeUnavailable));
+        model
+            .expect_complete()
+            .times(1)
+            .in_sequence(&mut sequence)
+            .withf(|request| request.provider_session_id().is_none())
+            .returning(|_| Err(ModelError::ResponseBodyTooLarge));
+        let directory = tempdir().expect("temporary directory should be created");
+        let harness = Harness::new(model).database(directory.path().join("harness.db"));
+        let mut session = harness
+            .session("session-a", object_schema())
+            .create()
+            .await
+            .expect("session should be created");
+        session
+            .send("first")
+            .await
+            .expect("first turn should succeed");
+
+        // Act
+        let error = session
+            .send("second")
+            .await
+            .expect_err("history replay should fail");
+
+        // Assert
+        assert!(matches!(
+            &error,
+            SessionError::Turn(TurnError::Model(ModelError::ResponseBodyTooLarge))
+        ));
     }
 
     #[tokio::test]

--- a/crates/ag-harness/src/lifecycle.rs
+++ b/crates/ag-harness/src/lifecycle.rs
@@ -161,12 +161,14 @@ pub enum LifecycleEventKind {
     },
 }
 
-/// Shape of a successful provider-neutral model response.
+/// Observable outcome of one provider-neutral model request.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ModelResponseType {
     /// Terminal, schema-validated structured output.
     Output,
+    /// Native continuation was unavailable and the request was replayed.
+    ResumeUnavailable,
     /// An intermediate native tool request.
     ToolCall,
 }
@@ -175,6 +177,7 @@ impl fmt::Display for ModelResponseType {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Output => formatter.write_str("output"),
+            Self::ResumeUnavailable => formatter.write_str("resume unavailable"),
             Self::ToolCall => formatter.write_str("tool call"),
         }
     }
@@ -822,13 +825,17 @@ mod tests {
     #[test]
     fn model_response_types_have_stable_display_names() {
         // Arrange
-        let response_types = [ModelResponseType::Output, ModelResponseType::ToolCall];
+        let response_types = [
+            ModelResponseType::Output,
+            ModelResponseType::ResumeUnavailable,
+            ModelResponseType::ToolCall,
+        ];
 
         // Act
         let display_names = response_types.map(|response_type| response_type.to_string());
 
         // Assert
-        assert_eq!(display_names, ["output", "tool call"]);
+        assert_eq!(display_names, ["output", "resume unavailable", "tool call"]);
     }
 
     fn recording_emitter() -> (LifecycleEmitter, Arc<Mutex<Vec<LifecycleEvent>>>) {

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -848,6 +848,7 @@ impl ModelErrorType {
 #[error("{source}")]
 struct ClassifiedRequestError {
     error_type: ModelErrorType,
+    http_status: Option<u16>,
     #[source]
     source: Box<dyn Error + Send + Sync>,
 }
@@ -908,7 +909,12 @@ impl ModelError {
         match self {
             Self::Request(source) => source
                 .downcast_ref::<ProviderRequestError>()
-                .map(|error| error.status.as_u16()),
+                .map(|error| error.status.as_u16())
+                .or_else(|| {
+                    source
+                        .downcast_ref::<ClassifiedRequestError>()
+                        .and_then(|error| error.http_status)
+                }),
             _ => None,
         }
     }
@@ -929,9 +935,14 @@ impl ModelError {
 
     pub(crate) fn classified_request(
         error_type: ModelErrorType,
+        http_status: Option<u16>,
         source: Box<dyn Error + Send + Sync>,
     ) -> Self {
-        Self::Request(Box::new(ClassifiedRequestError { error_type, source }))
+        Self::Request(Box::new(ClassifiedRequestError {
+            error_type,
+            http_status,
+            source,
+        }))
     }
 }
 
@@ -1661,10 +1672,11 @@ mod tests {
     }
 
     #[test]
-    fn classified_request_retains_source_and_type() {
+    fn classified_request_retains_source_type_and_status() {
         // Arrange
         let error = ModelError::classified_request(
             ModelErrorType::Transport,
+            Some(503),
             io::Error::other("connection reset").into(),
         );
 
@@ -1675,7 +1687,7 @@ mod tests {
 
         // Assert
         assert_eq!(error.error_type(), ModelErrorType::Transport);
-        assert_eq!(error.http_status(), None);
+        assert_eq!(error.http_status(), Some(503));
         assert_eq!(source.to_string(), "connection reset");
     }
 

--- a/crates/ag-harness/tests/public_api.rs
+++ b/crates/ag-harness/tests/public_api.rs
@@ -9,7 +9,8 @@ use ag_harness::{
     CompletionMetadata, CompletionUsage, FileSystem, Harness, LifecycleEventKind, LifecycleMetrics,
     LifecycleObserverSet, LifecycleTraceObserver, Model, ModelCompletion, ModelConfiguration,
     ModelError, ModelMessage, ModelMetadata, ModelProvider, ModelRequest, ModelResponse,
-    OutputSchema, OutputSchemaError, SessionError, SessionInfo, Tool, ToolCall, TurnError,
+    ModelResponseType, OutputSchema, OutputSchemaError, SessionError, SessionInfo, Tool, ToolCall,
+    TurnError,
 };
 use async_trait::async_trait;
 use serde_json::json;
@@ -271,6 +272,18 @@ async fn external_tool_call_still_requires_harness_permission() -> Result<(), Bo
     assert!(matches!(result, Err(TurnError::ToolDenied { name }) if name == "read"));
 
     Ok(())
+}
+
+#[test]
+fn external_consumer_can_inspect_resume_fallback_outcome() {
+    // Arrange
+    let response_type = ModelResponseType::ResumeUnavailable;
+
+    // Act
+    let response_type = response_type.to_string();
+
+    // Assert
+    assert_eq!(response_type, "resume unavailable");
 }
 
 struct ExternalModel;

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -60,9 +60,12 @@ excluded from replay when the configured byte budget is exceeded.
 On resume, the harness validates the stored model identity and restores completed
 history. If a completion includes a provider session identifier, the next request also
 offers it to the adapter. `ModelError::ResumeUnavailable` causes one retry with the
-provider identifier removed and the same SQLite history retained. Any failed turn clears
-the stored provider identifier because the harness cannot know whether the remote
-conversation advanced before the failure.
+provider identifier removed and the same SQLite history retained. The rejected native
+resume and the replay are reported as separate provider attempts. A successful replay
+replaces the stored continuation identifier with the one it returns, or clears the
+identifier when it returns none. Any failed turn clears the stored provider identifier
+because the harness cannot know whether the remote conversation advanced before the
+failure.
 
 ## Concurrency
 


### PR DESCRIPTION
- Reports rejected native resumes and history replays as separate model attempts, including resume-unavailable lifecycle outcomes.
- Retains continuation identifiers returned by replay and clears them when replay returns none.
- Preserves structured model errors while retaining request classifications and HTTP statuses through native-resume and replay failures.