### PR TITLE
Remove blocking operations from asynchronous tests

### DIFF
--- a/crates/ag-agent/src/agent/replay_test.rs
+++ b/crates/ag-agent/src/agent/replay_test.rs
@@ -368,13 +368,16 @@ async fn archive_preserves_unicode_middle_and_cleans_up_on_drop() {
 async fn live_archive_is_excluded_from_git() {
     // Arrange
     let folder = tempfile::tempdir().expect("workspace");
-    let initialized = std::process::Command::new("git")
+    let initialized = tokio::process::Command::new("git")
         .args(["init", "--quiet", "--template="])
         .arg(folder.path())
         .output()
+        .await
         .expect("initialize fixture repository");
     assert!(initialized.status.success());
-    std::fs::write(folder.path().join("control.txt"), "visible").expect("control file");
+    tokio::fs::write(folder.path().join("control.txt"), "visible")
+        .await
+        .expect("control file");
 
     // Act
     let context = ReplayContext::prepare(
@@ -383,7 +386,7 @@ async fn live_archive_is_excluded_from_git() {
     )
     .await
     .expect("archive");
-    let status = std::process::Command::new("git")
+    let status = tokio::process::Command::new("git")
         .args([
             "-c",
             "core.excludesFile=/dev/null",
@@ -393,6 +396,7 @@ async fn live_archive_is_excluded_from_git() {
         ])
         .current_dir(folder.path())
         .output()
+        .await
         .expect("inspect fixture status");
 
     // Assert

--- a/crates/ag-git/src/client_test.rs
+++ b/crates/ag-git/src/client_test.rs
@@ -557,11 +557,12 @@ async fn test_status_reads_preserve_index_with_stale_file_metadata() {
     );
     // Prove the fixture actually needs an index refresh when optional
     // writes are enabled, rather than merely reading an unchanged index.
-    let refresh = Command::new("git")
+    let refresh = tokio::process::Command::new("git")
         .args(["status", "--porcelain"])
         .env("GIT_OPTIONAL_LOCKS", "1")
         .current_dir(dir.path())
         .output()
+        .await
         .expect("failed to refresh index");
     assert!(refresh.status.success());
     assert_ne!(
@@ -735,10 +736,11 @@ async fn test_pull_rebase_targets_single_upstream_when_merge_targets_are_ambiguo
         &["config", "--add", "branch.main.merge", "refs/heads/feature"],
     );
 
-    let pull_without_explicit_target = Command::new("git")
+    let pull_without_explicit_target = tokio::process::Command::new("git")
         .args(["pull", "--rebase"])
         .current_dir(dir.path())
         .output()
+        .await
         .expect("failed to run pull --rebase");
 
     assert!(
@@ -788,10 +790,11 @@ async fn test_pull_rebase_targets_local_upstream_when_upstream_name_has_no_remot
         &["config", "--add", "branch.main.merge", "refs/heads/feature"],
     );
 
-    let pull_without_explicit_target = Command::new("git")
+    let pull_without_explicit_target = tokio::process::Command::new("git")
         .args(["pull", "--rebase"])
         .current_dir(dir.path())
         .output()
+        .await
         .expect("failed to run pull --rebase");
 
     assert!(

--- a/crates/ag-git/src/repo_test.rs
+++ b/crates/ag-git/src/repo_test.rs
@@ -54,10 +54,11 @@ fn test_apply_non_interactive_environment_sets_git_prompt_controls() {
 async fn test_async_git_command_timeout_cancels_process() {
     // Arrange
     let temp_dir = tempdir().expect("failed to create temporary repository");
-    let init_output = Command::new("git")
+    let init_output = tokio::process::Command::new("git")
         .args(["init", "--quiet"])
         .current_dir(temp_dir.path())
         .output()
+        .await
         .expect("failed to initialize temporary repository");
     assert!(init_output.status.success());
     let timeout = Duration::from_millis(25);

--- a/crates/ag-harness-cli/tests/cli.rs
+++ b/crates/ag-harness-cli/tests/cli.rs
@@ -1,7 +1,6 @@
 //! Process-level coverage for the `ag-harness` command-line interface.
 
 use std::fs;
-use std::io::{BufRead as _, BufReader, Read as _, Write as _};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
@@ -9,6 +8,7 @@ use ag_harness::{ModelProvider, ToolDefinition};
 use assert_cmd::cargo::cargo_bin;
 use serde_json::json;
 use testty::session::PtySessionBuilder;
+use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _, BufReader};
 use wiremock::matchers::{bearer_token, body_json, body_string_contains, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -555,7 +555,7 @@ async fn stdin_prompts_share_conversation_history() {
         .mount(&server)
         .await;
     let storage = tempfile::tempdir().expect("temporary storage should exist");
-    let mut child = Command::new(cargo_bin!("ag-harness"))
+    let mut child = tokio::process::Command::new(cargo_bin!("ag-harness"))
         .arg("--git-executable")
         .arg(test_git_executable())
         .args([
@@ -579,8 +579,12 @@ async fn stdin_prompts_share_conversation_history() {
         .take()
         .expect("stdin should be piped")
         .write_all(b"second question\n")
+        .await
         .expect("second prompt should be written");
-    let output = child.wait_with_output().expect("CLI chat should finish");
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("CLI chat should finish");
 
     // Assert
     assert!(
@@ -623,7 +627,7 @@ async fn resume_restores_history_from_the_default_database() {
         .mount(&server)
         .await;
     let storage = tempfile::tempdir().expect("temporary storage should exist");
-    let mut first = Command::new(cargo_bin!("ag-harness"));
+    let mut first = tokio::process::Command::new(cargo_bin!("ag-harness"));
     first
         .arg("--git-executable")
         .arg(test_git_executable())
@@ -640,8 +644,8 @@ async fn resume_restores_history_from_the_default_database() {
         .env("AG_HARNESS_ROOT", storage.path());
 
     // Act
-    let first_output = first.output().expect("first CLI request should run");
-    let mut second = Command::new(cargo_bin!("ag-harness"));
+    let first_output = first.output().await.expect("first CLI request should run");
+    let mut second = tokio::process::Command::new(cargo_bin!("ag-harness"));
     let second_output = second
         .arg("--git-executable")
         .arg(test_git_executable())
@@ -655,6 +659,7 @@ async fn resume_restores_history_from_the_default_database() {
         .env("MODEL_API_KEY", "test-key")
         .env("AG_HARNESS_ROOT", storage.path())
         .output()
+        .await
         .expect("resumed CLI request should run");
 
     // Assert
@@ -705,7 +710,7 @@ async fn stdin_chat_emits_failure_before_retry_and_exits_unsuccessfully() {
         .mount(&server)
         .await;
     let storage = tempfile::tempdir().expect("temporary storage should exist");
-    let mut child = Command::new(cargo_bin!("ag-harness"))
+    let mut child = tokio::process::Command::new(cargo_bin!("ag-harness"))
         .arg("--git-executable")
         .arg(test_git_executable())
         .args(["run", "muse-test", "--base-url", &server.uri()])
@@ -723,31 +728,37 @@ async fn stdin_chat_emits_failure_before_retry_and_exits_unsuccessfully() {
     let mut stdout = BufReader::new(stdout);
     stdin
         .write_all(b"first question\n")
+        .await
         .expect("first prompt should be written");
-    stdin.flush().expect("first prompt should be flushed");
+    stdin.flush().await.expect("first prompt should be flushed");
     let mut announcement = String::new();
     stdout
         .read_line(&mut announcement)
+        .await
         .expect("session identifier should be emitted");
     let mut failure = String::new();
     stdout
         .read_line(&mut failure)
+        .await
         .expect("failed turn should be emitted while stdin remains open");
     stdin
         .write_all(b"retry question\n")
+        .await
         .expect("retry prompt should be written");
     drop(stdin);
     let mut recovered = String::new();
     stdout
         .read_to_string(&mut recovered)
+        .await
         .expect("retry output should be readable");
-    let status = child.wait().expect("CLI chat should finish");
+    let status = child.wait().await.expect("CLI chat should finish");
     let mut stderr = String::new();
     child
         .stderr
         .take()
         .expect("stderr should be piped")
         .read_to_string(&mut stderr)
+        .await
         .expect("stderr should be readable");
 
     // Assert

--- a/crates/ag-harness/src/chat_completion_test/transport_test.rs
+++ b/crates/ag-harness/src/chat_completion_test/transport_test.rs
@@ -283,7 +283,7 @@ async fn retains_http_status_when_error_body_read_fails() {
     ));
     assert!(error.to_string().contains("error body read failed"));
     let source = std::error::Error::source(&error)
-        .and_then(|source| source.downcast_ref::<reqwest::Error>())
+        .and_then(<dyn std::error::Error>::downcast_ref::<reqwest::Error>)
         .expect("HTTP failure should retain its status-bearing source");
     assert_eq!(
         source.status(),

--- a/crates/ag-harness/src/provider/kimi_test/failure_test.rs
+++ b/crates/ag-harness/src/provider/kimi_test/failure_test.rs
@@ -145,7 +145,7 @@ async fn returns_request_error_for_http_failure() {
         std::error::Error::source(&error).expect("HTTP failure should retain its provider error");
     let source = provider_error
         .source()
-        .and_then(|source| source.downcast_ref::<reqwest::Error>())
+        .and_then(<dyn std::error::Error>::downcast_ref::<reqwest::Error>)
         .expect("HTTP failure should retain its reqwest source");
     assert_eq!(source.status(), Some(reqwest::StatusCode::UNAUTHORIZED));
 }

--- a/crates/ag-harness/src/provider/qwen_test/failure_test.rs
+++ b/crates/ag-harness/src/provider/qwen_test/failure_test.rs
@@ -145,7 +145,7 @@ async fn returns_request_error_for_http_failure() {
         std::error::Error::source(&error).expect("HTTP failure should retain its provider error");
     let source = provider_error
         .source()
-        .and_then(|source| source.downcast_ref::<reqwest::Error>())
+        .and_then(<dyn std::error::Error>::downcast_ref::<reqwest::Error>)
         .expect("HTTP failure should retain its reqwest source");
     assert_eq!(source.status(), Some(reqwest::StatusCode::UNAUTHORIZED));
     assert_eq!(error.error_type(), model::ModelErrorType::Provider);

--- a/crates/agentty/src/app/core/new_test.rs
+++ b/crates/agentty/src/app/core/new_test.rs
@@ -1,11 +1,11 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::Arc;
 
 use ag_git::GitClient;
 use tempfile::tempdir;
+use tokio::process::Command;
 
 use super::super::state::{App, AppClients};
 use super::{E2E_DISPLAY_VERSION, current_version_display_text};
@@ -152,6 +152,7 @@ async fn test_new_uses_production_client_bundle() {
     }
     let child_status = child
         .status()
+        .await
         .expect("failed to run isolated constructor test");
 
     // Assert

--- a/crates/agentty/src/app/core/state_fork_test.rs
+++ b/crates/agentty/src/app/core/state_fork_test.rs
@@ -35,7 +35,8 @@ async fn create_review_source_session_for_fork_test(app: &mut App) -> String {
         .expect("missing source session")
         .folder
         .clone();
-    std::fs::write(source_folder.join("README.md"), "dirty source worktree")
+    tokio::fs::write(source_folder.join("README.md"), "dirty source worktree")
+        .await
         .expect("failed to modify source worktree");
     crate::test_support::set_session_status_for_test(app, &source_session_id, Status::Review);
 

--- a/crates/agentty/src/app/core/state_test/support_test.rs
+++ b/crates/agentty/src/app/core/state_test/support_test.rs
@@ -121,8 +121,11 @@ pub(super) async fn seed_materialized_session(
         )
         .await
         .expect("failed to insert materialized session");
-    fs::create_dir_all(session::session_folder(base_path, session_id).join(SESSION_DATA_DIR))
-        .expect("failed to create materialized session data dir");
+    tokio::fs::create_dir_all(
+        session::session_folder(base_path, session_id).join(SESSION_DATA_DIR),
+    )
+    .await
+    .expect("failed to create materialized session data dir");
 }
 
 /// Seeds one review-ready session and its persisted focused review.
@@ -191,7 +194,9 @@ pub(super) async fn new_test_app_with_selected_session(
         crate::test_support::new_test_app_with_tmux_client_without_retained_base_dir(tmux_client)
             .await;
     if !session_folder.as_os_str().is_empty() {
-        std::fs::create_dir_all(&session_folder).expect("failed to create session folder");
+        tokio::fs::create_dir_all(&session_folder)
+            .await
+            .expect("failed to create session folder");
     }
 
     // Act
@@ -321,16 +326,11 @@ pub(super) async fn assert_synchronous_fork_is_ready_with_history(app: &mut App,
 /// so failed creation cannot leave resources that are invisible in the
 /// database.
 pub(super) async fn session_creation_resources(root: &Path) -> Vec<String> {
-    let mut snapshot: Vec<String> = fs::read_dir(root)
-        .expect("repository entries")
-        .map(|entry| {
-            entry
-                .expect("entry")
-                .file_name()
-                .to_string_lossy()
-                .into_owned()
-        })
-        .collect();
+    let mut entries = tokio::fs::read_dir(root).await.expect("repository entries");
+    let mut snapshot = Vec::new();
+    while let Some(entry) = entries.next_entry().await.expect("entry") {
+        snapshot.push(entry.file_name().to_string_lossy().into_owned());
+    }
     snapshot.sort();
     for arguments in [
         ["branch", "--list", "wt/*"],
@@ -548,12 +548,13 @@ pub(in crate::app::core) async fn insert_review_session_with_data_dir(app: &App,
         .await
         .expect("failed to insert session");
     let session_folder_name = session_id.chars().take(8).collect::<String>();
-    fs::create_dir_all(
+    tokio::fs::create_dir_all(
         app.services
             .base_path()
             .join(session_folder_name)
             .join(SESSION_DATA_DIR),
     )
+    .await
     .expect("failed to create session data dir");
 }
 

--- a/crates/agentty/src/runtime/mode/list_test.rs
+++ b/crates/agentty/src/runtime/mode/list_test.rs
@@ -197,15 +197,17 @@ async fn test_handle_add_key_opens_session_creation_overlay() {
 async fn test_handle_add_key_warns_before_options_when_pre_commit_hook_is_missing() {
     // Arrange
     let (mut app, base_dir) = crate::test_support::new_git_test_app().await;
-    std::fs::write(
+    tokio::fs::write(
         base_dir.path().join(".pre-commit-config.yaml"),
         "repos: []\n",
     )
+    .await
     .expect("failed to write pre-commit configuration");
-    let git_config_output = std::process::Command::new("git")
+    let git_config_output = tokio::process::Command::new("git")
         .args(["config", "core.hooksPath", ".missing-hooks"])
         .current_dir(base_dir.path())
         .output()
+        .await
         .expect("failed to configure missing hooks path");
     assert!(git_config_output.status.success());
     app.tabs.set(Tab::Sessions);

--- a/crates/agentty/tests/e2e/demo.rs
+++ b/crates/agentty/tests/e2e/demo.rs
@@ -10,13 +10,14 @@
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use agentty::db::{DB_DIR, DB_FILE, Database};
 use assert_cmd::cargo::cargo_bin;
 use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::{ConnectOptions, Connection, Executor};
+use tokio::fs;
+use tokio::process::Command;
 
 use crate::common::{
     BuilderEnv, PINNED_CLOCK_ENV_VAR, PINNED_CLOCK_UNIX_SECONDS, PINNED_CLOCK_UTC_OFFSET_ENV_VAR,
@@ -46,36 +47,36 @@ const GIF_NAME: &str = "demo";
 #[ignore = "requires VHS and regenerates a marketing asset"]
 async fn generate_marketing_demo_gif() -> DemoResult {
     // Arrange
-    if Command::new("vhs").arg("--version").output().is_err() {
+    if Command::new("vhs").arg("--version").output().await.is_err() {
         return Ok(());
     }
 
     // Use a short, clean /tmp path so project rows and the footer path read
     // nicely in the final GIF (macOS tempdirs live under /var/folders/...).
-    let demo_root = make_fresh_demo_root()?;
-    let env = make_demo_env(&demo_root)?;
+    let demo_root = make_fresh_demo_root().await?;
+    let env = make_demo_env(&demo_root).await?;
 
-    install_scripted_claude_stub(&env)?;
-    install_scripted_codex_stub(&env)?;
-    install_agent_availability_stubs(&env)?;
-    symlink_agentty_into_stub_bin(&env)?;
+    install_scripted_claude_stub(&env).await?;
+    install_scripted_codex_stub(&env).await?;
+    install_agent_availability_stubs(&env).await?;
+    symlink_agentty_into_stub_bin(&env).await?;
 
-    let fake_project_paths = create_fake_project_dirs(&env)?;
+    let fake_project_paths = create_fake_project_dirs(&env).await?;
     // Agentty reads `current_dir()` which is canonicalized; seed using the
     // same canonical form the app will upsert itself.
-    let canonical_cwd = env.workdir.canonicalize()?;
+    let canonical_cwd = fs::canonicalize(&env.workdir).await?;
     seed_database(&env, &fake_project_paths, &canonical_cwd).await?;
 
     let output_dir = repo_demo_dir();
-    std::fs::create_dir_all(&output_dir)?;
+    fs::create_dir_all(&output_dir).await?;
     let gif_path = output_dir.join(format!("{GIF_NAME}.gif"));
 
     let tape = build_demo_tape(&env, &gif_path);
     let tape_path = demo_root.join("demo.tape");
-    std::fs::write(&tape_path, &tape)?;
+    fs::write(&tape_path, &tape).await?;
 
     // Act
-    let output = Command::new("vhs").arg(&tape_path).output()?;
+    let output = Command::new("vhs").arg(&tape_path).output().await?;
 
     // Assert
     if !output.status.success() {
@@ -86,27 +87,27 @@ async fn generate_marketing_demo_gif() -> DemoResult {
         )
         .into());
     }
-    if !gif_path.exists() {
+    if !fs::try_exists(&gif_path).await? {
         return Err(format!("demo gif not produced at {}", gif_path.display()).into());
     }
 
     // Best-effort cleanup of the scratch directory.
-    let _ = std::fs::remove_dir_all(&demo_root);
+    let _ = fs::remove_dir_all(&demo_root).await;
 
     Ok(())
 }
 
 /// Returns a fresh `/tmp/agentty-demo-<nanos>/` directory so paths shown in
 /// the GIF are short and do not leak the operator's personal temp path.
-fn make_fresh_demo_root() -> std::io::Result<PathBuf> {
+async fn make_fresh_demo_root() -> std::io::Result<PathBuf> {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |duration| duration.as_nanos());
     let root = PathBuf::from(format!("/tmp/agentty-demo-{nanos}"));
-    if root.exists() {
-        std::fs::remove_dir_all(&root)?;
+    if fs::try_exists(&root).await? {
+        fs::remove_dir_all(&root).await?;
     }
-    std::fs::create_dir_all(&root)?;
+    fs::create_dir_all(&root).await?;
 
     Ok(root)
 }
@@ -114,16 +115,16 @@ fn make_fresh_demo_root() -> std::io::Result<PathBuf> {
 /// Builds a `BuilderEnv` whose workdir is named `opencloudtool` so the project
 /// row and path shown in the demo read cleanly while discovery uses a
 /// deterministic isolated home directory.
-fn make_demo_env(demo_root: &Path) -> std::io::Result<BuilderEnv> {
+async fn make_demo_env(demo_root: &Path) -> std::io::Result<BuilderEnv> {
     let agentty_root = demo_root.join("agentty_root");
     let home_dir = demo_root.join("home");
     let workdir = demo_root.join("opencloudtool");
     let stub_bin = demo_root.join("stub-bin");
 
-    std::fs::create_dir_all(&agentty_root)?;
-    std::fs::create_dir_all(&home_dir)?;
-    std::fs::create_dir_all(&workdir)?;
-    std::fs::create_dir_all(&stub_bin)?;
+    fs::create_dir_all(&agentty_root).await?;
+    fs::create_dir_all(&home_dir).await?;
+    fs::create_dir_all(&workdir).await?;
+    fs::create_dir_all(&stub_bin).await?;
 
     let env = BuilderEnv {
         agentty_root,
@@ -131,14 +132,20 @@ fn make_demo_env(demo_root: &Path) -> std::io::Result<BuilderEnv> {
         stub_bin,
         workdir,
     };
-    env.init_git()?;
+    // The shared fixture initializer is synchronous; keep its Git commands off
+    // the async worker without duplicating the initialization sequence here.
+    tokio::task::spawn_blocking(move || {
+        env.init_git()?;
 
-    Ok(env)
+        Ok(env)
+    })
+    .await
+    .map_err(std::io::Error::other)?
 }
 
 /// Creates the `agentty` git repository shown below the current project in
 /// the opening Projects list.
-fn create_fake_project_dirs(env: &BuilderEnv) -> std::io::Result<Vec<PathBuf>> {
+async fn create_fake_project_dirs(env: &BuilderEnv) -> std::io::Result<Vec<PathBuf>> {
     let demo_root = env
         .workdir
         .parent()
@@ -148,7 +155,8 @@ fn create_fake_project_dirs(env: &BuilderEnv) -> std::io::Result<Vec<PathBuf>> {
         .args(["clone", "-q"])
         .arg(&env.workdir)
         .arg(&path)
-        .status()?;
+        .status()
+        .await?;
     if !git_clone.success() {
         return Err(std::io::Error::other(
             "failed to clone demo agentty project",
@@ -161,7 +169,7 @@ fn create_fake_project_dirs(env: &BuilderEnv) -> std::io::Result<Vec<PathBuf>> {
 /// Overwrites the `claude` stub in `stub_bin` with a script that ignores its
 /// CLI args and stdin, pauses briefly, then emits Claude's `stream-json`
 /// protocol output with a canned reply.
-fn install_scripted_claude_stub(env: &BuilderEnv) -> std::io::Result<()> {
+async fn install_scripted_claude_stub(env: &BuilderEnv) -> std::io::Result<()> {
     let claude_path = env.stub_bin.join("claude");
     // Reply text is hard-coded to match session 1's stacked-commits prompt.
     // Session 2 in the tape never finishes, so the same canned output never
@@ -221,10 +229,10 @@ sleep 1
 printf '%s\n' '{result_event}'
 "#
     );
-    std::fs::write(&claude_path, &script)?;
+    fs::write(&claude_path, &script).await?;
     #[cfg(unix)]
     {
-        std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o750))?;
+        fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o750)).await?;
     }
 
     Ok(())
@@ -232,7 +240,7 @@ printf '%s\n' '{result_event}'
 
 /// Installs a scripted Codex app-server stub that completes bootstrap and
 /// leaves the demo's second turn running until VHS exits.
-fn install_scripted_codex_stub(env: &BuilderEnv) -> std::io::Result<()> {
+async fn install_scripted_codex_stub(env: &BuilderEnv) -> std::io::Result<()> {
     let codex_path = env.stub_bin.join("codex");
     let script = r#"#!/bin/sh
 if [ "$1" = "update" ]; then
@@ -266,10 +274,10 @@ while IFS= read -r request; do
     esac
 done
 "#;
-    std::fs::write(&codex_path, script)?;
+    fs::write(&codex_path, script).await?;
     #[cfg(unix)]
     {
-        std::fs::set_permissions(&codex_path, std::fs::Permissions::from_mode(0o750))?;
+        fs::set_permissions(&codex_path, std::fs::Permissions::from_mode(0o750)).await?;
     }
 
     Ok(())
@@ -283,15 +291,16 @@ done
 /// stubs makes every agent kind — Antigravity, Claude, and Codex — appear in
 /// the `/model` agent picker. The stub handles startup's update and version
 /// probes but is never used for a session.
-fn install_agent_availability_stubs(env: &BuilderEnv) -> std::io::Result<()> {
+async fn install_agent_availability_stubs(env: &BuilderEnv) -> std::io::Result<()> {
     let stub_path = env.stub_bin.join("agy");
-    std::fs::write(
+    fs::write(
         &stub_path,
         "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'agy 0.42.0'; fi\nexit 0\n",
-    )?;
+    )
+    .await?;
     #[cfg(unix)]
     {
-        std::fs::set_permissions(&stub_path, std::fs::Permissions::from_mode(0o750))?;
+        fs::set_permissions(&stub_path, std::fs::Permissions::from_mode(0o750)).await?;
     }
 
     Ok(())
@@ -300,15 +309,15 @@ fn install_agent_availability_stubs(env: &BuilderEnv) -> std::io::Result<()> {
 /// Symlinks the compiled `agentty` binary into `stub_bin` so that typing
 /// `agentty` at the shell (inside the VHS recording) resolves to the real
 /// binary through `PATH`.
-fn symlink_agentty_into_stub_bin(env: &BuilderEnv) -> std::io::Result<()> {
+async fn symlink_agentty_into_stub_bin(env: &BuilderEnv) -> std::io::Result<()> {
     let real_binary = cargo_bin("agentty");
     let link_path = env.stub_bin.join("agentty");
-    if link_path.exists() {
-        std::fs::remove_file(&link_path)?;
+    if fs::try_exists(&link_path).await? {
+        fs::remove_file(&link_path).await?;
     }
     #[cfg(unix)]
     {
-        std::os::unix::fs::symlink(&real_binary, &link_path)?;
+        fs::symlink(&real_binary, &link_path).await?;
     }
 
     Ok(())
@@ -461,7 +470,7 @@ async fn seed_pre_existing_sessions(
         let created = now_seconds - age;
         if !matches!(*status, "Done" | "Canceled") {
             let stub_worktree = wt_base.join(&id[..8]);
-            std::fs::create_dir_all(&stub_worktree)?;
+            fs::create_dir_all(&stub_worktree).await?;
         }
         let query = sqlx::query!(
             r"

--- a/crates/agentty/tests/e2e/session/provider.rs
+++ b/crates/agentty/tests/e2e/session/provider.rs
@@ -3,13 +3,13 @@
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
-use std::process::Command;
 use std::time::Duration;
 
 use agentty::domain::session_message::SessionMessageKind;
 use testty::assertion;
 use testty::region::Region;
 use testty::scenario::Scenario;
+use tokio::process::Command;
 
 use super::fixture::{
     CLAUDE_STRUCTURED_RESPONSE_TEXT, E2eResult, run_git, seed_claude_structured_output_project,
@@ -646,6 +646,7 @@ async fn test_session_commit_index_lock_recovers() -> E2eResult {
                         .args(["show", "HEAD:generated.txt"])
                         .current_dir(worktree)
                         .output()
+                        .await
                         .expect("committed file should be readable");
                     assert!(committed.status.success());
                     assert_eq!(committed.stdout, b"pending change\n");
@@ -889,6 +890,7 @@ async fn test_session_commit_input_limit_fallback() -> E2eResult {
                         .args(["log", "-1", "--format=%s"])
                         .current_dir(worktree.trim())
                         .output()
+                        .await
                         .expect("commit title should load");
                     assert!(output.status.success());
                     assert_eq!(
@@ -899,6 +901,7 @@ async fn test_session_commit_input_limit_fallback() -> E2eResult {
                         .args(["status", "--porcelain"])
                         .current_dir(worktree.trim())
                         .output()
+                        .await
                         .expect("status should load");
                     assert!(output.status.success());
                     assert_eq!(output.stdout, Vec::<u8>::new());


### PR DESCRIPTION
- Use Tokio subprocess and filesystem APIs throughout async test paths.
- Adopt explicit error downcast syntax for retained HTTP sources.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)