### PR TITLE
Supports configurable model reasoning effort

### DIFF
--- a/crates/ag-harness-cli/README.md
+++ b/crates/ag-harness-cli/README.md
@@ -31,7 +31,13 @@ cargo run --locked -p ag-harness-cli -- \
 ## Defaults
 
 - Repository writes are disabled unless `--allow-write` is set.
-- Sessions are stored in `~/.ag-harness/db/harness.db`.
+- Sessions are stored in `~/.ag-harness/db/harness.db`. Set `AG_HARNESS_ROOT`, or pass
+  `--database <FILE>`, to choose another location. If `HOME` is unavailable, one of
+  those explicit locations is required.
 - The first valid Git in `PATH` is used; `--git-executable <FILE>` overrides it.
 - Muse is the default provider. Run `cargo run --locked -p ag-harness-cli -- run --help`
   for Kimi, Qwen, model, and credential options.
+- CLI chats default to low model reasoning to reduce latency; pass
+  `--reasoning-effort <LEVEL>` to select deeper reasoning. Direct `ag-harness` library
+  users retain provider defaults unless they configure `Harness::model_reasoning_effort`
+  or `ModelRequest::with_model_reasoning_effort`.

--- a/crates/ag-harness-cli/src/main.rs
+++ b/crates/ag-harness-cli/src/main.rs
@@ -9,8 +9,8 @@ use std::process::ExitCode;
 use std::{env, io};
 
 use ag_harness::{
-    Harness, ModelConfiguration, ModelConfigurationError, ModelProvider, OutputSchema, Repository,
-    Session, SessionInfo, Tool, TurnOutcome,
+    Harness, ModelConfiguration, ModelConfigurationError, ModelProvider, OutputSchema,
+    ReasoningEffort, Repository, Session, SessionInfo, Tool, TurnOutcome,
 };
 use clap::builder::{PossibleValuesParser, TypedValueParser};
 use clap::{Args, Parser, Subcommand};
@@ -21,7 +21,13 @@ use tokio::io::{AsyncBufRead, AsyncBufReadExt as _, AsyncWrite, AsyncWriteExt as
 const READ_ONLY_SYSTEM_PROMPT: &str = concat!(
     "You are operating in a read-only repository harness. The read tool supports file, list, ",
     "search, diff, and show actions. For change review, call diff first, then use search, file, ",
-    "list, or show for evidence. Call the tool immediately and use its result before answering. ",
+    "list, or show for evidence. Use repository tools only when the user explicitly asks about ",
+    "repository contents. Treat an unambiguous reference to the repository, project, codebase, ",
+    "code, a file, or a change as an explicit repository request. Treat replies, response speed, ",
+    "response visibility, and model behavior as casual chat topics only when they are not ",
+    "explicitly tied to the repository, project, codebase, code, a file, or a change. ",
+    "Do not call tools for casual conversation or ambiguous requests. When needed, call the tool ",
+    "immediately and use its result before answering. ",
     "Never narrate, promise, or defer a future tool call. Never claim that you created, ",
     "modified, deleted, or executed files or commands because filesystem mutation and command ",
     "execution are unavailable. If asked to perform an unsupported action, state that it is ",
@@ -30,7 +36,13 @@ const READ_ONLY_SYSTEM_PROMPT: &str = concat!(
 const READ_WRITE_SYSTEM_PROMPT: &str = concat!(
     "You are operating in a repository harness with read and write tools. The read tool supports ",
     "file, list, search, diff, and show actions. For change review, call diff first. When a user ",
-    "asks about repository contents, call read immediately and use its result before answering. ",
+    "explicitly asks about repository contents, call read immediately and use its result before ",
+    "answering. Treat an unambiguous reference to the repository, project, codebase, code, a \
+     file, ",
+    "or a change as an explicit repository request. Treat replies, response speed, response ",
+    "visibility, and model behavior as casual chat topics only when they are not explicitly tied ",
+    "to the repository, project, codebase, code, a file, or a change. Do not ",
+    "call tools for casual conversation or ambiguous requests. ",
     "When a user asks to create or modify a file, call the write tool ",
     "immediately in the same response. Never narrate, promise, or defer a future tool call. Only ",
     "claim that a file was created or modified after the write tool succeeds. File deletion and ",
@@ -53,6 +65,14 @@ struct Cli {
     /// in PATH.
     #[arg(long, global = true, value_name = "FILE")]
     git_executable: Option<PathBuf>,
+    /// Model reasoning depth used for chat requests.
+    #[arg(
+        long,
+        global = true,
+        default_value = "low",
+        value_parser = reasoning_effort_parser()
+    )]
+    reasoning_effort: ReasoningEffort,
     #[command(subcommand)]
     command: Command,
 }
@@ -122,6 +142,18 @@ fn model_provider_parser() -> impl TypedValueParser<Value = ModelProvider> {
             .map(|provider| provider.as_str()),
     )
     .try_map(|provider| provider.parse::<ModelProvider>())
+}
+
+fn reasoning_effort_parser() -> impl TypedValueParser<Value = ReasoningEffort> {
+    PossibleValuesParser::new(ReasoningEffort::ALL.iter().map(|effort| effort.as_str())).try_map(
+        |effort| {
+            ReasoningEffort::ALL
+                .iter()
+                .copied()
+                .find(|candidate| candidate.as_str() == effort)
+                .ok_or_else(|| format!("unsupported reasoning effort `{effort}`"))
+        },
+    )
 }
 
 fn provider_help() -> String {
@@ -229,6 +261,7 @@ where
 {
     let database = database_path(cli.database, &mut environment)?;
     let git_executable = cli.git_executable;
+    let reasoning_effort = cli.reasoning_effort;
     match cli.command {
         Command::Run(args) => {
             let session_id = args
@@ -241,8 +274,13 @@ where
                 &mut environment,
             )?;
             let repository = repository_or_default(args.read_dir, git_executable)?;
-            let (harness, system_prompt) =
-                configured_harness(client, database, repository, args.allow_write);
+            let (harness, system_prompt) = configured_harness(
+                client,
+                database,
+                repository,
+                args.allow_write,
+                reasoning_effort,
+            );
             let mut session = harness
                 .session(&session_id, chat_schema()?)
                 .system_prompt(system_prompt)
@@ -259,7 +297,13 @@ where
             let client =
                 model_client(provider, &model, args.base_url.as_deref(), &mut environment)?;
             let repository = repository_or_default(args.read_dir, git_executable)?;
-            let (harness, _) = configured_harness(client, database, repository, args.allow_write);
+            let (harness, _) = configured_harness(
+                client,
+                database,
+                repository,
+                args.allow_write,
+                reasoning_effort,
+            );
             let mut session = harness.resume(&args.session).await?;
             let mut output = output;
             announce_session(&mut output, &args.session).await?;
@@ -353,9 +397,11 @@ fn configured_harness(
     database: PathBuf,
     repository: Repository,
     allow_write: bool,
+    reasoning_effort: ReasoningEffort,
 ) -> (Harness, &'static str) {
     let mut harness = Harness::new(client)
         .database(database)
+        .model_reasoning_effort(reasoning_effort)
         .repository(repository)
         .allow(Tool::Read);
     if allow_write {

--- a/crates/ag-harness-cli/tests/cli.rs
+++ b/crates/ag-harness-cli/tests/cli.rs
@@ -15,7 +15,13 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 const READ_ONLY_SYSTEM_PROMPT: &str = concat!(
     "You are operating in a read-only repository harness. The read tool supports file, list, ",
     "search, diff, and show actions. For change review, call diff first, then use search, file, ",
-    "list, or show for evidence. Call the tool immediately and use its result before answering. ",
+    "list, or show for evidence. Use repository tools only when the user explicitly asks about ",
+    "repository contents. Treat an unambiguous reference to the repository, project, codebase, ",
+    "code, a file, or a change as an explicit repository request. Treat replies, response speed, ",
+    "response visibility, and model behavior as casual chat topics only when they are not ",
+    "explicitly tied to the repository, project, codebase, code, a file, or a change. ",
+    "Do not call tools for casual conversation or ambiguous requests. When needed, call the tool ",
+    "immediately and use its result before answering. ",
     "Never narrate, promise, or defer a future tool call. Never claim that you created, ",
     "modified, deleted, or executed files or commands because filesystem mutation and command ",
     "execution are unavailable. If asked to perform an unsupported action, state that it is ",
@@ -24,7 +30,13 @@ const READ_ONLY_SYSTEM_PROMPT: &str = concat!(
 const READ_WRITE_SYSTEM_PROMPT: &str = concat!(
     "You are operating in a repository harness with read and write tools. The read tool supports ",
     "file, list, search, diff, and show actions. For change review, call diff first. When a user ",
-    "asks about repository contents, call read immediately and use its result before answering. ",
+    "explicitly asks about repository contents, call read immediately and use its result before ",
+    "answering. Treat an unambiguous reference to the repository, project, codebase, code, a \
+     file, ",
+    "or a change as an explicit repository request. Treat replies, response speed, response ",
+    "visibility, and model behavior as casual chat topics only when they are not explicitly tied ",
+    "to the repository, project, codebase, code, a file, or a change. Do not ",
+    "call tools for casual conversation or ambiguous requests. ",
     "When a user asks to create or modify a file, call the write tool ",
     "immediately in the same response. Never narrate, promise, or defer a future tool call. Only ",
     "claim that a file was created or modified after the write tool succeeds. File deletion and ",
@@ -122,6 +134,9 @@ fn help_describes_the_chat_interface() {
     assert!(stdout.contains("Usage: ag-harness [OPTIONS] <COMMAND>"));
     assert!(stdout.contains("--git-executable <FILE>"));
     assert!(stdout.contains("defaults to the first valid Git found in PATH"));
+    assert!(stdout.contains("--reasoning-effort <REASONING_EFFORT>"));
+    assert!(stdout.contains("[default: low]"));
+    assert!(stdout.contains("[possible values: low, medium, high, xhigh, max]"));
     assert!(stdout.contains("Commands:"));
     assert!(stdout.contains("Starts a new durable session"));
     assert!(stdout.contains("Resumes a durable session"));
@@ -239,17 +254,69 @@ fn run_help_describes_optional_initial_prompt() {
     assert!(stdout.contains("[default: .]"));
     assert!(stdout.contains("--allow-write"));
     assert!(stdout.contains("Enables repository writes through the write tool"));
+    assert!(stdout.contains("--reasoning-effort <REASONING_EFFORT>"));
     assert!(!stdout.contains("Chat behavior:"));
     assert!(!stdout.contains("--schema"));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn provider_flags_select_kimi_and_qwen_wire_formats() {
+async fn qwen_3_8_uses_graded_reasoning_effort() {
+    // Arrange
+    let server = MockServer::start().await;
+    let model = "qwen3.8-max";
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(bearer_token("test-key"))
+        .and(body_json(json!({
+            "messages": [
+                {"content": structured_output_instruction(), "role": "system"},
+                {"content": READ_ONLY_SYSTEM_PROMPT, "role": "system"},
+                {"content": "Hello", "role": "user"}
+            ],
+            "model": model,
+            "reasoning_effort": "xhigh",
+            "tools": [read_tool()]
+        })))
+        .respond_with(response("provider response", 4, 2))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let (_storage, mut command) = harness_command().expect("temporary storage should exist");
+
+    // Act
+    let output = command
+        .args([
+            "run",
+            model,
+            "Hello",
+            "--provider",
+            "qwen",
+            "--reasoning-effort",
+            "high",
+        ])
+        .env("DASHSCOPE_API_KEY", "test-key")
+        .env("DASHSCOPE_BASE_URL", server.uri())
+        .output()
+        .expect("Qwen3.8 request should run");
+
+    // Assert
+    assert!(
+        output.status.success(),
+        "Qwen3.8 CLI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("assistant> provider response"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn kimi_custom_models_use_supported_reasoning_formats() {
     // Arrange and Act
-    for provider in [ModelProvider::Kimi, ModelProvider::Qwen] {
-        let model = provider.known_models()[0];
+    for (model, reasoning) in [
+        ("kimi-k3", json!({"reasoning_effort": "low"})),
+        ("kimi-k2.7-code", json!({"thinking": {"type": "enabled"}})),
+    ] {
         let server = MockServer::start().await;
-        let expected_request = json!({
+        let mut expected_request = json!({
             "messages": [
                 {"content": structured_output_instruction(), "role": "system"},
                 {"content": READ_ONLY_SYSTEM_PROMPT, "role": "system"},
@@ -258,6 +325,65 @@ async fn provider_flags_select_kimi_and_qwen_wire_formats() {
             "model": model,
             "tools": [read_tool()]
         });
+        expected_request
+            .as_object_mut()
+            .expect("request fixture should be an object")
+            .extend(
+                reasoning
+                    .as_object()
+                    .expect("reasoning fixture should be an object")
+                    .clone(),
+            );
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(bearer_token("test-key"))
+            .and(body_json(expected_request))
+            .respond_with(response("provider response", 4, 2))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let (_storage, mut command) = harness_command().expect("temporary storage should exist");
+        let output = command
+            .args(["run", model, "Hello", "--provider", "kimi"])
+            .env("KIMI_API_KEY", "test-key")
+            .env("KIMI_BASE_URL", server.uri())
+            .output()
+            .expect("custom Kimi request should run");
+
+        // Assert
+        assert!(
+            output.status.success(),
+            "{model} CLI failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(String::from_utf8_lossy(&output.stdout).contains("assistant> provider response"));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn provider_flags_select_kimi_and_qwen_wire_formats() {
+    // Arrange and Act
+    for provider in [ModelProvider::Kimi, ModelProvider::Qwen] {
+        let model = provider.known_models()[0];
+        let server = MockServer::start().await;
+        let mut expected_request = json!({
+            "messages": [
+                {"content": structured_output_instruction(), "role": "system"},
+                {"content": READ_ONLY_SYSTEM_PROMPT, "role": "system"},
+                {"content": "Hello", "role": "user"}
+            ],
+            "model": model,
+            "tools": [read_tool()]
+        });
+        match provider {
+            ModelProvider::Kimi => {
+                expected_request["thinking"] = json!({"type": "disabled"});
+            }
+            ModelProvider::Qwen => {
+                expected_request["enable_thinking"] = json!(false);
+            }
+            ModelProvider::Muse => unreachable!("the test covers alternate providers"),
+        }
         Mock::given(method("POST"))
             .and(path("/chat/completions"))
             .and(bearer_token("test-key"))
@@ -307,6 +433,7 @@ async fn initial_prompt_prints_answer_and_model_metadata() {
                 {"content": "Hello", "role": "user"}
             ],
             "model": "muse-test",
+            "reasoning_effort": "low",
             "response_format": {
                 "type": "json_schema",
                 "json_schema": {
@@ -404,6 +531,7 @@ async fn stdin_prompts_share_conversation_history() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
+        .and(body_string_contains(r#""reasoning_effort":"low""#))
         .and(body_string_contains(
             r#""content":"first question","role":"user""#,
         ))
@@ -414,6 +542,7 @@ async fn stdin_prompts_share_conversation_history() {
         .await;
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
+        .and(body_string_contains(r#""reasoning_effort":"low""#))
         .and(body_string_contains(
             r#""content":"{\"message\":\"first answer\"}","role":"assistant""#,
         ))
@@ -470,6 +599,7 @@ async fn resume_restores_history_from_the_default_database() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
+        .and(body_string_contains(r#""reasoning_effort":"low""#))
         .and(body_string_contains(
             r#""content":"first question","role":"user""#,
         ))
@@ -480,6 +610,7 @@ async fn resume_restores_history_from_the_default_database() {
         .await;
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
+        .and(body_string_contains(r#""reasoning_effort":"low""#))
         .and(body_string_contains(
             r#""content":"{\"message\":\"first answer\"}","role":"assistant""#,
         ))
@@ -559,6 +690,7 @@ async fn stdin_chat_emits_failure_before_retry_and_exits_unsuccessfully() {
                 {"content": "retry question", "role": "user"}
             ],
             "model": "muse-test",
+            "reasoning_effort": "low",
             "response_format": {
                 "type": "json_schema",
                 "json_schema": {
@@ -639,6 +771,7 @@ async fn read_tool_reports_the_file_without_printing_its_contents() {
                 {"content": "Inspect the manifest", "role": "user"}
             ],
             "model": "muse-test",
+            "reasoning_effort": "low",
             "response_format": {
                 "type": "json_schema",
                 "json_schema": {
@@ -790,6 +923,7 @@ async fn redirected_output_with_terminal_stdin_is_one_shot() {
                 {"content": "Hello", "role": "user"}
             ],
             "model": "muse-test",
+            "reasoning_effort": "low",
             "response_format": {
                 "type": "json_schema",
                 "json_schema": {

--- a/crates/ag-harness/src/chat_completion.rs
+++ b/crates/ag-harness/src/chat_completion.rs
@@ -63,10 +63,23 @@ impl StructuredOutputMode {
 #[derive(Clone, Copy)]
 pub(crate) struct ChatCompletionProviderPolicy {
     pub(crate) display_name: &'static str,
+    pub(crate) reasoning_format: ReasoningFormat,
     pub(crate) response_format_with_tools: bool,
     pub(crate) structured_output: StructuredOutputMode,
     pub(crate) telemetry_name: &'static str,
     pub(crate) unsupported_schema_reason: &'static str,
+}
+
+/// Provider wire representation for a requested reasoning depth.
+#[derive(Clone, Copy)]
+pub(crate) enum ReasoningFormat {
+    Effort(fn(model::ReasoningEffort) -> &'static str),
+    EnableThinking,
+    None,
+    Thinking {
+        disable_supported: bool,
+        preserve_reasoning: bool,
+    },
 }
 
 /// Provider-neutral result of decoding one Chat Completions choice.
@@ -78,6 +91,7 @@ pub(crate) enum GeneratedResponse {
     Output {
         metadata: model::CompletionMetadata,
         output: String,
+        reasoning_content: Option<String>,
     },
     ToolCall {
         call: tool::ToolCall,
@@ -139,9 +153,12 @@ impl ChatCompletionBackend {
         let response_format = (tools.is_empty() || self.policy.response_format_with_tools)
             .then(|| self.response_format(request.schema()));
         let payload = ChatCompletionPayload {
+            enable_thinking: self.enable_thinking(request),
             messages: self.messages(request)?,
             model: &self.model,
+            reasoning_effort: self.reasoning_effort(request),
             response_format,
+            thinking: self.thinking(request),
             tools,
         };
         let payload = serde_json::to_value(payload).map_err(model::ModelError::request)?;
@@ -162,7 +179,16 @@ impl ChatCompletionBackend {
                 metadata,
             )),
             "stop" => Ok(match content {
-                Some(output) => GeneratedResponse::Output { metadata, output },
+                Some(output) => GeneratedResponse::Output {
+                    metadata,
+                    output,
+                    reasoning_content: self
+                        .policy
+                        .structured_output
+                        .assistant_reasoning_content()
+                        .then_some(reasoning_content)
+                        .flatten(),
+                },
                 None => GeneratedResponse::failed(model::ModelError::InvalidResponse, metadata),
             }),
             "tool_calls" => Ok(Self::decode_tool_call(
@@ -226,6 +252,16 @@ impl ChatCompletionBackend {
                 model::ModelMessage::Assistant(content) => {
                     messages.push(ChatCompletionMessagePayload::Text {
                         content: content.clone(),
+                        role: "assistant",
+                    });
+                }
+                model::ModelMessage::AssistantReasoning {
+                    content,
+                    reasoning_content,
+                } => {
+                    messages.push(ChatCompletionMessagePayload::AssistantReasoning {
+                        content: content.clone(),
+                        reasoning_content: reasoning_content.clone(),
                         role: "assistant",
                     });
                 }
@@ -322,6 +358,51 @@ impl ChatCompletionBackend {
         }
     }
 
+    fn enable_thinking(&self, request: &model::ModelRequest) -> Option<bool> {
+        match self.policy.reasoning_format {
+            ReasoningFormat::EnableThinking => {
+                request.model_reasoning_effort().map(reasoning_enabled)
+            }
+            ReasoningFormat::Effort(_)
+            | ReasoningFormat::None
+            | ReasoningFormat::Thinking { .. } => None,
+        }
+    }
+
+    fn reasoning_effort(&self, request: &model::ModelRequest) -> Option<&'static str> {
+        match self.policy.reasoning_format {
+            ReasoningFormat::Effort(name) => request.model_reasoning_effort().map(name),
+            ReasoningFormat::EnableThinking
+            | ReasoningFormat::None
+            | ReasoningFormat::Thinking { .. } => None,
+        }
+    }
+
+    fn thinking(&self, request: &model::ModelRequest) -> Option<Thinking> {
+        match self.policy.reasoning_format {
+            ReasoningFormat::Thinking {
+                disable_supported,
+                preserve_reasoning,
+            } => {
+                let enabled = request
+                    .model_reasoning_effort()
+                    .map_or(preserve_reasoning, |reasoning_effort| {
+                        !disable_supported || reasoning_enabled(reasoning_effort)
+                    });
+
+                (request.model_reasoning_effort().is_some() || preserve_reasoning).then(|| {
+                    Thinking {
+                        keep: (enabled && preserve_reasoning).then_some("all"),
+                        kind: if enabled { "enabled" } else { "disabled" },
+                    }
+                })
+            }
+            ReasoningFormat::Effort(_)
+            | ReasoningFormat::EnableThinking
+            | ReasoningFormat::None => None,
+        }
+    }
+
     fn map_completion_error(&self, error: ChatCompletionError) -> model::ModelError {
         match error {
             ChatCompletionError::Http {
@@ -415,6 +496,10 @@ impl ChatCompletionBackend {
             reasoning_content.map(str::to_string),
         )
     }
+}
+
+fn reasoning_enabled(reasoning_effort: model::ReasoningEffort) -> bool {
+    reasoning_effort != model::ReasoningEffort::Low
 }
 
 /// One provider-authenticated request using the Chat Completions wire API.
@@ -689,12 +774,26 @@ impl ChatCompletionError {
 
 #[derive(Serialize)]
 struct ChatCompletionPayload<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enable_thinking: Option<bool>,
     messages: Vec<ChatCompletionMessagePayload>,
     model: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning_effort: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     response_format: Option<ResponseFormat<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<Thinking>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tools: Vec<ChatCompletionTool<'a>>,
+}
+
+#[derive(Serialize)]
+struct Thinking {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    keep: Option<&'static str>,
+    #[serde(rename = "type")]
+    kind: &'static str,
 }
 
 #[derive(Serialize)]
@@ -702,6 +801,11 @@ struct ChatCompletionPayload<'a> {
 enum ChatCompletionMessagePayload {
     Text {
         content: String,
+        role: &'static str,
+    },
+    AssistantReasoning {
+        content: String,
+        reasoning_content: String,
         role: &'static str,
     },
     AssistantToolCall {
@@ -909,6 +1013,13 @@ mod tests {
 
     use super::*;
 
+    fn max_as_xhigh(reasoning_effort: model::ReasoningEffort) -> &'static str {
+        match reasoning_effort {
+            model::ReasoningEffort::Max => model::ReasoningEffort::XHigh.as_str(),
+            reasoning_effort => reasoning_effort.as_str(),
+        }
+    }
+
     fn native_schema_backend() -> ChatCompletionBackend {
         ChatCompletionBackend::with_client(
             "test-key".to_string(),
@@ -916,6 +1027,7 @@ mod tests {
             "native-schema-model".to_string(),
             ChatCompletionProviderPolicy {
                 display_name: "Native schema provider",
+                reasoning_format: ReasoningFormat::Effort(max_as_xhigh),
                 response_format_with_tools: true,
                 structured_output: StructuredOutputMode::JsonSchema,
                 telemetry_name: "native_schema",
@@ -932,6 +1044,153 @@ mod tests {
 
         // Assert
         assert_eq!(endpoint, "https://example.com/v1/chat/completions");
+    }
+
+    #[test]
+    fn maps_reasoning_effort_to_each_provider_wire_format() {
+        // Arrange
+        let schema = schema_contract::OutputSchema::new(serde_json::json!({
+            "type": "object"
+        }))
+        .expect("schema should be valid");
+        let backend = |reasoning_format| {
+            ChatCompletionBackend::with_client(
+                "test-key".to_string(),
+                "https://example.com/v1".to_string(),
+                "model".to_string(),
+                ChatCompletionProviderPolicy {
+                    display_name: "Provider",
+                    reasoning_format,
+                    response_format_with_tools: true,
+                    structured_output: StructuredOutputMode::JsonSchema,
+                    telemetry_name: "provider",
+                    unsupported_schema_reason: "object schema required",
+                },
+                default_client(),
+            )
+        };
+        let request = |reasoning_effort| {
+            model::ModelRequest::new("hello", schema.clone())
+                .with_model_reasoning_effort(reasoning_effort)
+        };
+
+        // Act
+        let effort_backend = backend(ReasoningFormat::Effort(max_as_xhigh));
+        let low_request = request(model::ReasoningEffort::Low);
+        let maximum_request = request(model::ReasoningEffort::Max);
+        let medium_request = request(model::ReasoningEffort::Medium);
+        let kimi_backend = backend(crate::provider::kimi_policy("kimi-k2.6").reasoning_format);
+        let kimi_k2_7_backend =
+            backend(crate::provider::kimi_policy("kimi-k2.7-code").reasoning_format);
+        let kimi_k3_backend = backend(crate::provider::kimi_policy("kimi-k3").reasoning_format);
+        let high_request = request(model::ReasoningEffort::High);
+        let xhigh_request = request(model::ReasoningEffort::XHigh);
+        let qwen_backend = backend(crate::provider::qwen_policy("qwen-plus").reasoning_format);
+        let qwen_3_8_backend =
+            backend(crate::provider::qwen_policy("qwen3.8-max").reasoning_format);
+
+        // Assert
+        assert_eq!(effort_backend.reasoning_effort(&low_request), Some("low"));
+        assert_eq!(
+            effort_backend.reasoning_effort(&maximum_request),
+            Some("xhigh")
+        );
+        assert_eq!(effort_backend.enable_thinking(&low_request), None);
+        assert!(effort_backend.thinking(&low_request).is_none());
+        assert_eq!(
+            kimi_backend
+                .thinking(&low_request)
+                .map(|thinking| thinking.kind),
+            Some("disabled")
+        );
+        assert_eq!(
+            kimi_backend
+                .thinking(&high_request)
+                .map(|thinking| thinking.kind),
+            Some("enabled")
+        );
+        assert_eq!(
+            kimi_k2_7_backend
+                .thinking(&low_request)
+                .map(|thinking| thinking.kind),
+            Some("enabled")
+        );
+        assert_eq!(kimi_k2_7_backend.reasoning_effort(&low_request), None);
+        assert!(kimi_k3_backend.thinking(&low_request).is_none());
+        assert_eq!(kimi_k3_backend.reasoning_effort(&low_request), Some("low"));
+        assert_eq!(
+            kimi_k3_backend.reasoning_effort(&medium_request),
+            Some("high")
+        );
+        assert_eq!(
+            kimi_k3_backend.reasoning_effort(&high_request),
+            Some("high")
+        );
+        assert_eq!(
+            kimi_k3_backend.reasoning_effort(&xhigh_request),
+            Some("max")
+        );
+        assert_eq!(
+            kimi_k3_backend.reasoning_effort(&maximum_request),
+            Some("max")
+        );
+        assert_eq!(qwen_backend.enable_thinking(&low_request), Some(false));
+        assert_eq!(qwen_backend.enable_thinking(&high_request), Some(true));
+        assert_eq!(qwen_backend.reasoning_effort(&high_request), None);
+        assert_eq!(qwen_3_8_backend.enable_thinking(&low_request), None);
+        assert_eq!(qwen_3_8_backend.reasoning_effort(&low_request), Some("low"));
+        assert_eq!(
+            qwen_3_8_backend.reasoning_effort(&medium_request),
+            Some("medium")
+        );
+        assert_eq!(
+            qwen_3_8_backend.reasoning_effort(&high_request),
+            Some("xhigh")
+        );
+        assert_eq!(
+            qwen_3_8_backend.reasoning_effort(&maximum_request),
+            Some("xhigh")
+        );
+    }
+
+    #[test]
+    fn preserves_k2_6_reasoning_only_while_thinking_is_enabled() {
+        // Arrange
+        let backend = ChatCompletionBackend::with_client(
+            "test-key".to_string(),
+            "https://example.com/v1".to_string(),
+            "kimi-k2.6".to_string(),
+            crate::provider::kimi_policy("kimi-k2.6"),
+            default_client(),
+        );
+        let schema = schema_contract::OutputSchema::new(serde_json::json!({
+            "type": "object"
+        }))
+        .expect("schema should be valid");
+        let default_request = model::ModelRequest::new("hello", schema.clone());
+        let low_request = model::ModelRequest::new("hello", schema.clone())
+            .with_model_reasoning_effort(model::ReasoningEffort::Low);
+        let high_request = model::ModelRequest::new("hello", schema)
+            .with_model_reasoning_effort(model::ReasoningEffort::High);
+
+        // Act
+        let default_thinking = backend
+            .thinking(&default_request)
+            .expect("K2.6 defaults should preserve thinking");
+        let low_thinking = backend
+            .thinking(&low_request)
+            .expect("explicit low effort should disable K2.6 thinking");
+        let high_thinking = backend
+            .thinking(&high_request)
+            .expect("explicit high effort should preserve K2.6 thinking");
+
+        // Assert
+        assert_eq!(default_thinking.kind, "enabled");
+        assert_eq!(default_thinking.keep, Some("all"));
+        assert_eq!(low_thinking.kind, "disabled");
+        assert_eq!(low_thinking.keep, None);
+        assert_eq!(high_thinking.kind, "enabled");
+        assert_eq!(high_thinking.keep, Some("all"));
     }
 
     #[test]
@@ -1070,7 +1329,7 @@ mod tests {
         }))
         .expect("schema should be valid");
         let mut request = model::ModelRequest::new("first question", schema.clone());
-        request.record_output(&serde_json::json!({"message": "first answer"}));
+        request.record_output_with_reasoning(&serde_json::json!({"message": "first answer"}), None);
         let mut messages = request.into_messages();
         messages.insert(
             0,
@@ -1535,6 +1794,7 @@ mod tests {
             "model".to_string(),
             ChatCompletionProviderPolicy {
                 display_name: "Provider",
+                reasoning_format: ReasoningFormat::Effort(max_as_xhigh),
                 response_format_with_tools: true,
                 structured_output: StructuredOutputMode::JsonSchema,
                 telemetry_name: "provider",

--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -14,7 +14,8 @@ use crate::lifecycle::{
     LifecycleEmitter, LifecycleId, LifecycleObserver, ToolErrorType, ToolLifecycle, TurnLifecycle,
 };
 use crate::model::{
-    Model, ModelError, ModelMessage, ModelRequest, ModelResponse, ensure_unique_tool_call_ids,
+    Model, ModelError, ModelMessage, ModelRequest, ModelResponse, ReasoningEffort,
+    ensure_unique_tool_call_ids,
 };
 use crate::policy::Policy;
 use crate::read::{self, ReadError, ReadTool};
@@ -216,6 +217,7 @@ pub struct Harness {
     max_history_bytes: usize,
     max_tool_calls: usize,
     model: Arc<dyn Model>,
+    model_reasoning_effort: Option<ReasoningEffort>,
     policy: Policy,
     repository: Option<Repository>,
 }
@@ -230,6 +232,7 @@ impl Harness {
             max_history_bytes: DEFAULT_MAX_HISTORY_BYTES,
             max_tool_calls: DEFAULT_MAX_TOOL_CALLS,
             model: Arc::new(model),
+            model_reasoning_effort: None,
             policy: Policy::default(),
             repository: None,
         }
@@ -293,6 +296,14 @@ impl Harness {
     #[must_use]
     pub fn max_history_bytes(mut self, max_history_bytes: NonZeroUsize) -> Self {
         self.max_history_bytes = max_history_bytes.get();
+
+        self
+    }
+
+    /// Sets the reasoning depth for model calls that do not specify one.
+    #[must_use]
+    pub fn model_reasoning_effort(mut self, reasoning_effort: ReasoningEffort) -> Self {
+        self.model_reasoning_effort = Some(reasoning_effort);
 
         self
     }
@@ -445,7 +456,13 @@ impl Harness {
         let mut tool_calls = Vec::new();
 
         loop {
-            let (response, activities, provider_session_id, native_resume_rejected) = self
+            let (
+                response,
+                activities,
+                provider_session_id,
+                native_resume_rejected,
+                reasoning_content,
+            ) = self
                 .complete_model_request(&request, model_request_index, turn_id)
                 .await?;
             if native_resume_rejected || provider_session_id.is_some() {
@@ -457,7 +474,7 @@ impl Harness {
 
             match response {
                 ModelResponse::Output(output) => {
-                    request.record_output(&output);
+                    request.record_output_with_reasoning(&output, reasoning_content);
                     let report = TurnReport::new(started_at.elapsed(), model_requests, tool_calls);
 
                     let provider_session_id = request.provider_session_id().map(str::to_string);
@@ -520,6 +537,11 @@ impl Harness {
         if self.lifecycle.is_enabled() {
             request.mark_lifecycle_observed();
         }
+        if request.model_reasoning_effort().is_none()
+            && let Some(reasoning_effort) = self.model_reasoning_effort
+        {
+            request = request.with_model_reasoning_effort(reasoning_effort);
+        }
         let read_allowed = self.policy.allows(Tool::Read);
         let write_allowed = self.policy.allows(Tool::Write);
         if !read_allowed && !write_allowed {
@@ -556,6 +578,7 @@ impl Harness {
             Vec<ModelRequestActivity>,
             Option<String>,
             bool,
+            Option<String>,
         ),
         TurnError,
     > {
@@ -564,9 +587,13 @@ impl Harness {
             .complete_model_attempt(request.clone(), model_request_index, turn_id)
             .await
         {
-            Ok((response, activity, provider_session_id)) => {
-                Ok((response, vec![activity], provider_session_id, false))
-            }
+            Ok((response, activity, provider_session_id, reasoning_content)) => Ok((
+                response,
+                vec![activity],
+                provider_session_id,
+                false,
+                reasoning_content,
+            )),
             Err(ModelAttemptError {
                 duration,
                 error: ModelError::ResumeUnavailable,
@@ -583,12 +610,15 @@ impl Harness {
                     .complete_model_attempt(replay_request, replay_index, turn_id)
                     .await
                 {
-                    Ok((response, replay_activity, provider_session_id)) => Ok((
-                        response,
-                        vec![rejected_activity, replay_activity],
-                        provider_session_id,
-                        true,
-                    )),
+                    Ok((response, replay_activity, provider_session_id, reasoning_content)) => {
+                        Ok((
+                            response,
+                            vec![rejected_activity, replay_activity],
+                            provider_session_id,
+                            true,
+                            reasoning_content,
+                        ))
+                    }
                     Err(failure) => Err(ResumeFailure::Replay {
                         source: failure.error,
                     }
@@ -610,7 +640,15 @@ impl Harness {
         request: ModelRequest,
         model_request_index: u64,
         turn_id: Option<LifecycleId>,
-    ) -> Result<(ModelResponse, ModelRequestActivity, Option<String>), ModelAttemptError> {
+    ) -> Result<
+        (
+            ModelResponse,
+            ModelRequestActivity,
+            Option<String>,
+            Option<String>,
+        ),
+        ModelAttemptError,
+    > {
         let started_at = Instant::now();
         let model_lifecycle =
             self.lifecycle
@@ -620,7 +658,7 @@ impl Harness {
             Some(model_lifecycle) => model_lifecycle.scope(operation).await,
             None => operation.await,
         };
-        let (response, completion, provider_session_id) = match completion {
+        let (response, completion, provider_session_id, reasoning_content) = match completion {
             Ok(completion) => completion.into_parts(),
             Err(error) => {
                 if let Some(model_lifecycle) = model_lifecycle {
@@ -656,7 +694,7 @@ impl Harness {
             model_lifecycle.completed(completion, response_type);
         }
 
-        Ok((response, activity, provider_session_id))
+        Ok((response, activity, provider_session_id, reasoning_content))
     }
 
     async fn execute_tool_call(
@@ -1409,6 +1447,52 @@ mod tests {
         assert!(turn_started_id(&events[1]).is_none());
         assert!(model_started_id(&events[0]).is_none());
         assert!(tool_requested_id(&events[0]).is_none());
+    }
+
+    #[tokio::test]
+    async fn applies_reasoning_effort_to_every_model_call() {
+        // Arrange
+        let mut model = model();
+        model
+            .expect_complete()
+            .times(1)
+            .withf(|request| request.model_reasoning_effort() == Some(ReasoningEffort::Low))
+            .returning(|_| {
+                Ok(response_without_metadata(ModelResponse::Output(json!({
+                    "summary": "quick"
+                }))))
+            });
+        let harness = Harness::new(model).model_reasoning_effort(ReasoningEffort::Low);
+
+        // Act
+        let output = harness
+            .run_once("reply quickly", object_schema())
+            .await
+            .expect("configured reasoning request should succeed");
+
+        // Assert
+        assert_eq!(output.output(), &json!({ "summary": "quick" }));
+    }
+
+    #[test]
+    fn preserves_request_reasoning_effort_over_harness_default() {
+        // Arrange
+        let harness = Harness::new(model()).model_reasoning_effort(ReasoningEffort::Low);
+        let request = ModelRequest::new("reply", object_schema())
+            .with_model_reasoning_effort(ReasoningEffort::High);
+
+        // Act
+        let (request, read_tool, write_tool) = harness
+            .prepare_request(request)
+            .expect("request preparation should succeed");
+
+        // Assert
+        assert_eq!(
+            request.model_reasoning_effort(),
+            Some(ReasoningEffort::High)
+        );
+        assert!(read_tool.is_none());
+        assert!(write_tool.is_none());
     }
 
     #[tokio::test]

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -31,6 +31,7 @@ pub use lifecycle::{
 pub use model::{
     CompletionMetadata, CompletionUsage, Model, ModelClient, ModelCompletion, ModelError,
     ModelErrorType, ModelMessage, ModelMetadata, ModelMetadataError, ModelRequest, ModelResponse,
+    ReasoningEffort,
 };
 pub use provider::{
     KIMI_K2_6, KimiConfig, MUSE_SPARK_1_3, MUSE_SPARK_1_3_CONTRIBUTOR, ModelConfiguration,

--- a/crates/ag-harness/src/model.rs
+++ b/crates/ag-harness/src/model.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use std::ops::Deref;
 
 use async_trait::async_trait;
+use serde::Serialize;
 use serde_json::Value;
 use thiserror::Error;
 
@@ -53,12 +54,9 @@ impl ModelClient {
     /// Returns [`ModelMetadataError`] when the configured model identifier is
     /// empty or contains only whitespace.
     pub fn kimi(config: KimiConfig) -> Result<Self, ModelMetadataError> {
-        Self::chat_completion(
-            config.api_key,
-            config.base_url,
-            config.model,
-            provider::KIMI_POLICY,
-        )
+        let policy = provider::kimi_policy(&config.model);
+
+        Self::chat_completion(config.api_key, config.base_url, config.model, policy)
     }
 
     /// Creates a client backed by Meta's Model API for Muse models.
@@ -83,12 +81,9 @@ impl ModelClient {
     /// Returns [`ModelMetadataError`] when the configured model identifier is
     /// empty or contains only whitespace.
     pub fn qwen(config: QwenConfig) -> Result<Self, ModelMetadataError> {
-        Self::chat_completion(
-            config.api_key,
-            config.base_url,
-            config.model,
-            provider::QWEN_POLICY,
-        )
+        let policy = provider::qwen_policy(&config.model);
+
+        Self::chat_completion(config.api_key, config.base_url, config.model, policy)
     }
 
     /// Returns the validated provider and model identity retained by the
@@ -129,18 +124,20 @@ impl ModelClient {
             Ok(chat_completion::GeneratedResponse::Failed { error, metadata }) => {
                 (Err(error), Some(metadata))
             }
-            Ok(chat_completion::GeneratedResponse::Output { metadata, output }) => {
-                match request.schema().parse_and_validate(&output) {
-                    Ok(response) => (
-                        Ok(ModelCompletion::new(
-                            metadata,
-                            ModelResponse::from_output(response),
-                        )),
-                        None,
+            Ok(chat_completion::GeneratedResponse::Output {
+                metadata,
+                output,
+                reasoning_content,
+            }) => match request.schema().parse_and_validate(&output) {
+                Ok(response) => (
+                    Ok(
+                        ModelCompletion::new(metadata, ModelResponse::from_output(response))
+                            .with_reasoning_content(reasoning_content),
                     ),
-                    Err(error) => (Err(ModelError::from(error)), Some(metadata)),
-                }
-            }
+                    None,
+                ),
+                Err(error) => (Err(ModelError::from(error)), Some(metadata)),
+            },
             Ok(chat_completion::GeneratedResponse::ToolCall { call, metadata }) => (
                 Ok(ModelCompletion::new(
                     metadata,
@@ -265,6 +262,7 @@ pub enum ModelMetadataError {
 pub struct ModelRequest {
     lifecycle_observed: bool,
     messages: Vec<ModelMessage>,
+    model_reasoning_effort: Option<ReasoningEffort>,
     prompt: String,
     provider_session_id: Option<String>,
     schema: OutputSchema,
@@ -279,6 +277,7 @@ impl ModelRequest {
         Self {
             lifecycle_observed: false,
             messages: vec![ModelMessage::User(prompt.clone())],
+            model_reasoning_effort: None,
             prompt,
             provider_session_id: None,
             schema,
@@ -298,11 +297,20 @@ impl ModelRequest {
         Self {
             lifecycle_observed: false,
             messages,
+            model_reasoning_effort: None,
             prompt,
             provider_session_id: None,
             schema,
             tools: Vec::new(),
         }
+    }
+
+    /// Requests a provider-supported reasoning depth for this completion.
+    #[must_use]
+    pub fn with_model_reasoning_effort(mut self, reasoning_effort: ReasoningEffort) -> Self {
+        self.model_reasoning_effort = Some(reasoning_effort);
+
+        self
     }
 
     /// Advertises one native function tool for this request.
@@ -343,6 +351,11 @@ impl ModelRequest {
     /// to support chat and tool execution. The harness owns its mutation.
     pub fn messages(&self) -> &[ModelMessage] {
         &self.messages
+    }
+
+    /// Returns the requested provider reasoning depth, when configured.
+    pub fn model_reasoning_effort(&self) -> Option<ReasoningEffort> {
+        self.model_reasoning_effort
     }
 
     pub(crate) fn advertises_tool(&self, name: &str) -> bool {
@@ -396,13 +409,58 @@ impl ModelRequest {
             );
     }
 
-    pub(crate) fn record_output(&mut self, output: &Value) {
-        self.messages
-            .push(ModelMessage::Assistant(output.to_string()));
+    pub(crate) fn record_output_with_reasoning(
+        &mut self,
+        output: &Value,
+        reasoning_content: Option<String>,
+    ) {
+        let content = output.to_string();
+        self.messages.push(match reasoning_content {
+            Some(reasoning_content) => ModelMessage::AssistantReasoning {
+                content,
+                reasoning_content,
+            },
+            None => ModelMessage::Assistant(content),
+        });
     }
 
     pub(crate) fn into_messages(self) -> Vec<ModelMessage> {
         self.messages
+    }
+}
+
+/// Provider-supported reasoning depth for one model completion.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ReasoningEffort {
+    /// Uses a light reasoning pass.
+    Low,
+    /// Uses a moderate reasoning pass.
+    Medium,
+    /// Uses a deep reasoning pass.
+    #[default]
+    High,
+    /// Uses an extra-high reasoning pass.
+    #[serde(rename = "xhigh")]
+    XHigh,
+    /// Uses the provider's maximum reasoning depth.
+    Max,
+}
+
+impl ReasoningEffort {
+    /// All selectable model reasoning efforts in display order.
+    pub const ALL: [Self; 5] = [Self::Low, Self::Medium, Self::High, Self::XHigh, Self::Max];
+
+    /// Returns the provider-neutral identifier for this effort.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::XHigh => "xhigh",
+            Self::Max => "max",
+        }
     }
 }
 
@@ -416,6 +474,14 @@ impl ModelRequest {
 pub enum ModelMessage {
     /// Validated structured assistant output serialized as JSON text.
     Assistant(String),
+    /// Validated assistant output paired with provider reasoning that must be
+    /// replayed.
+    AssistantReasoning {
+        /// Validated structured assistant output serialized as JSON text.
+        content: String,
+        /// Provider reasoning content replayed verbatim on the next request.
+        reasoning_content: String,
+    },
     /// One assistant tool call, followed by its result.
     AssistantToolCall(tool::ToolCall),
     /// An ordered assistant tool-call batch, followed by its ordered results.
@@ -439,6 +505,10 @@ impl ModelMessage {
     pub(crate) fn retained_bytes(&self) -> usize {
         match self {
             Self::Assistant(content) | Self::System(content) | Self::User(content) => content.len(),
+            Self::AssistantReasoning {
+                content,
+                reasoning_content,
+            } => content.len().saturating_add(reasoning_content.len()),
             Self::AssistantToolCall(call) => {
                 let arguments = call
                     .arguments_json()
@@ -478,6 +548,7 @@ impl ModelMessage {
 pub struct ModelCompletion {
     metadata: Option<CompletionMetadata>,
     provider_session_id: Option<String>,
+    reasoning_content: Option<String>,
     response: ModelResponse,
 }
 
@@ -487,6 +558,7 @@ impl ModelCompletion {
         Self {
             metadata: Some(metadata),
             provider_session_id: None,
+            reasoning_content: None,
             response,
         }
     }
@@ -496,6 +568,7 @@ impl ModelCompletion {
         Self {
             metadata: None,
             provider_session_id: None,
+            reasoning_content: None,
             response,
         }
     }
@@ -504,6 +577,12 @@ impl ModelCompletion {
     #[must_use]
     pub fn with_provider_session_id(mut self, provider_session_id: impl Into<String>) -> Self {
         self.provider_session_id = Some(provider_session_id.into());
+
+        self
+    }
+
+    pub(crate) fn with_reasoning_content(mut self, reasoning_content: Option<String>) -> Self {
+        self.reasoning_content = reasoning_content;
 
         self
     }
@@ -528,8 +607,20 @@ impl ModelCompletion {
         self.response
     }
 
-    pub(crate) fn into_parts(self) -> (ModelResponse, Option<CompletionMetadata>, Option<String>) {
-        (self.response, self.metadata, self.provider_session_id)
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        ModelResponse,
+        Option<CompletionMetadata>,
+        Option<String>,
+        Option<String>,
+    ) {
+        (
+            self.response,
+            self.metadata,
+            self.provider_session_id,
+            self.reasoning_content,
+        )
     }
 }
 
@@ -1328,6 +1419,34 @@ mod tests {
         assert_eq!(request.prompt(), "hello");
         assert_eq!(request.schema(), &schema);
         assert_eq!(request.tools(), []);
+    }
+
+    #[test]
+    fn request_uses_provider_neutral_reasoning_effort_names() {
+        // Arrange
+        let schema =
+            OutputSchema::new(json!({ "type": "object" })).expect("schema should be valid");
+        let names = ["low", "medium", "high", "xhigh", "max"];
+
+        // Act
+        let request =
+            ModelRequest::new("hello", schema).with_model_reasoning_effort(ReasoningEffort::High);
+        let serialized = ReasoningEffort::ALL
+            .iter()
+            .map(|effort| serde_json::to_value(effort).expect("effort should serialize"))
+            .collect::<Vec<_>>();
+
+        // Assert
+        assert_eq!(
+            request.model_reasoning_effort(),
+            Some(ReasoningEffort::High)
+        );
+        assert_eq!(
+            serialized,
+            names.map(|name| serde_json::Value::String(name.to_string()))
+        );
+        assert_eq!(ReasoningEffort::default(), ReasoningEffort::High);
+        assert_eq!(ReasoningEffort::ALL.map(ReasoningEffort::as_str), names);
     }
 
     #[test]

--- a/crates/ag-harness/src/provider.rs
+++ b/crates/ag-harness/src/provider.rs
@@ -8,9 +8,9 @@ mod qwen;
 pub use catalog::{
     ModelConfiguration, ModelConfigurationError, ModelProvider, ModelProviderParseError,
 };
-pub(crate) use kimi::POLICY as KIMI_POLICY;
+pub(crate) use kimi::policy as kimi_policy;
 pub use kimi::{KIMI_K2_6, KimiConfig};
 pub(crate) use muse::POLICY as MUSE_POLICY;
 pub use muse::{MUSE_SPARK_1_3, MUSE_SPARK_1_3_CONTRIBUTOR, Muse, MuseConfig};
-pub(crate) use qwen::POLICY as QWEN_POLICY;
+pub(crate) use qwen::policy as qwen_policy;
 pub use qwen::{QWEN_PLUS, QwenConfig};

--- a/crates/ag-harness/src/provider/kimi.rs
+++ b/crates/ag-harness/src/provider/kimi.rs
@@ -1,3 +1,4 @@
+use crate::model::ReasoningEffort;
 use crate::{chat_completion, telemetry};
 
 pub(crate) const KIMI_API_KEY_ENV: &str = "KIMI_API_KEY";
@@ -6,17 +7,41 @@ pub(crate) const KIMI_BASE_URL_ENV: &str = "KIMI_BASE_URL";
 /// Kimi K2.6 model identifier.
 pub const KIMI_K2_6: &str = "kimi-k2.6";
 
-pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
+pub(crate) fn policy(model: &str) -> chat_completion::ChatCompletionProviderPolicy {
     chat_completion::ChatCompletionProviderPolicy {
         display_name: "Kimi",
+        reasoning_format: match model {
+            "kimi-k2.6" => chat_completion::ReasoningFormat::Thinking {
+                disable_supported: true,
+                preserve_reasoning: true,
+            },
+            "kimi-k2.7-code" => chat_completion::ReasoningFormat::Thinking {
+                disable_supported: false,
+                preserve_reasoning: false,
+            },
+            "kimi-k3" => chat_completion::ReasoningFormat::Effort(reasoning_effort_name),
+            _ => chat_completion::ReasoningFormat::None,
+        },
         response_format_with_tools: false,
         structured_output: chat_completion::StructuredOutputMode::JsonObject {
-            assistant_reasoning_content: true,
+            assistant_reasoning_content: matches!(
+                model,
+                "kimi-k2.6" | "kimi-k2.7-code" | "kimi-k3"
+            ),
             tool_result_name: true,
         },
         telemetry_name: telemetry::PROVIDER_MOONSHOT_AI,
         unsupported_schema_reason: "Kimi JSON Object mode requires an explicit object root schema",
-    };
+    }
+}
+
+fn reasoning_effort_name(reasoning_effort: ReasoningEffort) -> &'static str {
+    match reasoning_effort {
+        ReasoningEffort::Low => "low",
+        ReasoningEffort::Medium | ReasoningEffort::High => "high",
+        ReasoningEffort::XHigh | ReasoningEffort::Max => "max",
+    }
+}
 
 /// Configuration for a Kimi model served through Moonshot AI's
 /// OpenAI-compatible API.
@@ -91,10 +116,14 @@ mod tests {
     }
 
     fn kimi(server: &MockServer) -> model::ModelClient {
+        kimi_model(server, "kimi-k2.6")
+    }
+
+    fn kimi_model(server: &MockServer, model: &str) -> model::ModelClient {
         model::ModelClient::kimi(KimiConfig {
             api_key: "test-key".to_string(),
             base_url: format!("{}/", server.uri()),
-            model: "kimi-k2.6".to_string(),
+            model: model.to_string(),
         })
         .expect("fixture configuration should be valid")
     }
@@ -153,7 +182,8 @@ mod tests {
                     {"content": prompt, "role": "user"}
                 ],
                 "model": "kimi-k2.6",
-                "response_format": {"type": "json_object"}
+                "response_format": {"type": "json_object"},
+                "thinking": {"keep": "all", "type": "enabled"}
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "choices": [{
@@ -182,6 +212,7 @@ mod tests {
                     {"content": prompt, "role": "user"}
                 ],
                 "model": "kimi-k2.6",
+                "thinking": {"keep": "all", "type": "enabled"},
                 "tools": [read_tool_wire()]
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -339,6 +370,7 @@ mod tests {
                     }
                 ],
                 "model": "kimi-k2.6",
+                "thinking": {"keep": "all", "type": "enabled"},
                 "tools": [read_tool_wire()]
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -370,6 +402,193 @@ mod tests {
 
         // Assert
         assert_eq!(response.output(), Some(&json!({ "name": "Cargo" })));
+    }
+
+    #[tokio::test]
+    async fn preserves_terminal_k3_reasoning_for_next_session_turn() {
+        // Arrange
+        let server = MockServer::start().await;
+        let first_prompt = "identify the person";
+        let second_prompt = "repeat the person";
+        let reasoning_content = "The requested name is Ada.";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(bearer_token("test-key"))
+            .and(body_json(json!({
+                "messages": [
+                    {
+                        "content": format!(
+                            "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
+                            person_schema_value()
+                        ),
+                        "role": "system"
+                    },
+                    {"content": first_prompt, "role": "user"}
+                ],
+                "model": "kimi-k3",
+                "response_format": {"type": "json_object"}
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {
+                        "content": r#"{"name":"Ada"}"#,
+                        "reasoning_content": reasoning_content
+                    }
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(bearer_token("test-key"))
+            .and(body_json(json!({
+                "messages": [
+                    {
+                        "content": format!(
+                            "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
+                            person_schema_value()
+                        ),
+                        "role": "system"
+                    },
+                    {"content": first_prompt, "role": "user"},
+                    {
+                        "content": r#"{"name":"Ada"}"#,
+                        "reasoning_content": reasoning_content,
+                        "role": "assistant"
+                    },
+                    {"content": second_prompt, "role": "user"}
+                ],
+                "model": "kimi-k3",
+                "response_format": {"type": "json_object"}
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": r#"{"name":"Ada"}"#}
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let harness = crate::Harness::new(kimi_model(&server, "kimi-k3"))
+            .database(directory.path().join("harness.db"));
+        let mut session = harness
+            .session("kimi-k3-reasoning", person_schema())
+            .create()
+            .await
+            .expect("session should be created");
+
+        // Act
+        let first = session
+            .send(first_prompt)
+            .await
+            .expect("first K3 turn should succeed");
+        let second = session
+            .send(second_prompt)
+            .await
+            .expect("continued K3 turn should succeed");
+
+        // Assert
+        assert_eq!(first.output(), &json!({ "name": "Ada" }));
+        assert_eq!(second.output(), first.output());
+    }
+
+    #[tokio::test]
+    async fn preserves_terminal_k2_6_reasoning_for_next_session_turn() {
+        // Arrange
+        let server = MockServer::start().await;
+        let first_prompt = "identify the person";
+        let second_prompt = "repeat the person";
+        let reasoning_content = "The requested name is Ada.";
+        let thinking = json!({"keep": "all", "type": "enabled"});
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(bearer_token("test-key"))
+            .and(body_json(json!({
+                "messages": [
+                    {
+                        "content": format!(
+                            "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
+                            person_schema_value()
+                        ),
+                        "role": "system"
+                    },
+                    {"content": first_prompt, "role": "user"}
+                ],
+                "model": "kimi-k2.6",
+                "response_format": {"type": "json_object"},
+                "thinking": thinking
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {
+                        "content": r#"{"name":"Ada"}"#,
+                        "reasoning_content": reasoning_content
+                    }
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(bearer_token("test-key"))
+            .and(body_json(json!({
+                "messages": [
+                    {
+                        "content": format!(
+                            "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
+                            person_schema_value()
+                        ),
+                        "role": "system"
+                    },
+                    {"content": first_prompt, "role": "user"},
+                    {
+                        "content": r#"{"name":"Ada"}"#,
+                        "reasoning_content": reasoning_content,
+                        "role": "assistant"
+                    },
+                    {"content": second_prompt, "role": "user"}
+                ],
+                "model": "kimi-k2.6",
+                "response_format": {"type": "json_object"},
+                "thinking": thinking
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": r#"{"name":"Ada"}"#}
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let harness =
+            crate::Harness::new(kimi(&server)).database(directory.path().join("harness.db"));
+        let mut session = harness
+            .session("kimi-k2.6-reasoning", person_schema())
+            .create()
+            .await
+            .expect("session should be created");
+
+        // Act
+        let first = session
+            .send(first_prompt)
+            .await
+            .expect("first K2.6 turn should succeed");
+        let second = session
+            .send(second_prompt)
+            .await
+            .expect("continued K2.6 turn should succeed");
+
+        // Assert
+        assert_eq!(first.output(), &json!({ "name": "Ada" }));
+        assert_eq!(second.output(), first.output());
     }
 
     #[tokio::test]

--- a/crates/ag-harness/src/provider/muse.rs
+++ b/crates/ag-harness/src/provider/muse.rs
@@ -4,7 +4,9 @@ use async_trait::async_trait;
 
 use super::catalog::{ModelConfiguration, ModelConfigurationError, ModelProvider};
 use crate::lifecycle::LifecycleObserver;
-use crate::model::{Model, ModelClient, ModelCompletion, ModelError, ModelMetadata, ModelRequest};
+use crate::model::{
+    Model, ModelClient, ModelCompletion, ModelError, ModelMetadata, ModelRequest, ReasoningEffort,
+};
 use crate::{chat_completion, telemetry};
 
 pub(crate) const DEFAULT_BASE_URL: &str = "https://api.meta.ai/v1";
@@ -22,11 +24,19 @@ pub const MUSE_SPARK_1_3_CONTRIBUTOR: &str = "muse-spark-1.3-contributor";
 pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
     chat_completion::ChatCompletionProviderPolicy {
         display_name: "Meta Model API",
+        reasoning_format: chat_completion::ReasoningFormat::Effort(reasoning_effort_name),
         response_format_with_tools: true,
         structured_output: chat_completion::StructuredOutputMode::JsonSchema,
         telemetry_name: telemetry::PROVIDER_META,
         unsupported_schema_reason: "Muse structured output requires an explicit object root schema",
     };
+
+fn reasoning_effort_name(reasoning_effort: ReasoningEffort) -> &'static str {
+    match reasoning_effort {
+        ReasoningEffort::Max => ReasoningEffort::XHigh.as_str(),
+        reasoning_effort => reasoning_effort.as_str(),
+    }
+}
 
 /// Muse model configured from the standard Model API environment variables.
 pub struct Muse {
@@ -169,6 +179,24 @@ mod tests {
 
         // Assert
         assert_eq!(models, ["muse-spark-1.3", "muse-spark-1.3-contributor"]);
+    }
+
+    #[test]
+    fn reasoning_effort_maps_max_to_xhigh_and_preserves_supported_values() {
+        // Arrange
+        let cases = [
+            (ReasoningEffort::Low, "low"),
+            (ReasoningEffort::Medium, "medium"),
+            (ReasoningEffort::High, "high"),
+            (ReasoningEffort::XHigh, "xhigh"),
+            (ReasoningEffort::Max, "xhigh"),
+        ];
+
+        // Act
+        let actual = cases.map(|(effort, _)| reasoning_effort_name(effort));
+
+        // Assert
+        assert_eq!(actual, cases.map(|(_, expected)| expected));
     }
 
     #[test]

--- a/crates/ag-harness/src/provider/qwen.rs
+++ b/crates/ag-harness/src/provider/qwen.rs
@@ -1,3 +1,4 @@
+use crate::model::ReasoningEffort;
 use crate::{chat_completion, telemetry};
 
 pub(crate) const DASHSCOPE_API_KEY_ENV: &str = "DASHSCOPE_API_KEY";
@@ -6,17 +7,36 @@ pub(crate) const DASHSCOPE_BASE_URL_ENV: &str = "DASHSCOPE_BASE_URL";
 /// Qwen Plus model identifier.
 pub const QWEN_PLUS: &str = "qwen-plus";
 
-pub(crate) const POLICY: chat_completion::ChatCompletionProviderPolicy =
+pub(crate) fn policy(model: &str) -> chat_completion::ChatCompletionProviderPolicy {
+    let preserves_reasoning = model.starts_with("qwen3.8-");
+
     chat_completion::ChatCompletionProviderPolicy {
         display_name: "Qwen",
+        reasoning_format: if preserves_reasoning {
+            chat_completion::ReasoningFormat::Effort(reasoning_effort_name)
+        } else if model == QWEN_PLUS {
+            chat_completion::ReasoningFormat::EnableThinking
+        } else {
+            chat_completion::ReasoningFormat::None
+        },
         response_format_with_tools: false,
         structured_output: chat_completion::StructuredOutputMode::JsonObject {
-            assistant_reasoning_content: false,
+            assistant_reasoning_content: preserves_reasoning,
             tool_result_name: false,
         },
         telemetry_name: telemetry::PROVIDER_ALIBABA_CLOUD,
         unsupported_schema_reason: "Qwen JSON Object mode requires an explicit object root schema",
-    };
+    }
+}
+
+fn reasoning_effort_name(reasoning_effort: ReasoningEffort) -> &'static str {
+    match reasoning_effort {
+        ReasoningEffort::Low | ReasoningEffort::Medium => reasoning_effort.as_str(),
+        ReasoningEffort::High | ReasoningEffort::XHigh | ReasoningEffort::Max => {
+            ReasoningEffort::XHigh.as_str()
+        }
+    }
+}
 
 /// Configuration for a Qwen model served through Alibaba Cloud Model Studio's
 /// OpenAI-compatible API.
@@ -118,10 +138,14 @@ mod tests {
     }
 
     fn qwen(server: &MockServer) -> model::ModelClient {
+        qwen_model(server, QWEN_PLUS)
+    }
+
+    fn qwen_model(server: &MockServer, model: &str) -> model::ModelClient {
         model::ModelClient::qwen(QwenConfig {
             api_key: "test-key".to_string(),
             base_url: format!("{}/", server.uri()),
-            model: "qwen-plus".to_string(),
+            model: model.to_string(),
         })
         .expect("fixture configuration should be valid")
     }
@@ -204,6 +228,102 @@ mod tests {
                 "choices": [{
                     "finish_reason": finish_reason,
                     "message": message
+                }]
+            })))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    async fn mount_qwen_3_8_tool_response(
+        server: &MockServer,
+        prompt: &str,
+        reasoning_content: &str,
+    ) {
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(bearer_token("test-key"))
+            .and(body_json(json!({
+                "messages": [
+                    {
+                        "content": format!(
+                            "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
+                            person_schema_value()
+                        ),
+                        "role": "system"
+                    },
+                    {"content": prompt, "role": "user"}
+                ],
+                "model": "qwen3.8-max",
+                "tools": [read_tool_wire()]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "content": null,
+                        "reasoning_content": reasoning_content,
+                        "tool_calls": [{
+                            "id": "call_qwen_read",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": r#"{"path":"Cargo.toml","offset":1,"limit":12}"#
+                            }
+                        }]
+                    }
+                }]
+            })))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    async fn mount_qwen_3_8_continuation(
+        server: &MockServer,
+        prompt: &str,
+        result: &str,
+        reasoning_content: &str,
+    ) {
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(bearer_token("test-key"))
+            .and(body_json(json!({
+                "messages": [
+                    {
+                        "content": format!(
+                            "{STRUCTURED_OUTPUT_INSTRUCTION}{}",
+                            person_schema_value()
+                        ),
+                        "role": "system"
+                    },
+                    {"content": prompt, "role": "user"},
+                    {
+                        "content": null,
+                        "reasoning_content": reasoning_content,
+                        "role": "assistant",
+                        "tool_calls": [{
+                            "function": {
+                                "arguments": r#"{"limit":12,"offset":1,"path":"Cargo.toml"}"#,
+                                "name": "read"
+                            },
+                            "id": "call_qwen_read",
+                            "type": "function"
+                        }]
+                    },
+                    {
+                        "content": result,
+                        "role": "tool",
+                        "tool_call_id": "call_qwen_read"
+                    }
+                ],
+                "model": "qwen3.8-max",
+                "tools": [read_tool_wire()]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": r#"{"name":"Cargo"}"#}
                 }]
             })))
             .expect(1)
@@ -406,6 +526,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn preserves_qwen_3_8_reasoning_for_tool_continuation() {
+        // Arrange
+        let server = MockServer::start().await;
+        let prompt = "inspect the manifest";
+        let result = r#"{"content":"[workspace]","end_line":1,"next_offset":null,"path":"Cargo.toml","start_line":1,"truncated":false}"#;
+        let reasoning_content = "I should inspect the manifest before answering.";
+        mount_qwen_3_8_tool_response(&server, prompt, reasoning_content).await;
+        mount_qwen_3_8_continuation(&server, prompt, result, reasoning_content).await;
+        let model = qwen_model(&server, "qwen3.8-max");
+
+        // Act
+        let tool_response = model
+            .complete(read_request(prompt))
+            .await
+            .expect("initial Qwen3.8 tool request should succeed");
+        let call = tool_response
+            .call()
+            .expect("initial response should contain a tool call")
+            .clone();
+        let mut model_request = read_request(prompt);
+        model_request.record_tool_result(call, result.to_string());
+        let response = model
+            .complete(model_request)
+            .await
+            .expect("continued Qwen3.8 request should succeed");
+
+        // Assert
+        assert_eq!(response.output(), Some(&json!({ "name": "Cargo" })));
+    }
+
+    #[tokio::test]
     async fn rejects_terminal_response_with_tool_calls() {
         // Arrange
         let server = MockServer::start().await;
@@ -584,7 +735,7 @@ mod tests {
             "stub-key".to_string(),
             "https://stub.example/v1/".to_string(),
             "qwen-stub".to_string(),
-            POLICY,
+            policy("qwen-stub"),
             Arc::new(StubClient),
         );
 

--- a/crates/ag-harness/src/session.rs
+++ b/crates/ag-harness/src/session.rs
@@ -1113,6 +1113,16 @@ impl EncodedMessage {
     fn from_message(message: &ModelMessage) -> Result<Self, SessionError> {
         let (kind, payload) = match message {
             ModelMessage::Assistant(content) => ("assistant", serialize_payload(content)),
+            ModelMessage::AssistantReasoning {
+                content,
+                reasoning_content,
+            } => (
+                "assistant_reasoning",
+                serialize_payload(&StoredAssistantReasoning {
+                    content,
+                    reasoning_content,
+                }),
+            ),
             ModelMessage::AssistantToolCall(call) => (
                 "assistant_tool_call",
                 serialize_payload(&StoredToolCall::from_call(call)?),
@@ -1157,6 +1167,14 @@ impl EncodedMessage {
     fn into_message(kind: &str, payload: &str) -> Result<ModelMessage, SessionError> {
         match kind {
             "assistant" => deserialize_payload(payload).map(ModelMessage::Assistant),
+            "assistant_reasoning" => {
+                let assistant = deserialize_payload::<StoredAssistantReasoningOwned>(payload)?;
+
+                Ok(ModelMessage::AssistantReasoning {
+                    content: assistant.content,
+                    reasoning_content: assistant.reasoning_content,
+                })
+            }
             "assistant_tool_call" => deserialize_payload::<StoredToolCall>(payload)?
                 .into_call()
                 .map(ModelMessage::AssistantToolCall),
@@ -1180,6 +1198,18 @@ impl EncodedMessage {
             }),
         }
     }
+}
+
+#[derive(Serialize)]
+struct StoredAssistantReasoning<'a> {
+    content: &'a str,
+    reasoning_content: &'a str,
+}
+
+#[derive(Deserialize)]
+struct StoredAssistantReasoningOwned {
+    content: String,
+    reasoning_content: String,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -2006,6 +2036,10 @@ ORDER BY turn_position, message_position
             .expect("session should be created");
         let messages = vec![
             ModelMessage::User("inspect and edit".to_string()),
+            ModelMessage::AssistantReasoning {
+                content: r#"{"summary":"thinking"}"#.to_string(),
+                reasoning_content: "I should inspect before editing.".to_string(),
+            },
             ModelMessage::AssistantToolCall(read_call("read-one")),
             ModelMessage::ToolResult {
                 call_id: "read-one".to_string(),


### PR DESCRIPTION
- Exposes provider-neutral reasoning settings through `ModelRequest` and `Harness`, with CLI chats defaulting to low effort.
- Translates reasoning settings to Muse, Kimi, and Qwen wire formats, including maximum-effort compatibility.
- Limits repository tools to explicit repository requests and verifies the updated request payloads.
- Adds configurable CLI reasoning defaults and per-request overrides.
- Adds Qwen3.8 graded reasoning levels.
- Maps reasoning settings to Muse, Kimi, and Qwen wire formats, and preserves provider reasoning content across tool continuations and session turns.
- Documents configurable harness storage locations, with coverage for CLI parsing, help text, and provider payloads.