### PR TITLE
Simplifies package metadata and test dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,8 @@ authors = [
 ]
 edition = "2024"
 license = "Apache-2.0"
-readme = "README.md"
 description = "Agentty is an ADE (Agentic Development Environment) for structured, controllable AI-assisted software development."
 repository = "https://github.com/agentty-xyz/agentty"
-homepage = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
 ag-agent = { path = "crates/ag-agent", version = "0.15.11" }

--- a/crates/ag-agent/Cargo.toml
+++ b/crates/ag-agent/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 license.workspace = true
 description.workspace = true
 repository.workspace = true
-homepage.workspace = true
 
 [dependencies]
 ag-protocol.workspace = true

--- a/crates/ag-clipboard/Cargo.toml
+++ b/crates/ag-clipboard/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 license.workspace = true
 description.workspace = true
 repository.workspace = true
-homepage.workspace = true
 
 [lints]
 workspace = true

--- a/crates/ag-forge/Cargo.toml
+++ b/crates/ag-forge/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 license.workspace = true
 description.workspace = true
 repository.workspace = true
-homepage.workspace = true
 
 [features]
 test-utils = ["dep:mockall"]

--- a/crates/ag-git/Cargo.toml
+++ b/crates/ag-git/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 license.workspace = true
 description.workspace = true
 repository.workspace = true
-homepage.workspace = true
 
 [features]
 test-utils = ["dep:mockall"]

--- a/crates/ag-harness-cli/Cargo.toml
+++ b/crates/ag-harness-cli/Cargo.toml
@@ -6,8 +6,6 @@ edition.workspace = true
 license.workspace = true
 description.workspace = true
 repository.workspace = true
-homepage.workspace = true
-readme = "README.md"
 
 [package.metadata.dist]
 # Publish this package only through the crates.io workflow.

--- a/crates/ag-harness/Cargo.toml
+++ b/crates/ag-harness/Cargo.toml
@@ -6,8 +6,6 @@ edition.workspace = true
 license.workspace = true
 description.workspace = true
 repository.workspace = true
-homepage.workspace = true
-readme = "README.md"
 
 [[test]]
 name = "e2e"

--- a/crates/ag-protocol/Cargo.toml
+++ b/crates/ag-protocol/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 license.workspace = true
 description.workspace = true
 repository.workspace = true
-homepage.workspace = true
 
 [dependencies]
 askama.workspace = true

--- a/crates/ag-session/Cargo.toml
+++ b/crates/ag-session/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 license.workspace = true
 description.workspace = true
 repository.workspace = true
-homepage.workspace = true
 
 [lints]
 workspace = true

--- a/crates/ag-store/Cargo.toml
+++ b/crates/ag-store/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 license.workspace = true
 description.workspace = true
 repository.workspace = true
-homepage.workspace = true
 include = ["/.sqlx/**", "/migrations/**", "/src/**"]
 
 [dependencies]

--- a/crates/ag-tui-text/Cargo.toml
+++ b/crates/ag-tui-text/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 license.workspace = true
 description.workspace = true
 repository.workspace = true
-homepage.workspace = true
 
 [lints]
 workspace = true

--- a/crates/ag-xtask/Cargo.toml
+++ b/crates/ag-xtask/Cargo.toml
@@ -5,7 +5,6 @@ authors.workspace = true
 edition.workspace = true
 description.workspace = true
 repository.workspace = true
-homepage.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/agentty/Cargo.toml
+++ b/crates/agentty/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 license.workspace = true
 description.workspace = true
 repository.workspace = true
-homepage.workspace = true
 
 [[bin]]
 name = "agentty"

--- a/crates/testty/Cargo.toml
+++ b/crates/testty/Cargo.toml
@@ -6,8 +6,6 @@ edition.workspace = true
 license.workspace = true
 description = "Rust-native TUI end-to-end testing framework using PTY-driven semantic assertions, native frame rendering, and VHS-driven GIF capture."
 repository.workspace = true
-homepage.workspace = true
-readme = "README.md"
 keywords = ["tui", "testing", "e2e", "pty", "ratatui"]
 categories = ["development-tools::testing", "command-line-interface"]
 include = [
@@ -33,7 +31,9 @@ image.workspace = true
 portable-pty.workspace = true
 serde.workspace = true
 serde_yaml_ng.workspace = true
-tempfile.workspace = true
 thiserror.workspace = true
 unicode-width.workspace = true
 vt100.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/testty/src/feature.rs
+++ b/crates/testty/src/feature.rs
@@ -529,7 +529,7 @@ fn update_fnv_hash(hash: &mut u64, bytes: &[u8]) {
 
 /// Returns frame bytes with volatile text normalized for hashing.
 ///
-/// Feature tests often run inside fresh [`tempfile::TempDir`] directories,
+/// Feature tests often run inside fresh `tempfile::TempDir` directories,
 /// while the captured TUI footer may display the absolute working directory.
 /// Normalizing those paths keeps freshness sidecars tied to visible UI state
 /// instead of one random temp directory name. Generated tokens the application


### PR DESCRIPTION
- Removes redundant homepage and README package metadata.
- Scopes `tempfile` to `testty` development dependencies.
- Uses a plain-text link for the `TempDir` documentation reference.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)