### PR TITLE
Session writes survive failed turns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "sqlx",
  "tempfile",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml_ng = "0.10"
+sha2 = "0.10"
 sqlx = { version = "0.9", default-features = false, features = ["macros", "migrate", "runtime-tokio", "sqlite"] }
 sysinfo = { version = "0.39", default-features = false, features = ["component"] }
 tachyonfx = { version = "0.25.0", default-features = false, features = ["std"] }

--- a/crates/ag-harness/.sqlx/query-07dba61cac792c689471090bfe362d44d9611f63eed7dd6ec69fad7b84484d80.json
+++ b/crates/ag-harness/.sqlx/query-07dba61cac792c689471090bfe362d44d9611f63eed7dd6ec69fad7b84484d80.json
@@ -1,0 +1,122 @@
+{
+  "db_name": "SQLite",
+  "query": "\nSELECT w.id AS \"id!\", w.call_id, w.expected_hash, w.path, w.repository_root, w.resulting_hash,\n       w.status, w.turn_position, t.status AS turn_status\nFROM session_write w\nJOIN session_turn t USING (session_id, turn_position)\nWHERE w.session_id = ? AND t.status != 'completed' AND w.acknowledged_by_turn IS NULL\nORDER BY w.turn_position DESC, w.id DESC\nLIMIT 64\n",
+  "describe": {
+    "columns": [
+      {
+        "name": "id!",
+        "ordinal": 0,
+        "type_info": "Integer",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "name": "call_id",
+        "ordinal": 1,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "call_id"
+          }
+        }
+      },
+      {
+        "name": "expected_hash",
+        "ordinal": 2,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "expected_hash"
+          }
+        }
+      },
+      {
+        "name": "path",
+        "ordinal": 3,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "path"
+          }
+        }
+      },
+      {
+        "name": "repository_root",
+        "ordinal": 4,
+        "type_info": "Blob",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "repository_root"
+          }
+        }
+      },
+      {
+        "name": "resulting_hash",
+        "ordinal": 5,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "resulting_hash"
+          }
+        }
+      },
+      {
+        "name": "status",
+        "ordinal": 6,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "status"
+          }
+        }
+      },
+      {
+        "name": "turn_position",
+        "ordinal": 7,
+        "type_info": "Integer",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "turn_position"
+          }
+        }
+      },
+      {
+        "name": "turn_status",
+        "ordinal": 8,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_turn",
+            "name": "status"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "07dba61cac792c689471090bfe362d44d9611f63eed7dd6ec69fad7b84484d80"
+}

--- a/crates/ag-harness/.sqlx/query-3de16657ffc446a31b8e99d9fd4cbe152e63bf63582071e8179072e1f9fb6224.json
+++ b/crates/ag-harness/.sqlx/query-3de16657ffc446a31b8e99d9fd4cbe152e63bf63582071e8179072e1f9fb6224.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\nINSERT INTO session_write (\n    session_id, turn_position, call_id, repository_root, path,\n    expected_hash, resulting_hash, status\n)\nSELECT session_id, turn_position, ?, ?, ?, ?, ?, 'pending'\nFROM session_turn\nWHERE session_id = ? AND turn_position = ? AND owner_token = ?\n  AND status = 'running' AND lease_expires_at > ?\nRETURNING id AS \"id!\"\n",
+  "describe": {
+    "columns": [
+      {
+        "name": "id!",
+        "ordinal": 0,
+        "type_info": "Integer",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "id"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 9
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "3de16657ffc446a31b8e99d9fd4cbe152e63bf63582071e8179072e1f9fb6224"
+}

--- a/crates/ag-harness/.sqlx/query-5a154ac017113f4c791411e37f59be4fd13a11263ab7a0c8c95770648b511d29.json
+++ b/crates/ag-harness/.sqlx/query-5a154ac017113f4c791411e37f59be4fd13a11263ab7a0c8c95770648b511d29.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\nUPDATE session_write SET acknowledged_by_turn = ?\nWHERE session_id = ? AND id = ? AND turn_position < ? AND acknowledged_by_turn IS NULL\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 4
+    },
+    "nullable": []
+  },
+  "hash": "5a154ac017113f4c791411e37f59be4fd13a11263ab7a0c8c95770648b511d29"
+}

--- a/crates/ag-harness/.sqlx/query-98bf66b49b25d60ca0858d509c5b9a56040b099c71e22a5e0db02f8b11d8e3fc.json
+++ b/crates/ag-harness/.sqlx/query-98bf66b49b25d60ca0858d509c5b9a56040b099c71e22a5e0db02f8b11d8e3fc.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE session_write SET status = ? WHERE id = ? AND session_id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "98bf66b49b25d60ca0858d509c5b9a56040b099c71e22a5e0db02f8b11d8e3fc"
+}

--- a/crates/ag-harness/.sqlx/query-990944d10ae65ffb59f8777cace7898fd5fb6e4519daaad8de3c95258974e148.json
+++ b/crates/ag-harness/.sqlx/query-990944d10ae65ffb59f8777cace7898fd5fb6e4519daaad8de3c95258974e148.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "SQLite",
+  "query": "\nSELECT COUNT(*) AS \"total!\"\nFROM session_write w\nJOIN session_turn t USING (session_id, turn_position)\nWHERE w.session_id = ? AND t.status != 'completed' AND w.acknowledged_by_turn IS NULL\n",
+  "describe": {
+    "columns": [
+      {
+        "name": "total!",
+        "ordinal": 0,
+        "type_info": "Integer",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "990944d10ae65ffb59f8777cace7898fd5fb6e4519daaad8de3c95258974e148"
+}

--- a/crates/ag-harness/.sqlx/query-c3af8307294e34b70771b0cbd4d46a06019fe8fc1a8fa8d930032ed79226dcb9.json
+++ b/crates/ag-harness/.sqlx/query-c3af8307294e34b70771b0cbd4d46a06019fe8fc1a8fa8d930032ed79226dcb9.json
@@ -1,0 +1,122 @@
+{
+  "db_name": "SQLite",
+  "query": "\nSELECT w.id AS \"id!\", w.call_id, w.expected_hash, w.path, w.repository_root, w.resulting_hash,\n       w.status, w.turn_position, t.status AS turn_status\nFROM session_write w\nJOIN session_turn t USING (session_id, turn_position)\nWHERE w.session_id = ?\n  AND (? = FALSE OR (t.status != 'completed' AND w.acknowledged_by_turn IS NULL))\nORDER BY w.turn_position, w.id\n",
+  "describe": {
+    "columns": [
+      {
+        "name": "id!",
+        "ordinal": 0,
+        "type_info": "Integer",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "name": "call_id",
+        "ordinal": 1,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "call_id"
+          }
+        }
+      },
+      {
+        "name": "expected_hash",
+        "ordinal": 2,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "expected_hash"
+          }
+        }
+      },
+      {
+        "name": "path",
+        "ordinal": 3,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "path"
+          }
+        }
+      },
+      {
+        "name": "repository_root",
+        "ordinal": 4,
+        "type_info": "Blob",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "repository_root"
+          }
+        }
+      },
+      {
+        "name": "resulting_hash",
+        "ordinal": 5,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "resulting_hash"
+          }
+        }
+      },
+      {
+        "name": "status",
+        "ordinal": 6,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "status"
+          }
+        }
+      },
+      {
+        "name": "turn_position",
+        "ordinal": 7,
+        "type_info": "Integer",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "turn_position"
+          }
+        }
+      },
+      {
+        "name": "turn_status",
+        "ordinal": 8,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_turn",
+            "name": "status"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c3af8307294e34b70771b0cbd4d46a06019fe8fc1a8fa8d930032ed79226dcb9"
+}

--- a/crates/ag-harness/Cargo.toml
+++ b/crates/ag-harness/Cargo.toml
@@ -28,6 +28,7 @@ reqwest.workspace = true
 rustix.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
+sha2.workspace = true
 sqlx.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true

--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -37,6 +37,15 @@ messages, tool calls, and tool results. Failed and interrupted turns remain visi
 the database but are not replayed. Different sessions can run concurrently; one session
 accepts only one active turn at a time.
 
+Writes have a separate durable journal. After a failed send or session reopen,
+`session.writes().await?` returns write intents, acknowledged outcomes, and current hash
+comparisons for uncertain writes. The next send includes diagnostics for writes from
+incomplete turns so retries can inspect the changed files. Provider diagnostics omit
+native repository roots, which remain available to the host through `writes()`. A
+successful turn acknowledges only the displayed diagnostics, allowing later sends to
+retain provider continuation. Recovery never reapplies a patch automatically. `run_once`
+does not create this journal.
+
 The library does not choose a database location. Configure it once with
 `Harness::database()`. The companion CLI defaults to `~/.ag-harness/db/harness.db`;
 override that with `AG_HARNESS_ROOT` or `--database`.

--- a/crates/ag-harness/migrations/004_add_session_write.sql
+++ b/crates/ag-harness/migrations/004_add_session_write.sql
@@ -1,0 +1,16 @@
+CREATE TABLE session_write (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    turn_position INTEGER NOT NULL,
+    call_id TEXT NOT NULL,
+    repository_root TEXT NOT NULL,
+    path TEXT NOT NULL,
+    expected_hash TEXT,
+    resulting_hash TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'applied', 'failed')),
+    FOREIGN KEY (session_id, turn_position)
+        REFERENCES session_turn(session_id, turn_position) ON DELETE CASCADE
+);
+
+CREATE INDEX session_write_session_turn_idx
+ON session_write (session_id, turn_position, id);

--- a/crates/ag-harness/migrations/005_update_session_write_diagnostics.sql
+++ b/crates/ag-harness/migrations/005_update_session_write_diagnostics.sql
@@ -1,0 +1,9 @@
+ALTER TABLE session_write
+ADD COLUMN repository_root_bytes BLOB NOT NULL DEFAULT X'';
+
+UPDATE session_write SET repository_root_bytes = CAST(repository_root AS BLOB);
+
+ALTER TABLE session_write DROP COLUMN repository_root;
+ALTER TABLE session_write RENAME COLUMN repository_root_bytes TO repository_root;
+
+ALTER TABLE session_write ADD COLUMN acknowledged_by_turn INTEGER;

--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -28,9 +28,13 @@ use crate::turn::{
     sanitize_report_text, sanitized_completion_metadata,
 };
 use crate::write::{WriteError, WriteTool};
+use crate::write_journal::{WriteJournal, WriteRecord, WriteRecordRow, WriteRecovery, WriteStatus};
 
 const DEFAULT_MAX_HISTORY_BYTES: usize = 256 * 1024;
 const DEFAULT_MAX_TOOL_CALLS: usize = 8;
+const MAX_WRITE_DIAGNOSTIC_BYTES: usize = 16 * 1024;
+// Leave room for a 1 KiB call ID after JSON escaping and write metadata.
+const MAX_WRITE_DIAGNOSTIC_PATH_BYTES: usize = 8 * 1024;
 
 /// Durable, resumable sequence of model turns.
 pub struct Session<'a> {
@@ -47,6 +51,47 @@ impl Session<'_> {
     /// Returns the stable application-provided session identifier.
     pub fn id(&self) -> &str {
         &self.id
+    }
+
+    /// Returns durable write intents and outcomes, including failed turns.
+    ///
+    /// Uncertain writes from inactive turns are compared with the original
+    /// repository's current content. No patch is reapplied. An active turn's
+    /// pending writes remain unclassified until it ends or its lease expires.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError`] if recovery or journal loading fails.
+    pub async fn writes(&self) -> Result<Vec<WriteRecord>, SessionError> {
+        self.database.recover_stale_turns(&self.id).await?;
+        WriteRecordRow::load(
+            self.database.pool(),
+            &self.id,
+            false,
+            self.write_tool().as_ref(),
+        )
+        .await
+    }
+
+    fn write_tool(&self) -> Option<WriteTool> {
+        self.harness.repository.as_ref().map(|repository| {
+            WriteTool::new(
+                self.harness.file_system.clone(),
+                repository.root().to_path_buf(),
+            )
+        })
+    }
+
+    async fn load_write_diagnostics(&self) -> Result<(String, Vec<i64>), SessionError> {
+        let (mut writes, total) =
+            WriteRecordRow::load_pending_page(self.database.pool(), &self.id).await?;
+        writes.drain(..writes.len() - retained_write_count(&writes));
+        let tool = self.write_tool();
+        for write in &mut writes {
+            write.reconcile(tool.as_ref()).await;
+        }
+
+        Ok(write_diagnostics(&writes, total))
     }
 
     /// Sends one prompt and durably records its lifecycle and messages.
@@ -95,9 +140,16 @@ impl Session<'_> {
         if let Some(system_prompt) = &self.system_prompt {
             messages.insert(0, ModelMessage::System(system_prompt.clone()));
         }
+        let (context, acknowledged_writes) = self.load_write_diagnostics().await?;
+        let context = (!acknowledged_writes.is_empty()).then_some(context);
+        if let Some(context) = &context {
+            messages.push(ModelMessage::System(context.clone()));
+            self.provider_session_id = None;
+        }
         let retained_messages = messages.len();
         let mut request = ModelRequest::with_history(messages, prompt, self.schema.clone());
         request.set_provider_session_id(self.provider_session_id.clone());
+        let journal = guard.write_journal();
         let result = tokio::select! {
             biased;
             error = guard.ownership_failure() => {
@@ -105,7 +157,7 @@ impl Session<'_> {
 
                 return Err(error);
             }
-            result = self.harness.run_turn(request, turn_id) => result,
+            result = self.harness.run_turn(request, turn_id, Some(journal)) => result,
         };
         let (outcome, mut messages, provider_session_id) = match result {
             Ok(result) => result,
@@ -128,7 +180,7 @@ impl Session<'_> {
                 return Err(error.into());
             }
         };
-        let turn = messages.split_off(retained_messages);
+        let mut turn = messages.split_off(retained_messages);
         let persistence = self
             .database
             .complete_turn(
@@ -136,6 +188,8 @@ impl Session<'_> {
                 turn_position,
                 &turn[1..],
                 provider_session_id.as_deref(),
+                &acknowledged_writes,
+                context.as_deref(),
             )
             .await;
         if let Err(error) = persistence {
@@ -145,6 +199,9 @@ impl Session<'_> {
         }
         guard.disarm();
         self.provider_session_id = provider_session_id;
+        if let Some(context) = context {
+            turn.insert(0, ModelMessage::System(context));
+        }
         self.history.push(turn);
 
         Ok(outcome)
@@ -227,6 +284,83 @@ fn retained_bytes(messages: &[ModelMessage]) -> usize {
     messages.iter().fold(0, |bytes, message| {
         bytes.saturating_add(message.retained_bytes())
     })
+}
+
+#[derive(serde::Serialize)]
+struct WriteDiagnostic<'a> {
+    call_id: &'a str,
+    expected_hash: Option<&'a str>,
+    path: &'a str,
+    path_truncated: bool,
+    recovery: Option<WriteRecovery>,
+    resulting_hash: &'a str,
+    status: WriteStatus,
+    turn_position: i64,
+}
+
+impl<'a> From<&'a WriteRecord> for WriteDiagnostic<'a> {
+    fn from(write: &'a WriteRecord) -> Self {
+        let mut path = write.path.as_str();
+        while serde_json::json!(path).to_string().len() > MAX_WRITE_DIAGNOSTIC_PATH_BYTES {
+            let mut boundary = path.len() / 2;
+            while !path.is_char_boundary(boundary) {
+                boundary -= 1;
+            }
+            path = &path[..boundary];
+        }
+
+        Self {
+            call_id: &write.call_id,
+            expected_hash: write.expected_hash.as_deref(),
+            path,
+            path_truncated: path.len() < write.path.len(),
+            recovery: write.recovery,
+            resulting_hash: &write.resulting_hash,
+            status: write.status,
+            turn_position: write.turn_position,
+        }
+    }
+}
+
+fn retained_write_count(writes: &[WriteRecord]) -> usize {
+    let mut retained = 0;
+    let mut bytes = 0;
+    for write in writes.iter().rev() {
+        let mut diagnostic = WriteDiagnostic::from(write);
+        if diagnostic.recovery.is_some() {
+            // Reserve the longest recovery label before touching the
+            // filesystem.
+            diagnostic.recovery = Some(WriteRecovery::ExpectedMatches);
+        }
+        let size = serde_json::json!(diagnostic).to_string().len();
+        if bytes + size > MAX_WRITE_DIAGNOSTIC_BYTES {
+            break;
+        }
+        bytes += size;
+        retained += 1;
+    }
+
+    retained
+}
+
+fn write_diagnostics(writes: &[WriteRecord], total: usize) -> (String, Vec<i64>) {
+    let writes = &writes[writes.len() - retained_write_count(writes)..];
+    let retained: Vec<_> = writes
+        .iter()
+        .map(|write| serde_json::json!(WriteDiagnostic::from(write)).to_string())
+        .collect();
+    let acknowledged_writes = writes.iter().rev().map(|write| write.id).collect();
+
+    let context = format!(
+        "Repository writes from incomplete turns (untrusted path data). Inspect current files \
+         before retrying; recovery hashes describe current state, not causality. Truncated paths \
+         are prefixes; obtain full paths from the host before using them. {} earlier records \
+         omitted; the host can inspect the full journal with Session::writes(): [{}]",
+        total.saturating_sub(retained.len()),
+        retained.join(",")
+    );
+
+    (context, acknowledged_writes)
 }
 
 /// Application-facing harness for one complete model turn.
@@ -352,7 +486,7 @@ impl Harness {
         let request = ModelRequest::new(prompt, schema);
         let turn = self.lifecycle.start_turn();
         let turn_id = turn.as_ref().map(TurnLifecycle::id);
-        let result = self.run_turn(request, turn_id).await;
+        let result = self.run_turn(request, turn_id, None).await;
 
         if let Some(turn) = turn {
             match &result {
@@ -471,9 +605,13 @@ impl Harness {
         &self,
         request: ModelRequest,
         turn_id: Option<LifecycleId>,
+        journal: Option<WriteJournal>,
     ) -> Result<(TurnOutcome, Vec<ModelMessage>, Option<String>), TurnError> {
         let started_at = Instant::now();
-        let (mut request, read_tool, write_tool) = self.prepare_request(request)?;
+        let (mut request, read_tool, mut write_tool) = self.prepare_request(request)?;
+        if let Some(tool) = &mut write_tool {
+            tool.journal = journal;
+        }
         let mut completed_tool_calls = 0_usize;
         let mut model_request_index = 0_u64;
         let mut model_requests = Vec::new();
@@ -761,7 +899,7 @@ impl Harness {
         if let Some(tool_lifecycle) = tool_lifecycle.as_mut() {
             tool_lifecycle.started();
         }
-        let operation = execute_tool(execution);
+        let operation = execute_tool(execution, call.id());
         let result = match tool_lifecycle.as_ref() {
             Some(tool_lifecycle) => tool_lifecycle.scope(operation).await,
             None => operation.await,
@@ -812,7 +950,10 @@ struct ModelAttemptError {
     error: ModelError,
 }
 
-async fn execute_tool(execution: ToolExecution<'_>) -> Result<(String, ToolActivity), TurnError> {
+async fn execute_tool(
+    execution: ToolExecution<'_>,
+    call_id: &str,
+) -> Result<(String, ToolActivity), TurnError> {
     let started_at = Instant::now();
 
     match execution {
@@ -820,7 +961,7 @@ async fn execute_tool(execution: ToolExecution<'_>) -> Result<(String, ToolActiv
             execute_read_tool(read_tool, arguments, started_at).await
         }
         ToolExecution::Write(write_tool, arguments) => {
-            execute_write_tool(write_tool, arguments, started_at).await
+            execute_write_tool(write_tool, arguments, started_at, call_id).await
         }
     }
 }
@@ -954,8 +1095,9 @@ async fn execute_write_tool(
     write_tool: &WriteTool,
     arguments: &WriteArguments,
     started_at: Instant,
+    call_id: &str,
 ) -> Result<(String, ToolActivity), TurnError> {
-    match write_tool.execute(arguments).await {
+    match write_tool.execute(arguments, call_id).await {
         Ok(output) => {
             let activity = ToolActivity::Write {
                 bytes_written: output.bytes_written(),

--- a/crates/ag-harness/src/harness_test.rs
+++ b/crates/ag-harness/src/harness_test.rs
@@ -4,6 +4,8 @@ mod cancellation;
 mod policy;
 #[path = "harness_test/read_test.rs"]
 mod read;
+#[path = "harness_test/recovery_test.rs"]
+mod recovery;
 #[path = "harness_test/session_test.rs"]
 mod session;
 #[path = "harness_test/support_test.rs"]

--- a/crates/ag-harness/src/harness_test/cancellation_test.rs
+++ b/crates/ag-harness/src/harness_test/cancellation_test.rs
@@ -443,3 +443,118 @@ async fn different_sessions_run_concurrently() {
     assert!(first_result.is_ok());
     assert!(second_result.is_ok());
 }
+
+#[tokio::test]
+async fn expired_turn_recovery_clears_continuation_without_blocking_acquisition() {
+    // Arrange
+    for recover_before_acquisition in [false, true] {
+        let mut model = model();
+        model.expect_complete().returning(|request| {
+            if request.prompt() == "retry" {
+                assert!(request.provider_session_id().is_none());
+            }
+
+            Ok(
+                response_without_metadata(ModelResponse::Output(json!({"summary": "done"})))
+                    .with_provider_session_id("new-session"),
+            )
+        });
+        let directory = tempdir().expect("directory");
+        let harness = Harness::new(model).database(directory.path().join("harness.db"));
+        let mut session = harness
+            .session("session-a", object_schema())
+            .create()
+            .await
+            .expect("session");
+        session.send("first").await.expect("establish continuation");
+        let mut old = session
+            .database
+            .begin_turn("session-a", "abandoned")
+            .await
+            .expect("abandoned turn");
+        sqlx::query("UPDATE session_turn SET lease_expires_at = 0 WHERE status = 'running'")
+            .execute(session.database.pool())
+            .await
+            .expect("expire lease");
+
+        // Act
+        if recover_before_acquisition {
+            session.writes().await.expect("explicit recovery");
+        }
+        tokio::time::timeout(Duration::from_secs(5), session.send("retry"))
+            .await
+            .expect("acquisition must converge")
+            .expect("recovery turn");
+        // Simulate delayed cleanup after a replacement turn has committed.
+        old.guard.mark_interrupted();
+        drop(old);
+        let replacement = session
+            .database
+            .begin_turn("session-a", "next")
+            .await
+            .expect("next turn");
+        let continuation = replacement.provider_session_id;
+
+        // Assert
+        assert_eq!(continuation.as_deref(), Some("new-session"));
+        let states: Vec<String> =
+            sqlx::query_scalar("SELECT status FROM session_turn ORDER BY turn_position")
+                .fetch_all(session.database.pool())
+                .await
+                .expect("states");
+        assert_eq!(states, ["completed", "interrupted", "completed", "running"]);
+    }
+}
+
+#[tokio::test]
+async fn interruption_rolls_back_when_continuation_cannot_be_cleared() {
+    // Arrange
+    let database = Database::open_in_memory().await.expect("database");
+    database
+        .create_session(&NewSession::new("session-a", object_schema()), None, 4096)
+        .await
+        .expect("session");
+    let mut old = database
+        .begin_turn("session-a", "abandoned")
+        .await
+        .expect("turn");
+    sqlx::query("UPDATE session SET provider_session_id = 'native-session'")
+        .execute(database.pool())
+        .await
+        .expect("continuation");
+    sqlx::query("UPDATE session_turn SET lease_expires_at = 0")
+        .execute(database.pool())
+        .await
+        .expect("expire lease");
+    sqlx::query(
+        "CREATE TRIGGER reject_clear BEFORE UPDATE OF provider_session_id ON session BEGIN SELECT \
+         RAISE(FAIL, 'continuation unavailable'); END",
+    )
+    .execute(database.pool())
+    .await
+    .expect("trigger");
+
+    // Act
+    let result = database.recover_stale_turns("session-a").await;
+    let state: (String, Option<String>) = sqlx::query_as(
+        "SELECT t.status, s.provider_session_id FROM session_turn t JOIN session s ON s.id = \
+         t.session_id",
+    )
+    .fetch_one(database.pool())
+    .await
+    .expect("state");
+    old.guard.disarm();
+
+    // Assert
+    assert!(matches!(
+        result,
+        Err(SessionError::QueryContext {
+            operation: "recover stale persistent session turns",
+            ..
+        })
+    ));
+    assert_eq!(
+        state,
+        ("running".to_string(), Some("native-session".to_string()))
+    );
+}

--- a/crates/ag-harness/src/harness_test/recovery_test.rs
+++ b/crates/ag-harness/src/harness_test/recovery_test.rs
@@ -1,0 +1,505 @@
+use std::io::Cursor;
+use std::num::NonZeroUsize;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use mockall::Sequence;
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+use super::support::{model, object_schema, response_without_metadata, write_call};
+use crate::file_system::MockFileSystem;
+use crate::harness::{
+    Harness, MAX_WRITE_DIAGNOSTIC_BYTES, WriteDiagnostic, retained_bytes, write_diagnostics,
+};
+use crate::model::{ModelError, ModelMessage, ModelResponse};
+use crate::repository::Repository;
+use crate::session::SessionError;
+use crate::tool::{Tool, WriteArguments};
+use crate::turn::TurnError;
+use crate::write_journal::{WriteRecord, WriteRecordRow};
+
+#[tokio::test]
+async fn session_exposes_applied_writes_after_failure_and_reopen() {
+    // Arrange
+    let mut model = model();
+    let mut sequence = Sequence::new();
+    model
+        .expect_complete()
+        .times(1)
+        .in_sequence(&mut sequence)
+        .returning(|_| {
+            Ok(response_without_metadata(ModelResponse::ToolCall(
+                write_call(
+                    "write-call",
+                    "--- /dev/null\n+++ b/src/lib.rs\n@@ -0,0 +1 @@\n+new\n",
+                ),
+            )))
+        });
+    model
+        .expect_complete()
+        .times(1)
+        .in_sequence(&mut sequence)
+        .returning(|_| Err(ModelError::InvalidResponse));
+    model
+        .expect_complete()
+        .times(1)
+        .in_sequence(&mut sequence)
+        .returning(|request| {
+            assert_eq!(request.messages().len(), 2);
+            assert!(
+                matches!(&request.messages()[0], ModelMessage::System(context)
+            if context.contains("write-call") && context.contains("applied"))
+            );
+            assert!(request.provider_session_id().is_none());
+
+            Ok(response_without_metadata(ModelResponse::Output(
+                json!({"summary": "recovered"}),
+            )))
+        });
+    let directory = tempdir().expect("repository");
+    let harness = Harness::new(model)
+        .database(directory.path().join("harness.db"))
+        .repository(Repository::fixture(directory.path()))
+        .allow(Tool::Write);
+    let mut session = harness
+        .session("session-a", object_schema())
+        .create()
+        .await
+        .expect("session");
+
+    // Act
+    let error = session
+        .send("write and fail")
+        .await
+        .expect_err("model failure");
+    let before = session.writes().await.expect("partial execution");
+    drop(session);
+    let mut reopened = harness.resume("session-a").await.expect("reopen");
+    let after = reopened.writes().await.expect("durable execution");
+    let retry = reopened.send("retry").await.expect("retry");
+    let history = reopened
+        .database
+        .load_session("session-a")
+        .await
+        .expect("history");
+
+    // Assert
+    assert!(matches!(
+        error,
+        SessionError::Turn(TurnError::Model(ModelError::InvalidResponse))
+    ));
+    assert_eq!(before, after);
+    assert_eq!(after.len(), 1);
+    assert_eq!(after[0].status, crate::WriteStatus::Applied);
+    assert_eq!(
+        tokio::fs::read(directory.path().join("src/lib.rs"))
+            .await
+            .expect("file"),
+        b"new\n"
+    );
+    assert_eq!(retry.output(), &json!({"summary": "recovered"}));
+    assert_eq!(
+        history.turns,
+        vec![vec![
+            ModelMessage::System(write_diagnostics(&after, after.len()).0),
+            ModelMessage::User("retry".to_string()),
+            ModelMessage::Assistant(r#"{"summary":"recovered"}"#.to_string()),
+        ]]
+    );
+}
+
+#[tokio::test]
+async fn recovery_snapshot_obeys_the_whole_turn_history_budget() {
+    // Arrange
+    for budget in [64, 4096] {
+        let mut model = model();
+        model.expect_complete().once().returning(|_| {
+            Ok(response_without_metadata(ModelResponse::Output(
+                json!({"summary": "done"}),
+            )))
+        });
+        let directory = tempdir().expect("database directory");
+        let harness = Harness::new(model)
+            .database(directory.path().join("harness.db"))
+            .max_history_bytes(NonZeroUsize::new(budget).expect("positive budget"));
+        let mut session = harness
+            .session("budget", object_schema())
+            .create()
+            .await
+            .expect("session");
+        let mut acquired = session
+            .database
+            .begin_turn("budget", "write")
+            .await
+            .expect("turn");
+        let journal = acquired.guard.write_journal();
+        let id = journal
+            .intent("write-call", directory.path(), "file.txt", None, b"new")
+            .await
+            .expect("intent");
+        journal.finish(id, true).await.expect("outcome");
+        session
+            .database
+            .fail_turn(
+                "budget",
+                acquired.turn_position,
+                &TurnError::Model(ModelError::InvalidResponse),
+            )
+            .await
+            .expect("failed turn");
+        acquired.guard.disarm();
+
+        // Act
+        session.send("recover").await.expect("recovery");
+        let in_memory = session.history.messages();
+        let reopened = harness.resume("budget").await.expect("reopen");
+        let persisted = reopened.history.messages();
+        let (_, pending) = WriteRecordRow::load_pending_page(session.database.pool(), "budget")
+            .await
+            .expect("pending count");
+
+        // Assert
+        assert_eq!(in_memory, persisted);
+        assert_eq!(pending, 0);
+        assert!(retained_bytes(&persisted) <= budget);
+        if budget == 64 {
+            assert!(persisted.is_empty(), "snapshot must count toward eviction");
+        } else {
+            assert_eq!(persisted.len(), 3);
+            assert!(matches!(&persisted[0], ModelMessage::System(context)
+                if context.contains("write-call")));
+            assert_eq!(persisted[1], ModelMessage::User("recover".to_string()));
+        }
+    }
+}
+
+#[test]
+fn write_diagnostics_bounds_context_and_keeps_latest_records_in_order() {
+    // Arrange
+    let record = diagnostic_record("file.txt");
+    let mut records = vec![record; 100];
+    for (position, record) in records.iter_mut().enumerate() {
+        record.turn_position = i64::try_from(position).expect("position");
+        record.id = record.turn_position;
+    }
+
+    // Act
+    let (context, acknowledged_writes) = write_diagnostics(&records, records.len());
+
+    // Assert
+    assert!(context.len() < MAX_WRITE_DIAGNOSTIC_BYTES + 512);
+    assert!(!context.contains("repository_root"));
+    assert!(!context.contains("host-user"));
+    assert!(!context.contains("secret-project"));
+    assert!(!acknowledged_writes.contains(&0));
+    assert!(acknowledged_writes.contains(&99));
+    let (_, encoded) = context.split_once(": [").expect("records");
+    let encoded: Vec<Value> =
+        serde_json::from_str(&format!("[{encoded}")).expect("diagnostic JSON");
+    assert_eq!(acknowledged_writes.len(), encoded.len());
+    assert!(!context.contains(r#""turn_position":0"#));
+    let penultimate = context
+        .find(r#""turn_position":98"#)
+        .expect("penultimate write");
+    let last = context.find(r#""turn_position":99"#).expect("latest write");
+    assert!(penultimate < last);
+}
+
+#[test]
+fn write_diagnostics_bounds_escaped_paths_without_splitting_unicode() {
+    for (path, truncated) in [
+        ("\u{1}".repeat(4096), true),
+        (
+            format!("{}é{}", "\u{1}".repeat(2047), "\u{1}".repeat(2047)),
+            true,
+        ),
+        ("a".repeat(4096), false),
+    ] {
+        // Arrange
+        let arguments: WriteArguments =
+            serde_json::from_value(json!({"path": path, "patch": "patch"}))
+                .expect("path must be valid tool input");
+        let mut record = diagnostic_record(arguments.path());
+        record.call_id = "\u{1}".repeat(1024);
+        record.expected_hash = Some("1".repeat(64));
+
+        // Act
+        let diagnostic =
+            serde_json::to_value(WriteDiagnostic::from(&record)).expect("provider diagnostic");
+
+        // Assert
+        assert_eq!(diagnostic["path_truncated"], truncated);
+        assert_eq!(diagnostic["call_id"], record.call_id);
+        assert_eq!(
+            diagnostic["expected_hash"],
+            record.expected_hash.expect("expected fingerprint")
+        );
+        assert_eq!(diagnostic["resulting_hash"], record.resulting_hash);
+        assert!(diagnostic.to_string().len() < MAX_WRITE_DIAGNOSTIC_BYTES);
+        let prefix = diagnostic["path"].as_str().expect("path prefix");
+        assert!(path.starts_with(prefix));
+        assert_ne!(prefix, "");
+        if truncated {
+            assert!(
+                serde_json::to_string(&path).expect("escaped path").len()
+                    > MAX_WRITE_DIAGNOSTIC_BYTES
+            );
+            assert!(prefix.len() < path.len());
+        } else {
+            assert_eq!(prefix, path);
+        }
+    }
+}
+
+#[tokio::test]
+async fn oversized_write_path_is_acknowledged_and_native_continuation_resumes() {
+    // Arrange
+    let mut model = model();
+    let mut sequence = Sequence::new();
+    model
+        .expect_complete()
+        .once()
+        .in_sequence(&mut sequence)
+        .returning(|request| {
+            assert!(request.provider_session_id().is_none());
+            let context = match &request.messages()[0] {
+                ModelMessage::System(context) => Some(context),
+                _ => None,
+            }
+            .expect("recovery diagnostics must be presented");
+            let (_, records) = context.split_once(": [").expect("diagnostic records");
+            let records: Vec<Value> = serde_json::from_str(&format!("[{records}")).expect("JSON");
+            assert_eq!(records.len(), 2);
+            assert_eq!(records[0]["call_id"], "older");
+            assert_eq!(records[1]["call_id"], "newest");
+            assert_eq!(records[1]["path_truncated"], true);
+            assert!(context.contains("Truncated paths are prefixes"));
+
+            Ok(
+                response_without_metadata(ModelResponse::Output(json!({"summary": "recovered"})))
+                    .with_provider_session_id("recovered-session"),
+            )
+        });
+    model
+        .expect_complete()
+        .once()
+        .in_sequence(&mut sequence)
+        .returning(|request| {
+            assert_eq!(request.provider_session_id(), Some("recovered-session"));
+            assert!(
+                matches!(&request.messages()[0], ModelMessage::System(context)
+                    if context.contains("newest") && context.contains("path_truncated"))
+            );
+
+            Ok(response_without_metadata(ModelResponse::Output(
+                json!({"summary": "continued"}),
+            )))
+        });
+    let directory = tempdir().expect("database directory");
+    let harness = Harness::new(model).database(directory.path().join("harness.db"));
+    let mut session = harness
+        .session("session-a", object_schema())
+        .create()
+        .await
+        .expect("session");
+    let mut acquired = session
+        .database
+        .begin_turn("session-a", "write")
+        .await
+        .expect("turn");
+    let journal = acquired.guard.write_journal();
+    let path = "\u{1}".repeat(4096);
+    for (call_id, path) in [("older", "file.txt"), ("newest", path.as_str())] {
+        let id = journal
+            .intent(call_id, directory.path(), path, None, b"new")
+            .await
+            .expect("intent");
+        journal.finish(id, true).await.expect("applied outcome");
+    }
+    session
+        .database
+        .fail_turn(
+            "session-a",
+            acquired.turn_position,
+            &TurnError::Model(ModelError::InvalidResponse),
+        )
+        .await
+        .expect("failed turn");
+    acquired.guard.disarm();
+
+    // Act
+    session.send("recover").await.expect("recovery turn");
+    let pending = WriteRecordRow::load(session.database.pool(), "session-a", true, None)
+        .await
+        .expect("pending diagnostics");
+    let writes = session.writes().await.expect("complete journal");
+    drop(session);
+    let mut reopened = harness.resume("session-a").await.expect("reopen");
+    let outcome = reopened
+        .send("continue")
+        .await
+        .expect("native continuation");
+
+    // Assert
+    assert_eq!(pending, Vec::<WriteRecord>::new());
+    assert_eq!(writes.len(), 2);
+    assert_eq!(writes[1].path, path);
+    assert_eq!(outcome.output(), &json!({"summary": "continued"}));
+}
+
+#[tokio::test]
+async fn diagnostic_backlog_reconciles_only_the_payload_and_advances_after_success() {
+    // Arrange
+    let model = diagnostic_backlog_model();
+    let paths = Arc::new(Mutex::new(Vec::new()));
+    let observed_paths = Arc::clone(&paths);
+    let mut file_system = MockFileSystem::new();
+    file_system
+        .expect_canonicalize()
+        .times(3)
+        .returning(|_| Ok(PathBuf::from("/repo")));
+    file_system
+        .expect_open_beneath()
+        .times(3)
+        .returning(move |_, path| {
+            observed_paths
+                .lock()
+                .expect("read paths")
+                .push(path.to_path_buf());
+
+            Ok(Box::new(Cursor::new(b"new")))
+        });
+    let directory = tempdir().expect("database directory");
+    let harness = Harness::new(model)
+        .database(directory.path().join("harness.db"))
+        .repository(Repository::fixture("repo"))
+        .file_system(file_system);
+    let mut session = harness
+        .session("session-a", object_schema())
+        .create()
+        .await
+        .expect("session");
+    let mut acquired = session
+        .database
+        .begin_turn("session-a", "write")
+        .await
+        .expect("turn");
+    let journal = acquired.guard.write_journal();
+    let mut ids = Vec::new();
+    for index in 0..70 {
+        let id = journal
+            .intent(
+                &format!("{}-{index:03}", "\u{1}".repeat(1020)),
+                Path::new("/repo"),
+                &format!("{}-{index:03}", "\u{1}".repeat(4092)),
+                None,
+                b"new",
+            )
+            .await
+            .expect("intent");
+        if index % 2 == 0 {
+            journal.finish(id, false).await.expect("failed write");
+        }
+        ids.push(id);
+    }
+    session
+        .database
+        .fail_turn(
+            "session-a",
+            acquired.turn_position,
+            &TurnError::Model(ModelError::InvalidResponse),
+        )
+        .await
+        .expect("failed turn");
+    acquired.guard.disarm();
+
+    // Act
+    let failed = session.send("retry").await.expect_err("model failure");
+    let (_, after_failure) =
+        WriteRecordRow::load_pending_page(session.database.pool(), "session-a")
+            .await
+            .expect("pending after failure");
+    session.send("recover").await.expect("recovery");
+    let (pending, after_success) =
+        WriteRecordRow::load_pending_page(session.database.pool(), "session-a")
+            .await
+            .expect("pending after success");
+    session.send("continue recovery").await.expect("next batch");
+    let (_, remaining) = WriteRecordRow::load_pending_page(session.database.pool(), "session-a")
+        .await
+        .expect("remaining writes");
+
+    // Assert
+    assert!(matches!(
+        failed,
+        SessionError::Turn(TurnError::Model(ModelError::InvalidResponse))
+    ));
+    assert_eq!(after_failure, 70);
+    assert_eq!(after_success, 69);
+    assert_eq!(pending.last().expect("newest pending").id, ids[68]);
+    assert_eq!(remaining, 68);
+    let paths = paths.lock().expect("read paths");
+    assert_eq!(paths.len(), 3);
+    assert_eq!(paths[0], paths[1]);
+    assert_ne!(paths[1], paths[2]);
+}
+
+fn diagnostic_backlog_model() -> crate::model::MockModel {
+    let mut model = model();
+    let calls = Arc::new(AtomicUsize::new(0));
+    model.expect_complete().times(3).returning(move |request| {
+        let index = calls.fetch_add(1, Ordering::SeqCst);
+        assert!(request.provider_session_id().is_none());
+        let context = request
+            .messages()
+            .iter()
+            .rev()
+            .find_map(|message| match message {
+                ModelMessage::System(context) => Some(context),
+                _ => None,
+            })
+            .expect("write diagnostics");
+        let (_, encoded) = context.split_once(": [").expect("records");
+        let records: Vec<Value> = serde_json::from_str(&format!("[{encoded}")).expect("JSON");
+        assert_eq!(records.len(), 1);
+        let expected = if index < 2 { "-069" } else { "-068" };
+        assert!(
+            records[0]["call_id"]
+                .as_str()
+                .expect("call id")
+                .ends_with(expected)
+        );
+        assert_eq!(records[0]["recovery"], "result_matches");
+        assert!(context.contains(if index < 2 {
+            "69 earlier records omitted"
+        } else {
+            "68 earlier records omitted"
+        }));
+        if index == 0 {
+            return Err(ModelError::InvalidResponse);
+        }
+
+        Ok(
+            response_without_metadata(ModelResponse::Output(json!({"summary": "recovered"})))
+                .with_provider_session_id("native-session"),
+        )
+    });
+
+    model
+}
+
+fn diagnostic_record(path: &str) -> WriteRecord {
+    WriteRecord {
+        call_id: "write-call".to_string(),
+        expected_hash: None,
+        id: 0,
+        path: path.to_string(),
+        recovery: None,
+        repository_root: PathBuf::from("/private/host-user/secret-project"),
+        resulting_hash: "0".repeat(64),
+        status: crate::WriteStatus::Applied,
+        turn_position: 0,
+    }
+}

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -21,6 +21,7 @@ mod tool;
 mod trace;
 mod turn;
 mod write;
+mod write_journal;
 
 pub use file_system::{FileSystem, LocalFileSystem};
 pub use harness::{Harness, Session, SessionBuilder};
@@ -50,3 +51,4 @@ pub use tool::{
 pub use trace::LifecycleTraceObserver;
 pub use turn::{ModelRequestActivity, ToolActivity, TurnError, TurnOutcome, TurnReport};
 pub use write::{WriteError, WriteOutput};
+pub use write_journal::{WriteRecord, WriteRecovery, WriteStatus};

--- a/crates/ag-harness/src/session.rs
+++ b/crates/ag-harness/src/session.rs
@@ -18,6 +18,7 @@ use tokio::time::{Instant, MissedTickBehavior};
 
 use crate::model::{ModelMessage, ModelMetadata};
 use crate::tool::{ReadArguments, ToolCall, WriteArguments};
+use crate::write_journal::WriteJournal;
 use crate::{OutputSchema, OutputSchemaError, TurnError};
 
 pub(crate) const TURN_LEASE_SECONDS: i64 = 300;
@@ -412,26 +413,14 @@ WHERE id = ?
                 .await
                 .session_context("recover abandoned persistent session turn")?;
         }
-        let session = sqlx::query_as::<_, (i64, Option<String>)>(
-            "SELECT max_history_bytes, provider_session_id FROM session WHERE id = ?",
-        )
-        .bind(session_id)
-        .fetch_optional(&mut *transaction)
-        .await
-        .session_context(operation)?
-        .ok_or_else(|| SessionError::NotFound {
-            id: session_id.to_string(),
-        })?;
-        let (max_history_bytes, provider_session_id) = session;
-        let max_history_bytes = decode_max_history_bytes(session_id, max_history_bytes)?;
-        let turn_position = next_turn_position(&mut transaction, session_id).await?;
-        let latest_completed_turn = latest_completed_turn(&mut transaction, session_id).await?;
-        if max_history_bytes != acquisition.max_history_bytes
-            || provider_session_id != acquisition.provider_session_id
-            || turn_position != acquisition.turn_position
-            || latest_completed_turn != acquisition.latest_completed_turn
+        if !acquisition
+            .matches_current(&mut transaction, session_id)
+            .await?
         {
+            // Keep recovered ownership and continuation state when retrying
+            // with a refreshed acquisition snapshot.
             transaction.commit().await.session_context(operation)?;
+            self.abandoned_turns.remove(&abandoned_turns);
 
             return Ok(None);
         }
@@ -498,6 +487,8 @@ RETURNING owner_token
         turn_position: i64,
         messages: &[ModelMessage],
         provider_session_id: Option<&str>,
+        acknowledged_writes: &[i64],
+        recovery_context: Option<&str>,
     ) -> Result<(), SessionError> {
         let encoded_messages = messages
             .iter()
@@ -509,6 +500,23 @@ RETURNING owner_token
             .begin()
             .await
             .session_context("complete persistent session turn")?;
+        if let Some(context) = recovery_context {
+            let message = EncodedMessage {
+                kind: "recovery_context",
+                payload: serialize_payload(&context)?,
+                retained_bytes: i64::try_from(context.len()).unwrap_or(i64::MAX),
+            };
+            insert_message(
+                &mut transaction,
+                session_id,
+                turn_position,
+                -1,
+                &message,
+                now,
+                "complete persistent session turn",
+            )
+            .await?;
+        }
         for (index, message) in encoded_messages.iter().enumerate() {
             let message_position = i64::try_from(index).unwrap_or(i64::MAX).saturating_add(1);
             insert_message(
@@ -553,6 +561,21 @@ WHERE id = ?
         .execute(&mut *transaction)
         .await
         .session_context("complete persistent session turn")?;
+        for write_id in acknowledged_writes {
+            sqlx::query!(
+                r"
+UPDATE session_write SET acknowledged_by_turn = ?
+WHERE session_id = ? AND id = ? AND turn_position < ? AND acknowledged_by_turn IS NULL
+",
+                turn_position,
+                session_id,
+                write_id,
+                turn_position
+            )
+            .execute(&mut *transaction)
+            .await
+            .session_context("acknowledge persistent write diagnostics")?;
+        }
         transaction
             .commit()
             .await
@@ -613,7 +636,7 @@ WHERE id = ?
         Ok(())
     }
 
-    async fn recover_stale_turns(&self, session_id: &str) -> Result<(), SessionError> {
+    pub(crate) async fn recover_stale_turns(&self, session_id: &str) -> Result<(), SessionError> {
         let now = self.timestamp_source.now_timestamp_seconds();
         let mut transaction = self
             .pool
@@ -627,6 +650,10 @@ WHERE id = ?
             .session_context("recover stale persistent session turns")?;
 
         Ok(())
+    }
+
+    pub(crate) fn pool(&self) -> &SqlitePool {
+        &self.pool
     }
 
     async fn load_turns(
@@ -717,7 +744,8 @@ pub enum SessionError {
     /// Durable session operations require a configured SQLite database.
     #[error("durable sessions require Harness::database(path)")]
     StorageRequired,
-    /// The model turn failed before it could be persisted.
+    /// The model turn failed; write records remain available through the
+    /// session.
     #[error(transparent)]
     Turn(#[from] TurnError),
     /// A model turn and the attempt to persist its failure both failed.
@@ -754,6 +782,34 @@ struct TurnAcquisition {
     provider_session_id: Option<String>,
     turn_position: i64,
     turns: Vec<Vec<ModelMessage>>,
+}
+
+impl TurnAcquisition {
+    async fn matches_current(
+        &self,
+        transaction: &mut Transaction<'_, sqlx::Sqlite>,
+        session_id: &str,
+    ) -> Result<bool, SessionError> {
+        let session = sqlx::query_as::<_, (i64, Option<String>)>(
+            "SELECT max_history_bytes, provider_session_id FROM session WHERE id = ?",
+        )
+        .bind(session_id)
+        .fetch_optional(&mut **transaction)
+        .await
+        .session_context("reserve persistent session turn")?
+        .ok_or_else(|| SessionError::NotFound {
+            id: session_id.to_string(),
+        })?;
+        let (max_history_bytes, provider_session_id) = session;
+        let max_history_bytes = decode_max_history_bytes(session_id, max_history_bytes)?;
+        let turn_position = next_turn_position(transaction, session_id).await?;
+        let latest_completed_turn = latest_completed_turn(transaction, session_id).await?;
+
+        Ok(max_history_bytes == self.max_history_bytes
+            && provider_session_id == self.provider_session_id
+            && turn_position == self.turn_position
+            && latest_completed_turn == self.latest_completed_turn)
+    }
 }
 
 #[derive(Clone, Eq, Hash, PartialEq)]
@@ -818,6 +874,16 @@ pub(crate) struct TurnGuard {
 }
 
 impl TurnGuard {
+    pub(crate) fn write_journal(&self) -> WriteJournal {
+        WriteJournal {
+            owner_token: self.owner.token.clone(),
+            pool: self.pool.clone(),
+            session_id: self.owner.session_id.clone(),
+            timestamp_source: Arc::clone(&self.timestamp_source),
+            turn_position: self.owner.turn_position,
+        }
+    }
+
     fn new(database: &Database, owner: TurnOwner) -> Self {
         Self {
             armed: true,
@@ -1025,6 +1091,7 @@ impl EncodedMessage {
                 })
             }
             "user" => deserialize_payload(payload).map(ModelMessage::User),
+            "recovery_context" => deserialize_payload(payload).map(ModelMessage::System),
             _ => Err(SessionError::InvalidData {
                 reason: format!("unknown persistent message kind `{kind}`"),
             }),
@@ -1112,7 +1179,7 @@ fn connect_options(path: &Path) -> SqliteConnectOptions {
         .create_if_missing(true)
         .busy_timeout(DB_BUSY_TIMEOUT)
         .journal_mode(SqliteJournalMode::Wal)
-        .synchronous(SqliteSynchronous::Normal)
+        .synchronous(SqliteSynchronous::Full)
         .foreign_keys(true)
 }
 
@@ -1334,19 +1401,11 @@ WHERE session_id = ?
     .execute(&mut **transaction)
     .await
     .session_context("recover stale persistent session turns")?;
+
     if result.rows_affected() > 0 {
-        sqlx::query(
-            r"
-UPDATE session
-SET provider_session_id = NULL, updated_at = ?
-WHERE id = ?
-",
-        )
-        .bind(now)
-        .bind(session_id)
-        .execute(&mut **transaction)
-        .await
-        .session_context("recover stale persistent session turns")?;
+        clear_provider_continuation(transaction, session_id, now)
+            .await
+            .session_context("recover stale persistent session turns")?;
     }
 
     Ok(())
@@ -1401,19 +1460,24 @@ WHERE session_id = ?
     .bind(&owner.token)
     .execute(&mut **transaction)
     .await?;
+
     if result.rows_affected() > 0 {
-        sqlx::query(
-            r"
-UPDATE session
-SET provider_session_id = NULL, updated_at = ?
-WHERE id = ?
-",
-        )
+        clear_provider_continuation(transaction, &owner.session_id, now).await?;
+    }
+
+    Ok(())
+}
+
+async fn clear_provider_continuation(
+    transaction: &mut Transaction<'_, sqlx::Sqlite>,
+    session_id: &str,
+    now: i64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE session SET provider_session_id = NULL, updated_at = ? WHERE id = ?")
         .bind(now)
-        .bind(&owner.session_id)
+        .bind(session_id)
         .execute(&mut **transaction)
         .await?;
-    }
 
     Ok(())
 }

--- a/crates/ag-harness/src/session_test/reservation_test.rs
+++ b/crates/ag-harness/src/session_test/reservation_test.rs
@@ -529,7 +529,7 @@ async fn failing_or_completing_a_turn_that_is_not_running_reports_invalid_data()
 
     // Act
     let error = database
-        .complete_turn("session-a", turn_position, &[], None)
+        .complete_turn("session-a", turn_position, &[], None, &[], None)
         .await
         .expect_err("non-running turn should fail");
     let repeated_failure = database
@@ -716,6 +716,8 @@ async fn delayed_or_unowned_cleanup_preserves_provider_continuation() {
             acquired.turn_position,
             &[],
             Some("replacement-session"),
+            &[],
+            None,
         )
         .await
         .expect("turn should complete");

--- a/crates/ag-harness/src/session_test/storage_test.rs
+++ b/crates/ag-harness/src/session_test/storage_test.rs
@@ -64,7 +64,7 @@ async fn on_disk_database_creates_parent_and_applies_connection_policy() {
     assert!(database_path.exists());
     assert_eq!(journal_mode, "wal");
     assert_eq!(foreign_keys, 1);
-    assert_eq!(synchronous, 1);
+    assert_eq!(synchronous, 2);
 }
 
 #[tokio::test]

--- a/crates/ag-harness/src/session_test/support_test.rs
+++ b/crates/ag-harness/src/session_test/support_test.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::json;
+use sqlx::SqlSafeStr as _;
 use sqlx::migrate::{Migration, MigrationType, Migrator};
 use sqlx::sqlite::SqlitePoolOptions;
-use sqlx::{SqlSafeStr as _, SqlitePool};
 
 use crate::model::{MockModel, ModelMessage, ModelMetadata};
 use crate::schema_contract::OutputSchema;
@@ -95,6 +95,8 @@ pub(super) async fn complete_native_turn(database: &Database, provider_session_i
             acquired.turn_position,
             &turn("first", "first")[1..],
             Some(provider_session_id),
+            &[],
+            None,
         )
         .await
         .expect("turn should complete");
@@ -271,10 +273,6 @@ impl Database {
             reservation_observer: Arc::new(()),
             timestamp_source,
         })
-    }
-
-    pub(crate) fn pool(&self) -> &SqlitePool {
-        &self.pool
     }
 
     pub(crate) async fn append_turn(

--- a/crates/ag-harness/src/write.rs
+++ b/crates/ag-harness/src/write.rs
@@ -9,6 +9,7 @@ use tokio::io::AsyncReadExt as _;
 use crate::file_system::FileSystem;
 use crate::schema_contract;
 use crate::tool::WriteArguments;
+use crate::write_journal::{WriteJournal, content_hash};
 
 const BYTE_ORDER_MARK: &[u8] = b"\xef\xbb\xbf";
 const MAX_FILE_BYTES: usize = 2 * 1024 * 1024;
@@ -108,12 +109,13 @@ pub enum WriteError {
         /// Bounded explanation of the unsupported operation.
         reason: String,
     },
-    /// Atomically replacing the target failed.
+    /// Replacing the target or recording its durable write intent/outcome
+    /// failed.
     #[error("failed to write target `{path}`: {source}")]
     WriteTarget {
         /// Repository-relative target path.
         path: String,
-        /// Underlying filesystem failure.
+        /// Underlying filesystem or journal persistence failure.
         #[source]
         source: io::Error,
     },
@@ -153,6 +155,7 @@ impl WriteError {
 }
 
 pub(crate) struct WriteTool {
+    pub(crate) journal: Option<WriteJournal>,
     file_system: Arc<dyn FileSystem>,
     repository_root: PathBuf,
 }
@@ -160,6 +163,7 @@ pub(crate) struct WriteTool {
 impl WriteTool {
     pub(crate) fn new(file_system: Arc<dyn FileSystem>, repository_root: PathBuf) -> Self {
         Self {
+            journal: None,
             file_system,
             repository_root,
         }
@@ -168,6 +172,7 @@ impl WriteTool {
     pub(crate) async fn execute(
         &self,
         arguments: &WriteArguments,
+        call_id: &str,
     ) -> Result<WriteOutput, WriteError> {
         let root = self
             .file_system
@@ -191,18 +196,66 @@ impl WriteTool {
             });
         }
         let bytes_written = result.len();
-        self.file_system
+        let intent = match &self.journal {
+            Some(journal) => Some(
+                journal
+                    .intent(
+                        call_id,
+                        &root,
+                        arguments.path(),
+                        current.as_deref(),
+                        &result,
+                    )
+                    .await
+                    .map_err(|source| WriteError::WriteTarget {
+                        path: arguments.path().to_string(),
+                        source: io::Error::other(source),
+                    })?,
+            ),
+            None => None,
+        };
+        let replacement = self
+            .file_system
             .replace_beneath(&root, Path::new(arguments.path()), current, result)
-            .await
-            .map_err(|source| WriteError::WriteTarget {
-                path: arguments.path().to_string(),
-                source,
-            })?;
+            .await;
+        if let (Some(journal), Some(intent)) = (&self.journal, intent) {
+            journal
+                .finish(intent, replacement.is_ok())
+                .await
+                .map_err(|source| WriteError::WriteTarget {
+                    path: arguments.path().to_string(),
+                    source: io::Error::other(source),
+                })?;
+        }
+        replacement.map_err(|source| WriteError::WriteTarget {
+            path: arguments.path().to_string(),
+            source,
+        })?;
 
         Ok(WriteOutput::new(
             arguments.path().to_string(),
             bytes_written,
         ))
+    }
+
+    pub(crate) async fn current_hash(
+        &self,
+        stored_root: &Path,
+        path: &str,
+    ) -> Option<Option<String>> {
+        let root = self
+            .file_system
+            .canonicalize(&self.repository_root)
+            .await
+            .ok()?;
+        if root != stored_root {
+            return None;
+        }
+
+        self.read_current(&root, path)
+            .await
+            .ok()
+            .map(|content| content.as_deref().map(content_hash))
     }
 
     async fn read_current(&self, root: &Path, path: &str) -> Result<Option<Vec<u8>>, WriteError> {

--- a/crates/ag-harness/src/write_journal.rs
+++ b/crates/ag-harness/src/write_journal.rs
@@ -1,0 +1,306 @@
+//! Write-ahead records independent of completed conversation history.
+
+use std::ffi::OsString;
+use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::Serialize;
+use sha2::{Digest as _, Sha256};
+use sqlx::SqlitePool;
+
+use crate::session::{SessionError, TimestampSource};
+use crate::write::WriteTool;
+
+/// A durable repository write intent and its acknowledged outcome.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WriteRecord {
+    /// Provider tool-call identifier; unique only within its model response.
+    pub call_id: String,
+    /// SHA-256 of the expected file, or `None` for a create operation.
+    pub expected_hash: Option<String>,
+    /// Stable identifier of this write intent within its database.
+    pub id: i64,
+    /// Repository-relative target path.
+    pub path: String,
+    /// Current observation for an unacknowledged or failed write.
+    pub recovery: Option<WriteRecovery>,
+    /// Canonical native repository root, serialized as Unix path bytes for
+    /// lossless host-side inspection.
+    #[serde(serialize_with = "serialize_repository_root")]
+    pub repository_root: PathBuf,
+    /// SHA-256 of the intended resulting file.
+    pub resulting_hash: String,
+    /// Whether replacement returned success, failed, or never acknowledged.
+    pub status: WriteStatus,
+    /// Persistent turn position that requested the write.
+    pub turn_position: i64,
+}
+
+impl WriteRecord {
+    pub(crate) async fn reconcile(&mut self, tool: Option<&WriteTool>) {
+        if self.recovery.is_none() {
+            return;
+        }
+        let observation = match tool {
+            Some(tool) => tool.current_hash(&self.repository_root, &self.path).await,
+            None => None,
+        };
+        self.recovery = Some(match observation {
+            Some(Some(hash)) if hash == self.resulting_hash => WriteRecovery::ResultMatches,
+            Some(hash) if hash == self.expected_hash => WriteRecovery::ExpectedMatches,
+            Some(_) => WriteRecovery::Conflict,
+            None => WriteRecovery::Unavailable,
+        });
+    }
+}
+
+/// Acknowledged filesystem outcome, preserved independently of turn success.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WriteStatus {
+    /// Intent is durable, but no filesystem result was recorded.
+    Pending,
+    /// The filesystem acknowledged successful replacement.
+    Applied,
+    /// The filesystem returned an error; inspect recovery before retrying.
+    Failed,
+}
+
+/// Present filesystem state, not proof of which process changed the file.
+///
+/// Observations are recomputed rather than sealed as historical outcomes: a
+/// cancelled filesystem operation can still finish after its future is dropped.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WriteRecovery {
+    /// The target currently has the intended resulting content.
+    ResultMatches,
+    /// The target currently has its expected content or remains absent.
+    ExpectedMatches,
+    /// The target matches neither fingerprint.
+    Conflict,
+    /// The original repository or target cannot be safely inspected.
+    Unavailable,
+}
+
+pub(crate) struct WriteRecordRow {
+    call_id: String,
+    expected_hash: Option<String>,
+    id: i64,
+    path: String,
+    repository_root: Vec<u8>,
+    resulting_hash: String,
+    status: String,
+    turn_position: i64,
+    turn_status: String,
+}
+
+impl WriteRecordRow {
+    pub(crate) async fn load_pending_page(
+        pool: &SqlitePool,
+        session_id: &str,
+    ) -> Result<(Vec<WriteRecord>, usize), SessionError> {
+        let total = sqlx::query_scalar!(
+            r#"
+SELECT COUNT(*) AS "total!"
+FROM session_write w
+JOIN session_turn t USING (session_id, turn_position)
+WHERE w.session_id = ? AND t.status != 'completed' AND w.acknowledged_by_turn IS NULL
+"#,
+            session_id
+        )
+        .fetch_one(pool)
+        .await
+        .map_err(|source| SessionError::QueryContext {
+            operation: "count pending write diagnostics",
+            source,
+        })?;
+        let rows = sqlx::query_as!(
+            WriteRecordRow,
+            r#"
+SELECT w.id AS "id!", w.call_id, w.expected_hash, w.path, w.repository_root, w.resulting_hash,
+       w.status, w.turn_position, t.status AS turn_status
+FROM session_write w
+JOIN session_turn t USING (session_id, turn_position)
+WHERE w.session_id = ? AND t.status != 'completed' AND w.acknowledged_by_turn IS NULL
+ORDER BY w.turn_position DESC, w.id DESC
+LIMIT 64
+"#,
+            session_id
+        )
+        .fetch_all(pool)
+        .await
+        .map_err(|source| SessionError::QueryContext {
+            operation: "load pending write diagnostics",
+            source,
+        })?;
+        let mut records = Vec::with_capacity(rows.len());
+        for row in rows.into_iter().rev() {
+            records.push(row.reconcile(None).await?);
+        }
+
+        Ok((records, usize::try_from(total).unwrap_or(usize::MAX)))
+    }
+
+    pub(crate) async fn load(
+        pool: &SqlitePool,
+        session_id: &str,
+        incomplete_only: bool,
+        tool: Option<&WriteTool>,
+    ) -> Result<Vec<WriteRecord>, SessionError> {
+        let rows = sqlx::query_as!(
+            WriteRecordRow,
+            r#"
+SELECT w.id AS "id!", w.call_id, w.expected_hash, w.path, w.repository_root, w.resulting_hash,
+       w.status, w.turn_position, t.status AS turn_status
+FROM session_write w
+JOIN session_turn t USING (session_id, turn_position)
+WHERE w.session_id = ?
+  AND (? = FALSE OR (t.status != 'completed' AND w.acknowledged_by_turn IS NULL))
+ORDER BY w.turn_position, w.id
+"#,
+            session_id,
+            incomplete_only
+        )
+        .fetch_all(pool)
+        .await
+        .map_err(|source| SessionError::QueryContext {
+            operation: "load persistent writes",
+            source,
+        })?;
+        let mut records = Vec::with_capacity(rows.len());
+        for row in rows {
+            records.push(row.reconcile(tool).await?);
+        }
+
+        Ok(records)
+    }
+
+    async fn reconcile(self, tool: Option<&WriteTool>) -> Result<WriteRecord, SessionError> {
+        let repository_root = PathBuf::from(OsString::from_vec(self.repository_root));
+        let status = match self.status.as_str() {
+            "pending" => WriteStatus::Pending,
+            "applied" => WriteStatus::Applied,
+            "failed" => WriteStatus::Failed,
+            _ => {
+                return Err(SessionError::InvalidData {
+                    reason: "invalid persistent write status".to_string(),
+                });
+            }
+        };
+        let recovery = if status == WriteStatus::Applied
+            || matches!(self.turn_status.as_str(), "pending" | "running")
+        {
+            None
+        } else {
+            Some(WriteRecovery::Unavailable)
+        };
+
+        let mut record = WriteRecord {
+            call_id: self.call_id,
+            expected_hash: self.expected_hash,
+            id: self.id,
+            path: self.path,
+            recovery,
+            repository_root,
+            resulting_hash: self.resulting_hash,
+            status,
+            turn_position: self.turn_position,
+        };
+        record.reconcile(tool).await;
+
+        Ok(record)
+    }
+}
+
+pub(crate) struct WriteJournal {
+    pub(crate) owner_token: Vec<u8>,
+    pub(crate) pool: SqlitePool,
+    pub(crate) session_id: String,
+    pub(crate) timestamp_source: Arc<dyn TimestampSource>,
+    pub(crate) turn_position: i64,
+}
+
+impl WriteJournal {
+    pub(crate) async fn intent(
+        &self,
+        call_id: &str,
+        root: &Path,
+        path: &str,
+        expected: Option<&[u8]>,
+        resulting: &[u8],
+    ) -> Result<i64, SessionError> {
+        let root = root.as_os_str().as_bytes();
+        let expected_hash = expected.map(content_hash);
+        let resulting_hash = content_hash(resulting);
+        let now = self.timestamp_source.now_timestamp_seconds();
+        let row = sqlx::query!(
+            r#"
+INSERT INTO session_write (
+    session_id, turn_position, call_id, repository_root, path,
+    expected_hash, resulting_hash, status
+)
+SELECT session_id, turn_position, ?, ?, ?, ?, ?, 'pending'
+FROM session_turn
+WHERE session_id = ? AND turn_position = ? AND owner_token = ?
+  AND status = 'running' AND lease_expires_at > ?
+RETURNING id AS "id!"
+"#,
+            call_id,
+            root,
+            path,
+            expected_hash,
+            resulting_hash,
+            self.session_id,
+            self.turn_position,
+            self.owner_token,
+            now
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|source| SessionError::QueryContext {
+            operation: "persist write intent",
+            source,
+        })?
+        .ok_or_else(|| SessionError::OwnershipLost {
+            id: self.session_id.clone(),
+            turn_position: self.turn_position,
+        })?;
+
+        Ok(row.id)
+    }
+
+    pub(crate) async fn finish(&self, id: i64, applied: bool) -> Result<(), SessionError> {
+        let status = if applied { "applied" } else { "failed" };
+        sqlx::query!(
+            "UPDATE session_write SET status = ? WHERE id = ? AND session_id = ?",
+            status,
+            id,
+            self.session_id
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|source| SessionError::QueryContext {
+            operation: "persist write outcome",
+            source,
+        })?;
+
+        Ok(())
+    }
+}
+
+pub(crate) fn content_hash(content: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(content))
+}
+
+fn serialize_repository_root<S: serde::Serializer>(
+    root: &Path,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_bytes(root.as_os_str().as_bytes())
+}
+
+#[cfg(test)]
+#[path = "write_journal_test.rs"]
+mod tests;

--- a/crates/ag-harness/src/write_journal_test.rs
+++ b/crates/ag-harness/src/write_journal_test.rs
@@ -1,0 +1,556 @@
+use std::io;
+
+use serde_json::json;
+use tempfile::tempdir;
+
+use super::*;
+use crate::file_system::{LocalFileSystem, MockFileSystem};
+use crate::session::{Database, NewSession, TurnGuard};
+use crate::tool::WriteArguments;
+use crate::{ModelError, OutputSchema, TurnError, WriteError};
+
+async fn fixture() -> (Database, TurnGuard) {
+    let database = Database::open_in_memory().await.expect("database");
+    let schema = OutputSchema::new(json!({"type": "object"})).expect("schema");
+    database
+        .create_session(&NewSession::new("session", schema), None, 4096)
+        .await
+        .expect("session");
+    let acquired = database.begin_turn("session", "write").await.expect("turn");
+
+    (database, acquired.guard)
+}
+
+async fn fail(database: &Database, guard: &mut TurnGuard) {
+    database
+        .fail_turn("session", 0, &TurnError::Model(ModelError::InvalidResponse))
+        .await
+        .expect("fail turn");
+    guard.disarm();
+}
+
+#[tokio::test]
+async fn diagnostic_pages_count_omitted_records_and_exclude_acknowledged_and_completed_writes() {
+    // Arrange
+    let (database, mut guard) = fixture().await;
+    let journal = guard.write_journal();
+    let mut ids = Vec::new();
+    for index in 0..70 {
+        ids.push(
+            journal
+                .intent(
+                    &format!("call-{index}"),
+                    Path::new("repo"),
+                    "file.txt",
+                    None,
+                    b"new",
+                )
+                .await
+                .expect("intent"),
+        );
+    }
+    fail(&database, &mut guard).await;
+
+    // Act
+    let (page, total) = WriteRecordRow::load_pending_page(database.pool(), "session")
+        .await
+        .expect("page");
+    let mut completed = database
+        .begin_turn("session", "recover")
+        .await
+        .expect("recovery");
+    completed
+        .guard
+        .write_journal()
+        .intent("completed", Path::new("repo"), "file.txt", None, b"new")
+        .await
+        .expect("completed turn intent");
+    database
+        .complete_turn(
+            "session",
+            completed.turn_position,
+            &[],
+            None,
+            &[ids[69]],
+            None,
+        )
+        .await
+        .expect("complete recovery");
+    completed.guard.disarm();
+    let (next, remaining) = WriteRecordRow::load_pending_page(database.pool(), "session")
+        .await
+        .expect("next page");
+
+    // Assert
+    assert_eq!(total, 70);
+    assert_eq!(page.len(), 64);
+    assert_eq!(page[0].id, ids[6]);
+    assert_eq!(page[63].id, ids[69]);
+    assert_eq!(page[63].recovery, Some(WriteRecovery::Unavailable));
+    assert_eq!(remaining, 69);
+    assert_eq!(next.len(), 64);
+    assert_eq!(next[0].id, ids[5]);
+    assert_eq!(next[63].id, ids[68]);
+}
+
+#[tokio::test]
+async fn diagnostic_pages_report_count_and_loading_failures() {
+    // Arrange
+    let (database, mut guard) = fixture().await;
+    fail(&database, &mut guard).await;
+    sqlx::query("ALTER TABLE session_write RENAME COLUMN path TO unavailable_path")
+        .execute(database.pool())
+        .await
+        .expect("break row loading");
+
+    // Act
+    let load_error = WriteRecordRow::load_pending_page(database.pool(), "session")
+        .await
+        .expect_err("loading error");
+    sqlx::query("DROP TABLE session_write")
+        .execute(database.pool())
+        .await
+        .expect("break counting");
+    let count_error = WriteRecordRow::load_pending_page(database.pool(), "session")
+        .await
+        .expect_err("count error");
+
+    // Assert
+    assert!(matches!(
+        load_error,
+        SessionError::QueryContext {
+            operation: "load pending write diagnostics",
+            ..
+        }
+    ));
+    assert!(matches!(
+        count_error,
+        SessionError::QueryContext {
+            operation: "count pending write diagnostics",
+            ..
+        }
+    ));
+}
+
+fn arguments() -> WriteArguments {
+    serde_json::from_value(json!({"path": "file.txt", "patch": "--- /dev/null\n+++ b/file.txt\n@@ -0,0 +1 @@\n+new\n"}))
+        .expect("write arguments")
+}
+
+#[tokio::test]
+async fn pending_writes_are_reconciled_without_reapplying_or_sealing_observations() {
+    // Arrange
+    let (database, mut guard) = fixture().await;
+    let directory = tempdir().expect("repository");
+    let root = directory.path().canonicalize().expect("root");
+    let tool = WriteTool::new(Arc::new(LocalFileSystem), root.clone());
+    let journal = guard.write_journal();
+    journal
+        .intent("create", &root, "file.txt", None, b"new\n")
+        .await
+        .expect("intent");
+
+    // Act and Assert
+    let active = WriteRecordRow::load(database.pool(), "session", true, Some(&tool))
+        .await
+        .expect("records");
+    assert_eq!(active[0].recovery, None);
+    fail(&database, &mut guard).await;
+    for (content, recovery) in [
+        (None, WriteRecovery::ExpectedMatches),
+        (Some(b"new\n".as_slice()), WriteRecovery::ResultMatches),
+        (Some(b"other\n".as_slice()), WriteRecovery::Conflict),
+    ] {
+        if let Some(content) = content {
+            tokio::fs::write(root.join("file.txt"), content)
+                .await
+                .expect("change target");
+        }
+        let records = WriteRecordRow::load(database.pool(), "session", true, Some(&tool))
+            .await
+            .expect("records");
+        assert_eq!(records[0].status, WriteStatus::Pending);
+        assert_eq!(records[0].recovery, Some(recovery));
+    }
+    let records = WriteRecordRow::load(database.pool(), "session", true, None)
+        .await
+        .expect("records");
+    assert_eq!(records[0].recovery, Some(WriteRecovery::Unavailable));
+    let other = tempdir().expect("other repository");
+    let other_tool = WriteTool::new(Arc::new(LocalFileSystem), other.path().to_path_buf());
+    let records = WriteRecordRow::load(database.pool(), "session", true, Some(&other_tool))
+        .await
+        .expect("records");
+    assert_eq!(records[0].recovery, Some(WriteRecovery::Unavailable));
+}
+
+#[tokio::test]
+async fn applied_and_failed_outcomes_survive_failed_turns() {
+    // Arrange
+    let (database, mut guard) = fixture().await;
+    let directory = tempdir().expect("repository");
+    let root = directory.path().canonicalize().expect("root");
+    let mut tool = WriteTool::new(Arc::new(LocalFileSystem), root.clone());
+    tool.journal = Some(guard.write_journal());
+
+    // Act
+    tool.execute(&arguments(), "create").await.expect("write");
+    let mut file_system = MockFileSystem::new();
+    let canonical_root = root.clone();
+    file_system
+        .expect_canonicalize()
+        .returning(move |_| Ok(canonical_root.clone()));
+    file_system
+        .expect_open_beneath()
+        .returning(|_, _| Err(io::ErrorKind::NotFound.into()));
+    file_system
+        .expect_replace_beneath()
+        .returning(|_, _, _, _| Err(io::Error::other("replacement failed")));
+    let mut failing_tool = WriteTool::new(Arc::new(file_system), root.clone());
+    failing_tool.journal = Some(guard.write_journal());
+    let error = failing_tool
+        .execute(&arguments(), "failed")
+        .await
+        .expect_err("filesystem failure");
+    fail(&database, &mut guard).await;
+    let records = WriteRecordRow::load(database.pool(), "session", true, Some(&tool))
+        .await
+        .expect("records");
+
+    // Assert
+    assert!(matches!(error, WriteError::WriteTarget { .. }));
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].status, WriteStatus::Applied);
+    assert_eq!(records[0].recovery, None);
+    assert_eq!(records[1].status, WriteStatus::Failed);
+    assert_eq!(records[1].recovery, Some(WriteRecovery::ResultMatches));
+    assert_eq!(
+        content_hash(b""),
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+}
+
+#[tokio::test]
+async fn intent_failure_prevents_mutation_and_outcome_failure_keeps_recoverable_intent() {
+    for phase in ["INSERT", "UPDATE"] {
+        // Arrange
+        let (database, mut guard) = fixture().await;
+        let directory = tempdir().expect("repository");
+        let root = directory.path().canonicalize().expect("root");
+        let mut tool = WriteTool::new(Arc::new(LocalFileSystem), root.clone());
+        tool.journal = Some(guard.write_journal());
+        let trigger = if phase == "INSERT" {
+            "CREATE TRIGGER fail_journal BEFORE INSERT ON session_write BEGIN SELECT RAISE(FAIL, \
+             'journal unavailable'); END"
+        } else {
+            "CREATE TRIGGER fail_journal BEFORE UPDATE ON session_write BEGIN SELECT RAISE(FAIL, \
+             'journal unavailable'); END"
+        };
+        sqlx::query(trigger)
+            .execute(database.pool())
+            .await
+            .expect("trigger");
+
+        // Act
+        let error = tool
+            .execute(&arguments(), "create")
+            .await
+            .expect_err("journal failure");
+        fail(&database, &mut guard).await;
+        let records = WriteRecordRow::load(database.pool(), "session", true, Some(&tool))
+            .await
+            .expect("records");
+
+        // Assert
+        assert!(!error.is_model_correctable());
+        let persistence = match &error {
+            WriteError::WriteTarget { path, source } => {
+                assert_eq!(path, "file.txt");
+                assert_eq!(source.kind(), io::ErrorKind::Other);
+                source
+                    .get_ref()
+                    .and_then(|source| source.downcast_ref::<SessionError>())
+            }
+            _ => None,
+        }
+        .expect("journal failure must retain its typed persistence source");
+        assert!(matches!(persistence, SessionError::QueryContext { .. }));
+        if phase == "INSERT" {
+            assert!(!root.join("file.txt").exists());
+            assert_eq!(records, Vec::<WriteRecord>::new());
+        } else {
+            assert_eq!(
+                tokio::fs::read(root.join("file.txt"))
+                    .await
+                    .expect("applied file"),
+                b"new\n"
+            );
+            assert_eq!(records[0].status, WriteStatus::Pending);
+            assert_eq!(records[0].recovery, Some(WriteRecovery::ResultMatches));
+        }
+    }
+}
+
+#[tokio::test]
+async fn journal_checks_ownership_with_native_roots() {
+    // Arrange
+    let (database, mut guard) = fixture().await;
+    let journal = guard.write_journal();
+    let native_root = PathBuf::from(OsString::from_vec(vec![b'/', 0xff]));
+    let mut file_system = MockFileSystem::new();
+    let canonical_root = native_root.clone();
+    file_system
+        .expect_canonicalize()
+        .times(1)
+        .returning(move |_| Ok(canonical_root.clone()));
+    file_system
+        .expect_open_beneath()
+        .times(1)
+        .withf(|root, path| {
+            root.as_os_str().as_bytes() == [47, 255] && path == Path::new("file.txt")
+        })
+        .returning(|_, _| Ok(Box::new(io::Cursor::new(b"new"))));
+    let tool = WriteTool::new(Arc::new(file_system), native_root.clone());
+
+    // Act
+    let id = journal
+        .intent("call", &native_root, "file.txt", None, b"new")
+        .await
+        .expect("native root");
+    fail(&database, &mut guard).await;
+    let lost = journal
+        .intent("call", Path::new("repo"), "file.txt", Some(b"old"), b"new")
+        .await
+        .expect_err("lost ownership");
+    let records = WriteRecordRow::load(database.pool(), "session", false, Some(&tool))
+        .await
+        .expect("native records");
+
+    // Assert
+    assert_eq!(records[0].id, id);
+    assert_eq!(records[0].repository_root, native_root);
+    assert_eq!(records[0].recovery, Some(WriteRecovery::ResultMatches));
+    assert_eq!(
+        serde_json::to_value(&records[0]).expect("lossless serialization")["repository_root"],
+        json!([47, 255])
+    );
+    assert!(matches!(
+        lost,
+        SessionError::OwnershipLost {
+            turn_position: 0,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn recovery_handles_update_fingerprints_unreadable_targets_and_invalid_storage() {
+    // Arrange
+    let (database, mut guard) = fixture().await;
+    let directory = tempdir().expect("repository");
+    let root = directory.path().canonicalize().expect("root");
+    let tool = WriteTool::new(Arc::new(LocalFileSystem), root.clone());
+    let journal = guard.write_journal();
+    journal
+        .intent("update", &root, "file.txt", Some(b"old"), b"new")
+        .await
+        .expect("intent");
+    tokio::fs::write(root.join("file.txt"), b"old")
+        .await
+        .expect("expected file");
+    fail(&database, &mut guard).await;
+
+    // Act and Assert
+    let records = WriteRecordRow::load(database.pool(), "session", true, Some(&tool))
+        .await
+        .expect("records");
+    assert_eq!(records[0].expected_hash, Some(content_hash(b"old")));
+    assert_eq!(records[0].recovery, Some(WriteRecovery::ExpectedMatches));
+    tokio::fs::remove_file(root.join("file.txt"))
+        .await
+        .expect("remove target");
+    tokio::fs::create_dir(root.join("file.txt"))
+        .await
+        .expect("invalid target");
+    let records = WriteRecordRow::load(database.pool(), "session", true, Some(&tool))
+        .await
+        .expect("records");
+    assert_eq!(records[0].recovery, Some(WriteRecovery::Unavailable));
+    let missing = WriteTool::new(Arc::new(LocalFileSystem), root.join("missing"));
+    assert_eq!(missing.current_hash(&root, "file.txt").await, None);
+    sqlx::query("PRAGMA ignore_check_constraints = ON")
+        .execute(database.pool())
+        .await
+        .expect("disable check for corruption test");
+    sqlx::query("UPDATE session_write SET status = 'invalid'")
+        .execute(database.pool())
+        .await
+        .expect("corrupt status");
+    assert!(matches!(
+        WriteRecordRow::load(database.pool(), "session", false, None).await,
+        Err(SessionError::InvalidData { .. })
+    ));
+    sqlx::query("DROP TABLE session_write")
+        .execute(database.pool())
+        .await
+        .expect("remove storage");
+    assert!(matches!(
+        WriteRecordRow::load(database.pool(), "session", false, None).await,
+        Err(SessionError::QueryContext { .. })
+    ));
+}
+
+#[tokio::test]
+async fn diagnostic_acknowledgement_is_atomic_and_scoped_to_presented_records() {
+    // Arrange
+    let (database, mut guard) = fixture().await;
+    let journal = guard.write_journal();
+    let shown = journal
+        .intent("shown", Path::new("/repo"), "one.txt", None, b"one")
+        .await
+        .expect("shown intent");
+    let omitted = journal
+        .intent("omitted", Path::new("/repo"), "two.txt", None, b"two")
+        .await
+        .expect("omitted intent");
+    fail(&database, &mut guard).await;
+    let mut retry = database
+        .begin_turn("session", "retry")
+        .await
+        .expect("retry");
+    sqlx::query(
+        "CREATE TRIGGER reject_ack BEFORE UPDATE OF acknowledged_by_turn ON session_write BEGIN \
+         SELECT RAISE(FAIL, 'ack unavailable'); END",
+    )
+    .execute(database.pool())
+    .await
+    .expect("trigger");
+
+    // Act
+    let error = database
+        .complete_turn(
+            "session",
+            retry.turn_position,
+            &[],
+            Some("new-session"),
+            &[shown],
+            Some("recovery snapshot"),
+        )
+        .await
+        .expect_err("acknowledgement failure");
+    let pending = WriteRecordRow::load(database.pool(), "session", true, None)
+        .await
+        .expect("pending diagnostics");
+    let before_commit = database
+        .load_session("session")
+        .await
+        .expect("rolled back session");
+    sqlx::query("DROP TRIGGER reject_ack")
+        .execute(database.pool())
+        .await
+        .expect("remove trigger");
+    database
+        .complete_turn(
+            "session",
+            retry.turn_position,
+            &[],
+            Some("new-session"),
+            &[shown],
+            Some("recovery snapshot"),
+        )
+        .await
+        .expect("atomic completion");
+    retry.guard.disarm();
+    let remaining = WriteRecordRow::load(database.pool(), "session", true, None)
+        .await
+        .expect("unacknowledged records");
+    let all = WriteRecordRow::load(database.pool(), "session", false, None)
+        .await
+        .expect("full journal");
+
+    // Assert
+    assert!(matches!(
+        error,
+        SessionError::QueryContext {
+            operation: "acknowledge persistent write diagnostics",
+            ..
+        }
+    ));
+    assert_eq!(pending.len(), 2);
+    assert_eq!(before_commit.provider_session_id, None);
+    assert_eq!(before_commit.turns, Vec::<Vec<crate::ModelMessage>>::new());
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].id, omitted);
+    assert_eq!(all.len(), 2);
+    let committed = database
+        .load_session("session")
+        .await
+        .expect("committed session");
+    assert_eq!(
+        committed.provider_session_id.as_deref(),
+        Some("new-session")
+    );
+    assert_eq!(
+        committed.turns,
+        vec![vec![
+            crate::ModelMessage::System("recovery snapshot".to_string()),
+            crate::ModelMessage::User("retry".to_string()),
+        ]]
+    );
+}
+
+#[tokio::test]
+async fn root_migration_preserves_existing_records_and_sequence() {
+    // Arrange
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("legacy database");
+    for migration in [
+        include_str!("../migrations/001_create_session.sql"),
+        include_str!("../migrations/002_add_session_turn_lifecycle.sql"),
+        include_str!("../migrations/003_add_session_turn_owner_token.sql"),
+        include_str!("../migrations/004_add_session_write.sql"),
+    ] {
+        sqlx::raw_sql(migration)
+            .execute(&pool)
+            .await
+            .expect("legacy migration");
+    }
+    sqlx::raw_sql(r#"
+INSERT INTO session (id, output_schema, max_history_bytes, created_at, updated_at)
+VALUES ('session', '{"type":"object"}', 4096, 0, 0);
+INSERT INTO session_turn (session_id, turn_position, status, created_at, updated_at)
+VALUES ('session', 0, 'failed', 0, 0);
+INSERT INTO session_write (id, session_id, turn_position, call_id, repository_root, path, resulting_hash, status)
+VALUES (7, 'session', 0, 'call', '/repo/λ', 'file.txt', 'hash', 'applied'),
+   (9, 'session', 0, 'deleted', '/repo/λ', 'file.txt', 'hash', 'pending');
+DELETE FROM session_write WHERE id = 9;
+"#).execute(&pool).await.expect("legacy data");
+
+    // Act
+    sqlx::raw_sql(include_str!(
+        "../migrations/005_update_session_write_diagnostics.sql"
+    ))
+    .execute(&pool)
+    .await
+    .expect("upgrade journal");
+    let records = WriteRecordRow::load(&pool, "session", true, None)
+        .await
+        .expect("migrated journal");
+    let sequence = sqlx::query_scalar::<_, i64>(
+        "SELECT seq FROM sqlite_sequence WHERE name = 'session_write'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("write sequence");
+
+    // Assert
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].id, 7);
+    assert_eq!(records[0].call_id, "call");
+    assert_eq!(records[0].repository_root, PathBuf::from("/repo/λ"));
+    assert_eq!(records[0].status, WriteStatus::Applied);
+    assert_eq!(sequence, 9);
+}

--- a/crates/ag-harness/src/write_test.rs
+++ b/crates/ag-harness/src/write_test.rs
@@ -393,7 +393,7 @@ async fn write_tool_applies_patch_through_file_system_boundary() {
 
     // Act
     let output = tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect("write should succeed");
 
@@ -430,7 +430,7 @@ async fn write_tool_creates_missing_file() {
 
     // Act
     let output = tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect("missing file should be created");
 
@@ -455,7 +455,7 @@ async fn write_tool_rejects_patch_that_makes_no_change() {
 
     // Act
     let error = tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect_err("no-op patch should fail");
 
@@ -484,7 +484,7 @@ async fn write_tool_returns_typed_replace_failure() {
 
     // Act
     let error = tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect_err("replace failure should be typed");
 
@@ -521,15 +521,15 @@ async fn write_tool_returns_typed_boundary_failures() {
 
     // Act
     let root_error = root_tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect_err("missing root should fail");
     let read_error = read_tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect_err("read boundary failure should fail");
     let content_error = content_tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect_err("content read failure should fail");
 
@@ -558,7 +558,7 @@ async fn write_tool_bounds_target_and_returns_correctable_rejection() {
 
     // Act
     let error = tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect_err("oversized target should fail");
     let result = error
@@ -593,7 +593,7 @@ async fn write_tool_bounds_resulting_file() {
 
     // Act
     let error = tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect_err("oversized result should fail");
 

--- a/crates/ag-harness/tests/public_api.rs
+++ b/crates/ag-harness/tests/public_api.rs
@@ -5,20 +5,49 @@
 mod repository;
 
 use std::error::Error;
+use std::ffi::OsString;
 use std::io::{self, Cursor};
+use std::os::unix::ffi::OsStringExt as _;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use ag_harness::{
     CompletionMetadata, CompletionUsage, FileSystem, Harness, LifecycleEventKind, LifecycleMetrics,
-    LifecycleObserverSet, LifecycleTraceObserver, Model, ModelCompletion, ModelConfiguration,
-    ModelError, ModelMessage, ModelMetadata, ModelProvider, ModelRequest, ModelResponse,
-    ModelResponseType, OutputSchema, OutputSchemaError, Repository, RepositoryError, SessionError,
-    SessionInfo, Tool, ToolCall, TurnError,
+    LifecycleObserverSet, LifecycleTraceObserver, LocalFileSystem, Model, ModelCompletion,
+    ModelConfiguration, ModelError, ModelMessage, ModelMetadata, ModelProvider, ModelRequest,
+    ModelResponse, ModelResponseType, OutputSchema, OutputSchemaError, Repository, RepositoryError,
+    SessionError, SessionInfo, Tool, ToolCall, TurnError, WriteError, WriteRecovery, WriteStatus,
 };
 use async_trait::async_trait;
 use serde_json::json;
 use tokio::io::AsyncRead;
+use tokio::sync::Notify;
+
+#[test]
+fn released_write_error_variants_remain_exhaustively_matchable() {
+    // Arrange
+    let error = WriteError::WriteTarget {
+        path: "file.txt".to_string(),
+        source: io::Error::other("write failure"),
+    };
+
+    // Act
+    let category = match error {
+        WriteError::BinaryTarget { .. } => "binary",
+        WriteError::Encode(_) => "encode",
+        WriteError::NoChange { .. } => "unchanged",
+        WriteError::Patch { .. } => "patch",
+        WriteError::PathMismatch { .. } => "path",
+        WriteError::ReadTarget { .. } => "read",
+        WriteError::RepositoryRoot { .. } => "root",
+        WriteError::TargetTooLarge { .. } => "size",
+        WriteError::Unsupported { .. } => "unsupported",
+        WriteError::WriteTarget { .. } => "write",
+    };
+
+    // Assert
+    assert_eq!(category, "write");
+}
 
 struct ExternalToolModel {
     batched: bool,
@@ -91,6 +120,187 @@ impl Model for ExternalToolModel {
 }
 
 struct NameFileSystem;
+
+struct FailingAfterWriteModel;
+
+#[async_trait]
+impl Model for FailingAfterWriteModel {
+    async fn complete(&self, request: ModelRequest) -> Result<ModelCompletion, ModelError> {
+        match request.messages().last() {
+            Some(ModelMessage::User(prompt)) if prompt == "write" => Ok(
+                ModelCompletion::from_response(ModelResponse::ToolCall(ToolCall::from_json(
+                    "write-name".to_string(),
+                    "write",
+                    &json!({
+                        "path": "name.txt",
+                        "patch": "--- /dev/null\n+++ b/name.txt\n@@ -0,0 +1 @@\n+Ada\n"
+                    })
+                    .to_string(),
+                    None,
+                )?)),
+            ),
+            Some(ModelMessage::User(prompt)) if prompt == "retry" || prompt == "retry-fails" => {
+                assert!(request.provider_session_id().is_none());
+                assert!(
+                    matches!(&request.messages()[0], ModelMessage::System(context)
+                    if context.contains("write-name") && context.contains("applied")
+                        && !context.contains("repository_root") && !context.contains("host-private"))
+                );
+                assert_eq!(request.messages().len(), 2);
+                if prompt == "retry-fails" {
+                    return Err(ModelError::InvalidResponse);
+                }
+
+                Ok(
+                    ModelCompletion::from_response(ModelResponse::Output(json!({"name": "Ada"})))
+                        .with_provider_session_id("recovered-session"),
+                )
+            }
+            Some(ModelMessage::User(prompt)) if prompt == "follow-up" => {
+                assert!(
+                    matches!(&request.messages()[0], ModelMessage::System(context)
+                        if context.contains("write-name") && context.contains("applied")
+                            && !context.contains("repository_root"))
+                );
+                assert_eq!(
+                    request.messages()[1],
+                    ModelMessage::User("retry".to_string())
+                );
+                assert_eq!(
+                    request
+                        .messages()
+                        .iter()
+                        .filter(|message| matches!(message, ModelMessage::System(_)))
+                        .count(),
+                    1
+                );
+                if let Some(id) = request.provider_session_id() {
+                    assert_eq!(id, "recovered-session");
+
+                    return Err(ModelError::ResumeUnavailable);
+                }
+
+                Ok(ModelCompletion::from_response(ModelResponse::Output(
+                    json!({"name": "Ada"}),
+                )))
+            }
+            _ => Err(ModelError::InvalidResponse),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct NativeRootFileSystem {
+    native_root: PathBuf,
+    physical_root: PathBuf,
+}
+
+#[async_trait]
+impl FileSystem for NativeRootFileSystem {
+    async fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        assert_eq!(path, self.physical_root);
+
+        Ok(self.native_root.clone())
+    }
+
+    async fn open_beneath(
+        &self,
+        root: &Path,
+        path: &Path,
+    ) -> io::Result<Box<dyn AsyncRead + Send + Unpin>> {
+        assert_eq!(root, self.native_root);
+
+        LocalFileSystem
+            .open_beneath(&self.physical_root, path)
+            .await
+    }
+
+    async fn replace_beneath(
+        &self,
+        root: &Path,
+        path: &Path,
+        expected: Option<Vec<u8>>,
+        content: Vec<u8>,
+    ) -> io::Result<()> {
+        assert_eq!(root, self.native_root);
+
+        LocalFileSystem
+            .replace_beneath(&self.physical_root, path, expected, content)
+            .await
+    }
+}
+
+#[tokio::test]
+async fn applied_write_survives_model_failure_and_session_reopen() -> Result<(), Box<dyn Error>> {
+    // Arrange
+    let directory = tempfile::tempdir()?;
+    let root = directory.path().canonicalize()?;
+    let native_root = root.join(OsString::from_vec(b"host-private-\xff".to_vec()));
+    let file_system = NativeRootFileSystem {
+        native_root: native_root.clone(),
+        physical_root: root.clone(),
+    };
+    let repository = Repository::new(&root, "/usr/bin/git")?;
+    let harness = Harness::new(FailingAfterWriteModel)
+        .database(directory.path().join("harness.db"))
+        .repository(repository.clone())
+        .file_system(file_system.clone())
+        .allow(Tool::Write);
+    let mut session = harness
+        .session("write-failure", request()?.schema().clone())
+        .create()
+        .await?;
+
+    // Act
+    let error = session
+        .send("write")
+        .await
+        .expect_err("model must fail after writing");
+    let before = session.writes().await?;
+    drop(session);
+    drop(harness);
+    let harness = Harness::new(FailingAfterWriteModel)
+        .database(directory.path().join("harness.db"))
+        .repository(repository)
+        .file_system(file_system)
+        .allow(Tool::Write);
+    let mut reopened = harness.resume("write-failure").await?;
+    let after = reopened.writes().await?;
+    let failed_retry = reopened
+        .send("retry-fails")
+        .await
+        .expect_err("failed diagnostics must remain pending");
+    let retry = reopened.send("retry").await?;
+    drop(reopened);
+    let mut recovered = harness.resume("write-failure").await?;
+    let follow_up = recovered.send("follow-up").await?;
+    let stateless_follow_up = recovered.send("follow-up").await?;
+
+    // Assert
+    assert!(matches!(
+        error,
+        SessionError::Turn(TurnError::Model(ModelError::InvalidResponse))
+    ));
+    assert!(matches!(
+        failed_retry,
+        SessionError::Turn(TurnError::Model(ModelError::InvalidResponse))
+    ));
+    assert_eq!(std::fs::read(root.join("name.txt"))?, b"Ada\n");
+    assert_eq!(before, after);
+    assert_eq!(after.len(), 1);
+    assert_eq!(after[0].status, WriteStatus::Applied);
+    assert_eq!(after[0].repository_root, native_root);
+    assert_eq!(after[0].path, "name.txt");
+    assert_eq!(after[0].call_id, "write-name");
+    assert_eq!(after[0].expected_hash, None);
+    assert_eq!(after[0].resulting_hash.len(), 64);
+    assert_eq!(retry.output(), &json!({"name": "Ada"}));
+    assert_eq!(follow_up.output(), &json!({"name": "Ada"}));
+    assert_eq!(stateless_follow_up.output(), &json!({"name": "Ada"}));
+    assert_eq!(recovered.writes().await?, after);
+
+    Ok(())
+}
 
 #[async_trait]
 impl FileSystem for NameFileSystem {
@@ -625,6 +835,141 @@ async fn external_observer_set_fans_out_lifecycle_events() -> Result<(), Box<dyn
         .expect("second event recorder should not be poisoned");
     assert!(!first_events.is_empty());
     assert_eq!(*first_events, *second_events);
+
+    Ok(())
+}
+
+struct CancellationWriteModel;
+
+#[async_trait]
+impl Model for CancellationWriteModel {
+    async fn complete(&self, request: ModelRequest) -> Result<ModelCompletion, ModelError> {
+        if request.prompt() == "first" {
+            return Ok(ModelCompletion::from_response(ModelResponse::Output(
+                json!({"name": "Ada"}),
+            ))
+            .with_provider_session_id("native-session"));
+        }
+        assert_eq!(request.provider_session_id(), Some("native-session"));
+
+        Ok(ModelCompletion::from_response(ModelResponse::ToolCall(ToolCall::from_json(
+            "late-write".to_string(), "write",
+            &json!({"path": "name.txt", "patch": "--- /dev/null\n+++ b/name.txt\n@@ -0,0 +1 @@\n+Ada\n"}).to_string(), None,
+        )?)))
+    }
+}
+
+struct LateWriteFileSystem {
+    finished: Arc<Notify>,
+    release: Arc<Notify>,
+    started: Arc<Notify>,
+}
+
+#[async_trait]
+impl FileSystem for LateWriteFileSystem {
+    async fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        LocalFileSystem.canonicalize(path).await
+    }
+
+    async fn open_beneath(
+        &self,
+        root: &Path,
+        path: &Path,
+    ) -> io::Result<Box<dyn AsyncRead + Send + Unpin>> {
+        LocalFileSystem.open_beneath(root, path).await
+    }
+
+    async fn replace_beneath(
+        &self,
+        root: &Path,
+        path: &Path,
+        expected: Option<Vec<u8>>,
+        content: Vec<u8>,
+    ) -> io::Result<()> {
+        let root = root.to_path_buf();
+        let path = path.to_path_buf();
+        let release = Arc::clone(&self.release);
+        let started = Arc::clone(&self.started);
+        let finished = Arc::clone(&self.finished);
+        tokio::spawn(async move {
+            started.notify_one();
+            release.notified().await;
+            let result = LocalFileSystem
+                .replace_beneath(&root, &path, expected, content)
+                .await;
+            finished.notify_one();
+
+            result
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+}
+
+#[tokio::test]
+async fn cancellation_returns_before_a_late_write_and_preserves_its_uncertainty()
+-> Result<(), Box<dyn Error>> {
+    // Arrange
+    let directory = tempfile::tempdir()?;
+    let started = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let finished = Arc::new(Notify::new());
+    let harness = Arc::new(
+        Harness::new(CancellationWriteModel)
+            .database(directory.path().join("harness.db"))
+            .repository(Repository::new(directory.path(), "/usr/bin/git")?)
+            .allow(Tool::Write)
+            .file_system(LateWriteFileSystem {
+                finished: Arc::clone(&finished),
+                release: Arc::clone(&release),
+                started: Arc::clone(&started),
+            }),
+    );
+    let mut session = harness
+        .session("cancel-write", request()?.schema().clone())
+        .create()
+        .await?;
+    session.send("first").await?;
+    drop(session);
+    let task_harness = Arc::clone(&harness);
+    let turn = tokio::spawn(async move {
+        task_harness
+            .resume("cancel-write")
+            .await?
+            .send("write")
+            .await
+    });
+    let timeout = std::time::Duration::from_secs(5);
+    tokio::time::timeout(timeout, started.notified()).await?;
+
+    // Act
+    turn.abort();
+    let cancelled = tokio::time::timeout(timeout, turn)
+        .await?
+        .expect_err("cancelled send");
+    let resumed = harness.resume("cancel-write").await?;
+    // Wait for asynchronous turn cleanup before observing recovery hashes.
+    let before = tokio::time::timeout(timeout, async {
+        loop {
+            let writes = resumed.writes().await?;
+            if writes[0].recovery.is_some() {
+                break Ok::<_, SessionError>(writes);
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await??;
+    release.notify_one();
+    tokio::time::timeout(timeout, finished.notified()).await?;
+    let after = resumed.writes().await?;
+
+    // Assert
+    assert!(cancelled.is_cancelled());
+    assert_eq!(before[0].status, WriteStatus::Pending);
+    assert_eq!(before[0].recovery, Some(WriteRecovery::ExpectedMatches));
+    assert_eq!(after[0].status, WriteStatus::Pending);
+    assert_eq!(after[0].recovery, Some(WriteRecovery::ResultMatches));
+    assert_eq!(std::fs::read(directory.path().join("name.txt"))?, b"Ada\n");
 
     Ok(())
 }

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -66,17 +66,56 @@ excluded from replay when the configured byte budget is exceeded.
 Starting a turn loads bounded completed history in a read-only snapshot, then opens a
 short writer transaction. The writer revalidates the snapshot and commits the turn as
 `running` with a fresh lease. If the snapshot changed, acquisition retries before
-persisting the prompt. This keeps cancellation before the commit side-effect free and
-keeps history canonical when multiple session handles were opened before the latest turn
-completed. Each active turn also has an opaque owner token. If cancellation races with a
-successful SQLite commit acknowledgment, cleanup scoped to the canonical database
-identity and owner token interrupts only that abandoned turn before another turn is
-reserved. The owner guard renews the lease while provider or tool work remains active;
-dropping the send future stops renewal and records the turn as interrupted by
-cancellation. A failed renewal or lost owner token cancels the in-flight request before
-it can continue model or tool work. If a turn fails and recording that failure also
-fails, `SessionError` retains both errors instead of replacing the original turn
-failure.
+persisting the prompt. Recovery of an abandoned turn can commit before that retry;
+cancellation before the reservation commit does not persist a new prompt. History stays
+canonical when multiple session handles were opened before the latest turn completed.
+Each active turn also has an opaque owner token. If cancellation races with a successful
+SQLite commit acknowledgment, cleanup scoped to the canonical database identity and
+owner token interrupts only that abandoned turn before another turn is reserved. The
+owner guard renews the lease while provider or tool work remains active; dropping the
+send future stops renewal and records the turn as interrupted by cancellation.
+Interruption atomically clears native provider continuation only when it actually
+transitions an owned or expired active turn; delayed cleanup cannot clear a newer
+completed turn's continuation. Cancellation returns promptly even when an
+already-started filesystem write may finish afterward. Writes without a recorded outcome
+remain `pending`; hash observations describe current content rather than proving whether
+the cancelled operation finished. A failed renewal or lost owner token cancels the
+in-flight request before it can continue model or tool work. If a turn fails and
+recording that failure also fails, `SessionError` retains both errors instead of
+replacing the original turn failure.
+
+Validated writes commit an independent journal intent before filesystem replacement,
+then record its acknowledged outcome before returning to the model. SQLite uses `FULL`
+synchronous commits so the intent is synced before file mutation. Each record retains
+the turn and tool-call identity, original repository root as native bytes, relative
+path, and SHA-256 fingerprints of the expected and intended content; missing expected
+content denotes a create. Journal failures stop execution. These records survive failed
+turns and history eviction without treating partial conversation messages as completed
+history.
+
+`Session::writes()` exposes the journal after errors and reopening. For inactive turns
+whose write outcome is pending or failed, it compares the original repository's current
+file with both fingerprints, reporting a result match, expected match, conflict, or
+unavailable observation. Observations do not prove which process wrote the file and are
+recomputed: a cancelled filesystem operation may finish later. Recovery never reapplies
+writes. Subsequent sends include write diagnostics from incomplete turns and disable
+native continuation for that request so the provider receives this context. A dedicated
+provider-facing representation omits the repository root; `Session::writes()` retains
+the native `PathBuf` for host-side inspection, including non-UTF-8 Unix paths. Retries
+count incomplete records in SQL and fetch at most 64 newest candidates. They select the
+16 KiB diagnostic payload before reconciling files, reserving space for the longest
+recovery label; omitted records cause no filesystem reads. Diagnostics report the total
+number omitted. Oversized JSON-escaped paths are shortened and marked as prefixes; the
+host can inspect their full paths with `Session::writes()`. Completion acknowledges only
+the displayed record IDs in the same transaction as the completed turn, its bounded
+diagnostic snapshot, and its provider continuation identifier. The snapshot precedes the
+turn prompt in local history, preserving recovery context across reopening and provider
+fallback. It counts toward the existing whole-turn history budget and is evicted with
+its turn; it is historical context, not a fresh filesystem observation. Failed turns and
+failed commits leave diagnostics pending, and omitted records remain eligible for later
+sends. Once all diagnostics are acknowledged, subsequent sends retain native
+continuation. `Session::writes()` always exposes the complete journal, including
+acknowledged records.
 
 ## Resume and provider fallback
 

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -38,11 +38,12 @@ For file-level detail, read the module docstrings directly.
   pending, running, completed, failed, and interrupted turns in SQLite, while replaying
   only bounded whole completed turns. `Harness` owns a lazily initialized database pool
   shared by its sessions; `Session::send` owns terminal lifecycle events through durable
-  completion. The `read` tool provides bounded worktree reads, path listing, literal
-  search, host-bound diffs, and base/HEAD file inspection; stale-safe patch writes and
-  file reads use the injectable `FileSystem` boundary. Application binaries own prompts,
-  tool permissions, and telemetry setup; the v0 read tool owns its fixed `main`
-  comparison base.
+  completion. A separate write journal retains intents and outcomes across turn failure
+  and reconciles uncertain writes through `FileSystem`. The `read` tool provides bounded
+  worktree reads, path listing, literal search, host-bound diffs, and base/HEAD file
+  inspection; stale-safe patch writes and file reads use the injectable `FileSystem`
+  boundary. Application binaries own prompts, tool permissions, and telemetry setup; the
+  v0 read tool owns its fixed `main` comparison base.
 - `crates/ag-harness-cli/`: Interactive `ag-harness` command-line application and its
   process-level tests. It derives provider parsing and help from `ag-harness`, then owns
   command-line defaults, application prompts, bounded repository permission selection,


### PR DESCRIPTION
- A durable SHA-256 journal records write intents and filesystem outcomes with native repository roots and tool-call identity before and after replacement.
- `Session::writes()` reconciles incomplete writes without replaying patches, while retries receive bounded, repository-root-free diagnostics and disable provider continuation until displayed records are acknowledged.
- FULL synchronous SQLite commits and migrations preserve journal ordering, recovery state, native paths, and unacknowledged records across reopen.
- Retry diagnostics use safe path prefixes.
- Retries select bounded newest diagnostics before filesystem reads.
- Recovery snapshots preserve journal state across cancellation, history eviction, and failed turns.
- Interruption cleanup preserves journal state.