### PR TITLE
Keep session creation responsive

### DIFF
--- a/crates/agentty/src/app.rs
+++ b/crates/agentty/src/app.rs
@@ -18,6 +18,7 @@ mod review_request;
 mod service;
 pub(crate) mod session;
 mod session_api;
+mod session_creation;
 mod session_diff;
 mod session_runtime;
 pub mod session_state;

--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -65,6 +65,12 @@ pub(crate) enum AppRuntimeEvent {
 /// [`App::apply_app_events`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum AppEvent {
+    /// Result of external session creation, acknowledged after snapshot
+    /// refresh.
+    SessionCreationCompleted {
+        request_id: String,
+        result: Result<String, String>,
+    },
     /// Indicates background-loaded prompt at-mention entries for one session.
     AtMentionEntriesLoaded {
         entries: Vec<FileEntry>,
@@ -263,6 +269,7 @@ pub(crate) enum AppEvent {
 /// Reduced representation of all app events currently queued for one tick.
 #[derive(Default)]
 pub(super) struct AppEventBatch {
+    pub(super) session_creations: Vec<(String, Result<String, String>)>,
     pub(super) applied_turns: HashMap<SessionId, TurnAppliedState>,
     pub(super) agent_cli_updates: Option<Vec<AgentCliInfo>>,
     pub(super) at_mention_entries_updates: HashMap<SessionId, Vec<FileEntry>>,
@@ -465,6 +472,16 @@ impl AppEventBatch {
     /// tick preserves cumulative usage from multiple completed turns.
     pub(super) fn collect_event(&mut self, event: AppEvent) {
         match event {
+            AppEvent::SessionOrchestrationProgressUpdated {
+                progress,
+                session_id,
+            } => {
+                self.session_orchestration_progress_updates
+                    .insert(session_id, progress);
+            }
+            AppEvent::SessionCreationCompleted { request_id, result } => {
+                self.session_creations.push((request_id, result));
+            }
             AppEvent::GitStatusUpdated {
                 generation,
                 session_statuses,
@@ -601,10 +618,11 @@ impl AppEventBatch {
             | AppEvent::StackedParentSyncCompleted { .. }
             | AppEvent::StackedParentMergeCompleted { .. }
             | AppEvent::SessionWorkflowNoticeUpdated { .. }
-            | AppEvent::SessionOrchestrationProgressUpdated { .. }
             | AppEvent::PublishedBranchSyncUpdated { .. }
             | AppEvent::ReviewRequestStatusUpdated { .. }) => self.collect_workflow_event(event),
-            AppEvent::GitStatusUpdated { .. }
+            AppEvent::SessionOrchestrationProgressUpdated { .. }
+            | AppEvent::SessionCreationCompleted { .. }
+            | AppEvent::GitStatusUpdated { .. }
             | AppEvent::VersionAvailabilityUpdated { .. }
             | AppEvent::AgentCliVersionsUpdated { .. }
             | AppEvent::UpdateStatusChanged { .. }
@@ -690,13 +708,6 @@ impl AppEventBatch {
             AppEvent::SessionWorkflowNoticeUpdated { notice, session_id } => {
                 self.collect_session_workflow_notice_updated(session_id, notice);
             }
-            AppEvent::SessionOrchestrationProgressUpdated {
-                progress,
-                session_id,
-            } => {
-                self.session_orchestration_progress_updates
-                    .insert(session_id, progress);
-            }
             AppEvent::PublishedBranchSyncUpdated {
                 persistent_notice,
                 session_id,
@@ -713,7 +724,9 @@ impl AppEventBatch {
                 result,
                 session_id,
             } => self.collect_review_request_status_updated(generation, result, session_id),
-            AppEvent::AtMentionEntriesLoaded { .. }
+            AppEvent::SessionOrchestrationProgressUpdated { .. }
+            | AppEvent::SessionCreationCompleted { .. }
+            | AppEvent::AtMentionEntriesLoaded { .. }
             | AppEvent::DiffPreviewLoaded { .. }
             | AppEvent::SessionDiffLoaded { .. }
             | AppEvent::GitStatusUpdated { .. }
@@ -1003,6 +1016,8 @@ impl App {
 
         self.apply_batch_session_snapshot_updates(&mut event_batch);
         self.apply_app_event_effects(after_snapshot_effects).await;
+        self.complete_session_creations(std::mem::take(&mut event_batch.session_creations))
+            .await;
 
         self.apply_worker_action_transitions(&mut event_batch);
 

--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -184,6 +184,8 @@ impl App {
             pending_project_sync_completions: std::collections::HashMap::new(),
             pending_project_sync_requests: std::collections::VecDeque::new(),
             pending_focused_review_persistence: std::collections::HashMap::new(),
+            pending_session_creations: std::collections::HashMap::new(),
+            interactive_session_creation: None,
             pending_session_diff_requests: std::collections::HashMap::new(),
             projects,
             services,

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -286,6 +286,11 @@ pub struct App {
     /// Retains focused-review cache generations until their durable writes
     /// settle so project-scoped refreshes cannot discard off-project output.
     pub(crate) pending_focused_review_persistence: HashMap<SessionId, FocusedReviewPersistence>,
+    /// Pending creation responses, completed only after foreground refresh.
+    pub(crate) pending_session_creations:
+        HashMap<String, crate::app::session_creation::PendingSessionCreation>,
+    /// Most recently opened creation notice; older results cannot steal focus.
+    pub(crate) interactive_session_creation: Option<String>,
     /// Tracks background session-diff loads by request generation so stale
     /// completions cannot change the active mode or review generation.
     pub(crate) pending_session_diff_requests: HashMap<u64, PendingSessionDiffRequest>,

--- a/crates/agentty/src/app/service.rs
+++ b/crates/agentty/src/app/service.rs
@@ -55,12 +55,14 @@ pub(crate) struct AppServiceDeps {
 }
 
 /// Shared app dependencies used by managers and background workflows.
+#[derive(Clone)]
 pub struct AppServices {
     available_agent_clis: Arc<Mutex<Vec<AgentCliInfo>>>,
     available_agent_kinds: Arc<[AgentKind]>,
     app_server_client_override: Option<Arc<dyn AppServerClient>>,
     base_path: PathBuf,
     cleanup_task_handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
+    creation_task_handles: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
     clipboard_image_client: Arc<dyn ClipboardImageClient>,
     clock: Arc<dyn Clock>,
     event_tx: mpsc::UnboundedSender<AppEvent>,
@@ -114,6 +116,7 @@ impl AppServices {
             app_server_client_override,
             base_path,
             cleanup_task_handles: Arc::default(),
+            creation_task_handles: Arc::default(),
             clipboard_image_client,
             clock,
             event_tx,
@@ -203,6 +206,35 @@ impl AppServices {
         self.emit_app_event(AppEvent::RefreshProjects);
     }
 
+    /// Tracks worktree creation, which must settle before cleanup because its
+    /// blocking Git operation cannot safely be canceled midway through setup.
+    pub(crate) fn track_session_creation_task(
+        &self,
+        request_id: String,
+        join_handle: JoinHandle<()>,
+    ) {
+        self.creation_task_handles
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(request_id, join_handle);
+    }
+
+    /// Releases a completed request's handle before acknowledging its result.
+    /// Completion is emitted after external work, so joining only settles the
+    /// task's return. Other requests remain tracked for shutdown.
+    pub(crate) async fn finish_session_creation_task(&self, request_id: &str) {
+        let task = self
+            .creation_task_handles
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(request_id);
+        if let Some(task) = task
+            && let Err(error) = task.await
+        {
+            warn!(error = %error, "session creation task failed during completion");
+        }
+    }
+
     /// Tracks one best-effort cleanup task that should complete before the app
     /// finishes graceful shutdown.
     pub(crate) fn track_cleanup_task(&self, join_handle: JoinHandle<()>) {
@@ -211,13 +243,27 @@ impl AppServices {
         }
     }
 
-    /// Waits for all tracked cleanup tasks to finish.
+    /// Settles worktree creation, then waits for tracked cleanup tasks.
     ///
     /// The task list is drained before awaiting so the synchronous mutex guard
     /// is never held across an `.await`. The loop repeats in case a cleanup
-    /// task registers additional cleanup work before it exits. All tasks share
-    /// one shutdown deadline; unfinished tasks are canceled after it expires.
+    /// task registers additional cleanup work before it exits. Cleanup tasks
+    /// share one shutdown deadline; unfinished tasks are canceled after it
+    /// expires.
     pub(crate) async fn wait_for_cleanup_tasks(&self) {
+        let creation_tasks = self
+            .creation_task_handles
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .drain()
+            .map(|(_, task)| task)
+            .collect::<Vec<_>>();
+        for task in creation_tasks {
+            if let Err(error) = task.await {
+                warn!(error = %error, "session creation task failed during shutdown");
+            }
+        }
+
         wait_for_cleanup_task_handles(
             self.cleanup_task_handles.as_ref(),
             CLEANUP_TASK_SHUTDOWN_TIMEOUT,
@@ -308,6 +354,7 @@ async fn wait_for_cleanup_task_handles(
 /// Returns a stable instrumentation label for one app event variant.
 fn app_event_label(event: &AppEvent) -> &'static str {
     match event {
+        AppEvent::SessionCreationCompleted { .. } => "SessionCreationCompleted",
         AppEvent::AtMentionEntriesLoaded { .. } => "AtMentionEntriesLoaded",
         AppEvent::DiffPreviewLoaded { .. } => "DiffPreviewLoaded",
         AppEvent::SessionDiffLoaded { .. } => "SessionDiffLoaded",
@@ -531,6 +578,145 @@ mod tests {
 
         // Assert
         assert_eq!(label, "SessionTurnStarted");
+    }
+
+    #[tokio::test]
+    async fn creation_completion_releases_handles_and_preserves_pending_work() {
+        // Arrange
+        let (mut app, _directory) = crate::test_support::new_test_app().await;
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        app.services.track_session_creation_task(
+            "pending".to_string(),
+            tokio::spawn(async move {
+                release_rx.await.expect("release pending creation");
+            }),
+        );
+
+        for index in 0..64 {
+            let request_id = format!("completed-{index}");
+            let services = app.services.clone();
+            let (settled_tx, mut settled_rx) = tokio::sync::oneshot::channel();
+            let task = tokio::spawn(async move {
+                // Joining must not retain the tracker lock.
+                let unlocked = services.creation_task_handles.try_lock().is_ok();
+                let _ = settled_tx.send(unlocked);
+            });
+            app.services
+                .track_session_creation_task(request_id.clone(), task);
+
+            // Act
+            app.complete_session_creations(vec![(request_id, Err("setup failed".to_string()))])
+                .await;
+
+            // Assert
+            assert!(
+                settled_rx
+                    .try_recv()
+                    .expect("task joined before completion")
+            );
+            let tasks = app.services.creation_task_handles.lock().expect("tracker");
+            assert_eq!(tasks.len(), 1);
+            assert!(
+                !tasks
+                    .get("pending")
+                    .expect("pending creation")
+                    .is_finished()
+            );
+        }
+
+        release_tx.send(()).expect("release creation");
+        app.services.wait_for_cleanup_tasks().await;
+        assert!(
+            app.services
+                .creation_task_handles
+                .lock()
+                .expect("tracker")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn creation_completion_releases_canceled_tasks_and_tolerates_duplicates() {
+        // Arrange
+        let (app, _directory) = crate::test_support::new_test_app().await;
+        let task = tokio::spawn(future::pending::<()>());
+        task.abort();
+        app.services
+            .track_session_creation_task("canceled".to_string(), task);
+
+        // Act
+        app.services.finish_session_creation_task("canceled").await;
+        app.services.finish_session_creation_task("canceled").await;
+
+        // Assert
+        assert!(
+            app.services
+                .creation_task_handles
+                .lock()
+                .expect("tracker")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_settles_creation_before_cleanup() {
+        // Arrange
+        let (app, _directory) = crate::test_support::new_test_app().await;
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let creation_finished = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        app.services.track_session_creation_task(
+            "pending".to_string(),
+            tokio::spawn({
+                let creation_finished = Arc::clone(&creation_finished);
+                async move {
+                    release_rx.await.expect("creation release");
+                    creation_finished.store(true, std::sync::atomic::Ordering::SeqCst);
+                }
+            }),
+        );
+
+        // Act
+        let shutdown = app.services.wait_for_cleanup_tasks();
+        tokio::pin!(shutdown);
+        let completed_before_release = tokio::select! {
+            () = &mut shutdown => true,
+            () = time::sleep(Duration::from_millis(25)) => false,
+        };
+        assert!(!completed_before_release, "shutdown abandoned creation");
+        release_tx.send(()).expect("release creation");
+        shutdown.await;
+
+        // Assert
+        assert!(creation_finished.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(
+            app.services
+                .creation_task_handles
+                .lock()
+                .expect("creation tasks")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_observes_canceled_creation_task() {
+        // Arrange
+        let (app, _directory) = crate::test_support::new_test_app().await;
+        let task = tokio::spawn(future::pending::<()>());
+        task.abort();
+        app.services
+            .track_session_creation_task("canceled".to_string(), task);
+
+        // Act
+        app.services.wait_for_cleanup_tasks().await;
+
+        // Assert
+        assert!(
+            app.services
+                .creation_task_handles
+                .lock()
+                .expect("creation tasks")
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/session/workflow/lifecycle.rs
+++ b/crates/agentty/src/app/session/workflow/lifecycle.rs
@@ -765,7 +765,7 @@ impl SessionManager {
         }
 
         let worktree_branch = session_branch(&session_id);
-        self.create_session_worktree(
+        Self::create_session_worktree(
             services,
             &session_id,
             &folder,
@@ -787,7 +787,7 @@ impl SessionManager {
             .fork_session_snapshot(snapshot)
             .await
         {
-            self.rollback_failed_session_creation(
+            Self::rollback_failed_session_creation(
                 services,
                 &folder,
                 &repo_root,
@@ -804,21 +804,15 @@ impl SessionManager {
 
         Self::record_session_creation_activity(services, &session_id).await;
 
-        if let Err(error) = agent::create_backend(source_agent.kind()).setup(&folder) {
-            self.rollback_failed_session_creation(
-                services,
-                &folder,
-                &repo_root,
-                &session_id,
-                &worktree_branch,
-                true,
-            )
-            .await;
-
-            return Err(SessionError::Workflow(format!(
-                "Failed to setup session backend: {error}"
-            )));
-        }
+        Self::setup_created_session_backend(
+            services,
+            agent::create_backend(source_agent.kind()).as_ref(),
+            &folder,
+            &repo_root,
+            &session_id,
+            &worktree_branch,
+        )
+        .await?;
 
         SessionTaskService::refresh_persisted_session_diff_stats(
             services.db(),
@@ -850,9 +844,30 @@ impl SessionManager {
         creation_settings: Option<SessionCreationSettings>,
         creation_kind: SessionCreationKind,
     ) -> Result<String, SessionError> {
-        let mut creation_settings = self
+        let creation_settings = self
             .resolve_session_creation_settings(services, project_id, creation_settings)
             .await?;
+
+        Self::materialize_session(
+            services,
+            project_id,
+            base_branch,
+            working_dir,
+            creation_settings,
+            creation_kind,
+        )
+        .await
+    }
+
+    /// Executes prepared session creation without borrowing foreground state.
+    pub(crate) async fn materialize_session(
+        services: &AppServices,
+        project_id: i64,
+        base_branch: &str,
+        working_dir: PathBuf,
+        mut creation_settings: SessionCreationSettings,
+        creation_kind: SessionCreationKind,
+    ) -> Result<String, SessionError> {
         creation_settings.role = creation_kind.role();
         let session_agent = creation_settings.agent;
         let session_model = session_agent.model();
@@ -876,7 +891,7 @@ impl SessionManager {
             .ok_or_else(|| {
                 SessionError::Workflow("Failed to find git repository root".to_string())
             })?;
-        self.create_session_worktree(
+        Self::create_session_worktree(
             services,
             &session_id,
             &folder,
@@ -910,7 +925,7 @@ impl SessionManager {
             })
             .await
         {
-            self.rollback_failed_session_creation(
+            Self::rollback_failed_session_creation(
                 services,
                 &folder,
                 &repo_root,
@@ -927,13 +942,37 @@ impl SessionManager {
 
         Self::record_session_creation_activity(services, &session_id).await;
 
-        if let Err(error) = agent::create_backend(session_agent.kind()).setup(&folder) {
-            self.rollback_failed_session_creation(
+        Self::setup_created_session_backend(
+            services,
+            agent::create_backend(session_agent.kind()).as_ref(),
+            &folder,
+            &repo_root,
+            &session_id,
+            &worktree_branch,
+        )
+        .await?;
+        services.emit_session_and_project_refresh_events();
+
+        Ok(session_id)
+    }
+
+    /// Configures a newly persisted session and rolls back its resources when
+    /// the injected backend rejects setup. Shared by creation and forking.
+    async fn setup_created_session_backend(
+        services: &AppServices,
+        backend: &dyn agent::AgentBackend,
+        folder: &Path,
+        repo_root: &Path,
+        session_id: &str,
+        worktree_branch: &str,
+    ) -> Result<(), SessionError> {
+        if let Err(error) = backend.setup(folder) {
+            Self::rollback_failed_session_creation(
                 services,
-                &folder,
-                &repo_root,
-                &session_id,
-                &worktree_branch,
+                folder,
+                repo_root,
+                session_id,
+                worktree_branch,
                 true,
             )
             .await;
@@ -942,9 +981,8 @@ impl SessionManager {
                 "Failed to setup session backend: {error}"
             )));
         }
-        services.emit_session_and_project_refresh_events();
 
-        Ok(session_id)
+        Ok(())
     }
 
     /// Creates the git worktree and session-local metadata directory for one
@@ -959,7 +997,6 @@ impl SessionManager {
     /// Returns an error if git worktree creation fails or the `.agentty`
     /// metadata directory cannot be created inside the worktree.
     async fn create_session_worktree(
-        &self,
         services: &AppServices,
         session_id: &str,
         folder: &Path,
@@ -982,7 +1019,7 @@ impl SessionManager {
 
         let data_dir = folder.join(SESSION_DATA_DIR);
         if let Err(error) = services.fs_client().create_dir_all(data_dir).await {
-            self.rollback_failed_session_creation(
+            Self::rollback_failed_session_creation(
                 services,
                 folder,
                 repo_root,
@@ -1058,7 +1095,7 @@ impl SessionManager {
 
         let repo_root = self.load_session_repo_root(services, session_id).await?;
 
-        self.create_session_worktree(
+        Self::create_session_worktree(
             services,
             &persisted_session_id,
             &folder,
@@ -3267,7 +3304,7 @@ impl SessionManager {
 
     /// Resolves project defaults unless the caller supplied a deterministic
     /// launch-settings snapshot.
-    async fn resolve_session_creation_settings(
+    pub(crate) async fn resolve_session_creation_settings(
         &mut self,
         services: &AppServices,
         project_id: i64,
@@ -3337,7 +3374,6 @@ impl SessionManager {
 
     /// Reverts filesystem and database changes after session creation failure.
     async fn rollback_failed_session_creation(
-        &self,
         services: &AppServices,
         folder: &Path,
         repo_root: &Path,
@@ -4738,7 +4774,6 @@ mod tests {
         // Arrange
         let session = test_session("", Status::Draft, None, "");
         let database = database_with_session(&session).await;
-        let session_manager = session_manager_with_one_session(session);
         let repo_root = PathBuf::from("/tmp/project");
         let folder = PathBuf::from("/tmp/session-worktree");
         let expected_repo_root = repo_root.clone();
@@ -4765,19 +4800,214 @@ mod tests {
         );
 
         // Act
-        let result = session_manager
-            .create_session_worktree(
-                &services,
-                "session-id",
-                folder.as_path(),
-                repo_root.as_path(),
-                "wt/session-id",
-                "main",
-            )
-            .await;
+        let result = SessionManager::create_session_worktree(
+            &services,
+            "session-id",
+            folder.as_path(),
+            repo_root.as_path(),
+            "wt/session-id",
+            "main",
+        )
+        .await;
 
         // Assert
         assert!(result.is_ok());
+    }
+
+    /// Expects rollback to remove both the worktree registration and branch.
+    fn rollback_git_client() -> git::MockGitClient {
+        let mut client = git::MockGitClient::new();
+        client
+            .expect_remove_worktree()
+            .once()
+            .returning(|_| Box::pin(async { Ok(()) }));
+        client
+            .expect_delete_branch()
+            .once()
+            .returning(|_, _| Box::pin(async { Ok(()) }));
+
+        client
+    }
+
+    #[tokio::test]
+    async fn creation_and_fork_roll_back_when_metadata_persistence_fails() {
+        for fork in [false, true] {
+            // Arrange
+            let source = test_session("source", Status::Review, Some("Source"), "history");
+            let source_id = source.id.clone();
+            let (database, pool) = database_with_session_and_pool(&source).await;
+            let project_id = database
+                .sessions()
+                .load_session_project_id(&source_id)
+                .await
+                .expect("project lookup")
+                .expect("source project");
+            sqlx::query(
+                "CREATE TRIGGER reject_creation BEFORE INSERT ON session BEGIN SELECT \
+                 RAISE(ABORT, 'creation rejected'); END",
+            )
+            .execute(&pool)
+            .await
+            .expect("failure trigger");
+            let mut manager = session_manager_with_one_session(source);
+            let mut git = rollback_git_client();
+            git.expect_find_git_repo_root()
+                .once()
+                .returning(|path| Box::pin(async move { Some(path) }));
+            git.expect_create_worktree()
+                .once()
+                .returning(|_, _, _, _| Box::pin(async { Ok(()) }));
+            let services = test_services_with_fs_client(
+                &database,
+                Arc::new(RealClock),
+                Arc::new(create_passthrough_mock_fs_client()),
+                Arc::new(git),
+                Arc::new(forge::MockReviewRequestClient::new()),
+            );
+
+            // Act
+            let result = if fork {
+                manager.fork_session(&services, &source_id).await
+            } else {
+                manager
+                    .create_session_for_project(
+                        &services,
+                        project_id,
+                        "main",
+                        PathBuf::from("/tmp/project"),
+                        None,
+                        SessionCreationKind::Worker,
+                    )
+                    .await
+            };
+
+            // Assert
+            assert!(
+                result
+                    .expect_err("persistence must fail")
+                    .to_string()
+                    .contains("creation rejected")
+            );
+            assert!(
+                database
+                    .sessions()
+                    .load_session(&source_id)
+                    .await
+                    .expect("source lookup")
+                    .is_some()
+            );
+            assert_eq!(
+                database
+                    .sessions()
+                    .load_sessions_metadata()
+                    .await
+                    .expect("session count")
+                    .0,
+                1
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn creation_rolls_back_when_metadata_directory_cannot_be_created() {
+        // Arrange
+        let source = test_session("source", Status::Review, None, "");
+        let database = database_with_session(&source).await;
+        let mut git = rollback_git_client();
+        git.expect_create_worktree()
+            .once()
+            .returning(|_, _, _, _| Box::pin(async { Ok(()) }));
+        let mut filesystem = fs::MockFsClient::new();
+        filesystem.expect_create_dir_all().once().returning(|_| {
+            Box::pin(async { Err(fs::FsError::Io(std::io::Error::other("directory rejected"))) })
+        });
+        filesystem
+            .expect_remove_dir_all()
+            .times(1..)
+            .returning(|_| Box::pin(async { Ok(()) }));
+        let services = test_services_with_fs_client(
+            &database,
+            Arc::new(RealClock),
+            Arc::new(filesystem),
+            Arc::new(git),
+            Arc::new(forge::MockReviewRequestClient::new()),
+        );
+
+        // Act
+        let result = SessionManager::create_session_worktree(
+            &services,
+            "new-session",
+            Path::new("/tmp/new-session"),
+            Path::new("/tmp/project"),
+            "wt/new-session",
+            "main",
+        )
+        .await;
+
+        // Assert
+        assert!(
+            result
+                .expect_err("directory creation must fail")
+                .to_string()
+                .contains("directory rejected")
+        );
+        assert_eq!(
+            database
+                .sessions()
+                .load_sessions_metadata()
+                .await
+                .expect("session count")
+                .0,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn backend_setup_failure_rolls_back_persisted_session() {
+        // Arrange
+        let session = test_session("", Status::Draft, None, "");
+        let session_id = session.id.clone();
+        let database = database_with_session(&session).await;
+        let services = test_services_with_fs_client(
+            &database,
+            Arc::new(RealClock),
+            Arc::new(create_passthrough_mock_fs_client()),
+            Arc::new(rollback_git_client()),
+            Arc::new(forge::MockReviewRequestClient::new()),
+        );
+        let mut backend = agent::MockAgentBackend::new();
+        backend.expect_setup().once().returning(|_| {
+            Err(agent::AgentBackendError::Setup(
+                "setup rejected".to_string(),
+            ))
+        });
+
+        // Act
+        let result = SessionManager::setup_created_session_backend(
+            &services,
+            &backend,
+            &session.folder,
+            Path::new("/tmp/project"),
+            &session_id,
+            "wt/new-session",
+        )
+        .await;
+
+        // Assert
+        assert!(
+            result
+                .expect_err("backend setup must fail")
+                .to_string()
+                .contains("setup rejected")
+        );
+        assert!(
+            database
+                .sessions()
+                .load_session(&session_id)
+                .await
+                .expect("session lookup")
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/agentty/src/app/session_api.rs
+++ b/crates/agentty/src/app/session_api.rs
@@ -22,6 +22,7 @@ use crate::app::orchestration::{OrchestrationApprovalOutcome, child_session_is_s
 use crate::app::session::{
     SessionCreationKind, SessionCreationSettings, migrate_session_off_retired_model,
 };
+use crate::app::session_creation::PreparedSessionCreation;
 use crate::app::{
     App, AppError, AppEvent, SessionError, SessionRuntimeAccess, SessionRuntimeCommand,
     SessionRuntimeHandle,
@@ -139,7 +140,9 @@ impl App {
     ///
     /// Background callers rely on the terminal event loop to drive the same
     /// mailbox. Foreground callers use this helper so awaiting their own
-    /// response never deadlocks the foreground executor.
+    /// response never deadlocks the foreground executor. Pending creation also
+    /// pumps reducer events so its background completion can acknowledge the
+    /// request; other commands retain their normal snapshot ordering.
     pub(crate) async fn drive_session_request<RequestFuture>(
         &mut self,
         request: RequestFuture,
@@ -154,8 +157,21 @@ impl App {
             tokio::select! {
                 biased;
                 result = &mut request => return result,
-                command = self.sessions.next_command() => {
-                    self.apply_session_runtime_command(command).await;
+                event = async {
+                    if self.pending_session_creations.is_empty() {
+                        crate::app::AppRuntimeEvent::Session(self.sessions.next_command().await)
+                    } else {
+                        self.next_runtime_event().await
+                    }
+                } => {
+                    match event {
+                        crate::app::AppRuntimeEvent::App(event) => {
+                            Box::pin(self.apply_app_events(*event)).await;
+                        }
+                        crate::app::AppRuntimeEvent::Session(command) => {
+                            self.apply_session_runtime_command(command).await;
+                        }
+                    }
                 }
             }
         }
@@ -168,7 +184,8 @@ impl App {
                 request,
                 response_tx,
             } => {
-                let _ = response_tx.send(self.create_api_session(request).await);
+                self.start_session_creation(request, Some(response_tx))
+                    .await;
             }
             SessionRuntimeCommand::Get {
                 response_tx,
@@ -298,12 +315,12 @@ impl App {
         }
     }
 
-    /// Creates one API-requested session, validating project relationships and
-    /// resolving optional inherited settings before creation mutates state.
-    async fn create_api_session(
+    /// Validates one creation request and captures its launch settings. Drafts
+    /// persist immediately; materialized worktrees return an owned effect plan.
+    pub(super) async fn prepare_api_session_creation(
         &mut self,
         request: CreateSessionRequest,
-    ) -> Result<SessionId, ApiSessionError> {
+    ) -> Result<PreparedSessionCreation, ApiSessionError> {
         self.validate_api_session_request(&request).await?;
         self.ensure_project_checkout_available(request.project_id)
             .map_err(api_error_from_app)?;
@@ -318,65 +335,24 @@ impl App {
             .map_or((None, None), |inherited| {
                 (Some(inherited.base_branch), Some(inherited.settings))
             });
-        let session_id = match request.mode {
-            CreateSessionMode::Regular => {
-                if creation_settings.is_none() {
-                    App::create_session(self).await
-                } else {
-                    self.create_api_materialized_session(
+        let creation_kind = match request.mode {
+            CreateSessionMode::Draft => {
+                let project = self.api_project_creation_context(base_branch_override)?;
+                let session_id = self
+                    .sessions
+                    .create_draft_session_for_project_with_settings(
+                        &self.services,
                         request.project_id,
-                        base_branch_override,
+                        &project.base_branch,
                         creation_settings,
-                        SessionCreationKind::Worker,
                     )
                     .await
-                }
-            }
-            CreateSessionMode::Draft => {
-                if creation_settings.is_none() {
-                    self.create_draft_session().await
-                } else {
-                    let project = self.api_project_creation_context(base_branch_override)?;
-                    self.sessions
-                        .create_draft_session_for_project_with_settings(
-                            &self.services,
-                            request.project_id,
-                            &project.base_branch,
-                            creation_settings,
-                        )
-                        .await
-                        .map_err(AppError::from)
-                }
-            }
-            CreateSessionMode::Orchestrator => {
-                self.create_api_materialized_session(
-                    request.project_id,
-                    base_branch_override,
-                    creation_settings,
-                    SessionCreationKind::Orchestrator,
-                )
-                .await
-            }
-            CreateSessionMode::OrchestrationChild { task_id } => {
-                self.create_api_materialized_session(
-                    request.project_id,
-                    base_branch_override,
-                    creation_settings,
-                    SessionCreationKind::OrchestrationChild { task_id },
-                )
-                .await
-            }
-            CreateSessionMode::OrchestrationResearch { task_id } => {
-                self.create_api_materialized_session(
-                    request.project_id,
-                    base_branch_override,
-                    creation_settings,
-                    SessionCreationKind::OrchestrationResearch { task_id },
-                )
-                .await
+                    .map_err(api_error_from_session)?;
+
+                return Ok(PreparedSessionCreation::Persisted(session_id));
             }
             CreateSessionMode::Stacked { parent_session_id } => {
-                if let Some(settings) = creation_settings {
+                let session_id = if let Some(settings) = creation_settings {
                     self.sessions
                         .create_stacked_draft_session_with_settings(
                             &self.services,
@@ -384,17 +360,42 @@ impl App {
                             settings,
                         )
                         .await
-                        .map_err(AppError::from)
                 } else {
-                    self.create_stacked_draft_session(&parent_session_id).await
+                    self.sessions
+                        .create_stacked_draft_session(&self.services, &parent_session_id)
+                        .await
                 }
+                .map_err(api_error_from_session)?;
+
+                return Ok(PreparedSessionCreation::Persisted(session_id));
             }
-        }
-        .map_err(api_error_from_app)?;
+            CreateSessionMode::Regular => SessionCreationKind::Worker,
+            CreateSessionMode::Orchestrator => SessionCreationKind::Orchestrator,
+            CreateSessionMode::OrchestrationChild { task_id } => {
+                SessionCreationKind::OrchestrationChild { task_id }
+            }
+            CreateSessionMode::OrchestrationResearch { task_id } => {
+                SessionCreationKind::OrchestrationResearch { task_id }
+            }
+        };
+        let project = self.api_project_creation_context(base_branch_override)?;
+        let settings = self
+            .sessions
+            .resolve_session_creation_settings(
+                &self.services,
+                request.project_id,
+                creation_settings,
+            )
+            .await
+            .map_err(api_error_from_session)?;
 
-        self.finish_api_session_creation(&session_id).await;
-
-        Ok(SessionId::from(session_id))
+        Ok(PreparedSessionCreation::Materialized {
+            base_branch: project.base_branch,
+            creation_kind,
+            project_id: request.project_id,
+            settings,
+            working_dir: project.working_dir,
+        })
     }
 
     async fn validate_api_session_request(
@@ -421,30 +422,6 @@ impl App {
         }
 
         Ok(())
-    }
-
-    async fn create_api_materialized_session(
-        &mut self,
-        project_id: i64,
-        base_branch_override: Option<String>,
-        creation_settings: Option<SessionCreationSettings>,
-        creation_kind: SessionCreationKind,
-    ) -> Result<String, AppError> {
-        let project = self
-            .api_project_creation_context(base_branch_override)
-            .map_err(|error| AppError::Workflow(error.to_string()))?;
-
-        self.sessions
-            .create_session_for_project(
-                &self.services,
-                project_id,
-                &project.base_branch,
-                project.working_dir,
-                creation_settings,
-                creation_kind,
-            )
-            .await
-            .map_err(AppError::from)
     }
 
     /// Loads one complete session aggregate from persistence plus live queue
@@ -948,7 +925,7 @@ impl App {
     /// Attempts to register a newly persisted active-project session before
     /// acknowledging creation, scheduling a refresh retry when loading is
     /// temporarily unavailable.
-    async fn finish_api_session_creation(&mut self, session_id: &str) {
+    pub(super) async fn finish_api_session_creation(&mut self, session_id: &str) {
         if self
             .sessions
             .sessions()

--- a/crates/agentty/src/app/session_creation.rs
+++ b/crates/agentty/src/app/session_creation.rs
@@ -1,0 +1,410 @@
+//! Prepared session creation and foreground completion routing.
+
+use std::path::PathBuf;
+
+use ag_session::{CreateSessionRequest, SessionError, SessionId};
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+use crate::app::session::{SessionCreationKind, SessionCreationSettings};
+use crate::app::{App, AppEvent, SessionManager};
+use crate::domain::input::InputState;
+use crate::presentation::app_mode::{AppMode, ChatFocus};
+use crate::presentation::prompt::{PromptAttachmentState, PromptHistoryState};
+
+/// Creation inputs captured before external work releases the foreground.
+pub(super) enum PreparedSessionCreation {
+    Materialized {
+        base_branch: String,
+        creation_kind: SessionCreationKind,
+        project_id: i64,
+        settings: SessionCreationSettings,
+        working_dir: PathBuf,
+    },
+    Persisted(String),
+}
+
+/// Recipient and project captured when a creation request is accepted.
+pub(crate) struct PendingSessionCreation {
+    project_id: i64,
+    response_tx: Option<oneshot::Sender<Result<SessionId, SessionError>>>,
+}
+
+impl App {
+    /// Starts creation without waiting for worktree setup. A missing response
+    /// channel identifies an interactive request whose notice may open a
+    /// composer.
+    pub(crate) async fn start_session_creation(
+        &mut self,
+        request: CreateSessionRequest,
+        response_tx: Option<oneshot::Sender<Result<SessionId, SessionError>>>,
+    ) {
+        let request_id = Uuid::new_v4().to_string();
+        if response_tx.is_none() {
+            self.interactive_session_creation = Some(request_id.clone());
+            self.mode = AppMode::SyncBlockedPopup {
+                default_branch: None,
+                is_loading: false,
+                message: "Creating session. Close this notice to continue browsing.".to_string(),
+                project_name: None,
+                title: "Creating session".to_string(),
+            };
+            self.mark_dirty();
+        }
+        self.pending_session_creations.insert(
+            request_id.clone(),
+            PendingSessionCreation {
+                project_id: request.project_id,
+                response_tx,
+            },
+        );
+
+        match self.prepare_api_session_creation(request).await {
+            Ok(PreparedSessionCreation::Materialized {
+                base_branch,
+                creation_kind,
+                project_id,
+                settings,
+                working_dir,
+            }) => {
+                let services = self.services.clone();
+                let completion_request_id = request_id.clone();
+                let task = tokio::spawn(async move {
+                    let result = SessionManager::materialize_session(
+                        &services,
+                        project_id,
+                        &base_branch,
+                        working_dir,
+                        settings,
+                        creation_kind,
+                    )
+                    .await
+                    .map_err(|error| error.to_string());
+                    services.emit_app_event(AppEvent::SessionCreationCompleted {
+                        request_id: completion_request_id,
+                        result,
+                    });
+                });
+                self.services.track_session_creation_task(request_id, task);
+            }
+            Ok(PreparedSessionCreation::Persisted(session_id)) => {
+                self.complete_session_creation(&request_id, Ok(session_id))
+                    .await;
+            }
+            Err(error) => {
+                self.complete_session_creation(&request_id, Err(error))
+                    .await;
+            }
+        }
+    }
+
+    /// Applies background creation results in their arrival order.
+    pub(crate) async fn complete_session_creations(
+        &mut self,
+        results: Vec<(String, Result<String, String>)>,
+    ) {
+        for (request_id, result) in results {
+            self.complete_session_creation(&request_id, result.map_err(SessionError::Operation))
+                .await;
+        }
+    }
+
+    /// Refreshes the active snapshot before acknowledging creation, and never
+    /// replaces navigation performed after the interactive notice was closed.
+    pub(crate) async fn complete_session_creation(
+        &mut self,
+        request_id: &str,
+        result: Result<String, SessionError>,
+    ) {
+        self.services.finish_session_creation_task(request_id).await;
+        let Some(pending) = self.pending_session_creations.remove(request_id) else {
+            return;
+        };
+        if let Ok(session_id) = &result {
+            self.finish_api_session_creation(session_id).await;
+        }
+        if let Some(response_tx) = pending.response_tx {
+            let _ = response_tx.send(result.map(SessionId::from));
+
+            return;
+        }
+
+        if self.interactive_session_creation.as_deref() != Some(request_id) {
+            return;
+        }
+        self.interactive_session_creation = None;
+        if pending.project_id != self.active_project_id()
+            || !matches!(&self.mode, AppMode::SyncBlockedPopup { title, .. } if title == "Creating session")
+        {
+            return;
+        }
+        self.mode = match result {
+            Ok(session_id) => {
+                let index = self
+                    .sessions
+                    .sessions()
+                    .iter()
+                    .position(|session| session.id == session_id);
+                self.sessions.select_session_index(index);
+
+                AppMode::Prompt {
+                    at_mention_state: None,
+                    attachment_state: PromptAttachmentState::default(),
+                    focus: ChatFocus::Input,
+                    history_state: PromptHistoryState::new(Vec::new()),
+                    slash_state: self.prompt_slash_state(),
+                    session_id: session_id.into(),
+                    input: InputState::default(),
+                    scroll_offset: None,
+                }
+            }
+            Err(error) => AppMode::SyncBlockedPopup {
+                default_branch: None,
+                is_loading: false,
+                message: error.to_string(),
+                project_name: None,
+                title: "Session creation unavailable".to_string(),
+            },
+        };
+        self.mark_dirty();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use ag_git::{GitError, MockGitClient};
+    use ag_session::CreateSessionMode;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use tokio::sync::Notify;
+
+    use super::*;
+    use crate::app::{AppServiceDeps, AppServices, SessionRuntimeCommand};
+    use crate::runtime::PresentationState;
+
+    /// Pauses worktree setup at its injected Git boundary until released.
+    async fn delayed_creation_app() -> (App, tempfile::TempDir, Arc<Notify>) {
+        let (mut app, directory) = crate::test_support::new_git_test_app().await;
+        let release = Arc::new(Notify::new());
+        let mut git = MockGitClient::new();
+        git.expect_find_git_repo_root()
+            .once()
+            .returning(|path| Box::pin(async move { Some(path) }));
+        git.expect_create_worktree().once().returning({
+            let release = Arc::clone(&release);
+            move |_, _, _, _| {
+                let release = Arc::clone(&release);
+
+                Box::pin(async move {
+                    release.notified().await;
+
+                    Err(GitError::CommandFailed {
+                        command: "git worktree add".to_string(),
+                        stderr: "delayed creation failed".to_string(),
+                    })
+                })
+            }
+        });
+        app.services = AppServices::new_with_agent_clis(
+            app.services.base_path().to_path_buf(),
+            app.services.clock(),
+            app.services.event_sender(),
+            AppServiceDeps {
+                app_server_client_override: app.services.app_server_client_override(),
+                available_agent_kinds: app.services.available_agent_kinds(),
+                clipboard_image_client_override: Some(app.services.clipboard_image_client()),
+                fs_client: app.services.fs_client(),
+                git_client: Arc::new(git),
+                one_shot_client_override: Some(app.services.one_shot_client()),
+                personality_catalog_client_override: Some(
+                    app.services.personality_catalog_client(),
+                ),
+                repositories: app.services.db().clone(),
+                review_request_client: app.services.review_request_client(),
+            },
+            app.services.available_agent_clis(),
+        );
+
+        (app, directory, release)
+    }
+
+    fn regular_request(app: &App) -> CreateSessionRequest {
+        CreateSessionRequest {
+            inherit_from_session_id: None,
+            mode: CreateSessionMode::Regular,
+            project_id: app.active_project_id(),
+        }
+    }
+
+    async fn finish_creation(app: &mut App) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while !app.pending_session_creations.is_empty() {
+                let event = app.next_app_event().await.expect("creation completion");
+                app.apply_app_events(event).await;
+            }
+        })
+        .await
+        .expect("creation must finish");
+    }
+
+    #[tokio::test]
+    async fn delayed_creation_allows_input_and_rendering_without_stealing_navigation() {
+        // Arrange
+        let (mut app, _directory, release) = delayed_creation_app().await;
+        let request = regular_request(&app);
+        let presentation = PresentationState::default();
+        let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("terminal");
+
+        // Act
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            app.start_session_creation(request, None),
+        )
+        .await
+        .expect("creation must return before Git finishes");
+        crate::runtime::mode::sync_blocked::handle(
+            &mut app,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+        );
+        crate::runtime::mode::list::handle(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE),
+        )
+        .await
+        .expect("help input");
+        terminal
+            .draw(|frame| presentation.render(&app.view_snapshot(), frame))
+            .expect("draw help");
+
+        // Assert
+        assert!(matches!(app.mode, AppMode::Help { .. }));
+        assert_eq!(app.pending_session_creations.len(), 1);
+        assert!(
+            terminal
+                .backend()
+                .buffer()
+                .content
+                .iter()
+                .any(|cell| cell.symbol() == "?")
+        );
+        release.notify_one();
+        finish_creation(&mut app).await;
+        assert!(matches!(app.mode, AppMode::Help { .. }));
+    }
+
+    #[tokio::test]
+    async fn delayed_api_creation_allows_other_commands_before_answering() {
+        // Arrange
+        let (mut app, _directory, release) = delayed_creation_app().await;
+        let (response_tx, mut response_rx) = oneshot::channel();
+        let request = regular_request(&app);
+        let (lookup_tx, lookup_rx) = oneshot::channel();
+
+        // Act
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            app.apply_session_runtime_command(SessionRuntimeCommand::Create {
+                request,
+                response_tx,
+            }),
+        )
+        .await
+        .expect("command must return before Git finishes");
+        app.apply_session_runtime_command(SessionRuntimeCommand::Get {
+            response_tx: lookup_tx,
+            session_id: "missing".into(),
+        })
+        .await;
+
+        // Assert
+        assert!(
+            lookup_rx
+                .await
+                .expect("lookup response")
+                .expect("lookup")
+                .is_none()
+        );
+        assert!(matches!(
+            response_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+        assert!(matches!(app.mode, AppMode::List));
+        release.notify_one();
+        finish_creation(&mut app).await;
+        assert!(
+            response_rx
+                .await
+                .expect("creation response")
+                .expect_err("delayed setup should fail")
+                .to_string()
+                .contains("delayed creation failed")
+        );
+    }
+
+    #[tokio::test]
+    async fn creation_completion_preserves_newer_notices_and_project_switches() {
+        // Arrange
+        let (mut app, _directory) = crate::test_support::new_test_app().await;
+        let project_id = app.active_project_id();
+        app.interactive_session_creation = Some("newer".to_string());
+        for (request_id, creation_project_id) in [("older", project_id), ("newer", project_id + 1)]
+        {
+            app.pending_session_creations.insert(
+                request_id.to_string(),
+                PendingSessionCreation {
+                    project_id: creation_project_id,
+                    response_tx: None,
+                },
+            );
+        }
+
+        // Act
+        app.complete_session_creation("older", Err(SessionError::NotFound))
+            .await;
+        app.complete_session_creation("newer", Err(SessionError::NotFound))
+            .await;
+        app.complete_session_creation("duplicate", Err(SessionError::NotFound))
+            .await;
+
+        // Assert
+        assert!(matches!(app.mode, AppMode::List));
+        assert!(app.pending_session_creations.is_empty());
+        assert!(app.interactive_session_creation.is_none());
+    }
+
+    #[tokio::test]
+    async fn creation_rejection_preserves_typed_api_error_even_when_caller_disconnects() {
+        // Arrange
+        let (mut app, _directory) = crate::test_support::new_test_app().await;
+        let (response_tx, response_rx) = oneshot::channel();
+        let request = CreateSessionRequest {
+            mode: CreateSessionMode::Stacked {
+                parent_session_id: "missing".into(),
+            },
+            ..regular_request(&app)
+        };
+
+        // Act
+        app.start_session_creation(request, Some(response_tx)).await;
+        let result = response_rx.await.expect("creation response");
+        let (response_tx, response_rx) = oneshot::channel();
+        drop(response_rx);
+        app.pending_session_creations.insert(
+            "disconnected".to_string(),
+            PendingSessionCreation {
+                project_id: app.active_project_id(),
+                response_tx: Some(response_tx),
+            },
+        );
+        app.complete_session_creation("disconnected", Err(SessionError::NotFound))
+            .await;
+
+        // Assert
+        assert_eq!(result, Err(SessionError::NotFound));
+        assert!(app.pending_session_creations.is_empty());
+    }
+}

--- a/crates/agentty/src/runtime/key_handler.rs
+++ b/crates/agentty/src/runtime/key_handler.rs
@@ -293,27 +293,15 @@ async fn create_selected_session(app: &mut App) -> io::Result<()> {
         _ => return Ok(()),
     };
     let project_id = app.active_project_id();
-    let service = app.session_service();
-    let request = service.create_session(CreateSessionRequest {
-        inherit_from_session_id: None,
-        mode,
-        project_id,
-    });
-    let session_id = match app.drive_session_request(request).await {
-        Ok(session_id) => session_id,
-        Err(error) => {
-            app.mode = AppMode::SyncBlockedPopup {
-                default_branch: None,
-                is_loading: false,
-                message: error.to_string(),
-                project_name: None,
-                title: "Session creation unavailable".to_string(),
-            };
-
-            return Ok(());
-        }
-    };
-    mode::list::open_session_prompt(app, session_id.into());
+    app.start_session_creation(
+        CreateSessionRequest {
+            inherit_from_session_id: None,
+            mode,
+            project_id,
+        },
+        None,
+    )
+    .await;
 
     Ok(())
 }
@@ -1165,6 +1153,15 @@ mod tests {
                 KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
             )
             .await;
+
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                while !app.pending_session_creations.is_empty() {
+                    let event = app.next_app_event().await.expect("creation event");
+                    app.apply_app_events(event).await;
+                }
+            })
+            .await
+            .expect("creation should finish");
 
             // Assert
             assert!(matches!(result, Ok(EventResult::Continue)));

--- a/crates/agentty/src/runtime/mode/list.rs
+++ b/crates/agentty/src/runtime/mode/list.rs
@@ -4,13 +4,12 @@ use ag_tui_text::text_util::inline_text;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::app::{App, Tab};
-use crate::domain::input::{InputCommand, InputState};
+use crate::domain::input::InputCommand;
 use crate::domain::session::{Session, Status};
-use crate::presentation::app_mode::{AppMode, ChatFocus, ConfirmationIntent, HelpContext};
+use crate::presentation::app_mode::{AppMode, ConfirmationIntent, HelpContext};
 use crate::presentation::help_action::{
     HelpAction, project_list_actions, session_list_actions, settings_actions,
 };
-use crate::presentation::prompt::{PromptAttachmentState, PromptHistoryState};
 use crate::presentation::settings::{SettingsAction, SettingsInput};
 use crate::runtime::EventResult;
 use crate::runtime::mode::confirmation::DEFAULT_OPTION_INDEX;
@@ -258,20 +257,6 @@ fn list_keybindings(app: &App) -> Vec<HelpAction> {
     session_list_actions(can_cancel_selected_session, can_open_selected_session)
 }
 
-/// Opens prompt mode for the provided session identifier.
-pub(crate) fn open_session_prompt(app: &mut App, session_id: String) {
-    app.mode = AppMode::Prompt {
-        at_mention_state: None,
-        attachment_state: PromptAttachmentState::default(),
-        focus: ChatFocus::Input,
-        history_state: PromptHistoryState::new(Vec::new()),
-        slash_state: app.prompt_slash_state(),
-        session_id: session_id.into(),
-        input: InputState::default(),
-        scroll_offset: None,
-    };
-}
-
 #[cfg(test)]
 mod tests {
     use crossterm::event::KeyModifiers;
@@ -280,10 +265,13 @@ mod tests {
     use crate::app::{
         AppEvent, MockSyncMainRunner, ProjectSyncPhase, SyncMainOutcome, SyncSessionStartError,
     };
+    use crate::domain::input::InputState;
     use crate::domain::question::QuestionItem;
     use crate::domain::theme::ColorTheme;
-    use crate::presentation::app_mode::PromptModeSnapshot;
-    use crate::presentation::prompt::PromptSlashState;
+    use crate::presentation::app_mode::{ChatFocus, PromptModeSnapshot};
+    use crate::presentation::prompt::{
+        PromptAttachmentState, PromptHistoryState, PromptSlashState,
+    };
 
     /// Builds a settings-focused test app with the `Launch Configurations` row
     /// selected.

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -6626,6 +6626,58 @@ fn session_question_reconcile_after_help_overlay() -> E2eResult {
     Ok(())
 }
 
+/// Delays the checkout hook so navigation must work before creation finishes.
+fn seed_delayed_session_creation(env: &BuilderEnv) -> E2eResult {
+    seed_sessions_tab(env)?;
+    let hook = env.workdir.join(".git/hooks/post-checkout");
+    std::fs::write(&hook, "#!/bin/sh\nsleep 8\n")?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o750))?;
+
+    Ok(())
+}
+
+/// Navigation and painting remain available during slow worktree setup.
+#[test]
+fn session_creation_keeps_navigation_responsive() -> E2eResult {
+    // Arrange
+    FeatureTest::new("session_creation_responsive")
+        .with_git()
+        .setup(seed_delayed_session_creation)
+        .run(
+            |scenario| {
+                // Act
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .press_key("a")
+                    .wait_for_text("Regular", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Close this notice", 2000)
+                    .capture_labeled("creating", "Worktree creation is pending")
+                    .press_key("Esc")
+                    .wait_for_stable_frame(300, 1000)
+                    .press_key("?")
+                    .wait_for_text("Keybindings", 2000)
+                    .capture_labeled("navigation", "Help opens before worktree setup finishes")
+                    .sleep_ms(9000)
+                    .capture_labeled("completed", "Creation completion preserves help")
+            },
+            |frame, report| {
+                // Assert
+                let pending = common::frame_from_capture(&report.captures[0]);
+                let pending_full = Region::full(pending.cols(), pending.rows());
+                assertion::assert_text_in_region(&pending, "Creating session", &pending_full);
+                let navigation = common::frame_from_capture(&report.captures[1]);
+                let navigation_full = Region::full(navigation.cols(), navigation.rows());
+                assertion::assert_text_in_region(&navigation, "Keybindings", &navigation_full);
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Keybindings", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
 /// Verify that pressing `a` on the Sessions tab opens the creation selector,
 /// and choosing the regular option opens prompt mode with the submit footer.
 #[test]
@@ -6782,7 +6834,6 @@ fn build_orchestration_scenario(scenario: Scenario) -> Scenario {
             "Workers stay grouped with their controller",
         )
         .wait_for_text("Phase: AwaitingIntegration", 30000)
-        .press_key("j")
         .wait_for_stable_frame(300, 5000)
         .press_key("Enter")
         .wait_for_text(

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -80,11 +80,12 @@ For file-level detail, read the module docstrings directly.
   campaign planning, managed-worker capability routing, the multi-session orchestration
   coordinator, branch publish, review, generation-matched background full-diff requests,
   typed prompt workflow requests and outcomes, the `session_api.rs` adapter for
-  `ag-session`, the bounded `session_runtime.rs` command actor, and the session module
-  (`app/session/`) with its per-session worker queues and workflow steps (`lifecycle`,
-  `turn`, `post_turn`, `merge`, `task`, `worker`). Prompt composers, slash-menu state,
-  and mode navigation remain presentation-owned. No direct process, filesystem, or clock
-  calls — everything external goes through `infra/` traits.
+  `ag-session`, the bounded `session_runtime.rs` command actor, prepared background
+  session creation with foreground completion, and the session module (`app/session/`)
+  with its per-session worker queues and workflow steps (`lifecycle`, `turn`,
+  `post_turn`, `merge`, `task`, `worker`). Prompt composers, slash-menu state, and mode
+  navigation remain presentation-owned. No direct process, filesystem, or clock calls —
+  everything external goes through `infra/` traits.
 - `domain/`: Pure Agentty-specific business entities and logic — render/runtime session
   snapshots, themes, clarification input progress, explicit transient-message slots and
   lifecycles, prompt-composer logic, the shared `InputState` command and undo/redo

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -85,20 +85,26 @@ flowchart TD
   process --> tick
 ```
 
-Programmatic session creation uses the same foreground-owned runtime, but its response
-is stricter than the asynchronous list refresh path: before returning a new session id,
-the runtime directly reloads the active-project session snapshot. A backlog of unrelated
-`AppEvent` values therefore cannot make an immediately following session command observe
-the new session as missing. Structured question answers similarly claim the current
-persisted question set before their continuation is queued directly on the per-session
-worker, preventing cloned API clients from enqueueing the same answer set twice and
-ensuring a turn entering `Question` cannot strand the accepted answer in the chat queue.
-The clarification answer is appended to durable history only after the worker accepts
-its continuation command; a rejected enqueue restores the claimed questions without
-leaving a duplicate answer or reply-error notice for the next attempt. If the
-post-create snapshot reload encounters a transient persistence failure, creation still
-returns the already-durable session id and queues another `RefreshSessions` event
-instead of returning an ambiguous error that could prompt duplicate creation.
+Session creation captures the project, base branch, and launch settings on the
+foreground task, then materializes regular and orchestration worktrees in a tracked
+background task. Completion returns through `AppEvent`; the reducer refreshes the
+active-project session snapshot before acknowledging the API request. A backlog of
+unrelated events therefore cannot make an immediately following session command observe
+the new session as missing. Interactive creation uses the same completion path and opens
+the composer only while its original notice remains active in the original project.
+Shutdown waits for creation to settle before starting the cleanup grace period, since
+its blocking Git operation cannot be safely abandoned midway through setup.
+
+Structured question answers similarly claim the current persisted question set before
+their continuation is queued directly on the per-session worker, preventing cloned API
+clients from enqueueing the same answer set twice and ensuring a turn entering
+`Question` cannot strand the accepted answer in the chat queue. The clarification answer
+is appended to durable history only after the worker accepts its continuation command; a
+rejected enqueue restores the claimed questions without leaving a duplicate answer or
+reply-error notice for the next attempt. If the post-create snapshot reload encounters a
+transient persistence failure, creation still returns the already-durable session id and
+queues another `RefreshSessions` event instead of returning an ambiguous error that
+could prompt duplicate creation.
 
 <a id="architecture-runtime-flow-notes"></a> Foreground loop details:
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -11,6 +11,11 @@ For keyboard shortcuts by view, see [Keybindings](@/docs/usage/keybindings.md).
 
 <!-- more -->
 
+Creating a regular or orchestrator session runs worktree setup in the background. Close
+the creation notice with `Esc` to continue browsing while setup finishes. If the notice
+stays open, completion opens the new session's composer; otherwise, open the session
+from the list when ready.
+
 ## Interface Layout
 
 <a id="usage-interface-layout"></a> Agentty organizes its interface into six primary


### PR DESCRIPTION
- Materialize regular and orchestration sessions in tracked background tasks, acknowledge them after refreshed snapshots, and roll back setup failures.
- Preserve interactive navigation and API responses across delayed or failed creation while preventing stale completions from changing newer UI state.
- Wait for creation tasks during shutdown and document the updated workflow.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)