### PR TITLE
Prevent concurrent Agentty instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ agentty --help       # Show supported command-line options
 agentty --version    # Show the installed Agentty version
 ```
 
+Only one Agentty instance can use a given Agentty root at a time. Close the running
+instance before launching another. Separate `AGENTTY_ROOT` directories can run
+independently.
+
 From the **Sessions** tab, create an `Orchestrator` session for broad goals. It can run
 temporary read-only research waves to map architecture, review risks, or answer design
 questions before proposing implementation workers. Research reports are verified by the

--- a/crates/agentty/src/infra/db.rs
+++ b/crates/agentty/src/infra/db.rs
@@ -1,5 +1,8 @@
 //! Agentty persistence facade and database-location policy.
 
+use std::fs::File;
+use std::io;
+use std::path::Path;
 use std::sync::Arc;
 
 pub use ag_store::*;
@@ -11,6 +14,33 @@ pub const DB_DIR: &str = "db";
 
 /// Default Agentty database filename.
 pub const DB_FILE: &str = "agentty.db";
+
+/// Acquires exclusive application ownership of one Agentty root.
+///
+/// Keep the returned file open until the application stops. The OS releases
+/// the lock when the handle closes or the process exits; the lock file must
+/// remain in place so concurrent starts always lock the same file.
+/// Acquire this before opening the database or running startup recovery.
+///
+/// # Errors
+/// Returns [`io::ErrorKind::WouldBlock`] when another instance owns this root,
+/// or an I/O error when the lock directory or file cannot be opened or locked.
+pub async fn acquire_instance_lock(root: &Path) -> io::Result<File> {
+    let directory = root.join(DB_DIR);
+    tokio::fs::create_dir_all(&directory).await?;
+    let file = tokio::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(directory.join("agentty.lock"))
+        .await?
+        .into_std()
+        .await;
+    file.try_lock()?;
+
+    Ok(file)
+}
 
 /// Returns a store timestamp source backed by Agentty's environment-selected
 /// clock.
@@ -26,6 +56,119 @@ pub fn timestamp_source_from_environment() -> Arc<dyn TimestampSource> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn instance_lock_is_exclusive_per_root_and_reusable_after_drop() {
+        // Arrange
+        let first_root = tempfile::tempdir().expect("first root");
+        let other_root = tempfile::tempdir().expect("other root");
+        let first = acquire_instance_lock(first_root.path())
+            .await
+            .expect("first lock");
+
+        // Act
+        let error = acquire_instance_lock(first_root.path())
+            .await
+            .expect_err("root is owned");
+        let other = acquire_instance_lock(other_root.path())
+            .await
+            .expect("independent root");
+        drop(first);
+        let restarted = acquire_instance_lock(first_root.path())
+            .await
+            .expect("released lock");
+
+        // Assert
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+        assert!(other.metadata().expect("other lock metadata").is_file());
+        assert!(
+            restarted
+                .metadata()
+                .expect("restarted lock metadata")
+                .is_file()
+        );
+    }
+
+    #[tokio::test]
+    async fn instance_lock_reports_directory_and_file_errors() {
+        // Arrange
+        let root = tempfile::tempdir().expect("root");
+        std::fs::write(root.path().join(DB_DIR), "blocked").expect("block directory");
+
+        // Act / Assert
+        assert!(acquire_instance_lock(root.path()).await.is_err());
+        std::fs::remove_file(root.path().join(DB_DIR)).expect("remove blocker");
+        std::fs::create_dir_all(root.path().join(DB_DIR).join("agentty.lock"))
+            .expect("block lock file");
+        assert!(acquire_instance_lock(root.path()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn instance_lock_is_released_after_process_exit_or_kill() {
+        const CHILD_ROOT: &str = "AGENTTY_LOCK_HOLDER_TEST_ROOT";
+
+        if let Some(root) = std::env::var_os(CHILD_ROOT) {
+            // Arrange
+            let root = std::path::PathBuf::from(root);
+            let _owner = acquire_instance_lock(&root).await.expect("child lock");
+
+            // Act / Assert: retain ownership until the parent requests exit
+            // or kills this process without dropping the handle.
+            while !root.join("stop").exists() {
+                tokio::fs::write(root.join("ready"), b"")
+                    .await
+                    .expect("signal ownership");
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+
+            return;
+        }
+
+        // Normal exit also lets the child flush coverage for the shared holder.
+        for terminate_abruptly in [false, true] {
+            // Arrange
+            let root = tempfile::tempdir().expect("root");
+            let mut child =
+                tokio::process::Command::new(std::env::current_exe().expect("test binary"))
+                    .arg("--exact")
+                    .arg("infra::db::tests::instance_lock_is_released_after_process_exit_or_kill")
+                    .env(CHILD_ROOT, root.path())
+                    .kill_on_drop(true)
+                    .spawn()
+                    .expect("lock holder process");
+            tokio::time::timeout(std::time::Duration::from_secs(10), async {
+                while !root.path().join("ready").exists() {
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("child should acquire lock");
+
+            // Act
+            let error = acquire_instance_lock(root.path())
+                .await
+                .expect_err("child owns root");
+            if terminate_abruptly {
+                child.kill().await.expect("kill and reap owner");
+            } else {
+                tokio::fs::write(root.path().join("stop"), b"")
+                    .await
+                    .expect("request graceful exit");
+                let status = tokio::time::timeout(std::time::Duration::from_secs(10), child.wait())
+                    .await
+                    .expect("child should exit")
+                    .expect("reap owner");
+                assert!(status.success());
+            }
+            let restarted = acquire_instance_lock(root.path())
+                .await
+                .expect("restart after process exit");
+
+            // Assert
+            assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+            assert!(restarted.metadata().expect("lock metadata").is_file());
+        }
+    }
 
     #[test]
     fn environment_timestamp_source_returns_a_unix_timestamp() {

--- a/crates/agentty/src/main.rs
+++ b/crates/agentty/src/main.rs
@@ -7,7 +7,8 @@ use std::process::ExitCode;
 use ag_git::{GitClient, RealGitClient};
 use agentty::app::{AGENTTY_WT_DIR, App, AppError, agentty_home};
 use agentty::infra::db::{
-    DB_DIR, DB_FILE, Database, timestamp_source_from_environment as environment_timestamp_source,
+    DB_DIR, DB_FILE, Database, acquire_instance_lock,
+    timestamp_source_from_environment as environment_timestamp_source,
 };
 use clap::Parser;
 
@@ -43,6 +44,17 @@ async fn main() -> ExitCode {
 /// execution fails.
 async fn run(cli: Cli) -> Result<(), AppError> {
     let home = agentty_home();
+    let _instance_lock = acquire_instance_lock(&home).await.map_err(|error| {
+        let message = if error.kind() == io::ErrorKind::WouldBlock {
+            "Another Agentty instance is already using this Agentty root. Close it before starting \
+             another instance."
+                .to_string()
+        } else {
+            format!("Failed to acquire the Agentty instance lock: {error}")
+        };
+
+        AppError::Workflow(message)
+    })?;
     let base_path = home.join(AGENTTY_WT_DIR);
     let working_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
     let git_client = RealGitClient;
@@ -66,6 +78,8 @@ mod tests {
 
     use super::*;
 
+    const LOCK_FAILURE_CHILD_ENV: &str = "AGENTTY_LOCK_FAILURE_CHILD";
+    const OWNED_ROOT_CHILD_ENV: &str = "AGENTTY_OWNED_ROOT_CHILD";
     const DATABASE_FAILURE_CHILD_ENV: &str = "AGENTTY_DATABASE_FAILURE_CHILD";
 
     #[test]
@@ -98,18 +112,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_reports_database_parent_creation_failure() {
-        if env::var_os(DATABASE_FAILURE_CHILD_ENV).is_some() {
+    async fn run_reports_instance_lock_parent_creation_failure() {
+        if env::var_os(LOCK_FAILURE_CHILD_ENV).is_some() {
             // Arrange
             let cli = Cli { no_update: false };
 
             // Act
             let error = run(cli)
                 .await
-                .expect_err("database startup should reject a file-backed root");
+                .expect_err("startup should reject a file-backed root");
 
             // Assert
-            assert!(matches!(error, AppError::Db(_)));
+            assert!(matches!(error, AppError::Workflow(_)));
+            assert!(
+                error
+                    .to_string()
+                    .contains("Failed to acquire the Agentty instance lock")
+            );
 
             return;
         }
@@ -125,12 +144,93 @@ mod tests {
         // Act
         let status = tokio::process::Command::new(test_binary)
             .arg("--exact")
-            .arg("tests::run_reports_database_parent_creation_failure")
-            .env(DATABASE_FAILURE_CHILD_ENV, "1")
+            .arg("tests::run_reports_instance_lock_parent_creation_failure")
+            .env(LOCK_FAILURE_CHILD_ENV, "1")
             .env("AGENTTY_ROOT", blocking_root)
             .status()
             .await
             .expect("isolated startup test should run");
+
+        // Assert
+        assert!(status.success());
+    }
+
+    #[tokio::test]
+    async fn run_rejects_an_owned_root_before_opening_the_database() {
+        if env::var_os(OWNED_ROOT_CHILD_ENV).is_some() {
+            // Arrange / Act
+            let error = run(Cli { no_update: true })
+                .await
+                .expect_err("root is owned");
+
+            // Assert
+            assert!(
+                error
+                    .to_string()
+                    .contains("Another Agentty instance is already using")
+            );
+
+            return;
+        }
+
+        // Arrange
+        let root = tempfile::tempdir().expect("root");
+        let owner = acquire_instance_lock(root.path())
+            .await
+            .expect("owner lock");
+        let database_path = root.path().join(DB_DIR).join(DB_FILE);
+
+        // Act
+        let status = tokio::process::Command::new(env::current_exe().expect("test binary"))
+            .arg("--exact")
+            .arg("tests::run_rejects_an_owned_root_before_opening_the_database")
+            .env(OWNED_ROOT_CHILD_ENV, "1")
+            .env("AGENTTY_ROOT", root.path())
+            .status()
+            .await
+            .expect("contending process");
+
+        // Assert
+        assert!(status.success());
+        assert!(
+            !database_path.exists(),
+            "contention must precede database creation"
+        );
+        drop(owner);
+    }
+
+    #[tokio::test]
+    async fn run_releases_instance_lock_after_database_open_failure() {
+        if env::var_os(DATABASE_FAILURE_CHILD_ENV).is_some() {
+            // Arrange / Act
+            let error = run(Cli { no_update: true })
+                .await
+                .expect_err("database path is a directory");
+
+            // Assert
+            assert!(matches!(error, AppError::Db(_)));
+            let _owner = acquire_instance_lock(&agentty_home())
+                .await
+                .expect("failed startup must release ownership");
+
+            return;
+        }
+
+        // Arrange
+        let root = tempfile::tempdir().expect("root");
+        tokio::fs::create_dir_all(root.path().join(DB_DIR).join(DB_FILE))
+            .await
+            .expect("block database opening");
+
+        // Act
+        let status = tokio::process::Command::new(env::current_exe().expect("test binary"))
+            .arg("--exact")
+            .arg("tests::run_releases_instance_lock_after_database_open_failure")
+            .env(DATABASE_FAILURE_CHILD_ENV, "1")
+            .env("AGENTTY_ROOT", root.path())
+            .status()
+            .await
+            .expect("startup process");
 
         // Assert
         assert!(status.success());

--- a/crates/agentty/tests/e2e/navigation.rs
+++ b/crates/agentty/tests/e2e/navigation.rs
@@ -1,5 +1,8 @@
 //! Navigation E2E tests: tab cycling, reverse tab cycling, and help overlay.
 
+use agentty::infra::db::{
+    DB_DIR, DB_FILE, Database, SessionPreparationState, acquire_instance_lock,
+};
 use testty::assertion;
 use testty::region::Region;
 
@@ -7,6 +10,81 @@ use crate::common;
 use crate::common::FeatureTest;
 
 type E2eResult = Result<(), Box<dyn std::error::Error>>;
+
+/// A contending CLI must exit before startup recovery mutates live work.
+#[tokio::test]
+async fn second_instance_preserves_live_operations() -> E2eResult {
+    // Arrange
+    let root = tempfile::tempdir()?;
+    let _owner = acquire_instance_lock(root.path()).await?;
+    let database = Database::open(&root.path().join(DB_DIR).join(DB_FILE)).await?;
+    let project_id = database
+        .projects()
+        .upsert_project("live-project", None)
+        .await?;
+    database
+        .sessions()
+        .insert_session("live", "gpt-5.6-sol", "main", "InProgress", project_id)
+        .await?;
+    database
+        .sessions()
+        .insert_session_preparation("live", "main")
+        .await?;
+    database
+        .operations()
+        .insert_session_operation("live-turn", "live", "rebase")
+        .await?;
+    database
+        .operations()
+        .mark_session_operation_running("live-turn")
+        .await?;
+
+    // Act
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        tokio::process::Command::new(assert_cmd::cargo::cargo_bin!("agentty"))
+            .arg("--no-update")
+            .env("AGENTTY_ROOT", root.path())
+            .current_dir(root.path())
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await??;
+
+    // Assert
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("Another Agentty instance is already using")
+    );
+    assert_eq!(
+        database
+            .sessions()
+            .load_session("live")
+            .await?
+            .expect("live session")
+            .status,
+        "InProgress"
+    );
+    assert_eq!(
+        database
+            .sessions()
+            .load_session_preparation("live")
+            .await?
+            .expect("live preparation")
+            .state,
+        SessionPreparationState::Preparing
+    );
+    let operations = database
+        .operations()
+        .load_unfinished_session_operations()
+        .await?;
+    assert_eq!(operations.len(), 1);
+    assert_eq!(operations[0].status, "running");
+    assert!(!operations[0].cancel_requested);
+
+    Ok(())
+}
 
 /// Verify that agentty startup renders the Sessions tab when an active
 /// project already exists.

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -45,6 +45,12 @@ these constraints:
 <a id="architecture-runtime-flow-main"></a> Primary foreground path from process start
 to one event-loop cycle:
 
+Before opening the database or recovering unfinished operations, the executable acquires
+an exclusive OS file lock for its Agentty root. It holds the handle throughout the
+application runtime, preventing a second instance from treating live work as abandoned.
+The lock file stays in place; closing the handle or exiting the process releases
+ownership.
+
 ```mermaid
 flowchart TD
   main["main.rs"]

--- a/docs/site/content/docs/getting-started/installation.md
+++ b/docs/site/content/docs/getting-started/installation.md
@@ -96,6 +96,11 @@ for third-party invocation through Agentty.
 1. Run `agentty`.
 1. Start a new session and let the agent work in its dedicated worktree branch.
 
+Only one Agentty instance can use a given Agentty root at a time. If startup reports
+that another instance is running, close that instance first. A crash releases ownership
+automatically; do not delete the lock file. Separate `AGENTTY_ROOT` directories can run
+independently.
+
 ## Review Changes
 
 <a id="installation-review-changes"></a> Inside `agentty`, open the diff view (`d`) to


### PR DESCRIPTION
- Acquire an exclusive root lock before opening the database or recovering unfinished operations.
- Report ownership conflicts and release the lock after startup failures or process termination.
- Cover lock behavior with unit and end-to-end tests and document separate-root usage.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)