### PR TITLE
Support per-turn harness options

### DIFF
--- a/crates/ag-harness/.sqlx/query-1e761f5e068a65d258edfb6eb5ce5a4d90646dd557891a4919d4a1ffa1528219.json
+++ b/crates/ag-harness/.sqlx/query-1e761f5e068a65d258edfb6eb5ce5a4d90646dd557891a4919d4a1ffa1528219.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "SQLite",
+  "query": "\nSELECT max_history_bytes AS \"max_history_bytes!: i64\", provider_session_id,\n       (SELECT turn_options FROM session_turn\n        WHERE session_id = session.id AND status = 'completed'\n        ORDER BY turn_position DESC LIMIT 1) AS \"turn_options?: String\"\nFROM session WHERE id = ?\n",
+  "describe": {
+    "columns": [
+      {
+        "name": "max_history_bytes!: i64",
+        "ordinal": 0,
+        "type_info": "Integer",
+        "origin": {
+          "Table": {
+            "table": "session",
+            "name": "max_history_bytes"
+          }
+        }
+      },
+      {
+        "name": "provider_session_id",
+        "ordinal": 1,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session",
+            "name": "provider_session_id"
+          }
+        }
+      },
+      {
+        "name": "turn_options?: String",
+        "ordinal": 2,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_turn",
+            "name": "turn_options"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "1e761f5e068a65d258edfb6eb5ce5a4d90646dd557891a4919d4a1ffa1528219"
+}

--- a/crates/ag-harness/.sqlx/query-e0ed7813e2de9a9ca86f7dd6336f509bd51c5469f3b896b9c42f8c62b9fb9baa.json
+++ b/crates/ag-harness/.sqlx/query-e0ed7813e2de9a9ca86f7dd6336f509bd51c5469f3b896b9c42f8c62b9fb9baa.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "\nSELECT provider,\n       model,\n       output_schema,\n       system_prompt,\n       max_history_bytes AS \"max_history_bytes!: i64\",\n       provider_session_id\nFROM session\nWHERE id = ?\n",
+  "query": "\nSELECT provider,\n       model,\n       output_schema,\n       system_prompt,\n       max_history_bytes AS \"max_history_bytes!: i64\",\n       provider_session_id,\n       (SELECT turn_options FROM session_turn\n        WHERE session_id = session.id ORDER BY turn_position DESC LIMIT 1) AS \"turn_options?: String\"\nFROM session\nWHERE id = ?\n",
   "describe": {
     "columns": [
       {
@@ -68,6 +68,17 @@
             "name": "provider_session_id"
           }
         }
+      },
+      {
+        "name": "turn_options?: String",
+        "ordinal": 6,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "session_turn",
+            "name": "turn_options"
+          }
+        }
       }
     ],
     "parameters": {
@@ -79,8 +90,9 @@
       false,
       true,
       false,
+      true,
       true
     ]
   },
-  "hash": "324a4345246d93c36980918aa3940fd1745ac3120b45edb7633ba1c684d4a3c7"
+  "hash": "e0ed7813e2de9a9ca86f7dd6336f509bd51c5469f3b896b9c42f8c62b9fb9baa"
 }

--- a/crates/ag-harness/.sqlx/query-e600a148224c991fdce82180c1e52830a586cf2e213824c66de31ed06fc109e9.json
+++ b/crates/ag-harness/.sqlx/query-e600a148224c991fdce82180c1e52830a586cf2e213824c66de31ed06fc109e9.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\nINSERT INTO session_turn (\n    session_id, turn_position, status, error_type, lease_expires_at, created_at, updated_at,\n    owner_token, turn_options\n)\nVALUES (?, ?, 'running', NULL, ?, ?, ?, randomblob(16), ?)\nRETURNING owner_token AS \"owner_token!: Vec<u8>\"\n",
+  "describe": {
+    "columns": [
+      {
+        "name": "owner_token!: Vec<u8>",
+        "ordinal": 0,
+        "type_info": "Blob",
+        "origin": {
+          "Table": {
+            "table": "session_turn",
+            "name": "owner_token"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 6
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "e600a148224c991fdce82180c1e52830a586cf2e213824c66de31ed06fc109e9"
+}

--- a/crates/ag-harness/.sqlx/query-edd9724a76467bd3a1250d8330db4960db80120e8d61963f407f661ebe086148.json
+++ b/crates/ag-harness/.sqlx/query-edd9724a76467bd3a1250d8330db4960db80120e8d61963f407f661ebe086148.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE session SET provider_session_id = NULL WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "edd9724a76467bd3a1250d8330db4960db80120e8d61963f407f661ebe086148"
+}

--- a/crates/ag-harness/migrations/006_add_turn_options.sql
+++ b/crates/ag-harness/migrations/006_add_turn_options.sql
@@ -1,0 +1,2 @@
+ALTER TABLE session_turn ADD COLUMN turn_options TEXT
+CHECK (turn_options IS NULL OR json_valid(turn_options));

--- a/crates/ag-harness/src/engine.rs
+++ b/crates/ag-harness/src/engine.rs
@@ -1,0 +1,573 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::file_system::FileSystem;
+use crate::lifecycle::{LifecycleEmitter, LifecycleId, ToolErrorType, ToolLifecycle};
+use crate::model::{
+    Model, ModelError, ModelMessage, ModelRequest, ModelResponse, ReasoningEffort,
+    ensure_unique_tool_call_ids,
+};
+use crate::read::{self, ReadError, ReadTool};
+use crate::repository::Repository;
+use crate::tool::{
+    ReadAction, ReadArguments, Tool, ToolCall, ToolCallArguments, ToolDefinition, WriteArguments,
+};
+use crate::turn::{
+    ModelRequestActivity, ResumeFailure, ToolActivity, TurnError, TurnOptions, TurnOutcome,
+    TurnReport, sanitize_report_text, sanitized_completion_metadata,
+};
+use crate::write::{WriteError, WriteTool};
+use crate::write_journal::WriteJournal;
+
+/// Shared execution dependencies and the immutable configuration for one turn.
+pub(crate) struct Engine<'a> {
+    pub(crate) file_system: &'a Arc<dyn FileSystem>,
+    pub(crate) lifecycle: &'a LifecycleEmitter,
+    pub(crate) model: &'a Arc<dyn Model>,
+    pub(crate) model_reasoning_effort: Option<ReasoningEffort>,
+    pub(crate) options: &'a TurnOptions,
+    pub(crate) repository: Option<&'a Repository>,
+}
+
+impl Engine<'_> {
+    pub(crate) async fn run(
+        &self,
+        request: ModelRequest,
+        turn_id: Option<LifecycleId>,
+        journal: Option<WriteJournal>,
+    ) -> Result<(TurnOutcome, Vec<ModelMessage>, Option<String>), TurnError> {
+        let started_at = Instant::now();
+        let (mut request, read_tool, write_tool) = self.prepare_request(request, journal)?;
+        let mut completed_tool_calls = 0_usize;
+        let mut model_request_index = 0_u64;
+        let mut model_requests = Vec::new();
+        let mut tool_calls = Vec::new();
+
+        loop {
+            let (
+                response,
+                activities,
+                provider_session_id,
+                native_resume_rejected,
+                reasoning_content,
+            ) = self
+                .complete_model_request(&request, model_request_index, turn_id)
+                .await?;
+            if native_resume_rejected || provider_session_id.is_some() {
+                request.set_provider_session_id(provider_session_id);
+            }
+            model_request_index = model_request_index
+                .saturating_add(u64::try_from(activities.len()).unwrap_or(u64::MAX));
+            model_requests.extend(activities);
+
+            match response {
+                ModelResponse::Output(output) => {
+                    request.record_output_with_reasoning(&output, reasoning_content);
+                    let report = TurnReport::new(started_at.elapsed(), model_requests, tool_calls);
+
+                    let provider_session_id = request.provider_session_id().map(str::to_string);
+
+                    return Ok((
+                        TurnOutcome::new(output, report),
+                        request.into_messages(),
+                        provider_session_id,
+                    ));
+                }
+                ModelResponse::ToolCall(call) => {
+                    let (result, activity) = self
+                        .execute_tool_call(
+                            &call,
+                            read_tool.as_ref(),
+                            write_tool.as_ref(),
+                            completed_tool_calls,
+                            turn_id,
+                        )
+                        .await?;
+                    request.record_tool_result(call, result);
+                    tool_calls.push(activity);
+                    completed_tool_calls += 1;
+                }
+                ModelResponse::ToolCalls(calls) => {
+                    if calls.is_empty() {
+                        return Err(ModelError::MissingToolCall.into());
+                    }
+                    ensure_unique_tool_call_ids(&calls)?;
+                    if calls.len()
+                        > self
+                            .options
+                            .limits()
+                            .max_tool_calls()
+                            .get()
+                            .saturating_sub(completed_tool_calls)
+                    {
+                        return Err(TurnError::ToolCallLimit {
+                            limit: self.options.limits().max_tool_calls().get(),
+                        });
+                    }
+                    let mut results = Vec::with_capacity(calls.len());
+                    for call in &calls {
+                        let (result, activity) = self
+                            .execute_tool_call(
+                                call,
+                                read_tool.as_ref(),
+                                write_tool.as_ref(),
+                                completed_tool_calls,
+                                turn_id,
+                            )
+                            .await?;
+                        results.push(result);
+                        tool_calls.push(activity);
+                        completed_tool_calls += 1;
+                    }
+                    request.record_tool_results(calls, results);
+                }
+            }
+        }
+    }
+
+    fn prepare_request(
+        &self,
+        mut request: ModelRequest,
+        journal: Option<WriteJournal>,
+    ) -> Result<(ModelRequest, Option<ReadTool>, Option<WriteTool>), TurnError> {
+        if self.lifecycle.is_enabled() {
+            request.mark_lifecycle_observed();
+        }
+        if request.model_reasoning_effort().is_none()
+            && let Some(reasoning_effort) = self.model_reasoning_effort
+        {
+            request = request.with_model_reasoning_effort(reasoning_effort);
+        }
+        let read_allowed = self.options.tool_policy().allows(Tool::Read);
+        let write_allowed = self.options.tool_policy().allows(Tool::Write);
+        if !read_allowed && !write_allowed {
+            return Ok((request, None, None));
+        }
+        let repository = self
+            .repository
+            .as_ref()
+            .ok_or(TurnError::RepositoryRequired)?;
+        let read_tool = read_allowed.then(|| {
+            request = request.clone().with_tool(ToolDefinition::read());
+            ReadTool::with_git(
+                Arc::clone(self.file_system),
+                repository.root().to_path_buf(),
+                repository.git_executable().to_path_buf(),
+            )
+        });
+        let write_tool = write_allowed.then(|| {
+            request = request.clone().with_tool(ToolDefinition::write());
+            let mut tool = WriteTool::new(
+                Arc::clone(self.file_system),
+                repository.root().to_path_buf(),
+            );
+            tool.journal = journal;
+
+            tool
+        });
+
+        Ok((request, read_tool, write_tool))
+    }
+
+    async fn complete_model_request(
+        &self,
+        request: &ModelRequest,
+        model_request_index: u64,
+        turn_id: Option<LifecycleId>,
+    ) -> Result<
+        (
+            ModelResponse,
+            Vec<ModelRequestActivity>,
+            Option<String>,
+            bool,
+            Option<String>,
+        ),
+        TurnError,
+    > {
+        let native_resume = request.provider_session_id().is_some();
+        match self
+            .complete_model_attempt(request.clone(), model_request_index, turn_id)
+            .await
+        {
+            Ok((response, activity, provider_session_id, reasoning_content)) => Ok((
+                response,
+                vec![activity],
+                provider_session_id,
+                false,
+                reasoning_content,
+            )),
+            Err(ModelAttemptError {
+                duration,
+                error: ModelError::ResumeUnavailable,
+            }) if native_resume => {
+                let rejected_activity = ModelRequestActivity::new(
+                    None,
+                    duration,
+                    crate::lifecycle::ModelResponseType::ResumeUnavailable,
+                );
+                let mut replay_request = request.clone();
+                replay_request.set_provider_session_id(None);
+                let replay_index = model_request_index.saturating_add(1);
+                match self
+                    .complete_model_attempt(replay_request, replay_index, turn_id)
+                    .await
+                {
+                    Ok((response, replay_activity, provider_session_id, reasoning_content)) => {
+                        Ok((
+                            response,
+                            vec![rejected_activity, replay_activity],
+                            provider_session_id,
+                            true,
+                            reasoning_content,
+                        ))
+                    }
+                    Err(failure) => Err(ResumeFailure::Replay {
+                        source: failure.error,
+                    }
+                    .into_model_error()
+                    .into()),
+                }
+            }
+            Err(failure) if native_resume => Err(ResumeFailure::Native {
+                source: failure.error,
+            }
+            .into_model_error()
+            .into()),
+            Err(failure) => Err(failure.error.into()),
+        }
+    }
+
+    async fn complete_model_attempt(
+        &self,
+        request: ModelRequest,
+        model_request_index: u64,
+        turn_id: Option<LifecycleId>,
+    ) -> Result<
+        (
+            ModelResponse,
+            ModelRequestActivity,
+            Option<String>,
+            Option<String>,
+        ),
+        ModelAttemptError,
+    > {
+        let started_at = Instant::now();
+        let model_lifecycle =
+            self.lifecycle
+                .start_model_request(self.model.metadata(), model_request_index, turn_id);
+        let operation = self.model.complete(request.clone());
+        let completion = match model_lifecycle.as_ref() {
+            Some(model_lifecycle) => model_lifecycle.scope(operation).await,
+            None => operation.await,
+        };
+        let (response, completion, provider_session_id, reasoning_content) = match completion {
+            Ok(completion) => completion.into_parts(),
+            Err(error) => {
+                if let Some(model_lifecycle) = model_lifecycle {
+                    model_lifecycle.failed(error.error_type(), error.http_status());
+                }
+
+                return Err(ModelAttemptError {
+                    duration: started_at.elapsed(),
+                    error,
+                });
+            }
+        };
+        if let Some(output) = response.output()
+            && let Err(error) = request.schema().validate_value(output)
+        {
+            let error = ModelError::from(error);
+            if let Some(model_lifecycle) = model_lifecycle {
+                model_lifecycle.failed(error.error_type(), error.http_status());
+            }
+
+            return Err(ModelAttemptError {
+                duration: started_at.elapsed(),
+                error,
+            });
+        }
+        let response_type = response.response_type();
+        let activity = ModelRequestActivity::new(
+            completion.as_ref().map(sanitized_completion_metadata),
+            started_at.elapsed(),
+            response_type,
+        );
+        if let Some(model_lifecycle) = model_lifecycle {
+            model_lifecycle.completed(completion, response_type);
+        }
+
+        Ok((response, activity, provider_session_id, reasoning_content))
+    }
+
+    async fn execute_tool_call(
+        &self,
+        call: &ToolCall,
+        read_tool: Option<&ReadTool>,
+        write_tool: Option<&WriteTool>,
+        completed_tool_calls: usize,
+        turn_id: Option<LifecycleId>,
+    ) -> Result<(String, ToolActivity), TurnError> {
+        let mut tool_lifecycle =
+            self.lifecycle
+                .request_tool(call.id().to_string(), call.name().to_string(), turn_id);
+        let execution = match call.arguments() {
+            ToolCallArguments::Read(arguments) => {
+                read_tool.map(|tool| ToolExecution::Read(tool, arguments))
+            }
+            ToolCallArguments::Write(arguments) => {
+                write_tool.map(|tool| ToolExecution::Write(tool, arguments))
+            }
+        };
+        let Some(execution) = execution else {
+            if let Some(tool_lifecycle) = tool_lifecycle {
+                tool_lifecycle.denied();
+            }
+
+            return Err(TurnError::ToolDenied {
+                name: call.name().to_string(),
+            });
+        };
+        if completed_tool_calls >= self.options.limits().max_tool_calls().get() {
+            if let Some(tool_lifecycle) = tool_lifecycle {
+                tool_lifecycle.failed(ToolErrorType::CallLimit);
+            }
+
+            return Err(TurnError::ToolCallLimit {
+                limit: self.options.limits().max_tool_calls().get(),
+            });
+        }
+        if let Some(tool_lifecycle) = tool_lifecycle.as_mut() {
+            tool_lifecycle.started();
+        }
+        let operation = execute_tool(execution, call.id());
+        let result = match tool_lifecycle.as_ref() {
+            Some(tool_lifecycle) => tool_lifecycle.scope(operation).await,
+            None => operation.await,
+        };
+
+        Self::finish_tool_call(result, tool_lifecycle)
+    }
+
+    fn finish_tool_call(
+        result: Result<(String, ToolActivity), TurnError>,
+        tool_lifecycle: Option<ToolLifecycle>,
+    ) -> Result<(String, ToolActivity), TurnError> {
+        match result {
+            Ok(result) => {
+                if let Some(tool_lifecycle) = tool_lifecycle {
+                    if matches!(
+                        &result.1,
+                        ToolActivity::ReadInspectionRejected { .. }
+                            | ToolActivity::ReadRejected { .. }
+                            | ToolActivity::WriteRejected { .. }
+                    ) {
+                        tool_lifecycle.failed(ToolErrorType::Execution);
+                    } else {
+                        tool_lifecycle.completed();
+                    }
+                }
+
+                Ok(result)
+            }
+            Err(error) => {
+                if let Some(tool_lifecycle) = tool_lifecycle {
+                    tool_lifecycle.failed(ToolErrorType::Execution);
+                }
+
+                Err(error)
+            }
+        }
+    }
+}
+
+enum ToolExecution<'a> {
+    Read(&'a ReadTool, &'a ReadArguments),
+    Write(&'a WriteTool, &'a WriteArguments),
+}
+
+struct ModelAttemptError {
+    duration: Duration,
+    error: ModelError,
+}
+
+async fn execute_tool(
+    execution: ToolExecution<'_>,
+    call_id: &str,
+) -> Result<(String, ToolActivity), TurnError> {
+    let started_at = Instant::now();
+
+    match execution {
+        ToolExecution::Read(read_tool, arguments) => {
+            execute_read_tool(read_tool, arguments, started_at).await
+        }
+        ToolExecution::Write(write_tool, arguments) => {
+            execute_write_tool(write_tool, arguments, started_at, call_id).await
+        }
+    }
+}
+
+async fn execute_read_tool(
+    read_tool: &ReadTool,
+    arguments: &ReadArguments,
+    started_at: Instant,
+) -> Result<(String, ToolActivity), TurnError> {
+    if let Some(error) = arguments.validation_error() {
+        return reject_invalid_read_arguments(arguments, error, started_at);
+    }
+    if arguments.action() == ReadAction::File {
+        return execute_file_read(read_tool, arguments, started_at).await;
+    }
+
+    execute_repository_inspection(read_tool, arguments, started_at).await
+}
+
+fn reject_invalid_read_arguments(
+    arguments: &ReadArguments,
+    error: &str,
+    started_at: Instant,
+) -> Result<(String, ToolActivity), TurnError> {
+    let summary = arguments
+        .path_filter()
+        .or_else(|| arguments.query())
+        .unwrap_or("read");
+    let result = read::invalid_arguments_tool_result(error, summary).map_err(ReadError::from)?;
+    let activity = if arguments.action() == ReadAction::File {
+        ToolActivity::ReadRejected {
+            duration: started_at.elapsed(),
+            path: sanitize_report_text(summary),
+        }
+    } else {
+        ToolActivity::ReadInspectionRejected {
+            action: arguments.action(),
+            duration: started_at.elapsed(),
+            summary: sanitize_report_text(summary),
+        }
+    };
+
+    Ok((result, activity))
+}
+
+async fn execute_file_read(
+    read_tool: &ReadTool,
+    arguments: &ReadArguments,
+    started_at: Instant,
+) -> Result<(String, ToolActivity), TurnError> {
+    match read_tool.execute(arguments).await {
+        Ok(output) => match output.to_tool_result() {
+            Ok(result) => Ok((
+                result,
+                ToolActivity::Read {
+                    duration: started_at.elapsed(),
+                    end_line: output.end_line(),
+                    path: sanitize_report_text(output.path()),
+                    start_line: output.start_line(),
+                    truncated: output.truncated(),
+                },
+            )),
+            Err(error) => error
+                .to_tool_result(output.path())
+                .map_err(ReadError::from)
+                .map_err(TurnError::from)
+                .map(|result| {
+                    (
+                        result,
+                        ToolActivity::ReadRejected {
+                            duration: started_at.elapsed(),
+                            path: sanitize_report_text(output.path()),
+                        },
+                    )
+                }),
+        },
+        Err(error) if error.is_model_correctable() => error
+            .to_tool_result(arguments.path())
+            .map_err(ReadError::from)
+            .map_err(TurnError::from)
+            .map(|result| {
+                (
+                    result,
+                    ToolActivity::ReadRejected {
+                        duration: started_at.elapsed(),
+                        path: sanitize_report_text(arguments.path()),
+                    },
+                )
+            }),
+        Err(error) => Err(error.into()),
+    }
+}
+
+async fn execute_repository_inspection(
+    read_tool: &ReadTool,
+    arguments: &ReadArguments,
+    started_at: Instant,
+) -> Result<(String, ToolActivity), TurnError> {
+    let fallback_summary = arguments
+        .path_filter()
+        .or_else(|| arguments.query())
+        .unwrap_or("read");
+    match read_tool.execute_inspection(arguments).await {
+        Ok((result, summary)) => Ok((
+            result,
+            ToolActivity::ReadInspection {
+                action: arguments.action(),
+                duration: started_at.elapsed(),
+                summary: sanitize_report_text(&summary),
+            },
+        )),
+        Err(error) if error.is_model_correctable() => error
+            .to_tool_result(fallback_summary)
+            .map_err(ReadError::from)
+            .map_err(TurnError::from)
+            .map(|result| {
+                (
+                    result,
+                    ToolActivity::ReadInspectionRejected {
+                        action: arguments.action(),
+                        duration: started_at.elapsed(),
+                        summary: sanitize_report_text(fallback_summary),
+                    },
+                )
+            }),
+        Err(error) => Err(error.into_read_error(fallback_summary.to_string()).into()),
+    }
+}
+
+async fn execute_write_tool(
+    write_tool: &WriteTool,
+    arguments: &WriteArguments,
+    started_at: Instant,
+    call_id: &str,
+) -> Result<(String, ToolActivity), TurnError> {
+    match write_tool.execute(arguments, call_id).await {
+        Ok(output) => {
+            let activity = ToolActivity::Write {
+                bytes_written: output.bytes_written(),
+                duration: started_at.elapsed(),
+                path: sanitize_report_text(output.path()),
+            };
+            let result = output
+                .to_tool_result()
+                .map_err(WriteError::from)
+                .map_err(TurnError::from)?;
+
+            Ok((result, activity))
+        }
+        Err(error) if error.is_model_correctable() => error
+            .to_tool_result(arguments.path())
+            .map_err(WriteError::from)
+            .map_err(TurnError::from)
+            .map(|result| {
+                (
+                    result,
+                    ToolActivity::WriteRejected {
+                        duration: started_at.elapsed(),
+                        path: sanitize_report_text(arguments.path()),
+                    },
+                )
+            }),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(test)]
+#[path = "engine_test.rs"]
+mod tests;

--- a/crates/ag-harness/src/engine_test.rs
+++ b/crates/ag-harness/src/engine_test.rs
@@ -1,0 +1,51 @@
+use std::sync::Arc;
+
+use serde_json::json;
+
+use crate::engine::Engine;
+use crate::file_system::{FileSystem, LocalFileSystem};
+use crate::lifecycle::LifecycleEmitter;
+use crate::model::{MockModel, Model, ModelRequest, ReasoningEffort};
+use crate::{OutputSchema, ToolPolicy, TurnLimits, TurnOptions};
+
+fn object_schema() -> OutputSchema {
+    OutputSchema::new(json!({"type": "object"})).expect("valid schema")
+}
+
+#[test]
+fn preserves_request_reasoning_effort_over_harness_default() {
+    // Arrange
+    let mut model = MockModel::new();
+    model.expect_metadata().return_const(None);
+    let model: Arc<dyn Model> = Arc::new(model);
+    let file_system: Arc<dyn FileSystem> = Arc::new(LocalFileSystem);
+    let options = TurnOptions::new(
+        object_schema(),
+        ToolPolicy::default(),
+        TurnLimits::default(),
+    );
+    let lifecycle = LifecycleEmitter::default();
+    let engine = Engine {
+        file_system: &file_system,
+        lifecycle: &lifecycle,
+        model: &model,
+        model_reasoning_effort: Some(ReasoningEffort::Low),
+        options: &options,
+        repository: None,
+    };
+    let request = ModelRequest::new("reply", object_schema())
+        .with_model_reasoning_effort(ReasoningEffort::High);
+
+    // Act
+    let (request, read_tool, write_tool) = engine
+        .prepare_request(request, None)
+        .expect("request preparation should succeed");
+
+    // Assert
+    assert_eq!(
+        request.model_reasoning_effort(),
+        Some(ReasoningEffort::High)
+    );
+    assert!(read_tool.is_none());
+    assert!(write_tool.is_none());
+}

--- a/crates/ag-harness/src/harness.rs
+++ b/crates/ag-harness/src/harness.rs
@@ -2,36 +2,25 @@ use std::collections::VecDeque;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use tokio::sync::OnceCell;
 
+use crate::engine::Engine;
 use crate::file_system::{FileSystem, LocalFileSystem};
 use crate::lifecycle::{
-    LifecycleEmitter, LifecycleId, LifecycleObserver, ToolErrorType, ToolLifecycle, TurnErrorType,
-    TurnLifecycle,
+    LifecycleEmitter, LifecycleId, LifecycleObserver, TurnErrorType, TurnLifecycle,
 };
-use crate::model::{
-    Model, ModelError, ModelMessage, ModelRequest, ModelResponse, ReasoningEffort,
-    ensure_unique_tool_call_ids,
-};
-use crate::policy::Policy;
-use crate::read::{self, ReadError, ReadTool};
+use crate::model::{Model, ModelMessage, ModelRequest, ReasoningEffort};
+use crate::policy::ToolPolicy;
 use crate::repository::Repository;
 use crate::schema_contract::OutputSchema;
 use crate::session::{AcquiredTurn, Database, LoadedSession, NewSession, SessionError};
-use crate::tool::{
-    ReadAction, ReadArguments, Tool, ToolCall, ToolCallArguments, ToolDefinition, WriteArguments,
-};
-use crate::turn::{
-    ModelRequestActivity, ResumeFailure, ToolActivity, TurnError, TurnOutcome, TurnReport,
-    sanitize_report_text, sanitized_completion_metadata,
-};
-use crate::write::{WriteError, WriteTool};
-use crate::write_journal::{WriteJournal, WriteRecord, WriteRecordRow};
+use crate::tool::Tool;
+use crate::turn::{TurnError, TurnLimits, TurnOptions, TurnOutcome};
+use crate::write_journal::{WriteRecord, WriteRecordRow};
 
 const DEFAULT_MAX_HISTORY_BYTES: usize = 256 * 1024;
-const DEFAULT_MAX_TOOL_CALLS: usize = 8;
 
 /// Durable, resumable sequence of model turns.
 pub struct Session<'a> {
@@ -66,15 +55,39 @@ impl Session<'_> {
 
     /// Sends one prompt and durably records its lifecycle and messages.
     ///
+    /// Resolves the stored session schema and current harness permission and
+    /// tool-limit defaults afresh; earlier explicit overrides are not
+    /// inherited.
+    ///
     /// # Errors
     ///
     /// Returns [`SessionError`] when the model turn or persistence operation
     /// fails.
     pub async fn send(&mut self, prompt: impl Into<String>) -> Result<TurnOutcome, SessionError> {
+        self.send_with_options(prompt, self.harness.default_options(self.schema.clone()))
+            .await
+    }
+
+    /// Sends a durable turn using exactly these options, without changing
+    /// defaults.
+    ///
+    /// Schema or permission changes discard native continuation and replay
+    /// completed history. Permission downgrades retain earlier tool results.
+    /// Options are persisted before execution; completion is reported only
+    /// after the resulting messages are committed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError`] if execution or persistence fails.
+    pub async fn send_with_options(
+        &mut self,
+        prompt: impl Into<String>,
+        options: TurnOptions,
+    ) -> Result<TurnOutcome, SessionError> {
         let started_at = Instant::now();
         let turn = self.harness.lifecycle.start_turn();
         let turn_id = turn.as_ref().map(TurnLifecycle::id);
-        let mut result = self.send_turn(prompt.into(), turn_id).await;
+        let mut result = self.send_turn(prompt.into(), &options, turn_id).await;
         if let Ok(outcome) = &mut result {
             outcome.set_duration(started_at.elapsed());
         }
@@ -96,6 +109,7 @@ impl Session<'_> {
     async fn send_turn(
         &mut self,
         prompt: String,
+        options: &TurnOptions,
         turn_id: Option<LifecycleId>,
     ) -> Result<TurnOutcome, SessionError> {
         let AcquiredTurn {
@@ -103,7 +117,7 @@ impl Session<'_> {
             provider_session_id,
             turn_position,
             turns,
-        } = self.database.begin_turn(&self.id, &prompt).await?;
+        } = self.database.begin_turn(&self.id, &prompt, options).await?;
         self.history.replace(turns);
         self.provider_session_id = provider_session_id;
         let mut messages = self.history.messages();
@@ -111,9 +125,10 @@ impl Session<'_> {
             messages.insert(0, ModelMessage::System(system_prompt.clone()));
         }
         let retained_messages = messages.len();
-        let mut request = ModelRequest::with_history(messages, prompt, self.schema.clone());
+        let mut request = ModelRequest::with_history(messages, prompt, options.schema().clone());
         request.set_provider_session_id(self.provider_session_id.clone());
         let journal = guard.write_journal();
+        let engine = self.harness.engine(options);
         let result = tokio::select! {
             biased;
             error = guard.ownership_failure() => {
@@ -121,7 +136,7 @@ impl Session<'_> {
 
                 return Err(error);
             }
-            result = self.harness.run_turn(request, turn_id, Some(journal)) => result,
+            result = engine.run(request, turn_id, Some(journal)) => result,
         };
         let (outcome, mut messages, provider_session_id) = match result {
             Ok(result) => result,
@@ -255,11 +270,11 @@ pub struct Harness {
     database_path: Option<PathBuf>,
     file_system: Arc<dyn FileSystem>,
     lifecycle: LifecycleEmitter,
+    limits: TurnLimits,
     max_history_bytes: usize,
-    max_tool_calls: usize,
     model: Arc<dyn Model>,
     model_reasoning_effort: Option<ReasoningEffort>,
-    policy: Policy,
+    policy: ToolPolicy,
     repository: Option<Repository>,
 }
 
@@ -271,11 +286,11 @@ impl Harness {
             database_path: None,
             file_system: Arc::new(LocalFileSystem),
             lifecycle: LifecycleEmitter::default(),
+            limits: TurnLimits::default(),
             max_history_bytes: DEFAULT_MAX_HISTORY_BYTES,
-            max_tool_calls: DEFAULT_MAX_TOOL_CALLS,
             model: Arc::new(model),
             model_reasoning_effort: None,
-            policy: Policy::default(),
+            policy: ToolPolicy::default(),
             repository: None,
         }
     }
@@ -301,10 +316,12 @@ impl Harness {
         self
     }
 
-    /// Enables one built-in tool for model requests.
+    /// Allows one built-in tool by default for `run_once` and `Session::send`.
+    ///
+    /// Explicit turn options replace this default policy completely.
     #[must_use]
     pub fn allow(mut self, tool: Tool) -> Self {
-        self.policy.allow(tool);
+        self.policy = self.policy.allow(tool);
 
         self
     }
@@ -330,7 +347,7 @@ impl Harness {
     /// Overrides the maximum number of native calls allowed in one turn.
     #[must_use]
     pub fn max_tool_calls(mut self, max_tool_calls: NonZeroUsize) -> Self {
-        self.max_tool_calls = max_tool_calls.get();
+        self.limits = TurnLimits::new(max_tool_calls);
 
         self
     }
@@ -365,10 +382,27 @@ impl Harness {
         prompt: impl Into<String>,
         schema: OutputSchema,
     ) -> Result<TurnOutcome, TurnError> {
-        let request = ModelRequest::new(prompt, schema);
+        self.run_once_with_options(prompt, self.default_options(schema))
+            .await
+    }
+
+    /// Runs an ephemeral turn with a complete options snapshot.
+    ///
+    /// Options replace harness schema, permission, and tool-limit defaults;
+    /// an empty policy denies all tools. This never opens a database.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TurnError`] when model execution, validation, or tools fail.
+    pub async fn run_once_with_options(
+        &self,
+        prompt: impl Into<String>,
+        options: TurnOptions,
+    ) -> Result<TurnOutcome, TurnError> {
+        let request = ModelRequest::new(prompt, options.schema().clone());
         let turn = self.lifecycle.start_turn();
         let turn_id = turn.as_ref().map(TurnLifecycle::id);
-        let result = self.run_turn(request, turn_id, None).await;
+        let result = self.engine(&options).run(request, turn_id, None).await;
 
         if let Some(turn) = turn {
             match &result {
@@ -380,7 +414,10 @@ impl Harness {
         result.map(|(outcome, _, _)| outcome)
     }
 
-    /// Builds a new durable session whose responses must match `schema`.
+    /// Builds a durable session with `schema` as its default output contract.
+    ///
+    /// Explicit turn options may select a different schema without changing
+    /// the stored default.
     pub fn session(&self, id: impl Into<String>, schema: OutputSchema) -> SessionBuilder<'_> {
         SessionBuilder {
             harness: self,
@@ -483,532 +520,19 @@ impl Harness {
         Ok(())
     }
 
-    async fn run_turn(
-        &self,
-        request: ModelRequest,
-        turn_id: Option<LifecycleId>,
-        journal: Option<WriteJournal>,
-    ) -> Result<(TurnOutcome, Vec<ModelMessage>, Option<String>), TurnError> {
-        let started_at = Instant::now();
-        let (mut request, read_tool, write_tool) = self.prepare_request(request, journal)?;
-        let mut completed_tool_calls = 0_usize;
-        let mut model_request_index = 0_u64;
-        let mut model_requests = Vec::new();
-        let mut tool_calls = Vec::new();
-
-        loop {
-            let (
-                response,
-                activities,
-                provider_session_id,
-                native_resume_rejected,
-                reasoning_content,
-            ) = self
-                .complete_model_request(&request, model_request_index, turn_id)
-                .await?;
-            if native_resume_rejected || provider_session_id.is_some() {
-                request.set_provider_session_id(provider_session_id);
-            }
-            model_request_index = model_request_index
-                .saturating_add(u64::try_from(activities.len()).unwrap_or(u64::MAX));
-            model_requests.extend(activities);
-
-            match response {
-                ModelResponse::Output(output) => {
-                    request.record_output_with_reasoning(&output, reasoning_content);
-                    let report = TurnReport::new(started_at.elapsed(), model_requests, tool_calls);
-
-                    let provider_session_id = request.provider_session_id().map(str::to_string);
-
-                    return Ok((
-                        TurnOutcome::new(output, report),
-                        request.into_messages(),
-                        provider_session_id,
-                    ));
-                }
-                ModelResponse::ToolCall(call) => {
-                    let (result, activity) = self
-                        .execute_tool_call(
-                            &call,
-                            read_tool.as_ref(),
-                            write_tool.as_ref(),
-                            completed_tool_calls,
-                            turn_id,
-                        )
-                        .await?;
-                    request.record_tool_result(call, result);
-                    tool_calls.push(activity);
-                    completed_tool_calls += 1;
-                }
-                ModelResponse::ToolCalls(calls) => {
-                    if calls.is_empty() {
-                        return Err(ModelError::MissingToolCall.into());
-                    }
-                    ensure_unique_tool_call_ids(&calls)?;
-                    if calls.len() > self.max_tool_calls.saturating_sub(completed_tool_calls) {
-                        return Err(TurnError::ToolCallLimit {
-                            limit: self.max_tool_calls,
-                        });
-                    }
-                    let mut results = Vec::with_capacity(calls.len());
-                    for call in &calls {
-                        let (result, activity) = self
-                            .execute_tool_call(
-                                call,
-                                read_tool.as_ref(),
-                                write_tool.as_ref(),
-                                completed_tool_calls,
-                                turn_id,
-                            )
-                            .await?;
-                        results.push(result);
-                        tool_calls.push(activity);
-                        completed_tool_calls += 1;
-                    }
-                    request.record_tool_results(calls, results);
-                }
-            }
-        }
+    fn default_options(&self, schema: OutputSchema) -> TurnOptions {
+        TurnOptions::new(schema, self.policy, self.limits)
     }
 
-    fn prepare_request(
-        &self,
-        mut request: ModelRequest,
-        journal: Option<WriteJournal>,
-    ) -> Result<(ModelRequest, Option<ReadTool>, Option<WriteTool>), TurnError> {
-        if self.lifecycle.is_enabled() {
-            request.mark_lifecycle_observed();
+    fn engine<'a>(&'a self, options: &'a TurnOptions) -> Engine<'a> {
+        Engine {
+            file_system: &self.file_system,
+            lifecycle: &self.lifecycle,
+            model: &self.model,
+            model_reasoning_effort: self.model_reasoning_effort,
+            options,
+            repository: self.repository.as_ref(),
         }
-        if request.model_reasoning_effort().is_none()
-            && let Some(reasoning_effort) = self.model_reasoning_effort
-        {
-            request = request.with_model_reasoning_effort(reasoning_effort);
-        }
-        let read_allowed = self.policy.allows(Tool::Read);
-        let write_allowed = self.policy.allows(Tool::Write);
-        if !read_allowed && !write_allowed {
-            return Ok((request, None, None));
-        }
-        let repository = self
-            .repository
-            .as_ref()
-            .ok_or(TurnError::RepositoryRequired)?;
-        let read_tool = read_allowed.then(|| {
-            request = request.clone().with_tool(ToolDefinition::read());
-            ReadTool::with_git(
-                self.file_system.clone(),
-                repository.root().to_path_buf(),
-                repository.git_executable().to_path_buf(),
-            )
-        });
-        let write_tool = write_allowed.then(|| {
-            request = request.clone().with_tool(ToolDefinition::write());
-            let mut tool =
-                WriteTool::new(self.file_system.clone(), repository.root().to_path_buf());
-            tool.journal = journal;
-
-            tool
-        });
-
-        Ok((request, read_tool, write_tool))
-    }
-
-    async fn complete_model_request(
-        &self,
-        request: &ModelRequest,
-        model_request_index: u64,
-        turn_id: Option<LifecycleId>,
-    ) -> Result<
-        (
-            ModelResponse,
-            Vec<ModelRequestActivity>,
-            Option<String>,
-            bool,
-            Option<String>,
-        ),
-        TurnError,
-    > {
-        let native_resume = request.provider_session_id().is_some();
-        match self
-            .complete_model_attempt(request.clone(), model_request_index, turn_id)
-            .await
-        {
-            Ok((response, activity, provider_session_id, reasoning_content)) => Ok((
-                response,
-                vec![activity],
-                provider_session_id,
-                false,
-                reasoning_content,
-            )),
-            Err(ModelAttemptError {
-                duration,
-                error: ModelError::ResumeUnavailable,
-            }) if native_resume => {
-                let rejected_activity = ModelRequestActivity::new(
-                    None,
-                    duration,
-                    crate::lifecycle::ModelResponseType::ResumeUnavailable,
-                );
-                let mut replay_request = request.clone();
-                replay_request.set_provider_session_id(None);
-                let replay_index = model_request_index.saturating_add(1);
-                match self
-                    .complete_model_attempt(replay_request, replay_index, turn_id)
-                    .await
-                {
-                    Ok((response, replay_activity, provider_session_id, reasoning_content)) => {
-                        Ok((
-                            response,
-                            vec![rejected_activity, replay_activity],
-                            provider_session_id,
-                            true,
-                            reasoning_content,
-                        ))
-                    }
-                    Err(failure) => Err(ResumeFailure::Replay {
-                        source: failure.error,
-                    }
-                    .into_model_error()
-                    .into()),
-                }
-            }
-            Err(failure) if native_resume => Err(ResumeFailure::Native {
-                source: failure.error,
-            }
-            .into_model_error()
-            .into()),
-            Err(failure) => Err(failure.error.into()),
-        }
-    }
-
-    async fn complete_model_attempt(
-        &self,
-        request: ModelRequest,
-        model_request_index: u64,
-        turn_id: Option<LifecycleId>,
-    ) -> Result<
-        (
-            ModelResponse,
-            ModelRequestActivity,
-            Option<String>,
-            Option<String>,
-        ),
-        ModelAttemptError,
-    > {
-        let started_at = Instant::now();
-        let model_lifecycle =
-            self.lifecycle
-                .start_model_request(self.model.metadata(), model_request_index, turn_id);
-        let operation = self.model.complete(request.clone());
-        let completion = match model_lifecycle.as_ref() {
-            Some(model_lifecycle) => model_lifecycle.scope(operation).await,
-            None => operation.await,
-        };
-        let (response, completion, provider_session_id, reasoning_content) = match completion {
-            Ok(completion) => completion.into_parts(),
-            Err(error) => {
-                if let Some(model_lifecycle) = model_lifecycle {
-                    model_lifecycle.failed(error.error_type(), error.http_status());
-                }
-
-                return Err(ModelAttemptError {
-                    duration: started_at.elapsed(),
-                    error,
-                });
-            }
-        };
-        if let Some(output) = response.output()
-            && let Err(error) = request.schema().validate_value(output)
-        {
-            let error = ModelError::from(error);
-            if let Some(model_lifecycle) = model_lifecycle {
-                model_lifecycle.failed(error.error_type(), error.http_status());
-            }
-
-            return Err(ModelAttemptError {
-                duration: started_at.elapsed(),
-                error,
-            });
-        }
-        let response_type = response.response_type();
-        let activity = ModelRequestActivity::new(
-            completion.as_ref().map(sanitized_completion_metadata),
-            started_at.elapsed(),
-            response_type,
-        );
-        if let Some(model_lifecycle) = model_lifecycle {
-            model_lifecycle.completed(completion, response_type);
-        }
-
-        Ok((response, activity, provider_session_id, reasoning_content))
-    }
-
-    async fn execute_tool_call(
-        &self,
-        call: &ToolCall,
-        read_tool: Option<&ReadTool>,
-        write_tool: Option<&WriteTool>,
-        completed_tool_calls: usize,
-        turn_id: Option<LifecycleId>,
-    ) -> Result<(String, ToolActivity), TurnError> {
-        let mut tool_lifecycle =
-            self.lifecycle
-                .request_tool(call.id().to_string(), call.name().to_string(), turn_id);
-        let execution = match call.arguments() {
-            ToolCallArguments::Read(arguments) => {
-                read_tool.map(|tool| ToolExecution::Read(tool, arguments))
-            }
-            ToolCallArguments::Write(arguments) => {
-                write_tool.map(|tool| ToolExecution::Write(tool, arguments))
-            }
-        };
-        let Some(execution) = execution else {
-            if let Some(tool_lifecycle) = tool_lifecycle {
-                tool_lifecycle.denied();
-            }
-
-            return Err(TurnError::ToolDenied {
-                name: call.name().to_string(),
-            });
-        };
-        if completed_tool_calls >= self.max_tool_calls {
-            if let Some(tool_lifecycle) = tool_lifecycle {
-                tool_lifecycle.failed(ToolErrorType::CallLimit);
-            }
-
-            return Err(TurnError::ToolCallLimit {
-                limit: self.max_tool_calls,
-            });
-        }
-        if let Some(tool_lifecycle) = tool_lifecycle.as_mut() {
-            tool_lifecycle.started();
-        }
-        let operation = execute_tool(execution, call.id());
-        let result = match tool_lifecycle.as_ref() {
-            Some(tool_lifecycle) => tool_lifecycle.scope(operation).await,
-            None => operation.await,
-        };
-
-        Self::finish_tool_call(result, tool_lifecycle)
-    }
-
-    fn finish_tool_call(
-        result: Result<(String, ToolActivity), TurnError>,
-        tool_lifecycle: Option<ToolLifecycle>,
-    ) -> Result<(String, ToolActivity), TurnError> {
-        match result {
-            Ok(result) => {
-                if let Some(tool_lifecycle) = tool_lifecycle {
-                    if matches!(
-                        &result.1,
-                        ToolActivity::ReadInspectionRejected { .. }
-                            | ToolActivity::ReadRejected { .. }
-                            | ToolActivity::WriteRejected { .. }
-                    ) {
-                        tool_lifecycle.failed(ToolErrorType::Execution);
-                    } else {
-                        tool_lifecycle.completed();
-                    }
-                }
-
-                Ok(result)
-            }
-            Err(error) => {
-                if let Some(tool_lifecycle) = tool_lifecycle {
-                    tool_lifecycle.failed(ToolErrorType::Execution);
-                }
-
-                Err(error)
-            }
-        }
-    }
-}
-
-enum ToolExecution<'a> {
-    Read(&'a ReadTool, &'a ReadArguments),
-    Write(&'a WriteTool, &'a WriteArguments),
-}
-
-struct ModelAttemptError {
-    duration: Duration,
-    error: ModelError,
-}
-
-async fn execute_tool(
-    execution: ToolExecution<'_>,
-    call_id: &str,
-) -> Result<(String, ToolActivity), TurnError> {
-    let started_at = Instant::now();
-
-    match execution {
-        ToolExecution::Read(read_tool, arguments) => {
-            execute_read_tool(read_tool, arguments, started_at).await
-        }
-        ToolExecution::Write(write_tool, arguments) => {
-            execute_write_tool(write_tool, arguments, started_at, call_id).await
-        }
-    }
-}
-
-async fn execute_read_tool(
-    read_tool: &ReadTool,
-    arguments: &ReadArguments,
-    started_at: Instant,
-) -> Result<(String, ToolActivity), TurnError> {
-    if let Some(error) = arguments.validation_error() {
-        return reject_invalid_read_arguments(arguments, error, started_at);
-    }
-    if arguments.action() == ReadAction::File {
-        return execute_file_read(read_tool, arguments, started_at).await;
-    }
-
-    execute_repository_inspection(read_tool, arguments, started_at).await
-}
-
-fn reject_invalid_read_arguments(
-    arguments: &ReadArguments,
-    error: &str,
-    started_at: Instant,
-) -> Result<(String, ToolActivity), TurnError> {
-    let summary = arguments
-        .path_filter()
-        .or_else(|| arguments.query())
-        .unwrap_or("read");
-    let result = read::invalid_arguments_tool_result(error, summary).map_err(ReadError::from)?;
-    let activity = if arguments.action() == ReadAction::File {
-        ToolActivity::ReadRejected {
-            duration: started_at.elapsed(),
-            path: sanitize_report_text(summary),
-        }
-    } else {
-        ToolActivity::ReadInspectionRejected {
-            action: arguments.action(),
-            duration: started_at.elapsed(),
-            summary: sanitize_report_text(summary),
-        }
-    };
-
-    Ok((result, activity))
-}
-
-async fn execute_file_read(
-    read_tool: &ReadTool,
-    arguments: &ReadArguments,
-    started_at: Instant,
-) -> Result<(String, ToolActivity), TurnError> {
-    match read_tool.execute(arguments).await {
-        Ok(output) => match output.to_tool_result() {
-            Ok(result) => Ok((
-                result,
-                ToolActivity::Read {
-                    duration: started_at.elapsed(),
-                    end_line: output.end_line(),
-                    path: sanitize_report_text(output.path()),
-                    start_line: output.start_line(),
-                    truncated: output.truncated(),
-                },
-            )),
-            Err(error) => error
-                .to_tool_result(output.path())
-                .map_err(ReadError::from)
-                .map_err(TurnError::from)
-                .map(|result| {
-                    (
-                        result,
-                        ToolActivity::ReadRejected {
-                            duration: started_at.elapsed(),
-                            path: sanitize_report_text(output.path()),
-                        },
-                    )
-                }),
-        },
-        Err(error) if error.is_model_correctable() => error
-            .to_tool_result(arguments.path())
-            .map_err(ReadError::from)
-            .map_err(TurnError::from)
-            .map(|result| {
-                (
-                    result,
-                    ToolActivity::ReadRejected {
-                        duration: started_at.elapsed(),
-                        path: sanitize_report_text(arguments.path()),
-                    },
-                )
-            }),
-        Err(error) => Err(error.into()),
-    }
-}
-
-async fn execute_repository_inspection(
-    read_tool: &ReadTool,
-    arguments: &ReadArguments,
-    started_at: Instant,
-) -> Result<(String, ToolActivity), TurnError> {
-    let fallback_summary = arguments
-        .path_filter()
-        .or_else(|| arguments.query())
-        .unwrap_or("read");
-    match read_tool.execute_inspection(arguments).await {
-        Ok((result, summary)) => Ok((
-            result,
-            ToolActivity::ReadInspection {
-                action: arguments.action(),
-                duration: started_at.elapsed(),
-                summary: sanitize_report_text(&summary),
-            },
-        )),
-        Err(error) if error.is_model_correctable() => error
-            .to_tool_result(fallback_summary)
-            .map_err(ReadError::from)
-            .map_err(TurnError::from)
-            .map(|result| {
-                (
-                    result,
-                    ToolActivity::ReadInspectionRejected {
-                        action: arguments.action(),
-                        duration: started_at.elapsed(),
-                        summary: sanitize_report_text(fallback_summary),
-                    },
-                )
-            }),
-        Err(error) => Err(error.into_read_error(fallback_summary.to_string()).into()),
-    }
-}
-
-async fn execute_write_tool(
-    write_tool: &WriteTool,
-    arguments: &WriteArguments,
-    started_at: Instant,
-    call_id: &str,
-) -> Result<(String, ToolActivity), TurnError> {
-    match write_tool.execute(arguments, call_id).await {
-        Ok(output) => {
-            let activity = ToolActivity::Write {
-                bytes_written: output.bytes_written(),
-                duration: started_at.elapsed(),
-                path: sanitize_report_text(output.path()),
-            };
-            let result = output
-                .to_tool_result()
-                .map_err(WriteError::from)
-                .map_err(TurnError::from)?;
-
-            Ok((result, activity))
-        }
-        Err(error) if error.is_model_correctable() => error
-            .to_tool_result(arguments.path())
-            .map_err(WriteError::from)
-            .map_err(TurnError::from)
-            .map(|result| {
-                (
-                    result,
-                    ToolActivity::WriteRejected {
-                        duration: started_at.elapsed(),
-                        path: sanitize_report_text(arguments.path()),
-                    },
-                )
-            }),
-        Err(error) => Err(error.into()),
     }
 }
 

--- a/crates/ag-harness/src/harness_test.rs
+++ b/crates/ag-harness/src/harness_test.rs
@@ -1,5 +1,7 @@
 #[path = "harness_test/cancellation_test.rs"]
 mod cancellation;
+#[path = "harness_test/options_test.rs"]
+mod options;
 #[path = "harness_test/policy_test.rs"]
 mod policy;
 #[path = "harness_test/read_test.rs"]

--- a/crates/ag-harness/src/harness_test/options_test.rs
+++ b/crates/ag-harness/src/harness_test/options_test.rs
@@ -1,0 +1,358 @@
+use std::io::Cursor;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+use super::support::{model, object_schema, read_call, response_without_metadata};
+use crate::file_system::MockFileSystem;
+use crate::harness::Harness;
+use crate::lifecycle::{LifecycleEvent, LifecycleEventKind, TurnErrorType};
+use crate::model::{ModelMessage, ModelRequest, ModelResponse, ReasoningEffort};
+use crate::repository::Repository;
+use crate::session::{Database, SessionError};
+use crate::{OutputSchema, Tool, ToolPolicy, TurnError, TurnLimits, TurnOptions};
+
+fn options(schema: OutputSchema, policy: ToolPolicy, limit: usize) -> TurnOptions {
+    TurnOptions::new(
+        schema,
+        policy,
+        TurnLimits::new(NonZeroUsize::new(limit).expect("nonzero budget")),
+    )
+}
+
+fn readable_file_system() -> MockFileSystem {
+    let mut file_system = MockFileSystem::new();
+    file_system
+        .expect_canonicalize()
+        .returning(|path| Ok(path.to_path_buf()));
+    file_system
+        .expect_open_beneath()
+        .returning(|_, _| Ok(Box::new(Cursor::new(b"[workspace]"))));
+
+    file_system
+}
+
+#[tokio::test]
+async fn equivalent_ephemeral_and_durable_turns_send_the_same_requests() {
+    // Arrange
+    let requests = Arc::new(Mutex::new(Vec::<ModelRequest>::new()));
+    let recorded = Arc::clone(&requests);
+    let mut model = model();
+    model.expect_complete().times(4).returning(move |request| {
+        let response = if matches!(request.messages().last(), Some(ModelMessage::User(_))) {
+            ModelResponse::ToolCall(read_call("read"))
+        } else {
+            ModelResponse::Output(json!({"summary": "done"}))
+        };
+        recorded.lock().expect("requests lock").push(request);
+        Ok(response_without_metadata(response))
+    });
+    let directory = tempdir().expect("temporary directory");
+    let harness = Harness::new(model)
+        .database(directory.path().join("history.db"))
+        .repository(Repository::fixture("repo"))
+        .file_system(readable_file_system())
+        .model_reasoning_effort(ReasoningEffort::Low);
+    let options = options(object_schema(), ToolPolicy::default().allow(Tool::Read), 2);
+
+    // Act
+    harness
+        .run_once_with_options("read", options.clone())
+        .await
+        .expect("one-shot turn");
+    let mut session = harness
+        .session("session", object_schema())
+        .create()
+        .await
+        .expect("session");
+    session
+        .send_with_options("read", options)
+        .await
+        .expect("durable turn");
+
+    // Assert
+    let requests = requests.lock().expect("requests lock");
+    for (once, durable) in requests[..2].iter().zip(&requests[2..]) {
+        assert_eq!(once.messages(), durable.messages());
+        assert_eq!(once.schema(), durable.schema());
+        assert_eq!(once.tools(), durable.tools());
+        assert_eq!(
+            once.model_reasoning_effort(),
+            durable.model_reasoning_effort()
+        );
+        assert_eq!(once.provider_session_id(), durable.provider_session_id());
+    }
+}
+
+#[tokio::test]
+async fn changing_options_uses_canonical_state_without_changing_session_defaults() {
+    // Arrange
+    let requests = Arc::new(Mutex::new(Vec::<ModelRequest>::new()));
+    let recorded = Arc::clone(&requests);
+    let mut model = model();
+    model.expect_complete().times(6).returning(move |request| {
+        let output = if request.schema().value()["type"] == "integer" {
+            json!(42)
+        } else {
+            json!({"summary": "done"})
+        };
+        recorded.lock().expect("requests lock").push(request);
+        Ok(response_without_metadata(ModelResponse::Output(output))
+            .with_provider_session_id("native"))
+    });
+    let directory = tempdir().expect("temporary directory");
+    let database_path = directory.path().join("history.db");
+    let harness = Harness::new(model)
+        .database(&database_path)
+        .repository(Repository::fixture("repo"));
+    let mut session = harness
+        .session("session", object_schema())
+        .create()
+        .await
+        .expect("session");
+    let mut stale = harness.resume("session").await.expect("stale handle");
+    let read = options(object_schema(), ToolPolicy::default().allow(Tool::Read), 1);
+    let integer = OutputSchema::new(json!({"type":"integer"})).expect("integer schema");
+
+    // Act
+    session.send("default").await.expect("default turn");
+    stale
+        .send_with_options("policy change", read)
+        .await
+        .expect("policy change");
+    session
+        .send_with_options(
+            "schema change",
+            options(integer.clone(), ToolPolicy::default().allow(Tool::Read), 1),
+        )
+        .await
+        .expect("schema change");
+    stale
+        .send_with_options(
+            "budget change",
+            options(integer, ToolPolicy::default().allow(Tool::Read), 2),
+        )
+        .await
+        .expect("budget change");
+    let mut reopened = harness.resume("session").await.expect("reopened session");
+    reopened
+        .send("defaults again")
+        .await
+        .expect("default turn after reopen");
+    reopened
+        .send("same defaults")
+        .await
+        .expect("compatible turn");
+    let database = Database::open(&database_path).await.expect("database");
+    let snapshots: Vec<String> =
+        sqlx::query_scalar("SELECT turn_options FROM session_turn ORDER BY turn_position")
+            .fetch_all(database.pool())
+            .await
+            .expect("snapshots");
+
+    // Assert
+    let requests = requests.lock().expect("requests lock");
+    let continuations: Vec<_> = requests
+        .iter()
+        .map(ModelRequest::provider_session_id)
+        .collect();
+    assert_eq!(
+        continuations,
+        [None, None, None, Some("native"), None, Some("native")]
+    );
+    assert_eq!(requests[0].tools().len(), 0);
+    assert_eq!(requests[1].tools().len(), 1);
+    assert_eq!(requests[2].schema().value(), &json!({"type":"integer"}));
+    assert_eq!(requests[4].schema(), &object_schema());
+    assert_eq!(requests[4].tools().len(), 0);
+    assert_eq!(requests[4].messages().len(), 9);
+    let snapshots: Vec<Value> = snapshots
+        .iter()
+        .map(|snapshot| serde_json::from_str(snapshot).expect("snapshot JSON"))
+        .collect();
+    assert_eq!(
+        snapshots[1]["tool_policy"],
+        json!({"read":true, "write":false})
+    );
+    assert_eq!(snapshots[2]["max_tool_calls"], 1);
+    assert_eq!(snapshots[3]["max_tool_calls"], 2);
+    assert_eq!(snapshots[0], snapshots[4]);
+}
+
+#[tokio::test]
+async fn empty_explicit_policy_denies_calls_despite_allowed_harness_defaults() {
+    // Arrange
+    let mut model = model();
+    model.expect_complete().times(2).returning(|request| {
+        assert_eq!(request.tools().len(), 0);
+        Ok(response_without_metadata(ModelResponse::ToolCall(
+            read_call("denied"),
+        )))
+    });
+    let directory = tempdir().expect("temporary directory");
+    let harness = Harness::new(model)
+        .allow(Tool::Read)
+        .allow(Tool::Write)
+        .database(directory.path().join("history.db"));
+    let denied = options(object_schema(), ToolPolicy::default(), 1);
+
+    // Act
+    let once = harness
+        .run_once_with_options("denied", denied.clone())
+        .await;
+    let mut session = harness
+        .session("session", object_schema())
+        .create()
+        .await
+        .expect("session");
+    let durable = session.send_with_options("denied", denied).await;
+
+    // Assert
+    assert!(matches!(once, Err(TurnError::ToolDenied { .. })));
+    assert!(matches!(
+        durable,
+        Err(SessionError::Turn(TurnError::ToolDenied { .. }))
+    ));
+}
+
+#[tokio::test]
+async fn explicit_budget_replaces_default_and_resets_for_the_next_turn() {
+    // Arrange
+    let mut model = model();
+    model.expect_complete().times(3).returning(|request| {
+        let response = if matches!(request.messages().last(), Some(ModelMessage::User(_))) {
+            ModelResponse::ToolCalls(vec![read_call("first"), read_call("second")])
+        } else {
+            ModelResponse::Output(json!({"summary":"done"}))
+        };
+        Ok(response_without_metadata(response))
+    });
+    let directory = tempdir().expect("temporary directory");
+    let harness = Harness::new(model)
+        .allow(Tool::Read)
+        .repository(Repository::fixture("repo"))
+        .file_system(readable_file_system())
+        .max_tool_calls(NonZeroUsize::new(1).expect("nonzero budget"))
+        .database(directory.path().join("history.db"));
+    let mut session = harness
+        .session("session", object_schema())
+        .create()
+        .await
+        .expect("session");
+
+    // Act
+    let allowed = session
+        .send_with_options(
+            "two calls",
+            options(object_schema(), ToolPolicy::default().allow(Tool::Read), 2),
+        )
+        .await;
+    let limited = session.send("two calls again").await;
+
+    // Assert
+    assert_eq!(
+        allowed
+            .expect("explicit budget")
+            .report()
+            .tool_calls()
+            .len(),
+        2
+    );
+    assert!(matches!(
+        limited,
+        Err(SessionError::Turn(TurnError::ToolCallLimit { limit: 1 }))
+    ));
+}
+
+#[tokio::test]
+async fn options_persistence_failure_prevents_execution_and_reports_session_failure() {
+    // Arrange
+    let directory = tempdir().expect("temporary directory");
+    let database_path = directory.path().join("history.db");
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let recorded = Arc::clone(&events);
+    let harness = Harness::new(model())
+        .database(&database_path)
+        .with_lifecycle_observer(move |event: LifecycleEvent| {
+            recorded.lock().expect("events lock").push(event);
+        });
+    let mut session = harness
+        .session("session", object_schema())
+        .create()
+        .await
+        .expect("session");
+    let database = Database::open(&database_path).await.expect("database");
+    sqlx::query(
+        "CREATE TRIGGER reject_options BEFORE INSERT ON session_turn WHEN NEW.turn_options IS NOT \
+         NULL BEGIN SELECT RAISE(ABORT, 'options unavailable'); END",
+    )
+    .execute(database.pool())
+    .await
+    .expect("failure trigger");
+
+    // Act
+    let result = session
+        .send_with_options(
+            "never executed",
+            options(object_schema(), ToolPolicy::default(), 1),
+        )
+        .await;
+    let messages: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM session_message")
+        .fetch_one(database.pool())
+        .await
+        .expect("message count");
+
+    // Assert
+    assert!(matches!(result, Err(SessionError::QueryContext { .. })));
+    assert_eq!(messages, 0);
+    let events = events.lock().expect("events lock");
+    assert!(events.iter().any(|event| matches!(
+        event.kind(),
+        LifecycleEventKind::TurnFailed {
+            error_type: TurnErrorType::Session,
+            ..
+        }
+    )));
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event.kind(), LifecycleEventKind::TurnCompleted { .. }))
+    );
+}
+
+#[tokio::test]
+async fn failed_schema_override_does_not_leak_into_the_next_turn() {
+    // Arrange
+    let mut model = model();
+    model.expect_complete().times(2).returning(|_| {
+        Ok(response_without_metadata(ModelResponse::Output(
+            json!({"summary":"done"}),
+        )))
+    });
+    let directory = tempdir().expect("temporary directory");
+    let harness = Harness::new(model).database(directory.path().join("history.db"));
+    let mut session = harness
+        .session("session", object_schema())
+        .create()
+        .await
+        .expect("session");
+    let integer = OutputSchema::new(json!({"type":"integer"})).expect("integer schema");
+
+    // Act
+    let invalid = session
+        .send_with_options("integer", options(integer, ToolPolicy::default(), 1))
+        .await;
+    let valid = session.send("default schema").await;
+
+    // Assert
+    assert!(matches!(
+        invalid,
+        Err(SessionError::Turn(TurnError::Model(_)))
+    ));
+    assert_eq!(
+        valid.expect("default schema remains valid").output(),
+        &json!({"summary":"done"})
+    );
+}

--- a/crates/ag-harness/src/harness_test/policy_test.rs
+++ b/crates/ag-harness/src/harness_test/policy_test.rs
@@ -13,7 +13,7 @@ use super::support::{
 };
 use crate::file_system::MockFileSystem;
 use crate::harness::Harness;
-use crate::lifecycle::{LifecycleEventKind, TurnErrorType};
+use crate::lifecycle::{LifecycleEvent, LifecycleEventKind, ToolErrorType, TurnErrorType};
 use crate::model::{ModelError, ModelErrorType, ModelMessage, ModelResponse};
 use crate::tool::ToolDefinition;
 use crate::turn::TurnError;
@@ -271,26 +271,45 @@ async fn rejects_disabled_read_call() {
 
 #[tokio::test]
 async fn enforces_tool_call_limit() {
-    // Arrange
-    let mut model = model();
-    model.expect_complete().times(2).returning(|_| {
-        Ok(response_without_metadata(ModelResponse::ToolCall(
-            read_call("call_read"),
-        )))
-    });
-    let harness = read_harness(model, readable_file_system())
-        .max_tool_calls(NonZeroUsize::new(1).expect("limit should be non-zero"))
-        .with_lifecycle_observer(|_| {});
+    for observed in [false, true] {
+        // Arrange
+        let mut model = model();
+        model.expect_complete().times(2).returning(|_| {
+            Ok(response_without_metadata(ModelResponse::ToolCall(
+                read_call("call_read"),
+            )))
+        });
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut harness = read_harness(model, readable_file_system())
+            .max_tool_calls(NonZeroUsize::new(1).expect("limit should be non-zero"));
+        if observed {
+            let events = Arc::clone(&events);
+            harness = harness.with_lifecycle_observer(move |event: LifecycleEvent| {
+                events.lock().expect("events lock").push(event);
+            });
+        }
 
-    // Act
-    let error = harness
-        .run_once("inspect", object_schema())
-        .await
-        .expect_err("second tool call should exceed the limit");
+        // Act
+        let error = harness
+            .run_once("inspect", object_schema())
+            .await
+            .expect_err("second tool call should exceed the limit");
 
-    // Assert
-    assert!(matches!(&error, TurnError::ToolCallLimit { limit: 1 }));
-    assert_eq!(error.error_type(), TurnErrorType::ToolCallLimit);
+        // Assert
+        assert!(matches!(&error, TurnError::ToolCallLimit { limit: 1 }));
+        assert_eq!(error.error_type(), TurnErrorType::ToolCallLimit);
+        let events = events.lock().expect("events lock");
+        assert_eq!(
+            events.iter().any(|event| matches!(
+                event.kind(),
+                LifecycleEventKind::ToolFailed {
+                    error_type: ToolErrorType::CallLimit,
+                    ..
+                }
+            )),
+            observed
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/ag-harness/src/harness_test/read_test.rs
+++ b/crates/ag-harness/src/harness_test/read_test.rs
@@ -15,7 +15,7 @@ use super::support::{
 use crate::file_system::MockFileSystem;
 use crate::harness::Harness;
 use crate::lifecycle::{LifecycleEvent, LifecycleEventKind, ModelResponseType, ToolErrorType};
-use crate::model::{ModelMessage, ModelRequest, ModelResponse, ReasoningEffort};
+use crate::model::{ModelMessage, ModelResponse, ReasoningEffort};
 use crate::read::ReadError;
 use crate::repository::Repository;
 use crate::tool::{ReadAction, Tool, ToolCall, ToolDefinition};
@@ -44,27 +44,6 @@ async fn applies_reasoning_effort_to_every_model_call() {
 
     // Assert
     assert_eq!(output.output(), &json!({ "summary": "quick" }));
-}
-
-#[test]
-fn preserves_request_reasoning_effort_over_harness_default() {
-    // Arrange
-    let harness = Harness::new(model()).model_reasoning_effort(ReasoningEffort::Low);
-    let request = ModelRequest::new("reply", object_schema())
-        .with_model_reasoning_effort(ReasoningEffort::High);
-
-    // Act
-    let (request, read_tool, write_tool) = harness
-        .prepare_request(request, None)
-        .expect("request preparation should succeed");
-
-    // Assert
-    assert_eq!(
-        request.model_reasoning_effort(),
-        Some(ReasoningEffort::High)
-    );
-    assert!(read_tool.is_none());
-    assert!(write_tool.is_none());
 }
 
 #[tokio::test]

--- a/crates/ag-harness/src/lib.rs
+++ b/crates/ag-harness/src/lib.rs
@@ -6,6 +6,7 @@
 //! remain behind injectable boundaries.
 
 mod chat_completion;
+mod engine;
 mod file_system;
 mod harness;
 mod lifecycle;
@@ -34,6 +35,7 @@ pub use model::{
     ModelErrorType, ModelMessage, ModelMetadata, ModelMetadataError, ModelRequest, ModelResponse,
     ReasoningEffort,
 };
+pub use policy::ToolPolicy;
 pub use provider::{
     KIMI_K2_6, KimiConfig, MUSE_SPARK_1_3, MUSE_SPARK_1_3_CONTRIBUTOR, ModelConfiguration,
     ModelConfigurationError, ModelProvider, ModelProviderParseError, Muse, MuseConfig, QWEN_PLUS,
@@ -49,6 +51,8 @@ pub use tool::{
     WriteArguments,
 };
 pub use trace::LifecycleTraceObserver;
-pub use turn::{ModelRequestActivity, ToolActivity, TurnError, TurnOutcome, TurnReport};
+pub use turn::{
+    ModelRequestActivity, ToolActivity, TurnError, TurnLimits, TurnOptions, TurnOutcome, TurnReport,
+};
 pub use write::{WriteError, WriteOutput};
 pub use write_journal::{WriteRecord, WriteStatus};

--- a/crates/ag-harness/src/policy.rs
+++ b/crates/ag-harness/src/policy.rs
@@ -1,21 +1,41 @@
+use serde::{Deserialize, Serialize};
+
 use crate::tool::Tool;
 
 /// Default-deny permissions for built-in harness tools.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(crate) struct Policy {
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ToolPolicy {
     read: bool,
     write: bool,
 }
 
-impl Policy {
-    pub(crate) fn allow(&mut self, tool: Tool) {
+impl ToolPolicy {
+    /// Returns a policy that explicitly allows `tool`.
+    #[must_use]
+    pub fn allow(mut self, tool: Tool) -> Self {
         match tool {
             Tool::Read => self.read = true,
             Tool::Write => self.write = true,
         }
+
+        self
     }
 
-    pub(crate) fn allows(self, tool: Tool) -> bool {
+    /// Returns a policy that denies `tool`, including a previously allowed
+    /// tool.
+    #[must_use]
+    pub fn deny(mut self, tool: Tool) -> Self {
+        match tool {
+            Tool::Read => self.read = false,
+            Tool::Write => self.write = false,
+        }
+
+        self
+    }
+
+    /// Returns whether this policy permits executing and advertising `tool`.
+    pub fn allows(self, tool: Tool) -> bool {
         match tool {
             Tool::Read => self.read,
             Tool::Write => self.write,

--- a/crates/ag-harness/src/policy_test.rs
+++ b/crates/ag-harness/src/policy_test.rs
@@ -1,20 +1,35 @@
-use super::Policy;
+use crate::policy::ToolPolicy;
 use crate::tool::Tool;
 
 #[test]
 fn policy_denies_tools_by_default_and_allows_them_explicitly() {
     // Arrange
-    let mut policy = Policy::default();
+    let mut policy = ToolPolicy::default();
 
     // Act
     let read_denied_by_default = policy.allows(Tool::Read);
     let write_denied_by_default = policy.allows(Tool::Write);
-    policy.allow(Tool::Read);
-    policy.allow(Tool::Write);
+    policy = policy.allow(Tool::Read);
+    policy = policy.allow(Tool::Write);
 
     // Assert
     assert!(!read_denied_by_default);
     assert!(!write_denied_by_default);
     assert!(policy.allows(Tool::Read));
     assert!(policy.allows(Tool::Write));
+}
+
+#[test]
+fn policy_revokes_previously_allowed_tools_without_mutating_the_original() {
+    // Arrange
+    let allowed = ToolPolicy::default().allow(Tool::Read).allow(Tool::Write);
+
+    // Act
+    let denied = allowed.deny(Tool::Read).deny(Tool::Write);
+
+    // Assert
+    assert!(allowed.allows(Tool::Read));
+    assert!(allowed.allows(Tool::Write));
+    assert!(!denied.allows(Tool::Read));
+    assert!(!denied.allows(Tool::Write));
 }

--- a/crates/ag-harness/src/session.rs
+++ b/crates/ag-harness/src/session.rs
@@ -1,6 +1,7 @@
 //! Completed-turn persistence for resumable harness chats.
 
 use std::collections::HashSet;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -8,7 +9,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Value, json};
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
 use sqlx::{SqliteConnection, SqlitePool, Transaction};
 use thiserror::Error;
@@ -19,7 +20,7 @@ use tokio::time::{Instant, MissedTickBehavior};
 use crate::model::{ModelMessage, ModelMetadata};
 use crate::tool::{ReadArguments, ToolCall, WriteArguments};
 use crate::write_journal::WriteJournal;
-use crate::{OutputSchema, OutputSchemaError, TurnError};
+use crate::{OutputSchema, OutputSchemaError, ToolPolicy, TurnError, TurnLimits, TurnOptions};
 
 pub(crate) const TURN_LEASE_SECONDS: i64 = 300;
 pub(crate) const TURN_LEASE_RENEWAL_INTERVAL_SECONDS: u64 = 100;
@@ -46,6 +47,14 @@ struct SessionRow {
     provider: Option<String>,
     provider_session_id: Option<String>,
     system_prompt: Option<String>,
+    turn_options: Option<String>,
+}
+
+#[derive(Eq, PartialEq)]
+struct TurnConfigurationRow {
+    max_history_bytes: i64,
+    provider_session_id: Option<String>,
+    turn_options: Option<String>,
 }
 
 struct TurnSizeRow {
@@ -289,7 +298,9 @@ SELECT provider,
        output_schema,
        system_prompt,
        max_history_bytes AS "max_history_bytes!: i64",
-       provider_session_id
+       provider_session_id,
+       (SELECT turn_options FROM session_turn
+        WHERE session_id = session.id ORDER BY turn_position DESC LIMIT 1) AS "turn_options?: String"
 FROM session
 WHERE id = ?
 "#,
@@ -306,6 +317,9 @@ WHERE id = ?
             }
         })?;
         let schema = OutputSchema::new(output_schema)?;
+        if let Some(snapshot) = row.turn_options {
+            StoredTurnOptions::decode(&snapshot)?;
+        }
         let turns = self.load_turns(id, max_history_bytes).await?;
 
         Ok(LoadedSession {
@@ -340,18 +354,31 @@ WHERE id = ?
         &self,
         session_id: &str,
         prompt: &str,
+        options: &TurnOptions,
     ) -> Result<AcquiredTurn, SessionError> {
         let message = EncodedMessage::from_message(&ModelMessage::User(prompt.to_string()))?;
 
         loop {
             let acquisition = self.load_turn_acquisition(session_id).await?;
+            let previous_options = acquisition
+                .configuration
+                .turn_options
+                .as_deref()
+                .map(StoredTurnOptions::decode)
+                .transpose()?;
+            let compatible = previous_options
+                .as_ref()
+                .is_some_and(|previous| options.continuation_compatible(previous));
             if let Some(guard) = self
-                .reserve_turn(session_id, &message, &acquisition)
+                .reserve_turn(session_id, &message, &acquisition, options, compatible)
                 .await?
             {
                 return Ok(AcquiredTurn {
                     guard,
-                    provider_session_id: acquisition.provider_session_id,
+                    provider_session_id: acquisition
+                        .configuration
+                        .provider_session_id
+                        .filter(|_| compatible),
                     turn_position: acquisition.turn_position,
                     turns: acquisition.turns,
                 });
@@ -368,18 +395,9 @@ WHERE id = ?
             .begin()
             .await
             .session_context("load persistent session turn acquisition")?;
-        let session = sqlx::query_as::<_, (i64, Option<String>)>(
-            "SELECT max_history_bytes, provider_session_id FROM session WHERE id = ?",
-        )
-        .bind(session_id)
-        .fetch_optional(&mut *transaction)
-        .await
-        .session_context("load persistent session turn acquisition")?
-        .ok_or_else(|| SessionError::NotFound {
-            id: session_id.to_string(),
-        })?;
-        let (max_history_bytes, provider_session_id) = session;
-        let max_history_bytes = decode_max_history_bytes(session_id, max_history_bytes)?;
+        let configuration = load_turn_configuration(&mut transaction, session_id).await?;
+        let max_history_bytes =
+            decode_max_history_bytes(session_id, configuration.max_history_bytes)?;
         let turn_position = next_turn_position(&mut transaction, session_id).await?;
         let latest_completed_turn = latest_completed_turn(&mut transaction, session_id).await?;
         let turns = load_turns_from(&mut transaction, session_id, max_history_bytes).await?;
@@ -389,9 +407,8 @@ WHERE id = ?
             .session_context("load persistent session turn acquisition")?;
 
         Ok(TurnAcquisition {
+            configuration,
             latest_completed_turn,
-            max_history_bytes,
-            provider_session_id,
             turn_position,
             turns,
         })
@@ -402,6 +419,8 @@ WHERE id = ?
         session_id: &str,
         message: &EncodedMessage,
         acquisition: &TurnAcquisition,
+        options: &TurnOptions,
+        continuation_compatible: bool,
     ) -> Result<Option<TurnGuard>, SessionError> {
         let operation = "reserve persistent session turn";
         let recovery_now = self.timestamp_source.now_timestamp_seconds();
@@ -413,22 +432,10 @@ WHERE id = ?
                 .await
                 .session_context("recover abandoned persistent session turn")?;
         }
-        let session = sqlx::query_as::<_, (i64, Option<String>)>(
-            "SELECT max_history_bytes, provider_session_id FROM session WHERE id = ?",
-        )
-        .bind(session_id)
-        .fetch_optional(&mut *transaction)
-        .await
-        .session_context(operation)?
-        .ok_or_else(|| SessionError::NotFound {
-            id: session_id.to_string(),
-        })?;
-        let (max_history_bytes, provider_session_id) = session;
-        let max_history_bytes = decode_max_history_bytes(session_id, max_history_bytes)?;
+        let configuration = load_turn_configuration(&mut transaction, session_id).await?;
         let turn_position = next_turn_position(&mut transaction, session_id).await?;
         let latest_completed_turn = latest_completed_turn(&mut transaction, session_id).await?;
-        if max_history_bytes != acquisition.max_history_bytes
-            || provider_session_id != acquisition.provider_session_id
+        if configuration != acquisition.configuration
             || turn_position != acquisition.turn_position
             || latest_completed_turn != acquisition.latest_completed_turn
         {
@@ -438,21 +445,23 @@ WHERE id = ?
         }
         let reservation_now = self.timestamp_source.now_timestamp_seconds();
         let lease_expires_at = reservation_now.saturating_add(TURN_LEASE_SECONDS);
-        let result = sqlx::query_scalar::<_, Vec<u8>>(
-            r"
+        let snapshot = StoredTurnOptions::encode(options);
+        let result = sqlx::query_scalar!(
+            r#"
 INSERT INTO session_turn (
     session_id, turn_position, status, error_type, lease_expires_at, created_at, updated_at,
-    owner_token
+    owner_token, turn_options
 )
-VALUES (?, ?, 'running', NULL, ?, ?, ?, randomblob(16))
-RETURNING owner_token
-",
+VALUES (?, ?, 'running', NULL, ?, ?, ?, randomblob(16), ?)
+RETURNING owner_token AS "owner_token!: Vec<u8>"
+"#,
+            session_id,
+            acquisition.turn_position,
+            lease_expires_at,
+            reservation_now,
+            reservation_now,
+            snapshot
         )
-        .bind(session_id)
-        .bind(acquisition.turn_position)
-        .bind(lease_expires_at)
-        .bind(reservation_now)
-        .bind(reservation_now)
         .fetch_one(&mut *transaction)
         .await;
         let owner_token = result.map_err(|error| {
@@ -485,6 +494,15 @@ RETURNING owner_token
             operation,
         )
         .await?;
+        if !continuation_compatible {
+            sqlx::query!(
+                "UPDATE session SET provider_session_id = NULL WHERE id = ?",
+                session_id
+            )
+            .execute(&mut *transaction)
+            .await
+            .session_context(operation)?;
+        }
         transaction.commit().await.session_context(operation)?;
         self.reservation_observer.committed().await;
         self.abandoned_turns.remove(&abandoned_turns);
@@ -754,10 +772,46 @@ pub(crate) struct LoadedSession {
     pub(crate) turns: Vec<Vec<ModelMessage>>,
 }
 
+/// Versioned durable representation; omitted legacy permissions remain unknown.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoredTurnOptions {
+    max_tool_calls: NonZeroUsize,
+    output_schema: Value,
+    tool_policy: ToolPolicy,
+    version: u8,
+}
+
+impl StoredTurnOptions {
+    fn encode(options: &TurnOptions) -> String {
+        json!({
+            "max_tool_calls": options.limits().max_tool_calls(),
+            "output_schema": options.schema().value(),
+            "tool_policy": options.tool_policy(),
+            "version": 1,
+        })
+        .to_string()
+    }
+
+    fn decode(snapshot: &str) -> Result<TurnOptions, SessionError> {
+        let stored: Self = deserialize_payload(snapshot)?;
+        if stored.version != 1 {
+            return Err(SessionError::InvalidData {
+                reason: format!("unsupported turn options version {}", stored.version),
+            });
+        }
+
+        Ok(TurnOptions::new(
+            OutputSchema::new(stored.output_schema)?,
+            stored.tool_policy,
+            TurnLimits::new(stored.max_tool_calls),
+        ))
+    }
+}
+
 struct TurnAcquisition {
+    configuration: TurnConfigurationRow,
     latest_completed_turn: Option<i64>,
-    max_history_bytes: usize,
-    provider_session_id: Option<String>,
     turn_position: i64,
     turns: Vec<Vec<ModelMessage>>,
 }
@@ -1130,6 +1184,29 @@ fn connect_options(path: &Path) -> SqliteConnectOptions {
         .journal_mode(SqliteJournalMode::Wal)
         .synchronous(SqliteSynchronous::Full)
         .foreign_keys(true)
+}
+
+async fn load_turn_configuration(
+    connection: &mut SqliteConnection,
+    session_id: &str,
+) -> Result<TurnConfigurationRow, SessionError> {
+    sqlx::query_as!(
+        TurnConfigurationRow,
+        r#"
+SELECT max_history_bytes AS "max_history_bytes!: i64", provider_session_id,
+       (SELECT turn_options FROM session_turn
+        WHERE session_id = session.id AND status = 'completed'
+        ORDER BY turn_position DESC LIMIT 1) AS "turn_options?: String"
+FROM session WHERE id = ?
+"#,
+        session_id
+    )
+    .fetch_optional(connection)
+    .await
+    .session_context("load persistent session turn acquisition")?
+    .ok_or_else(|| SessionError::NotFound {
+        id: session_id.to_string(),
+    })
 }
 
 async fn load_turns_from(

--- a/crates/ag-harness/src/session_test.rs
+++ b/crates/ag-harness/src/session_test.rs
@@ -2,6 +2,8 @@
 mod chat;
 #[path = "session_test/history_test.rs"]
 mod history;
+#[path = "session_test/options_test.rs"]
+mod options;
 #[path = "session_test/reservation_test.rs"]
 mod reservation;
 #[path = "session_test/storage_test.rs"]

--- a/crates/ag-harness/src/session_test/options_test.rs
+++ b/crates/ag-harness/src/session_test/options_test.rs
@@ -1,0 +1,174 @@
+use std::num::NonZeroUsize;
+
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+use super::support::{create_version_one_database, schema, turn_options};
+use crate::session::{Database, NewSession, SessionError, StoredTurnOptions};
+use crate::{Tool, ToolPolicy, TurnError, TurnLimits, TurnOptions};
+
+#[test]
+fn snapshots_round_trip_and_reject_unknown_or_invalid_configuration() {
+    // Arrange
+    let options = TurnOptions::new(
+        schema(),
+        ToolPolicy::default().allow(Tool::Write),
+        TurnLimits::new(NonZeroUsize::new(3).expect("nonzero budget")),
+    );
+    let encoded = StoredTurnOptions::encode(&options);
+    let snapshot: Value = serde_json::from_str(&encoded).expect("snapshot JSON");
+    let mut invalid = Vec::new();
+    for (key, value) in [
+        ("version", json!(2)),
+        ("max_tool_calls", json!(0)),
+        ("output_schema", json!({"type":"invalid"})),
+        ("tool_policy", json!({"read":true})),
+        ("unknown", json!(true)),
+    ] {
+        let mut value_snapshot = snapshot.clone();
+        value_snapshot[key] = value;
+        invalid.push(value_snapshot.to_string());
+    }
+    invalid.push("invalid JSON".to_string());
+
+    // Act
+    let decoded = StoredTurnOptions::decode(&encoded).expect("decode snapshot");
+    let errors: Vec<_> = invalid
+        .iter()
+        .map(|snapshot| StoredTurnOptions::decode(snapshot))
+        .collect();
+
+    // Assert
+    assert_eq!(decoded, options);
+    assert!(errors.iter().all(Result::is_err));
+}
+
+#[tokio::test]
+async fn snapshots_are_committed_before_execution_and_survive_failure_and_interruption() {
+    // Arrange
+    let database = Database::open_in_memory().await.expect("database");
+    database
+        .create_session(&NewSession::new("session", schema()), None, 4096)
+        .await
+        .expect("session");
+    let options = turn_options();
+
+    // Act
+    let mut first = database
+        .begin_turn("session", "failed", &options)
+        .await
+        .expect("reservation");
+    let running: (String, String) =
+        sqlx::query_as("SELECT status, turn_options FROM session_turn WHERE turn_position = 0")
+            .fetch_one(database.pool())
+            .await
+            .expect("running snapshot");
+    database
+        .fail_turn(
+            "session",
+            first.turn_position,
+            &TurnError::ToolCallLimit { limit: 8 },
+        )
+        .await
+        .expect("failed turn");
+    first.guard.disarm();
+    let second = database
+        .begin_turn("session", "interrupted", &options)
+        .await
+        .expect("second reservation");
+    drop(second);
+    database
+        .load_session("session")
+        .await
+        .expect("recover session");
+    let rows: Vec<(String, String)> =
+        sqlx::query_as("SELECT status, turn_options FROM session_turn ORDER BY turn_position")
+            .fetch_all(database.pool())
+            .await
+            .expect("retained snapshots");
+
+    // Assert
+    assert_eq!(running.0, "running");
+    assert_eq!(
+        StoredTurnOptions::decode(&running.1).expect("running options"),
+        options
+    );
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].0, "failed");
+    assert_eq!(rows[1].0, "interrupted");
+    assert!(rows.iter().all(|(_, snapshot)| snapshot == &running.1));
+}
+
+#[tokio::test]
+async fn legacy_history_keeps_its_schema_but_replays_unknown_native_configuration() {
+    // Arrange
+    let directory = tempdir().expect("temporary directory");
+    let database_path = directory.path().join("legacy.db");
+    create_version_one_database(&database_path).await;
+    let database = Database::open(&database_path)
+        .await
+        .expect("migrated database");
+    sqlx::query("UPDATE session SET provider_session_id = 'legacy-native' WHERE id = 'session-a'")
+        .execute(database.pool())
+        .await
+        .expect("legacy continuation");
+
+    // Act
+    let loaded = database
+        .load_session("session-a")
+        .await
+        .expect("legacy session");
+    let acquired = database
+        .begin_turn("session-a", "new", &turn_options())
+        .await
+        .expect("new turn");
+    let native: Option<String> =
+        sqlx::query_scalar("SELECT provider_session_id FROM session WHERE id = 'session-a'")
+            .fetch_one(database.pool())
+            .await
+            .expect("canonical continuation");
+
+    // Assert
+    assert_eq!(loaded.schema, schema());
+    assert_eq!(acquired.turns.len(), 2);
+    assert!(acquired.provider_session_id.is_none());
+    assert!(native.is_none());
+}
+
+#[tokio::test]
+async fn corrupt_snapshots_are_rejected_on_reopen_and_before_reservation() {
+    // Arrange
+    let database = Database::open_in_memory().await.expect("database");
+    database
+        .create_session(&NewSession::new("session", schema()), None, 4096)
+        .await
+        .expect("session");
+    let mut first = database
+        .begin_turn("session", "first", &turn_options())
+        .await
+        .expect("reservation");
+    database
+        .complete_turn("session", first.turn_position, &[], Some("native"))
+        .await
+        .expect("completion");
+    first.guard.disarm();
+    sqlx::query("UPDATE session_turn SET turn_options = json_set(turn_options, '$.version', 2)")
+        .execute(database.pool())
+        .await
+        .expect("corrupt version");
+
+    // Act
+    let loaded = database.load_session("session").await;
+    let reserved = database
+        .begin_turn("session", "second", &turn_options())
+        .await;
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM session_turn")
+        .fetch_one(database.pool())
+        .await
+        .expect("turn count");
+
+    // Assert
+    assert!(matches!(loaded, Err(SessionError::InvalidData { .. })));
+    assert!(matches!(reserved, Err(SessionError::InvalidData { .. })));
+    assert_eq!(count, 1);
+}

--- a/crates/ag-harness/src/session_test/reservation_test.rs
+++ b/crates/ag-harness/src/session_test/reservation_test.rs
@@ -6,7 +6,7 @@ use sqlx::sqlite::SqlitePoolOptions;
 use tempfile::tempdir;
 
 use super::support::{
-    ReservationCommitControl, active_turn_owner, complete_native_turn, schema, turn,
+    ReservationCommitControl, active_turn_owner, complete_native_turn, schema, turn, turn_options,
 };
 use crate::model::{ModelError, ModelMessage};
 use crate::session::{
@@ -75,7 +75,7 @@ async fn beginning_a_turn_for_a_missing_session_reports_not_found() {
 
     // Act
     let error = database
-        .begin_turn("missing", "prompt")
+        .begin_turn("missing", "prompt", &turn_options())
         .await
         .err()
         .expect("missing session should fail");
@@ -109,7 +109,7 @@ END
 
     // Act
     let error = database
-        .begin_turn("session-a", "prompt")
+        .begin_turn("session-a", "prompt", &turn_options())
         .await
         .err()
         .expect("database failure should be preserved");
@@ -139,7 +139,7 @@ async fn beginning_a_turn_does_not_reserve_when_history_loading_fails() {
 
     // Act
     let error = database
-        .begin_turn("session-a", "new prompt")
+        .begin_turn("session-a", "new prompt", &turn_options())
         .await
         .err()
         .expect("invalid history should fail acquisition");
@@ -181,7 +181,7 @@ async fn beginning_a_turn_calculates_the_lease_when_reserving() {
 
     // Act
     let acquired = database
-        .begin_turn("session-a", "prompt")
+        .begin_turn("session-a", "prompt", &turn_options())
         .await
         .expect("turn should begin");
     let row = sqlx::query_as::<_, (String, i64, i64, i64)>(
@@ -224,7 +224,7 @@ async fn reserving_a_turn_rejects_a_stale_acquisition_snapshot() {
 
     // Act
     let reserved = database
-        .reserve_turn("session-a", &message, &acquisition)
+        .reserve_turn("session-a", &message, &acquisition, &turn_options(), true)
         .await
         .expect("reservation should be checked");
     let active_turns = sqlx::query_scalar::<_, i64>(
@@ -262,7 +262,7 @@ async fn reserving_a_turn_for_a_removed_session_reports_not_found() {
 
     // Act
     let result = database
-        .reserve_turn("session-a", &message, &acquisition)
+        .reserve_turn("session-a", &message, &acquisition, &turn_options(), true)
         .await;
 
     // Assert
@@ -293,7 +293,7 @@ async fn cancelling_turn_acquisition_leaves_no_active_turn() {
     // Act
     let cancellation = tokio::time::timeout(
         Duration::from_millis(50),
-        database.begin_turn("session-a", "cancelled"),
+        database.begin_turn("session-a", "cancelled", &turn_options()),
     )
     .await;
     blocker
@@ -301,7 +301,7 @@ async fn cancelling_turn_acquisition_leaves_no_active_turn() {
         .await
         .expect("blocking transaction should roll back");
     let acquired = database
-        .begin_turn("session-a", "replacement")
+        .begin_turn("session-a", "replacement", &turn_options())
         .await
         .expect("replacement turn should begin immediately");
 
@@ -332,12 +332,12 @@ async fn cancelling_after_commit_recovers_the_owned_turn_immediately() {
     // Act
     let cancellation = tokio::time::timeout(
         Duration::from_secs(1),
-        database.begin_turn("session-a", "cancelled"),
+        database.begin_turn("session-a", "cancelled", &turn_options()),
     )
     .await;
     let commit_seen = commit_control.commit_seen.load(Ordering::SeqCst);
     let acquired = replacement_database
-        .begin_turn("session-a", "replacement")
+        .begin_turn("session-a", "replacement", &turn_options())
         .await
         .expect("replacement turn should begin immediately");
     let turns = sqlx::query_as::<_, (i64, String)>(
@@ -374,7 +374,7 @@ async fn registered_cancelled_owner_preserves_its_reason_during_recovery() {
         .expect("session should be created");
     complete_native_turn(&database, "native-session").await;
     let abandoned = database
-        .begin_turn("session-a", "abandoned")
+        .begin_turn("session-a", "abandoned", &turn_options())
         .await
         .expect("turn should begin");
     let mut owner = active_turn_owner(&database, "session-a", abandoned.turn_position).await;
@@ -383,7 +383,7 @@ async fn registered_cancelled_owner_preserves_its_reason_during_recovery() {
 
     // Act
     let replacement = database
-        .begin_turn("session-a", "replacement")
+        .begin_turn("session-a", "replacement", &turn_options())
         .await
         .expect("replacement turn should begin");
     let turns = sqlx::query_as::<_, (i64, String, Option<String>)>(
@@ -422,7 +422,7 @@ async fn stopped_ownership_monitor_reports_ownership_loss() {
         .await
         .expect("session should be created");
     let mut acquired = database
-        .begin_turn("session-a", "prompt")
+        .begin_turn("session-a", "prompt", &turn_options())
         .await
         .expect("turn should begin");
     acquired
@@ -470,11 +470,11 @@ async fn abandoned_owners_are_scoped_to_their_database() {
             .expect("session should be created");
     }
     let first_turn = first_database
-        .begin_turn("session-a", "first abandoned")
+        .begin_turn("session-a", "first abandoned", &turn_options())
         .await
         .expect("first turn should begin");
     let second_turn = second_database
-        .begin_turn("session-a", "second abandoned")
+        .begin_turn("session-a", "second abandoned", &turn_options())
         .await
         .expect("second turn should begin");
     let first_owner =
@@ -486,14 +486,14 @@ async fn abandoned_owners_are_scoped_to_their_database() {
 
     // Act
     let second_replacement = second_database
-        .begin_turn("session-a", "second replacement")
+        .begin_turn("session-a", "second replacement", &turn_options())
         .await
         .expect("second replacement should begin");
     let first_owners = first_database
         .abandoned_turns
         .for_session(&first_database.identity, "session-a");
     let first_replacement = first_database
-        .begin_turn("session-a", "first replacement")
+        .begin_turn("session-a", "first replacement", &turn_options())
         .await
         .expect("first replacement should begin");
 
@@ -514,7 +514,7 @@ async fn failing_or_completing_a_turn_that_is_not_running_reports_invalid_data()
         .await
         .expect("session should be created");
     let turn_position = database
-        .begin_turn("session-a", "prompt")
+        .begin_turn("session-a", "prompt", &turn_options())
         .await
         .expect("turn should begin")
         .turn_position;
@@ -564,7 +564,7 @@ async fn database_recovers_expired_active_turns_as_interrupted() {
         .expect("session should be created");
     complete_native_turn(&database, "native-session").await;
     let mut abandoned = database
-        .begin_turn("session-a", "abandoned")
+        .begin_turn("session-a", "abandoned", &turn_options())
         .await
         .expect("turn should begin");
     abandoned.guard.disarm();
@@ -584,7 +584,7 @@ async fn database_recovers_expired_active_turns_as_interrupted() {
         .await
         .expect("session should load");
     let replacement = database
-        .begin_turn("session-a", "replacement")
+        .begin_turn("session-a", "replacement", &turn_options())
         .await
         .expect("replacement turn should begin");
     let status = sqlx::query_scalar::<_, String>(
@@ -617,7 +617,7 @@ async fn interruption_rolls_back_when_clearing_continuation_fails() {
             .expect("session should be created");
         complete_native_turn(&database, "native-session").await;
         let mut acquired = database
-            .begin_turn("session-a", "abandoned")
+            .begin_turn("session-a", "abandoned", &turn_options())
             .await
             .expect("turn should begin");
         acquired.guard.disarm();
@@ -685,7 +685,7 @@ async fn delayed_or_unowned_cleanup_preserves_provider_continuation() {
         .expect("session should be created");
     complete_native_turn(&database, "native-session").await;
     let mut acquired = database
-        .begin_turn("session-a", "pending")
+        .begin_turn("session-a", "pending", &turn_options())
         .await
         .expect("turn should begin");
     acquired.guard.disarm();

--- a/crates/ag-harness/src/session_test/support_test.rs
+++ b/crates/ag-harness/src/session_test/support_test.rs
@@ -86,7 +86,7 @@ pub(super) fn turn(prompt: &str, answer: &str) -> Vec<ModelMessage> {
 
 pub(super) async fn complete_native_turn(database: &Database, provider_session_id: &str) {
     let mut acquired = database
-        .begin_turn("session-a", "first")
+        .begin_turn("session-a", "first", &turn_options())
         .await
         .expect("turn should begin");
     database
@@ -388,4 +388,12 @@ impl ReservationObserver for ReservationCommitControl {
             std::future::pending::<()>().await;
         }
     }
+}
+
+pub(super) fn turn_options() -> crate::TurnOptions {
+    crate::TurnOptions::new(
+        schema(),
+        crate::ToolPolicy::default(),
+        crate::TurnLimits::default(),
+    )
 }

--- a/crates/ag-harness/src/turn.rs
+++ b/crates/ag-harness/src/turn.rs
@@ -1,6 +1,7 @@
-//! Public turn outcomes, observable activity, and terminal errors.
+//! Immutable turn options, outcomes, observable activity, and terminal errors.
 
 use std::fmt;
+use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use serde_json::Value;
@@ -8,9 +9,77 @@ use thiserror::Error;
 
 use crate::lifecycle::{ModelResponseType, TurnErrorType};
 use crate::model::{CompletionMetadata, ModelError};
+use crate::policy::ToolPolicy;
 use crate::read::ReadError;
+use crate::schema_contract::OutputSchema;
 use crate::tool::ReadAction;
 use crate::write::WriteError;
+
+/// Fully resolved configuration, fixed for the lifetime of one engine run.
+///
+/// Construct a new value for each turn. Explicit options never inherit
+/// permissions or schema changes from an earlier turn. Counters, cancellation,
+/// and conversation history belong to execution state, not this snapshot.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TurnOptions {
+    limits: TurnLimits,
+    schema: OutputSchema,
+    tool_policy: ToolPolicy,
+}
+
+impl TurnOptions {
+    /// Resolves a required schema, explicit permissions, and execution limits.
+    pub fn new(schema: OutputSchema, tool_policy: ToolPolicy, limits: TurnLimits) -> Self {
+        Self {
+            limits,
+            schema,
+            tool_policy,
+        }
+    }
+
+    /// Returns the execution bounds for this turn.
+    pub fn limits(&self) -> TurnLimits {
+        self.limits
+    }
+
+    /// Returns the schema required for every terminal model output.
+    pub fn schema(&self) -> &OutputSchema {
+        &self.schema
+    }
+
+    /// Returns the complete permissions for this turn.
+    pub fn tool_policy(&self) -> ToolPolicy {
+        self.tool_policy
+    }
+
+    pub(crate) fn continuation_compatible(&self, other: &Self) -> bool {
+        self.schema == other.schema && self.tool_policy == other.tool_policy
+    }
+}
+
+/// Immutable execution bounds; consuming a budget does not modify these limits.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TurnLimits {
+    max_tool_calls: NonZeroUsize,
+}
+
+impl TurnLimits {
+    /// Sets the total permitted tool calls, including calls in batches.
+    pub fn new(max_tool_calls: NonZeroUsize) -> Self {
+        Self { max_tool_calls }
+    }
+
+    /// Returns the total permitted tool calls in a turn.
+    pub fn max_tool_calls(self) -> NonZeroUsize {
+        self.max_tool_calls
+    }
+}
+
+impl Default for TurnLimits {
+    fn default() -> Self {
+        Self::new(NonZeroUsize::new(8).unwrap_or(NonZeroUsize::MIN))
+    }
+}
 
 /// Successful model turn paired with observable execution activity.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/ag-harness/src/write_journal_test.rs
+++ b/crates/ag-harness/src/write_journal_test.rs
@@ -16,16 +16,20 @@ use crate::session::{Database, NewSession, SessionError, TurnGuard};
 use crate::tool::WriteArguments;
 use crate::write::WriteTool;
 use crate::write_journal::{WriteRecord, WriteRecordRow, WriteStatus, content_hash};
-use crate::{ModelError, OutputSchema, TurnError, WriteError};
+use crate::{ModelError, OutputSchema, ToolPolicy, TurnError, TurnLimits, TurnOptions, WriteError};
 
 async fn fixture() -> (Database, TurnGuard) {
     let database = Database::open_in_memory().await.expect("database");
     let schema = OutputSchema::new(json!({"type": "object"})).expect("schema");
+    let options = TurnOptions::new(schema.clone(), ToolPolicy::default(), TurnLimits::default());
     database
         .create_session(&NewSession::new("session", schema), None, 4096)
         .await
         .expect("session");
-    let acquired = database.begin_turn("session", "write").await.expect("turn");
+    let acquired = database
+        .begin_turn("session", "write", &options)
+        .await
+        .expect("turn");
 
     (database, acquired.guard)
 }

--- a/crates/ag-harness/tests/public_api.rs
+++ b/crates/ag-harness/tests/public_api.rs
@@ -16,7 +16,8 @@ use ag_harness::{
     LifecycleObserverSet, LifecycleTraceObserver, LocalFileSystem, Model, ModelCompletion,
     ModelConfiguration, ModelError, ModelMessage, ModelMetadata, ModelProvider, ModelRequest,
     ModelResponse, ModelResponseType, OutputSchema, OutputSchemaError, Repository, RepositoryError,
-    SessionError, SessionInfo, Tool, ToolCall, TurnError, WriteStatus,
+    SessionError, SessionInfo, Tool, ToolCall, ToolPolicy, TurnError, TurnLimits, TurnOptions,
+    WriteStatus,
 };
 use async_trait::async_trait;
 use serde_json::json;
@@ -738,6 +739,51 @@ async fn applied_write_survives_model_failure_and_session_reopen() -> Result<(),
     assert_eq!(after[0].call_id, "write-name");
     assert_eq!(after[0].expected_hash, None);
     assert_eq!(after[0].resulting_hash.len(), 64);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn explicit_options_support_both_entry_points_and_retain_history_after_revocation()
+-> Result<(), Box<dyn Error>> {
+    // Arrange
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let model = ExternalToolModel {
+        batched: false,
+        requests: Arc::clone(&requests),
+    };
+    let directory = tempfile::tempdir()?;
+    let harness = Harness::new(model)
+        .database(directory.path().join("options.db"))
+        .repository(repository::repository_with_host_git(directory.path()))
+        .file_system(NameFileSystem);
+    let schema = request()?.schema().clone();
+    let policy = ToolPolicy::default().allow(Tool::Read);
+    let limits = TurnLimits::default();
+    let options = TurnOptions::new(schema.clone(), policy, limits);
+
+    // Act
+    let once = harness
+        .run_once_with_options("Read the name", options.clone())
+        .await?;
+    let mut session = harness.session("options", schema.clone()).create().await?;
+    let durable = session
+        .send_with_options("Read the name", options.clone())
+        .await?;
+    let denied = TurnOptions::new(schema.clone(), policy.deny(Tool::Read), limits);
+    let recalled = session.send_with_options("Recall the name", denied).await?;
+
+    // Assert
+    assert_eq!(once.output(), durable.output());
+    assert_eq!(recalled.output(), &json!({"name":"Ada"}));
+    assert_eq!(recalled.report().tool_calls().len(), 0);
+    assert_eq!(options.schema(), &schema);
+    assert!(options.tool_policy().allows(Tool::Read));
+    assert_eq!(options.limits().max_tool_calls().get(), 8);
+    let requests = requests
+        .lock()
+        .map_err(|_| io::Error::other("requests lock poisoned"))?;
+    assert!(requests.last().expect("last request").iter().any(|message| matches!(message, ModelMessage::ToolResult { content, .. } if content.contains("Ada"))));
 
     Ok(())
 }

--- a/docs/site/content/docs/architecture/ag-harness-design.md
+++ b/docs/site/content/docs/architecture/ag-harness-design.md
@@ -7,7 +7,8 @@ weight = 6
 # `ag-harness`
 
 `ag-harness` is a Rust library for structured model turns. Applications select a model,
-an output schema, a SQLite database, and the repository tools the model may use.
+per-turn output schemas and tool permissions, and a SQLite database for durable
+sessions.
 
 ```mermaid
 flowchart LR
@@ -19,8 +20,12 @@ flowchart LR
 
 ## Public boundary
 
-- `Harness` owns the model, repository policy, lifecycle observers, and shared database
-  pool.
+- `Harness` owns the model, validated repository, configured defaults, lifecycle
+  observers, and shared database pool.
+- One internal engine prepares requests, runs provider attempts and tools, retries
+  rejected native continuations, and validates output for both entry points.
+- Immutable `TurnOptions` fixes the required schema, effective `ToolPolicy`, and
+  `TurnLimits` for one execution. A later turn can use different options.
 - `Session` is the only multi-turn abstraction. It persists and restores bounded
   history.
 - `Model` is the object-safe provider boundary. `ModelCompletion` carries the response,
@@ -36,6 +41,26 @@ override. `Repository` canonicalizes the selection once and never performs its o
 `PATH` discovery. Unix hosts also verify effective execute access; other platforms defer
 that check to process creation. Repository-relative tool arguments reject `.git`
 components before filesystem access.
+
+## Per-turn options
+
+`Harness::run_once_with_options` and `Session::send_with_options` accept a complete
+`TurnOptions` snapshot. Explicit permissions replace harness defaults; they are never
+merged with defaults or earlier turns. An empty `ToolPolicy` denies every tool. Denied
+tools are neither advertised nor executable. The tool-call budget applies across all
+provider attempts and counts individual calls inside batches.
+
+Existing `run_once` and `send` methods resolve fresh options from configured defaults.
+`send` uses the stored session schema and the current harness permissions and tool-call
+budget. An explicit override never changes these defaults, including after reopening.
+Permission downgrades retain completed conversation history and previously read content;
+they govern current tool execution. Changes during execution apply to a later turn;
+immediate revocation requires cancellation.
+
+The future Agentty adapters will resolve new options from each request's protocol
+profile and permission mode. Agentty owns review-loop behavior. Mutable counters,
+cancellation, and shared provider-call budget accounting remain execution state rather
+than configuration. Sandboxed Bash and Agentty permission mapping remain later work.
 
 ## Session lifecycle
 
@@ -60,8 +85,14 @@ Only completed turns are replayed. A process that disappears may leave a leased 
 entering model context.
 
 The database stores the output schema, system prompt, model identity, history budget,
-provider continuation identifier, messages, and turn state. Oldest complete turns are
-excluded from replay when the configured byte budget is exceeded.
+provider continuation identifier, messages, and turn state. Each new durable turn also
+stores a versioned snapshot of its effective schema, permissions, and tool-call budget,
+atomically with reservation and the prompt before execution. The session schema remains
+the default for legacy callers. Historical turns without options remain readable;
+missing historical permissions are unknown, never inferred from current defaults.
+Recovery validates stored options and marks abandoned turns interrupted without
+re-executing them. Oldest complete turns are excluded from replay when the configured
+byte budget is exceeded.
 
 Starting a turn loads bounded completed history in a read-only snapshot, then opens a
 short writer transaction. The writer revalidates the snapshot and commits the turn as
@@ -98,15 +129,20 @@ continue without a journal.
 
 On resume, the harness validates the stored model identity and restores completed
 history. If a completion includes a provider session identifier, the next request also
-offers it to the adapter. `ModelError::ResumeUnavailable` causes one retry with the
-provider identifier removed and the same SQLite history retained. The rejected native
-resume and the replay are reported as separate provider attempts. A successful replay
-replaces the stored continuation identifier with the one it returns, or clears the
-identifier when it returns none. Failed turns, cancellation, and expired-lease recovery
-clear the stored provider identifier atomically with the terminal turn state because the
-harness cannot know whether the remote conversation advanced. Cleanup clears the
-identifier only when it actually interrupts an active turn, so delayed cleanup cannot
-invalidate a newer continuation. The next request replays completed SQLite history.
+offers it to the adapter only when the last completed turn's schema and permissions
+match the current options. Acquisition checks canonical persisted options, including for
+stale session handles. Schema or permission changes, or missing legacy options, clear
+the native identifier atomically with reservation and replay completed history. A
+tool-budget change alone does not invalidate continuation.
+`ModelError::ResumeUnavailable` causes one retry with the provider identifier removed
+and the same SQLite history retained. The rejected native resume and the replay are
+reported as separate provider attempts. A successful replay replaces the stored
+continuation identifier with the one it returns, or clears the identifier when it
+returns none. Failed turns, cancellation, and expired-lease recovery clear the stored
+provider identifier atomically with the terminal turn state because the harness cannot
+know whether the remote conversation advanced. Cleanup clears the identifier only when
+it actually interrupts an active turn, so delayed cleanup cannot invalidate a newer
+continuation. The next request replays completed SQLite history.
 
 ## Concurrency
 
@@ -133,11 +169,6 @@ tool failures retain their original classification even if recording the failure
 fails. Dropping either operation emits cancellation once.
 
 ## Next iterations
-
-1. **Shared turn engine and options**
-
-   Move output schemas and tool permissions to per-turn options used by both durable and
-   one-shot execution.
 
 1. **Owned sessions and stores**
 

--- a/docs/site/content/docs/architecture/module-map.md
+++ b/docs/site/content/docs/architecture/module-map.md
@@ -33,8 +33,10 @@ For file-level detail, read the module docstrings directly.
   object-safe `Model` boundary, its `ModelClient` implementation, the built-in provider
   catalog and environment-backed configuration, private Qwen, Kimi, and Muse policies, a
   shared Chat Completions backend with JSON Object and JSON Schema modes,
-  backend-neutral request-duration telemetry, and a deny-by-default `Harness` loop with
-  closed built-in `read` and `write` capabilities. Its durable `Session` API records
+  backend-neutral request-duration telemetry, and a shared internal engine with closed
+  built-in `read` and `write` capabilities. Both durable and one-shot entry points pass
+  immutable `TurnOptions` with a required schema, effective deny-by-default
+  `ToolPolicy`, and tool-call budget to that engine. Its durable `Session` API records
   pending, running, completed, failed, and interrupted turns in SQLite, while replaying
   only bounded whole completed turns. `Harness` owns a lazily initialized database pool
   shared by its sessions; `Session::send` owns terminal lifecycle events through durable

--- a/docs/site/content/docs/architecture/runtime-flow.md
+++ b/docs/site/content/docs/architecture/runtime-flow.md
@@ -1048,3 +1048,10 @@ runtime flow:
 - External integrations (`GitClient`, `ReviewRequestClient`, `AppServerClient`,
   `AgentChannel`, `EventSource`, `FsClient`, `TmuxClient`) isolate side effects and
   enable deterministic tests.
+
+The standalone `ag-harness` library resolves immutable options before each engine run.
+Durable acquisition commits those options with the prompt and revalidates native
+continuation against the last completed turn's schema and permissions. Its session emits
+completion only after persisting the result; one-shot execution uses the same engine
+without opening SQLite. These are library boundaries for the planned Agentty adapters,
+not a replacement for the current Agentty runtime.

--- a/docs/site/content/docs/architecture/testability-boundaries.md
+++ b/docs/site/content/docs/architecture/testability-boundaries.md
@@ -90,7 +90,11 @@ deterministic in unit tests. The runtime also accepts `Terminal<B: Backend>` via
 Persistent `ag-harness` sessions inject a timestamp source and a reservation observer.
 The observer marks the boundary after SQLite commits a turn reservation, allowing tests
 to exercise cancellation at that point without conditional production control flow. Unit
-suites and their fixtures live in separate test files.
+suites and their fixtures live in separate test files. Shared-engine tests compare
+provider requests across durable and ephemeral execution. Persistence tests cover
+options snapshots, legacy reads, and continuation invalidation against canonical
+configuration; terminal lifecycle tests retain the persistence-before-completion
+boundary.
 
 The `ag-agent` crate keeps provider routers, parsers, and concrete transport adapters
 private. Application workflows that submit isolated utility prompts inject


### PR DESCRIPTION
- Share one execution engine across ephemeral and durable turns with immutable schemas, tool policies, and call limits.
- Persist and validate per-turn option snapshots before execution while invalidating native continuation when schemas or permissions change.
- Cover parity, overrides, budgets, failures, legacy data, lifecycle, and continuation handling with tests and architecture documentation.