### PR TITLE
Diff comments support file lookup

### DIFF
--- a/crates/agentty/src/app/core/events.rs
+++ b/crates/agentty/src/app/core/events.rs
@@ -1898,9 +1898,9 @@ impl App {
         )
     }
 
-    /// Applies loaded at-mention entries to the currently focused prompt or
-    /// question session, if the mention query is still active. Question updates
-    /// only refresh an open picker: a queued load must not undo dismissal.
+    /// Applies loaded entries to an active prompt, question, or diff-comment
+    /// query. Question and comment updates only refresh an open picker so
+    /// queued loads cannot undo dismissal.
     fn apply_prompt_at_mention_entries(&mut self, session_id: &str, entries: Vec<FileEntry>) {
         let (at_mention_state, has_query) = match &mut self.mode {
             AppMode::Prompt {
@@ -1918,6 +1918,21 @@ impl App {
                 ..
             } if mode_session_id == session_id && at_mention_state.is_some() => {
                 (at_mention_state, input.at_mention_query().is_some())
+            }
+            AppMode::Diff {
+                line_comments,
+                session_id: mode_session_id,
+                ..
+            } if mode_session_id == session_id && line_comments.at_mention_state.is_some() => {
+                let has_query = line_comments
+                    .editing_input_mut()
+                    .is_some_and(|input| input.at_mention_query().is_some());
+                if has_query && let Some(state) = &mut line_comments.at_mention_state {
+                    state.all_entries = entries;
+                    state.selected_index = 0;
+                }
+
+                return;
             }
             _ => return,
         };

--- a/crates/agentty/src/presentation/app_mode.rs
+++ b/crates/agentty/src/presentation/app_mode.rs
@@ -221,6 +221,8 @@ pub struct DiffLineComment {
 /// File and inline comments accumulated while the unified diff remains open.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DiffLineComments {
+    /// Repository lookup for the comment currently receiving input.
+    pub(crate) at_mention_state: Option<Box<PromptAtMentionState>>,
     /// Comments retained in the order in which their targets were selected.
     pub(crate) comments: Vec<DiffLineComment>,
     /// Index of the comment currently receiving text input.
@@ -316,6 +318,7 @@ impl DiffLineComments {
         let Some(editing_index) = self.editing_index.take() else {
             return;
         };
+        self.at_mention_state = None;
         self.selection_anchor_index = None;
         if self
             .comments

--- a/crates/agentty/src/presentation/prompt.rs
+++ b/crates/agentty/src/presentation/prompt.rs
@@ -10,7 +10,7 @@ pub use crate::domain::composer::{
 use crate::domain::file_entry::FileEntry;
 
 /// UI state for prompt `@` file and directory mention selection.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PromptAtMentionState {
     /// Cached list of all files and directories in the session directory.
     pub all_entries: Vec<FileEntry>,

--- a/crates/agentty/src/runtime/mode/diff.rs
+++ b/crates/agentty/src/runtime/mode/diff.rs
@@ -10,9 +10,11 @@ use crate::presentation::app_mode::{
     DiffSidebarFocus, HelpContext, PromptModeSnapshot, ViewportRect,
     allows_diff_line_comment_reply,
 };
-use crate::presentation::prompt::{PromptAttachmentState, PromptHistoryState};
+use crate::presentation::prompt::{
+    PromptAtMentionState, PromptAttachmentState, PromptHistoryState,
+};
 use crate::runtime::EventResult;
-use crate::runtime::mode::input_key;
+use crate::runtime::mode::{at_mention, input_key};
 use crate::ui::component::file_explorer::FileExplorer;
 use crate::ui::{RenderCacheStore, diff_util, page};
 
@@ -463,6 +465,29 @@ fn handle_line_comment_edit_key(app: &mut App, key: KeyEvent) -> bool {
         return false;
     }
 
+    if !input_key::should_insert_newline(key)
+        && let Some(state) = &mut line_comments.at_mention_state
+        && let Some(input) = line_comments
+            .editing_index
+            .and_then(|index| line_comments.comments.get_mut(index))
+            .map(|comment| &mut comment.input)
+    {
+        match key.code {
+            KeyCode::Esc => line_comments.at_mention_state = None,
+            KeyCode::Up => at_mention::move_selection_up(state),
+            KeyCode::Down => at_mention::move_selection_down(input, state),
+            KeyCode::Tab | KeyCode::Enter | KeyCode::Char('\r' | '\n') => {
+                if let Some(selection) = at_mention::selected_replacement(input, state) {
+                    input.replace_range(selection.at_start, selection.at_end, &selection.text);
+                }
+                line_comments.at_mention_state = None;
+            }
+            _ => return apply_comment_input_key(app, key),
+        }
+
+        return true;
+    }
+
     if key.code == KeyCode::Esc
         || (input_key::is_enter_key(key.code) && !input_key::should_insert_newline(key))
     {
@@ -474,13 +499,58 @@ fn handle_line_comment_edit_key(app: &mut App, key: KeyEvent) -> bool {
 
         return true;
     }
-    if let Some(command) = input_key::command_for_key(key, input_key::InputCapabilities::MULTILINE)
+    apply_comment_input_key(app, key)
+}
+
+/// Applies text editing before refreshing the repository lookup.
+fn apply_comment_input_key(app: &mut App, key: KeyEvent) -> bool {
+    if let AppMode::Diff { line_comments, .. } = &mut app.mode
+        && let Some(command) =
+            input_key::command_for_key(key, input_key::InputCapabilities::MULTILINE)
         && let Some(input) = line_comments.editing_input_mut()
     {
         input.apply(command);
+        sync_comment_at_mention(app);
     }
 
     true
+}
+
+/// Refreshes lookup state after typing, cursor movement, or paste.
+fn sync_comment_at_mention(app: &mut App) {
+    let AppMode::Diff {
+        line_comments,
+        session_id,
+        ..
+    } = &mut app.mode
+    else {
+        return;
+    };
+    let Some(index) = line_comments.editing_index else {
+        return;
+    };
+    match at_mention::sync_action(
+        &line_comments.comments[index].input,
+        line_comments.at_mention_state.as_deref(),
+    ) {
+        at_mention::AtMentionSyncAction::Dismiss => line_comments.at_mention_state = None,
+        at_mention::AtMentionSyncAction::KeepOpen => {
+            if let Some(state) = &mut line_comments.at_mention_state {
+                at_mention::reset_selection(state);
+            }
+        }
+        at_mention::AtMentionSyncAction::Activate => {
+            line_comments.at_mention_state = Some(Box::new(PromptAtMentionState::new(Vec::new())));
+            let session_id = session_id.clone();
+            let lookup_root = app.at_mention_lookup_root(&session_id);
+            at_mention::start_loading_entries(
+                app.services.event_sender(),
+                lookup_root,
+                session_id,
+                &mut app.sessions,
+            );
+        }
+    }
 }
 
 /// Inserts normalized pasted text into the active multiline diff comment
@@ -494,6 +564,7 @@ pub(crate) fn handle_paste(app: &mut App, pasted_text: &str) {
     };
 
     input.insert_text(&input_key::normalize_pasted_text(pasted_text));
+    sync_comment_at_mention(app);
 }
 
 /// Replaces Diff mode with one next-turn prompt containing every comment.
@@ -1353,6 +1424,117 @@ mod tests {
             .expect("at-mention state must survive leaving diff");
         assert_eq!(at_mention_state.selected_index, 1);
         assert_eq!(at_mention_state.all_entries, vec![prompt_mention_entry()]);
+    }
+
+    #[tokio::test]
+    async fn test_comment_lookup_selection_and_dismissal() {
+        for code in [
+            KeyCode::Tab,
+            KeyCode::Enter,
+            KeyCode::Char('\r'),
+            KeyCode::Char('\n'),
+            KeyCode::Esc,
+        ] {
+            for has_match in [true, false] {
+                // Arrange
+                let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+                app.mode = diff_mode_fixture(
+                    "diff --git a/src/main.rs b/src/main.rs\n+review();\n",
+                    1,
+                    DiffFocus::Content,
+                    DiffPreview::default(),
+                );
+                if let AppMode::Diff { line_comments, .. } = &mut app.mode {
+                    line_comments.start_editing_target(DiffCommentTarget::File {
+                        path: "src/main.rs".into(),
+                    });
+                    let input = line_comments
+                        .editing_input_mut()
+                        .expect("comment is editable");
+                    *input = InputState::with_text("Use @src/pending after".into());
+                    input.cursor = "Use @src".len();
+                }
+                sync_comment_at_mention(&mut app);
+                let entries = if has_match {
+                    vec![crate::domain::file_entry::FileEntry {
+                        is_dir: false,
+                        path: "src/lib.rs".into(),
+                    }]
+                } else {
+                    Vec::new()
+                };
+                app.apply_app_events(AppEvent::AtMentionEntriesLoaded {
+                    entries: entries.clone(),
+                    session_id: "session-id".into(),
+                })
+                .await;
+
+                // Act
+                for key in [KeyCode::Down, KeyCode::Up, code] {
+                    handle_line_comment_edit_key(&mut app, KeyEvent::new(key, KeyModifiers::NONE));
+                }
+                app.apply_app_events(AppEvent::AtMentionEntriesLoaded {
+                    entries,
+                    session_id: "session-id".into(),
+                })
+                .await;
+
+                // Assert
+                let AppMode::Diff { line_comments, .. } = &app.mode else {
+                    unreachable!("diff mode expected")
+                };
+                assert!(line_comments.is_editing());
+                assert!(line_comments.at_mention_state.is_none());
+                assert_eq!(
+                    line_comments.comments[0].input.text(),
+                    if has_match && code != KeyCode::Esc {
+                        "Use @src/lib.rs  after"
+                    } else {
+                        "Use @src/pending after"
+                    }
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_comment_lookup_edits_paste_and_newline() {
+        // Arrange
+        let mut app = crate::test_support::new_test_app_without_retained_base_dir().await;
+        sync_comment_at_mention(&mut app);
+        apply_comment_input_key(&mut app, KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
+        app.mode = diff_mode_fixture(
+            "diff --git a/src/main.rs b/src/main.rs\n+review();\n",
+            1,
+            DiffFocus::Content,
+            DiffPreview::default(),
+        );
+        sync_comment_at_mention(&mut app);
+        if let AppMode::Diff { line_comments, .. } = &mut app.mode {
+            line_comments.start_editing_target(DiffCommentTarget::File {
+                path: "src/main.rs".into(),
+            });
+        }
+
+        // Act
+        handle_paste(&mut app, "@sr");
+        handle_line_comment_edit_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE),
+        );
+
+        // Assert
+        assert!(
+            matches!(&app.mode, AppMode::Diff { line_comments, .. } if line_comments.at_mention_state.is_some())
+        );
+
+        // Act
+        handle_line_comment_edit_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT));
+
+        // Assert
+        assert!(
+            matches!(&app.mode, AppMode::Diff { line_comments, .. } if line_comments.at_mention_state.is_none() && line_comments.comments[0].input.text() == "@src\n" && line_comments.is_editing())
+        );
     }
 
     #[tokio::test]

--- a/crates/agentty/src/ui/page/diff.rs
+++ b/crates/agentty/src/ui/page/diff.rs
@@ -20,6 +20,7 @@ use crate::presentation::app_mode::{
     DiffLineSide, DiffPreview, DiffPreviewUnavailableReason, DiffReviewComments, DiffSidebarFocus,
 };
 use crate::presentation::{help_action, review_comment as review_comment_selection};
+use crate::ui::component::chat_input::ChatInput;
 use crate::ui::component::file_explorer::FileExplorer;
 use crate::ui::component::vertical_scrollbar::VerticalScrollbar;
 #[cfg(test)]
@@ -28,7 +29,7 @@ use crate::ui::diff_util::{
     DiffLine, DiffLineKind, FileTreeItem, diff_header_new_path, diff_header_paths, parse_diff_lines,
 };
 use crate::ui::page::review_comment;
-use crate::ui::{Component, Page, diff_util, markdown, style};
+use crate::ui::{Component, Page, diff_util, input_layout, markdown, prompt_format, style};
 
 const WRAPPED_CHUNK_START_INDEX: usize = 0;
 const DIFF_COMMENT_CACHE_ENTRY_LIMIT: usize = 64;
@@ -1901,6 +1902,67 @@ impl DiffPage<'_> {
         .selected_index(self.file_explorer_selected_index)
         .focused(self.sidebar_focus == DiffSidebarFocus::Files && self.focus == DiffFocus::Files)
     }
+
+    /// Paints repository suggestions adjacent to the active comment input.
+    fn render_comment_lookup(&self, f: &mut Frame, diff_area: Rect, footer_area: Rect) {
+        let Some(state) = &self.line_comments.at_mention_state else {
+            return;
+        };
+        let Some(index) = self.line_comments.editing_index else {
+            return;
+        };
+        let content = self.diff_layout_cache.content(self.diff);
+        let layout = self.diff_layout_cache.resolved_layout(
+            &content,
+            self.line_comments,
+            self.file_explorer_selected_index,
+            diff_area,
+        );
+        let scroll_offset = diff_util::clamp_diff_scroll_offset(
+            self.scroll_offset,
+            layout.line_count,
+            layout.render_layout.viewport_height,
+        );
+        let viewport = Rect::new(
+            diff_area.x + 1,
+            diff_area.y + 1,
+            u16::try_from(layout.render_layout.content_width).unwrap_or(u16::MAX),
+            layout.render_layout.viewport_height,
+        );
+        let lookup_area = |height| {
+            layout
+                .comment_insertions
+                .iter()
+                .find(|insertion| insertion.comment == index)
+                .and_then(|insertion| {
+                    comment_lookup_area(
+                        viewport,
+                        insertion.display_row..insertion.display_row + insertion.height,
+                        scroll_offset,
+                        height,
+                    )
+                })
+        };
+        let menu = lookup_area(12).and_then(|area| {
+            let input = &self.line_comments.comments[index].input;
+            prompt_format::file_lookup_suggestion_list(
+                input.text(),
+                input.cursor,
+                state,
+                usize::from(area.height.saturating_sub(2)),
+            )
+        });
+        let help = if let Some(menu) = menu
+            && let Some(area) =
+                lookup_area(input_layout::suggestion_dropdown_height(menu.items.len()))
+        {
+            ChatInput::render_suggestion_dropdown(f, area, &menu);
+            "Up/Down: navigate  Tab/Enter: select  Esc: dismiss lookup"
+        } else {
+            "Esc: dismiss lookup"
+        };
+        f.render_widget(Paragraph::new(help), footer_area);
+    }
 }
 
 impl Page for DiffPage<'_> {
@@ -2009,7 +2071,46 @@ impl Page for DiffPage<'_> {
             }),
         ));
         f.render_widget(help_message, areas.footer_area);
+        self.render_comment_lookup(f, areas.diff_area, areas.footer_area);
     }
+}
+
+/// Anchors the lookup to the visible comment, preferring the space above it.
+/// Top-edge comments use the space below rather than covering their own input.
+fn comment_lookup_area(
+    viewport: Rect,
+    rows: Range<usize>,
+    scroll_offset: u16,
+    desired_height: u16,
+) -> Option<Rect> {
+    let scroll_offset = usize::from(scroll_offset);
+    if rows.end <= scroll_offset || rows.start >= scroll_offset + usize::from(viewport.height) {
+        return None;
+    }
+    let top = u16::try_from(rows.start.saturating_sub(scroll_offset)).unwrap_or(u16::MAX);
+    let bottom = u16::try_from(rows.end.saturating_sub(scroll_offset))
+        .unwrap_or(u16::MAX)
+        .min(viewport.height);
+    let margin = u16::try_from(COMMENT_INPUT_HORIZONTAL_MARGIN)
+        .unwrap_or(u16::MAX)
+        .min(viewport.width);
+    let input_area = Rect::new(
+        viewport.x + margin,
+        viewport.y + top,
+        viewport.width - margin,
+        bottom.saturating_sub(top),
+    );
+    if top >= 3 {
+        return input_layout::overlay_area_above(viewport, input_area, desired_height);
+    }
+    let height = viewport.height.saturating_sub(bottom).min(desired_height);
+
+    (height >= 3).then_some(Rect::new(
+        input_area.x,
+        input_area.bottom(),
+        input_area.width,
+        height,
+    ))
 }
 
 /// Returns the preview path when it still matches the active markdown row.
@@ -2153,6 +2254,8 @@ fn preview_unavailable_message(reason: &DiffPreviewUnavailableReason) -> &str {
 
 #[cfg(test)]
 mod tests {
+    use ratatui::buffer::Cell;
+
     use super::*;
     use crate::domain::theme::ColorTheme;
     use crate::presentation::app_mode::DiffLineCommentTarget;
@@ -2431,6 +2534,133 @@ mod tests {
         assert_eq!(new_line.side, DiffLineSide::New);
         assert_eq!(old_line_index, Some(0));
         assert_eq!(new_line_index, Some(1));
+    }
+
+    #[test]
+    fn test_comment_lookup_tracks_input_and_scroll_position() {
+        // Arrange
+        let viewport = Rect::new(20, 2, 70, 20);
+
+        // Act, Assert
+        for (rows, scroll, expected) in [
+            (8..11, 0, Some(Rect::new(21, 5, 69, 5))),
+            (8..11, 4, Some(Rect::new(21, 2, 69, 4))),
+            (0..3, 0, Some(Rect::new(21, 5, 69, 5))),
+            (0..3, 1, Some(Rect::new(21, 4, 69, 5))),
+            (0..3, 3, None),
+            (20..23, 0, None),
+            (0..19, 0, None),
+        ] {
+            assert_eq!(comment_lookup_area(viewport, rows, scroll, 5), expected);
+        }
+    }
+
+    #[test]
+    fn test_diff_comment_lookup_renders_matches_and_constrained_footer() {
+        for (height, has_match, editing) in [
+            (14, true, true),
+            (3, true, true),
+            (14, false, true),
+            (14, true, false),
+        ] {
+            // Arrange
+            let diff = concat!(
+                "diff --git a/src/main.rs b/src/main.rs\n",
+                "@@ -0,0 +1,2 @@\n",
+                "+fn main() {}\n",
+                "+review();\n",
+            );
+            let mut line_comments = DiffLineComments::default();
+            line_comments.start_editing_target(DiffLineCommentTarget::single(
+                DiffLineCommentAnchor {
+                    content: "fn main() {}".to_string(),
+                    line: 1,
+                    path: "src/main.rs".to_string(),
+                    side: DiffLineSide::New,
+                },
+            ));
+            line_comments
+                .editing_input_mut()
+                .expect("inline comment should be editable")
+                .insert_text("@src");
+            line_comments.at_mention_state = Some(Box::new(
+                crate::presentation::prompt::PromptAtMentionState::new(if has_match {
+                    vec![crate::domain::file_entry::FileEntry {
+                        is_dir: false,
+                        path: "src/lookup.rs".into(),
+                    }]
+                } else {
+                    Vec::new()
+                }),
+            ));
+            if !editing {
+                line_comments.editing_index = None;
+            }
+            let session = session_fixture();
+            let diff_layout_cache = DiffLayoutCache::default();
+            let markdown_render_cache = markdown::MarkdownRenderCache::default();
+            let mut page = DiffPage::new(DiffPageInput {
+                can_comment: true,
+                diff,
+                diff_layout_cache: &diff_layout_cache,
+                file_explorer_selected_index: 1,
+                focus: DiffFocus::Content,
+                line_comments: &line_comments,
+                markdown_render_cache: &markdown_render_cache,
+                preview: test_diff_preview(),
+                review_comments: None,
+                scroll_offset: 0,
+                selected_diff_line_index: 0,
+                session: &session,
+                sidebar_focus: DiffSidebarFocus::Files,
+            });
+            let backend = ratatui::backend::TestBackend::new(100, height);
+            let mut terminal = ratatui::Terminal::new(backend).expect("failed to create terminal");
+
+            // Act
+            terminal
+                .draw(|frame| page.render(frame, frame.area()))
+                .expect("failed to render diff page");
+
+            // Assert
+            let text = buffer_text(terminal.backend().buffer());
+            assert_eq!(text.contains("Esc: dismiss lookup"), editing);
+            assert_eq!(
+                text.contains("Tab/Enter: select"),
+                height == 14 && has_match && editing
+            );
+            assert_eq!(
+                text.contains("src/lookup.rs"),
+                height == 14 && has_match && editing
+            );
+            if height == 14 && has_match && editing {
+                let areas = diff_util::diff_page_areas(Rect::new(0, 0, 100, height));
+                assert_comment_lookup_position(terminal.backend().buffer(), areas.diff_area);
+            }
+        }
+    }
+
+    /// Checks that suggestions stay in the diff pane without covering the
+    /// draft.
+    fn assert_comment_lookup_position(buffer: &ratatui::buffer::Buffer, diff_area: Rect) {
+        let row_texts: Vec<String> = buffer
+            .content
+            .chunks(100)
+            .map(|row| row.iter().map(Cell::symbol).collect())
+            .collect();
+        let (lookup_row, lookup_text) = row_texts
+            .iter()
+            .enumerate()
+            .find(|(_, row)| row.contains("src/lookup.rs"))
+            .expect("lookup row");
+        let input_row = row_texts
+            .iter()
+            .position(|row| row.contains("@src|"))
+            .expect("input row");
+        assert_ne!(lookup_row, input_row);
+        assert!(
+            lookup_text.find("src/lookup.rs").expect("lookup column") >= usize::from(diff_area.x)
+        );
     }
 
     #[test]

--- a/crates/agentty/tests/e2e/session.rs
+++ b/crates/agentty/tests/e2e/session.rs
@@ -9678,6 +9678,62 @@ fn test_diff_changed_line_navigation() -> E2eResult {
 /// Verify that file and changed-line comments survive navigation until one
 /// batch is submitted as the next session turn.
 #[test]
+fn test_diff_comment_file_lookup() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("diff_comment_file_lookup")
+        .with_git()
+        .zola(
+            "Look up files in diff comments",
+            "Reference repository files while writing diff feedback.",
+            48,
+        )
+        .setup(|env| {
+            seed_review_ready_session(env)?;
+            seed_linked_review_worktree_with_diff(env)?;
+            seed_line_comment_codex_stub(env)?;
+            seed_line_comment_review_stub(env)?;
+            seed_sessions_startup_tab(env)
+        })
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::open_selected_session_view())
+                    .press_key("d")
+                    .wait_for_text("main.rs", 5000)
+                    .press_key("j")
+                    .wait_for_text("Enter/l: open", 5000)
+                    .write_text("C")
+                    .wait_for_text("File comment", 5000)
+                    .write_text("See @src/ma")
+                    .wait_for_text("Tab/Enter: select", 5000)
+                    .capture_labeled(
+                        "comment_lookup",
+                        "File lookup beside the active comment input",
+                    )
+                    .press_key("Tab")
+                    .write_text("for context")
+                    .wait_for_text("See @src/main.rs for context", 5000)
+                    .capture_labeled(
+                        "lookup_selected",
+                        "File reference inserted without leaving the comment editor",
+                    )
+            },
+            |frame, report| {
+                let lookup = common::frame_from_capture(&report.captures[0]);
+                let content =
+                    Region::new(lookup.cols() / 5, 0, lookup.cols() * 4 / 5, lookup.rows());
+                assertion::assert_text_in_region(&lookup, "src/main.rs", &content);
+                assertion::assert_text_in_region(&lookup, "Files (", &content);
+                let full = Region::full(frame.cols(), frame.rows());
+                assertion::assert_text_in_region(frame, "See @src/main.rs for context", &full);
+            },
+        )?;
+
+    Ok(())
+}
+
+#[test]
 fn test_diff_line_comments() -> E2eResult {
     // Arrange, Act, Assert
     FeatureTest::new("diff_line_comments")

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -848,10 +848,11 @@ their triggers:
   classification also requires `Draft` status before an empty prompt can be treated as
   the first message, so lightweight list rows cannot replace an existing title.
 
-- **At-mention file indexing** (`@` in prompt or question input): lists session files
-  for the mention picker, falling back to the project root for unstarted drafts. Loaded
-  entries remain cached, but only refresh an already-open question picker; delayed
-  results never reopen a dismissed question lookup.
+- **At-mention file indexing** (`@` in prompt, question, or diff-comment input): lists
+  session files for the mention picker, falling back to the project root for unstarted
+  drafts. Loaded entries remain cached, but only refresh an already-open question or
+  diff-comment picker; delayed results never reopen a dismissed question or diff-comment
+  lookup.
 
 - **Session-size refresh** (`Enter` on a session in list mode): recomputes the diff-size
   bucket off the key-handling path.

--- a/docs/site/content/docs/usage/keybindings.md
+++ b/docs/site/content/docs/usage/keybindings.md
@@ -339,6 +339,12 @@ markdown file loads automatically, while folders and other file types continue s
 their normal diff. Deleted, binary, oversized, and unreadable markdown files show a
 short availability notice. Press `p` again to return to raw diff lines.
 
+Type `@` in a diff comment to look up repository files. `Up` / `Down` navigate matches,
+and `Tab` / `Enter` insert the selected path without finishing the comment. `Esc`
+dismisses the lookup while preserving the draft; press it again to finish editing. With
+no matches, `Tab` / `Enter` dismiss the lookup. Modified `Enter` still inserts a
+newline.
+
 Whole-file comments stay visible above the selected file's patch, while line and range
 comments stay beneath their source. Press `Enter` again on a completed comment to edit
 it; clearing its text and finishing removes it. Completed comments use a distinct inset

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -274,6 +274,13 @@ range, press `Shift+V` on the first changed row, extend the visual selection wit
 `k` or the arrow keys, then press `Enter`; `Esc` cancels the selection without leaving
 the patch. The full range stays highlighted while its inline editor is open and after
 the comment is finished, so every inline comment retains its visible source context.
+Type `@` in a diff comment to look up repository files. The lookup aligns with the
+comment input, opening above it when space allows and below it near the top edge. `Up` /
+`Down` navigate matches, and `Tab` / `Enter` insert the selected path without finishing
+the comment. `Esc` dismisses the lookup while preserving the draft; press it again to
+finish editing. With no matches, `Tab` / `Enter` dismiss the lookup. Modified `Enter`
+still inserts a newline.
+
 Finishing empty text removes the comment and its source highlight. Completed comments
 keep a distinct inset background, and the active editor uses the stronger selection
 highlight. Leaving Diff mode keeps every completed comment with that session, so


### PR DESCRIPTION
- `@` lookups navigate and insert repository paths without finishing the comment.
- Drafts persist when lookups are dismissed or delayed, and newline insertion remains available.
- Unit, rendering, and end-to-end tests cover lookup behavior, with controls documented.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)