### PR TITLE
Repository tools require trusted Git executables

### DIFF
--- a/crates/ag-harness-cli/README.md
+++ b/crates/ag-harness-cli/README.md
@@ -4,6 +4,7 @@ Start a durable session:
 
 ```sh
 MODEL_API_KEY=your-key cargo run -p ag-harness-cli -- \
+  --git-executable /absolute/path/to/git \
   run muse-spark-1.3 --session review-42
 ```
 
@@ -11,12 +12,13 @@ Resume it later:
 
 ```sh
 MODEL_API_KEY=your-key cargo run -p ag-harness-cli -- \
-  resume review-42
+  --git-executable /absolute/path/to/git resume review-42
 ```
 
 The current directory is readable by default. Add `--allow-write` to permit patches or
-`--read-dir <DIR>` to choose another repository root. Select Kimi or Qwen with
-`--provider`; `--base-url` overrides the provider endpoint.
+`--read-dir <DIR>` to choose another repository root. `--git-executable <FILE>` is
+required and must select an absolute Git executable outside the containing worktree.
+Select Kimi or Qwen with `--provider`; `--base-url` overrides the provider endpoint.
 
 Session history defaults to `~/.ag-harness/db/harness.db`. Set `AG_HARNESS_ROOT`, or
 pass `--database <FILE>`, to choose another location. If `HOME` is unavailable, one of

--- a/crates/ag-harness-cli/src/main.rs
+++ b/crates/ag-harness-cli/src/main.rs
@@ -8,8 +8,8 @@ use std::process::ExitCode;
 use std::{env, io};
 
 use ag_harness::{
-    Harness, ModelConfiguration, ModelConfigurationError, ModelProvider, OutputSchema, Session,
-    SessionInfo, Tool, TurnOutcome,
+    Harness, ModelConfiguration, ModelConfigurationError, ModelProvider, OutputSchema, Repository,
+    Session, SessionInfo, Tool, TurnOutcome,
 };
 use clap::builder::{PossibleValuesParser, TypedValueParser};
 use clap::{Args, Parser, Subcommand};
@@ -42,12 +42,16 @@ const READ_WRITE_SYSTEM_PROMPT: &str = concat!(
     name = "ag-harness",
     version,
     about = "Chats with models through a repository harness",
-    after_help = provider_help()
+    after_help = provider_help(),
+    group(clap::ArgGroup::new("repository").required(true).args(["git_executable"]))
 )]
 struct Cli {
     /// SQLite database used for durable session history.
     #[arg(long, global = true, value_name = "FILE")]
     database: Option<PathBuf>,
+    /// Absolute path to the host-controlled Git executable.
+    #[arg(long, global = true, value_name = "FILE")]
+    git_executable: Option<PathBuf>,
     #[command(subcommand)]
     command: Command,
 }
@@ -223,6 +227,7 @@ where
     Output: AsyncWrite + Unpin,
 {
     let database = database_path(cli.database, &mut environment)?;
+    let git_executable = cli.git_executable;
     match cli.command {
         Command::Run(args) => {
             let session_id = args
@@ -234,8 +239,14 @@ where
                 args.base_url.as_deref(),
                 &mut environment,
             )?;
-            let (harness, system_prompt) =
-                configured_harness(client, database, args.read_dir, args.allow_write);
+            let git_executable = git_executable.ok_or(CliError::GitExecutableRequired)?;
+            let (harness, system_prompt) = configured_harness(
+                client,
+                database,
+                args.read_dir,
+                git_executable,
+                args.allow_write,
+            )?;
             let mut session = harness
                 .session(&session_id, chat_schema()?)
                 .system_prompt(system_prompt)
@@ -251,8 +262,14 @@ where
             let (provider, model) = stored_model_identity(&info)?;
             let client =
                 model_client(provider, &model, args.base_url.as_deref(), &mut environment)?;
-            let (harness, _) =
-                configured_harness(client, database, args.read_dir, args.allow_write);
+            let git_executable = git_executable.ok_or(CliError::GitExecutableRequired)?;
+            let (harness, _) = configured_harness(
+                client,
+                database,
+                args.read_dir,
+                git_executable,
+                args.allow_write,
+            )?;
             let mut session = harness.resume(&args.session).await?;
             let mut output = output;
             announce_session(&mut output, &args.session).await?;
@@ -313,9 +330,11 @@ fn model_client(
 fn configured_harness(
     client: ag_harness::ModelClient,
     database: PathBuf,
-    repository: PathBuf,
+    repository_root: PathBuf,
+    git_executable: PathBuf,
     allow_write: bool,
-) -> (Harness, &'static str) {
+) -> Result<(Harness, &'static str), CliError> {
+    let repository = Repository::new(repository_root, git_executable)?;
     let mut harness = Harness::new(client)
         .database(database)
         .repository(repository)
@@ -323,9 +342,9 @@ fn configured_harness(
     if allow_write {
         harness = harness.allow(Tool::Write);
 
-        (harness, READ_WRITE_SYSTEM_PROMPT)
+        Ok((harness, READ_WRITE_SYSTEM_PROMPT))
     } else {
-        (harness, READ_ONLY_SYSTEM_PROMPT)
+        Ok((harness, READ_ONLY_SYSTEM_PROMPT))
     }
 }
 
@@ -609,6 +628,8 @@ enum CliError {
     ChatTurnsFailed,
     #[error("--database, AG_HARNESS_ROOT, or HOME is required for durable session storage")]
     DatabaseLocation,
+    #[error("--git-executable is required for repository tools")]
+    GitExecutableRequired,
     #[error("model output did not contain a message")]
     MissingMessage,
     #[error("stored session does not identify a supported built-in model")]
@@ -619,6 +640,8 @@ enum CliError {
     ModelConfiguration(ModelConfigurationError),
     #[error(transparent)]
     OutputSchema(#[from] ag_harness::OutputSchemaError),
+    #[error(transparent)]
+    Repository(#[from] ag_harness::RepositoryError),
     #[error(transparent)]
     Session(#[from] ag_harness::SessionError),
     #[error(transparent)]
@@ -636,6 +659,8 @@ impl From<ModelConfigurationError> for CliError {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsString;
+    use std::path::Path;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use async_trait::async_trait;
@@ -702,12 +727,64 @@ mod tests {
         }
     }
 
+    fn with_repository_controlled_git(mut cli: Cli) -> Result<Cli, io::Error> {
+        let git_executable = std::env::current_exe()?;
+        let repository_root = git_executable
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| io::Error::other("test executable should have a parent"))?;
+        cli.git_executable = Some(git_executable);
+        match &mut cli.command {
+            Command::Run(arguments) => arguments.read_dir = repository_root,
+            Command::Resume(arguments) => arguments.read_dir = repository_root,
+        }
+
+        Ok(cli)
+    }
+
+    fn parse_cli<I, T>(arguments: I) -> Result<Cli, clap::Error>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString>,
+    {
+        let mut arguments = arguments.into_iter().map(Into::into).collect::<Vec<_>>();
+        arguments.splice(
+            1..1,
+            [
+                OsString::from("--git-executable"),
+                test_git_executable().into_os_string(),
+            ],
+        );
+
+        Cli::try_parse_from(arguments)
+    }
+
+    fn test_git_executable() -> PathBuf {
+        let executable_name = format!("git{}", std::env::consts::EXE_SUFFIX);
+        let path = std::env::var_os("PATH");
+        assert!(path.is_some(), "test PATH should be configured");
+        let executables = path
+            .iter()
+            .flat_map(|path| std::env::split_paths(path))
+            .filter(|directory| directory.is_absolute())
+            .map(|directory| directory.join(&executable_name))
+            .filter_map(|candidate| candidate.canonicalize().ok())
+            .filter(|path| path.is_file())
+            .collect::<Vec<_>>();
+        assert!(
+            !executables.is_empty(),
+            "trusted Git executable should be available on PATH"
+        );
+
+        executables[0].clone()
+    }
+
     #[test]
     fn cli_accepts_chat_with_or_without_an_initial_prompt() {
         // Arrange and Act
-        let without_prompt = Cli::try_parse_from(["ag-harness", "run", "muse-custom"])
-            .expect("chat arguments should parse");
-        let with_prompt = Cli::try_parse_from([
+        let without_prompt =
+            parse_cli(["ag-harness", "run", "muse-custom"]).expect("chat arguments should parse");
+        let with_prompt = parse_cli([
             "ag-harness",
             "run",
             "muse-custom",
@@ -721,10 +798,10 @@ mod tests {
             "--allow-write",
         ])
         .expect("an initial prompt should parse");
-        let blank_prompt = Cli::try_parse_from(["ag-harness", "run", "muse-custom", "  "])
+        let blank_prompt = parse_cli(["ag-harness", "run", "muse-custom", "  "])
             .expect_err("a blank initial prompt should be rejected");
         let unknown_provider =
-            Cli::try_parse_from(["ag-harness", "run", "muse-custom", "--provider", "unknown"])
+            parse_cli(["ag-harness", "run", "muse-custom", "--provider", "unknown"])
                 .expect_err("an unknown provider should be rejected");
 
         // Assert
@@ -763,7 +840,7 @@ mod tests {
         let providers = ModelProvider::all()
             .iter()
             .map(|provider| {
-                Cli::try_parse_from([
+                parse_cli([
                     "ag-harness",
                     "run",
                     "model-id",
@@ -784,7 +861,7 @@ mod tests {
     #[test]
     fn cli_accepts_resume_and_database_override() {
         // Arrange and Act
-        let cli = Cli::try_parse_from([
+        let cli = parse_cli([
             "ag-harness",
             "--database",
             "state.db",
@@ -802,10 +879,10 @@ mod tests {
         assert_eq!(args.prompt.as_deref(), Some("continue"));
         assert!(args.allow_write);
 
-        let resume_probe = Cli::try_parse_from(["ag-harness", "resume", "session-b"])
+        let resume_probe = parse_cli(["ag-harness", "resume", "session-b"])
             .expect("resume arguments should parse");
-        let run_probe = Cli::try_parse_from(["ag-harness", "run", "model"])
-            .expect("run arguments should parse");
+        let run_probe =
+            parse_cli(["ag-harness", "run", "model"]).expect("run arguments should parse");
         assert!(run_arguments(resume_probe.command).is_none());
         assert!(resume_arguments(run_probe.command).is_none());
     }
@@ -867,11 +944,11 @@ mod tests {
     #[test]
     fn chat_mode_accounts_for_both_terminal_streams_and_initial_prompt() {
         // Arrange
-        let with_prompt = Cli::try_parse_from(["ag-harness", "run", "muse", "hello"])
-            .expect("chat arguments should parse");
-        let without_prompt = Cli::try_parse_from(["ag-harness", "run", "muse"])
-            .expect("chat arguments should parse");
-        let resume = Cli::try_parse_from(["ag-harness", "resume", "session-a", "continue"])
+        let with_prompt =
+            parse_cli(["ag-harness", "run", "muse", "hello"]).expect("chat arguments should parse");
+        let without_prompt =
+            parse_cli(["ag-harness", "run", "muse"]).expect("chat arguments should parse");
+        let resume = parse_cli(["ag-harness", "resume", "session-a", "continue"])
             .expect("resume arguments should parse");
 
         // Act and Assert
@@ -948,7 +1025,7 @@ mod tests {
             .await;
         let storage = tempfile::tempdir().expect("temporary storage should exist");
         let database = storage.path().join("harness.db");
-        let cli = Cli::try_parse_from([
+        let cli = parse_cli([
             "ag-harness",
             "run",
             "muse-test",
@@ -1004,7 +1081,7 @@ mod tests {
             .await;
         let storage = tempfile::tempdir().expect("temporary storage should exist");
         let database = storage.path().join("harness.db");
-        let run = Cli::try_parse_from([
+        let run = parse_cli([
             "ag-harness",
             "--database",
             &database.to_string_lossy(),
@@ -1017,7 +1094,7 @@ mod tests {
             &server.uri(),
         ])
         .expect("run arguments should parse");
-        let resume = Cli::try_parse_from([
+        let resume = parse_cli([
             "ag-harness",
             "--database",
             &database.to_string_lossy(),
@@ -1028,6 +1105,20 @@ mod tests {
             &server.uri(),
         ])
         .expect("resume arguments should parse");
+        let invalid_resume = with_repository_controlled_git(
+            parse_cli([
+                "ag-harness",
+                "--database",
+                &database.to_string_lossy(),
+                "resume",
+                "session-a",
+                "third",
+                "--base-url",
+                &server.uri(),
+            ])
+            .expect("invalid resume fixture should parse"),
+        )
+        .expect("repository-controlled Git fixture should resolve");
         let mut first_output = Vec::new();
         let mut second_output = Vec::new();
 
@@ -1050,6 +1141,15 @@ mod tests {
         )
         .await
         .expect("second process should resume the session");
+        let invalid_error = execute(
+            invalid_resume,
+            |_| Ok("test-key".to_string()),
+            BufReader::new(&b""[..]),
+            Vec::new(),
+            ChatMode::OneShot,
+        )
+        .await
+        .expect_err("repository-controlled Git should reject resume");
 
         // Assert
         let first_output = String::from_utf8(first_output).expect("output should be UTF-8");
@@ -1058,12 +1158,16 @@ mod tests {
         assert!(first_output.contains("assistant> first answer\n"));
         assert!(second_output.contains("session: session-a\n"));
         assert!(second_output.contains("assistant> second answer\n"));
+        assert!(matches!(
+            invalid_error,
+            CliError::Repository(ag_harness::RepositoryError::GitExecutableInsideRepository { .. })
+        ));
     }
 
     #[tokio::test]
     async fn execute_reports_missing_provider_credentials_before_creating_a_session() {
         // Arrange
-        let cli = Cli::try_parse_from([
+        let cli = parse_cli([
             "ag-harness",
             "--database",
             "unused.db",
@@ -1093,6 +1197,64 @@ mod tests {
         assert_eq!(output, [] as [u8; 0]);
     }
 
+    #[test]
+    fn cli_requires_an_explicit_git_executable() {
+        // Arrange
+        let arguments = [
+            "ag-harness",
+            "--database",
+            "unused.db",
+            "run",
+            "muse-test",
+            "Hello",
+        ];
+
+        // Act
+        let error = Cli::try_parse_from(arguments)
+            .expect_err("missing Git executable should fail during argument parsing");
+
+        // Assert
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+        assert!(error.to_string().contains("--git-executable <FILE>"));
+    }
+
+    #[tokio::test]
+    async fn execute_rejects_repository_controlled_git_for_new_sessions() {
+        // Arrange
+        let cli = with_repository_controlled_git(
+            parse_cli([
+                "ag-harness",
+                "--database",
+                "unused.db",
+                "run",
+                "muse-test",
+                "Hello",
+            ])
+            .expect("run arguments should parse"),
+        )
+        .expect("repository-controlled Git fixture should resolve");
+
+        // Act
+        let error = execute(
+            cli,
+            |_| Ok("test-key".to_string()),
+            BufReader::new(&b""[..]),
+            Vec::new(),
+            ChatMode::OneShot,
+        )
+        .await
+        .expect_err("repository-controlled Git should reject a new session");
+
+        // Assert
+        assert!(matches!(
+            error,
+            CliError::Repository(ag_harness::RepositoryError::GitExecutableInsideRepository { .. })
+        ));
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_advertises_writes_only_when_explicitly_enabled() {
         // Arrange
@@ -1108,7 +1270,7 @@ mod tests {
             .await;
         let storage = tempfile::tempdir().expect("temporary storage should exist");
         let database = storage.path().join("harness.db");
-        let cli = Cli::try_parse_from([
+        let cli = parse_cli([
             "ag-harness",
             "run",
             "muse-test",
@@ -1182,7 +1344,7 @@ mod tests {
         let database = repository.path().join("harness.db");
         std::fs::write(repository.path().join("input.txt"), "contents")
             .expect("read fixture should be written");
-        let cli = Cli::try_parse_from([
+        let cli = parse_cli([
             "ag-harness",
             "run",
             "muse-test",
@@ -1280,9 +1442,11 @@ mod tests {
     async fn interactive_chat_prints_prompts_and_handles_blank_input() {
         // Arrange
         let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let repository = Repository::new(env!("CARGO_MANIFEST_DIR"), test_git_executable())
+            .expect("repository fixture should be valid");
         let harness = Harness::new(FixedModel(json!({"message": "hello"})))
             .database(directory.path().join("harness.db"))
-            .repository(".")
+            .repository(repository)
             .allow(Tool::Read);
         let mut session = harness
             .session(

--- a/crates/ag-harness-cli/tests/cli.rs
+++ b/crates/ag-harness-cli/tests/cli.rs
@@ -82,9 +82,32 @@ fn response(message: &str, input_tokens: u64, output_tokens: u64) -> ResponseTem
 fn harness_command() -> std::io::Result<(tempfile::TempDir, Command)> {
     let storage = tempfile::tempdir()?;
     let mut command = Command::new(cargo_bin!("ag-harness"));
-    command.env("AG_HARNESS_ROOT", storage.path());
+    command
+        .arg("--git-executable")
+        .arg(test_git_executable())
+        .env("AG_HARNESS_ROOT", storage.path());
 
     Ok((storage, command))
+}
+
+fn test_git_executable() -> std::path::PathBuf {
+    let executable_name = format!("git{}", std::env::consts::EXE_SUFFIX);
+    let path = std::env::var_os("PATH");
+    assert!(path.is_some(), "test PATH should be configured");
+    let executables = path
+        .iter()
+        .flat_map(|path| std::env::split_paths(path))
+        .filter(|directory| directory.is_absolute())
+        .map(|directory| directory.join(&executable_name))
+        .filter_map(|candidate| candidate.canonicalize().ok())
+        .filter(|path| path.is_file())
+        .collect::<Vec<_>>();
+    assert!(
+        !executables.is_empty(),
+        "trusted Git executable should be available on PATH"
+    );
+
+    executables[0].clone()
 }
 
 #[test]
@@ -99,7 +122,8 @@ fn help_describes_the_chat_interface() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).expect("help should be UTF-8");
     assert!(stdout.contains("Chats with models through a repository harness"));
-    assert!(stdout.contains("Usage: ag-harness [OPTIONS] <COMMAND>"));
+    assert!(stdout.contains("Usage: ag-harness [OPTIONS] <--git-executable <FILE>> <COMMAND>"));
+    assert!(stdout.contains("--git-executable <FILE>"));
     assert!(stdout.contains("Commands:"));
     assert!(stdout.contains("Starts a new durable session"));
     assert!(stdout.contains("Resumes a durable session"));
@@ -119,6 +143,24 @@ fn help_describes_the_chat_interface() {
 }
 
 #[test]
+fn missing_git_executable_is_a_clap_error() {
+    // Arrange
+    let mut command = Command::new(cargo_bin!("ag-harness"));
+
+    // Act
+    let output = command
+        .args(["run", "muse-custom"])
+        .output()
+        .expect("CLI argument validation should run");
+
+    // Assert
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8(output.stderr).expect("argument error should be UTF-8");
+    assert!(stderr.contains("required arguments were not provided"));
+    assert!(stderr.contains("--git-executable <FILE>"));
+}
+
+#[test]
 fn run_help_describes_optional_initial_prompt() {
     // Arrange
     let (_storage, mut command) = harness_command().expect("temporary storage should exist");
@@ -132,7 +174,10 @@ fn run_help_describes_optional_initial_prompt() {
     // Assert
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).expect("help should be UTF-8");
-    assert!(stdout.contains("Usage: ag-harness run [OPTIONS] <MODEL> [PROMPT]"));
+    assert!(
+        stdout
+            .contains("Usage: ag-harness <--git-executable <FILE>> run [OPTIONS] <MODEL> [PROMPT]")
+    );
     assert!(stdout.contains("Optional first prompt"));
     assert!(stdout.contains("--base-url <URL>"));
     for provider in ModelProvider::all() {
@@ -343,6 +388,8 @@ async fn stdin_prompts_share_conversation_history() {
         .await;
     let storage = tempfile::tempdir().expect("temporary storage should exist");
     let mut child = Command::new(cargo_bin!("ag-harness"))
+        .arg("--git-executable")
+        .arg(test_git_executable())
         .args([
             "run",
             "muse-test",
@@ -408,6 +455,8 @@ async fn resume_restores_history_from_the_default_database() {
     let storage = tempfile::tempdir().expect("temporary storage should exist");
     let mut first = Command::new(cargo_bin!("ag-harness"));
     first
+        .arg("--git-executable")
+        .arg(test_git_executable())
         .args([
             "run",
             "muse-test",
@@ -424,6 +473,8 @@ async fn resume_restores_history_from_the_default_database() {
     let first_output = first.output().expect("first CLI request should run");
     let mut second = Command::new(cargo_bin!("ag-harness"));
     let second_output = second
+        .arg("--git-executable")
+        .arg(test_git_executable())
         .args([
             "resume",
             "cli-resume",
@@ -484,6 +535,8 @@ async fn stdin_chat_emits_failure_before_retry_and_exits_unsuccessfully() {
         .await;
     let storage = tempfile::tempdir().expect("temporary storage should exist");
     let mut child = Command::new(cargo_bin!("ag-harness"))
+        .arg("--git-executable")
+        .arg(test_git_executable())
         .args(["run", "muse-test", "--base-url", &server.uri()])
         .env("MODEL_API_KEY", "test-key")
         .env("AG_HARNESS_ROOT", storage.path())
@@ -713,12 +766,16 @@ async fn redirected_output_with_terminal_stdin_is_one_shot() {
         .await;
     let temp_dir = tempfile::TempDir::new().expect("temporary directory should be created");
     let output_path = temp_dir.path().join("stdout.txt");
-    let command = r#"exec "$AG_HARNESS_BIN" run muse-test Hello --base-url "$MODEL_BASE_URL" > "$MODEL_OUTPUT_PATH""#;
+    let command = r#"exec "$AG_HARNESS_BIN" --git-executable "$AG_HARNESS_GIT" run muse-test Hello --base-url "$MODEL_BASE_URL" > "$MODEL_OUTPUT_PATH""#;
     let mut session = PtySessionBuilder::new("/bin/sh")
         .args(["-c", command])
         .env(
             "AG_HARNESS_BIN",
             cargo_bin!("ag-harness").to_string_lossy().into_owned(),
+        )
+        .env(
+            "AG_HARNESS_GIT",
+            test_git_executable().to_string_lossy().into_owned(),
         )
         .env("MODEL_API_KEY", "test-key")
         .env("MODEL_BASE_URL", server.uri())

--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -6,11 +6,12 @@ SQLite sessions.
 ## Durable sessions
 
 ```rust
-use ag_harness::{Harness, Muse, MUSE_SPARK_1_3, Tool};
+use ag_harness::{Harness, Muse, MUSE_SPARK_1_3, Repository, Tool};
 
+let repository = Repository::new(".", git_executable)?;
 let harness = Harness::new(Muse::from_env(MUSE_SPARK_1_3)?)
     .database("harness.db")
-    .repository(".")
+    .repository(repository)
     .allow(Tool::Read)
     .allow(Tool::Write);
 
@@ -52,7 +53,9 @@ let result = harness.run_once("Summarize Cargo.toml", output_schema).await?;
 
 Tools are denied by default. `Tool::Read` provides bounded file, list, search, diff, and
 show operations. `Tool::Write` applies one bounded unified diff. Enabling either tool
-requires `Harness::repository()`.
+requires a `Repository` built from the repository root and an absolute, host-controlled
+Git executable. Construction canonicalizes both paths and rejects an executable inside
+the containing worktree before any model request.
 
 External providers implement the single `Model` trait and return `ModelCompletion`. They
 receive the complete ordered history in `ModelRequest::messages()`. A provider may also

--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -19,6 +19,7 @@ use crate::model::{
 };
 use crate::policy::Policy;
 use crate::read::{self, ReadError, ReadTool};
+use crate::repository::Repository;
 use crate::schema_contract::OutputSchema;
 use crate::session::{AcquiredTurn, Database, LoadedSession, NewSession, SessionError};
 use crate::tool::{
@@ -432,7 +433,7 @@ pub struct Harness {
     max_tool_calls: usize,
     model: Arc<dyn Model>,
     policy: Policy,
-    repository_root: Option<PathBuf>,
+    repository: Option<Repository>,
 }
 
 impl Harness {
@@ -446,7 +447,7 @@ impl Harness {
             max_tool_calls: DEFAULT_MAX_TOOL_CALLS,
             model: Arc::new(model),
             policy: Policy::default(),
-            repository_root: None,
+            repository: None,
         }
     }
 
@@ -458,10 +459,11 @@ impl Harness {
         self
     }
 
-    /// Roots repository-scoped tools at `repository_root`.
+    /// Configures the validated repository root and Git executable used by
+    /// tools.
     #[must_use]
-    pub fn repository(mut self, repository_root: impl Into<PathBuf>) -> Self {
-        self.repository_root = Some(repository_root.into());
+    pub fn repository(mut self, repository: Repository) -> Self {
+        self.repository = Some(repository);
 
         self
     }
@@ -743,17 +745,21 @@ impl Harness {
         if !read_allowed && !write_allowed {
             return Ok((request, None, None));
         }
-        let repository_root = self
-            .repository_root
+        let repository = self
+            .repository
             .as_ref()
             .ok_or(TurnError::RepositoryRequired)?;
         let read_tool = read_allowed.then(|| {
             request = request.clone().with_tool(ToolDefinition::read());
-            ReadTool::new(self.file_system.clone(), repository_root.clone())
+            ReadTool::with_git(
+                self.file_system.clone(),
+                repository.root().to_path_buf(),
+                repository.git_executable().to_path_buf(),
+            )
         });
         let write_tool = write_allowed.then(|| {
             request = request.clone().with_tool(ToolDefinition::write());
-            WriteTool::new(self.file_system.clone(), repository_root.clone())
+            WriteTool::new(self.file_system.clone(), repository.root().to_path_buf())
         });
 
         Ok((request, read_tool, write_tool))
@@ -1330,14 +1336,14 @@ mod tests {
 
     fn read_harness(model: impl Model + 'static, file_system: MockFileSystem) -> Harness {
         Harness::new(model)
-            .repository("repo")
+            .repository(Repository::fixture("repo"))
             .allow(Tool::Read)
             .file_system(file_system)
     }
 
     fn write_harness(model: impl Model + 'static, file_system: MockFileSystem) -> Harness {
         Harness::new(model)
-            .repository("repo")
+            .repository(Repository::fixture("repo"))
             .allow(Tool::Write)
             .file_system(file_system)
     }
@@ -1628,7 +1634,7 @@ mod tests {
             }))))
         });
         let harness = Harness::new(model)
-            .repository(env!("CARGO_MANIFEST_DIR"))
+            .repository(Repository::fixture(env!("CARGO_MANIFEST_DIR")))
             .allow(Tool::Read);
 
         // Act
@@ -1791,7 +1797,7 @@ mod tests {
             }))))
         });
         let harness = Harness::new(model)
-            .repository(env!("CARGO_MANIFEST_DIR"))
+            .repository(Repository::fixture(env!("CARGO_MANIFEST_DIR")))
             .allow(Tool::Read);
 
         // Act

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -13,6 +13,7 @@ mod model;
 mod policy;
 mod provider;
 mod read;
+mod repository;
 mod schema_contract;
 mod session;
 mod telemetry;
@@ -39,6 +40,7 @@ pub use provider::{
     QwenConfig,
 };
 pub use read::{ReadError, ReadOutput};
+pub use repository::{Repository, RepositoryError};
 pub use schema_contract::{OutputSchema, OutputSchemaError};
 pub use session::{SessionError, SessionInfo};
 pub use telemetry::LifecycleMetrics;

--- a/crates/ag-harness/src/read.rs
+++ b/crates/ag-harness/src/read.rs
@@ -1,4 +1,3 @@
-use std::ffi::OsStr;
 use std::fmt;
 use std::future::Future;
 use std::io::{self, Cursor};
@@ -14,6 +13,8 @@ use tokio::io::{AsyncBufReadExt as _, AsyncRead, AsyncReadExt as _, BufReader};
 use tokio::process::Command;
 
 use crate::file_system::FileSystem;
+#[cfg(test)]
+use crate::repository::test_git_executable;
 use crate::schema_contract;
 use crate::tool::{MAX_TOOL_RESULT_BYTES, ReadAction, ReadArguments, ReadSide};
 
@@ -67,7 +68,15 @@ trait RepositoryCommandRunner: Send + Sync {
     ) -> io::Result<RepositoryCommandOutput>;
 }
 
-struct LocalRepositoryCommandRunner;
+struct LocalRepositoryCommandRunner {
+    git_executable: PathBuf,
+}
+
+impl LocalRepositoryCommandRunner {
+    fn new(git_executable: PathBuf) -> Self {
+        Self { git_executable }
+    }
+}
 
 #[async_trait]
 impl RepositoryCommandRunner for LocalRepositoryCommandRunner {
@@ -91,10 +100,9 @@ impl LocalRepositoryCommandRunner {
         arguments: &[String],
         stdout_limit: usize,
     ) -> io::Result<RepositoryCommandOutput> {
-        let git_executable = Self::resolve_git_executable(root).await?;
         let verification = self
             .run_git_bounded(
-                &git_executable,
+                &self.git_executable,
                 root,
                 &["rev-parse".to_string(), "--show-toplevel".to_string()],
                 MAX_COMMAND_DIAGNOSTIC_BYTES,
@@ -102,7 +110,7 @@ impl LocalRepositoryCommandRunner {
             .await?;
         Self::verify_repository_root(root, verification).await?;
 
-        self.run_git_bounded(&git_executable, root, arguments, stdout_limit)
+        self.run_git_bounded(&self.git_executable, root, arguments, stdout_limit)
             .await
     }
 
@@ -153,39 +161,6 @@ impl LocalRepositoryCommandRunner {
         };
 
         Self::with_timeout(REPOSITORY_COMMAND_TIMEOUT, operation).await
-    }
-
-    async fn resolve_git_executable(root: &Path) -> io::Result<PathBuf> {
-        let path = std::env::var_os("PATH").unwrap_or_default();
-
-        Self::resolve_git_executable_in_path(root, &path).await
-    }
-
-    async fn resolve_git_executable_in_path(root: &Path, path: &OsStr) -> io::Result<PathBuf> {
-        let root = tokio::fs::canonicalize(root).await?;
-        let executable_name = format!("git{}", std::env::consts::EXE_SUFFIX);
-        for directory in std::env::split_paths(path).filter(|directory| directory.is_absolute()) {
-            let candidate = directory.join(&executable_name);
-            let Ok(candidate) = tokio::fs::canonicalize(candidate).await else {
-                continue;
-            };
-            if candidate.starts_with(&root) {
-                continue;
-            }
-            let is_file = tokio::fs::metadata(&candidate)
-                .await
-                .is_ok_and(|metadata| metadata.is_file());
-            if !is_file {
-                continue;
-            }
-
-            return Ok(candidate);
-        }
-
-        Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            "trusted Git executable was not found in absolute PATH entries",
-        ))
     }
 
     async fn with_timeout<T>(
@@ -505,12 +480,21 @@ pub(crate) struct ReadTool {
 
 impl ReadTool {
     /// Creates a repository reader backed by an injected filesystem.
-    pub(crate) fn new(file_system: Arc<dyn FileSystem>, repository_root: PathBuf) -> Self {
+    pub(crate) fn with_git(
+        file_system: Arc<dyn FileSystem>,
+        repository_root: PathBuf,
+        git_executable: PathBuf,
+    ) -> Self {
         Self {
-            command_runner: Arc::new(LocalRepositoryCommandRunner),
+            command_runner: Arc::new(LocalRepositoryCommandRunner::new(git_executable)),
             file_system,
             repository_root,
         }
+    }
+
+    #[cfg(test)]
+    fn new(file_system: Arc<dyn FileSystem>, repository_root: PathBuf) -> Self {
+        Self::with_git(file_system, repository_root, test_git_executable())
     }
 
     #[cfg(test)]
@@ -2200,7 +2184,7 @@ mod tests {
         ];
 
         // Act
-        let output = LocalRepositoryCommandRunner
+        let output = LocalRepositoryCommandRunner::new(test_git_executable())
             .run(root, &arguments)
             .await
             .expect("read-only Git command should run");
@@ -2232,6 +2216,7 @@ mod tests {
         std::fs::set_permissions(&fake_git, permissions)
             .expect("fake Git executable permissions should be installed");
         let inherited_path = std::env::var_os("PATH").expect("test PATH should be configured");
+        let git_executable = test_git_executable();
         let path = std::env::join_paths(
             [PathBuf::from("."), fake_directory.path().to_path_buf()]
                 .into_iter()
@@ -2249,6 +2234,7 @@ mod tests {
             .env("GIT_DIR", "missing-git-dir")
             .env("GIT_WORK_TREE", "/")
             .env("GIT_INDEX_FILE", "missing-index")
+            .env("AG_HARNESS_TEST_GIT", git_executable)
             .env("PATH", path)
             .output()
             .expect("isolated Git environment test should run");
@@ -2267,9 +2253,12 @@ mod tests {
         // Arrange
         let root = Path::new(env!("CARGO_MANIFEST_DIR"));
         let arguments = ["rev-parse".to_string(), "--show-prefix".to_string()];
+        let git_executable = std::env::var_os("AG_HARNESS_TEST_GIT")
+            .map(PathBuf::from)
+            .expect("trusted test Git executable should be configured");
 
         // Act
-        let output = LocalRepositoryCommandRunner
+        let output = LocalRepositoryCommandRunner::new(git_executable)
             .run(root, &arguments)
             .await
             .expect("sanitized Git inspection should run");
@@ -2314,33 +2303,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn git_resolver_rejects_non_file_candidate() {
-        // Arrange
-        let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
-        let root = crate_root
-            .parent()
-            .expect("crate directory should have a parent")
-            .join("ag-agent");
-        let search_directory = tempfile::Builder::new()
-            .prefix("ag-harness-non-file-git-")
-            .tempdir_in(crate_root)
-            .expect("search directory should be created inside the workspace");
-        std::fs::create_dir(search_directory.path().join("git"))
-            .expect("non-file Git candidate should be created");
-
-        // Act
-        let error = LocalRepositoryCommandRunner::resolve_git_executable_in_path(
-            &root,
-            search_directory.path().as_os_str(),
-        )
-        .await
-        .expect_err("a Git directory should not be selected as an executable");
-
-        // Assert
-        assert_eq!(error.kind(), io::ErrorKind::NotFound);
-    }
-
-    #[tokio::test]
     async fn treats_repository_path_filters_as_literal() {
         // Arrange
         let tool = ReadTool::new(
@@ -2376,7 +2338,7 @@ mod tests {
         ];
 
         // Act
-        let output = LocalRepositoryCommandRunner
+        let output = LocalRepositoryCommandRunner::new(test_git_executable())
             .run(root, &arguments)
             .await
             .expect("large read-only Git command should be bounded");

--- a/crates/ag-harness/src/repository.rs
+++ b/crates/ag-harness/src/repository.rs
@@ -1,0 +1,478 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use rustix::fs as rustix_fs;
+use thiserror::Error;
+
+/// Validated host configuration for repository-scoped tools.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Repository {
+    git_executable: PathBuf,
+    root: PathBuf,
+}
+
+impl Repository {
+    /// Validates a repository root and the host-selected Git executable.
+    ///
+    /// Both paths are canonicalized immediately. The executable and its
+    /// configured location must be outside the containing worktree. On
+    /// Unix, the executable must also be an executable regular file. Other
+    /// platforms enforce the regular file check but defer executable-access
+    /// validation to process creation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RepositoryError`] when either path cannot be resolved or the
+    /// executable does not satisfy the host-trust requirements.
+    pub fn new(
+        root: impl AsRef<Path>,
+        git_executable: impl AsRef<Path>,
+    ) -> Result<Self, RepositoryError> {
+        let root = canonical_directory(root.as_ref()).map_err(|source| RepositoryError::Root {
+            path: root.as_ref().to_path_buf(),
+            source,
+        })?;
+        if root.components().any(|component| {
+            component
+                .as_os_str()
+                .as_encoded_bytes()
+                .eq_ignore_ascii_case(b".git")
+        }) {
+            return Err(RepositoryError::RootIsGitAdministrative { path: root });
+        }
+
+        let worktree_root = containing_worktree_root(&root, |path| fs::symlink_metadata(path))?;
+        let requested_executable = git_executable.as_ref();
+        if !requested_executable.is_absolute() {
+            return Err(RepositoryError::GitExecutableNotAbsolute {
+                path: requested_executable.to_path_buf(),
+            });
+        }
+        let git_executable = fs::canonicalize(requested_executable).map_err(|source| {
+            RepositoryError::GitExecutable {
+                path: requested_executable.to_path_buf(),
+                source,
+            }
+        })?;
+        if !git_executable.is_file() {
+            return Err(RepositoryError::GitExecutableNotFile {
+                path: git_executable,
+            });
+        }
+        if !is_executable(&git_executable) {
+            return Err(RepositoryError::GitExecutableNotExecutable {
+                path: git_executable,
+            });
+        }
+        let requested_parent =
+            canonical_executable_parent(requested_executable, |path| fs::canonicalize(path))?;
+        let target_inside_worktree = git_executable.starts_with(&worktree_root);
+        if requested_executable.starts_with(&worktree_root)
+            || requested_parent.is_some_and(|parent| parent.starts_with(&worktree_root))
+            || target_inside_worktree
+        {
+            return Err(RepositoryError::GitExecutableInsideRepository {
+                path: if target_inside_worktree {
+                    git_executable
+                } else {
+                    requested_executable.to_path_buf()
+                },
+                root: worktree_root,
+            });
+        }
+
+        Ok(Self {
+            git_executable,
+            root,
+        })
+    }
+
+    pub(crate) fn git_executable(&self) -> &Path {
+        &self.git_executable
+    }
+
+    pub(crate) fn root(&self) -> &Path {
+        &self.root
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fixture(root: impl Into<PathBuf>) -> Self {
+        Self {
+            git_executable: test_git_executable(),
+            root: root.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_git_executable() -> PathBuf {
+    let executable_name = format!("git{}", std::env::consts::EXE_SUFFIX);
+    let path = std::env::var_os("PATH");
+    assert!(path.is_some(), "test PATH should be configured");
+    let executables = path
+        .iter()
+        .flat_map(|path| std::env::split_paths(path))
+        .filter(|directory| directory.is_absolute())
+        .map(|directory| directory.join(&executable_name))
+        .filter_map(|candidate| candidate.canonicalize().ok())
+        .filter(|path| path.is_file() && is_executable(path))
+        .collect::<Vec<_>>();
+    assert!(
+        !executables.is_empty(),
+        "trusted Git executable should be available on PATH"
+    );
+
+    executables[0].clone()
+}
+
+/// Invalid host configuration for repository-scoped tools.
+#[derive(Debug, Error)]
+pub enum RepositoryError {
+    /// The configured repository root could not be resolved to a directory.
+    #[error("failed to resolve repository root `{path}`: {source}")]
+    Root {
+        /// Repository root supplied by the host.
+        path: PathBuf,
+        /// Filesystem failure returned while resolving the root.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The configured root was itself inside Git administrative state.
+    #[error("repository root must not access Git administrative state: `{path}`")]
+    RootIsGitAdministrative {
+        /// Canonical repository root.
+        path: PathBuf,
+    },
+    /// The Git executable could not be resolved or inspected.
+    #[error("failed to resolve Git executable `{path}`: {source}")]
+    GitExecutable {
+        /// Git executable supplied by the host.
+        path: PathBuf,
+        /// Filesystem failure returned while resolving the executable.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The Git executable path was not absolute.
+    #[error("Git executable must be absolute: `{path}`")]
+    GitExecutableNotAbsolute {
+        /// Relative executable path supplied by the host.
+        path: PathBuf,
+    },
+    /// The configured Git executable location or canonical target was inside
+    /// the containing worktree.
+    #[error("Git executable `{path}` must be outside repository-controlled worktree `{root}`")]
+    GitExecutableInsideRepository {
+        /// Rejected configured location or canonical executable path.
+        path: PathBuf,
+        /// Canonical containing worktree root.
+        root: PathBuf,
+    },
+    /// The canonical Git executable was not a regular file.
+    #[error("Git executable is not a regular file: `{path}`")]
+    GitExecutableNotFile {
+        /// Canonical executable path.
+        path: PathBuf,
+    },
+    /// The canonical Git executable lacked executable permissions.
+    #[error("Git executable is not executable: `{path}`")]
+    GitExecutableNotExecutable {
+        /// Canonical executable path.
+        path: PathBuf,
+    },
+}
+
+fn canonical_directory(path: &Path) -> std::io::Result<PathBuf> {
+    let canonical = fs::canonicalize(path)?;
+    if !fs::metadata(&canonical)?.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "path is not a directory",
+        ));
+    }
+
+    Ok(canonical)
+}
+
+fn canonical_executable_parent(
+    path: &Path,
+    canonicalize: impl Fn(&Path) -> std::io::Result<PathBuf>,
+) -> Result<Option<PathBuf>, RepositoryError> {
+    path.parent()
+        .map(canonicalize)
+        .transpose()
+        .map_err(|source| RepositoryError::GitExecutable {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+fn containing_worktree_root(
+    root: &Path,
+    inspect_entry: impl Fn(&Path) -> std::io::Result<fs::Metadata>,
+) -> Result<PathBuf, RepositoryError> {
+    let mut worktree_root = root;
+    for ancestor in root.ancestors() {
+        match inspect_entry(&ancestor.join(".git")) {
+            Ok(_) => worktree_root = ancestor,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {}
+            Err(source) => {
+                return Err(RepositoryError::Root {
+                    path: root.to_path_buf(),
+                    source,
+                });
+            }
+        }
+    }
+
+    Ok(worktree_root.to_path_buf())
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    rustix_fs::accessat(
+        rustix_fs::CWD,
+        path,
+        rustix_fs::Access::EXEC_OK,
+        rustix_fs::AtFlags::EACCESS,
+    )
+    .is_ok()
+}
+
+#[cfg(not(unix))]
+fn is_executable(_path: &Path) -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    use std::os::unix::fs::{PermissionsExt as _, symlink};
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[cfg(unix)]
+    fn executable(path: &Path) {
+        fs::write(path, "#!/bin/sh\nexit 0\n").expect("executable fixture should be written");
+        let mut permissions = fs::metadata(path)
+            .expect("executable metadata should exist")
+            .permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(path, permissions).expect("fixture should be executable");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validates_and_canonicalizes_host_repository_configuration() {
+        // Arrange
+        let parent = tempdir().expect("temporary parent should exist");
+        let root = parent.path().join("repository");
+        let executable_path = parent.path().join("git");
+        fs::create_dir(&root).expect("repository fixture should exist");
+        executable(&executable_path);
+        let linked_executable = parent.path().join("git-link");
+        symlink(&executable_path, &linked_executable).expect("executable symlink should exist");
+
+        // Act
+        let repository = Repository::new(&root, &linked_executable)
+            .expect("valid host configuration should be accepted");
+
+        // Assert
+        assert_eq!(
+            repository.root(),
+            root.canonicalize()
+                .expect("repository fixture should canonicalize")
+        );
+        assert_eq!(
+            repository.git_executable(),
+            executable_path
+                .canonicalize()
+                .expect("executable fixture should canonicalize")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_untrusted_git_executable_configurations() {
+        // Arrange
+        let parent = tempdir().expect("temporary parent should exist");
+        let root = parent.path().join("repository");
+        fs::create_dir(&root).expect("repository fixture should exist");
+        let directory = parent.path().join("git-directory");
+        fs::create_dir(&directory).expect("directory fixture should exist");
+        let inert = parent.path().join("inert-git");
+        fs::write(&inert, "not executable").expect("inert fixture should be written");
+        let inside = root.join("git");
+        executable(&inside);
+        let administrative_root = parent.path().join(".GIT");
+        fs::create_dir(&administrative_root).expect("administrative root fixture should exist");
+
+        // Act
+        let relative = Repository::new(&root, "git");
+        let missing = Repository::new(&root, parent.path().join("missing"));
+        let non_file = Repository::new(&root, &directory);
+        let non_executable = Repository::new(&root, &inert);
+        let inside_repository = Repository::new(&root, &inside);
+        let missing_root = Repository::new(parent.path().join("missing-root"), &inside);
+        let file_root = Repository::new(&inert, &inside);
+        let git_root = Repository::new(&administrative_root, &inside);
+
+        // Assert
+        assert!(matches!(
+            relative,
+            Err(RepositoryError::GitExecutableNotAbsolute { .. })
+        ));
+        assert!(
+            matches!(missing, Err(RepositoryError::GitExecutable { .. })),
+            "unexpected missing executable result: {missing:?}"
+        );
+        assert!(matches!(
+            non_file,
+            Err(RepositoryError::GitExecutableNotFile { .. })
+        ));
+        assert!(matches!(
+            non_executable,
+            Err(RepositoryError::GitExecutableNotExecutable { .. })
+        ));
+        assert!(matches!(
+            inside_repository,
+            Err(RepositoryError::GitExecutableInsideRepository { .. })
+        ));
+        assert!(matches!(missing_root, Err(RepositoryError::Root { .. })));
+        assert!(matches!(file_root, Err(RepositoryError::Root { .. })));
+        assert!(matches!(
+            git_root,
+            Err(RepositoryError::RootIsGitAdministrative { .. })
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_git_executable_inside_containing_worktree() {
+        // Arrange
+        let parent = tempdir().expect("temporary parent should exist");
+        let worktree = parent.path().join("checkout");
+        let root = worktree.join("crate");
+        fs::create_dir_all(worktree.join(".git"))
+            .expect("worktree and administrative directory should exist");
+        fs::create_dir(&root).expect("nested repository root should exist");
+        let executable_path = worktree.join("fake-git");
+        executable(&executable_path);
+        let canonical_worktree = worktree
+            .canonicalize()
+            .expect("worktree fixture should canonicalize");
+
+        // Act
+        let result = Repository::new(&root, &executable_path);
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(RepositoryError::GitExecutableInsideRepository {
+                root: rejected_root,
+                ..
+            }) if rejected_root == canonical_worktree
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_git_symlink_located_inside_containing_worktree() {
+        // Arrange
+        let parent = tempdir().expect("temporary parent should exist");
+        let worktree = parent.path().join("checkout");
+        let root = worktree.join("crate");
+        fs::create_dir_all(worktree.join(".git"))
+            .expect("worktree and administrative directory should exist");
+        fs::create_dir(&root).expect("nested repository root should exist");
+        let executable_path = parent.path().join("git");
+        executable(&executable_path);
+        let linked_executable = worktree.join("git-link");
+        symlink(&executable_path, &linked_executable).expect("executable symlink should exist");
+
+        // Act
+        let result = Repository::new(&root, &linked_executable);
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(RepositoryError::GitExecutableInsideRepository { path, .. })
+                if path == linked_executable
+        ));
+    }
+
+    #[test]
+    fn rejects_uninspectable_containing_worktree_boundary() {
+        // Arrange
+        let repository = tempdir().expect("temporary repository root should exist");
+        let root = repository
+            .path()
+            .canonicalize()
+            .expect("repository root should canonicalize");
+        let expected_root = root.clone();
+
+        // Act
+        let result = containing_worktree_root(&root, |_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "denied",
+            ))
+        });
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(RepositoryError::Root { path, source })
+                if path == expected_root && source.kind() == std::io::ErrorKind::PermissionDenied
+        ));
+    }
+
+    #[test]
+    fn rejects_uninspectable_git_executable_parent() {
+        // Arrange
+        let executable = Path::new("/host/git");
+
+        // Act
+        let result = canonical_executable_parent(executable, |_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "denied",
+            ))
+        });
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(RepositoryError::GitExecutable { path, source })
+                if path == executable && source.kind() == std::io::ErrorKind::PermissionDenied
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validates_execute_permission_for_effective_identity() {
+        // Arrange
+        let parent = tempdir().expect("temporary parent should exist");
+        let root = parent.path().join("repository");
+        fs::create_dir(&root).expect("repository fixture should exist");
+        let executable_path = parent.path().join("git");
+        executable(&executable_path);
+        let mut permissions = fs::metadata(&executable_path)
+            .expect("executable metadata should exist")
+            .permissions();
+        permissions.set_mode(u32::from(!rustix::process::geteuid().is_root()));
+        fs::set_permissions(&executable_path, permissions)
+            .expect("fixture should not be executable by the effective identity");
+
+        // Act
+        let result = Repository::new(&root, &executable_path);
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(RepositoryError::GitExecutableNotExecutable { .. })
+        ));
+    }
+}

--- a/crates/ag-harness/src/tool.rs
+++ b/crates/ag-harness/src/tool.rs
@@ -127,7 +127,11 @@ fn repository_path_schema() -> Value {
         "type": "string",
         "minLength": 1,
         "maxLength": MAX_PATH_BYTES,
-        "pattern": "^(?:[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.\\.[^/\\\\\\u0000]+)(?:/(?:[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.\\.[^/\\\\\\u0000]+))*$"
+        "pattern": "^(?:[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.\\.[^/\\\\\\u0000]+)(?:/(?:[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.[^./\\\\\\u0000][^/\\\\\\u0000]*|\\.\\.[^/\\\\\\u0000]+))*$",
+        "not": {
+            "type": "string",
+            "pattern": "(^|/)\\.[gG][iI][tT](/|$)"
+        }
     })
 }
 
@@ -647,6 +651,12 @@ fn validate_repository_path(path: String) -> Result<String, &'static str> {
             "path must not contain empty, current-directory, or parent-directory components",
         );
     }
+    if path
+        .split('/')
+        .any(|component| component.eq_ignore_ascii_case(".git"))
+    {
+        return Err("path must not access Git administrative state");
+    }
 
     Ok(path)
 }
@@ -869,6 +879,8 @@ mod tests {
             json!({ "action": "file", "path": "/Cargo.toml" }),
             json!({ "action": "file", "path": "C:\\Cargo.toml" }),
             json!({ "action": "file", "path": "../Cargo.toml" }),
+            json!({ "action": "file", "path": ".git/config" }),
+            json!({ "action": "file", "path": "nested/.GIT/index" }),
             json!({ "action": "file", "path": "Cargo\0.toml" }),
             json!({ "action": "search", "query": "needle\0suffix" }),
             json!({ "action": "file", "path": "Cargo.toml", "offset": 0 }),
@@ -1034,6 +1046,8 @@ mod tests {
             json!({ "path": "src/lib.rs" }),
             json!({ "path": "src/lib.rs", "patch": "" }),
             json!({ "path": "../lib.rs", "patch": "patch" }),
+            json!({ "path": ".git/config", "patch": "patch" }),
+            json!({ "path": "nested/.GIT/index", "patch": "patch" }),
             json!({ "path": "src/lib.rs", "patch": "patch", "extra": true }),
             json!({ "path": "a".repeat(MAX_PATH_BYTES + 1), "patch": "patch" }),
             json!({ "path": "src/lib.rs", "patch": "x".repeat(MAX_PATCH_BYTES + 1) }),
@@ -1111,6 +1125,9 @@ mod tests {
             "src//lib.rs",
             "src/./lib.rs",
             "../lib.rs",
+            ".git",
+            ".git/config",
+            "nested/.GIT/index",
             "Cargo\0.toml",
         ];
 

--- a/crates/ag-harness/src/trace.rs
+++ b/crates/ag-harness/src/trace.rs
@@ -856,7 +856,7 @@ mod tests {
             observed_baggage: Arc::clone(&observed_baggage),
         })
         .file_system(file_system)
-        .repository("repo")
+        .repository(crate::Repository::fixture("repo"))
         .allow(Tool::Read)
         .with_lifecycle_observer(LifecycleTraceObserver::new());
 

--- a/crates/ag-harness/tests/benchmark/README.md
+++ b/crates/ag-harness/tests/benchmark/README.md
@@ -24,9 +24,12 @@ fixed tool surface can validly measure.
 ## Run
 
 Configure `KIMI_API_KEY`, `KIMI_BASE_URL`, `KIMI_MODEL`, `MODEL_API_KEY`,
-`DASHSCOPE_API_KEY`, and `DASHSCOPE_BASE_URL`, then run:
+`DASHSCOPE_API_KEY`, and `DASHSCOPE_BASE_URL`. Repository-backed cases also require
+`AG_HARNESS_GIT_EXECUTABLE` to be an absolute path to a host-controlled Git executable
+outside the worktree. To run the full benchmark:
 
 ```sh
+AG_HARNESS_GIT_EXECUTABLE=/absolute/path/to/git \
 AG_HARNESS_BENCHMARK_REPETITIONS=2 \
   cargo test --locked -p ag-harness --test benchmark
 ```

--- a/crates/ag-harness/tests/benchmark/main.rs
+++ b/crates/ag-harness/tests/benchmark/main.rs
@@ -3,14 +3,15 @@
 mod summary;
 
 use std::collections::BTreeSet;
-use std::io::Write as _;
+use std::io::{self, Write as _};
+use std::path::Path;
 use std::time::{Duration, Instant};
 use std::{env, fmt};
 
 use ag_harness::{
     Harness, KimiConfig, LifecycleMetrics, LifecycleObserverSet, LifecycleTraceObserver,
     MUSE_SPARK_1_3, ModelClient, ModelRequestActivity, ModelResponseType, MuseConfig, OutputSchema,
-    QwenConfig, Tool, ToolActivity, TurnOutcome,
+    QwenConfig, Repository, Tool, ToolActivity, TurnOutcome,
 };
 use opentelemetry::global;
 use opentelemetry::trace::SpanId;
@@ -21,6 +22,7 @@ use serde_json::{Value, json};
 type DynError = Box<dyn std::error::Error + Send + Sync>;
 
 const MODEL_API_BASE_URL: &str = "https://api.meta.ai/v1";
+const GIT_EXECUTABLE_ENV: &str = "AG_HARNESS_GIT_EXECUTABLE";
 const KIMI_CASE_INTERVAL: Duration = Duration::from_secs(60);
 const PERSISTENT_TURNS_PER_CASE: usize = 2;
 
@@ -166,14 +168,26 @@ fn structured(provider: Provider) -> CaseFuture {
     })
 }
 
+fn benchmark_repository(root: &Path) -> Result<Repository, DynError> {
+    let git_executable = env::var_os(GIT_EXECUTABLE_ENV).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("{GIT_EXECUTABLE_ENV} must select the host Git executable"),
+        )
+    })?;
+
+    Repository::new(root, git_executable).map_err(Into::into)
+}
+
 fn parallel_read(provider: Provider) -> CaseFuture {
     Box::pin(async move {
         let repository = tempfile::tempdir()?;
         std::fs::write(repository.path().join("alpha.txt"), "first=amber\n")?;
         std::fs::write(repository.path().join("beta.txt"), "second=17\n")?;
         let schema = string_value_schema("code")?;
+        let repository = benchmark_repository(repository.path())?;
         let outcome = Harness::new(provider.client()?)
-            .repository(repository.path())
+            .repository(repository)
             .allow(Tool::Read)
             .run_once(
                 "In one response, call read twice using exactly the paths alpha.txt and beta.txt \
@@ -224,8 +238,9 @@ fn read_recovery(provider: Provider) -> CaseFuture {
         let repository = tempfile::tempdir()?;
         std::fs::write(repository.path().join("fallback.txt"), "code=violet-29\n")?;
         let schema = string_value_schema("code")?;
+        let repository = benchmark_repository(repository.path())?;
         let outcome = Harness::new(provider.client()?)
-            .repository(repository.path())
+            .repository(repository)
             .allow(Tool::Read)
             .run_once(
                 "First read missing.txt. When that is rejected, recover by reading fallback.txt \
@@ -262,8 +277,9 @@ fn write(provider: Provider) -> CaseFuture {
             "required": ["changed"],
             "additionalProperties": false
         }))?;
+        let repository = benchmark_repository(repository.path())?;
         let outcome = Harness::new(provider.client()?)
-            .repository(repository.path())
+            .repository(repository)
             .allow(Tool::Write)
             .run_once(
                 "Use the write tool to change status.txt from status=pending to status=complete.",

--- a/crates/ag-harness/tests/e2e/README.md
+++ b/crates/ag-harness/tests/e2e/README.md
@@ -24,10 +24,12 @@ cargo test --locked -p ag-harness --test e2e muse::test_muse -- --exact --ignore
 ```
 
 The `muse-read` check lets Muse read this package's manifest and return its package
-name:
+name. `AG_HARNESS_GIT_EXECUTABLE` must be an absolute path to a host-controlled Git
+executable outside the worktree:
 
 ```sh
 MODEL_API_KEY=... \
+AG_HARNESS_GIT_EXECUTABLE=/absolute/path/to/git \
 cargo test --locked -p ag-harness --test e2e muse_read::test_muse_read -- --exact --ignored --nocapture
 ```
 

--- a/crates/ag-harness/tests/e2e/muse_read.rs
+++ b/crates/ag-harness/tests/e2e/muse_read.rs
@@ -1,12 +1,14 @@
 //! Live Muse read-tool check.
 
 use std::io::{self, Write as _};
+use std::path::PathBuf;
 
-use ag_harness::{Harness, MUSE_SPARK_1_3, Muse, OutputSchema, Tool};
+use ag_harness::{Harness, MUSE_SPARK_1_3, Muse, OutputSchema, Repository, Tool};
 use serde_json::json;
 
 use crate::DynError;
 
+const GIT_EXECUTABLE_ENV: &str = "AG_HARNESS_GIT_EXECUTABLE";
 const PROMPT: &str = concat!(
     "Use the read tool to inspect Cargo.toml. ",
     "Return the exact package name from its [package] table."
@@ -17,12 +19,20 @@ const PROMPT: &str = concat!(
 async fn test_muse_read() -> Result<(), DynError> {
     // Arrange
     let model = Muse::from_env(MUSE_SPARK_1_3)?;
+    let git_executable = std::env::var_os(GIT_EXECUTABLE_ENV)
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("{GIT_EXECUTABLE_ENV} must select the host Git executable"),
+            )
+        })?;
 
     // Act and Assert
-    inspect_manifest(model).await
+    inspect_manifest(model, git_executable).await
 }
 
-async fn inspect_manifest(model: Muse) -> Result<(), DynError> {
+async fn inspect_manifest(model: Muse, git_executable: PathBuf) -> Result<(), DynError> {
     let schema = OutputSchema::new(json!({
         "type": "object",
         "properties": {
@@ -34,8 +44,9 @@ async fn inspect_manifest(model: Muse) -> Result<(), DynError> {
         "required": ["package"],
         "additionalProperties": false
     }))?;
+    let repository = Repository::new(env!("CARGO_MANIFEST_DIR"), git_executable)?;
     let output = Harness::new(model)
-        .repository(env!("CARGO_MANIFEST_DIR"))
+        .repository(repository)
         .allow(Tool::Read)
         .run_once(PROMPT, schema)
         .await?;

--- a/crates/ag-harness/tests/public_api.rs
+++ b/crates/ag-harness/tests/public_api.rs
@@ -9,8 +9,8 @@ use ag_harness::{
     CompletionMetadata, CompletionUsage, FileSystem, Harness, LifecycleEventKind, LifecycleMetrics,
     LifecycleObserverSet, LifecycleTraceObserver, Model, ModelCompletion, ModelConfiguration,
     ModelError, ModelMessage, ModelMetadata, ModelProvider, ModelRequest, ModelResponse,
-    ModelResponseType, OutputSchema, OutputSchemaError, SessionError, SessionInfo, Tool, ToolCall,
-    TurnError,
+    ModelResponseType, OutputSchema, OutputSchemaError, Repository, RepositoryError, SessionError,
+    SessionInfo, Tool, ToolCall, TurnError,
 };
 use async_trait::async_trait;
 use serde_json::json;
@@ -99,7 +99,7 @@ impl FileSystem for NameFileSystem {
         root: &Path,
         path: &Path,
     ) -> io::Result<Box<dyn AsyncRead + Send + Unpin>> {
-        assert_eq!(root, Path::new("fixture"));
+        assert!(root.is_absolute());
         assert_eq!(path, Path::new("name.txt"));
 
         Ok(Box::new(Cursor::new(b"Ada\n")))
@@ -116,6 +116,25 @@ impl FileSystem for NameFileSystem {
     }
 }
 
+#[test]
+fn external_repository_configuration_rejects_relative_git_executable() -> Result<(), Box<dyn Error>>
+{
+    // Arrange
+    let repository = tempfile::tempdir()?;
+
+    // Act
+    let error = Repository::new(repository.path(), "git")
+        .expect_err("relative Git executable should be rejected");
+
+    // Assert
+    assert!(matches!(
+        error,
+        RepositoryError::GitExecutableNotAbsolute { .. }
+    ));
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn external_model_reads_tool_results_and_retains_chat_history() -> Result<(), Box<dyn Error>>
 {
@@ -127,9 +146,10 @@ async fn external_model_reads_tool_results_and_retains_chat_history() -> Result<
             requests: Arc::clone(&requests),
         };
         let directory = tempfile::tempdir()?;
+        let repository = Repository::new(directory.path(), std::env::current_exe()?)?;
         let harness = Harness::new(model)
             .database(directory.path().join("harness.db"))
-            .repository("fixture")
+            .repository(repository)
             .file_system(NameFileSystem)
             .allow(Tool::Read);
         let mut chat = harness

--- a/crates/ag-harness/tests/telemetry.rs
+++ b/crates/ag-harness/tests/telemetry.rs
@@ -1663,6 +1663,12 @@ fn lifecycle_harness(server: &MockServer, repository: &std::path::Path) -> Harne
     let observers = LifecycleObserverSet::new(LifecycleMetrics::new())
         .with_observer(LifecycleTraceObserver::new());
 
+    let repository = ag_harness::Repository::new(
+        repository,
+        std::env::current_exe().expect("test executable should be available"),
+    )
+    .expect("repository fixture should be valid");
+
     Harness::new(PolicyDenialModel { client })
         .repository(repository)
         .allow(Tool::Read)

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -27,7 +27,12 @@ flowchart LR
 - `run_once` executes a turn without durable history.
 
 Repository tools are denied by default. `Tool::Read` and `Tool::Write` must be enabled
-explicitly, and both are rooted by `Harness::repository()`.
+explicitly, and both receive a validated `Repository` configuration. The host selects an
+absolute Git executable whose configured location and canonical target are outside the
+containing worktree. Configuration canonicalizes it once and never discovers Git from
+`PATH`. Unix hosts also verify effective execute access; other platforms defer that
+check to process creation. Repository-relative tool arguments reject `.git` components
+before filesystem access.
 
 ## Session lifecycle
 


### PR DESCRIPTION
- Repository configuration canonicalizes roots and host-selected Git executables, checks effective-identity execute permission, and rejects Git administrative paths and executables inside the containing worktree.
- Repository tools use the validated executable directly instead of resolving Git from `PATH`, and repository paths reject `.git` components.
- The CLI, live read E2E check, and repository-backed benchmarks require explicit Git configuration.
- Harness consumers, the CLI, live read E2E checks, and repository-backed benchmarks require explicit Git configuration.