### PR TITLE
Each harness shares one database pool across durable sessions

### DIFF
--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -6,12 +6,12 @@ use std::time::{Duration, Instant};
 
 #[cfg(test)]
 use serde_json::Value;
+use tokio::sync::OnceCell;
 
 use crate::file_system::{FileSystem, LocalFileSystem};
-#[cfg(test)]
-use crate::lifecycle::TurnErrorType;
 use crate::lifecycle::{
-    LifecycleEmitter, LifecycleId, LifecycleObserver, ToolErrorType, ToolLifecycle, TurnLifecycle,
+    LifecycleEmitter, LifecycleId, LifecycleObserver, ToolErrorType, ToolLifecycle, TurnErrorType,
+    TurnLifecycle,
 };
 use crate::model::{
     Model, ModelError, ModelMessage, ModelRequest, ModelResponse, ensure_unique_tool_call_ids,
@@ -57,7 +57,33 @@ impl Session<'_> {
     /// Returns [`SessionError`] when the model turn or persistence operation
     /// fails.
     pub async fn send(&mut self, prompt: impl Into<String>) -> Result<TurnOutcome, SessionError> {
-        let prompt = prompt.into();
+        let started_at = Instant::now();
+        let turn = self.harness.lifecycle.start_turn();
+        let turn_id = turn.as_ref().map(TurnLifecycle::id);
+        let mut result = self.send_turn(prompt.into(), turn_id).await;
+        if let Ok(outcome) = &mut result {
+            outcome.set_duration(started_at.elapsed());
+        }
+        if let Some(turn) = turn {
+            match &result {
+                Ok(_) => turn.completed(),
+                Err(
+                    SessionError::Turn(error) | SessionError::TurnPersistence { turn: error, .. },
+                ) => {
+                    turn.failed(error.error_type());
+                }
+                Err(_) => turn.failed(TurnErrorType::Session),
+            }
+        }
+
+        result
+    }
+
+    async fn send_turn(
+        &mut self,
+        prompt: String,
+        turn_id: Option<LifecycleId>,
+    ) -> Result<TurnOutcome, SessionError> {
         let AcquiredTurn {
             mut guard,
             provider_session_id,
@@ -80,7 +106,7 @@ impl Session<'_> {
 
                 return Err(error);
             }
-            result = self.harness.run_request(request) => result,
+            result = self.harness.run_turn(request, turn_id) => result,
         };
         let (outcome, mut messages, provider_session_id) = match result {
             Ok(result) => result,
@@ -210,6 +236,7 @@ fn retained_bytes(messages: &[ModelMessage]) -> usize {
 /// returns tool results to the model, and finishes with locally validated
 /// structured output.
 pub struct Harness {
+    database: OnceCell<Database>,
     database_path: Option<PathBuf>,
     file_system: Arc<dyn FileSystem>,
     lifecycle: LifecycleEmitter,
@@ -224,6 +251,7 @@ impl Harness {
     /// Creates a deny-by-default harness backed by the local filesystem.
     pub fn new(model: impl Model + 'static) -> Self {
         Self {
+            database: OnceCell::new(),
             database_path: None,
             file_system: Arc::new(LocalFileSystem),
             lifecycle: LifecycleEmitter::default(),
@@ -236,8 +264,12 @@ impl Harness {
     }
 
     /// Configures the SQLite database used by durable sessions.
+    ///
+    /// The first create or resume initializes one shared connection pool and
+    /// runs migrations. Reconfiguring the path resets that shared database.
     #[must_use]
     pub fn database(mut self, path: impl Into<PathBuf>) -> Self {
+        self.database = OnceCell::new();
         self.database_path = Some(path.into());
 
         self
@@ -309,9 +341,18 @@ impl Harness {
         schema: OutputSchema,
     ) -> Result<TurnOutcome, TurnError> {
         let request = ModelRequest::new(prompt, schema);
-        self.run_request(request)
-            .await
-            .map(|(outcome, _, _)| outcome)
+        let turn = self.lifecycle.start_turn();
+        let turn_id = turn.as_ref().map(TurnLifecycle::id);
+        let result = self.run_turn(request, turn_id).await;
+
+        if let Some(turn) = turn {
+            match &result {
+                Ok(_) => turn.completed(),
+                Err(error) => turn.failed(error.error_type()),
+            }
+        }
+
+        result.map(|(outcome, _, _)| outcome)
     }
 
     /// Builds a new durable session whose responses must match `schema`.
@@ -378,7 +419,10 @@ impl Harness {
             .as_deref()
             .ok_or(SessionError::StorageRequired)?;
 
-        Database::open(path).await
+        self.database
+            .get_or_try_init(|| Database::open(path))
+            .await
+            .cloned()
     }
 
     fn validate_session_model(&self, id: &str, loaded: &LoadedSession) -> Result<(), SessionError> {
@@ -412,24 +456,6 @@ impl Harness {
         }
 
         Ok(())
-    }
-
-    async fn run_request(
-        &self,
-        request: ModelRequest,
-    ) -> Result<(TurnOutcome, Vec<ModelMessage>, Option<String>), TurnError> {
-        let turn = self.lifecycle.start_turn();
-        let turn_id = turn.as_ref().map(TurnLifecycle::id);
-        let result = self.run_turn(request, turn_id).await;
-
-        if let Some(turn) = turn {
-            match &result {
-                Ok(_) => turn.completed(),
-                Err(error) => turn.failed(error.error_type()),
-            }
-        }
-
-        result
     }
 
     async fn run_turn(
@@ -2771,6 +2797,81 @@ END
     }
 
     #[tokio::test]
+    async fn concurrent_session_creation_and_resume_share_one_database_pool() {
+        // Arrange
+        let directory = tempdir().expect("temporary directory should be created");
+        let harness = Harness::new(model()).database(directory.path().join("harness.db"));
+        assert!(harness.database.get().is_none());
+
+        // Act
+        let (first, second) = tokio::join!(
+            harness.session("first", object_schema()).create(),
+            harness.session("second", object_schema()).create()
+        );
+        let first = first.expect("first session should be created");
+        let second = second.expect("second session should be created");
+        let resumed = harness
+            .resume("first")
+            .await
+            .expect("session should resume");
+        first.database.pool().close().await;
+
+        // Assert
+        assert!(second.database.pool().is_closed());
+        assert!(resumed.database.pool().is_closed());
+        assert!(
+            harness
+                .database
+                .get()
+                .expect("database should be initialized")
+                .pool()
+                .is_closed()
+        );
+    }
+
+    #[tokio::test]
+    async fn database_initialization_retries_after_failure_and_resets_on_reconfiguration() {
+        // Arrange
+        let directory = tempdir().expect("temporary directory should be created");
+        let parent = directory.path().join("blocked");
+        tokio::fs::write(&parent, "not a directory")
+            .await
+            .expect("blocking file should exist");
+        let harness = Harness::new(model()).database(parent.join("harness.db"));
+
+        // Act
+        let error = harness
+            .session("first", object_schema())
+            .create()
+            .await
+            .err();
+        assert!(harness.database.get().is_none());
+        tokio::fs::remove_file(&parent)
+            .await
+            .expect("blocking file should be removed");
+        let session = harness
+            .session("first", object_schema())
+            .create()
+            .await
+            .expect("initialization should retry");
+        let original = session.database.clone();
+        drop(session);
+        let harness = harness.database(directory.path().join("other.db"));
+        let missing = harness.resume("first").await.err();
+        let session = harness
+            .session("first", object_schema())
+            .create()
+            .await
+            .expect("new database should allow the same id");
+        original.pool().close().await;
+
+        // Assert
+        assert!(matches!(error, Some(SessionError::Io(_))));
+        assert!(matches!(missing, Some(SessionError::NotFound { .. })));
+        assert!(!session.database.pool().is_closed());
+    }
+
+    #[tokio::test]
     async fn completion_persistence_failure_interrupts_the_session_turn() {
         // Arrange
         let directory = tempdir().expect("temporary directory should be created");
@@ -2781,7 +2882,18 @@ END
                 "summary": "done"
             }))))
         });
-        let harness = Arc::new(Harness::new(model).database(&database_path));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let observed_events = Arc::clone(&events);
+        let harness = Arc::new(
+            Harness::new(model)
+                .database(&database_path)
+                .with_lifecycle_observer(move |event| {
+                    observed_events
+                        .lock()
+                        .expect("events should lock")
+                        .push(event);
+                }),
+        );
         let session = harness
             .session("session-a", object_schema())
             .create()
@@ -2819,6 +2931,21 @@ END
                 .contains("injected completion persistence failure")
         );
         assert_eq!(state, expected_state);
+        let events = events.lock().expect("events should lock");
+        assert_eq!(events.len(), 4);
+        let turn_id = turn_started_id(&events[0]).expect("turn should start");
+        assert!(matches!(
+            events[3].kind(),
+            crate::LifecycleEventKind::TurnFailed {
+                error_type: TurnErrorType::Session,
+                turn_id: event_turn_id,
+                ..
+            } if *event_turn_id == turn_id
+        ));
+        assert!(!events.iter().any(|event| matches!(
+            event.kind(),
+            crate::LifecycleEventKind::TurnCompleted { .. }
+        )));
     }
 
     #[tokio::test]
@@ -2831,7 +2958,16 @@ END
             .expect_complete()
             .times(1)
             .returning(|_| Err(ModelError::InvalidResponse));
-        let harness = Harness::new(model).database(&database_path);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let observed_events = Arc::clone(&events);
+        let harness = Harness::new(model)
+            .database(&database_path)
+            .with_lifecycle_observer(move |event| {
+                observed_events
+                    .lock()
+                    .expect("events should lock")
+                    .push(event);
+            });
         let mut session = harness
             .session("session-a", object_schema())
             .create()
@@ -2859,6 +2995,15 @@ END
 
         // Assert
         assert!(matches!(&error, SessionError::TurnPersistence { .. }));
+        let events = events.lock().expect("events should lock");
+        assert_eq!(events.len(), 4);
+        assert!(matches!(
+            events[3].kind(),
+            crate::LifecycleEventKind::TurnFailed {
+                error_type: TurnErrorType::Model(crate::ModelErrorType::InvalidResponse),
+                ..
+            }
+        ));
         if let SessionError::TurnPersistence { turn, persistence } = error {
             assert!(matches!(
                 turn,

--- a/crates/ag-harness/src/lifecycle.rs
+++ b/crates/ag-harness/src/lifecycle.rs
@@ -199,6 +199,8 @@ pub enum TurnErrorType {
     ToolCallLimit,
     /// A repository-scoped tool was enabled without a repository root.
     RepositoryRequired,
+    /// Durable session coordination or persistence failed.
+    Session,
 }
 
 impl TurnErrorType {
@@ -211,6 +213,7 @@ impl TurnErrorType {
             Self::ToolDenied => crate::telemetry::ERROR_TOOL_DENIED,
             Self::ToolCallLimit => crate::telemetry::ERROR_TOOL_CALL_LIMIT,
             Self::RepositoryRequired => crate::telemetry::ERROR_REPOSITORY_REQUIRED,
+            Self::Session => crate::telemetry::ERROR_SESSION,
         }
     }
 }

--- a/crates/ag-harness/src/telemetry.rs
+++ b/crates/ag-harness/src/telemetry.rs
@@ -45,6 +45,7 @@ pub(crate) const ERROR_TOOL_CALL_LIMIT: &str = "tool_call_limit";
 pub(crate) const ERROR_TOOL_DENIED: &str = "tool_denied";
 pub(crate) const ERROR_TOOL_EXECUTION: &str = "tool_execution_error";
 pub(crate) const ERROR_REPOSITORY_REQUIRED: &str = "repository_required";
+pub(crate) const ERROR_SESSION: &str = "session_error";
 pub(crate) const ERROR_UNSUPPORTED_OUTPUT: &str = "unsupported_output";
 pub(crate) const INSTRUMENTATION_SCOPE: &str = "ag-harness";
 pub(crate) const OPERATION_CHAT: &str = "chat";

--- a/crates/ag-harness/src/trace.rs
+++ b/crates/ag-harness/src/trace.rs
@@ -964,6 +964,7 @@ mod tests {
             TurnErrorType::ToolDenied,
             TurnErrorType::ToolCallLimit,
             TurnErrorType::RepositoryRequired,
+            TurnErrorType::Session,
         ];
         let tool_errors = [
             ToolErrorType::Cancelled,
@@ -985,6 +986,7 @@ mod tests {
                 "tool_denied",
                 "tool_call_limit",
                 "repository_required",
+                "session_error",
             ]
         );
         assert_eq!(

--- a/crates/ag-harness/src/turn.rs
+++ b/crates/ag-harness/src/turn.rs
@@ -38,6 +38,10 @@ impl TurnOutcome {
     pub(crate) fn new(output: Value, report: TurnReport) -> Self {
         Self { output, report }
     }
+
+    pub(crate) fn set_duration(&mut self, duration: Duration) {
+        self.report.duration = duration;
+    }
 }
 
 /// Observable, content-free activity from one successful model turn.
@@ -49,7 +53,8 @@ pub struct TurnReport {
 }
 
 impl TurnReport {
-    /// Returns the complete elapsed turn time.
+    /// Returns the complete elapsed turn time, including persistence for
+    /// durable session turns.
     pub fn duration(&self) -> Duration {
         self.duration
     }

--- a/crates/ag-harness/tests/lifecycle.rs
+++ b/crates/ag-harness/tests/lifecycle.rs
@@ -9,6 +9,7 @@ use ag_harness::{
     LifecycleEvent, LifecycleEventKind, LifecycleObserver, ModelErrorType, ModelResponseType,
     TurnErrorType,
 };
+use async_trait::async_trait;
 use serde_json::json;
 use tokio::sync::Notify;
 use wiremock::matchers::{method, path};
@@ -48,6 +49,26 @@ impl Respond for PendingResponse {
         ResponseTemplate::new(200)
             .set_delay(Duration::from_secs(10))
             .set_body_json(success_body())
+    }
+}
+
+struct GatedModel {
+    release: Arc<Notify>,
+    started: Arc<Notify>,
+}
+
+#[async_trait]
+impl ag_harness::Model for GatedModel {
+    async fn complete(
+        &self,
+        _request: ag_harness::ModelRequest,
+    ) -> Result<ag_harness::ModelCompletion, ag_harness::ModelError> {
+        self.started.notify_one();
+        self.release.notified().await;
+
+        Ok(ag_harness::ModelCompletion::from_response(
+            ag_harness::ModelResponse::Output(json!({"name": "done"})),
+        ))
     }
 }
 
@@ -117,6 +138,34 @@ fn assert_sequence(events: &[LifecycleEvent]) {
             .collect::<Vec<_>>(),
         (0..events.len() as u64).collect::<Vec<_>>()
     );
+}
+
+fn assert_durable_terminal(events: &[LifecycleEvent], cancel: bool, persistence_wait: Duration) {
+    assert_sequence(events);
+    assert_eq!(events.len(), 4);
+    let turn_id = match events[0].kind() {
+        LifecycleEventKind::TurnStarted { turn_id } => Some(turn_id),
+        _ => None,
+    }
+    .expect("first event should start the turn");
+    if cancel {
+        assert!(matches!(
+            events[3].kind(),
+            LifecycleEventKind::TurnFailed {
+                error_type: TurnErrorType::Cancelled,
+                turn_id: failed_id,
+                ..
+            } if failed_id == turn_id
+        ));
+    } else {
+        assert!(matches!(
+            events[3].kind(),
+            LifecycleEventKind::TurnCompleted {
+                duration,
+                turn_id: completed_id,
+            } if completed_id == turn_id && *duration >= persistence_wait
+        ));
+    }
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -345,4 +394,105 @@ async fn cancelling_harness_turn_closes_model_and_turn_lifecycles_once() {
             ..
         }
     ));
+}
+
+#[tokio::test]
+async fn durable_lifecycle_and_duration_include_completion_persistence() {
+    for cancel in [false, true] {
+        // Arrange
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let database_path = directory.path().join("harness.db");
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let model_completed = Arc::new(Notify::new());
+        let events = EventRecorder::default();
+        let observed_events = events.clone();
+        let observed_completion = Arc::clone(&model_completed);
+        let harness = Arc::new(
+            ag_harness::Harness::new(GatedModel {
+                release: Arc::clone(&release),
+                started: Arc::clone(&started),
+            })
+            .database(&database_path)
+            .with_lifecycle_observer(move |event: LifecycleEvent| {
+                if matches!(
+                    event.kind(),
+                    LifecycleEventKind::ModelRequestCompleted { .. }
+                ) {
+                    observed_completion.notify_one();
+                }
+                observed_events.observe(event);
+            }),
+        );
+        harness
+            .session("durable", request().schema().clone())
+            .create()
+            .await
+            .expect("session should be created");
+        let database = sqlx::SqlitePool::connect_with(
+            sqlx::sqlite::SqliteConnectOptions::new().filename(&database_path),
+        )
+        .await
+        .expect("inspection database should open");
+        let mut turn = tokio::spawn(async move {
+            let mut session = harness
+                .resume("durable")
+                .await
+                .expect("session should resume");
+            session.send("complete").await
+        });
+
+        // Act
+        wait_for_provider(&started, &mut turn)
+            .await
+            .expect("model should start");
+        let writer = database
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .expect("writer lock should be acquired");
+        release.notify_one();
+        wait_for_provider(&model_completed, &mut turn)
+            .await
+            .expect("model should complete");
+        let persistence_started = std::time::Instant::now();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let persistence_wait = persistence_started.elapsed();
+
+        // Assert
+        assert_eq!(
+            events.events().len(),
+            3,
+            "turn must stay active while its commit is blocked"
+        );
+        assert!(!turn.is_finished());
+        if cancel {
+            turn.abort();
+            assert!(
+                turn.await
+                    .expect_err("turn should be cancelled")
+                    .is_cancelled()
+            );
+            writer
+                .rollback()
+                .await
+                .expect("writer lock should be released");
+        } else {
+            writer
+                .commit()
+                .await
+                .expect("writer lock should be released");
+            let outcome = turn
+                .await
+                .expect("turn task should finish")
+                .expect("durable send should succeed");
+            assert!(outcome.report().duration() >= persistence_wait);
+            let status: String = sqlx::query_scalar("SELECT status FROM session_turn")
+                .fetch_one(&database)
+                .await
+                .expect("turn state should load");
+            assert_eq!(status, "completed");
+        }
+        assert_durable_terminal(&events.events(), cancel, persistence_wait);
+        database.close().await;
+    }
 }

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -19,7 +19,8 @@ flowchart LR
 
 ## Public boundary
 
-- `Harness` owns the model, repository policy, lifecycle observers, and database path.
+- `Harness` owns the model, repository policy, lifecycle observers, and shared database
+  pool.
 - `Session` is the only multi-turn abstraction. It persists and restores bounded
   history.
 - `Model` is the object-safe provider boundary. `ModelCompletion` carries the response,
@@ -91,6 +92,11 @@ failure.
 
 ## Concurrency
 
+The first create or resume initializes the harness's database pool and runs migrations.
+Concurrent initialization is serialized, and failed initialization can be retried. All
+sessions created or resumed through that harness share its four-connection limit.
+Reconfiguring the database path resets the pool; separate harnesses own separate pools.
+
 Different session IDs may run concurrently through the SQLite connection pool. A partial
 unique index permits only one `pending` or `running` turn for a given session, so
 concurrent writers receive `SessionError::Busy` instead of interleaving messages.
@@ -100,3 +106,10 @@ concurrent writers receive `SessionError::Busy` instead of interleaving messages
 Lifecycle observers receive content-free turn, model-request, and tool events. The host
 chooses exporters. `LifecycleMetrics` and `LifecycleTraceObserver` project this stream
 to OpenTelemetry without storing prompts or tool output in telemetry.
+
+`run_once` owns terminal events for ephemeral turns. `Session::send` owns them for
+durable turns and emits `TurnCompleted` only after committing messages and updating
+session state. Durable turn durations include acquisition and persistence. Session
+coordination or persistence failures emit `TurnFailed` with `session_error`; model or
+tool failures retain their original classification even if recording the failure also
+fails. Dropping either operation emits cancellation once.

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -36,11 +36,13 @@ For file-level detail, read the module docstrings directly.
   backend-neutral request-duration telemetry, and a deny-by-default `Harness` loop with
   closed built-in `read` and `write` capabilities. Its durable `Session` API records
   pending, running, completed, failed, and interrupted turns in SQLite, while replaying
-  only bounded whole completed turns. The `read` tool provides bounded worktree reads,
-  path listing, literal search, host-bound diffs, and base/HEAD file inspection;
-  stale-safe patch writes and file reads use the injectable `FileSystem` boundary.
-  Application binaries own prompts, tool permissions, and telemetry setup; the v0 read
-  tool owns its fixed `main` comparison base.
+  only bounded whole completed turns. `Harness` owns a lazily initialized database pool
+  shared by its sessions; `Session::send` owns terminal lifecycle events through durable
+  completion. The `read` tool provides bounded worktree reads, path listing, literal
+  search, host-bound diffs, and base/HEAD file inspection; stale-safe patch writes and
+  file reads use the injectable `FileSystem` boundary. Application binaries own prompts,
+  tool permissions, and telemetry setup; the v0 read tool owns its fixed `main`
+  comparison base.
 - `crates/ag-harness-cli/`: Interactive `ag-harness` command-line application and its
   process-level tests. It derives provider parsing and help from `ag-harness`, then owns
   command-line defaults, application prompts, bounded repository permission selection,


### PR DESCRIPTION
- Harnesses lazily initialize, retry, and reconfigure shared SQLite pools.
- Durable turns emit terminal lifecycle events after persistence and include persistence in reported duration.
- Session coordination and persistence failures use a dedicated telemetry classification while model and tool errors retain their original types.