### PR TITLE
Limit concurrent subagents for native providers

### DIFF
--- a/crates/ag-agent/src/agent/app_server/command.rs
+++ b/crates/ag-agent/src/agent/app_server/command.rs
@@ -7,12 +7,20 @@
 use std::path::Path;
 use std::process::Command;
 
+use crate::agent::backend::MAX_CONCURRENT_SUBAGENTS;
+
 /// Builds one `codex app-server` process command for one session folder.
+///
+/// Applies the subagent limit at process startup, including resumed threads.
 pub(crate) fn build_codex_app_server_command(folder: &Path, model: &str) -> Command {
     let mut command = Command::new("codex");
     command
         .arg("--model")
         .arg(model)
+        .arg("-c")
+        .arg(format!(
+            "agents.max_concurrent_threads_per_session={MAX_CONCURRENT_SUBAGENTS}"
+        ))
         .arg("app-server")
         .arg("--listen")
         .arg("stdio://")

--- a/crates/ag-agent/src/agent/backend.rs
+++ b/crates/ag-agent/src/agent/backend.rs
@@ -10,6 +10,12 @@ use crate::model::agent::ReasoningLevel;
 use crate::model::permission::PermissionMode;
 use crate::model::session::SpeedMode;
 
+/// Maximum concurrent subagents requested from providers with a native limit.
+///
+/// Excludes the parent agent. Provider exceptions still apply; this is not a
+/// host-wide CPU or memory limit.
+pub(super) const MAX_CONCURRENT_SUBAGENTS: usize = 2;
+
 /// Transport runtime used to execute turns for one backend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AgentTransport {

--- a/crates/ag-agent/src/agent/claude.rs
+++ b/crates/ag-agent/src/agent/claude.rs
@@ -3,7 +3,9 @@ use std::process::{Command, Stdio};
 
 use ag_protocol::{SchemaRequiredPolicy, protocol_output_schema};
 
-use super::backend::{AgentBackend, AgentBackendError, BuildCommandRequest};
+use super::backend::{
+    AgentBackend, AgentBackendError, BuildCommandRequest, MAX_CONCURRENT_SUBAGENTS,
+};
 use super::prompt::{CliPromptAccessRootMode, append_cli_prompt_access_directories};
 
 /// Lists the Claude tools Agentty enables for unattended sessions.
@@ -94,6 +96,10 @@ impl AgentBackend for ClaudeBackend {
         );
         command
             .env("ANTHROPIC_MODEL", model)
+            .env(
+                "CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS",
+                MAX_CONCURRENT_SUBAGENTS.to_string(),
+            )
             .current_dir(folder)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
@@ -261,6 +267,9 @@ mod tests {
         assert!(debug_command.contains("stream-json"));
         assert!(!debug_command.contains("--permission-mode"));
         assert!(!args.iter().any(String::is_empty));
+        assert!(command.get_envs().any(|(key, value)| {
+            key == "CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS" && value == Some(OsStr::new("2"))
+        }));
 
         let settings = settings_argument(&command);
         assert_eq!(

--- a/crates/ag-agent/src/agent/codex.rs
+++ b/crates/ag-agent/src/agent/codex.rs
@@ -115,6 +115,8 @@ mod tests {
             vec![
                 "--model",
                 "gpt-5.6-sol",
+                "-c",
+                "agents.max_concurrent_threads_per_session=2",
                 "app-server",
                 "--listen",
                 "stdio://"
@@ -158,6 +160,8 @@ mod tests {
             vec![
                 "--model",
                 "gpt-5.6-luna",
+                "-c",
+                "agents.max_concurrent_threads_per_session=2",
                 "app-server",
                 "--listen",
                 "stdio://"

--- a/crates/ag-agent/tests/subagent_limit.rs
+++ b/crates/ag-agent/tests/subagent_limit.rs
@@ -1,0 +1,62 @@
+//! Verifies native subagent limits at the public provider command boundary.
+
+use std::ffi::OsStr;
+
+use ag_agent::{
+    AgentKind, AgentRequestKind, BuildCommandRequest, PermissionMode, ReasoningLevel, SpeedMode,
+    create_backend,
+};
+use tempfile::tempdir;
+
+#[test]
+fn native_subagent_limits_apply_to_new_resumed_and_utility_sessions() {
+    // Arrange
+    let workspace = tempdir().expect("workspace should exist");
+    let request_kinds = [
+        AgentRequestKind::SessionStart,
+        AgentRequestKind::SessionResume,
+        AgentRequestKind::UtilityPrompt,
+        AgentRequestKind::FocusedReview,
+    ];
+
+    for (kind, model) in [
+        (AgentKind::Codex, "gpt-5.6-sol"),
+        (AgentKind::Claude, "claude-sonnet-5"),
+    ] {
+        let backend = create_backend(kind);
+        for request_kind in &request_kinds {
+            for permission_mode in PermissionMode::ALL {
+                // Act
+                let command = backend
+                    .build_command(BuildCommandRequest {
+                        attachments: &[],
+                        folder: workspace.path(),
+                        main_checkout_root: None,
+                        model,
+                        permission_mode,
+                        personality_prompt: None,
+                        prompt: "Inspect this project",
+                        reasoning_level: ReasoningLevel::default(),
+                        replay_transcript: None,
+                        request_kind,
+                        speed_mode: SpeedMode::default(),
+                    })
+                    .expect("provider command should build");
+
+                // Assert
+                assert_eq!(command.get_current_dir(), Some(workspace.path()));
+                if kind == AgentKind::Codex {
+                    let arguments = command.get_args().collect::<Vec<_>>();
+                    assert!(arguments.windows(2).any(|pair| {
+                        pair[0] == "-c" && pair[1] == "agents.max_concurrent_threads_per_session=2"
+                    }));
+                } else {
+                    assert!(command.get_envs().any(|(key, value)| {
+                        key == "CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS"
+                            && value == Some(OsStr::new("2"))
+                    }));
+                }
+            }
+        }
+    }
+}

--- a/docs/site/content/docs/agents/backends.md
+++ b/docs/site/content/docs/agents/backends.md
@@ -56,6 +56,23 @@ after you authenticate with that provider's CLI. It does not implement OAuth flo
 provider OAuth tokens directly, or call private provider APIs. You are responsible for
 choosing an authentication method permitted for your account, plan, and usage pattern.
 
+## Subagent Limits
+
+Agentty requests a limit of two concurrent subagents per Codex or Claude session,
+excluding the parent agent. It applies the limit when starting the provider process,
+including when resuming a saved session. Restart Agentty after updating to apply the
+limit to existing sessions.
+
+Codex limits concurrently open child-agent threads. Claude limits ordinary subagent
+spawning, but provider exceptions such as resumed subagents can exceed the limit.
+Enforcement depends on the installed CLI supporting its native setting. Gemini and
+Antigravity have no verified concurrency setting, so Agentty does not cap their internal
+subagents.
+
+These are per-session provider limits, not host-wide CPU or memory limits. Multiple
+sessions each have their own allowance, and builds or tests can consume additional
+resources.
+
 ## Authentication and Usage
 
 ### Codex


### PR DESCRIPTION
- Configure Codex and Claude sessions to allow two concurrent subagents, including resumed sessions.
- Verify limits across provider request kinds and document provider exceptions and per-session scope.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)