### PR TITLE
Defaults harness CLI to Git from PATH

### DIFF
--- a/crates/ag-harness-cli/README.md
+++ b/crates/ag-harness-cli/README.md
@@ -1,26 +1,37 @@
 # `ag-harness-cli`
 
-Start a durable session:
+Chat with models through a repository-aware, durable terminal harness.
+
+## Get started
 
 ```sh
-MODEL_API_KEY=your-key cargo run -p ag-harness-cli -- \
-  --git-executable /absolute/path/to/git \
-  run muse-spark-1.3 --session review-42
+export MODEL_API_KEY="your-key"
+cargo run --locked -p ag-harness-cli -- run muse-spark-1.3
 ```
 
-Resume it later:
+This starts an interactive chat with read-only access to the current directory.
+
+## Common commands
 
 ```sh
-MODEL_API_KEY=your-key cargo run -p ag-harness-cli -- \
-  --git-executable /absolute/path/to/git resume review-42
+# Start a named session
+cargo run --locked -p ag-harness-cli -- run muse-spark-1.3 --session review-42
+
+# Resume it later
+cargo run --locked -p ag-harness-cli -- resume review-42
+
+# Allow repository writes
+cargo run --locked -p ag-harness-cli -- run muse-spark-1.3 --allow-write
+
+# Chat about another repository
+cargo run --locked -p ag-harness-cli -- \
+  run muse-spark-1.3 --read-dir /path/to/repository
 ```
 
-The current directory is readable by default. Add `--allow-write` to permit patches or
-`--read-dir <DIR>` to choose another repository root. `--git-executable <FILE>` is
-required and must select an absolute Git executable outside the containing worktree.
-Select Kimi or Qwen with `--provider`; `--base-url` overrides the provider endpoint.
+## Defaults
 
-Session history defaults to `~/.ag-harness/db/harness.db`. Set `AG_HARNESS_ROOT`, or
-pass `--database <FILE>`, to choose another location. If `HOME` is unavailable, one of
-those explicit locations is required. Run `ag-harness --help` for the complete provider
-and credential list.
+- Repository writes are disabled unless `--allow-write` is set.
+- Sessions are stored in `~/.ag-harness/db/harness.db`.
+- The first valid Git in `PATH` is used; `--git-executable <FILE>` overrides it.
+- Muse is the default provider. Run `cargo run --locked -p ag-harness-cli -- run --help`
+  for Kimi, Qwen, model, and credential options.

--- a/crates/ag-harness-cli/src/main.rs
+++ b/crates/ag-harness-cli/src/main.rs
@@ -1,9 +1,10 @@
 //! Interactive command-line chat powered by the `ag-harness` model runtime.
 
 use std::borrow::Cow;
+use std::ffi::OsStr;
 #[cfg(not(test))]
 use std::io::IsTerminal as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::{env, io};
 
@@ -42,14 +43,14 @@ const READ_WRITE_SYSTEM_PROMPT: &str = concat!(
     name = "ag-harness",
     version,
     about = "Chats with models through a repository harness",
-    after_help = provider_help(),
-    group(clap::ArgGroup::new("repository").required(true).args(["git_executable"]))
+    after_help = provider_help()
 )]
 struct Cli {
     /// SQLite database used for durable session history.
     #[arg(long, global = true, value_name = "FILE")]
     database: Option<PathBuf>,
-    /// Absolute path to the host-controlled Git executable.
+    /// Absolute Git executable override; defaults to the first valid Git found
+    /// in PATH.
     #[arg(long, global = true, value_name = "FILE")]
     git_executable: Option<PathBuf>,
     #[command(subcommand)]
@@ -239,14 +240,9 @@ where
                 args.base_url.as_deref(),
                 &mut environment,
             )?;
-            let git_executable = git_executable.ok_or(CliError::GitExecutableRequired)?;
-            let (harness, system_prompt) = configured_harness(
-                client,
-                database,
-                args.read_dir,
-                git_executable,
-                args.allow_write,
-            )?;
+            let repository = repository_or_default(args.read_dir, git_executable)?;
+            let (harness, system_prompt) =
+                configured_harness(client, database, repository, args.allow_write);
             let mut session = harness
                 .session(&session_id, chat_schema()?)
                 .system_prompt(system_prompt)
@@ -262,14 +258,8 @@ where
             let (provider, model) = stored_model_identity(&info)?;
             let client =
                 model_client(provider, &model, args.base_url.as_deref(), &mut environment)?;
-            let git_executable = git_executable.ok_or(CliError::GitExecutableRequired)?;
-            let (harness, _) = configured_harness(
-                client,
-                database,
-                args.read_dir,
-                git_executable,
-                args.allow_write,
-            )?;
+            let repository = repository_or_default(args.read_dir, git_executable)?;
+            let (harness, _) = configured_harness(client, database, repository, args.allow_write);
             let mut session = harness.resume(&args.session).await?;
             let mut output = output;
             announce_session(&mut output, &args.session).await?;
@@ -311,6 +301,37 @@ fn database_path(
     Ok(PathBuf::from(home).join(".ag-harness/db/harness.db"))
 }
 
+fn repository_or_default(root: PathBuf, explicit: Option<PathBuf>) -> Result<Repository, CliError> {
+    if let Some(explicit) = explicit {
+        return Repository::new(root, explicit).map_err(CliError::from);
+    }
+    let path = env::var_os("PATH");
+
+    repository_from_path(&root, path.as_deref())
+}
+
+fn repository_from_path(root: &Path, path: Option<&OsStr>) -> Result<Repository, CliError> {
+    let executable_name = format!("git{}", env::consts::EXE_SUFFIX);
+
+    let candidates = path
+        .iter()
+        .flat_map(env::split_paths)
+        .filter(|directory| directory.is_absolute())
+        .map(|directory| directory.join(&executable_name));
+    for candidate in candidates {
+        match Repository::new(root, candidate) {
+            Ok(repository) => return Ok(repository),
+            Err(
+                error @ (ag_harness::RepositoryError::Root { .. }
+                | ag_harness::RepositoryError::RootIsGitAdministrative { .. }),
+            ) => return Err(error.into()),
+            Err(_) => {}
+        }
+    }
+
+    Err(CliError::GitExecutableNotFound)
+}
+
 fn model_client(
     provider: ModelProvider,
     model: &str,
@@ -330,11 +351,9 @@ fn model_client(
 fn configured_harness(
     client: ag_harness::ModelClient,
     database: PathBuf,
-    repository_root: PathBuf,
-    git_executable: PathBuf,
+    repository: Repository,
     allow_write: bool,
-) -> Result<(Harness, &'static str), CliError> {
-    let repository = Repository::new(repository_root, git_executable)?;
+) -> (Harness, &'static str) {
     let mut harness = Harness::new(client)
         .database(database)
         .repository(repository)
@@ -342,9 +361,9 @@ fn configured_harness(
     if allow_write {
         harness = harness.allow(Tool::Write);
 
-        Ok((harness, READ_WRITE_SYSTEM_PROMPT))
+        (harness, READ_WRITE_SYSTEM_PROMPT)
     } else {
-        Ok((harness, READ_ONLY_SYSTEM_PROMPT))
+        (harness, READ_ONLY_SYSTEM_PROMPT)
     }
 }
 
@@ -628,8 +647,8 @@ enum CliError {
     ChatTurnsFailed,
     #[error("--database, AG_HARNESS_ROOT, or HOME is required for durable session storage")]
     DatabaseLocation,
-    #[error("--git-executable is required for repository tools")]
-    GitExecutableRequired,
+    #[error("No valid Git executable was found in PATH; pass --git-executable <FILE>")]
+    GitExecutableNotFound,
     #[error("model output did not contain a message")]
     MissingMessage,
     #[error("stored session does not identify a supported built-in model")]
@@ -1198,7 +1217,7 @@ mod tests {
     }
 
     #[test]
-    fn cli_requires_an_explicit_git_executable() {
+    fn cli_accepts_the_default_git_executable() {
         // Arrange
         let arguments = [
             "ag-harness",
@@ -1210,15 +1229,85 @@ mod tests {
         ];
 
         // Act
-        let error = Cli::try_parse_from(arguments)
-            .expect_err("missing Git executable should fail during argument parsing");
+        let cli = Cli::try_parse_from(arguments)
+            .expect("missing Git executable override should use the default");
+
+        // Assert
+        assert_eq!(cli.git_executable, None);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn git_executable_default_skips_a_non_executable_file() {
+        // Arrange
+        let storage = tempfile::tempdir().expect("temporary storage should exist");
+        let executable_name = format!("git{}", env::consts::EXE_SUFFIX);
+        let inert = storage.path().join(executable_name);
+        std::fs::write(&inert, "not executable").expect("inert Git fixture should be written");
+        let trusted_git = test_git_executable();
+        let trusted_directory = trusted_git
+            .parent()
+            .expect("trusted Git executable should have a parent");
+        let path = env::join_paths([storage.path(), trusted_directory])
+            .expect("test PATH should be valid");
+        let root = env::current_dir().expect("current directory should resolve");
+        let expected = Repository::new(&root, trusted_git)
+            .expect("trusted Git executable should configure the repository");
+
+        // Act
+        let actual = repository_from_path(&root, Some(path.as_os_str()));
 
         // Assert
         assert_eq!(
-            error.kind(),
-            clap::error::ErrorKind::MissingRequiredArgument
+            actual.expect("non-executable Git should be skipped"),
+            expected
         );
-        assert!(error.to_string().contains("--git-executable <FILE>"));
+    }
+
+    #[test]
+    fn git_executable_default_uses_the_process_path() {
+        // Arrange
+        let root = env::current_dir().expect("current directory should resolve");
+        let expected = Repository::new(&root, test_git_executable())
+            .expect("trusted Git executable should configure the repository");
+
+        // Act
+        let actual = repository_or_default(root, None)
+            .expect("test PATH should contain a trusted Git executable");
+
+        // Assert
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn git_executable_default_requires_git_on_path() {
+        // Arrange
+        let root = env::current_dir().expect("current directory should resolve");
+
+        // Act
+        let error = repository_from_path(&root, None)
+            .expect_err("missing PATH should not produce a Git executable");
+
+        // Assert
+        assert!(matches!(error, CliError::GitExecutableNotFound));
+    }
+
+    #[test]
+    fn git_executable_default_preserves_repository_root_errors() {
+        // Arrange
+        let storage = tempfile::tempdir().expect("temporary storage should exist");
+        let missing_root = storage.path().join("missing-root");
+        let path = env::var_os("PATH").expect("test PATH should be configured");
+
+        // Act
+        let error = repository_from_path(&missing_root, Some(path.as_os_str()))
+            .expect_err("missing repository root should fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            CliError::Repository(ag_harness::RepositoryError::Root { .. })
+        ));
     }
 
     #[tokio::test]

--- a/crates/ag-harness-cli/tests/cli.rs
+++ b/crates/ag-harness-cli/tests/cli.rs
@@ -82,10 +82,7 @@ fn response(message: &str, input_tokens: u64, output_tokens: u64) -> ResponseTem
 fn harness_command() -> std::io::Result<(tempfile::TempDir, Command)> {
     let storage = tempfile::tempdir()?;
     let mut command = Command::new(cargo_bin!("ag-harness"));
-    command
-        .arg("--git-executable")
-        .arg(test_git_executable())
-        .env("AG_HARNESS_ROOT", storage.path());
+    command.env("AG_HARNESS_ROOT", storage.path());
 
     Ok((storage, command))
 }
@@ -122,8 +119,9 @@ fn help_describes_the_chat_interface() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).expect("help should be UTF-8");
     assert!(stdout.contains("Chats with models through a repository harness"));
-    assert!(stdout.contains("Usage: ag-harness [OPTIONS] <--git-executable <FILE>> <COMMAND>"));
+    assert!(stdout.contains("Usage: ag-harness [OPTIONS] <COMMAND>"));
     assert!(stdout.contains("--git-executable <FILE>"));
+    assert!(stdout.contains("defaults to the first valid Git found in PATH"));
     assert!(stdout.contains("Commands:"));
     assert!(stdout.contains("Starts a new durable session"));
     assert!(stdout.contains("Resumes a durable session"));
@@ -142,22 +140,66 @@ fn help_describes_the_chat_interface() {
     assert!(!stdout.contains("Examples:"));
 }
 
+#[cfg(unix)]
 #[test]
-fn missing_git_executable_is_a_clap_error() {
+fn default_git_skips_a_non_executable_path_entry() {
     // Arrange
-    let mut command = Command::new(cargo_bin!("ag-harness"));
+    let (storage, mut command) = harness_command().expect("temporary storage should exist");
+    let inert_directory = storage.path().join("inert-bin");
+    fs::create_dir(&inert_directory).expect("inert PATH directory should exist");
+    fs::write(inert_directory.join("git"), "not executable")
+        .expect("inert Git fixture should be written");
+    let inherited_path = std::env::var_os("PATH").expect("test PATH should be configured");
+    let path = std::env::join_paths(
+        std::iter::once(inert_directory).chain(std::env::split_paths(&inherited_path)),
+    )
+    .expect("test PATH should be valid");
 
     // Act
     let output = command
-        .args(["run", "muse-custom"])
+        .args([
+            "run",
+            "muse-custom",
+            "--base-url",
+            "https://models.example/v1",
+        ])
+        .env("MODEL_API_KEY", "test-key")
+        .env("PATH", path)
         .output()
-        .expect("CLI argument validation should run");
+        .expect("CLI default discovery should run");
 
     // Assert
-    assert_eq!(output.status.code(), Some(2));
-    let stderr = String::from_utf8(output.stderr).expect("argument error should be UTF-8");
-    assert!(stderr.contains("required arguments were not provided"));
-    assert!(stderr.contains("--git-executable <FILE>"));
+    assert!(
+        output.status.success(),
+        "CLI should use the later executable Git: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn missing_default_git_executable_is_a_runtime_error() {
+    // Arrange
+    let (_storage, mut command) = harness_command().expect("temporary storage should exist");
+
+    // Act
+    let output = command
+        .args([
+            "run",
+            "muse-custom",
+            "Hello",
+            "--base-url",
+            "https://models.example/v1",
+        ])
+        .env("MODEL_API_KEY", "test-key")
+        .env_remove("PATH")
+        .output()
+        .expect("CLI default validation should run");
+
+    // Assert
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).expect("runtime error should be UTF-8");
+    assert!(stderr.contains("No valid Git executable was found in PATH"));
+    assert!(stderr.contains("pass --git-executable <FILE>"));
 }
 
 #[test]
@@ -174,10 +216,7 @@ fn run_help_describes_optional_initial_prompt() {
     // Assert
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).expect("help should be UTF-8");
-    assert!(
-        stdout
-            .contains("Usage: ag-harness <--git-executable <FILE>> run [OPTIONS] <MODEL> [PROMPT]")
-    );
+    assert!(stdout.contains("Usage: ag-harness run [OPTIONS] <MODEL> [PROMPT]"));
     assert!(stdout.contains("Optional first prompt"));
     assert!(stdout.contains("--base-url <URL>"));
     for provider in ModelProvider::all() {

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -27,12 +27,14 @@ flowchart LR
 - `run_once` executes a turn without durable history.
 
 Repository tools are denied by default. `Tool::Read` and `Tool::Write` must be enabled
-explicitly, and both receive a validated `Repository` configuration. The host selects an
-absolute Git executable whose configured location and canonical target are outside the
-containing worktree. Configuration canonicalizes it once and never discovers Git from
-`PATH`. Unix hosts also verify effective execute access; other platforms defer that
-check to process creation. Repository-relative tool arguments reject `.git` components
-before filesystem access.
+explicitly, and both receive a validated `Repository` configuration. The library host
+selects an absolute Git executable whose configured location and canonical target are
+outside the containing worktree. The companion CLI defaults to the first valid `git`
+executable found in an absolute `PATH` entry and exposes `--git-executable` as an
+override. `Repository` canonicalizes the selection once and never performs its own
+`PATH` discovery. Unix hosts also verify effective execute access; other platforms defer
+that check to process creation. Repository-relative tool arguments reject `.git`
+components before filesystem access.
 
 ## Session lifecycle
 


### PR DESCRIPTION
- Selects the first file-backed `git` executable in an absolute `PATH` entry while retaining `--git-executable` as an override.
- Reports missing Git at runtime and documents the CLI discovery behavior and repository-tool boundary.