### PR TITLE
Custom GitHub Actions use `$/` references

### DIFF
--- a/.github/actions/run-coverage/action.yml
+++ b/.github/actions/run-coverage/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Setup Rust and `prek`
-      uses: ./.github/actions/setup-rust-prek
+      uses: $/.github/actions/setup-rust-prek
       with:
         cargo-llvm-cov: "true"
         llvm-tools-preview: "true"

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -62,7 +62,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust and `prek`
-        uses: ./.github/actions/setup-rust-prek
+        uses: $/.github/actions/setup-rust-prek
 
       - name: Run source tests
         id: source-tests
@@ -82,7 +82,7 @@ jobs:
 
   validate:
     name: Workspace checks
-    uses: ./.github/workflows/workspace-validation.yml
+    uses: $/.github/workflows/workspace-validation.yml
     with:
       cargo-audit: true
       cargo-machete: true
@@ -102,11 +102,11 @@ jobs:
           persist-credentials: false
 
       - name: Generate and publish coverage
-        uses: ./.github/actions/run-coverage
+        uses: $/.github/actions/run-coverage
         with:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           summarize: "true"
 
   e2e:
     name: End-to-end feature tests
-    uses: ./.github/workflows/e2e.yml
+    uses: $/.github/workflows/e2e.yml

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -24,17 +24,17 @@ jobs:
           persist-credentials: false
 
       - name: Generate and publish coverage
-        uses: ./.github/actions/run-coverage
+        uses: $/.github/actions/run-coverage
         with:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
 
   e2e:
     name: End-to-end feature tests
-    uses: ./.github/workflows/e2e.yml
+    uses: $/.github/workflows/e2e.yml
 
   validate:
     name: Workspace checks
-    uses: ./.github/workflows/workspace-validation.yml
+    uses: $/.github/workflows/workspace-validation.yml
     with:
       cargo-audit: true
       cargo-machete: true

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -10,7 +10,7 @@ jobs:
   validate:
     name: Release validation
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-    uses: ./.github/workflows/workspace-validation.yml
+    uses: $/.github/workflows/workspace-validation.yml
     with:
       llvm-tools-preview: true
       workspace-tests: true
@@ -18,4 +18,4 @@ jobs:
   e2e:
     name: Release E2E
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-    uses: ./.github/workflows/e2e.yml
+    uses: $/.github/workflows/e2e.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
           path: plan-dist-manifest.json
 
   custom-release-checks:
-    uses: ./.github/workflows/release-checks.yml
+    uses: $/.github/workflows/release-checks.yml
 
   # Build and packages all the platform-specific things
   build-local-artifacts:
@@ -390,7 +390,7 @@ jobs:
       - plan
       - host
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
-    uses: ./.github/workflows/publish-npm-oidc.yml
+    uses: $/.github/workflows/publish-npm-oidc.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     # publish jobs get escalated permissions
@@ -403,7 +403,7 @@ jobs:
       - plan
       - host
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
-    uses: ./.github/workflows/publish-crates-io.yml
+    uses: $/.github/workflows/publish-crates-io.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     # publish jobs get escalated permissions

--- a/.github/workflows/workspace-validation.yml
+++ b/.github/workflows/workspace-validation.yml
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust and `prek`
-        uses: ./.github/actions/setup-rust-prek
+        uses: $/.github/actions/setup-rust-prek
         with:
           cargo-audit: ${{ inputs['cargo-audit'] && 'true' || 'false' }}
           cargo-machete: ${{ inputs['cargo-machete'] && 'true' || 'false' }}

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,12 +8,14 @@ cargo-dist-version = "0.31.0"
 # CI backends to support
 ci = "github"
 # Keep release CI marked as intentionally customized because the checked-in
-# workflow avoids blanket secret forwarding on custom jobs that do not need it,
+# workflow uses `$/` self-repository references for custom jobs and avoids
+# blanket secret forwarding on custom jobs that do not need it,
 # and the generated `host` job is patched to require release checks before
 # creating the GitHub release announcement and to reuse an existing draft when a
 # release upload is retried. The generated workflow still runs the release plan
 # on pull requests and merge queue checks, while release-only validation is
-# tag-gated in `.github/workflows/release-checks.yml`.
+# tag-gated in `.github/workflows/release-checks.yml`. Reapply these customizations
+# after `dist init`; dist 0.31.0 still generates `./` workflow references.
 allow-dirty = ["ci"]
 # The installers to generate for each app
 installers = ["shell", "npm"]


### PR DESCRIPTION
- Keep generated release workflows compatible with repository-local custom jobs.
- Document that `dist init` requires reapplying these customizations because cargo-dist 0.31.0 still generates `./` references.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)