### PR TITLE
Ships version 0.15.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.15.13] - 2026-09-09
+
+### Added
+
+- agentty: support repository file lookup in diff comments while preserving drafts.
+
+### Changed
+
+- release: bump workspace crate metadata and lockfile package versions to `0.15.13`.
+
+### Contributors
+
+- @minev-dev
+
 ## [v0.15.12] - 2026-09-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ag-agent"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "ag-protocol",
  "agent-client-protocol",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ag-clipboard"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "image",
  "mockall",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "ag-forge"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "mockall",
  "serde",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "ag-git"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "mockall",
  "rustix",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "ag-harness"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "async-trait",
  "jsonschema",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "ag-harness-cli"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "ag-harness",
  "assert_cmd",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "ag-orchestration"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "ag-agent",
  "ag-git",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "ag-protocol"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "askama",
  "schemars 1.2.2",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "ag-session"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "ag-agent",
  "ag-forge",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "ag-store"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "ag-agent",
  "ag-session",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "ag-tui-text"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "ratatui",
  "rustc-hash",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "ag-xtask"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "clap",
  "tempfile",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "agentty"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "ag-agent",
  "ag-clipboard",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "testty"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "base64 0.23.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.15.12"
+version = "0.15.13"
 authors = [
   "Vladimir Minev <minev.dev@gmail.com>",
   "Andrei Agaev <andagaev@gmail.com>",
@@ -14,17 +14,17 @@ description = "Agentty is an ADE (Agentic Development Environment) for structure
 repository = "https://github.com/agentty-xyz/agentty"
 
 [workspace.dependencies]
-ag-agent = { path = "crates/ag-agent", version = "0.15.12" }
-ag-clipboard = { path = "crates/ag-clipboard", version = "0.15.12" }
-ag-forge = { path = "crates/ag-forge", version = "0.15.12" }
-ag-git = { path = "crates/ag-git", version = "0.15.12" }
-ag-harness = { path = "crates/ag-harness", version = "0.15.12" }
-ag-orchestration = { path = "crates/ag-orchestration", version = "0.15.12" }
-ag-protocol = { path = "crates/ag-protocol", version = "0.15.12" }
-ag-session = { path = "crates/ag-session", version = "0.15.12" }
-ag-store = { path = "crates/ag-store", version = "0.15.12" }
-ag-tui-text = { path = "crates/ag-tui-text", version = "0.15.12" }
-testty = { path = "crates/testty", version = "0.15.12" }
+ag-agent = { path = "crates/ag-agent", version = "0.15.13" }
+ag-clipboard = { path = "crates/ag-clipboard", version = "0.15.13" }
+ag-forge = { path = "crates/ag-forge", version = "0.15.13" }
+ag-git = { path = "crates/ag-git", version = "0.15.13" }
+ag-harness = { path = "crates/ag-harness", version = "0.15.13" }
+ag-orchestration = { path = "crates/ag-orchestration", version = "0.15.13" }
+ag-protocol = { path = "crates/ag-protocol", version = "0.15.13" }
+ag-session = { path = "crates/ag-session", version = "0.15.13" }
+ag-store = { path = "crates/ag-store", version = "0.15.13" }
+ag-tui-text = { path = "crates/ag-tui-text", version = "0.15.13" }
+testty = { path = "crates/testty", version = "0.15.13" }
 async-trait = "0.1"
 agent-client-protocol = "2.0.0"
 assert_cmd = "2"


### PR DESCRIPTION
- Supports repository file lookup in diff comments while preserving drafts.
- Bumps workspace crate metadata and lockfile package versions to `0.15.13`.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)