### PR TITLE
Allow recovery of missing rebase worktrees

### DIFF
--- a/crates/ag-git/src/client.rs
+++ b/crates/ag-git/src/client.rs
@@ -149,7 +149,8 @@ pub trait GitClient: Send + Sync {
     /// Returns whether rebase metadata exists in `repo_path`.
     ///
     /// # Errors
-    /// Returns an error when git state cannot be inspected.
+    /// Returns [`GitError::RepositoryUnavailable`] when the repository folder
+    /// is missing, or another error when git state cannot be inspected.
     fn is_rebase_in_progress(&self, repo_path: PathBuf) -> GitFuture<Result<bool, GitError>>;
 
     /// Returns detected in-progress git operation metadata in `repo_path`.

--- a/crates/ag-git/src/rebase.rs
+++ b/crates/ag-git/src/rebase.rs
@@ -274,11 +274,25 @@ pub(crate) async fn abort_rebase(repo_path: PathBuf) -> Result<(), GitError> {
 /// otherwise.
 ///
 /// # Errors
-/// Returns a [`GitError`] when the git directory cannot be resolved.
+/// Returns [`GitError::RepositoryUnavailable`] when the repository folder is
+/// missing, or another [`GitError`] when its git directory cannot be resolved.
 pub(crate) async fn is_rebase_in_progress(repo_path: PathBuf) -> Result<bool, GitError> {
     spawn_blocking(move || -> Result<bool, GitError> {
-        let git_dir = resolve_git_dir(&repo_path)
-            .ok_or_else(|| GitError::OutputParse("Failed to resolve git directory".to_string()))?;
+        match fs::metadata(&repo_path) {
+            Ok(_) => {}
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                return Err(GitError::RepositoryUnavailable {
+                    detail: format!("Repository folder is missing: {}", repo_path.display()),
+                });
+            }
+            Err(error) => return Err(error.into()),
+        }
+        let git_dir = resolve_git_dir(&repo_path).ok_or_else(|| {
+            GitError::OutputParse(format!(
+                "Failed to resolve git directory for `{}`",
+                repo_path.display()
+            ))
+        })?;
 
         Ok(has_rebase_metadata(&git_dir))
     })
@@ -627,6 +641,77 @@ mod tests {
 
     use super::*;
     use crate::MockSleeper;
+
+    #[tokio::test]
+    async fn rebase_probe_reports_missing_repository() {
+        // Arrange
+        let directory = tempdir().expect("temporary directory should exist");
+        let missing = directory.path().join("removed-worktree");
+
+        // Act
+        let error = is_rebase_in_progress(missing.clone())
+            .await
+            .expect_err("missing worktree should be classified");
+
+        // Assert
+        assert!(
+            matches!(error, GitError::RepositoryUnavailable { ref detail }
+            if detail.contains(&missing.display().to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn rebase_probe_preserves_invalid_repository_and_io_errors() {
+        // Arrange
+        let directory = tempdir().expect("temporary directory should exist");
+        let parent_file = directory.path().join("file");
+        fs::write(&parent_file, "not a directory").expect("file should be written");
+
+        // Act
+        let invalid_repository = is_rebase_in_progress(directory.path().to_path_buf()).await;
+        let io_error = is_rebase_in_progress(parent_file.join("worktree")).await;
+
+        // Assert
+        assert!(
+            matches!(invalid_repository, Err(GitError::OutputParse(message))
+            if message.contains(&directory.path().display().to_string()))
+        );
+        assert!(matches!(io_error, Err(GitError::Io(_))));
+    }
+
+    #[tokio::test]
+    async fn rebase_probe_detects_metadata_in_checkout_and_linked_worktree() {
+        // Arrange
+        let directory = tempdir().expect("temporary directory should exist");
+        let checkout = directory.path().join("checkout");
+        let linked = directory.path().join("linked");
+        let git_dir = checkout.join(".git");
+        fs::create_dir_all(&git_dir).expect("git directory should exist");
+        fs::create_dir(&linked).expect("worktree directory should exist");
+        fs::write(linked.join(".git"), "gitdir: ../checkout/.git\n")
+            .expect("gitdir file should be written");
+
+        // Act / Assert
+        assert!(
+            !is_rebase_in_progress(checkout.clone())
+                .await
+                .expect("probe should succeed")
+        );
+        for metadata in ["rebase-merge", "rebase-apply"] {
+            fs::create_dir(git_dir.join(metadata)).expect("rebase metadata should exist");
+            assert!(
+                is_rebase_in_progress(checkout.clone())
+                    .await
+                    .expect("probe should succeed")
+            );
+            assert!(
+                is_rebase_in_progress(linked.clone())
+                    .await
+                    .expect("probe should succeed")
+            );
+            fs::remove_dir(git_dir.join(metadata)).expect("rebase metadata should be removed");
+        }
+    }
 
     #[test]
     fn test_run_git_command_with_index_lock_retry_retries_and_sleeps_before_success() {

--- a/crates/agentty/src/app/session/workflow/worker.rs
+++ b/crates/agentty/src/app/session/workflow/worker.rs
@@ -740,7 +740,8 @@ impl SessionWorkerService {
     /// Aborts stale git rebase state left by interrupted worker operations.
     ///
     /// Only worker-backed rebase operations are handled here because merge
-    /// tasks are not yet persisted in `session_operation`.
+    /// tasks are not yet persisted in `session_operation`. Missing worktrees
+    /// need no Git cleanup; their operations still undergo durable recovery.
     ///
     /// # Errors
     /// Returns an error when Git cannot inspect or abort interrupted rebase
@@ -760,7 +761,12 @@ impl SessionWorkerService {
 
         for session_id in rebase_session_ids {
             let folder = session_folder(base_path, session_id);
-            let is_rebase_in_progress = git_client.is_rebase_in_progress(folder.clone()).await?;
+            let is_rebase_in_progress = match git_client.is_rebase_in_progress(folder.clone()).await
+            {
+                Ok(in_progress) => in_progress,
+                Err(ag_git::GitError::RepositoryUnavailable { .. }) => continue,
+                Err(error) => return Err(error.into()),
+            };
             if is_rebase_in_progress {
                 git_client.abort_rebase(folder).await?;
             }
@@ -7533,6 +7539,80 @@ mod tests {
         // Assert
         assert!(matches!(result, Err(SessionError::Git(_))));
         assert!(operation_is_unfinished);
+    }
+
+    #[tokio::test]
+    /// Verifies a removed worktree does not trap startup in recovery.
+    async fn test_restart_recovery_completes_for_missing_rebase_worktree() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let db = AppRepositories::in_memory().await.expect("db should open");
+        seed_recovery_test_operation(&db, Status::Rebasing, REBASE_OPERATION_KIND).await;
+
+        // Act
+        SessionWorkerService::fail_unfinished_operations_from_previous_run_at(
+            &db,
+            base_dir.path(),
+            Arc::new(ag_git::RealGitClient),
+            300,
+        )
+        .await
+        .expect("missing worktree should not prevent recovery");
+        let sessions = db
+            .sessions()
+            .load_sessions()
+            .await
+            .expect("sessions should load");
+        let unfinished = db
+            .operations()
+            .load_unfinished_session_operations()
+            .await
+            .expect("operations should load");
+
+        // Assert
+        assert_eq!(sessions[0].status, "Review");
+        assert!(unfinished.is_empty());
+    }
+
+    #[tokio::test]
+    /// Verifies an existing worktree with invalid metadata remains retryable.
+    async fn test_restart_recovery_preserves_git_inspection_failure() {
+        // Arrange
+        let base_dir = tempdir().expect("failed to create temp dir");
+        let db = AppRepositories::in_memory().await.expect("db should open");
+        seed_recovery_test_operation(&db, Status::Rebasing, REBASE_OPERATION_KIND).await;
+        let mut git_client = MockGitClient::new();
+        git_client
+            .expect_is_rebase_in_progress()
+            .once()
+            .returning(|_| {
+                Box::pin(async { Err(ag_git::GitError::OutputParse("invalid gitdir".to_string())) })
+            });
+        git_client.expect_abort_rebase().times(0);
+
+        // Act
+        let result = SessionWorkerService::fail_unfinished_operations_from_previous_run_at(
+            &db,
+            base_dir.path(),
+            Arc::new(git_client),
+            300,
+        )
+        .await;
+        let sessions = db
+            .sessions()
+            .load_sessions()
+            .await
+            .expect("sessions should load");
+        let unfinished = db
+            .operations()
+            .load_unfinished_session_operations()
+            .await
+            .expect("operations should load");
+
+        // Assert
+        assert!(matches!(result, Err(SessionError::Git(_))));
+        assert_eq!(sessions[0].status, "Rebasing");
+        assert_eq!(unfinished.len(), 1);
     }
 
     #[tokio::test]

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -569,10 +569,11 @@ restart-safe:
   ids to their current provider/model replacements before project-scoped snapshots load.
 - On startup, recovery loads unfinished operations, aborts stale interrupted-rebase
   metadata, resets impacted sessions to `Review`, then fails the operations with reason
-  `Interrupted by app restart`. Each step must succeed before the next begins. A storage
-  or Git failure stops startup before any sessions are admitted, preserving unfinished
-  operation rows so the next startup can retry recovery. Pending post-merge
-  stacked-child syncs are requeued only after this recovery completes.
+  `Interrupted by app restart`. Missing worktree folders skip Git cleanup but still
+  undergo session and operation reconciliation. Each step must succeed before the next
+  begins. A storage or Git failure stops startup before any sessions are admitted,
+  preserving unfinished operation rows so the next startup can retry recovery. Pending
+  post-merge stacked-child syncs are requeued only after this recovery completes.
 
 ### Status Transition Rules
 

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -19,6 +19,10 @@ images whose turns never began, so `s` can submit them again. Saved prompts surv
 restart; review the previous turn if dispatch was interrupted. If you switch projects, a
 saved prompt resumes when you return to its project.
 
+Startup marks interrupted rebases as failed and restores their sessions to **Review**. A
+removed session worktree does not block this recovery. Storage errors or Git inspection
+and cleanup failures in existing worktrees must be resolved before startup can complete.
+
 Drafts keep their staging controls: `Enter` saves a draft, and `s` starts background
 workspace setup for the staged prompt. Stacked drafts still require a review-ready
 parent and an idle stack. Forks capture the source history and commit before setup.


### PR DESCRIPTION
- Classify missing repository folders separately from Git inspection failures.
- Skip cleanup for removed worktrees while completing durable operation recovery.
- Preserve failures for existing worktrees so unfinished operations remain retryable.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)