### PR TITLE
Session writes persist durable intents and outcomes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "sqlx",
  "tempfile",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml_ng = "0.10"
+sha2 = "0.10"
 sqlx = { version = "0.9", default-features = false, features = ["macros", "migrate", "runtime-tokio", "sqlite"] }
 sysinfo = { version = "0.39", default-features = false, features = ["component"] }
 tachyonfx = { version = "0.25.0", default-features = false, features = ["std"] }

--- a/crates/ag-harness/.sqlx/query-3de16657ffc446a31b8e99d9fd4cbe152e63bf63582071e8179072e1f9fb6224.json
+++ b/crates/ag-harness/.sqlx/query-3de16657ffc446a31b8e99d9fd4cbe152e63bf63582071e8179072e1f9fb6224.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\nINSERT INTO session_write (\n    session_id, turn_position, call_id, repository_root, path,\n    expected_hash, resulting_hash, status\n)\nSELECT session_id, turn_position, ?, ?, ?, ?, ?, 'pending'\nFROM session_turn\nWHERE session_id = ? AND turn_position = ? AND owner_token = ?\n  AND status = 'running' AND lease_expires_at > ?\nRETURNING id AS \"id!\"\n",
+  "describe": {
+    "columns": [
+      {
+        "name": "id!",
+        "ordinal": 0,
+        "type_info": "Integer",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "id"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 9
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "3de16657ffc446a31b8e99d9fd4cbe152e63bf63582071e8179072e1f9fb6224"
+}

--- a/crates/ag-harness/.sqlx/query-98bf66b49b25d60ca0858d509c5b9a56040b099c71e22a5e0db02f8b11d8e3fc.json
+++ b/crates/ag-harness/.sqlx/query-98bf66b49b25d60ca0858d509c5b9a56040b099c71e22a5e0db02f8b11d8e3fc.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE session_write SET status = ? WHERE id = ? AND session_id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "98bf66b49b25d60ca0858d509c5b9a56040b099c71e22a5e0db02f8b11d8e3fc"
+}

--- a/crates/ag-harness/.sqlx/query-d79773e92a773602eeb8d971029a4a0ba2e748321584b3874151f04f2c7a8bfe.json
+++ b/crates/ag-harness/.sqlx/query-d79773e92a773602eeb8d971029a4a0ba2e748321584b3874151f04f2c7a8bfe.json
@@ -1,0 +1,110 @@
+{
+  "db_name": "SQLite",
+  "query": "\nSELECT w.id AS \"id!\", w.call_id, w.expected_hash, w.path, w.repository_root, w.resulting_hash,\n       w.status, w.turn_position\nFROM session_write w\nWHERE w.session_id = ?\nORDER BY w.turn_position, w.id\n",
+  "describe": {
+    "columns": [
+      {
+        "name": "id!",
+        "ordinal": 0,
+        "type_info": "Integer",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "name": "call_id",
+        "ordinal": 1,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "call_id"
+          }
+        }
+      },
+      {
+        "name": "expected_hash",
+        "ordinal": 2,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "expected_hash"
+          }
+        }
+      },
+      {
+        "name": "path",
+        "ordinal": 3,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "path"
+          }
+        }
+      },
+      {
+        "name": "repository_root",
+        "ordinal": 4,
+        "type_info": "Blob",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "repository_root"
+          }
+        }
+      },
+      {
+        "name": "resulting_hash",
+        "ordinal": 5,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "resulting_hash"
+          }
+        }
+      },
+      {
+        "name": "status",
+        "ordinal": 6,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "status"
+          }
+        }
+      },
+      {
+        "name": "turn_position",
+        "ordinal": 7,
+        "type_info": "Integer",
+        "origin": {
+          "Table": {
+            "table": "session_write",
+            "name": "turn_position"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d79773e92a773602eeb8d971029a4a0ba2e748321584b3874151f04f2c7a8bfe"
+}

--- a/crates/ag-harness/Cargo.toml
+++ b/crates/ag-harness/Cargo.toml
@@ -41,6 +41,7 @@ reqwest.workspace = true
 rustix.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
+sha2.workspace = true
 sqlx.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true

--- a/crates/ag-harness/README.md
+++ b/crates/ag-harness/README.md
@@ -37,6 +37,14 @@ messages, tool calls, and tool results. Failed and interrupted turns remain visi
 the database but are not replayed. Different sessions can run concurrently; one session
 accepts only one active turn at a time.
 
+Session writes have a separate durable journal. After a failed send or session reopen,
+`session.writes().await?` returns write intents and recorded `pending`, `applied`, or
+`failed` outcomes, including writes from turns evicted from replay history. Records
+include the tool-call identifier, native repository root, relative path, and SHA-256
+fingerprints of expected and intended content. Inspection reads stored outcomes; a
+`pending` or `failed` outcome does not establish the file's current contents. `run_once`
+does not create this journal.
+
 The library does not choose a database location. Configure it once with
 `Harness::database()`. The companion CLI defaults to `~/.ag-harness/db/harness.db`;
 override that with `AG_HARNESS_ROOT` or `--database`.

--- a/crates/ag-harness/migrations/004_add_session_write.sql
+++ b/crates/ag-harness/migrations/004_add_session_write.sql
@@ -1,0 +1,16 @@
+CREATE TABLE session_write (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    turn_position INTEGER NOT NULL,
+    call_id TEXT NOT NULL,
+    repository_root TEXT NOT NULL,
+    path TEXT NOT NULL,
+    expected_hash TEXT,
+    resulting_hash TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'applied', 'failed')),
+    FOREIGN KEY (session_id, turn_position)
+        REFERENCES session_turn(session_id, turn_position) ON DELETE CASCADE
+);
+
+CREATE INDEX session_write_session_turn_idx
+ON session_write (session_id, turn_position, id);

--- a/crates/ag-harness/migrations/005_update_session_write_diagnostics.sql
+++ b/crates/ag-harness/migrations/005_update_session_write_diagnostics.sql
@@ -1,0 +1,11 @@
+ALTER TABLE session_write
+ADD COLUMN repository_root_bytes BLOB NOT NULL DEFAULT X'';
+
+UPDATE session_write
+SET repository_root_bytes = CAST(repository_root AS BLOB)
+WHERE repository_root_bytes = X'';
+
+ALTER TABLE session_write DROP COLUMN repository_root;
+ALTER TABLE session_write RENAME COLUMN repository_root_bytes TO repository_root;
+
+ALTER TABLE session_write ADD COLUMN acknowledged_by_turn INTEGER;

--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -28,6 +28,7 @@ use crate::turn::{
     sanitize_report_text, sanitized_completion_metadata,
 };
 use crate::write::{WriteError, WriteTool};
+use crate::write_journal::{WriteJournal, WriteRecord, WriteRecordRow};
 
 const DEFAULT_MAX_HISTORY_BYTES: usize = 256 * 1024;
 const DEFAULT_MAX_TOOL_CALLS: usize = 8;
@@ -47,6 +48,20 @@ impl Session<'_> {
     /// Returns the stable application-provided session identifier.
     pub fn id(&self) -> &str {
         &self.id
+    }
+
+    /// Returns durable write intents and recorded outcomes, including failed
+    /// turns.
+    ///
+    /// Records survive history eviction and reopening. This reads stored
+    /// outcomes without inspecting or modifying the repository's current
+    /// files.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError`] if journal loading fails.
+    pub async fn writes(&self) -> Result<Vec<WriteRecord>, SessionError> {
+        WriteRecordRow::load(self.database.pool(), &self.id).await
     }
 
     /// Sends one prompt and durably records its lifecycle and messages.
@@ -98,6 +113,7 @@ impl Session<'_> {
         let retained_messages = messages.len();
         let mut request = ModelRequest::with_history(messages, prompt, self.schema.clone());
         request.set_provider_session_id(self.provider_session_id.clone());
+        let journal = guard.write_journal();
         let result = tokio::select! {
             biased;
             error = guard.ownership_failure() => {
@@ -105,7 +121,7 @@ impl Session<'_> {
 
                 return Err(error);
             }
-            result = self.harness.run_turn(request, turn_id) => result,
+            result = self.harness.run_turn(request, turn_id, Some(journal)) => result,
         };
         let (outcome, mut messages, provider_session_id) = match result {
             Ok(result) => result,
@@ -352,7 +368,7 @@ impl Harness {
         let request = ModelRequest::new(prompt, schema);
         let turn = self.lifecycle.start_turn();
         let turn_id = turn.as_ref().map(TurnLifecycle::id);
-        let result = self.run_turn(request, turn_id).await;
+        let result = self.run_turn(request, turn_id, None).await;
 
         if let Some(turn) = turn {
             match &result {
@@ -471,9 +487,10 @@ impl Harness {
         &self,
         request: ModelRequest,
         turn_id: Option<LifecycleId>,
+        journal: Option<WriteJournal>,
     ) -> Result<(TurnOutcome, Vec<ModelMessage>, Option<String>), TurnError> {
         let started_at = Instant::now();
-        let (mut request, read_tool, write_tool) = self.prepare_request(request)?;
+        let (mut request, read_tool, write_tool) = self.prepare_request(request, journal)?;
         let mut completed_tool_calls = 0_usize;
         let mut model_request_index = 0_u64;
         let mut model_requests = Vec::new();
@@ -557,6 +574,7 @@ impl Harness {
     fn prepare_request(
         &self,
         mut request: ModelRequest,
+        journal: Option<WriteJournal>,
     ) -> Result<(ModelRequest, Option<ReadTool>, Option<WriteTool>), TurnError> {
         if self.lifecycle.is_enabled() {
             request.mark_lifecycle_observed();
@@ -585,7 +603,11 @@ impl Harness {
         });
         let write_tool = write_allowed.then(|| {
             request = request.clone().with_tool(ToolDefinition::write());
-            WriteTool::new(self.file_system.clone(), repository.root().to_path_buf())
+            let mut tool =
+                WriteTool::new(self.file_system.clone(), repository.root().to_path_buf());
+            tool.journal = journal;
+
+            tool
         });
 
         Ok((request, read_tool, write_tool))
@@ -761,7 +783,7 @@ impl Harness {
         if let Some(tool_lifecycle) = tool_lifecycle.as_mut() {
             tool_lifecycle.started();
         }
-        let operation = execute_tool(execution);
+        let operation = execute_tool(execution, call.id());
         let result = match tool_lifecycle.as_ref() {
             Some(tool_lifecycle) => tool_lifecycle.scope(operation).await,
             None => operation.await,
@@ -812,7 +834,10 @@ struct ModelAttemptError {
     error: ModelError,
 }
 
-async fn execute_tool(execution: ToolExecution<'_>) -> Result<(String, ToolActivity), TurnError> {
+async fn execute_tool(
+    execution: ToolExecution<'_>,
+    call_id: &str,
+) -> Result<(String, ToolActivity), TurnError> {
     let started_at = Instant::now();
 
     match execution {
@@ -820,7 +845,7 @@ async fn execute_tool(execution: ToolExecution<'_>) -> Result<(String, ToolActiv
             execute_read_tool(read_tool, arguments, started_at).await
         }
         ToolExecution::Write(write_tool, arguments) => {
-            execute_write_tool(write_tool, arguments, started_at).await
+            execute_write_tool(write_tool, arguments, started_at, call_id).await
         }
     }
 }
@@ -954,8 +979,9 @@ async fn execute_write_tool(
     write_tool: &WriteTool,
     arguments: &WriteArguments,
     started_at: Instant,
+    call_id: &str,
 ) -> Result<(String, ToolActivity), TurnError> {
-    match write_tool.execute(arguments).await {
+    match write_tool.execute(arguments, call_id).await {
         Ok(output) => {
             let activity = ToolActivity::Write {
                 bytes_written: output.bytes_written(),

--- a/crates/ag-harness/src/harness_test.rs
+++ b/crates/ag-harness/src/harness_test.rs
@@ -8,3 +8,5 @@ mod read;
 mod session;
 #[path = "harness_test/support_test.rs"]
 mod support;
+#[path = "harness_test/write_journal_test.rs"]
+mod write_journal;

--- a/crates/ag-harness/src/harness_test/read_test.rs
+++ b/crates/ag-harness/src/harness_test/read_test.rs
@@ -55,7 +55,7 @@ fn preserves_request_reasoning_effort_over_harness_default() {
 
     // Act
     let (request, read_tool, write_tool) = harness
-        .prepare_request(request)
+        .prepare_request(request, None)
         .expect("request preparation should succeed");
 
     // Assert

--- a/crates/ag-harness/src/harness_test/write_journal_test.rs
+++ b/crates/ag-harness/src/harness_test/write_journal_test.rs
@@ -1,0 +1,176 @@
+use std::num::NonZeroUsize;
+
+use mockall::Sequence;
+use serde_json::json;
+use tempfile::tempdir;
+
+use super::support::{model, object_schema, response_without_metadata, write_call};
+use crate::harness::Harness;
+use crate::model::{ModelError, ModelMessage, ModelResponse};
+use crate::repository::Repository;
+use crate::session::SessionError;
+use crate::tool::Tool;
+use crate::turn::TurnError;
+use crate::write_journal::WriteStatus;
+
+#[tokio::test]
+async fn session_exposes_writes_after_failed_or_evicted_turns_and_reopen() {
+    for complete in [false, true] {
+        // Arrange
+        let mut model = model();
+        let mut sequence = Sequence::new();
+        model
+            .expect_complete()
+            .once()
+            .in_sequence(&mut sequence)
+            .returning(|_| {
+                Ok(response_without_metadata(ModelResponse::ToolCall(
+                    write_call(
+                        "write-call",
+                        "--- /dev/null\n+++ b/src/lib.rs\n@@ -0,0 +1 @@\n+new\n",
+                    ),
+                )))
+            });
+        model
+            .expect_complete()
+            .once()
+            .in_sequence(&mut sequence)
+            .returning(move |_| {
+                if complete {
+                    Ok(response_without_metadata(ModelResponse::Output(
+                        json!({"summary": "done"}),
+                    )))
+                } else {
+                    Err(ModelError::InvalidResponse)
+                }
+            });
+        let directory = tempdir().expect("repository");
+        let harness = Harness::new(model)
+            .database(directory.path().join("harness.db"))
+            .repository(Repository::fixture(directory.path()))
+            .max_history_bytes(NonZeroUsize::new(1).expect("positive budget"))
+            .allow(Tool::Write);
+        let mut session = harness
+            .session("session-a", object_schema())
+            .create()
+            .await
+            .expect("session");
+
+        // Act
+        let result = session.send("write").await;
+        let before = session.writes().await.expect("write outcome");
+        drop(session);
+        let reopened = harness.resume("session-a").await.expect("reopen");
+        let after = reopened.writes().await.expect("durable outcome");
+        let history = reopened
+            .database
+            .load_session("session-a")
+            .await
+            .expect("history");
+
+        // Assert
+        if complete {
+            assert_eq!(
+                result.expect("completed turn").output(),
+                &json!({"summary": "done"})
+            );
+        } else {
+            assert!(matches!(
+                result,
+                Err(SessionError::Turn(TurnError::Model(
+                    ModelError::InvalidResponse
+                )))
+            ));
+        }
+        assert_eq!(before, after);
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].status, WriteStatus::Applied);
+        assert_eq!(after[0].call_id, "write-call");
+        assert_eq!(
+            tokio::fs::read(directory.path().join("src/lib.rs"))
+                .await
+                .expect("file"),
+            b"new\n"
+        );
+        assert_eq!(history.turns, Vec::<Vec<ModelMessage>>::new());
+        assert_eq!(reopened.history.messages(), Vec::<ModelMessage>::new());
+    }
+}
+
+#[tokio::test]
+async fn session_inspection_reports_storage_failure() {
+    // Arrange
+    let directory = tempdir().expect("database directory");
+    let harness = Harness::new(model()).database(directory.path().join("harness.db"));
+    let session = harness
+        .session("session-a", object_schema())
+        .create()
+        .await
+        .expect("session");
+    sqlx::query("DROP TABLE session_write")
+        .execute(session.database.pool())
+        .await
+        .expect("remove journal");
+
+    // Act
+    let error = session.writes().await.expect_err("storage failure");
+
+    // Assert
+    assert!(matches!(
+        error,
+        SessionError::QueryContext {
+            operation: "load persistent writes",
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn run_once_writes_without_opening_the_session_database() {
+    // Arrange
+    let mut model = model();
+    let mut sequence = Sequence::new();
+    model
+        .expect_complete()
+        .once()
+        .in_sequence(&mut sequence)
+        .returning(|_| {
+            Ok(response_without_metadata(ModelResponse::ToolCall(
+                write_call(
+                    "write-call",
+                    "--- /dev/null\n+++ b/src/lib.rs\n@@ -0,0 +1 @@\n+new\n",
+                ),
+            )))
+        });
+    model
+        .expect_complete()
+        .once()
+        .in_sequence(&mut sequence)
+        .returning(|_| {
+            Ok(response_without_metadata(ModelResponse::Output(
+                json!({"summary": "done"}),
+            )))
+        });
+    let directory = tempdir().expect("repository");
+    let database = directory.path().join("unused.db");
+    let harness = Harness::new(model)
+        .database(&database)
+        .repository(Repository::fixture(directory.path()))
+        .allow(Tool::Write);
+
+    // Act
+    let result = harness
+        .run_once("write", object_schema())
+        .await
+        .expect("stateless write");
+
+    // Assert
+    assert_eq!(result.output(), &json!({"summary": "done"}));
+    assert_eq!(
+        tokio::fs::read(directory.path().join("src/lib.rs"))
+            .await
+            .expect("file"),
+        b"new\n"
+    );
+    assert!(!database.exists());
+}

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -21,6 +21,7 @@ mod tool;
 mod trace;
 mod turn;
 mod write;
+mod write_journal;
 
 pub use file_system::{FileSystem, LocalFileSystem};
 pub use harness::{Harness, Session, SessionBuilder};
@@ -50,3 +51,4 @@ pub use tool::{
 pub use trace::LifecycleTraceObserver;
 pub use turn::{ModelRequestActivity, ToolActivity, TurnError, TurnOutcome, TurnReport};
 pub use write::{WriteError, WriteOutput};
+pub use write_journal::{WriteRecord, WriteStatus};

--- a/crates/ag-harness/src/session.rs
+++ b/crates/ag-harness/src/session.rs
@@ -18,6 +18,7 @@ use tokio::time::{Instant, MissedTickBehavior};
 
 use crate::model::{ModelMessage, ModelMetadata};
 use crate::tool::{ReadArguments, ToolCall, WriteArguments};
+use crate::write_journal::WriteJournal;
 use crate::{OutputSchema, OutputSchemaError, TurnError};
 
 pub(crate) const TURN_LEASE_SECONDS: i64 = 300;
@@ -613,6 +614,10 @@ WHERE id = ?
         Ok(())
     }
 
+    pub(crate) fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
+
     async fn recover_stale_turns(&self, session_id: &str) -> Result<(), SessionError> {
         let now = self.timestamp_source.now_timestamp_seconds();
         let mut transaction = self
@@ -717,7 +722,8 @@ pub enum SessionError {
     /// Durable session operations require a configured SQLite database.
     #[error("durable sessions require Harness::database(path)")]
     StorageRequired,
-    /// The model turn failed before it could be persisted.
+    /// The model turn failed; durable write records remain available through
+    /// [`crate::Session::writes`].
     #[error(transparent)]
     Turn(#[from] TurnError),
     /// A model turn and the attempt to persist its failure both failed.
@@ -818,6 +824,16 @@ pub(crate) struct TurnGuard {
 }
 
 impl TurnGuard {
+    pub(crate) fn write_journal(&self) -> WriteJournal {
+        WriteJournal {
+            owner_token: self.owner.token.clone(),
+            pool: self.pool.clone(),
+            session_id: self.owner.session_id.clone(),
+            timestamp_source: Arc::clone(&self.timestamp_source),
+            turn_position: self.owner.turn_position,
+        }
+    }
+
     fn new(database: &Database, owner: TurnOwner) -> Self {
         Self {
             armed: true,
@@ -1112,7 +1128,7 @@ fn connect_options(path: &Path) -> SqliteConnectOptions {
         .create_if_missing(true)
         .busy_timeout(DB_BUSY_TIMEOUT)
         .journal_mode(SqliteJournalMode::Wal)
-        .synchronous(SqliteSynchronous::Normal)
+        .synchronous(SqliteSynchronous::Full)
         .foreign_keys(true)
 }
 

--- a/crates/ag-harness/src/session_test/storage_test.rs
+++ b/crates/ag-harness/src/session_test/storage_test.rs
@@ -64,7 +64,7 @@ async fn on_disk_database_creates_parent_and_applies_connection_policy() {
     assert!(database_path.exists());
     assert_eq!(journal_mode, "wal");
     assert_eq!(foreign_keys, 1);
-    assert_eq!(synchronous, 1);
+    assert_eq!(synchronous, 2);
 }
 
 #[tokio::test]

--- a/crates/ag-harness/src/session_test/support_test.rs
+++ b/crates/ag-harness/src/session_test/support_test.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::json;
+use sqlx::SqlSafeStr as _;
 use sqlx::migrate::{Migration, MigrationType, Migrator};
 use sqlx::sqlite::SqlitePoolOptions;
-use sqlx::{SqlSafeStr as _, SqlitePool};
 
 use crate::model::{MockModel, ModelMessage, ModelMetadata};
 use crate::schema_contract::OutputSchema;
@@ -271,10 +271,6 @@ impl Database {
             reservation_observer: Arc::new(()),
             timestamp_source,
         })
-    }
-
-    pub(crate) fn pool(&self) -> &SqlitePool {
-        &self.pool
     }
 
     pub(crate) async fn append_turn(

--- a/crates/ag-harness/src/write.rs
+++ b/crates/ag-harness/src/write.rs
@@ -9,6 +9,7 @@ use tokio::io::AsyncReadExt as _;
 use crate::file_system::FileSystem;
 use crate::schema_contract;
 use crate::tool::WriteArguments;
+use crate::write_journal::WriteJournal;
 
 const BYTE_ORDER_MARK: &[u8] = b"\xef\xbb\xbf";
 const MAX_FILE_BYTES: usize = 2 * 1024 * 1024;
@@ -108,12 +109,13 @@ pub enum WriteError {
         /// Bounded explanation of the unsupported operation.
         reason: String,
     },
-    /// Atomically replacing the target failed.
+    /// Replacing the target or recording its durable write intent/outcome
+    /// failed.
     #[error("failed to write target `{path}`: {source}")]
     WriteTarget {
         /// Repository-relative target path.
         path: String,
-        /// Underlying filesystem failure.
+        /// Underlying filesystem or journal persistence failure.
         #[source]
         source: io::Error,
     },
@@ -153,6 +155,7 @@ impl WriteError {
 }
 
 pub(crate) struct WriteTool {
+    pub(crate) journal: Option<WriteJournal>,
     file_system: Arc<dyn FileSystem>,
     repository_root: PathBuf,
 }
@@ -160,6 +163,7 @@ pub(crate) struct WriteTool {
 impl WriteTool {
     pub(crate) fn new(file_system: Arc<dyn FileSystem>, repository_root: PathBuf) -> Self {
         Self {
+            journal: None,
             file_system,
             repository_root,
         }
@@ -168,6 +172,7 @@ impl WriteTool {
     pub(crate) async fn execute(
         &self,
         arguments: &WriteArguments,
+        call_id: &str,
     ) -> Result<WriteOutput, WriteError> {
         let root = self
             .file_system
@@ -191,13 +196,41 @@ impl WriteTool {
             });
         }
         let bytes_written = result.len();
-        self.file_system
+        let intent = match &self.journal {
+            Some(journal) => Some(
+                journal
+                    .intent(
+                        call_id,
+                        &root,
+                        arguments.path(),
+                        current.as_deref(),
+                        &result,
+                    )
+                    .await
+                    .map_err(|source| WriteError::WriteTarget {
+                        path: arguments.path().to_string(),
+                        source: io::Error::other(source),
+                    })?,
+            ),
+            None => None,
+        };
+        let replacement = self
+            .file_system
             .replace_beneath(&root, Path::new(arguments.path()), current, result)
-            .await
-            .map_err(|source| WriteError::WriteTarget {
-                path: arguments.path().to_string(),
-                source,
-            })?;
+            .await;
+        if let (Some(journal), Some(intent)) = (&self.journal, intent) {
+            journal
+                .finish(intent, replacement.is_ok())
+                .await
+                .map_err(|source| WriteError::WriteTarget {
+                    path: arguments.path().to_string(),
+                    source: io::Error::other(source),
+                })?;
+        }
+        replacement.map_err(|source| WriteError::WriteTarget {
+            path: arguments.path().to_string(),
+            source,
+        })?;
 
         Ok(WriteOutput::new(
             arguments.path().to_string(),

--- a/crates/ag-harness/src/write_journal.rs
+++ b/crates/ag-harness/src/write_journal.rs
@@ -1,0 +1,219 @@
+//! Write-ahead records independent of completed conversation history.
+
+use std::ffi::OsString;
+use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::Serialize;
+use sha2::{Digest as _, Sha256};
+use sqlx::SqlitePool;
+
+use crate::session::{SessionError, TimestampSource};
+
+/// A durable repository write intent and its acknowledged outcome.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WriteRecord {
+    /// Provider tool-call identifier; unique only within its model response.
+    pub call_id: String,
+    /// SHA-256 of the expected file, or `None` for a create operation.
+    pub expected_hash: Option<String>,
+    /// Stable identifier of this write intent within its database.
+    pub id: i64,
+    /// Repository-relative target path.
+    pub path: String,
+    /// Canonical native repository root, serialized as Unix path bytes for
+    /// lossless host-side inspection.
+    #[serde(serialize_with = "serialize_repository_root")]
+    pub repository_root: PathBuf,
+    /// SHA-256 of the intended resulting file.
+    pub resulting_hash: String,
+    /// Whether replacement returned success, failed, or never acknowledged.
+    pub status: WriteStatus,
+    /// Persistent turn position that requested the write.
+    pub turn_position: i64,
+}
+
+/// Acknowledged filesystem outcome, preserved independently of turn success.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WriteStatus {
+    /// Intent is durable, but no filesystem result was recorded.
+    Pending,
+    /// The filesystem acknowledged successful replacement.
+    Applied,
+    /// The filesystem returned an error; this does not prove the file is
+    /// unchanged.
+    Failed,
+}
+
+pub(crate) struct WriteRecordRow {
+    call_id: String,
+    expected_hash: Option<String>,
+    id: i64,
+    path: String,
+    repository_root: Vec<u8>,
+    resulting_hash: String,
+    status: String,
+    turn_position: i64,
+}
+
+impl WriteRecordRow {
+    pub(crate) async fn load(
+        pool: &SqlitePool,
+        session_id: &str,
+    ) -> Result<Vec<WriteRecord>, SessionError> {
+        let rows = sqlx::query_as!(
+            WriteRecordRow,
+            r#"
+SELECT w.id AS "id!", w.call_id, w.expected_hash, w.path, w.repository_root, w.resulting_hash,
+       w.status, w.turn_position
+FROM session_write w
+WHERE w.session_id = ?
+ORDER BY w.turn_position, w.id
+"#,
+            session_id
+        )
+        .fetch_all(pool)
+        .await
+        .map_err(|source| SessionError::QueryContext {
+            operation: "load persistent writes",
+            source,
+        })?;
+
+        rows.into_iter().map(Self::into_record).collect()
+    }
+
+    fn into_record(self) -> Result<WriteRecord, SessionError> {
+        let repository_root = PathBuf::from(OsString::from_vec(self.repository_root));
+        let status = match self.status.as_str() {
+            "pending" => WriteStatus::Pending,
+            "applied" => WriteStatus::Applied,
+            "failed" => WriteStatus::Failed,
+            _ => {
+                return Err(SessionError::InvalidData {
+                    reason: "invalid persistent write status".to_string(),
+                });
+            }
+        };
+
+        Ok(WriteRecord {
+            call_id: self.call_id,
+            expected_hash: self.expected_hash,
+            id: self.id,
+            path: self.path,
+            repository_root,
+            resulting_hash: self.resulting_hash,
+            status,
+            turn_position: self.turn_position,
+        })
+    }
+}
+
+pub(crate) struct WriteJournal {
+    pub(crate) owner_token: Vec<u8>,
+    pub(crate) pool: SqlitePool,
+    pub(crate) session_id: String,
+    pub(crate) timestamp_source: Arc<dyn TimestampSource>,
+    pub(crate) turn_position: i64,
+}
+
+impl WriteJournal {
+    pub(crate) async fn intent(
+        &self,
+        call_id: &str,
+        root: &Path,
+        path: &str,
+        expected: Option<&[u8]>,
+        resulting: &[u8],
+    ) -> Result<i64, SessionError> {
+        let root = root.as_os_str().as_bytes();
+        let expected_hash = expected.map(content_hash);
+        let resulting_hash = content_hash(resulting);
+        let mut transaction =
+            self.pool
+                .begin()
+                .await
+                .map_err(|source| SessionError::QueryContext {
+                    operation: "begin write intent",
+                    source,
+                })?;
+        let now = self.timestamp_source.now_timestamp_seconds();
+        let row = sqlx::query!(
+            r#"
+INSERT INTO session_write (
+    session_id, turn_position, call_id, repository_root, path,
+    expected_hash, resulting_hash, status
+)
+SELECT session_id, turn_position, ?, ?, ?, ?, ?, 'pending'
+FROM session_turn
+WHERE session_id = ? AND turn_position = ? AND owner_token = ?
+  AND status = 'running' AND lease_expires_at > ?
+RETURNING id AS "id!"
+"#,
+            call_id,
+            root,
+            path,
+            expected_hash,
+            resulting_hash,
+            self.session_id,
+            self.turn_position,
+            self.owner_token,
+            now
+        )
+        .fetch_optional(&mut *transaction)
+        .await
+        .map_err(|source| SessionError::QueryContext {
+            operation: "persist write intent",
+            source,
+        })?
+        .ok_or_else(|| SessionError::OwnershipLost {
+            id: self.session_id.clone(),
+            turn_position: self.turn_position,
+        })?;
+
+        // `RETURNING` can yield an ID before SQLite reports commit errors.
+        transaction
+            .commit()
+            .await
+            .map_err(|source| SessionError::QueryContext {
+                operation: "commit write intent",
+                source,
+            })?;
+
+        Ok(row.id)
+    }
+
+    pub(crate) async fn finish(&self, id: i64, applied: bool) -> Result<(), SessionError> {
+        let status = if applied { "applied" } else { "failed" };
+        sqlx::query!(
+            "UPDATE session_write SET status = ? WHERE id = ? AND session_id = ?",
+            status,
+            id,
+            self.session_id
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|source| SessionError::QueryContext {
+            operation: "persist write outcome",
+            source,
+        })?;
+
+        Ok(())
+    }
+}
+
+pub(crate) fn content_hash(content: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(content))
+}
+
+fn serialize_repository_root<S: serde::Serializer>(
+    root: &Path,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_bytes(root.as_os_str().as_bytes())
+}
+
+#[cfg(test)]
+#[path = "write_journal_test.rs"]
+mod tests;

--- a/crates/ag-harness/src/write_journal_test.rs
+++ b/crates/ag-harness/src/write_journal_test.rs
@@ -1,0 +1,485 @@
+use std::ffi::OsString;
+use std::io;
+use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use serde_json::json;
+use sqlx::SqlitePool;
+use tempfile::tempdir;
+use tokio::io::AsyncRead;
+
+use crate::file_system::{FileSystem, LocalFileSystem, MockFileSystem};
+use crate::session::{Database, NewSession, SessionError, TurnGuard};
+use crate::tool::WriteArguments;
+use crate::write::WriteTool;
+use crate::write_journal::{WriteRecord, WriteRecordRow, WriteStatus, content_hash};
+use crate::{ModelError, OutputSchema, TurnError, WriteError};
+
+async fn fixture() -> (Database, TurnGuard) {
+    let database = Database::open_in_memory().await.expect("database");
+    let schema = OutputSchema::new(json!({"type": "object"})).expect("schema");
+    database
+        .create_session(&NewSession::new("session", schema), None, 4096)
+        .await
+        .expect("session");
+    let acquired = database.begin_turn("session", "write").await.expect("turn");
+
+    (database, acquired.guard)
+}
+
+async fn fail(database: &Database, guard: &mut TurnGuard) {
+    database
+        .fail_turn("session", 0, &TurnError::Model(ModelError::InvalidResponse))
+        .await
+        .expect("fail turn");
+    guard.disarm();
+}
+
+fn arguments() -> WriteArguments {
+    serde_json::from_value(json!({"path": "file.txt", "patch": "--- /dev/null\n+++ b/file.txt\n@@ -0,0 +1 @@\n+new\n"}))
+        .expect("write arguments")
+}
+
+#[tokio::test]
+async fn applied_and_failed_outcomes_survive_failed_turns() {
+    // Arrange
+    let (database, mut guard) = fixture().await;
+    let directory = tempdir().expect("repository");
+    let root = directory.path().canonicalize().expect("root");
+    let mut tool = WriteTool::new(Arc::new(LocalFileSystem), root.clone());
+    tool.journal = Some(guard.write_journal());
+
+    // Act
+    tool.execute(&arguments(), "create").await.expect("write");
+    let mut file_system = MockFileSystem::new();
+    let canonical_root = root.clone();
+    file_system
+        .expect_canonicalize()
+        .returning(move |_| Ok(canonical_root.clone()));
+    file_system
+        .expect_open_beneath()
+        .returning(|_, _| Err(io::ErrorKind::NotFound.into()));
+    file_system
+        .expect_replace_beneath()
+        .returning(|_, _, _, _| Err(io::Error::other("replacement failed")));
+    let mut failing_tool = WriteTool::new(Arc::new(file_system), root);
+    failing_tool.journal = Some(guard.write_journal());
+    let error = failing_tool
+        .execute(&arguments(), "failed")
+        .await
+        .expect_err("filesystem failure");
+    fail(&database, &mut guard).await;
+    let records = WriteRecordRow::load(database.pool(), "session")
+        .await
+        .expect("records");
+
+    // Assert
+    assert!(matches!(error, WriteError::WriteTarget { .. }));
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].status, WriteStatus::Applied);
+    assert_eq!(records[1].status, WriteStatus::Failed);
+    assert_eq!(
+        content_hash(b""),
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+}
+
+#[tokio::test]
+async fn intent_failure_prevents_mutation_and_outcome_failure_keeps_pending_intent() {
+    for phase in ["INSERT", "UPDATE"] {
+        // Arrange
+        let (database, mut guard) = fixture().await;
+        let directory = tempdir().expect("repository");
+        let root = directory.path().canonicalize().expect("root");
+        let mut tool = WriteTool::new(Arc::new(LocalFileSystem), root.clone());
+        tool.journal = Some(guard.write_journal());
+        let trigger = if phase == "INSERT" {
+            "CREATE TRIGGER fail_journal BEFORE INSERT ON session_write BEGIN SELECT RAISE(FAIL, \
+             'journal unavailable'); END"
+        } else {
+            "CREATE TRIGGER fail_journal BEFORE UPDATE ON session_write BEGIN SELECT RAISE(FAIL, \
+             'journal unavailable'); END"
+        };
+        sqlx::query(trigger)
+            .execute(database.pool())
+            .await
+            .expect("trigger");
+
+        // Act
+        let error = tool
+            .execute(&arguments(), "create")
+            .await
+            .expect_err("journal failure");
+        fail(&database, &mut guard).await;
+        let records = WriteRecordRow::load(database.pool(), "session")
+            .await
+            .expect("records");
+
+        // Assert
+        assert!(!error.is_model_correctable());
+        let persistence = match &error {
+            WriteError::WriteTarget { path, source } => {
+                assert_eq!(path, "file.txt");
+                assert_eq!(source.kind(), io::ErrorKind::Other);
+                source
+                    .get_ref()
+                    .and_then(|source| source.downcast_ref::<SessionError>())
+            }
+            _ => None,
+        }
+        .expect("journal failure must retain its typed persistence source");
+        assert!(matches!(persistence, SessionError::QueryContext { .. }));
+        if phase == "INSERT" {
+            assert!(!root.join("file.txt").exists());
+            assert_eq!(records, Vec::<WriteRecord>::new());
+        } else {
+            assert_eq!(
+                tokio::fs::read(root.join("file.txt"))
+                    .await
+                    .expect("applied file"),
+                b"new\n"
+            );
+            assert_eq!(records[0].status, WriteStatus::Pending);
+        }
+    }
+}
+
+#[tokio::test]
+async fn rejected_intent_commit_prevents_file_mutation() {
+    // Arrange
+    let (database, mut guard) = fixture().await;
+    let directory = tempdir().expect("repository");
+    let root = directory.path().canonicalize().expect("root");
+    let mut tool = WriteTool::new(Arc::new(LocalFileSystem), root.clone());
+    tool.journal = Some(guard.write_journal());
+    let commits = Arc::new(AtomicUsize::new(0));
+    {
+        let commits = Arc::clone(&commits);
+        let mut connection = database.pool().acquire().await.expect("connection");
+        connection
+            .lock_handle()
+            .await
+            .expect("SQLite handle")
+            .set_commit_hook(move || {
+                commits.fetch_add(1, Ordering::SeqCst);
+
+                false
+            });
+    }
+
+    // Act
+    let result = tool.execute(&arguments(), "create").await;
+    let records = WriteRecordRow::load(database.pool(), "session")
+        .await
+        .expect("journal after rejected commit");
+    guard.disarm();
+
+    // Assert
+    assert!(!root.join("file.txt").exists());
+    assert_eq!(commits.load(Ordering::SeqCst), 1);
+    assert_eq!(records, Vec::<WriteRecord>::new());
+    let error = result.expect_err("commit rejection must fail the write");
+    assert!(!error.is_model_correctable());
+    let persistence = match &error {
+        WriteError::WriteTarget { source, .. } => source
+            .get_ref()
+            .and_then(|source| source.downcast_ref::<SessionError>()),
+        _ => None,
+    };
+    assert!(matches!(
+        persistence,
+        Some(SessionError::QueryContext {
+            operation: "commit write intent",
+            ..
+        })
+    ));
+}
+
+#[tokio::test]
+async fn unavailable_intent_transaction_prevents_file_mutation() {
+    // Arrange
+    let (database, mut guard) = fixture().await;
+    let directory = tempdir().expect("repository");
+    let root = directory.path().canonicalize().expect("root");
+    let mut tool = WriteTool::new(Arc::new(LocalFileSystem), root.clone());
+    tool.journal = Some(guard.write_journal());
+    guard.disarm();
+    database.pool().close().await;
+
+    // Act
+    let error = tool
+        .execute(&arguments(), "create")
+        .await
+        .expect_err("closed pool");
+
+    // Assert
+    assert!(!root.join("file.txt").exists());
+    let persistence = match &error {
+        WriteError::WriteTarget { source, .. } => source
+            .get_ref()
+            .and_then(|source| source.downcast_ref::<SessionError>()),
+        _ => None,
+    };
+    assert!(matches!(
+        persistence,
+        Some(SessionError::QueryContext {
+            operation: "begin write intent",
+            source: sqlx::Error::PoolClosed,
+        })
+    ));
+}
+
+#[tokio::test]
+async fn root_migration_preserves_existing_records_and_sequence() {
+    // Arrange
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("legacy database");
+    for migration in [
+        include_str!("../migrations/001_create_session.sql"),
+        include_str!("../migrations/002_add_session_turn_lifecycle.sql"),
+        include_str!("../migrations/003_add_session_turn_owner_token.sql"),
+        include_str!("../migrations/004_add_session_write.sql"),
+    ] {
+        sqlx::raw_sql(migration)
+            .execute(&pool)
+            .await
+            .expect("legacy migration");
+    }
+    sqlx::raw_sql(r#"
+INSERT INTO session (id, output_schema, max_history_bytes, created_at, updated_at)
+VALUES ('session', '{"type":"object"}', 4096, 0, 0);
+INSERT INTO session_turn (session_id, turn_position, status, created_at, updated_at)
+VALUES ('session', 0, 'failed', 0, 0);
+INSERT INTO session_write (id, session_id, turn_position, call_id, repository_root, path, resulting_hash, status)
+VALUES (7, 'session', 0, 'call', '/repo/λ', 'file.txt', 'hash', 'applied'),
+   (9, 'session', 0, 'deleted', '/repo/λ', 'file.txt', 'hash', 'pending');
+DELETE FROM session_write WHERE id = 9;
+"#).execute(&pool).await.expect("legacy data");
+
+    // Act
+    sqlx::raw_sql(include_str!(
+        "../migrations/005_update_session_write_diagnostics.sql"
+    ))
+    .execute(&pool)
+    .await
+    .expect("upgrade journal");
+    let records = WriteRecordRow::load(&pool, "session")
+        .await
+        .expect("migrated journal");
+    let sequence = sqlx::query_scalar::<_, i64>(
+        "SELECT seq FROM sqlite_sequence WHERE name = 'session_write'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("write sequence");
+
+    // Assert
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].id, 7);
+    assert_eq!(records[0].call_id, "call");
+    assert_eq!(records[0].repository_root, PathBuf::from("/repo/λ"));
+    assert_eq!(records[0].status, WriteStatus::Applied);
+    assert_eq!(sequence, 9);
+}
+
+#[tokio::test]
+async fn journal_preserves_native_roots_fingerprints_and_duplicate_call_ids() {
+    // Arrange
+    let (database, mut guard) = fixture().await;
+    let journal = guard.write_journal();
+    let native_root = PathBuf::from(OsString::from_vec(vec![b'/', 0xff]));
+
+    // Act
+    let first = journal
+        .intent("call", &native_root, "file.txt", Some(b"old"), b"new")
+        .await
+        .expect("update intent");
+    let second = journal
+        .intent("call", &native_root, "other.txt", None, b"new")
+        .await
+        .expect("same identifier in a later model response");
+    fail(&database, &mut guard).await;
+    let records = WriteRecordRow::load(database.pool(), "session")
+        .await
+        .expect("native records");
+
+    // Assert
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].id, first);
+    assert_eq!(records[1].id, second);
+    assert!(second > first);
+    assert_eq!(records[0].call_id, records[1].call_id);
+    assert_eq!(records[0].expected_hash, Some(content_hash(b"old")));
+    assert_eq!(records[1].expected_hash, None);
+    assert_eq!(records[0].resulting_hash, content_hash(b"new"));
+    assert_eq!(records[0].status, WriteStatus::Pending);
+    assert_eq!(records[0].turn_position, 0);
+    assert_eq!(records[0].repository_root, native_root);
+    assert_eq!(
+        serde_json::to_value(&records[0]).expect("lossless serialization")["repository_root"],
+        json!(native_root.as_os_str().as_bytes())
+    );
+}
+
+#[tokio::test]
+async fn journal_rejects_lost_ownership_before_file_mutation() {
+    for invalidate in [
+        "UPDATE session_turn SET owner_token = X'00'",
+        "UPDATE session_turn SET lease_expires_at = 0",
+        "UPDATE session_turn SET status = 'failed', lease_expires_at = NULL",
+    ] {
+        // Arrange
+        let (database, mut guard) = fixture().await;
+        let directory = tempdir().expect("repository");
+        let root = directory.path().canonicalize().expect("root");
+        let mut tool = WriteTool::new(Arc::new(LocalFileSystem), root.clone());
+        tool.journal = Some(guard.write_journal());
+        sqlx::raw_sql(invalidate)
+            .execute(database.pool())
+            .await
+            .expect("invalidate owner");
+
+        // Act
+        let error = tool
+            .execute(&arguments(), "call")
+            .await
+            .expect_err("lost owner");
+        let records = WriteRecordRow::load(database.pool(), "session")
+            .await
+            .expect("journal");
+        guard.disarm();
+
+        // Assert
+        let source = match error {
+            WriteError::WriteTarget { source, .. } => Some(source),
+            _ => None,
+        }
+        .expect("expected persistence error");
+        assert!(matches!(
+            source
+                .get_ref()
+                .and_then(|error| error.downcast_ref::<SessionError>()),
+            Some(SessionError::OwnershipLost {
+                turn_position: 0,
+                ..
+            })
+        ));
+        assert!(!root.join("file.txt").exists());
+        assert_eq!(records, Vec::<WriteRecord>::new());
+    }
+}
+
+#[tokio::test]
+async fn journal_reports_corrupt_status_and_unavailable_storage() {
+    // Arrange
+    let (database, mut guard) = fixture().await;
+    guard
+        .write_journal()
+        .intent("call", Path::new("repo"), "file.txt", None, b"new")
+        .await
+        .expect("intent");
+    fail(&database, &mut guard).await;
+    sqlx::query("PRAGMA ignore_check_constraints = ON")
+        .execute(database.pool())
+        .await
+        .expect("disable check for corruption test");
+    sqlx::query("UPDATE session_write SET status = 'invalid'")
+        .execute(database.pool())
+        .await
+        .expect("corrupt status");
+
+    // Act
+    let invalid = WriteRecordRow::load(database.pool(), "session").await;
+    sqlx::query("DROP TABLE session_write")
+        .execute(database.pool())
+        .await
+        .expect("remove storage");
+    let missing = WriteRecordRow::load(database.pool(), "session").await;
+
+    // Assert
+    assert!(matches!(invalid, Err(SessionError::InvalidData { .. })));
+    assert!(matches!(
+        missing,
+        Err(SessionError::QueryContext {
+            operation: "load persistent writes",
+            ..
+        })
+    ));
+}
+
+struct InspectingFileSystem {
+    pool: SqlitePool,
+}
+
+#[async_trait]
+impl FileSystem for InspectingFileSystem {
+    async fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        LocalFileSystem.canonicalize(path).await
+    }
+
+    async fn open_beneath(
+        &self,
+        root: &Path,
+        path: &Path,
+    ) -> io::Result<Box<dyn AsyncRead + Send + Unpin>> {
+        LocalFileSystem.open_beneath(root, path).await
+    }
+
+    async fn replace_beneath(
+        &self,
+        root: &Path,
+        path: &Path,
+        expected: Option<Vec<u8>>,
+        content: Vec<u8>,
+    ) -> io::Result<()> {
+        let records = WriteRecordRow::load(&self.pool, "session")
+            .await
+            .expect("committed intent");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].status, WriteStatus::Pending);
+        assert_eq!(records[0].call_id, "create");
+        assert_eq!(records[0].expected_hash, None);
+        assert_eq!(records[0].resulting_hash, content_hash(&content));
+        assert!(!root.join(path).exists());
+
+        LocalFileSystem
+            .replace_beneath(root, path, expected, content)
+            .await
+    }
+}
+
+#[tokio::test]
+async fn intent_is_committed_before_replacement_and_outcome_before_return() {
+    // Arrange
+    let (database, mut guard) = fixture().await;
+    let directory = tempdir().expect("repository");
+    let mut tool = WriteTool::new(
+        Arc::new(InspectingFileSystem {
+            pool: database.pool().clone(),
+        }),
+        directory.path().to_path_buf(),
+    );
+    tool.journal = Some(guard.write_journal());
+
+    // Act
+    tool.execute(&arguments(), "create").await.expect("write");
+    let records = WriteRecordRow::load(database.pool(), "session")
+        .await
+        .expect("outcome");
+    guard.disarm();
+
+    // Assert
+    assert_eq!(records[0].status, WriteStatus::Applied);
+    assert_eq!(
+        tokio::fs::read(directory.path().join("file.txt"))
+            .await
+            .expect("file"),
+        b"new\n"
+    );
+}

--- a/crates/ag-harness/src/write_test.rs
+++ b/crates/ag-harness/src/write_test.rs
@@ -393,7 +393,7 @@ async fn write_tool_applies_patch_through_file_system_boundary() {
 
     // Act
     let output = tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect("write should succeed");
 
@@ -430,7 +430,7 @@ async fn write_tool_creates_missing_file() {
 
     // Act
     let output = tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect("missing file should be created");
 
@@ -455,7 +455,7 @@ async fn write_tool_rejects_patch_that_makes_no_change() {
 
     // Act
     let error = tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect_err("no-op patch should fail");
 
@@ -484,7 +484,7 @@ async fn write_tool_returns_typed_replace_failure() {
 
     // Act
     let error = tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect_err("replace failure should be typed");
 
@@ -521,15 +521,15 @@ async fn write_tool_returns_typed_boundary_failures() {
 
     // Act
     let root_error = root_tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect_err("missing root should fail");
     let read_error = read_tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect_err("read boundary failure should fail");
     let content_error = content_tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect_err("content read failure should fail");
 
@@ -558,7 +558,7 @@ async fn write_tool_bounds_target_and_returns_correctable_rejection() {
 
     // Act
     let error = tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect_err("oversized target should fail");
     let result = error
@@ -593,7 +593,7 @@ async fn write_tool_bounds_resulting_file() {
 
     // Act
     let error = tool
-        .execute(&arguments)
+        .execute(&arguments, "write-call")
         .await
         .expect_err("oversized result should fail");
 

--- a/crates/ag-harness/tests/public_api.rs
+++ b/crates/ag-harness/tests/public_api.rs
@@ -5,16 +5,18 @@
 mod repository;
 
 use std::error::Error;
+use std::ffi::OsString;
 use std::io::{self, Cursor};
+use std::os::unix::ffi::OsStringExt as _;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use ag_harness::{
     CompletionMetadata, CompletionUsage, FileSystem, Harness, LifecycleEventKind, LifecycleMetrics,
-    LifecycleObserverSet, LifecycleTraceObserver, Model, ModelCompletion, ModelConfiguration,
-    ModelError, ModelMessage, ModelMetadata, ModelProvider, ModelRequest, ModelResponse,
-    ModelResponseType, OutputSchema, OutputSchemaError, Repository, RepositoryError, SessionError,
-    SessionInfo, Tool, ToolCall, TurnError,
+    LifecycleObserverSet, LifecycleTraceObserver, LocalFileSystem, Model, ModelCompletion,
+    ModelConfiguration, ModelError, ModelMessage, ModelMetadata, ModelProvider, ModelRequest,
+    ModelResponse, ModelResponseType, OutputSchema, OutputSchemaError, Repository, RepositoryError,
+    SessionError, SessionInfo, Tool, ToolCall, TurnError, WriteStatus,
 };
 use async_trait::async_trait;
 use serde_json::json;
@@ -625,6 +627,117 @@ async fn external_observer_set_fans_out_lifecycle_events() -> Result<(), Box<dyn
         .expect("second event recorder should not be poisoned");
     assert!(!first_events.is_empty());
     assert_eq!(*first_events, *second_events);
+
+    Ok(())
+}
+
+struct FailingAfterWriteModel;
+
+#[async_trait]
+impl Model for FailingAfterWriteModel {
+    async fn complete(&self, request: ModelRequest) -> Result<ModelCompletion, ModelError> {
+        match request.messages().last() {
+            Some(ModelMessage::User(prompt)) if prompt == "write" => Ok(
+                ModelCompletion::from_response(ModelResponse::ToolCall(ToolCall::from_json(
+                    "write-name".to_string(), "write",
+                    &json!({"path": "name.txt", "patch": "--- /dev/null\n+++ b/name.txt\n@@ -0,0 +1 @@\n+Ada\n"}).to_string(), None,
+                )?)),
+            ),
+            _ => Err(ModelError::InvalidResponse),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct NativeRootFileSystem {
+    native_root: PathBuf,
+    physical_root: PathBuf,
+}
+
+#[async_trait]
+impl FileSystem for NativeRootFileSystem {
+    async fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        assert_eq!(path, self.physical_root);
+
+        Ok(self.native_root.clone())
+    }
+
+    async fn open_beneath(
+        &self,
+        root: &Path,
+        path: &Path,
+    ) -> io::Result<Box<dyn AsyncRead + Send + Unpin>> {
+        assert_eq!(root, self.native_root);
+
+        LocalFileSystem
+            .open_beneath(&self.physical_root, path)
+            .await
+    }
+
+    async fn replace_beneath(
+        &self,
+        root: &Path,
+        path: &Path,
+        expected: Option<Vec<u8>>,
+        content: Vec<u8>,
+    ) -> io::Result<()> {
+        assert_eq!(root, self.native_root);
+
+        LocalFileSystem
+            .replace_beneath(&self.physical_root, path, expected, content)
+            .await
+    }
+}
+
+#[tokio::test]
+async fn applied_write_survives_model_failure_and_session_reopen() -> Result<(), Box<dyn Error>> {
+    // Arrange
+    let directory = tempfile::tempdir()?;
+    let root = directory.path().canonicalize()?;
+    let native_root = root.join(OsString::from_vec(b"host-private-\xff".to_vec()));
+    let file_system = NativeRootFileSystem {
+        native_root: native_root.clone(),
+        physical_root: root.clone(),
+    };
+    let repository = repository::repository_with_host_git(&root);
+    let harness = Harness::new(FailingAfterWriteModel)
+        .database(directory.path().join("harness.db"))
+        .repository(repository)
+        .file_system(file_system)
+        .allow(Tool::Write);
+    let mut session = harness
+        .session("write-failure", request()?.schema().clone())
+        .create()
+        .await?;
+
+    // Act
+    let error = session
+        .send("write")
+        .await
+        .expect_err("model must fail after writing");
+    let before = session.writes().await?;
+    drop(session);
+    drop(harness);
+    // Inspection works without the original filesystem or a configured
+    // repository.
+    let inspector = Harness::new(ExternalModel).database(directory.path().join("harness.db"));
+    let reopened = inspector.resume("write-failure").await?;
+    let after = reopened.writes().await?;
+
+    // Assert
+    assert!(matches!(
+        error,
+        SessionError::Turn(TurnError::Model(ModelError::InvalidResponse))
+    ));
+    assert_eq!(std::fs::read(root.join("name.txt"))?, b"Ada\n");
+    assert_eq!(before, after);
+    assert_eq!(after.len(), 1);
+    assert_eq!(after[0].status, WriteStatus::Applied);
+    assert_eq!(after[0].repository_root, native_root);
+    assert_eq!(after[0].path, "name.txt");
+    assert_eq!(after[0].call_id, "write-name");
+    assert_eq!(after[0].expected_hash, None);
+    assert_eq!(after[0].resulting_hash.len(), 64);
 
     Ok(())
 }

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -78,6 +78,22 @@ it can continue model or tool work. If a turn fails and recording that failure a
 fails, `SessionError` retains both errors instead of replacing the original turn
 failure.
 
+Validated session writes commit a separate journal intent before filesystem replacement,
+then record its outcome before returning to the model. SQLite uses `FULL` synchronous
+commits so the intent is synced before file mutation. The intent requires the running
+turn's owner token and an unexpired lease. It retains the turn and tool-call identity,
+canonical repository root as native bytes, relative path, and SHA-256 fingerprints of
+expected and intended content; missing expected content denotes a create.
+
+Intent persistence failure prevents replacement. Outcome persistence failure stops the
+turn and leaves the durable intent `pending`, even if the file was changed.
+`Session::writes()` exposes these records after errors and reopening, independently of
+completed conversation history and its eviction budget. It returns stored outcomes
+without reading current files: `applied` records filesystem success, `failed` records a
+filesystem error, and `pending` means no outcome was recorded. Native roots remain
+lossless for host inspection, including non-UTF-8 Unix paths. Stateless `run_once` calls
+continue without a journal.
+
 ## Resume and provider fallback
 
 On resume, the harness validates the stored model identity and restores completed

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -38,11 +38,12 @@ For file-level detail, read the module docstrings directly.
   pending, running, completed, failed, and interrupted turns in SQLite, while replaying
   only bounded whole completed turns. `Harness` owns a lazily initialized database pool
   shared by its sessions; `Session::send` owns terminal lifecycle events through durable
-  completion. The `read` tool provides bounded worktree reads, path listing, literal
-  search, host-bound diffs, and base/HEAD file inspection; stale-safe patch writes and
-  file reads use the injectable `FileSystem` boundary. Application binaries own prompts,
-  tool permissions, and telemetry setup; the v0 read tool owns its fixed `main`
-  comparison base.
+  completion. A separate write journal retains intents and recorded outcomes across turn
+  failure and history eviction for host inspection. The `read` tool provides bounded
+  worktree reads, path listing, literal search, host-bound diffs, and base/HEAD file
+  inspection; stale-safe patch writes and file reads use the injectable `FileSystem`
+  boundary. Application binaries own prompts, tool permissions, and telemetry setup; the
+  v0 read tool owns its fixed `main` comparison base.
 - `crates/ag-harness-cli/`: Interactive `ag-harness` command-line application and its
   process-level tests. It derives provider parsing and help from `ag-harness`, then owns
   command-line defaults, application prompts, bounded repository permission selection,


### PR DESCRIPTION
- Validated write intents commit before filesystem replacement, while applied or failed outcomes record afterward; failed outcome persistence leaves intents pending, and failed intent persistence prevents mutation.
- Records survive failed turns, history eviction, and session reopen through `Session::writes()`, while stateless `run_once` remains unjournaled.
- SQLite migrations and offline metadata store call IDs, lossless native roots, paths, hashes, and acknowledgements with `FULL` synchronization.