### PR TITLE
Support file lookup in question answers

### DIFF
--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -1899,7 +1899,8 @@ impl App {
     }
 
     /// Applies loaded at-mention entries to the currently focused prompt or
-    /// question session, if the mention query is still active.
+    /// question session, if the mention query is still active. Question updates
+    /// only refresh an open picker: a queued load must not undo dismissal.
     fn apply_prompt_at_mention_entries(&mut self, session_id: &str, entries: Vec<FileEntry>) {
         let (at_mention_state, has_query) = match &mut self.mode {
             AppMode::Prompt {
@@ -1915,7 +1916,7 @@ impl App {
                 input,
                 session_id: mode_session_id,
                 ..
-            } if mode_session_id == session_id => {
+            } if mode_session_id == session_id && at_mention_state.is_some() => {
                 (at_mention_state, input.at_mention_query().is_some())
             }
             _ => return,

--- a/crates/agentty/src/runtime/mode/at_mention.rs
+++ b/crates/agentty/src/runtime/mode/at_mention.rs
@@ -9,7 +9,7 @@ use crate::app::at_mention_task;
 use crate::app::session::SessionManager;
 use crate::app::{AppEvent, TaskService};
 use crate::domain::file_entry::{FileEntry, filter_entries};
-use crate::domain::input::InputState;
+use crate::domain::input::{InputState, is_at_mention_query_character};
 use crate::domain::session::SessionId;
 use crate::presentation::prompt::PromptAtMentionState;
 
@@ -28,12 +28,12 @@ pub(crate) enum AtMentionSyncAction {
 /// Text replacement derived from the currently highlighted `@`-mention row.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct AtMentionSelection {
-    /// End character index of the active `@query`.
-    pub cursor: usize,
-    /// Replacement text inserted into the input.
-    pub text: String,
+    /// Exclusive end character index of the complete active `@query` token.
+    pub at_end: usize,
     /// Start character index of the active `@query`.
     pub at_start: usize,
+    /// Replacement text inserted into the input.
+    pub text: String,
 }
 
 /// Returns the next `@`-mention sync action for one input buffer and dropdown
@@ -92,7 +92,8 @@ pub(crate) fn move_selection_down(input: &InputState, at_mention_state: &mut Pro
 }
 
 /// Returns the replacement text for the highlighted `@`-mention entry, if the
-/// input still contains an active `@query`.
+/// input still contains an active `@query`. The replacement spans the whole
+/// token, including any suffix after the cursor, and preserves its delimiters.
 pub(crate) fn selected_replacement(
     input: &InputState,
     at_mention_state: &PromptAtMentionState,
@@ -102,10 +103,17 @@ pub(crate) fn selected_replacement(
     let clamped_index = at_mention_state
         .selected_index
         .min(filtered.len().saturating_sub(1));
+    let at_end = input.cursor
+        + input
+            .text()
+            .chars()
+            .skip(input.cursor)
+            .take_while(|character| is_at_mention_query_character(*character))
+            .count();
 
     filtered.get(clamped_index).map(|entry| AtMentionSelection {
+        at_end,
         at_start,
-        cursor: input.cursor,
         text: format_mention_text(entry),
     })
 }
@@ -201,11 +209,37 @@ mod tests {
         assert_eq!(
             selection,
             AtMentionSelection {
+                at_end: 4,
                 at_start: 0,
-                cursor: 4,
                 text: "@src/ ".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn test_selected_replacement_replaces_full_token_and_preserves_surrounding_text() {
+        for (draft, prefix, expected) in [
+            ("@src/lib", "@src/li", "@src/lib.rs "),
+            ("Use @src/lib next", "Use @src/li", "Use @src/lib.rs  next"),
+            ("See (@src/lib)", "See (@src/li", "See (@src/lib.rs )"),
+            ("é @src/文件 next", "é @src/", "é @src/lib.rs  next"),
+            ("@src/lib.rs", "@src/lib.rs", "@src/lib.rs "),
+        ] {
+            // Arrange
+            let mut input = InputState::with_text(draft.to_string());
+            input.cursor = prefix.chars().count();
+            let state = PromptAtMentionState::new(vec![FileEntry {
+                is_dir: false,
+                path: "src/lib.rs".to_string(),
+            }]);
+
+            // Act
+            let selection = selected_replacement(&input, &state).expect("expected file selection");
+            input.replace_range(selection.at_start, selection.at_end, &selection.text);
+
+            // Assert
+            assert_eq!(input.text(), expected);
+        }
     }
 
     #[tokio::test]

--- a/crates/agentty/src/runtime/mode/prompt.rs
+++ b/crates/agentty/src/runtime/mode/prompt.rs
@@ -1327,7 +1327,7 @@ async fn handle_at_mention_select(app: &mut App) {
         app,
         InputCommand::ReplaceRange {
             start: selection.at_start,
-            end: selection.cursor,
+            end: selection.at_end,
             text: selection.text,
         },
     )
@@ -3888,7 +3888,10 @@ mod tests {
             },
         ]);
         state.selected_index = 9;
-        let (mut app, _base_dir) = new_test_prompt_app("@src/ma", Some(state)).await;
+        let (mut app, _base_dir) = new_test_prompt_app("@src/main", Some(state)).await;
+        if let AppMode::Prompt { input, .. } = &mut app.mode {
+            input.cursor = "@src/ma".chars().count();
+        }
 
         // Act
         handle_at_mention_select(&mut app).await;

--- a/crates/agentty/src/runtime/mode/question.rs
+++ b/crates/agentty/src/runtime/mode/question.rs
@@ -23,7 +23,8 @@ const NO_ANSWER: &str = "no answer";
 /// Applies one key event in question-answer mode.
 ///
 /// `Tab` toggles focus between the question panel and the chat output for
-/// scrolling. When chat is focused, scroll keys (`j`/`k`/`Up`/`Down`/`g`/`G`/
+/// scrolling, unless an open `@` lookup consumes it for file selection. When
+/// chat is focused, scroll keys (`j`/`k`/`Up`/`Down`/`g`/`G`/
 /// `Ctrl+d`/`Ctrl+u`) navigate the session transcript. `Enter` submits the
 /// typed answer (or `no answer` when blank), `Ctrl+C` ends the entire turn
 /// without sending a reply while the answer input is focused, `Esc` dismisses
@@ -35,11 +36,22 @@ pub(crate) async fn handle_with_cache(
     app: &mut App,
     render_cache_store: &RenderCacheStore,
     terminal_size: Rect,
-    key: KeyEvent,
+    mut key: KeyEvent,
 ) -> EventResult {
+    // Canonicalize plain terminal Enter encodings before lookup and submission
+    // routing. Modified character forms retain their multiline editing meaning.
+    if key.modifiers.is_empty() && input_key::is_enter_key(key.code) {
+        key.code = KeyCode::Enter;
+    }
+
     if is_plain_q(key) && should_exit_to_list_on_q(app) {
         exit_to_list_saving_progress(app);
 
+        return EventResult::Continue;
+    }
+
+    if is_answer_input_focused(app) && is_active_at_mention(app) && handle_at_mention_key(app, key)
+    {
         return EventResult::Continue;
     }
 
@@ -52,10 +64,6 @@ pub(crate) async fn handle_with_cache(
             end_turn_no_answer(app).await;
         }
 
-        return EventResult::Continue;
-    }
-
-    if is_active_at_mention(app) && handle_at_mention_key(app, key) {
         return EventResult::Continue;
     }
 
@@ -476,6 +484,10 @@ fn is_active_at_mention(app: &App) -> bool {
 ///
 /// Returns `true` when the key was consumed by the at-mention handler.
 fn handle_at_mention_key(app: &mut App, key: KeyEvent) -> bool {
+    if input_key::should_insert_newline(key) {
+        return false;
+    }
+
     match key.code {
         KeyCode::Esc => dismiss_question_at_mention(app),
         KeyCode::Enter | KeyCode::Tab => {
@@ -598,7 +610,7 @@ fn handle_question_at_mention_select(app: &mut App) {
     if let Some(selection) = replacement
         && let AppMode::Question { input, .. } = &mut app.mode
     {
-        input.replace_range(selection.at_start, selection.cursor, &selection.text);
+        input.replace_range(selection.at_start, selection.at_end, &selection.text);
     }
 
     sync_question_at_mention_state(app);
@@ -905,6 +917,320 @@ mod tests {
 
     /// Fake terminal size used by tests that don't exercise scrolling.
     const TEST_TERMINAL_SIZE: Rect = Rect::new(0, 0, 80, 24);
+
+    #[tokio::test]
+    async fn test_question_lookup_selects_file_without_submitting_or_changing_focus() {
+        for selection_key in [
+            KeyCode::Tab,
+            KeyCode::Enter,
+            KeyCode::Char('\r'),
+            KeyCode::Char('\n'),
+        ] {
+            // Arrange
+            let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+            app.mode = question_mode_with_options();
+            if let AppMode::Question {
+                at_mention_state,
+                input,
+                selected_option_index,
+                ..
+            } = &mut app.mode
+            {
+                *selected_option_index = None;
+                *input = InputState::with_text("Use @src/pending".to_string());
+                input.cursor = "Use @src".chars().count();
+                *at_mention_state = Some(PromptAtMentionState::new(vec![
+                    crate::domain::file_entry::FileEntry {
+                        is_dir: false,
+                        path: "src/first.rs".to_string(),
+                    },
+                    crate::domain::file_entry::FileEntry {
+                        is_dir: false,
+                        path: "src/second.rs".to_string(),
+                    },
+                ]));
+            }
+
+            // Act
+            for code in [KeyCode::Down, KeyCode::Up, KeyCode::Down, selection_key] {
+                handle(
+                    &mut app,
+                    TEST_TERMINAL_SIZE,
+                    KeyEvent::new(code, KeyModifiers::NONE),
+                )
+                .await;
+            }
+
+            // Assert
+            assert!(matches!(
+                &app.mode,
+                AppMode::Question {
+                    at_mention_state: None,
+                    current_index: 0,
+                    focus: ChatFocus::Input,
+                    input,
+                    responses,
+                    selected_option_index: None,
+                    ..
+                } if input.text() == "Use @src/second.rs " && responses.is_empty()
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_question_enter_encodings_submit_without_lookup() {
+        for code in [KeyCode::Enter, KeyCode::Char('\r'), KeyCode::Char('\n')] {
+            for (selected_option, draft, expected) in [
+                (Some(1), "ignored draft", "Option B"),
+                (None, "typed answer", "typed answer"),
+                (None, "", NO_ANSWER),
+            ] {
+                // Arrange
+                let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+                app.mode = question_mode_with_options();
+                if let AppMode::Question {
+                    input,
+                    questions,
+                    selected_option_index,
+                    ..
+                } = &mut app.mode
+                {
+                    *input = InputState::with_text(draft.to_string());
+                    *selected_option_index = selected_option;
+                    questions.push(QuestionItem::new("Anything else?"));
+                }
+
+                // Act
+                handle(
+                    &mut app,
+                    TEST_TERMINAL_SIZE,
+                    KeyEvent::new(code, KeyModifiers::NONE),
+                )
+                .await;
+
+                // Assert
+                assert!(matches!(
+                    &app.mode,
+                    AppMode::Question {
+                        current_index: 1,
+                        input,
+                        responses,
+                        focus: ChatFocus::Input,
+                        ..
+                    } if responses == &vec![expected.to_string()] && input.is_empty()
+                ));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_question_lookup_modified_enter_inserts_newline() {
+        for (code, modifiers) in [
+            (KeyCode::Enter, KeyModifiers::ALT),
+            (KeyCode::Enter, KeyModifiers::SHIFT),
+            (KeyCode::Char('\r'), KeyModifiers::ALT),
+            (KeyCode::Char('\r'), KeyModifiers::SHIFT),
+            (KeyCode::Char('\n'), KeyModifiers::ALT),
+            (KeyCode::Char('\n'), KeyModifiers::SHIFT),
+            (KeyCode::Char('\r'), KeyModifiers::CONTROL),
+            (KeyCode::Char('\n'), KeyModifiers::CONTROL),
+            (KeyCode::Char('j'), KeyModifiers::CONTROL),
+            (KeyCode::Char('m'), KeyModifiers::CONTROL),
+        ] {
+            // Arrange
+            let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+            app.mode = question_mode_with_options();
+            if let AppMode::Question {
+                at_mention_state,
+                input,
+                selected_option_index,
+                ..
+            } = &mut app.mode
+            {
+                *selected_option_index = None;
+                *input = InputState::with_text("@src".to_string());
+                *at_mention_state = Some(PromptAtMentionState::new(vec![
+                    crate::domain::file_entry::FileEntry {
+                        is_dir: false,
+                        path: "src/lib.rs".to_string(),
+                    },
+                ]));
+            }
+
+            // Act
+            handle(&mut app, TEST_TERMINAL_SIZE, KeyEvent::new(code, modifiers)).await;
+
+            // Assert
+            assert!(matches!(
+                &app.mode,
+                AppMode::Question {
+                    at_mention_state: None,
+                    current_index: 0,
+                    focus: ChatFocus::Input,
+                    input,
+                    responses,
+                    ..
+                } if input.text() == "@src\n" && responses.is_empty()
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_question_empty_lookup_selection_closes_without_submitting() {
+        for code in [
+            KeyCode::Tab,
+            KeyCode::Enter,
+            KeyCode::Char('\r'),
+            KeyCode::Char('\n'),
+        ] {
+            for entries in [
+                Vec::new(),
+                vec![crate::domain::file_entry::FileEntry {
+                    is_dir: false,
+                    path: "src/lib.rs".to_string(),
+                }],
+            ] {
+                // Arrange
+                let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+                app.mode = question_mode_with_options();
+                if let AppMode::Question {
+                    at_mention_state,
+                    input,
+                    selected_option_index,
+                    ..
+                } = &mut app.mode
+                {
+                    *selected_option_index = None;
+                    *input = InputState::with_text("@missing".to_string());
+                    *at_mention_state = Some(PromptAtMentionState::new(entries));
+                }
+
+                // Act
+                handle(
+                    &mut app,
+                    TEST_TERMINAL_SIZE,
+                    KeyEvent::new(code, KeyModifiers::NONE),
+                )
+                .await;
+
+                // Assert
+                assert!(matches!(
+                    &app.mode,
+                    AppMode::Question {
+                        at_mention_state: None,
+                        current_index: 0,
+                        focus: ChatFocus::Input,
+                        input,
+                        responses,
+                        ..
+                    } if input.text() == "@missing" && responses.is_empty()
+                ));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_question_delayed_lookup_result_respects_dismissal() {
+        for dismissal in [
+            None,
+            Some(KeyCode::Esc),
+            Some(KeyCode::Tab),
+            Some(KeyCode::Enter),
+        ] {
+            // Arrange
+            let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+            app.mode = question_mode_with_options();
+            if let AppMode::Question {
+                at_mention_state,
+                input,
+                selected_option_index,
+                ..
+            } = &mut app.mode
+            {
+                *selected_option_index = None;
+                *input = InputState::with_text("@src".to_string());
+                *at_mention_state = Some(PromptAtMentionState::new(Vec::new()));
+            }
+            let entries = vec![crate::domain::file_entry::FileEntry {
+                is_dir: false,
+                path: "src/lib.rs".to_string(),
+            }];
+            let lookup_root = app.at_mention_lookup_root("session-id");
+            let delayed_result = AppEvent::AtMentionEntriesLoaded {
+                entries: entries.clone(),
+                session_id: "session-id".into(),
+            };
+
+            // Act: deliver the queued load after the dismissal key was handled.
+            if let Some(code) = dismissal {
+                handle(
+                    &mut app,
+                    TEST_TERMINAL_SIZE,
+                    KeyEvent::new(code, KeyModifiers::NONE),
+                )
+                .await;
+            }
+            app.apply_app_events(delayed_result).await;
+
+            // Assert: late results may populate the cache, but cannot reopen
+            // the picker.
+            assert_eq!(
+                app.sessions.at_mention_index_for_root(&lookup_root),
+                Some(entries.clone())
+            );
+            let expected_entries = dismissal.is_none().then_some(entries);
+            assert!(matches!(
+                &app.mode,
+                AppMode::Question {
+                    at_mention_state,
+                    input,
+                    focus: ChatFocus::Input,
+                    ..
+                } if input.text() == "@src"
+                    && at_mention_state.as_ref().map(|state| &state.all_entries)
+                        == expected_entries.as_ref()
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_question_lookup_escape_preserves_draft_and_restores_tab_focus_toggle() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        app.mode = question_mode_with_options();
+        if let AppMode::Question {
+            at_mention_state,
+            input,
+            selected_option_index,
+            ..
+        } = &mut app.mode
+        {
+            *selected_option_index = None;
+            *input = InputState::with_text("@src".to_string());
+            *at_mention_state = Some(PromptAtMentionState::new(Vec::new()));
+        }
+
+        // Act
+        for code in [KeyCode::Esc, KeyCode::Tab] {
+            handle(
+                &mut app,
+                TEST_TERMINAL_SIZE,
+                KeyEvent::new(code, KeyModifiers::NONE),
+            )
+            .await;
+        }
+
+        // Assert
+        assert!(matches!(
+            &app.mode,
+            AppMode::Question {
+                at_mention_state: None,
+                focus: ChatFocus::Chat,
+                input,
+                ..
+            } if input.text() == "@src"
+        ));
+    }
 
     #[tokio::test]
     async fn test_question_at_mention_loads_parent_worktree_entries_for_stacked_session() {

--- a/crates/agentty/src/ui/layout.rs
+++ b/crates/agentty/src/ui/layout.rs
@@ -195,7 +195,8 @@ pub fn prompt_panel_areas(area: Rect) -> PromptPanelAreas {
     }
 }
 
-/// Returns how many lookup entries can fit above the question input overlay.
+/// Returns the lookup row capacity above the question input, excluding borders.
+/// Returns zero when no complete item row fits.
 pub(crate) fn question_at_mention_max_visible(
     bottom_area: Rect,
     input_area: Rect,
@@ -203,7 +204,7 @@ pub(crate) fn question_at_mention_max_visible(
 ) -> usize {
     usize::from(input_area.y.saturating_sub(bottom_area.y))
         .saturating_sub(2)
-        .clamp(1, default_max_visible)
+        .min(default_max_visible)
 }
 
 /// Calculates the height split for question mode's prompt, input, and footer.
@@ -1089,14 +1090,25 @@ mod tests {
     #[test]
     fn test_question_at_mention_max_visible_clamps_to_available_rows() {
         // Arrange
-        let bottom_area = Rect::new(1, 10, 78, 8);
-        let input_area = Rect::new(1, 15, 78, 2);
+        let bottom_area = Rect::new(1, 10, 78, 20);
 
-        // Act
-        let max_visible = question_at_mention_max_visible(bottom_area, input_area, 10);
+        for (available_rows, limit, expected) in [
+            (0, 10, 0),
+            (1, 10, 0),
+            (2, 10, 0),
+            (3, 10, 1),
+            (5, 10, 3),
+            (20, 10, 10),
+            (5, 0, 0),
+        ] {
+            let input_area = Rect::new(1, 10 + available_rows, 78, 2);
 
-        // Assert
-        assert_eq!(max_visible, 3);
+            // Act
+            let max_visible = question_at_mention_max_visible(bottom_area, input_area, limit);
+
+            // Assert
+            assert_eq!(max_visible, expected);
+        }
     }
 
     #[test]
@@ -1152,10 +1164,11 @@ mod tests {
 
         // Act
         let unchanged_chat_focus_line =
-            question_help_footer_line(ChatFocus::Chat, false, false, false);
+            question_help_footer_line(ChatFocus::Chat, false, false, QuestionLookupState::Closed);
         let changed_chat_focus_line =
-            question_help_footer_line(ChatFocus::Chat, true, false, false);
-        let answer_focus_line = question_help_footer_line(ChatFocus::Input, false, false, false);
+            question_help_footer_line(ChatFocus::Chat, true, false, QuestionLookupState::Closed);
+        let answer_focus_line =
+            question_help_footer_line(ChatFocus::Input, false, false, QuestionLookupState::Closed);
 
         // Assert
         assert_eq!(
@@ -1182,9 +1195,11 @@ mod tests {
 
         // Act
         let answer_focus_with_options =
-            question_help_footer_line(ChatFocus::Input, false, true, false).to_string();
+            question_help_footer_line(ChatFocus::Input, false, true, QuestionLookupState::Closed)
+                .to_string();
         let answer_focus_with_overlay =
-            question_help_footer_line(ChatFocus::Input, false, false, true).to_string();
+            question_help_footer_line(ChatFocus::Input, false, false, QuestionLookupState::Matches)
+                .to_string();
 
         // Assert
         assert_eq!(
@@ -1193,7 +1208,7 @@ mod tests {
         );
         assert_eq!(
             answer_focus_with_overlay,
-            "Tab: focus | Enter: send | Esc: cancel @ | Ctrl+C: end turn"
+            "Tab/Enter: select | Up/Down: navigate | Esc: cancel @ | Ctrl+C: end turn"
         );
     }
 

--- a/crates/agentty/src/ui/page/session_chat.rs
+++ b/crates/agentty/src/ui/page/session_chat.rs
@@ -635,7 +635,7 @@ fn render_question_panel(
     let input_placeholder = "Type answer";
     let at_mention_max_visible =
         layout::question_at_mention_max_visible(bottom_area, panel_areas.input_area, 10);
-    let at_mention_menu = if is_free_text_mode {
+    let at_mention_menu = if is_free_text_mode && at_mention_max_visible > 0 {
         at_mention_state.and_then(|state| {
             prompt_format::file_lookup_suggestion_list(
                 display_text,
@@ -656,6 +656,15 @@ fn render_question_panel(
 
     let is_at_mention_open =
         is_free_text_mode && at_mention_state.is_some() && input.at_mention_query().is_some();
+    let lookup_state = if !is_at_mention_open {
+        question_format::QuestionLookupState::Closed
+    } else if at_mention_max_visible == 0 {
+        question_format::QuestionLookupState::Clipped
+    } else if at_mention_menu.is_some() {
+        question_format::QuestionLookupState::Matches
+    } else {
+        question_format::QuestionLookupState::Empty
+    };
     render_question_at_mention_overlay(f, bottom_area, panel_areas.input_area, at_mention_menu);
     render_question_help_footer(
         f,
@@ -664,7 +673,7 @@ fn render_question_panel(
         focus,
         has_session_diff,
         !is_free_text_mode,
-        is_at_mention_open,
+        lookup_state,
     );
 }
 
@@ -675,9 +684,8 @@ fn render_question_panel(
 ///
 /// `is_navigating_options` mirrors the runtime predicate that treats plain `q`
 /// as a sessions-list shortcut, so the footer can surface it whenever the
-/// shortcut is actually wired up. `is_at_mention_open` mirrors the runtime
-/// predicate that routes `Esc` to the at-mention dropdown so the footer can
-/// add a separate `Esc: cancel @` hint while the overlay is visible.
+/// shortcut is actually wired up. `lookup_state` only advertises selection
+/// and navigation when the prepared suggestion list contains matches.
 fn render_question_help_footer(
     f: &mut Frame,
     area: Rect,
@@ -685,7 +693,7 @@ fn render_question_help_footer(
     focus: ChatFocus,
     has_session_diff: bool,
     is_navigating_options: bool,
-    is_at_mention_open: bool,
+    lookup_state: question_format::QuestionLookupState,
 ) {
     if help_height == 0 {
         return;
@@ -695,7 +703,7 @@ fn render_question_help_footer(
         focus,
         has_session_diff,
         is_navigating_options,
-        is_at_mention_open,
+        lookup_state,
     ))
     .alignment(ratatui::layout::Alignment::Left);
     f.render_widget(help_para, area);
@@ -1364,6 +1372,135 @@ mod tests {
         assert!(text.contains("Options:"), "should render options header");
         assert!(text.contains("Yes"), "should render first option");
         assert!(text.contains("No"), "should render second option");
+    }
+
+    #[test]
+    fn test_render_question_lookup_shows_file_and_selection_controls() {
+        // Arrange
+        let session = session_fixture();
+        let mode = AppMode::Question {
+            at_mention_state: Some(PromptAtMentionState::new(vec![
+                crate::domain::file_entry::FileEntry {
+                    is_dir: false,
+                    path: "src/session_chat.rs".to_string(),
+                },
+            ])),
+            current_index: 0,
+            focus: ChatFocus::Input,
+            input: InputState::with_text("@session".to_string()),
+            questions: vec![QuestionItem::new("Which file?")],
+            responses: Vec::new(),
+            scroll_offset: None,
+            selected_option_index: None,
+            session_id: "session-id".into(),
+        };
+        let mut page = test_session_chat_page(&session, &mode);
+        let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(100, 24))
+            .expect("failed to create terminal");
+
+        // Act
+        terminal
+            .draw(|frame| Page::render(&mut page, frame, frame.area()))
+            .expect("failed to draw question lookup");
+
+        // Assert
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(text.contains("src/session_chat.rs"));
+        assert!(text.contains("Tab/Enter: select"));
+        assert!(text.contains("Up/Down: navigate"));
+        assert!(text.contains("Esc: cancel @"));
+        assert!(!text.contains("Enter: send"));
+    }
+
+    #[test]
+    fn test_render_question_lookup_requires_space_for_a_complete_result_row() {
+        for height in 4..=7 {
+            // Arrange
+            let input = InputState::with_text("@src".to_string());
+            let questions = vec![QuestionItem::new("Which file?")];
+            let lookup = PromptAtMentionState::new(vec![crate::domain::file_entry::FileEntry {
+                is_dir: false,
+                path: "src/lib.rs".to_string(),
+            }]);
+            let state = QuestionPanelState {
+                at_mention_state: Some(&lookup),
+                current_index: 0,
+                focus: ChatFocus::Input,
+                has_session_diff: false,
+                input: &input,
+                questions: &questions,
+                selected_option_index: None,
+            };
+            let mut terminal =
+                ratatui::Terminal::new(ratatui::backend::TestBackend::new(100, height))
+                    .expect("failed to create terminal");
+
+            // Act
+            terminal
+                .draw(|frame| {
+                    let area = frame.area();
+                    let panel_areas = layout::question_panel_areas(
+                        area,
+                        "Which file?",
+                        input.text(),
+                        0,
+                        CHAT_INPUT_MAX_PANEL_HEIGHT,
+                    );
+                    render_question_panel(frame, area, Some(panel_areas), &state);
+                })
+                .expect("failed to draw constrained lookup");
+
+            // Assert
+            let text = buffer_text(terminal.backend().buffer());
+            assert!(text.contains("@src"));
+            assert!(text.contains("Esc: cancel @"));
+            assert!(!text.contains("Tab/Enter: close @"));
+            assert_eq!(text.contains("src/lib.rs"), height == 7);
+            assert_eq!(text.contains("Tab/Enter: select"), height == 7);
+            assert_eq!(text.contains("Up/Down: navigate"), height == 7);
+        }
+    }
+
+    #[test]
+    fn test_render_question_empty_lookup_shows_only_dismissal_controls() {
+        for entries in [
+            Vec::new(),
+            vec![crate::domain::file_entry::FileEntry {
+                is_dir: false,
+                path: "src/session_chat.rs".to_string(),
+            }],
+        ] {
+            // Arrange
+            let session = session_fixture();
+            let mode = AppMode::Question {
+                at_mention_state: Some(PromptAtMentionState::new(entries)),
+                current_index: 0,
+                focus: ChatFocus::Input,
+                input: InputState::with_text("@missing".to_string()),
+                questions: vec![QuestionItem::new("Which file?")],
+                responses: Vec::new(),
+                scroll_offset: None,
+                selected_option_index: None,
+                session_id: "session-id".into(),
+            };
+            let mut page = test_session_chat_page(&session, &mode);
+            let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(100, 24))
+                .expect("failed to create terminal");
+
+            // Act
+            terminal
+                .draw(|frame| Page::render(&mut page, frame, frame.area()))
+                .expect("failed to draw empty question lookup");
+
+            // Assert
+            let text = buffer_text(terminal.backend().buffer());
+            assert!(text.contains("@missing"));
+            assert!(text.contains("Tab/Enter: close @"));
+            assert!(text.contains("Esc: cancel @"));
+            assert!(!text.contains("Tab/Enter: select"));
+            assert!(!text.contains("Up/Down: navigate"));
+            assert!(!text.contains("Enter: send"));
+        }
     }
 
     #[test]

--- a/crates/agentty/src/ui/question_format.rs
+++ b/crates/agentty/src/ui/question_format.rs
@@ -8,6 +8,19 @@ use crate::presentation::app_mode::ChatFocus;
 use crate::presentation::help_action;
 use crate::ui::style;
 
+/// Availability of file matches in the current question-answer lookup.
+#[derive(Clone, Copy)]
+pub enum QuestionLookupState {
+    /// The terminal has no room for a visible suggestion row.
+    Clipped,
+    /// No lookup is active at the input cursor.
+    Closed,
+    /// A lookup is active but has no results yet, or no matching files.
+    Empty,
+    /// The lookup has a nonempty suggestion list.
+    Matches,
+}
+
 /// Returns wrapped question-panel lines with the correct focus styling.
 pub(crate) fn question_panel_lines(
     question_title: &str,
@@ -87,19 +100,45 @@ pub(crate) fn question_option_lines(
 /// as a navigation key while the user is moving through predefined options. The
 /// `q: Sessions` hint is surfaced whenever that predicate is satisfied so the
 /// shortcut stays discoverable in answer focus too, not only in chat focus.
-/// `is_at_mention_open` mirrors the runtime predicate that routes `Esc` to the
-/// at-mention dropdown dismissal, so an `Esc: cancel @` hint is surfaced while
-/// the dropdown is visible.
+/// `lookup_state` distinguishes selectable matches from an active lookup that
+/// can only be dismissed while entries are loading or no files match.
 ///
 /// Footer entries follow the canonical composer-footer ordering shared with
 /// prompt mode: the `Tab` focus toggle first as the stable anchor, then the
-/// primary `Enter` action, reading extras, and exit actions last.
+/// primary `Enter` action, reading extras, and exit actions last. An active
+/// file lookup replaces focus and send actions with selection controls.
 pub fn question_help_footer_line(
     focus: ChatFocus,
     has_session_diff: bool,
     is_navigating_options: bool,
-    is_at_mention_open: bool,
+    lookup_state: QuestionLookupState,
 ) -> Line<'static> {
+    if focus == ChatFocus::Input
+        && !is_navigating_options
+        && !matches!(lookup_state, QuestionLookupState::Closed)
+    {
+        let mut help_actions = if matches!(lookup_state, QuestionLookupState::Matches) {
+            vec![
+                help_action::HelpAction::new("select", "Tab/Enter", "Select file"),
+                help_action::HelpAction::new("navigate", "Up/Down", "Navigate files"),
+            ]
+        } else if matches!(lookup_state, QuestionLookupState::Empty) {
+            vec![help_action::HelpAction::new(
+                "close @",
+                "Tab/Enter",
+                "Close lookup",
+            )]
+        } else {
+            Vec::new()
+        };
+        help_actions.extend([
+            help_action::HelpAction::new("cancel @", "Esc", "Cancel @"),
+            help_action::HelpAction::new("end turn", "Ctrl+C", "End turn"),
+        ]);
+
+        return crate::ui::help_format::footer_line(&help_actions);
+    }
+
     let is_chat_focused = focus == ChatFocus::Chat;
     let focus_label = if is_chat_focused { "Answer" } else { "Chat" };
     let mut help_actions = vec![help_action::HelpAction::new("focus", "Tab", focus_label)];
@@ -118,9 +157,6 @@ pub fn question_help_footer_line(
     }
 
     if !is_chat_focused {
-        if is_at_mention_open {
-            help_actions.push(help_action::HelpAction::new("cancel @", "Esc", "Cancel @"));
-        }
         help_actions.push(help_action::HelpAction::new(
             "end turn", "Ctrl+C", "End turn",
         ));

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -6171,6 +6171,139 @@ fn session_stop_turn_returns_to_review() -> E2eResult {
     Ok(())
 }
 
+/// Seeds clarification questions and a file lookup target without a live agent.
+fn seed_question_at_lookup_session(env: &BuilderEnv) -> E2eResult {
+    let session_id = "question-lookup-session";
+    common::seed_session(
+        env,
+        SessionSeed::regular(session_id, "claude-haiku-4-5-20251001", "main", "Question")
+            .with_title("File answer"),
+    )?;
+    let session_folder = test_support::session_folder(&env.agentty_root.join("wt"), session_id);
+    std::fs::create_dir_all(&session_folder)?;
+    std::fs::write(
+        session_folder.join("answer_lookup_target.rs"),
+        "// lookup target\n",
+    )?;
+    common::seed_runtime()?.block_on(async {
+        let database = common::open_database(env).await?;
+        database
+            .sessions()
+            .update_session_questions(
+                session_id,
+                r#"[{"text":"Which file?","options":[]},{"text":"Anything else?","options":[]}]"#,
+            )
+            .await
+    })?;
+
+    Ok(())
+}
+
+/// Verify file lookup inserts into a clarification answer before submission.
+#[test]
+fn test_question_answer_at_lookup() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("question_answer_at_lookup")
+        .with_git()
+        .setup(seed_question_at_lookup_session)
+        .zola(
+            "File lookup in answers",
+            "Reference repository files while answering an agent's clarification question.",
+            51,
+        )
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .wait_for_text("File answer", 5000)
+                    .press_key("Enter")
+                    .wait_for_text("Question 1/2", 5000)
+                    .write_text("@missing")
+                    .wait_for_text("Tab/Enter: close @", 5000)
+                    .capture_labeled("empty", "An empty lookup offers dismissal controls")
+                    .press_key("Tab")
+                    .press_key("ctrl+w")
+                    .write_text("@answer_lookup")
+                    .wait_for_text("answer_lookup_target.rs", 5000)
+                    .wait_for_text("Tab/Enter: select", 5000)
+                    .write_text("\x1b[13;2u")
+                    .wait_for_text("Enter: send", 5000)
+                    .capture_labeled("newline", "Shift+Enter inserts a newline during lookup")
+                    .write_text("@answer_lookup")
+                    .wait_for_text("answer_lookup_target.rs", 5000)
+                    .press_key("Left")
+                    .wait_for_text("Tab/Enter: select", 5000)
+                    .capture_labeled("lookup", "Repository file suggestions in the answer input")
+                    .press_key("Enter")
+                    .wait_for_text("@answer_lookup_target.rs", 5000)
+                    .write_text("please")
+                    .wait_for_text("@answer_lookup_target.rs please", 5000)
+                    .capture_labeled(
+                        "inserted",
+                        "Enter inserts the file and keeps the answer editable",
+                    )
+                    .press_key("Enter")
+                    .wait_for_text("Question 2/2", 5000)
+            },
+            |frame, report| {
+                let empty_frame = common::frame_from_capture(&report.captures[0]);
+                assertion::assert_not_visible(&empty_frame, "Tab/Enter: select");
+                assertion::assert_not_visible(&empty_frame, "Up/Down: navigate");
+                let newline_frame = common::frame_from_capture(&report.captures[1]);
+                let newline_area = Region::full(newline_frame.cols(), newline_frame.rows());
+                assertion::assert_text_in_region(&newline_frame, "@answer_lookup", &newline_area);
+                assertion::assert_not_visible(&newline_frame, "answer_lookup_target.rs");
+                let inserted_frame = common::frame_from_capture(&report.captures[3]);
+                let inserted_area = Region::full(inserted_frame.cols(), inserted_frame.rows());
+                assertion::assert_text_in_region(&inserted_frame, "Question 1/2", &inserted_area);
+                assertion::assert_text_in_region(
+                    &inserted_frame,
+                    "@answer_lookup_target.rs please",
+                    &inserted_area,
+                );
+                assertion::assert_not_visible(&inserted_frame, "Tab/Enter: select");
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "Question 2/2", &full);
+            },
+        )
+}
+
+/// Verify a short terminal hides lookup controls when no result row fits.
+#[test]
+fn test_question_answer_at_lookup_clipped() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("question_answer_at_lookup_clipped")
+        .with_git()
+        .with_terminal_size(100, 10)
+        .setup(seed_question_at_lookup_session)
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("Enter")
+                    .wait_for_text("Enter: send", 5000)
+                    .write_text("@answer_lookup")
+                    .wait_for_text("Esc: cancel @", 5000)
+                    .wait_for_stable_frame(300, 5000)
+                    .capture_labeled("clipped", "No selection hints without space for a result")
+                    .press_key("Esc")
+                    .wait_for_text("Enter: send", 5000)
+            },
+            |frame, report| {
+                let clipped = common::frame_from_capture(&report.captures[0]);
+                assertion::assert_not_visible(&clipped, "answer_lookup_target.rs");
+                assertion::assert_not_visible(&clipped, "Tab/Enter: select");
+                assertion::assert_not_visible(&clipped, "Up/Down: navigate");
+                assertion::assert_not_visible(&clipped, "Tab/Enter: close @");
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "@answer_lookup", &full);
+                assertion::assert_text_in_region(frame, "Enter: send", &full);
+            },
+        )
+}
+
 /// Verify that `Esc` leaves a clarification question active, then answering
 /// one question, leaving with `q`, and reopening resumes at the next
 /// unanswered question instead of restarting from the first.

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -844,7 +844,9 @@ their triggers:
   the first message, so lightweight list rows cannot replace an existing title.
 
 - **At-mention file indexing** (`@` in prompt or question input): lists session files
-  for the mention picker, falling back to the project root for unstarted drafts.
+  for the mention picker, falling back to the project root for unstarted drafts. Loaded
+  entries remain cached, but only refresh an already-open question picker; delayed
+  results never reopen a dismissed question lookup.
 
 - **Session-size refresh** (`Enter` on a session in list mode): recomputes the diff-size
   bucket off the key-handling path.

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -441,6 +441,15 @@ exist:
 | `Ctrl+Y` / `Ctrl+Shift+Z`        | Redo                                 |
 | `Tab`                            | Focus chat output for scrolling      |
 
+Type `@` followed by a file-name fragment to look up repository files in your answer.
+While the lookup has matches, `Up` / `Down` navigate them and `Tab` / `Enter` replace
+the entire `@` token with the selected path, including any query text after the cursor.
+With no matches, `Tab` / `Enter` close the lookup. `Esc` always dismisses the lookup,
+and `Alt+Enter` / `Shift+Enter` still insert a newline. After selecting a file with
+`Enter`, press `Enter` again to send the answer; `Tab` switches focus as usual. When the
+terminal is too short to show a result row, the footer hides lookup selection hints;
+`Esc` still dismisses the lookup.
+
 In free-text mode every other printable character — including `q` — is inserted into the
 answer. To leave without answering, press `Tab` to focus the chat output and then `q`,
 or press `Ctrl+C` while the answer input is focused.

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -790,6 +790,11 @@ reply; it is ignored while chat output is focused. `q` (outside free-text input)
 to the sessions list with the **Question** state kept for later; answers already
 submitted are saved, and reopening the session resumes at the next unanswered question.
 
+In a free-text answer, type `@` to look up repository files. Use `Up` / `Down` to choose
+a match and `Tab` / `Enter` to insert it without submitting the answer. `Esc` closes the
+lookup while keeping your draft, even if file loading finishes afterward. Editing the
+query can open the lookup again.
+
 ## Prompt Input Extras
 
 <a id="usage-prompt-extras"></a> In prompt input, `Ctrl+V`, `Ctrl+Shift+V`, and `Alt+V`


### PR DESCRIPTION
- Let `@` lookups consume navigation and selection keys without submitting or changing focus.
- Replace the full `@` token while preserving surrounding draft text and support empty-result dismissal and newline insertion.
- Show lookup-specific controls and insert the selected repository path into the draft.
- Cover the behavior with unit, rendering, and end-to-end tests and document the controls.
- Hide selection controls when no result row fits and prevent delayed loads from reopening dismissed lookups.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)