### PR TITLE
Strengthens durable session lifecycle handling

### DIFF
--- a/crates/ag-harness/Cargo.toml
+++ b/crates/ag-harness/Cargo.toml
@@ -41,6 +41,7 @@ opentelemetry-otlp.workspace = true
 opentelemetry-proto.workspace = true
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 prost.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 wiremock.workspace = true
 
 [lints]

--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -300,6 +300,7 @@ impl Session<'_> {
     pub async fn send(&mut self, prompt: impl Into<String>) -> Result<TurnOutcome, SessionError> {
         let prompt = prompt.into();
         let AcquiredTurn {
+            mut guard,
             provider_session_id,
             turn_position,
             turns,
@@ -313,27 +314,52 @@ impl Session<'_> {
         let retained_messages = messages.len();
         let mut request = ModelRequest::with_history(messages, prompt, self.schema.clone());
         request.set_provider_session_id(self.provider_session_id.clone());
-        let result = self.harness.run_request(request).await;
+        let result = tokio::select! {
+            biased;
+            error = guard.ownership_failure() => {
+                guard.mark_interrupted();
+
+                return Err(error);
+            }
+            result = self.harness.run_request(request) => result,
+        };
         let (outcome, mut messages, provider_session_id) = match result {
             Ok(result) => result,
             Err(error) => {
                 self.provider_session_id = None;
-                self.database
+                let persistence = self
+                    .database
                     .fail_turn(&self.id, turn_position, &error)
-                    .await?;
+                    .await;
+                if let Err(persistence) = persistence {
+                    guard.mark_interrupted();
+
+                    return Err(SessionError::TurnPersistence {
+                        turn: error,
+                        persistence: Box::new(persistence),
+                    });
+                }
+                guard.disarm();
 
                 return Err(error.into());
             }
         };
         let turn = messages.split_off(retained_messages);
-        self.database
+        let persistence = self
+            .database
             .complete_turn(
                 &self.id,
                 turn_position,
                 &turn[1..],
                 provider_session_id.as_deref(),
             )
-            .await?;
+            .await;
+        if let Err(error) = persistence {
+            guard.mark_interrupted();
+
+            return Err(error);
+        }
+        guard.disarm();
         self.provider_session_id = provider_session_id;
         self.history.push(turn);
 
@@ -1244,14 +1270,16 @@ fn sanitize_report_text(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use std::io::{self, Cursor};
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::Mutex;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
 
     use async_trait::async_trait;
     use mockall::Sequence;
     use serde_json::json;
     use tempfile::tempdir;
+    use tokio::io::AsyncRead;
+    use tokio::sync::Notify;
 
     use super::*;
     use crate::file_system::MockFileSystem;
@@ -1410,6 +1438,190 @@ mod tests {
                 "summary": "done"
             }))))
         }
+    }
+
+    struct PendingModel {
+        started: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl Model for PendingModel {
+        async fn complete(
+            &self,
+            _request: ModelRequest,
+        ) -> Result<crate::ModelCompletion, ModelError> {
+            self.started.notify_one();
+            std::future::pending().await
+        }
+    }
+
+    struct PendingToolFileSystem {
+        started: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl FileSystem for PendingToolFileSystem {
+        async fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+            if path == Path::new("repo") {
+                Ok(PathBuf::from("/repo"))
+            } else {
+                Ok(PathBuf::from("/repo/Cargo.toml"))
+            }
+        }
+
+        async fn open_beneath(
+            &self,
+            _root: &Path,
+            _path: &Path,
+        ) -> io::Result<Box<dyn AsyncRead + Send + Unpin>> {
+            self.started.notify_one();
+            std::future::pending().await
+        }
+
+        async fn replace_beneath(
+            &self,
+            _root: &Path,
+            _path: &Path,
+            _expected: Option<Vec<u8>>,
+            _content: Vec<u8>,
+        ) -> io::Result<()> {
+            Err(io::Error::other(
+                "pending read fixture must not replace files",
+            ))
+        }
+    }
+
+    struct LeaseExpiryModel {
+        call_count: AtomicUsize,
+        release_first: Arc<Notify>,
+        started_first: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl Model for LeaseExpiryModel {
+        async fn complete(
+            &self,
+            _request: ModelRequest,
+        ) -> Result<crate::ModelCompletion, ModelError> {
+            if self.call_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                self.started_first.notify_one();
+                self.release_first.notified().await;
+            }
+
+            Ok(response_without_metadata(ModelResponse::Output(json!({
+                "summary": "done"
+            }))))
+        }
+    }
+
+    struct RequestDropNotifier {
+        dropped: Arc<Notify>,
+    }
+
+    impl Drop for RequestDropNotifier {
+        fn drop(&mut self) {
+            self.dropped.notify_one();
+        }
+    }
+
+    struct LeaseOwnershipModel {
+        call_count: AtomicUsize,
+        dropped_first: Arc<Notify>,
+        started_first: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl Model for LeaseOwnershipModel {
+        async fn complete(
+            &self,
+            _request: ModelRequest,
+        ) -> Result<crate::ModelCompletion, ModelError> {
+            if self.call_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                let _drop_notifier = RequestDropNotifier {
+                    dropped: Arc::clone(&self.dropped_first),
+                };
+                self.started_first.notify_one();
+                std::future::pending::<()>().await;
+            }
+
+            Ok(response_without_metadata(ModelResponse::Output(json!({
+                "summary": "done"
+            }))))
+        }
+    }
+
+    async fn send_with_resumed_session(
+        harness: Arc<Harness>,
+        prompt: &'static str,
+    ) -> Result<TurnOutcome, SessionError> {
+        let mut session = harness
+            .resume("session-a")
+            .await
+            .expect("session should resume");
+
+        session.send(prompt).await
+    }
+
+    async fn wait_for_fixture(notify: &Notify, description: &str) {
+        let result = tokio::time::timeout(Duration::from_secs(5), notify.notified()).await;
+
+        assert!(result.is_ok(), "timed out waiting for {description}");
+    }
+
+    async fn stored_turn_state(database: &Database) -> (String, Option<String>) {
+        sqlx::query_as::<_, (String, Option<String>)>(
+            "SELECT status, error_type FROM session_turn ORDER BY turn_position DESC LIMIT 1",
+        )
+        .fetch_one(database.pool())
+        .await
+        .expect("stored turn state should load")
+    }
+
+    async fn wait_for_stored_turn_state(
+        database: &Database,
+        expected: &(String, Option<String>),
+    ) -> (String, Option<String>) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+
+        loop {
+            let state = stored_turn_state(database).await;
+            if &state == expected || Instant::now() >= deadline {
+                return state;
+            }
+
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    async fn stored_lease_expiry(database: &Database) -> i64 {
+        sqlx::query_scalar::<_, i64>(
+            "SELECT lease_expires_at FROM session_turn WHERE session_id = ?",
+        )
+        .bind("session-a")
+        .fetch_one(database.pool())
+        .await
+        .expect("active lease should load")
+    }
+
+    fn elapsed_timestamp(origin: i64, started_at: tokio::time::Instant) -> i64 {
+        let elapsed_seconds = i64::try_from(started_at.elapsed().as_secs()).unwrap_or(i64::MAX);
+
+        origin.saturating_add(elapsed_seconds)
+    }
+
+    async fn wait_for_lease_extension(database: &Database, previous_expiry: i64) -> Option<i64> {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let lease_expiry = stored_lease_expiry(database).await;
+                if lease_expiry > previous_expiry {
+                    return lease_expiry;
+                }
+
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .ok()
     }
 
     fn write_call(id: &str, patch: &str) -> ToolCall {
@@ -2308,6 +2520,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sequential_resumed_handles_reload_completed_canonical_history() {
+        // Arrange
+        let mut model = model();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        model.expect_complete().times(2).returning(move |request| {
+            let call_index = call_count.fetch_add(1, Ordering::SeqCst);
+            let expected = if call_index == 0 {
+                vec![ModelMessage::User("first".to_string())]
+            } else {
+                vec![
+                    ModelMessage::User("first".to_string()),
+                    ModelMessage::Assistant(r#"{"summary":"one"}"#.to_string()),
+                    ModelMessage::User("second".to_string()),
+                ]
+            };
+            assert_eq!(request.messages(), expected);
+
+            Ok(response_without_metadata(ModelResponse::Output(json!({
+                "summary": if call_index == 0 { "one" } else { "two" }
+            }))))
+        });
+        let directory = tempdir().expect("temporary directory should be created");
+        let harness = Harness::new(model).database(directory.path().join("harness.db"));
+        let mut first_handle = harness
+            .session("session-a", object_schema())
+            .create()
+            .await
+            .expect("session should be created");
+        let mut stale_handle = harness
+            .resume("session-a")
+            .await
+            .expect("second handle should resume before the first turn");
+
+        // Act
+        let first = first_handle
+            .send("first")
+            .await
+            .expect("first handle should complete its turn");
+        let second = stale_handle
+            .send("second")
+            .await
+            .expect("stale handle should reload the completed turn");
+
+        // Assert
+        assert_eq!(first.output(), &json!({"summary": "one"}));
+        assert_eq!(second.output(), &json!({"summary": "two"}));
+    }
+
+    #[tokio::test]
     async fn session_does_not_replay_a_failed_turn() {
         // Arrange
         let mut model = model();
@@ -2606,6 +2867,460 @@ mod tests {
             &error,
             SessionError::Turn(TurnError::Model(ModelError::ResponseBodyTooLarge))
         ));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancelling_a_provider_request_durably_interrupts_the_session_turn() {
+        // Arrange
+        let directory = tempdir().expect("temporary directory should be created");
+        let database_path = directory.path().join("harness.db");
+        let request_started = Arc::new(Notify::new());
+        let harness = Arc::new(
+            Harness::new(PendingModel {
+                started: Arc::clone(&request_started),
+            })
+            .database(&database_path),
+        );
+        let session = harness
+            .session("session-a", object_schema())
+            .create()
+            .await
+            .expect("session should be created");
+        drop(session);
+        let turn = tokio::spawn(send_with_resumed_session(
+            Arc::clone(&harness),
+            "pending provider request",
+        ));
+        wait_for_fixture(&request_started, "the provider request").await;
+        let database = Database::open(&database_path)
+            .await
+            .expect("database should reopen");
+        let expected_state = ("interrupted".to_string(), Some("cancelled".to_string()));
+
+        // Act
+        let cancellation = async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            turn.abort();
+
+            turn.await.expect_err("turn should be cancelled")
+        };
+        let (state, cancellation) = tokio::join!(
+            wait_for_stored_turn_state(&database, &expected_state),
+            cancellation
+        );
+
+        // Assert
+        assert!(cancellation.is_cancelled());
+        assert_eq!(state, expected_state);
+    }
+
+    #[tokio::test]
+    async fn pending_tool_file_system_rejects_replace_requests() {
+        // Arrange
+        let file_system = PendingToolFileSystem {
+            started: Arc::new(Notify::new()),
+        };
+
+        // Act
+        let error = file_system
+            .replace_beneath(Path::new("repo"), Path::new("Cargo.toml"), None, Vec::new())
+            .await
+            .expect_err("pending read fixture should reject replacement");
+
+        // Assert
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancelling_a_tool_request_durably_interrupts_the_session_turn() {
+        // Arrange
+        let directory = tempdir().expect("temporary directory should be created");
+        let database_path = directory.path().join("harness.db");
+        let tool_started = Arc::new(Notify::new());
+        let mut model = model();
+        model.expect_complete().times(1).returning(|_| {
+            Ok(response_without_metadata(ModelResponse::ToolCall(
+                read_call("pending-read"),
+            )))
+        });
+        let harness = Arc::new(
+            Harness::new(model)
+                .database(&database_path)
+                .repository("repo")
+                .allow(Tool::Read)
+                .file_system(PendingToolFileSystem {
+                    started: Arc::clone(&tool_started),
+                }),
+        );
+        let session = harness
+            .session("session-a", object_schema())
+            .create()
+            .await
+            .expect("session should be created");
+        drop(session);
+        let turn = tokio::spawn(send_with_resumed_session(
+            Arc::clone(&harness),
+            "pending tool request",
+        ));
+        wait_for_fixture(&tool_started, "the tool request").await;
+
+        // Act
+        turn.abort();
+        let cancellation = turn.await.expect_err("turn should be cancelled");
+        let database = Database::open(&database_path)
+            .await
+            .expect("database should reopen");
+        let expected_state = ("interrupted".to_string(), Some("cancelled".to_string()));
+        let state = wait_for_stored_turn_state(&database, &expected_state).await;
+
+        // Assert
+        assert!(cancellation.is_cancelled());
+        assert_eq!(state, expected_state);
+    }
+
+    #[tokio::test]
+    async fn active_session_turn_renews_its_lease_during_a_long_model_request() {
+        // Arrange
+        let timestamp_origin = 10;
+        let clock_origin = tokio::time::Instant::now();
+        let timestamp_source: Arc<dyn crate::session::TimestampSource> =
+            Arc::new(move || elapsed_timestamp(timestamp_origin, clock_origin));
+        let database = Database::open_in_memory_with_timestamp_source(timestamp_source)
+            .await
+            .expect("database should open");
+        database
+            .create_session(
+                &NewSession::new("session-a", object_schema()),
+                None,
+                DEFAULT_MAX_HISTORY_BYTES,
+            )
+            .await
+            .expect("session should be created");
+        let first_started = Arc::new(Notify::new());
+        let first_release = Arc::new(Notify::new());
+        let harness = Harness::new(LeaseExpiryModel {
+            call_count: AtomicUsize::new(0),
+            release_first: Arc::clone(&first_release),
+            started_first: Arc::clone(&first_started),
+        });
+        let mut first = Session {
+            database: database.clone(),
+            harness: &harness,
+            history: SessionHistory::new(DEFAULT_MAX_HISTORY_BYTES),
+            id: "session-a".to_string(),
+            provider_session_id: None,
+            schema: object_schema(),
+            system_prompt: None,
+        };
+        let mut second = Session {
+            database,
+            harness: &harness,
+            history: SessionHistory::new(DEFAULT_MAX_HISTORY_BYTES),
+            id: "session-a".to_string(),
+            provider_session_id: None,
+            schema: object_schema(),
+            system_prompt: None,
+        };
+
+        // Act
+        let (first_result, second_result) = tokio::join!(first.send("first"), async {
+            wait_for_fixture(&first_started, "the long model request").await;
+            tokio::task::yield_now().await;
+            let original_expiry = stored_lease_expiry(&second.database).await;
+            let lease_duration = Duration::from_secs(
+                u64::try_from(crate::session::TURN_LEASE_SECONDS)
+                    .expect("turn lease duration should be positive"),
+            );
+            let renewal_interval =
+                Duration::from_secs(crate::session::TURN_LEASE_RENEWAL_INTERVAL_SECONDS);
+            assert!(renewal_interval < lease_duration);
+            tokio::time::pause();
+            tokio::time::advance(renewal_interval).await;
+            tokio::time::resume();
+            let renewal_timestamp = elapsed_timestamp(timestamp_origin, clock_origin);
+            assert!(renewal_timestamp < original_expiry);
+            let first_renewed_expiry =
+                wait_for_lease_extension(&second.database, original_expiry).await;
+            let first_renewed_expiry =
+                first_renewed_expiry.expect("active turn should renew its lease before expiry");
+            tokio::time::pause();
+            tokio::time::advance(renewal_interval).await;
+            tokio::time::resume();
+            let next_renewal_timestamp = elapsed_timestamp(timestamp_origin, clock_origin);
+            assert!(next_renewal_timestamp < first_renewed_expiry);
+            let next_renewed_expiry =
+                wait_for_lease_extension(&second.database, first_renewed_expiry).await;
+            let next_renewed_expiry = next_renewed_expiry
+                .expect("active turn should keep renewing its lease during a long request");
+            let current_timestamp = elapsed_timestamp(timestamp_origin, clock_origin);
+            let recovery_advance = Duration::from_secs(
+                u64::try_from(
+                    first_renewed_expiry
+                        .saturating_add(1)
+                        .saturating_sub(current_timestamp),
+                )
+                .expect("first renewed lease should expire in the future"),
+            );
+            tokio::time::pause();
+            tokio::time::advance(recovery_advance).await;
+            tokio::time::resume();
+            let recovery_timestamp = elapsed_timestamp(timestamp_origin, clock_origin);
+            assert!(recovery_timestamp > first_renewed_expiry);
+            assert!(next_renewed_expiry > recovery_timestamp);
+            let result = second.send("second").await;
+            first_release.notify_one();
+
+            result
+        });
+
+        // Assert
+        first_result.expect("the lease owner should complete its turn");
+        assert!(matches!(second_result, Err(SessionError::Busy { .. })));
+    }
+
+    #[tokio::test]
+    async fn recovered_lease_cancels_the_original_model_request() {
+        // Arrange
+        let now = Arc::new(AtomicI64::new(10));
+        let timestamp_source: Arc<dyn crate::session::TimestampSource> = {
+            let now = Arc::clone(&now);
+
+            Arc::new(move || now.load(Ordering::SeqCst))
+        };
+        let database = Database::open_in_memory_with_timestamp_source(timestamp_source)
+            .await
+            .expect("database should open");
+        database
+            .create_session(
+                &NewSession::new("session-a", object_schema()),
+                None,
+                DEFAULT_MAX_HISTORY_BYTES,
+            )
+            .await
+            .expect("session should be created");
+        let first_started = Arc::new(Notify::new());
+        let first_dropped = Arc::new(Notify::new());
+        let harness = Harness::new(LeaseOwnershipModel {
+            call_count: AtomicUsize::new(0),
+            dropped_first: Arc::clone(&first_dropped),
+            started_first: Arc::clone(&first_started),
+        });
+        let mut first = Session {
+            database: database.clone(),
+            harness: &harness,
+            history: SessionHistory::new(DEFAULT_MAX_HISTORY_BYTES),
+            id: "session-a".to_string(),
+            provider_session_id: None,
+            schema: object_schema(),
+            system_prompt: None,
+        };
+        let mut second = Session {
+            database,
+            harness: &harness,
+            history: SessionHistory::new(DEFAULT_MAX_HISTORY_BYTES),
+            id: "session-a".to_string(),
+            provider_session_id: None,
+            schema: object_schema(),
+            system_prompt: None,
+        };
+
+        // Act
+        let (first_result, second_result) = tokio::join!(first.send("first"), async {
+            wait_for_fixture(&first_started, "the original model request").await;
+            let original_expiry = stored_lease_expiry(&second.database).await;
+            now.store(original_expiry.saturating_add(1), Ordering::SeqCst);
+            let result = second.send("second").await;
+            tokio::time::pause();
+            tokio::time::advance(Duration::from_secs(
+                crate::session::TURN_LEASE_RENEWAL_INTERVAL_SECONDS,
+            ))
+            .await;
+            tokio::time::resume();
+            wait_for_fixture(&first_dropped, "the original model request cancellation").await;
+
+            result
+        });
+
+        // Assert
+        assert!(matches!(
+            first_result,
+            Err(SessionError::OwnershipLost {
+                ref id,
+                turn_position: 0,
+            }) if id == "session-a"
+        ));
+        second_result.expect("the replacement turn should complete");
+    }
+
+    #[tokio::test]
+    async fn lease_renewal_failure_cancels_the_model_request() {
+        // Arrange
+        let database = Database::open_in_memory()
+            .await
+            .expect("database should open");
+        database
+            .create_session(
+                &NewSession::new("session-a", object_schema()),
+                None,
+                DEFAULT_MAX_HISTORY_BYTES,
+            )
+            .await
+            .expect("session should be created");
+        sqlx::query(
+            r"
+CREATE TRIGGER reject_turn_lease_renewal
+BEFORE UPDATE OF lease_expires_at ON session_turn
+WHEN OLD.status = 'running' AND NEW.status = 'running'
+BEGIN
+    SELECT RAISE(ABORT, 'injected lease renewal failure');
+END
+",
+        )
+        .execute(database.pool())
+        .await
+        .expect("renewal failure trigger should be created");
+        let request_started = Arc::new(Notify::new());
+        let request_dropped = Arc::new(Notify::new());
+        let harness = Harness::new(LeaseOwnershipModel {
+            call_count: AtomicUsize::new(0),
+            dropped_first: Arc::clone(&request_dropped),
+            started_first: Arc::clone(&request_started),
+        });
+        let mut session = Session {
+            database: database.clone(),
+            harness: &harness,
+            history: SessionHistory::new(DEFAULT_MAX_HISTORY_BYTES),
+            id: "session-a".to_string(),
+            provider_session_id: None,
+            schema: object_schema(),
+            system_prompt: None,
+        };
+
+        // Act
+        let (result, ()) = tokio::join!(session.send("pending"), async {
+            wait_for_fixture(&request_started, "the model request").await;
+            tokio::time::pause();
+            tokio::time::advance(Duration::from_secs(
+                crate::session::TURN_LEASE_RENEWAL_INTERVAL_SECONDS,
+            ))
+            .await;
+            tokio::time::resume();
+            wait_for_fixture(&request_dropped, "the model request cancellation").await;
+        });
+        let expected_state = ("interrupted".to_string(), Some("interrupted".to_string()));
+        let state = wait_for_stored_turn_state(&database, &expected_state).await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(SessionError::QueryContext {
+                operation: "renew persistent session turn lease",
+                ..
+            })
+        ));
+        assert_eq!(state, expected_state);
+    }
+
+    #[tokio::test]
+    async fn completion_persistence_failure_interrupts_the_session_turn() {
+        // Arrange
+        let directory = tempdir().expect("temporary directory should be created");
+        let database_path = directory.path().join("harness.db");
+        let mut model = model();
+        model.expect_complete().times(1).returning(|_| {
+            Ok(response_without_metadata(ModelResponse::Output(json!({
+                "summary": "done"
+            }))))
+        });
+        let harness = Arc::new(Harness::new(model).database(&database_path));
+        let session = harness
+            .session("session-a", object_schema())
+            .create()
+            .await
+            .expect("session should be created");
+        drop(session);
+        let database = harness.open_database().await.expect("database should open");
+        sqlx::query(
+            r"
+CREATE TRIGGER reject_turn_completion
+BEFORE UPDATE OF status ON session_turn
+WHEN NEW.status = 'completed'
+BEGIN
+    SELECT RAISE(ABORT, 'injected completion persistence failure');
+END
+",
+        )
+        .execute(database.pool())
+        .await
+        .expect("completion failure trigger should be created");
+
+        // Act
+        let error = send_with_resumed_session(Arc::clone(&harness), "complete").await;
+        let database = Database::open(&database_path)
+            .await
+            .expect("database should reopen");
+        let expected_state = ("interrupted".to_string(), Some("interrupted".to_string()));
+        let state = wait_for_stored_turn_state(&database, &expected_state).await;
+
+        // Assert
+        assert!(
+            error
+                .expect_err("completion persistence should fail")
+                .to_string()
+                .contains("injected completion persistence failure")
+        );
+        assert_eq!(state, expected_state);
+    }
+
+    #[tokio::test]
+    async fn session_error_preserves_model_and_failure_persistence_errors() {
+        // Arrange
+        let directory = tempdir().expect("temporary directory should be created");
+        let database_path = directory.path().join("harness.db");
+        let mut model = model();
+        model
+            .expect_complete()
+            .times(1)
+            .returning(|_| Err(ModelError::InvalidResponse));
+        let harness = Harness::new(model).database(&database_path);
+        let mut session = harness
+            .session("session-a", object_schema())
+            .create()
+            .await
+            .expect("session should be created");
+        sqlx::query(
+            r"
+CREATE TRIGGER reject_turn_failure
+BEFORE UPDATE OF status ON session_turn
+WHEN NEW.status = 'failed'
+BEGIN
+    SELECT RAISE(ABORT, 'injected persistence failure');
+END
+",
+        )
+        .execute(session.database.pool())
+        .await
+        .expect("failure trigger should be created");
+
+        // Act
+        let error = session
+            .send("fail twice")
+            .await
+            .expect_err("model and persistence failures should be returned");
+
+        // Assert
+        assert!(matches!(&error, SessionError::TurnPersistence { .. }));
+        if let SessionError::TurnPersistence { turn, persistence } = error {
+            assert!(matches!(
+                turn,
+                TurnError::Model(ModelError::InvalidResponse)
+            ));
+            assert!(
+                persistence
+                    .to_string()
+                    .contains("injected persistence failure")
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/ag-harness/src/session.rs
+++ b/crates/ag-harness/src/session.rs
@@ -11,14 +11,19 @@ use serde_json::Value;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
 use sqlx::{SqliteConnection, SqlitePool, Transaction};
 use thiserror::Error;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tokio::time::{Instant, MissedTickBehavior};
 
 use crate::model::{ModelMessage, ModelMetadata};
 use crate::tool::{ReadArguments, ToolCall, WriteArguments};
 use crate::{OutputSchema, OutputSchemaError, TurnError};
 
+pub(crate) const TURN_LEASE_SECONDS: i64 = 300;
+pub(crate) const TURN_LEASE_RENEWAL_INTERVAL_SECONDS: u64 = 100;
+
 const DB_POOL_MAX_CONNECTIONS: u32 = 4;
 const DB_BUSY_TIMEOUT: Duration = Duration::from_secs(2);
-const TURN_LEASE_SECONDS: i64 = 300;
 const TURN_SIZE_PAGE_SIZE: i64 = 64;
 
 struct ModelIdentityRow {
@@ -377,11 +382,12 @@ WHERE id = ?
 
         loop {
             let acquisition = self.load_turn_acquisition(session_id).await?;
-            if self
+            if let Some(guard) = self
                 .reserve_turn(session_id, &message, &acquisition)
                 .await?
             {
                 return Ok(AcquiredTurn {
+                    guard,
                     provider_session_id: acquisition.provider_session_id,
                     turn_position: acquisition.turn_position,
                     turns: acquisition.turns,
@@ -433,7 +439,7 @@ WHERE id = ?
         session_id: &str,
         message: &EncodedMessage,
         acquisition: &TurnAcquisition,
-    ) -> Result<bool, SessionError> {
+    ) -> Result<Option<TurnGuard>, SessionError> {
         let recovery_now = self.timestamp_source.now_timestamp_seconds();
         let mut transaction = self
             .pool
@@ -443,7 +449,7 @@ WHERE id = ?
         recover_stale_turns(&mut transaction, session_id, recovery_now).await?;
         let abandoned_turns = self.abandoned_turns.for_session(&self.identity, session_id);
         for owner in &abandoned_turns {
-            interrupt_abandoned_turn(&mut transaction, owner, recovery_now)
+            interrupt_owned_turn(&mut transaction, owner, recovery_now)
                 .await
                 .session_context("recover abandoned persistent session turn")?;
         }
@@ -466,7 +472,7 @@ WHERE id = ?
             || turn_position != acquisition.turn_position
             || latest_completed_turn != acquisition.latest_completed_turn
         {
-            return Ok(false);
+            return Ok(None);
         }
         let reservation_now = self.timestamp_source.now_timestamp_seconds();
         let lease_expires_at = reservation_now.saturating_add(TURN_LEASE_SECONDS);
@@ -501,11 +507,12 @@ RETURNING owner_token
         })?;
         let owner = TurnOwner {
             database: self.identity.clone(),
+            interruption_error_type: "interrupted",
             session_id: session_id.to_string(),
             token: owner_token,
             turn_position: acquisition.turn_position,
         };
-        let mut reservation_guard = TurnReservationGuard::new(self, owner);
+        let mut guard = TurnGuard::new(self, owner);
         insert_message(
             &mut transaction,
             session_id,
@@ -529,9 +536,9 @@ RETURNING owner_token
             std::future::pending::<()>().await;
         }
         self.abandoned_turns.remove(&abandoned_turns);
-        reservation_guard.disarm();
+        guard.activate();
 
-        Ok(true)
+        Ok(Some(guard))
     }
 
     pub(crate) async fn complete_turn(
@@ -674,6 +681,11 @@ WHERE session_id = ?
         .session_context("recover stale persistent session turns")?;
 
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pool(&self) -> &SqlitePool {
+        &self.pool
     }
 
     #[cfg(test)]
@@ -821,6 +833,14 @@ pub enum SessionError {
         /// Missing session identifier.
         id: String,
     },
+    /// The active turn's lease was recovered by another owner.
+    #[error("persistent session `{id}` lost ownership of turn {turn_position}")]
+    OwnershipLost {
+        /// Session identifier whose turn lost ownership.
+        id: String,
+        /// Position of the turn that lost ownership.
+        turn_position: i64,
+    },
     /// A named SQLite operation failed.
     #[error("persistent session operation `{operation}` failed: {source}")]
     QueryContext {
@@ -839,9 +859,19 @@ pub enum SessionError {
     /// The model turn failed before it could be persisted.
     #[error(transparent)]
     Turn(#[from] TurnError),
+    /// A model turn and the attempt to persist its failure both failed.
+    #[error("{turn}; additionally failed to persist the turn failure: {persistence}")]
+    TurnPersistence {
+        /// Failure returned by the model turn.
+        #[source]
+        turn: TurnError,
+        /// Failure returned while recording the turn failure.
+        persistence: Box<SessionError>,
+    },
 }
 
 pub(crate) struct AcquiredTurn {
+    pub(crate) guard: TurnGuard,
     pub(crate) provider_session_id: Option<String>,
     pub(crate) turn_position: i64,
     pub(crate) turns: Vec<Vec<ModelMessage>>,
@@ -868,6 +898,7 @@ struct TurnAcquisition {
 #[derive(Clone, Eq, Hash, PartialEq)]
 struct TurnOwner {
     database: DatabaseIdentity,
+    interruption_error_type: &'static str,
     session_id: String,
     token: Vec<u8>,
     turn_position: i64,
@@ -913,35 +944,112 @@ fn shared_abandoned_turn_registry() -> Arc<AbandonedTurnRegistry> {
     Arc::clone(REGISTRY.get_or_init(Arc::default))
 }
 
-struct TurnReservationGuard {
-    owner: Option<TurnOwner>,
+pub(crate) struct TurnGuard {
+    armed: bool,
+    owner: TurnOwner,
+    ownership_failure: Option<oneshot::Receiver<SessionError>>,
     pool: SqlitePool,
     registry: Arc<AbandonedTurnRegistry>,
+    renewal_stop: Option<oneshot::Sender<()>>,
+    renewal_task: Option<JoinHandle<()>>,
     runtime: tokio::runtime::Handle,
     timestamp_source: Arc<dyn TimestampSource>,
 }
 
-impl TurnReservationGuard {
+impl TurnGuard {
     fn new(database: &Database, owner: TurnOwner) -> Self {
         Self {
-            owner: Some(owner),
+            armed: true,
+            owner,
+            ownership_failure: None,
             pool: database.pool.clone(),
             registry: Arc::clone(&database.abandoned_turns),
+            renewal_stop: None,
+            renewal_task: None,
             runtime: tokio::runtime::Handle::current(),
             timestamp_source: Arc::clone(&database.timestamp_source),
         }
     }
 
-    fn disarm(&mut self) {
-        self.owner = None;
+    fn activate(&mut self) {
+        self.owner.interruption_error_type = "cancelled";
+        let owner = self.owner.clone();
+        let interval = Duration::from_secs(TURN_LEASE_RENEWAL_INTERVAL_SECONDS);
+        let first_renewal = Instant::now() + interval;
+        let pool = self.pool.clone();
+        let timestamp_source = Arc::clone(&self.timestamp_source);
+        let (renewal_stop, mut stop_requested) = oneshot::channel();
+        let (ownership_failed, ownership_failure) = oneshot::channel();
+        self.renewal_stop = Some(renewal_stop);
+        self.ownership_failure = Some(ownership_failure);
+        self.renewal_task = Some(self.runtime.spawn(async move {
+            let mut ticker = tokio::time::interval_at(first_renewal, interval);
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            loop {
+                tokio::select! {
+                    _ = ticker.tick() => {
+                        let now = timestamp_source.now_timestamp_seconds();
+                        let failure = match renew_owned_turn(&pool, &owner, now).await {
+                            Ok(true) => continue,
+                            Ok(false) => SessionError::OwnershipLost {
+                                id: owner.session_id.clone(),
+                                turn_position: owner.turn_position,
+                            },
+                            Err(source) => SessionError::QueryContext {
+                                operation: "renew persistent session turn lease",
+                                source,
+                            },
+                        };
+                        let _ = ownership_failed.send(failure);
+
+                        break;
+                    }
+                    _ = &mut stop_requested => break,
+                }
+            }
+        }));
+    }
+
+    pub(crate) async fn ownership_failure(&mut self) -> SessionError {
+        let Some(failure) = self.ownership_failure.take() else {
+            return SessionError::OwnershipLost {
+                id: self.owner.session_id.clone(),
+                turn_position: self.owner.turn_position,
+            };
+        };
+
+        failure
+            .await
+            .unwrap_or_else(|_| SessionError::OwnershipLost {
+                id: self.owner.session_id.clone(),
+                turn_position: self.owner.turn_position,
+            })
+    }
+
+    pub(crate) fn disarm(&mut self) {
+        self.stop_renewal();
+        self.armed = false;
+    }
+
+    pub(crate) fn mark_interrupted(&mut self) {
+        self.owner.interruption_error_type = "interrupted";
+    }
+
+    fn stop_renewal(&mut self) {
+        if let Some(stop) = self.renewal_stop.take() {
+            let _ = stop.send(());
+        }
+        self.renewal_task.take();
     }
 }
 
-impl Drop for TurnReservationGuard {
+impl Drop for TurnGuard {
     fn drop(&mut self) {
-        let Some(owner) = self.owner.take() else {
+        self.stop_renewal();
+        if !self.armed {
             return;
-        };
+        }
+        let owner = self.owner.clone();
         self.registry.register(owner.clone());
 
         let pool = self.pool.clone();
@@ -950,7 +1058,7 @@ impl Drop for TurnReservationGuard {
         std::mem::drop(self.runtime.spawn(async move {
             let result = async {
                 let mut connection = pool.acquire().await?;
-                interrupt_abandoned_turn(
+                interrupt_owned_turn(
                     &mut connection,
                     &owner,
                     timestamp_source.now_timestamp_seconds(),
@@ -1368,7 +1476,34 @@ WHERE session_id = ?
     Ok(())
 }
 
-async fn interrupt_abandoned_turn(
+async fn renew_owned_turn(
+    pool: &SqlitePool,
+    owner: &TurnOwner,
+    now: i64,
+) -> Result<bool, sqlx::Error> {
+    let lease_expires_at = now.saturating_add(TURN_LEASE_SECONDS);
+    let result = sqlx::query(
+        r"
+UPDATE session_turn
+SET lease_expires_at = ?, updated_at = ?
+WHERE session_id = ?
+  AND turn_position = ?
+  AND owner_token = ?
+  AND status = 'running'
+",
+    )
+    .bind(lease_expires_at)
+    .bind(now)
+    .bind(&owner.session_id)
+    .bind(owner.turn_position)
+    .bind(&owner.token)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected() == 1)
+}
+
+async fn interrupt_owned_turn(
     connection: &mut SqliteConnection,
     owner: &TurnOwner,
     now: i64,
@@ -1376,13 +1511,14 @@ async fn interrupt_abandoned_turn(
     sqlx::query(
         r"
 UPDATE session_turn
-SET status = 'interrupted', error_type = 'interrupted', lease_expires_at = NULL, updated_at = ?
+SET status = 'interrupted', error_type = ?, lease_expires_at = NULL, updated_at = ?
 WHERE session_id = ?
   AND turn_position = ?
   AND owner_token = ?
   AND status IN ('pending', 'running')
 ",
     )
+    .bind(owner.interruption_error_type)
     .bind(now)
     .bind(&owner.session_id)
     .bind(owner.turn_position)
@@ -1429,6 +1565,8 @@ mod tests {
     use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
 
     use serde_json::json;
+    use sqlx::SqlSafeStr;
+    use sqlx::migrate::{Migration, MigrationType, Migrator};
     use tempfile::tempdir;
 
     use super::*;
@@ -1518,10 +1656,112 @@ mod tests {
 
         TurnOwner {
             database: database.identity.clone(),
+            interruption_error_type: "interrupted",
             session_id: session_id.to_string(),
             token,
             turn_position,
         }
+    }
+
+    type HistoricalMessage = (i64, i64, &'static str, &'static str, i64, i64);
+
+    const MIGRATION_ONE_SNAPSHOT: &str = r"CREATE TABLE session (
+    id TEXT PRIMARY KEY NOT NULL,
+    provider TEXT,
+    model TEXT,
+    output_schema TEXT NOT NULL,
+    system_prompt TEXT,
+    max_history_bytes INTEGER NOT NULL CHECK (max_history_bytes > 0),
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    CHECK (
+        (provider IS NULL AND model IS NULL)
+        OR (provider IS NOT NULL AND model IS NOT NULL)
+    )
+);
+
+CREATE TABLE session_message (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES session(id) ON DELETE CASCADE,
+    turn_position INTEGER NOT NULL,
+    message_position INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    retained_bytes INTEGER NOT NULL CHECK (retained_bytes >= 0),
+    created_at INTEGER NOT NULL,
+    UNIQUE (session_id, turn_position, message_position)
+);
+
+CREATE INDEX session_message_session_id_turn_position_idx
+ON session_message (session_id, turn_position);
+";
+
+    async fn create_version_one_database(path: &Path) -> [HistoricalMessage; 4] {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(connect_options(path))
+            .await
+            .expect("version-one database should open");
+        Migrator::with_migrations(vec![Migration::new(
+            1,
+            "create session".into(),
+            MigrationType::Simple,
+            MIGRATION_ONE_SNAPSHOT.into_sql_str(),
+            false,
+        )])
+        .run(&pool)
+        .await
+        .expect("frozen migration one should apply");
+        sqlx::query(
+            r"
+INSERT INTO session (
+    id, provider, model, output_schema, system_prompt, max_history_bytes, created_at, updated_at
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+",
+        )
+        .bind("session-a")
+        .bind("provider")
+        .bind("model")
+        .bind(schema().value().to_string())
+        .bind("persistent instructions")
+        .bind(100_000_i64)
+        .bind(5_i64)
+        .bind(30_i64)
+        .execute(&pool)
+        .await
+        .expect("historical session should be inserted");
+        let historical_messages = [
+            (3_i64, 0_i64, "user", r#""first""#, 5_i64, 10_i64),
+            (3, 1, "assistant", r#""{\"summary\":\"one\"}""#, 17, 11),
+            (8, 0, "user", r#""second""#, 6, 20),
+            (8, 1, "assistant", r#""{\"summary\":\"two\"}""#, 17, 21),
+        ];
+        for (turn_position, message_position, kind, payload, retained_bytes, created_at) in
+            historical_messages
+        {
+            sqlx::query(
+                r"
+INSERT INTO session_message (
+    session_id, turn_position, message_position, kind, payload, retained_bytes, created_at
+)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+",
+            )
+            .bind("session-a")
+            .bind(turn_position)
+            .bind(message_position)
+            .bind(kind)
+            .bind(payload)
+            .bind(retained_bytes)
+            .bind(created_at)
+            .execute(&pool)
+            .await
+            .expect("historical message should be inserted");
+        }
+        pool.close().await;
+
+        historical_messages
     }
 
     #[test]
@@ -1662,6 +1902,93 @@ VALUES ('session-a', 0, 'running', NULL, 310, 10, 10)
         // Assert
         assert!(on_disk.timestamp_source.now_timestamp_seconds() > 0);
         assert!(in_memory.timestamp_source.now_timestamp_seconds() > 0);
+    }
+
+    #[tokio::test]
+    async fn migration_two_backfills_historical_turn_lifecycle_without_data_loss() {
+        // Arrange
+        let temp_dir = tempdir().expect("temporary directory should be created");
+        let database_path = temp_dir.path().join("harness.db");
+        let historical_messages = create_version_one_database(&database_path).await;
+
+        // Act
+        let database = Database::open(&database_path)
+            .await
+            .expect("database should upgrade to migration two");
+        let loaded = database
+            .load_session("session-a")
+            .await
+            .expect("upgraded session should load");
+        let session_row = sqlx::query_as::<_, (i64, i64, Option<String>)>(
+            "SELECT created_at, updated_at, provider_session_id FROM session WHERE id = ?",
+        )
+        .bind("session-a")
+        .fetch_one(database.pool())
+        .await
+        .expect("upgraded session row should load");
+        let turns = sqlx::query_as::<_, (i64, String, Option<String>, Option<i64>, i64, i64)>(
+            r"
+SELECT turn_position, status, error_type, lease_expires_at, created_at, updated_at
+FROM session_turn
+WHERE session_id = ?
+ORDER BY turn_position
+",
+        )
+        .bind("session-a")
+        .fetch_all(database.pool())
+        .await
+        .expect("backfilled turns should load");
+        let messages = sqlx::query_as::<_, (i64, i64, String, String, i64, i64)>(
+            r"
+SELECT turn_position, message_position, kind, payload, retained_bytes, created_at
+FROM session_message
+WHERE session_id = ?
+ORDER BY turn_position, message_position
+",
+        )
+        .bind("session-a")
+        .fetch_all(database.pool())
+        .await
+        .expect("historical messages should load");
+
+        // Assert
+        assert_eq!(session_row, (5, 30, None));
+        assert_eq!(
+            turns,
+            vec![
+                (3, "completed".to_string(), None, None, 10, 11),
+                (8, "completed".to_string(), None, None, 20, 21),
+            ]
+        );
+        assert_eq!(
+            messages,
+            historical_messages
+                .into_iter()
+                .map(
+                    |(
+                        turn_position,
+                        message_position,
+                        kind,
+                        payload,
+                        retained_bytes,
+                        created_at,
+                    )| {
+                        (
+                            turn_position,
+                            message_position,
+                            kind.to_string(),
+                            payload.to_string(),
+                            retained_bytes,
+                            created_at,
+                        )
+                    },
+                )
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            loaded.turns,
+            vec![turn("first", "one"), turn("second", "two")]
+        );
     }
 
     #[tokio::test]
@@ -1940,7 +2267,7 @@ WHERE session_id = ? AND turn_position = ?
         .expect("active turn count should load");
 
         // Assert
-        assert!(!reserved);
+        assert!(reserved.is_none());
         assert_eq!(active_turns, 0);
     }
 
@@ -1966,13 +2293,12 @@ WHERE session_id = ? AND turn_position = ?
             .expect("message should encode");
 
         // Act
-        let error = database
+        let result = database
             .reserve_turn("session-a", &message, &acquisition)
-            .await
-            .expect_err("missing session should fail reservation");
+            .await;
 
         // Assert
-        assert!(matches!(error, SessionError::NotFound { .. }));
+        assert!(matches!(result, Err(SessionError::NotFound { .. })));
     }
 
     #[tokio::test]
@@ -2069,7 +2395,7 @@ ORDER BY turn_position
     }
 
     #[tokio::test]
-    async fn registered_abandoned_owner_is_recovered_before_reservation() {
+    async fn registered_cancelled_owner_preserves_its_reason_during_recovery() {
         // Arrange
         let database = Database::open_in_memory()
             .await
@@ -2082,7 +2408,8 @@ ORDER BY turn_position
             .begin_turn("session-a", "abandoned")
             .await
             .expect("turn should begin");
-        let owner = active_turn_owner(&database, "session-a", abandoned.turn_position).await;
+        let mut owner = active_turn_owner(&database, "session-a", abandoned.turn_position).await;
+        owner.interruption_error_type = "cancelled";
         database.abandoned_turns.register(owner);
 
         // Act
@@ -2090,9 +2417,9 @@ ORDER BY turn_position
             .begin_turn("session-a", "replacement")
             .await
             .expect("replacement turn should begin");
-        let turns = sqlx::query_as::<_, (i64, String)>(
+        let turns = sqlx::query_as::<_, (i64, String, Option<String>)>(
             r"
-SELECT turn_position, status
+SELECT turn_position, status, error_type
 FROM session_turn
 WHERE session_id = 'session-a'
 ORDER BY turn_position
@@ -2106,8 +2433,53 @@ ORDER BY turn_position
         assert_eq!(replacement.turn_position, 1);
         assert_eq!(
             turns,
-            vec![(0, "interrupted".to_string()), (1, "running".to_string())]
+            vec![
+                (0, "interrupted".to_string(), Some("cancelled".to_string())),
+                (1, "running".to_string(), None),
+            ]
         );
+    }
+
+    #[tokio::test]
+    async fn stopped_ownership_monitor_reports_ownership_loss() {
+        // Arrange
+        let database = Database::open_in_memory()
+            .await
+            .expect("database should open");
+        database
+            .create_session(&NewSession::new("session-a", schema()), None, 100_000)
+            .await
+            .expect("session should be created");
+        let mut acquired = database
+            .begin_turn("session-a", "prompt")
+            .await
+            .expect("turn should begin");
+        acquired
+            .guard
+            .renewal_task
+            .take()
+            .expect("ownership monitor should be running")
+            .abort();
+
+        // Act
+        let error = acquired.guard.ownership_failure().await;
+        let repeated_error = acquired.guard.ownership_failure().await;
+
+        // Assert
+        assert!(matches!(
+            error,
+            SessionError::OwnershipLost {
+                ref id,
+                turn_position: 0,
+            } if id == "session-a"
+        ));
+        assert!(matches!(
+            repeated_error,
+            SessionError::OwnershipLost {
+                ref id,
+                turn_position: 0,
+            } if id == "session-a"
+        ));
     }
 
     #[tokio::test]

--- a/crates/ag-harness/tests/public_api.rs
+++ b/crates/ag-harness/tests/public_api.rs
@@ -425,6 +425,42 @@ async fn durable_session_requires_explicit_storage() -> Result<(), Box<dyn Error
     Ok(())
 }
 
+#[test]
+fn compound_session_error_exposes_turn_and_persistence_failures() {
+    // Arrange
+    let error = SessionError::TurnPersistence {
+        turn: TurnError::Model(ModelError::InvalidResponse),
+        persistence: Box::new(SessionError::StorageRequired),
+    };
+
+    // Act and Assert
+    assert!(matches!(
+        error,
+        SessionError::TurnPersistence {
+            turn: TurnError::Model(ModelError::InvalidResponse),
+            persistence,
+        } if matches!(*persistence, SessionError::StorageRequired)
+    ));
+}
+
+#[test]
+fn ownership_lost_session_error_exposes_the_turn_identity() {
+    // Arrange
+    let error = SessionError::OwnershipLost {
+        id: "session-a".to_string(),
+        turn_position: 2,
+    };
+
+    // Act and Assert
+    assert!(matches!(
+        error,
+        SessionError::OwnershipLost {
+            ref id,
+            turn_position: 2,
+        } if id == "session-a"
+    ));
+}
+
 #[tokio::test]
 async fn session_info_exposes_stored_model_identity() -> Result<(), Box<dyn Error>> {
     // Arrange

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -63,7 +63,12 @@ keeps history canonical when multiple session handles were opened before the lat
 completed. Each active turn also has an opaque owner token. If cancellation races with a
 successful SQLite commit acknowledgment, cleanup scoped to the canonical database
 identity and owner token interrupts only that abandoned turn before another turn is
-reserved.
+reserved. The owner guard renews the lease while provider or tool work remains active;
+dropping the send future stops renewal and records the turn as interrupted by
+cancellation. A failed renewal or lost owner token cancels the in-flight request before
+it can continue model or tool work. If a turn fails and recording that failure also
+fails, `SessionError` retains both errors instead of replacing the original turn
+failure.
 
 ## Resume and provider fallback
 


### PR DESCRIPTION
- Stale handles reload completed history, and replay fallback persists replacement provider continuations.
- Cancelled provider or tool work remains durably interrupted while active leases renew through long requests and concurrency checks stay enforced.
- Migration backfills historical turn lifecycle data without losing messages, while session errors retain both model and persistence failures.
- Cancellation, lease expiry, and renewal or ownership failures durably interrupt provider and tool work while active leases renew through long requests and concurrency checks stay enforced.