### PR TITLE
Skip duplicate automatic focused reviews

### DIFF
--- a/crates/ag-store/.sqlx/query-4b8a85a02575d7436ac1f3463495b9046705e8b415b6c1bce57c57ba01cabea9.json
+++ b/crates/ag-store/.sqlx/query-4b8a85a02575d7436ac1f3463495b9046705e8b415b6c1bce57c57ba01cabea9.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT CASE WHEN focused_review_status = 'Pending' AND focused_review_diff_hash IS NOT NULL\n                    THEN NULL ELSE review_diff_hash END AS \"review_diff_hash?: String\"\n               FROM session WHERE id = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "review_diff_hash?: String",
+        "ordinal": 0,
+        "type_info": "Text",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "4b8a85a02575d7436ac1f3463495b9046705e8b415b6c1bce57c57ba01cabea9"
+}

--- a/crates/ag-store/.sqlx/query-ba34391008fddb1ca3515850a1896758677aba268300798ec364bce790a2505a.json
+++ b/crates/ag-store/.sqlx/query-ba34391008fddb1ca3515850a1896758677aba268300798ec364bce790a2505a.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE session SET review_diff_hash = ? WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "ba34391008fddb1ca3515850a1896758677aba268300798ec364bce790a2505a"
+}

--- a/crates/ag-store/migrations/080_add_session_review_diff_hash.sql
+++ b/crates/ag-store/migrations/080_add_session_review_diff_hash.sql
@@ -1,0 +1,5 @@
+ALTER TABLE session ADD COLUMN review_diff_hash TEXT;
+
+UPDATE session
+SET review_diff_hash = focused_review_diff_hash
+WHERE focused_review_diff_hash IS NOT NULL;

--- a/crates/ag-store/src/connection_test.rs
+++ b/crates/ag-store/src/connection_test.rs
@@ -2956,6 +2956,176 @@ async fn test_load_session_focused_reviews_for_project_returns_persisted_review(
 }
 
 #[tokio::test]
+async fn review_diff_baseline_survives_output_clear_and_database_reopen() {
+    // Arrange
+    let directory = tempdir().expect("temporary directory should exist");
+    let path = directory.path().join("review.db");
+    let database = Database::open(&path).await.expect("database should open");
+    let project_id = database
+        .projects()
+        .upsert_project("review-project", None)
+        .await
+        .expect("project should persist");
+    database
+        .sessions()
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Review", project_id)
+        .await
+        .expect("session should persist");
+
+    // Act
+    let first = database
+        .sessions()
+        .load_session_review_diff_hash("session-a")
+        .await
+        .expect("empty baseline should load");
+    database
+        .sessions()
+        .update_session_review_diff_hash("session-a", "42", false)
+        .await
+        .expect("baseline should persist");
+    database
+        .sessions()
+        .update_session_focused_review("session-a", None, None, None)
+        .await
+        .expect("output should clear");
+    database.pool().close().await;
+    let database = Database::open(&path).await.expect("database should reopen");
+    let recovered = database
+        .sessions()
+        .load_session_review_diff_hash("session-a")
+        .await
+        .expect("baseline should survive restart");
+    database
+        .sessions()
+        .update_session_review_diff_hash("session-a", "43", true)
+        .await
+        .expect("baseline and review claim should persist");
+    database.pool().close().await;
+    let database = Database::open(&path)
+        .await
+        .expect("claimed review should reopen");
+    let pending = database
+        .sessions()
+        .load_pending_focused_review_session_ids(project_id)
+        .await
+        .expect("review claim should survive restart");
+    let missing = database
+        .sessions()
+        .load_session_review_diff_hash("missing")
+        .await
+        .expect("missing session should be harmless");
+    let unfinished = database
+        .sessions()
+        .load_session_review_diff_hash("session-a")
+        .await
+        .expect("unfinished review should remain recoverable");
+    database
+        .sessions()
+        .defer_session_focused_review("session-a")
+        .await
+        .expect("deferred review should persist");
+    let deferred = database
+        .sessions()
+        .load_session_review_diff_hash("session-a")
+        .await
+        .expect("deferred turn should retain its baseline");
+
+    // Assert
+    assert_eq!(first, None);
+    assert_eq!(recovered.as_deref(), Some("42"));
+    assert_eq!(pending, vec!["session-a".to_string()]);
+    assert_eq!(missing, None);
+    assert_eq!(unfinished, None);
+    assert_eq!(deferred.as_deref(), Some("43"));
+}
+
+#[tokio::test]
+async fn review_diff_claim_failure_rolls_back_baseline() {
+    // Arrange
+    let database = Database::open_in_memory()
+        .await
+        .expect("database should open");
+    let project_id = database
+        .projects()
+        .upsert_project("review-project", None)
+        .await
+        .expect("project should persist");
+    database
+        .sessions()
+        .insert_session("session-a", "gpt-5.6-sol", "main", "Review", project_id)
+        .await
+        .expect("session should persist");
+    database
+        .sessions()
+        .update_session_review_diff_hash("session-a", "42", false)
+        .await
+        .expect("old baseline should persist");
+    sqlx::raw_sql(
+        "CREATE TRIGGER reject_review_claim BEFORE UPDATE OF focused_review_status ON session
+         WHEN NEW.focused_review_status = 'Pending' BEGIN SELECT RAISE(ABORT, 'claim failed'); END;",
+    )
+    .execute(database.pool())
+    .await
+    .expect("claim failure should be injected");
+
+    // Act
+    let result = database
+        .sessions()
+        .update_session_review_diff_hash("session-a", "43", true)
+        .await;
+    let baseline = database
+        .sessions()
+        .load_session_review_diff_hash("session-a")
+        .await
+        .expect("baseline should load after rollback");
+    let pending = database
+        .sessions()
+        .load_pending_focused_review_session_ids(project_id)
+        .await
+        .expect("pending reviews should load");
+
+    // Assert
+    assert!(result.is_err());
+    assert_eq!(baseline.as_deref(), Some("42"));
+    assert_eq!(pending, [] as [String; 0]);
+}
+
+#[tokio::test]
+async fn review_diff_baseline_migration_preserves_existing_review_hashes() {
+    // Arrange
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("database should open");
+    sqlx::raw_sql(
+        "CREATE TABLE session (id TEXT, focused_review_diff_hash TEXT); INSERT INTO session \
+         VALUES ('reviewed', '42'), ('empty', NULL);",
+    )
+    .execute(&pool)
+    .await
+    .expect("legacy rows should exist");
+
+    // Act
+    rerun_embedded_migration(&pool, 80).await;
+    let rows = sqlx::query_as::<_, (String, Option<String>)>(
+        "SELECT id, review_diff_hash FROM session ORDER BY id",
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("migrated baselines should load");
+
+    // Assert
+    assert_eq!(
+        rows,
+        vec![
+            ("empty".to_string(), None),
+            ("reviewed".to_string(), Some("42".to_string()))
+        ]
+    );
+}
+
+#[tokio::test]
 async fn test_update_session_focused_review_clears_persisted_review() {
     // Arrange
     let database = Database::open_in_memory()

--- a/crates/ag-store/src/session.rs
+++ b/crates/ag-store/src/session.rs
@@ -689,6 +689,21 @@ pub trait SessionRepository: crate::SessionPreparationRepository + Send + Sync {
         text: Option<String>,
     ) -> Result<(), DbError>;
 
+    /// Loads the prior diff baseline independently of focused-review output.
+    /// An unfinished generated review returns no baseline so restart recovery
+    /// can regenerate it instead of treating it as an unchanged completed turn.
+    async fn load_session_review_diff_hash(&self, id: &str) -> Result<Option<String>, DbError>;
+
+    /// Persists the observed diff baseline, atomically claiming a pending
+    /// focused review when `claim_review` is true. Callers must commit this
+    /// claim before starting review generation.
+    async fn update_session_review_diff_hash(
+        &self,
+        id: &str,
+        diff_hash: &str,
+        claim_review: bool,
+    ) -> Result<(), DbError>;
+
     /// Updates the display title for a session row.
     async fn update_session_title(&self, id: &str, title: &str) -> Result<(), DbError>;
 
@@ -2669,6 +2684,59 @@ WHERE id = ?
         )
         .execute(&self.0)
         .await?;
+
+        Ok(())
+    }
+
+    async fn load_session_review_diff_hash(&self, id: &str) -> Result<Option<String>, DbError> {
+        let previous = sqlx::query_scalar!(
+            r#"SELECT CASE WHEN focused_review_status = 'Pending' AND focused_review_diff_hash IS NOT NULL
+                    THEN NULL ELSE review_diff_hash END AS "review_diff_hash?: String"
+               FROM session WHERE id = ?"#,
+            id
+        )
+            .fetch_optional(&self.0)
+            .await?
+            .flatten();
+
+        Ok(previous)
+    }
+
+    async fn update_session_review_diff_hash(
+        &self,
+        id: &str,
+        diff_hash: &str,
+        claim_review: bool,
+    ) -> Result<(), DbError> {
+        let mut transaction = self.0.begin().await?;
+        sqlx::query!(
+            "UPDATE session SET review_diff_hash = ? WHERE id = ?",
+            diff_hash,
+            id
+        )
+        .execute(&mut *transaction)
+        .await?;
+        if claim_review {
+            let now = self.now();
+            sqlx::query!(
+                r"
+UPDATE session
+SET focused_review_status = ?,
+    focused_review_diff_hash = ?,
+    focused_review_text = ?,
+    updated_at = ?
+WHERE id = ?
+",
+                "Pending",
+                diff_hash,
+                None::<String>,
+                now,
+                id
+            )
+            .execute(&mut *transaction)
+            .await?;
+        }
+        transaction.commit().await?;
 
         Ok(())
     }

--- a/crates/agentty/src/app/core/new.rs
+++ b/crates/agentty/src/app/core/new.rs
@@ -20,6 +20,7 @@ use crate::infra::db::AppRepositories;
 use crate::infra::fs::FsClient;
 #[cfg(test)]
 use crate::infra::project_discovery::ProjectDiscoveryClient;
+use crate::presentation::settings::SettingsPresentationState;
 
 /// Environment flag that pins the version rendered by feature-test runs.
 const E2E_PIN_DISPLAY_VERSION_ENV_VAR: &str = "AGENTTY_E2E_PIN_DISPLAY_VERSION";
@@ -172,8 +173,7 @@ impl App {
             mode: crate::presentation::app_mode::AppMode::List,
             needs_redraw: true,
             settings,
-            settings_presentation:
-                crate::presentation::settings::SettingsPresentationState::default(),
+            settings_presentation: SettingsPresentationState::default(),
             tabs: crate::app::tab::TabManager::new(initial_tab),
             current_version_display_text,
             prompt_progress: std::collections::HashMap::new(),
@@ -194,6 +194,7 @@ impl App {
             event_rx,
             is_tmux_session: clients.is_tmux_session,
             review_cache,
+            review_diff_hashes: std::collections::HashMap::new(),
             latest_available_version: None,
             last_seen_session_update_versions: std::collections::HashMap::new(),
             merge_queue: crate::app::merge_queue::MergeQueue::default(),

--- a/crates/agentty/src/app/core/state.rs
+++ b/crates/agentty/src/app/core/state.rs
@@ -275,6 +275,10 @@ pub struct App {
     /// switches, is hydrated after restart, and is ready when the user presses
     /// `f`.
     pub(crate) review_cache: HashMap<SessionId, ReviewCacheEntry>,
+    /// Caches the persisted review diff baseline across turns and project
+    /// switches independently of visible output. Lazily recovered after
+    /// restart and removed when the session is deleted.
+    pub(crate) review_diff_hashes: HashMap<SessionId, u64>,
     /// Counts automatic focused-review remediation turns in the current
     /// user-initiated cycle for each session.
     pub(crate) auto_address_review_iterations: HashMap<SessionId, u8>,
@@ -1040,10 +1044,19 @@ impl App {
     }
 
     /// Clears cached focused-review state, invalidates pending `/apply`
-    /// continuations, and retracts its display slot.
+    /// continuations, and retracts its display slot while retaining the diff
+    /// baseline for automatic review of the next turn.
     pub(crate) fn clear_review_output(&mut self, session_id: &str) {
         self.discard_pending_apply_review_diff_loads(&SessionId::from(session_id));
-        self.review_cache.remove(session_id);
+        if let Some(diff_hash) = self
+            .review_cache
+            .remove(session_id)
+            .and_then(|entry| entry.diff_hash())
+        {
+            self.review_diff_hashes
+                .entry(SessionId::from(session_id))
+                .or_insert(diff_hash);
+        }
         if let Some(session) = self.sessions.state_mut().session_mut_for_id(session_id) {
             session
                 .transient_messages

--- a/crates/agentty/src/app/session_diff.rs
+++ b/crates/agentty/src/app/session_diff.rs
@@ -172,6 +172,7 @@ impl App {
     /// owned by a deleted session so detached task completions remain stale.
     pub(crate) fn discard_deleted_session_diff_state(&mut self, session_id: &SessionId) {
         self.auto_address_review_iterations.remove(session_id);
+        self.review_diff_hashes.remove(session_id);
         self.diff_comment_progress.remove(session_id);
         self.pending_session_diff_requests
             .retain(|_, request| request.session_id != *session_id);
@@ -909,53 +910,97 @@ impl App {
             }
         };
         let diff_hash = review::diff_content_hash(&diff);
-        if diff.trim().is_empty() {
-            if is_manual {
-                let _ = self
-                    .services
-                    .db()
-                    .sessions()
-                    .update_session_focused_review(&session_id, None, None, None)
-                    .await;
-                self.set_review_ready_output(
+        let should_start = match self
+            .prepare_review_diff(
+                &session_id,
+                diff_hash,
+                !diff.trim().is_empty() && cached_diff_hash != Some(diff_hash),
+                is_manual,
+            )
+            .await
+        {
+            Ok(should_start) => should_start,
+            Err(error) => {
+                warn!(%session_id, %error, "Failed to claim focused review");
+                let persistence = review::fail_review_preparation(
+                    &mut self.review_cache,
+                    self.sessions.state_mut(),
                     &session_id,
-                    diff_hash,
-                    review::REVIEW_NO_DIFF_MESSAGE.to_string(),
+                    format!("Failed to claim focused review: {error}"),
                 );
-            } else if cached_diff_hash.is_none() {
-                let _ = self
-                    .services
-                    .db()
-                    .sessions()
-                    .update_session_focused_review(&session_id, None, None, None)
-                    .await;
-                self.clear_review_output(&session_id);
+                self.persist_focused_review_updates(vec![persistence]).await;
+                review::restore_session_review_status(self.sessions.state_mut(), &session_id);
+
+                return;
             }
-            review::restore_session_review_status(self.sessions.state_mut(), &session_id);
+        };
+        if should_start {
+            self.start_review_assist(
+                &session_id,
+                &target.folder,
+                diff_hash,
+                &diff,
+                target.review_agent,
+            )
+            .await;
 
             return;
         }
-        if cached_diff_hash == Some(diff_hash) {
-            review::restore_session_review_status(self.sessions.state_mut(), &session_id);
-
-            return;
+        if is_manual && diff.trim().is_empty() {
+            let _ = self
+                .services
+                .db()
+                .sessions()
+                .update_session_focused_review(&session_id, None, None, None)
+                .await;
+            self.set_review_ready_output(
+                &session_id,
+                diff_hash,
+                review::REVIEW_NO_DIFF_MESSAGE.to_string(),
+            );
+        } else if !is_manual && cached_diff_hash.is_none() {
+            let _ = self
+                .services
+                .db()
+                .sessions()
+                .update_session_focused_review(&session_id, None, None, None)
+                .await;
+            self.clear_review_output(&session_id);
         }
+        review::restore_session_review_status(self.sessions.state_mut(), &session_id);
+    }
 
-        self.start_review_assist(
-            &session_id,
-            &target.folder,
-            diff_hash,
-            &diff,
-            target.review_agent,
-        )
-        .await;
-        self.persist_focused_review_updates(vec![FocusedReviewPersistence {
-            diff_hash: Some(diff_hash),
-            session_id,
-            status: FocusedReviewStatus::Pending,
-            text: None,
-        }])
-        .await;
+    /// Recovers the baseline and commits it together with any pending-review
+    /// claim before the caller starts generation. Failed writes leave the
+    /// in-memory baseline unchanged so a later attempt can retry.
+    async fn prepare_review_diff(
+        &mut self,
+        session_id: &SessionId,
+        diff_hash: u64,
+        review_allowed: bool,
+        is_manual: bool,
+    ) -> Result<bool, DbError> {
+        let persisted = self
+            .services
+            .db()
+            .sessions()
+            .load_session_review_diff_hash(session_id)
+            .await?;
+        let previous = self
+            .review_diff_hashes
+            .get(session_id)
+            .copied()
+            .or_else(|| persisted.and_then(|hash| hash.parse().ok()));
+        let should_start = review_allowed && (is_manual || previous != Some(diff_hash));
+        self.services
+            .db()
+            .sessions()
+            .update_session_review_diff_hash(session_id, &diff_hash.to_string(), should_start)
+            .await?;
+        self.review_diff_hashes
+            .insert(session_id.clone(), diff_hash);
+
+        Ok(should_start)
     }
 }
 
@@ -980,6 +1025,30 @@ mod tests {
                 .expect("session should be created"),
         );
         app.sessions.sessions_mut()[0].status = Status::Review;
+
+        (app, base_dir, session_id)
+    }
+
+    /// Builds a persisted review session without requiring a real worktree.
+    async fn review_app_with_mock_backend() -> (App, tempfile::TempDir, SessionId) {
+        let (mut app, base_dir) = crate::test_support::new_test_app_with_mock_tmux_client().await;
+        let mut session =
+            crate::test_support::session_fixture_with_folder(base_dir.path().to_path_buf());
+        session.status = Status::Review;
+        let session_id = session.id.clone();
+        app.services
+            .db()
+            .sessions()
+            .insert_session(
+                &session_id,
+                "gpt-5.6-sol",
+                "main",
+                "Review",
+                app.projects.active_project_id(),
+            )
+            .await
+            .expect("failed to persist review session");
+        app.sessions.push_session(session);
 
         (app, base_dir, session_id)
     }
@@ -1497,6 +1566,312 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn review_diff_after_new_turn_compares_content_and_allows_manual_review() {
+        for (previous_diff, current_diff, is_manual, expects_review) in [
+            ("+old line", "+old line", false, false),
+            ("+old line", "+new line", false, true),
+            ("+old line", "+old line", true, true),
+            ("+old line", "", false, false),
+            ("", "+old line", false, true),
+        ] {
+            // Arrange
+            let (mut app, _base_dir, session_id) = review_app_with_mock_backend().await;
+            app.set_review_ready_output(
+                &session_id,
+                review::diff_content_hash(previous_diff),
+                "Previous review".to_string(),
+            );
+
+            // Act
+            app.clear_review_output(&session_id);
+            app.supersede_review_diff_loads(&HashSet::from([session_id.clone()]));
+            let target = test_review_target(&app, &session_id);
+            app.apply_review_diff_update(
+                SessionDiffUpdate {
+                    request_id: 1,
+                    result: Ok(current_diff.to_string()),
+                    session_id: session_id.clone(),
+                },
+                None,
+                is_manual,
+                target,
+            )
+            .await;
+
+            // Assert
+            assert_eq!(app.review_is_loading(&session_id), expects_review);
+            assert_eq!(
+                app.review_diff_hashes.get(&session_id),
+                Some(&review::diff_content_hash(current_diff))
+            );
+            assert_eq!(
+                app.sessions.sessions()[0].status,
+                if expects_review {
+                    Status::AgentReview
+                } else {
+                    Status::Review
+                }
+            );
+            if !expects_review {
+                assert_eq!(app.review_view_state(&session_id), (None, None));
+                assert_eq!(app.sessions.sessions()[0].transient_messages.messages(), []);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn unchanged_review_diff_clears_durable_trigger_across_consecutive_turns() {
+        // Arrange
+        let (mut app, _base_dir, session_id) = review_app_with_mock_backend().await;
+        let diff = "+existing change";
+        let diff_hash = review::diff_content_hash(diff);
+        app.set_review_ready_output(&session_id, diff_hash, "Previous review".to_string());
+
+        for request_id in 1..=2 {
+            // Act
+            app.clear_review_output(&session_id);
+            app.defer_auto_review_session(&session_id).await;
+            let target = test_review_target(&app, &session_id);
+            app.apply_review_diff_update(
+                SessionDiffUpdate {
+                    request_id,
+                    result: Ok(diff.to_string()),
+                    session_id: session_id.clone(),
+                },
+                None,
+                false,
+                target,
+            )
+            .await;
+
+            // Assert
+            assert!(!app.review_cache.contains_key(&session_id));
+            assert!(!app.deferred_auto_review_session_ids.contains(&session_id));
+            assert_eq!(app.review_diff_hashes.get(&session_id), Some(&diff_hash));
+            assert_eq!(
+                app.services
+                    .db()
+                    .sessions()
+                    .load_pending_focused_review_session_ids(app.projects.active_project_id())
+                    .await
+                    .expect("failed to load pending reviews"),
+                [] as [String; 0]
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn restart_during_turn_recovers_review_diff_baseline() {
+        for (current_diff, expects_review) in [("+old line", false), ("+new line", true)] {
+            // Arrange
+            let (mut app, base_dir, session_id) = review_app_with_mock_backend().await;
+            std::fs::create_dir_all(session::session_folder(base_dir.path(), &session_id))
+                .expect("persisted session worktree directory should exist");
+            let diff_hash = review::diff_content_hash("+old line");
+            app.prepare_review_diff(&session_id, diff_hash, false, false)
+                .await
+                .expect("baseline should persist");
+            app.set_review_ready_output(&session_id, diff_hash, "Previous review".to_string());
+            let repositories = app.services.db().clone();
+            repositories
+                .sessions()
+                .update_session_focused_review(
+                    &session_id,
+                    Some(FocusedReviewStatus::Ready),
+                    Some(diff_hash.to_string()),
+                    Some("Previous review".to_string()),
+                )
+                .await
+                .expect("previous review should persist");
+
+            // Act: a new turn clears the output, then the application restarts.
+            app.clear_review_output(&session_id);
+            repositories
+                .sessions()
+                .update_session_focused_review(&session_id, None, None, None)
+                .await
+                .expect("new turn should clear review output");
+            repositories
+                .sessions()
+                .update_session_status_with_timing_at(&session_id, "InProgress", 1)
+                .await
+                .expect("turn should be running before restart");
+            drop(app);
+            let base_path = base_dir.path().to_path_buf();
+            let mut app = App::new_with_clients(
+                base_path.clone(),
+                base_path,
+                None,
+                repositories,
+                crate::test_support::test_app_clients_with_mock_app_server(),
+            )
+            .await
+            .expect("application should restart with persisted sessions");
+            assert!(app.review_diff_hashes.is_empty());
+            app.sessions
+                .state_mut()
+                .session_mut_for_id(&session_id)
+                .expect("session should survive restart")
+                .status = Status::Review;
+            let target = test_review_target(&app, &session_id);
+            app.apply_review_diff_update(
+                SessionDiffUpdate {
+                    request_id: 1,
+                    result: Ok(current_diff.to_string()),
+                    session_id: session_id.clone(),
+                },
+                None,
+                false,
+                target,
+            )
+            .await;
+
+            // Assert
+            assert_eq!(app.review_is_loading(&session_id), expects_review);
+            assert_eq!(
+                app.review_diff_hashes.get(&session_id),
+                Some(&review::diff_content_hash(current_diff))
+            );
+            if !expects_review {
+                assert_eq!(app.review_view_state(&session_id), (None, None));
+                assert_eq!(app.sessions.sessions()[0].status, Status::Review);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn restart_after_review_claim_recovers_before_worker_starts() {
+        // Arrange
+        let (mut app, base_dir, session_id) = review_app_with_mock_backend().await;
+        std::fs::create_dir_all(session::session_folder(base_dir.path(), &session_id))
+            .expect("persisted session worktree directory should exist");
+        app.prepare_review_diff(
+            &session_id,
+            review::diff_content_hash("+old line"),
+            false,
+            false,
+        )
+        .await
+        .expect("old baseline should persist");
+        let repositories = app.services.db().clone();
+        let diff = "+changed line";
+        let diff_hash = review::diff_content_hash(diff);
+
+        // Act: stop immediately after preparation, before spawning the worker.
+        assert!(
+            app.prepare_review_diff(&session_id, diff_hash, true, false)
+                .await
+                .expect("new baseline and claim should commit")
+        );
+        assert!(!app.review_is_loading(&session_id));
+        drop(app);
+        let base_path = base_dir.path().to_path_buf();
+        let mut app = App::new_with_clients(
+            base_path.clone(),
+            base_path,
+            None,
+            repositories,
+            crate::test_support::test_app_clients_with_mock_app_server(),
+        )
+        .await
+        .expect("application should restart");
+        let pending = app
+            .services
+            .db()
+            .sessions()
+            .load_pending_focused_review_session_ids(app.projects.active_project_id())
+            .await
+            .expect("startup trigger should persist");
+        let request_id = app
+            .pending_session_diff_requests
+            .iter()
+            .find_map(|(request_id, request)| {
+                (request.session_id == session_id).then_some(*request_id)
+            })
+            .expect("startup should schedule review diff recovery");
+        app.apply_session_diff_update(SessionDiffUpdate {
+            request_id,
+            result: Ok(diff.to_string()),
+            session_id: session_id.clone(),
+        })
+        .await;
+
+        // Assert
+        assert_eq!(pending, vec![session_id.to_string()]);
+        assert!(app.review_is_loading(&session_id));
+        assert_eq!(app.review_diff_hashes.get(&session_id), Some(&diff_hash));
+        assert_eq!(app.sessions.sessions()[0].status, Status::AgentReview);
+    }
+
+    #[tokio::test]
+    async fn review_diff_baseline_tolerates_invalid_hash_and_database_failure() {
+        // Arrange
+        let base_dir = tempfile::tempdir().expect("temporary directory should exist");
+        let database = crate::infra::db::Database::open_in_memory()
+            .await
+            .expect("database should open");
+        let base_path = base_dir.path().to_path_buf();
+        let mut app = App::new_with_clients(
+            base_path.clone(),
+            base_path,
+            None,
+            database.clone(),
+            crate::test_support::test_app_clients_with_mock_app_server(),
+        )
+        .await
+        .expect("application should start");
+        let session_id = SessionId::from("baseline-failure");
+        database
+            .sessions()
+            .insert_session(
+                &session_id,
+                "gpt-5.6-sol",
+                "main",
+                "Review",
+                app.projects.active_project_id(),
+            )
+            .await
+            .expect("session should persist");
+        database
+            .sessions()
+            .update_session_review_diff_hash(&session_id, "invalid", false)
+            .await
+            .expect("baseline should persist");
+
+        let mut session =
+            crate::test_support::session_fixture_with_folder(base_dir.path().to_path_buf());
+        session.id = session_id.clone();
+        session.status = Status::Review;
+        app.sessions.push_session(session);
+
+        // Act
+        let invalid_previous = app.prepare_review_diff(&session_id, 42, true, false).await;
+        database.pool().close().await;
+        let target = test_review_target(&app, &session_id);
+        app.apply_review_diff_update(
+            SessionDiffUpdate {
+                request_id: 1,
+                result: Ok("+new line".to_string()),
+                session_id: session_id.clone(),
+            },
+            None,
+            false,
+            target,
+        )
+        .await;
+
+        // Assert
+        assert!(invalid_previous.expect("invalid baseline should allow review"));
+        assert_eq!(app.review_diff_hashes.get(&session_id), Some(&42));
+        assert!(!app.review_is_loading(&session_id));
+        assert!(matches!(
+            app.review_cache.get(&session_id),
+            Some(ReviewCacheEntry::Failed { .. })
+        ));
+        assert_eq!(app.sessions.sessions()[0].status, Status::Review);
+    }
+
+    #[tokio::test]
     async fn automatic_empty_review_diff_clears_durable_trigger() {
         // Arrange
         let (mut app, _base_dir, session_id) = review_app().await;
@@ -1575,6 +1950,7 @@ mod tests {
     async fn deleting_session_discards_pending_review_diff_and_late_completion() {
         // Arrange
         let (mut app, _base_dir, session_id) = review_app().await;
+        app.review_diff_hashes.insert(session_id.clone(), 42);
         let request_id = 42;
         app.pending_session_diff_requests.insert(
             request_id,
@@ -1602,6 +1978,7 @@ mod tests {
         // Assert
         assert!(app.pending_session_diff_requests.is_empty());
         assert!(!app.deferred_auto_review_session_ids.contains(&session_id));
+        assert!(!app.review_diff_hashes.contains_key(&session_id));
     }
 
     #[tokio::test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -1021,7 +1021,8 @@ fn seed_auto_address_review_lifecycle(env: &BuilderEnv) -> Result<(), Box<dyn st
 }
 
 /// Installs one prompt-aware Claude stub that exposes both automatic-review
-/// stop conditions through stable transcript text.
+/// stop conditions through stable transcript text. Coding turns change the
+/// tracked fixture so each completed turn remains eligible for review.
 fn install_auto_address_review_lifecycle_stub(
     env: &BuilderEnv,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -1062,12 +1063,15 @@ case "$prompt" in
     esac
     ;;
   *"Verify the focused-review suggestions against the current code"*)
+    printf '// Automatic remediation %s\n' "$review_count" >> src/main.rs
     result='{\"answer\":\"Automatic remediation turn completed.\",\"questions\":[]}'
     ;;
   *"Start the no-suggestions lifecycle"*)
+    printf '// Start no-suggestions lifecycle\n' >> src/main.rs
     result='{\"answer\":\"No-suggestions lifecycle turn completed.\",\"questions\":[]}'
     ;;
   *"Start the iteration-limit lifecycle"*)
+    printf '// Start iteration-limit lifecycle\n' >> src/main.rs
     result='{\"answer\":\"Iteration-limit lifecycle turn completed.\",\"questions\":[]}'
     ;;
   *)

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -184,14 +184,19 @@ focused-review state application and persistence run afterward. Key behaviors:
   and request generation; the reducer discards canceled or superseded completions, so
   Git work never blocks terminal redraw or input handling. Automatic review checks start
   only from completed-turn and session-status events, not unrelated per-session updates.
-  A completed turn supersedes pending review and `/apply` diff continuations before
-  queued diff results are reduced, and repeated `/apply` checks are deduplicated per
-  session. Clearing or regenerating focused review also invalidates pending `/apply`
-  continuations, whose completions revalidate the current review-ready cache generation
-  before submitting an agent turn. Sessions in `Auto Edit + Auto Address Comments` reuse
-  this continuation automatically when a ready review has actionable suggestions. Each
-  resulting turn re-enters focused review, and an in-memory per-user-prompt counter
-  stops automatic application after three turns.
+  The last observed diff hash is persisted independently of review output and recovered
+  after restart. It survives clearing review output for a new turn, so an unchanged diff
+  does not launch another automatic review. A changed diff and its pending-review claim
+  are committed atomically before generation starts, so a restart cannot lose that
+  review. Manual review can still run. A completed turn supersedes pending review and
+  `/apply` diff continuations before queued diff results are reduced, and repeated
+  `/apply` checks are deduplicated per session. Clearing or regenerating focused review
+  also invalidates pending `/apply` continuations, whose completions revalidate the
+  current review-ready cache generation before submitting an agent turn. Sessions in
+  `Auto Edit + Auto Address Comments` reuse this continuation automatically when a ready
+  review has actionable suggestions. Each resulting turn rechecks its diff for focused
+  review, and an in-memory per-user-prompt counter stops automatic application after
+  three turns.
 - Externally merged review requests transition sessions to read-only `Merged`; only a
   successful user-triggered sync of the request's local target advances them to `Done`.
   Closed requests transition editable sessions to `Canceled`.

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -136,12 +136,15 @@ The shortcuts available in each state are listed in
 [Keybindings](@/docs/usage/keybindings.md).
 
 When an eligible session enters **Review**, Agentty starts focused review in the
-background. Orchestrator controller sessions skip this automatic review because they
-coordinate child branches without owning changes themselves. While focused review is
-running, **AgentReview** keeps the review-oriented shortcuts available; pressing `r`
-starts session sync immediately and cancels pending focused-review output so stale
-review text cannot reappear after the rebase begins. Provider progress and commentary
-remain transient; only the terminal focused-review answer is stored and rendered.
+background when its diff has changed since the previous turn. Follow-up turns that leave
+the diff unchanged skip automatic review, including after an application restart; manual
+focused review remains available. Orchestrator controller sessions skip this automatic
+review because they coordinate child branches without owning changes themselves. While
+focused review is running, **AgentReview** keeps the review-oriented shortcuts
+available; pressing `r` starts session sync immediately and cancels pending
+focused-review output so stale review text cannot reappear after the rebase begins.
+Provider progress and commentary remain transient; only the terminal focused-review
+answer is stored and rendered.
 
 ### Typical Transitions
 


### PR DESCRIPTION
- Persist the last observed review diff hash across cleared output, restarts, and project switches.
- Recheck changed diffs while preserving manual review and clearing unchanged automatic-review triggers.
- Atomically claim pending reviews before generation.
- Remove retained diff state when sessions are deleted.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)