### PR TITLE
Preserve findings across bounded focused reviews

### DIFF
--- a/crates/agentty/src/app.rs
+++ b/crates/agentty/src/app.rs
@@ -14,6 +14,7 @@ mod project;
 pub(crate) mod prompt_intent;
 mod reducer;
 mod review;
+mod review_prompt;
 mod review_request;
 mod service;
 pub(crate) mod session;

--- a/crates/agentty/src/app/diff_prompt.rs
+++ b/crates/agentty/src/app/diff_prompt.rs
@@ -11,13 +11,13 @@ use ag_agent::{
 /// Leaves room for provider instructions and output instead of approaching the
 /// Codex per-input character ceiling. Smaller provider limits trigger
 /// reduction.
-const PROMPT_BUDGET: usize = 60_000;
+pub(super) const PROMPT_BUDGET: usize = 60_000;
 // Size input fragments independently of the desired summary output size.
 // Check the rendered prompt too, since pathological fences can exceed this
 // margin.
 const SUMMARY_CHUNK_BYTES: usize = PROMPT_BUDGET - 2_048;
-const MAX_PROVIDER_CALLS: usize = 64;
-const MIN_CHUNK_BYTES: usize = 512;
+pub(super) const MAX_PROVIDER_CALLS: usize = 64;
+pub(super) const MIN_CHUNK_BYTES: usize = 512;
 const SUMMARY_LIMIT: usize = 2_000;
 
 /// Submits a diff prompt, summarizing oversized input in isolated utility
@@ -80,7 +80,7 @@ pub(super) async fn submit(
 
 /// Reduces all input chunks, then reduces their summaries again when necessary.
 /// Strict output bounds guarantee each reduction round makes progress.
-async fn summarize(
+pub(super) async fn summarize(
     client: &dyn OneShotClient,
     request: &OneShotRequest,
     input: &str,
@@ -105,8 +105,8 @@ async fn summarize(
     Ok(input)
 }
 
-/// Summarizes every fragment once, splitting rejected fragments within the
-/// shared provider budget and enforcing each response's output limit.
+/// Retains small fragments verbatim and summarizes larger ones, repairing
+/// invalid output before splitting rejected fragments within the shared budget.
 async fn summarize_round(
     client: &dyn OneShotClient,
     request: &OneShotRequest,
@@ -118,7 +118,10 @@ async fn summarize_round(
     let mut chunks = chunks(input, SUMMARY_CHUNK_BYTES);
     let mut summaries = Vec::new();
     while let Some(chunk) = chunks.pop_front() {
-        let summary_limit = summary_limit.min((chunk.len() / 4).max(64));
+        if chunk.len() <= summary_limit.min(MIN_CHUNK_BYTES) {
+            summaries.push(chunk);
+            continue;
+        }
         let mut request = request.clone();
         request.permission_mode = PermissionMode::ReadOnly;
         request.request_kind = AgentRequestKind::UtilityPrompt;
@@ -139,23 +142,14 @@ async fn summarize_round(
                 "Input exceeds the maximum length of the summary prompt budget",
             ))
         } else {
-            call_budget.ensure_available()?;
-            client.submit(request).await
+            summary_with_repair(client, &request, summary_limit, call_budget).await
         };
         match submission {
-            Ok(submission) => {
-                let summary = submission.response.answer.trim();
-                if summary.is_empty() || summary.len() > summary_limit {
-                    return Err(OneShotError::new(
-                        "Input exceeds the maximum length reduction budget: summary is empty or \
-                         too large; changes are preserved",
-                    ));
-                }
-                summaries.push(summary.to_string());
-            }
+            Ok(summary) => summaries.push(summary),
             Err(error)
                 if is_input_size_error(&error.to_string()) && chunk.len() > MIN_CHUNK_BYTES =>
             {
+                call_budget.ensure_available()?;
                 let smaller = self::chunks(&chunk, chunk.len() / 2);
                 for chunk in smaller.into_iter().rev() {
                     chunks.push_front(chunk);
@@ -168,9 +162,56 @@ async fn summarize_round(
     Ok(summaries)
 }
 
+/// Gives an invalid summary one corrective retry without replaying its
+/// potentially oversized response. Both attempts use the original source and
+/// the same provider-call budget; persistent invalid output can be split by
+/// the caller just like a provider input-size rejection.
+async fn summary_with_repair(
+    client: &dyn OneShotClient,
+    request: &OneShotRequest,
+    limit: usize,
+    call_budget: &ag_agent::ProviderCallBudget,
+) -> Result<String, OneShotError> {
+    let mut correction = String::new();
+    let mut problem = String::new();
+    for _ in 0..2 {
+        let mut request = request.clone();
+        request.prompt = format!("{correction}{}", request.prompt);
+        if request.prompt.len() > PROMPT_BUDGET {
+            return Err(OneShotError::new(
+                "Input exceeds the maximum length of the summary repair prompt budget",
+            ));
+        }
+        call_budget.ensure_available()?;
+        let submission = client.submit(request).await?;
+        let summary = submission.response.answer.trim();
+        if !summary.is_empty() && summary.len() <= limit {
+            return Ok(summary.to_string());
+        }
+        problem = if summary.is_empty() {
+            "summary was empty".to_string()
+        } else {
+            format!(
+                "summary was {} UTF-8 bytes, exceeding {limit}",
+                summary.len()
+            )
+        };
+        correction = format!(
+            "The previous {problem}. Return a nonempty, shorter summary in answer. Aim for at \
+             most {} UTF-8 bytes; the hard limit is {limit}.\n\n",
+            limit / 2
+        );
+    }
+
+    Err(OneShotError::new(format!(
+        "Input exceeds the maximum length reduction budget: {problem} after repair; changes are \
+         preserved"
+    )))
+}
+
 /// Splits without dropping bytes, preferring complete lines and carrying the
 /// current file header into continuation chunks for path attribution.
-fn chunks(input: &str, limit: usize) -> VecDeque<String> {
+pub(super) fn chunks(input: &str, limit: usize) -> VecDeque<String> {
     let mut remaining = input;
     let mut result = VecDeque::new();
     let mut file_header = "";

--- a/crates/agentty/src/app/diff_prompt_test.rs
+++ b/crates/agentty/src/app/diff_prompt_test.rs
@@ -8,7 +8,10 @@ use ag_agent::{
 };
 use ag_protocol::AgentResponse;
 
-use super::{MAX_PROVIDER_CALLS, PROMPT_BUDGET, SUMMARY_CHUNK_BYTES, chunks, submit, summarize};
+use super::{
+    MAX_PROVIDER_CALLS, PROMPT_BUDGET, SUMMARY_CHUNK_BYTES, chunks, submit, summarize,
+    summary_with_repair,
+};
 
 fn request() -> OneShotRequest {
     OneShotRequest {
@@ -260,6 +263,211 @@ async fn summary_failure_and_invalid_summary_stop_generation() {
 
         // Assert
         assert!(result.is_err());
+    }
+}
+
+#[tokio::test]
+async fn invalid_summary_is_repaired_from_original_input_with_byte_feedback() {
+    // Arrange
+    for (invalid, diagnostic) in [
+        ("   ".to_string(), "summary was empty"),
+        ("🦀".repeat(200), "800 UTF-8 bytes"),
+    ] {
+        let mut attempts = 0;
+        let mut client = MockOneShotClient::new();
+        client.expect_submit().times(2).returning(move |request| {
+            request
+                .provider_call_budget
+                .as_ref()
+                .expect("budget")
+                .consume()?;
+            assert!(request.prompt.contains("ORIGINAL SOURCE"));
+            assert_eq!(request.permission_mode, PermissionMode::ReadOnly);
+            attempts += 1;
+            if attempts == 1 {
+                return Ok(answer(&invalid));
+            }
+            assert!(request.prompt.contains(diagnostic));
+            assert!(request.prompt.contains("nonempty, shorter summary"));
+            assert!(!request.prompt.contains('🦀'));
+            Ok(answer("Repaired summary."))
+        });
+        let request = request();
+
+        // Act
+        let summary = summarize(
+            &client,
+            &request,
+            &"ORIGINAL SOURCE\n".repeat(200),
+            2000,
+            request.provider_call_budget.as_ref().expect("budget"),
+        )
+        .await
+        .expect("repair");
+
+        // Assert
+        assert!(summary.contains("Repaired summary."));
+    }
+}
+
+#[tokio::test]
+async fn failed_summary_repair_splits_original_input_without_losing_tail() {
+    // Arrange
+    let mut attempts = 0;
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let prompts = Arc::clone(&seen);
+    let mut client = MockOneShotClient::new();
+    client.expect_submit().returning(move |request| {
+        request
+            .provider_call_budget
+            .as_ref()
+            .expect("budget")
+            .consume()?;
+        prompts.lock().expect("prompts").push(request.prompt);
+        attempts += 1;
+        Ok(answer(if attempts <= 2 { "" } else { "Recovered." }))
+    });
+    let request = request();
+
+    // Act
+    let summary = summarize(
+        &client,
+        &request,
+        &format!("{}TAIL", "x".repeat(5000)),
+        2000,
+        request.provider_call_budget.as_ref().expect("budget"),
+    )
+    .await
+    .expect("split recovery");
+
+    // Assert
+    let prompts = seen.lock().expect("prompts");
+    assert_eq!(prompts.len(), 4);
+    assert!(prompts[2].len() < prompts[0].len());
+    assert!(prompts[3].contains("TAIL"));
+    assert!(summary.contains("Recovered."));
+}
+
+#[tokio::test]
+async fn small_tail_is_retained_verbatim_without_a_tiny_summary_request() {
+    // Arrange
+    let mut client = MockOneShotClient::new();
+    client
+        .expect_submit()
+        .once()
+        .returning(|_| Ok(answer("Large fragment summarized.")));
+    let request = request();
+
+    // Act
+    let summary = summarize(
+        &client,
+        &request,
+        &format!("{}TAIL🦀", "x".repeat(SUMMARY_CHUNK_BYTES)),
+        8000,
+        request.provider_call_budget.as_ref().expect("budget"),
+    )
+    .await
+    .expect("summary");
+
+    // Assert
+    assert!(summary.ends_with("TAIL🦀"));
+}
+
+#[tokio::test]
+async fn provider_splitting_still_summarizes_fragments_below_the_output_limit() {
+    // Arrange
+    let mut client = MockOneShotClient::new();
+    client.expect_submit().returning(|request| {
+        request
+            .provider_call_budget
+            .as_ref()
+            .expect("budget")
+            .consume()?;
+        if request.prompt.len() > 4_000 {
+            return Err(OneShotError::new("contextWindowExceeded"));
+        }
+        Ok(answer("Small provider fragment summarized."))
+    });
+    let request = request();
+
+    // Act
+    let summary = summarize(
+        &client,
+        &request,
+        &"x".repeat(30_000),
+        10_000,
+        request.provider_call_budget.as_ref().expect("budget"),
+    )
+    .await
+    .expect("smaller provider still makes progress");
+
+    // Assert
+    assert!(summary.len() < 10_000);
+    assert!(summary.contains("Small provider fragment summarized."));
+}
+
+#[tokio::test]
+async fn summary_repair_respects_prompt_and_shared_call_budgets() {
+    // Arrange
+    for (prompt_size, budget_size, diagnostic) in [
+        (PROMPT_BUDGET, 2, "repair prompt budget"),
+        (100, 1, "provider call limit reached"),
+    ] {
+        let mut request = request();
+        request.prompt = "x".repeat(prompt_size);
+        let budget = ag_agent::ProviderCallBudget::new(budget_size);
+        request.provider_call_budget = Some(budget.clone());
+        let mut client = MockOneShotClient::new();
+        client.expect_submit().once().returning(|request| {
+            request
+                .provider_call_budget
+                .as_ref()
+                .expect("budget")
+                .consume()?;
+            Ok(answer(""))
+        });
+
+        // Act
+        let error = summary_with_repair(&client, &request, 100, &budget)
+            .await
+            .expect_err("bounded repair");
+
+        // Assert
+        assert!(error.to_string().contains(diagnostic));
+    }
+}
+
+#[tokio::test]
+async fn persistent_invalid_summary_reports_distinct_terminal_diagnostics() {
+    // Arrange
+    for (output, diagnostic) in [
+        (String::new(), "summary was empty"),
+        ("🦀".repeat(200), "800 UTF-8 bytes, exceeding 127"),
+    ] {
+        let mut client = MockOneShotClient::new();
+        client
+            .expect_submit()
+            .times(2)
+            .returning(move |_| Ok(answer(&output)));
+        let request = request();
+
+        // Act
+        let error = summarize(
+            &client,
+            &request,
+            &"x".repeat(512),
+            511,
+            request.provider_call_budget.as_ref().expect("budget"),
+        )
+        .await
+        .expect_err("terminal diagnostic");
+
+        // Assert
+        // The target's quarter is the hard byte limit, with no per-tail
+        // shrinkage.
+        assert!(error.to_string().contains(diagnostic));
+        assert!(error.to_string().contains("after repair"));
+        assert!(is_input_size_error(&error.to_string()));
     }
 }
 
@@ -585,7 +793,10 @@ async fn provider_size_rejections_consume_the_shared_call_budget() {
     .expect_err("repeated splitting should exhaust the budget");
 
     // Assert
-    assert!(error.to_string().contains("provider call limit reached"));
+    assert!(
+        error.to_string().contains("provider call limit reached"),
+        "{error}"
+    );
 }
 
 #[tokio::test]

--- a/crates/agentty/src/app/review_prompt.rs
+++ b/crates/agentty/src/app/review_prompt.rs
@@ -1,0 +1,239 @@
+//! Bounded reviews of original diff fragments, retaining completed findings.
+
+use std::collections::VecDeque;
+
+use ag_agent::{
+    AgentRequestKind, OneShotClient, OneShotError, OneShotRequest, PermissionMode,
+    ProviderCallBudget, is_input_size_error,
+};
+use ag_protocol::{AgentResponse, FocusedReview, FocusedReviewSeverity};
+
+use super::diff_prompt::{self, MAX_PROVIDER_CALLS, MIN_CHUNK_BYTES, PROMPT_BUDGET};
+
+/// Reviews original diff text in bounded fragments. History alone may be
+/// summarized. All fragments, history repairs, and the cross-file pass share
+/// one provider budget. A failed later pass preserves earlier findings and
+/// explicitly identifies incomplete coverage.
+pub(super) async fn submit(
+    client: &dyn OneShotClient,
+    mut request: OneShotRequest,
+    diff: &str,
+    context: &str,
+    render: impl Fn(&str, &str) -> Result<String, OneShotError>,
+) -> Result<String, OneShotError> {
+    let budget = ProviderCallBudget::new(MAX_PROVIDER_CALLS);
+    request.provider_call_budget = Some(budget.clone());
+    request.permission_mode = PermissionMode::ReadOnly;
+    request.request_kind = AgentRequestKind::FocusedReview;
+    let mut context = context.to_string();
+    if render(diff, &context)?.len() > PROMPT_BUDGET {
+        context = diff_prompt::summarize(client, &request, &context, 7_500, &budget).await?;
+    }
+    let mut pending = VecDeque::from([diff.to_string()]);
+    let mut review = FocusedReview {
+        project_impact: Vec::new(),
+        suggestions: Vec::new(),
+    };
+    let mut completed = 0;
+    let mut coverage = String::new();
+    while let Some(fragment) = pending.pop_front() {
+        let result =
+            review_fragment(client, &request, &fragment, &mut context, &render, &budget).await;
+        match result {
+            Ok(result) => {
+                merge(&mut review, result);
+                completed += 1;
+            }
+            Err(error)
+                if is_input_size_error(&error.to_string())
+                    && fragment.len() > MIN_CHUNK_BYTES
+                    && budget.ensure_available().is_ok() =>
+            {
+                // Fill useful batches for very large inputs, leaving room
+                // for bounded history and the focused-review schema.
+                let chunk_limit = (fragment.len() / 2).min(PROMPT_BUDGET - 12_000);
+                for chunk in diff_prompt::chunks(&fragment, chunk_limit)
+                    .into_iter()
+                    .rev()
+                {
+                    pending.push_front(chunk);
+                }
+            }
+            Err(error) => {
+                if completed == 0 {
+                    return Err(error);
+                }
+                pending.push_front(fragment);
+                coverage = format!(
+                    "Partial review: {completed} batches completed; {} fragments remain \
+                     unreviewed. {error}\n\nUnreviewed diff headers:\n{}\n\nPress `f` to retry \
+                     the review.",
+                    pending.len(),
+                    file_headers(
+                        &pending
+                            .iter()
+                            .map(String::as_str)
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    )
+                );
+                break;
+            }
+        }
+    }
+    if completed > 1 && coverage.is_empty() {
+        let cross_file =
+            cross_file_review(client, &request, &review, diff, &context, &render, &budget).await;
+        match cross_file {
+            Ok(result) => merge(&mut review, result),
+            Err(error) => {
+                coverage = format!(
+                    "Partial review: all {completed} batches completed, but the cross-file pass \
+                     failed: {error}. Press `f` to retry the review."
+                );
+            }
+        }
+    }
+    if context.contains("[Summarized input;") {
+        coverage.push_str(
+            "\nReview coverage is limited: session history was summarized; accepted decisions may \
+             require checking against the original conversation.",
+        );
+    }
+    let text = review.to_markdown();
+    if coverage.is_empty() {
+        return Ok(text);
+    }
+
+    Ok(format!("{text}\n\n### Coverage\n\n{}", coverage.trim()))
+}
+
+/// Parses the transport-normalized focused-review response.
+pub(super) fn parse_response(response: &AgentResponse) -> Result<FocusedReview, OneShotError> {
+    let json = response.answer.trim();
+    if json.is_empty() {
+        return Err(OneShotError::new("Review assist returned empty output"));
+    }
+
+    serde_json::from_str(json).map_err(|error| {
+        OneShotError::new(format!(
+            "Review assist returned invalid structured output: {error}"
+        ))
+    })
+}
+
+/// Adapts history to a provider's smaller input limit before splitting the
+/// original diff. Failures return to the batch loop so earlier findings
+/// survive.
+async fn review_fragment(
+    client: &dyn OneShotClient,
+    request: &OneShotRequest,
+    fragment: &str,
+    context: &mut String,
+    render: &impl Fn(&str, &str) -> Result<String, OneShotError>,
+    budget: &ProviderCallBudget,
+) -> Result<FocusedReview, OneShotError> {
+    let mut request = request.clone();
+    loop {
+        request.prompt = render(fragment, context)?;
+        let result = submit_review(client, &request, budget).await;
+        if result
+            .as_ref()
+            .is_err_and(|error| is_input_size_error(&error.to_string()))
+            && request.prompt.len() <= PROMPT_BUDGET
+            && context.len() > MIN_CHUNK_BYTES
+        {
+            *context = diff_prompt::summarize(
+                client,
+                &request,
+                context,
+                (context.len() / 2).max(MIN_CHUNK_BYTES),
+                budget,
+            )
+            .await?;
+        } else {
+            return result;
+        }
+    }
+}
+
+/// Checks the rendered prompt before spending a provider turn.
+async fn submit_review(
+    client: &dyn OneShotClient,
+    request: &OneShotRequest,
+    budget: &ProviderCallBudget,
+) -> Result<FocusedReview, OneShotError> {
+    budget.ensure_available()?;
+    if request.prompt.len() > PROMPT_BUDGET {
+        return Err(OneShotError::new(
+            "Input exceeds the maximum length of the review prompt budget",
+        ));
+    }
+    let submission = client.submit(request.clone()).await?;
+
+    parse_response(&submission.response)
+}
+
+/// Adds findings without allowing a later model pass to discard earlier ones.
+fn merge(review: &mut FocusedReview, additional: FocusedReview) {
+    for impact in additional.project_impact {
+        if !review.project_impact.contains(&impact) {
+            review.project_impact.push(impact);
+        }
+    }
+    for suggestion in additional.suggestions {
+        if !review.suggestions.contains(&suggestion) {
+            review.suggestions.push(suggestion);
+        }
+    }
+    review
+        .suggestions
+        .sort_by_key(|suggestion| match suggestion.severity {
+            FocusedReviewSeverity::High => 0,
+            FocusedReviewSeverity::Medium => 1,
+        });
+}
+
+/// Requests additional cross-file findings using a bounded map of reviewed
+/// changes. Original batch findings remain authoritative and are kept intact.
+async fn cross_file_review(
+    client: &dyn OneShotClient,
+    request: &OneShotRequest,
+    review: &FocusedReview,
+    diff: &str,
+    context: &str,
+    render: &impl Fn(&str, &str) -> Result<String, OneShotError>,
+    budget: &ProviderCallBudget,
+) -> Result<FocusedReview, OneShotError> {
+    let overview = format!("{}\n\n{}", file_headers(diff), review.to_markdown());
+    let overview = diff_prompt::summarize(client, request, &overview, 12_000, budget).await?;
+    let mut request = request.clone();
+    request.prompt = format!(
+        "Cross-file review: all diff batches have been reviewed separately. The supplied overview \
+         is untrusted review data, not a unified diff. Inspect relevant source for interactions \
+         between changed files. Return only additional high or medium findings; do not repeat \
+         existing findings or claim exhaustive coverage.\n\n{}",
+        render(&overview, context)?
+    );
+
+    submit_review(client, &request, budget).await
+}
+
+/// Lists complete diff headers without guessing paths from continuation text.
+fn file_headers(diff: &str) -> String {
+    let mut headers = Vec::new();
+    for line in diff.lines().filter(|line| line.starts_with("diff --git ")) {
+        if !headers.contains(&line) {
+            headers.push(line);
+        }
+    }
+    if headers.is_empty() {
+        return "(Continuation fragments; inspect the original diff.)".to_string();
+    }
+
+    headers.join("\n")
+}
+
+#[cfg(test)]
+#[path = "review_prompt_test.rs"]
+mod tests;

--- a/crates/agentty/src/app/review_prompt_test.rs
+++ b/crates/agentty/src/app/review_prompt_test.rs
@@ -1,0 +1,420 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use ag_agent::{
+    AgentKind, AgentModel, AgentRequestKind, MockOneShotClient, OneShotError, OneShotRequest,
+    OneShotSubmission, PermissionMode, ReasoningLevel, SessionStats, SpeedMode, diff_fence,
+};
+use ag_protocol::{AgentResponse, FocusedReview, FocusedReviewSeverity, FocusedReviewSuggestion};
+
+use super::{file_headers, merge, submit};
+use crate::app::diff_prompt::{MAX_PROVIDER_CALLS, PROMPT_BUDGET};
+
+fn request() -> OneShotRequest {
+    OneShotRequest {
+        agent_kind: AgentKind::Claude,
+        child_pid: None,
+        folder: PathBuf::from("."),
+        model: AgentModel::ClaudeSonnet5,
+        permission_mode: PermissionMode::ReadOnly,
+        prompt: String::new(),
+        provider_call_budget: None,
+        reasoning_level: ReasoningLevel::Medium,
+        request_kind: AgentRequestKind::FocusedReview,
+        speed_mode: SpeedMode::Normal,
+    }
+}
+
+fn response() -> OneShotSubmission {
+    OneShotSubmission {
+        response: AgentResponse::plain(
+            r#"{"project_impact":["Original changes reviewed."],"suggestions":[{"severity":"high","details":"Preserved finding."}]}"#,
+        ),
+        stats: SessionStats::default(),
+    }
+}
+
+fn render(diff: &str, context: &str) -> String {
+    let fence = diff_fence(diff);
+    format!("{context}\n{fence}diff\n{diff}\n{fence}")
+}
+
+#[tokio::test]
+async fn batches_original_unicode_diff_then_checks_cross_file_interactions() {
+    // Arrange
+    let diff = format!(
+        "diff --git a/source b/source\n{}\nTAIL",
+        "+🦀\n".repeat(30_000)
+    );
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let prompts = Arc::clone(&seen);
+    let mut client = MockOneShotClient::new();
+    client.expect_submit().returning(move |request| {
+        request
+            .provider_call_budget
+            .as_ref()
+            .expect("budget")
+            .consume()?;
+        assert_eq!(request.request_kind, AgentRequestKind::FocusedReview);
+        assert_eq!(request.permission_mode, PermissionMode::ReadOnly);
+        assert_eq!(request.model, AgentModel::ClaudeSonnet5);
+        assert!(request.prompt.len() <= PROMPT_BUDGET);
+        assert!(request.prompt.contains("Accepted decision"));
+        prompts.lock().expect("prompts").push(request.prompt);
+        Ok(response())
+    });
+
+    // Act
+    let text = submit(
+        &client,
+        request(),
+        &diff,
+        "Accepted decision",
+        |diff, context| Ok(render(diff, context)),
+    )
+    .await
+    .expect("review");
+
+    // Assert
+    let prompts = seen.lock().expect("prompts");
+    assert!(prompts.len() > 2);
+    assert_eq!(
+        prompts
+            .iter()
+            .map(|prompt| prompt.matches('🦀').count())
+            .sum::<usize>(),
+        30_000
+    );
+    assert_eq!(
+        prompts
+            .iter()
+            .filter(|prompt| prompt.contains("TAIL"))
+            .count(),
+        1
+    );
+    assert!(
+        prompts
+            .last()
+            .expect("cross-file pass")
+            .starts_with("Cross-file review:")
+    );
+    assert_eq!(text.matches("Preserved finding.").count(), 1);
+    assert!(!text.contains("Partial review"));
+}
+
+#[tokio::test]
+async fn splits_fencing_overhead_and_provider_size_rejections_without_summaries() {
+    // Arrange
+    let mut client = MockOneShotClient::new();
+    client.expect_submit().returning(|request| {
+        request
+            .provider_call_budget
+            .as_ref()
+            .expect("budget")
+            .consume()?;
+        assert!(request.prompt.len() <= PROMPT_BUDGET);
+        if request.prompt.len() > 5_000 {
+            return Err(OneShotError::new("contextWindowExceeded"));
+        }
+        Ok(response())
+    });
+
+    // Act
+    let text = submit(
+        &client,
+        request(),
+        &"`".repeat(25_000),
+        "",
+        |diff, context| Ok(render(diff, context)),
+    )
+    .await
+    .expect("review");
+
+    // Assert
+    assert!(text.contains("Preserved finding."));
+    assert!(!text.contains("Partial review"));
+}
+
+#[tokio::test]
+async fn failed_later_batch_retains_findings_and_identifies_unreviewed_files() {
+    // Arrange
+    let mut calls = 0;
+    let mut client = MockOneShotClient::new();
+    client.expect_submit().times(2).returning(move |_| {
+        calls += 1;
+        if calls == 2 {
+            return Err(OneShotError::new("network timeout"));
+        }
+        Ok(response())
+    });
+    let diff = format!(
+        "diff --git a/first b/first\n{}diff --git a/last b/last\n{}",
+        "+first\n".repeat(8_000),
+        "+last\n".repeat(8_000)
+    );
+
+    // Act
+    let text = submit(&client, request(), &diff, "", |diff, context| {
+        Ok(render(diff, context))
+    })
+    .await
+    .expect("partial review");
+
+    // Assert
+    assert!(text.contains("Preserved finding."));
+    assert!(text.contains("Partial review: 1 batches completed"));
+    assert!(text.contains("diff --git a/last b/last"));
+    assert!(text.contains("network timeout"));
+    assert!(text.contains("Press `f` to retry"));
+    let suggestions = ag_session::review_suggestions(&text).expect("actionable finding");
+    assert!(!suggestions.contains("Partial review"));
+}
+
+#[tokio::test]
+async fn failed_cross_file_pass_preserves_all_batch_findings() {
+    // Arrange
+    let mut client = MockOneShotClient::new();
+    client.expect_submit().returning(|request| {
+        if request.prompt.starts_with("Cross-file review:") {
+            return Err(OneShotError::new("network timeout"));
+        }
+        Ok(response())
+    });
+
+    // Act
+    let text = submit(
+        &client,
+        request(),
+        &"x".repeat(90_000),
+        "",
+        |diff, context| Ok(render(diff, context)),
+    )
+    .await
+    .expect("partial review");
+
+    // Assert
+    assert!(text.contains("Preserved finding."));
+    assert!(text.contains("cross-file pass failed: network timeout"));
+}
+
+#[tokio::test]
+async fn exhausted_shared_budget_preserves_completed_batches() {
+    // Arrange
+    let mut client = MockOneShotClient::new();
+    client
+        .expect_submit()
+        .times(MAX_PROVIDER_CALLS)
+        .returning(|request| {
+            request
+                .provider_call_budget
+                .as_ref()
+                .expect("budget")
+                .consume()?;
+            Ok(response())
+        });
+
+    // Act
+    let text = submit(
+        &client,
+        request(),
+        &"x".repeat(4_000_000),
+        "",
+        |diff, context| Ok(render(diff, context)),
+    )
+    .await
+    .expect("partial review");
+
+    // Assert
+    assert!(text.contains("Partial review: 64 batches completed"));
+    assert!(text.contains("provider call limit reached"));
+    assert!(text.contains("Preserved finding."));
+}
+
+#[tokio::test]
+async fn errors_before_any_completed_review_propagate() {
+    // Arrange
+    for diagnostic in ["network timeout", "contextWindowExceeded"] {
+        let mut client = MockOneShotClient::new();
+        client
+            .expect_submit()
+            .once()
+            .returning(move |_| Err(OneShotError::new(diagnostic)));
+
+        // Act
+        let error = submit(&client, request(), "tiny", "", |diff, context| {
+            Ok(render(diff, context))
+        })
+        .await
+        .expect_err("no review");
+
+        // Assert
+        assert_eq!(error.to_string(), diagnostic);
+    }
+}
+
+#[tokio::test]
+async fn render_and_invalid_response_errors_propagate() {
+    // Arrange
+    let mut client = MockOneShotClient::new();
+    client.expect_submit().once().returning(|_| {
+        Ok(OneShotSubmission {
+            response: AgentResponse::plain("invalid"),
+            stats: SessionStats::default(),
+        })
+    });
+
+    // Act
+    let invalid = submit(&client, request(), "tiny", "", |diff, context| {
+        Ok(render(diff, context))
+    })
+    .await
+    .expect_err("invalid review");
+    let render_error = submit(&client, request(), "tiny", "", |_, _| {
+        Err(OneShotError::new("render"))
+    })
+    .await
+    .expect_err("invalid template");
+
+    // Assert
+    assert!(invalid.to_string().contains("invalid structured output"));
+    assert_eq!(render_error.to_string(), "render");
+}
+
+#[test]
+fn merge_retains_unique_findings_with_high_severity_first() {
+    // Arrange
+    let high = FocusedReviewSuggestion {
+        details: "High".to_string(),
+        severity: FocusedReviewSeverity::High,
+    };
+    let medium = FocusedReviewSuggestion {
+        details: "Medium".to_string(),
+        severity: FocusedReviewSeverity::Medium,
+    };
+    let mut review = FocusedReview {
+        project_impact: vec!["Impact".to_string()],
+        suggestions: vec![medium.clone()],
+    };
+
+    // Act
+    merge(
+        &mut review,
+        FocusedReview {
+            project_impact: vec!["Impact".to_string(), "Another".to_string()],
+            suggestions: vec![medium.clone(), high.clone()],
+        },
+    );
+
+    // Assert
+    assert_eq!(review.project_impact, ["Impact", "Another"]);
+    assert_eq!(review.suggestions, [high, medium]);
+}
+
+#[test]
+fn headers_keep_renames_and_deduplicate_continuations() {
+    // Arrange
+    let diff = "diff --git a/old b/new\n+hunk\ndiff --git a/old b/new\n+continued\ndiff --git \
+                a/next b/next\n";
+
+    // Act
+    let headers = file_headers(diff);
+
+    // Assert
+    assert_eq!(headers, "diff --git a/old b/new\ndiff --git a/next b/next");
+    assert!(file_headers("+continuation").contains("Continuation fragments"));
+}
+
+#[tokio::test]
+async fn smaller_provider_limit_reduces_history_without_summarizing_diff() {
+    // Arrange
+    let mut client = MockOneShotClient::new();
+    client.expect_submit().times(3).returning(|request| {
+        request
+            .provider_call_budget
+            .as_ref()
+            .expect("budget")
+            .consume()?;
+        if request.request_kind == AgentRequestKind::UtilityPrompt {
+            assert!(request.prompt.contains("Accepted decision"));
+            return Ok(OneShotSubmission {
+                response: AgentResponse::plain("Accepted decision retained."),
+                stats: SessionStats::default(),
+            });
+        }
+        if request.prompt.len() > 2_000 {
+            return Err(OneShotError::new("contextWindowExceeded"));
+        }
+        assert!(request.prompt.contains("ORIGINAL DIFF"));
+        Ok(OneShotSubmission {
+            response: AgentResponse::plain(r#"{"project_impact":[],"suggestions":[]}"#),
+            stats: SessionStats::default(),
+        })
+    });
+
+    // Act
+    let text = submit(
+        &client,
+        request(),
+        "ORIGINAL DIFF",
+        &"Accepted decision\n".repeat(200),
+        |diff, context| Ok(render(diff, context)),
+    )
+    .await
+    .expect("review");
+
+    // Assert
+    assert!(text.contains("session history was summarized"));
+    assert!(ag_session::review_suggestions(&text).is_none());
+}
+
+#[tokio::test]
+async fn cross_file_overview_is_bounded_without_discarding_batch_findings() {
+    // Arrange
+    let mut client = MockOneShotClient::new();
+    client.expect_submit().returning(|request| {
+        request
+            .provider_call_budget
+            .as_ref()
+            .expect("budget")
+            .consume()?;
+        assert!(request.prompt.len() <= PROMPT_BUDGET);
+        if request.request_kind == AgentRequestKind::UtilityPrompt {
+            return Ok(OneShotSubmission {
+                response: AgentResponse::plain(
+                    "Large batch impact retained for cross-file inspection.",
+                ),
+                stats: SessionStats::default(),
+            });
+        }
+        if request.prompt.starts_with("Cross-file review:") {
+            assert!(request.prompt.contains("Large batch impact retained"));
+            return Ok(response());
+        }
+        Ok(OneShotSubmission {
+            response: AgentResponse::plain(
+                serde_json::json!({
+                    "project_impact": ["Large batch impact. ".repeat(1000)],
+                    "suggestions": [{"severity": "medium", "details": "Original batch finding."}],
+                })
+                .to_string(),
+            ),
+            stats: SessionStats::default(),
+        })
+    });
+
+    // Act
+    let text = submit(
+        &client,
+        request(),
+        &"x".repeat(90_000),
+        "",
+        |diff, context| Ok(render(diff, context)),
+    )
+    .await
+    .expect("review");
+
+    // Assert
+    assert!(text.contains("Original batch finding."));
+    assert!(text.contains("Preserved finding."));
+    assert_eq!(text.matches("Large batch impact.").count(), 1000);
+}

--- a/crates/agentty/src/app/session/workflow/task_test/transition_test.rs
+++ b/crates/agentty/src/app/session/workflow/task_test/transition_test.rs
@@ -550,15 +550,17 @@ async fn test_commit_session_changes_falls_back_to_files_and_chat() {
             .times(1)
             .returning(|_| Box::pin(async { Ok("abc123".into()) }));
         let mut client = MockOneShotClient::new();
-        let mut sequence = mockall::Sequence::new();
         client
             .expect_submit()
-            .times(1)
-            .in_sequence(&mut sequence)
+            .times(if oversized_diff { 2..=64 } else { 1..=1 })
+            .withf(|request| request.prompt.contains("DIFF_ONLY_SECRET"))
             .returning(move |request| {
-                assert!(request.prompt.contains("DIFF_ONLY_SECRET"));
                 if oversized_diff {
-                    assert!(request.prompt.starts_with("Summarize"));
+                    assert!(request.prompt.contains("Summarize this fragment"));
+                    request
+                        .provider_call_budget
+                        .expect("shared budget")
+                        .consume()?;
                     return Ok(one_shot_submission("", 0, 0));
                 }
                 Err(agent::OneShotError::new("Input exceeds the maximum length"))
@@ -566,11 +568,10 @@ async fn test_commit_session_changes_falls_back_to_files_and_chat() {
         client
             .expect_submit()
             .times(1)
-            .in_sequence(&mut sequence)
+            .withf(|request| request.prompt.contains("Use only the changed file list"))
             .returning(|request| {
                 assert_eq!(request.permission_mode, agent::PermissionMode::ReadOnly);
                 assert_eq!(request.reasoning_level, ReasoningLevel::Low);
-                assert!(request.prompt.contains("Use only the changed file list"));
                 assert!(
                     request
                         .prompt

--- a/crates/agentty/src/app/task.rs
+++ b/crates/agentty/src/app/task.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use ag_agent::{self as agent, OneShotClient};
 use ag_forge::{ForgeRemote, ReviewCommentAnchorSide, ReviewCommentSnapshot, ReviewRequestClient};
 use ag_git::GitClient;
-use ag_protocol::{AgentResponse, FocusedReview, focused_review_json_schema_json};
+use ag_protocol::focused_review_json_schema_json;
 use askama::Template;
 use async_trait::async_trait;
 use tokio::sync::mpsc;
@@ -580,7 +580,7 @@ impl TaskService {
         session_chat_history: Option<&str>,
         one_shot_client: &dyn OneShotClient,
     ) -> Result<String, AppError> {
-        let (submission, summarized) = crate::app::diff_prompt::submit(
+        let review = crate::app::review_prompt::submit(
             one_shot_client,
             agent::OneShotRequest {
                 provider_call_budget: None,
@@ -602,14 +602,6 @@ impl TaskService {
             },
         )
         .await?;
-        let review = Self::review_output_text(&submission.response)?;
-        if summarized {
-            return Ok(format!(
-                "{review}\n\nReview coverage is limited: large diff or history was summarized; \
-                 this is not a complete review of every changed line."
-            ));
-        }
-
         Ok(review)
     }
 
@@ -635,24 +627,6 @@ impl TaskService {
                 session_id,
             },
         }
-    }
-
-    /// Parses one structured review from the agent response and formats it for
-    /// the session transcript.
-    fn review_output_text(agent_response: &AgentResponse) -> Result<String, AppError> {
-        let review_json = agent_response.answer.trim();
-        if review_json.is_empty() {
-            return Err(AppError::Workflow(
-                "Review assist returned empty output".to_string(),
-            ));
-        }
-        let review = serde_json::from_str::<FocusedReview>(review_json).map_err(|error| {
-            AppError::Workflow(format!(
-                "Review assist returned invalid structured output: {error}"
-            ))
-        })?;
-
-        Ok(review.to_markdown())
     }
 
     /// Renders the review assist prompt from the markdown template.

--- a/crates/agentty/src/app/task_test.rs
+++ b/crates/agentty/src/app/task_test.rs
@@ -23,7 +23,7 @@ use crate::domain::agent::{AgentCliInfo, AgentKind, AgentModel, AgentSelection, 
 use crate::domain::file_entry::FileEntry;
 
 #[tokio::test]
-async fn oversized_review_discloses_summary_coverage_and_preserves_schema() {
+async fn oversized_review_batches_original_diff_and_discloses_summarized_history() {
     // Arrange
     let mut client = agent::MockOneShotClient::new();
     client.expect_submit().returning(|request| {
@@ -959,7 +959,8 @@ fn review_output_text_formats_structured_agent_response() {
     );
 
     // Act
-    let review_text = TaskService::review_output_text(&agent_response)
+    let review_text = crate::app::review_prompt::parse_response(&agent_response)
+        .map(|review| review.to_markdown())
         .expect("structured output should be accepted");
 
     // Assert
@@ -972,21 +973,18 @@ fn review_output_text_formats_structured_agent_response() {
 
 #[test]
 /// Verifies whitespace-only review output is rejected as
-/// [`AppError::Workflow`] so users see a clear error instead of a blank
+/// a diagnostic so users see a clear error instead of a blank
 /// review pane.
 fn review_output_text_rejects_blank_agent_response_text() {
     // Arrange
     let agent_response = AgentResponse::plain(" \n\t ");
 
     // Act
-    let result = TaskService::review_output_text(&agent_response);
+    let result = crate::app::review_prompt::parse_response(&agent_response)
+        .map(|review| review.to_markdown());
 
     // Assert
     let error = result.expect_err("blank output should be rejected");
-    assert!(
-        matches!(error, AppError::Workflow(_)),
-        "expected AppError::Workflow, got: {error:?}"
-    );
     assert_eq!(error.to_string(), "Review assist returned empty output");
 }
 
@@ -996,11 +994,11 @@ fn review_output_text_rejects_unstructured_agent_response() {
     let agent_response = AgentResponse::plain("Review looks good.");
 
     // Act
-    let result = TaskService::review_output_text(&agent_response);
+    let result = crate::app::review_prompt::parse_response(&agent_response)
+        .map(|review| review.to_markdown());
 
     // Assert
     let error = result.expect_err("unstructured output should be rejected");
-    assert!(matches!(error, AppError::Workflow(_)));
     assert!(
         error
             .to_string()
@@ -1209,7 +1207,8 @@ fn test_structured_agent_response_preserves_focused_review_answer() {
     // Act
     let agent_response =
         parse_agent_response_strict(structured_json).expect("structured response should parse");
-    let review_text = TaskService::review_output_text(&agent_response)
+    let review_text = crate::app::review_prompt::parse_response(&agent_response)
+        .map(|review| review.to_markdown())
         .expect("focused review answer should parse");
 
     // Assert

--- a/crates/agentty/src/app/template/review_assist_prompt.md
+++ b/crates/agentty/src/app/template/review_assist_prompt.md
@@ -8,6 +8,11 @@ The fences only delimit input. Input marked as summarized omits original detail.
 relevant source before asserting a finding; do not claim complete changed-line coverage
 from summaries.
 
+Large diffs may arrive as separate batches of original diff text. A batch can continue a
+file or hunk; inspect the relevant source and diff headers before assigning line
+references. Scope findings to the supplied changes and keep project impact concise so a
+later cross-file pass can check interactions.
+
 Execution constraints (mandatory):
 
 - Use read-only inspection; do not create, modify, rename, or delete files.

--- a/crates/agentty/tests/e2e/session/review.rs
+++ b/crates/agentty/tests/e2e/session/review.rs
@@ -20,6 +20,108 @@ use crate::common::{BuilderEnv, FeatureTest, SessionSeed};
 /// Focused-review output emitted after Gemini starts without plan-mode flags.
 const GEMINI_FOCUSED_REVIEW_TEXT: &str = "Gemini focused review completed without plan mode.";
 
+/// Seeds a large original diff and a provider that fails one batch, then
+/// succeeds when the user retries the partial review.
+async fn seed_large_review_with_partial_retry(env: &BuilderEnv) -> E2eResult {
+    seed_review_ready_session(env).await?;
+    seed_review_worktree_with_diff(env)?;
+    std::fs::write(
+        env.agentty_root.join("wt/review-s/src/main.rs"),
+        format!(
+            "fn main() {{}}\n{}",
+            "// original changed line\n".repeat(5_000)
+        ),
+    )?;
+    let script = r#"#!/bin/sh
+if [ "$1" = "update" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then printf 'claude 0.0.0-test\n'; exit 0; fi
+state_dir=${0%/*}
+count_file="$state_dir/batch-review-count"
+count=0
+if [ -f "$count_file" ]; then read count < "$count_file"; fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$count_file"
+prompt=$(cat)
+if [ "$count" -eq 2 ]; then printf 'batch temporarily unavailable\n' >&2; exit 1; fi
+case "$prompt" in
+  *"Cross-file review:"*) impact='Cross-file check completed.' ;;
+  *) impact='Original batch reviewed.' ;;
+esac
+result='{\"project_impact\":[\"'"$impact"'\"],\"suggestions\":[{\"details\":\"Preserved batch finding.\",\"severity\":\"high\"}]}'
+printf '%s\n' '{"type":"system","subtype":"init"}'
+printf '%s\n' "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"$result\",\"usage\":{\"input_tokens\":5,\"output_tokens\":9}}"
+"#;
+    let claude_path = env.stub_bin.join("claude");
+    std::fs::write(&claude_path, script)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&claude_path, std::fs::Permissions::from_mode(0o750))?;
+
+    seed_project_settings(
+        env,
+        &[
+            ("DefaultReviewAgent", "claude"),
+            ("DefaultReviewModel", "claude-haiku-4-5-20251001"),
+        ],
+    )
+    .await
+}
+
+/// Large reviews keep completed findings after a batch failure, and `f`
+/// retries the same unchanged diff through the complete cross-file pass.
+#[tokio::test]
+async fn test_large_review_partial_retry() -> E2eResult {
+    // Arrange, Act, Assert
+    FeatureTest::new("large_review_partial_retry")
+        .with_git()
+        .setup(|env| Box::pin(async move { seed_large_review_with_partial_retry(env).await }))
+        .run(
+            |scenario| {
+                scenario
+                    .compose(&common::wait_for_agentty_startup())
+                    .compose(&common::switch_to_tab("Sessions"))
+                    .press_key("Enter")
+                    .press_key("f")
+                    .wait_for_text("Partial review:", 30000)
+                    .press_key("g")
+                    .wait_for_text("Preserved batch finding.", 5000)
+                    .capture_labeled(
+                        "partial_review",
+                        "Completed batch findings survive a later failure",
+                    )
+                    .press_key("f")
+                    .wait_for_text("Regenerate focused review?", 5000)
+                    .press_key("y")
+                    .wait_for_text("Cross-file check completed.", 30000)
+                    .capture_labeled("retried_review", "Retry completes the original diff review")
+            },
+            |frame, report| {
+                Box::pin(async move {
+                    let partial = common::frame_from_capture(&report.captures[0]);
+                    assertion::assert_text_in_region(
+                        &partial,
+                        "Preserved batch finding.",
+                        &Region::full(partial.cols(), partial.rows()),
+                    );
+                    assertion::assert_text_in_region(
+                        frame,
+                        "Preserved batch finding.",
+                        &Region::full(frame.cols(), frame.rows()),
+                    );
+                    assertion::assert_text_in_region(
+                        frame,
+                        "Cross-file check completed.",
+                        &Region::full(frame.cols(), frame.rows()),
+                    );
+                    assertion::assert_not_visible(frame, "Partial review:");
+                    assertion::assert_not_visible(frame, "Review assist unavailable");
+                })
+            },
+        )
+        .await?;
+
+    Ok(())
+}
+
 /// Seeds a Codex focused review whose first direct review has an unknown field,
 /// then returns a valid direct review for the schema-repair turn. Both turns
 /// include a blank duplicate final item in `turn/completed`.

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -888,21 +888,25 @@ their triggers:
   every mutation permission request, avoiding plan-mode sandbox initialization;
   persistent read-only research sessions continue to use sandboxed plan mode.
 
-  Commit-message and review preparation share a bounded prompt pipeline. It budgets the
-  rendered prompt, reduces oversized diff and context chunks through isolated read-only
-  utility calls, and combines their summaries before submission. Summary input chunks
-  use the prompt budget independently of the final summary size. All chunk summaries,
-  recursive reductions, and final attempts share a limit of 64 provider turns. The
-  shared budget is charged immediately before CLI execution or each app-server attempt,
-  including protocol repairs and transport restart retries. Size rejection reduces the
-  budget instead of restarting the same request or entering commit repair. Reviews
-  prepared from summaries explicitly disclose limited coverage. Commit generation
-  catches input-size and reduction-budget failures and starts one separately bounded
-  fallback using cumulative changed filenames, the user/assistant conversation, and the
-  existing session commit message to retain earlier work. The fallback excludes the diff
-  and workflow notices, forbids retrieving diffs or file contents, and preserves
-  read-only utility permissions and commit validation. Both post-turn and pre-sync
-  commits supply the session transcript; fallback failure propagates normally.
+  Review preparation budgets the rendered prompt and splits oversized original diffs
+  into read-only review batches, preserving all source fragments. It combines distinct
+  findings in severity order without letting a later pass discard earlier findings, then
+  checks cross-file interactions from the file headers and batch results. A later
+  failure preserves completed findings and adds a separate coverage section with retry
+  guidance. Incomplete reviews reuse the existing `f` regeneration flow.
+
+  Commit-message preparation and review history use the shared bounded summary reducer.
+  Small fragments stay verbatim; empty or oversized summaries receive one corrective
+  retry before splitting their original input. Review history, batch submissions, and
+  the cross-file pass share a limit of 64 provider turns; commit-message preparation has
+  its own limit. Budgets include protocol repairs and transport restart retries. History
+  summaries explicitly disclose limited context coverage. Commit generation catches
+  input-size and reduction-budget failures and starts one separately bounded fallback
+  using cumulative changed filenames, the user/assistant conversation, and the existing
+  session commit message to retain earlier work. The fallback excludes the diff and
+  workflow notices, forbids retrieving diffs or file contents, and preserves read-only
+  utility permissions and commit validation. Both post-turn and pre-sync commits supply
+  the session transcript; fallback failure propagates normally.
 
 - **Sync-main workflow** (list-mode `s`): captures an immutable project ID, operation
   ID, path, branch, and review-target snapshot before queueing pull/rebase/push through

--- a/docs/site/content/docs/usage/workflow.md
+++ b/docs/site/content/docs/usage/workflow.md
@@ -463,9 +463,16 @@ diff preparation exceeds the agent’s input or reduction limit, Agentty retries
 only the changed file list, your chat history, and the existing session commit message,
 without the diff. The existing message keeps earlier work represented. This preserves
 the complete worktree and the single evolving commit. If that fallback also exceeds its
-limit, auto-commit stops without invoking code-repair assistance. Focused review also
-bounds large diffs and history, and reports limited coverage when it uses summaries.
-Preparation stops if its provider-call limit is reached, leaving your changes intact.
+limit, auto-commit stops without invoking code-repair assistance. Empty or oversized
+summaries get a bounded repair attempt before their source fragments are split again.
+Small fragments are kept verbatim.
+
+Focused review checks large diffs in batches of original changes, then checks cross-file
+interactions. Session history may be summarized, with limited context coverage
+disclosed. If a later batch or the cross-file check fails, completed findings remain
+available under an explicit partial-review notice identifying the unfinished work. Press
+`f` and confirm regeneration to retry. Preparation stops at its provider-call limit,
+leaving your changes intact.
 
 Auto-commit waits up to five seconds in total for a busy Git index to become available.
 If an index lock still blocks auto-commit, Agentty stops and records a `[Commit Error]`


### PR DESCRIPTION
- Batch oversized original diffs, retain completed findings, and add a cross-file interaction pass.
- Repair invalid summaries once, preserve small fragments verbatim, and enforce shared provider-call budgets.
- Surface incomplete coverage with retry guidance and add focused unit and E2E coverage.

Co-Authored-By: [Agentty](https://github.com/agentty-xyz/agentty)